### PR TITLE
Add GCM_ENABLED flag to manifest.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_dev",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "false",
                                     internal_features      : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKey")]
@@ -125,6 +126,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_candidate",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "true",
                                     internal_features      : "false",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyCand")]
@@ -152,6 +154,7 @@ android {
                                     sharedUserId           : "com.waz.userid",
                                     internal_features      : "false",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKeyProd"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyProd")]
 
@@ -178,6 +181,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_internal",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "false",
                                     internal_features      : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyInternal")]
@@ -206,6 +210,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_playground",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "false",
                                     internal_features      : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyAvs")]
@@ -233,6 +238,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_playground",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "false",
                                     internal_features      : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyQaavs")]
@@ -261,6 +267,7 @@ android {
                                     applicationIcon        : "@drawable/ic_launcher_wire_playground",
                                     sharedUserId           : "",
                                     use_audio_link         : "false",
+                                    gcm_enabled            : "false",
                                     internal_features      : "true",
                                     localyticsAppKey       : getApiKey("localyticsAppKey"),
                                     hockeyAppKey           : getApiKey("hockeyAppKeyExperimental")]

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -301,6 +301,7 @@
         <meta-data android:name="AUDIOLINK_ENABLED" android:value="${use_audio_link}" />
         <!-- Internal features from SE -->
         <meta-data android:name="INTERNAL" android:value="${internal_features}"/>
+        <meta-data android:name="GCM_ENABLED" android:value="${gcm_enabled}" />
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
     playServicesVersion = '7.8.+'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.195.0@aar'
-    zMessagingDevVersionBase = '76.1146'
+    zMessagingDevVersionBase = '76.1148'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '76.0.282@aar'


### PR DESCRIPTION
Disabled GCM for all internal builds to test web socket fallback.

With GCM_ENABLED set to 'false' client will not register for GCM notifications, but will always use our own web socket connection. 
This connection is meant to be used in cases where Play Services are not available, but for now we want to force it on internal builds to test how it affects the device.