### PR TITLE
Update gradle version to 2.14.1, android gradle plugin to 2.2.0-beta1 and android build tools to 24.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 apply plugin: 'jp.leafytree.android-scala'
 apply plugin: 'android-apt'
@@ -115,8 +114,6 @@ android {
             buildConfigField 'int', 'LOG_LEVEL_UI', logLevelWarn()
             buildConfigField 'int', 'LOG_LEVEL_SE', logLevelSupress()
             buildConfigField 'int', 'LOG_LEVEL_AVS', logLevelVerbose()
-
-            patchKeepSpecs()
         }
 
         candidate {
@@ -291,8 +288,6 @@ android {
             buildConfigField 'int', 'LOG_LEVEL_UI', logLevelVerbose()
             buildConfigField 'int', 'LOG_LEVEL_SE', logLevelVerbose()
             buildConfigField 'int', 'LOG_LEVEL_AVS', logLevelVerbose()
-
-            patchKeepSpecs()
         }
     }
 
@@ -317,76 +312,6 @@ android {
         exclude 'META-INF/NOTICE'
         exclude 'APK_LICENSE.txt'
         exclude 'LICENSE.txt'
-    }
-}
-
-def patchKeepSpecs() {
-    def taskClass = "com.android.build.gradle.internal.tasks.multidex.CreateManifestKeepList";
-    def clazz = this.class.classLoader.loadClass(taskClass)
-    def keepSpecsField = clazz.getDeclaredField("KEEP_SPECS")
-    keepSpecsField.setAccessible(true)
-    def keepSpecsMap = (Map) keepSpecsField.get(null)
-    if (keepSpecsMap.remove("activity") != null) {
-        println "KEEP_SPECS patched: removed 'activity' root"
-    } else {
-        println "Failed to patch KEEP_SPECS: no 'activity' root found"
-    }
-
-    if (keepSpecsMap.remove("instrumentation") != null) {
-        println "KEEP_SPECS patched: removed 'instrumentation' root"
-    } else {
-        println "Failed to patch KEEP_SPECS: no 'instrumentation' root found"
-    }
-
-    if (keepSpecsMap.remove("service") != null) {
-        println "KEEP_SPECS patched: removed 'service' root"
-    } else {
-        println "Failed to patch KEEP_SPECS: no 'service' root found"
-    }
-
-
-
-
-}
-
-afterEvaluate {
-    //Pretty big hack to keep the main dex class list down
-    Task collectTask = project.tasks.findByName("collectDevDebugMultiDexComponents")
-    Task processManifestTask = project.tasks.findByName("processDevDebugManifest")
-
-    if (!collectTask || !processManifestTask)
-        return
-
-    collectTask.dependsOn(processManifestTask) << {
-        File androidManifestFile = processManifestTask.outputs.files.filter {
-            it.absolutePath.matches('.*full.*AndroidManifest\\.xml')
-        }.singleFile
-
-        File manifestKeepFile = collectTask.outputs.files.filter {
-            it.absolutePath.endsWith('manifest_keep.txt')
-        }.singleFile
-
-        def nonExportedClasses = new XmlSlurper().parse(androidManifestFile).application.'**'.findAll { node ->
-            if (node.name().matches('(activity|service|receiver|provider)')) {
-                return (node.'@android:exported' == 'false'
-                        || (node.'@android:exported' != 'true'
-                        && node.'intent-filter'.size() == 0))
-            }
-        }.collect {
-            it.'@android:name'.text()
-        }
-
-        def manifestKeepText = manifestKeepFile.text
-        manifestKeepFile.withWriter('utf-8') { writer ->
-            manifestKeepText.eachLine { line ->
-                boolean isNonExportedLine = nonExportedClasses.any {
-                    line.contains(it)
-                }
-
-                if (!isNonExportedLine)
-                    writer.writeLine(line)
-            }
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.mutualmobile.gradle.plugins:dexinfo:0.1.2'
         classpath 'com.wire:gradle-android-scala-plugin:1.5.0'
@@ -60,7 +59,7 @@ ext {
     compileSdkVersion = 23
     minSdkVersion = 17
     targetSdkVersion = 23
-    buildToolsVersion = '23.0.3'
+    buildToolsVersion = '24.0.1'
     scalaMajorVersion = '2.11'
     scalaVersion = scalaMajorVersion + '.8'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
### Description
The latest android gradle plugin (2.2.x) only ever prepares a minimal dex list, so now we don't have to do this the hacky way (documented here: http://blog.osom.info/2014/12/too-many-methods-in-main-dex.html). The plugin also provides in-built support for automatically downloading packages, so we can remove the now deprecated sdkmanager plugin by Wharton. Gradle 2.14 also provides some potential performance benefits.
