### PR TITLE
Add GlobalControllerObserver interface to listen to onCameraReleased …

### DIFF
--- a/app/src/main/java/com/waz/zclient/camera/CameraPreviewObserver.java
+++ b/app/src/main/java/com/waz/zclient/camera/CameraPreviewObserver.java
@@ -26,16 +26,11 @@ public interface CameraPreviewObserver {
 
     void onCameraLoadingFailed();
 
-    /**
-     * This method needs to be overriden if the view using the CameraPreview wants to leave the app (and potentially
-     * let another app use the camera). Only when this callback method returns can we be sure that the camera is closed
-     * and that it's safe for other apps to attempt to open it.
-     */
-    void onCameraReleased();
-
     void onPictureTaken(ImageAsset imageAsset);
 
     void onFocusBegin(Rect focusArea);
 
     void onFocusComplete();
+
+    void onCameraReleased();
 }

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -25,7 +25,7 @@ import com.waz.api.{NetworkMode, ZMessagingApi, ZMessagingApiFactory}
 import com.waz.service.{MediaManagerService, PreferenceService, ZMessaging}
 import com.waz.utils.events.{EventContext, Signal, Subscription}
 import com.waz.zclient.calling.{CallPermissionsController, CurrentCallController}
-import com.waz.zclient.camera.CameraPreviewController
+import com.waz.zclient.camera.GlobalCameraController
 
 object WireApplication {
   var APP_INSTANCE: WireApplication = _
@@ -34,7 +34,7 @@ object WireApplication {
     bind[Signal[Option[ZMessaging]]] to ZMessaging.currentUi.currentZms
     bind[PreferenceService] to new PreferenceService(inject[Context])
     bind[GlobalCallingController] to new GlobalCallingController(inject[Context])
-    bind[CameraPreviewController] to new CameraPreviewController(inject[Context])(EventContext.Global)
+    bind[GlobalCameraController] to new GlobalCameraController(inject[Context])(EventContext.Global)
     bind[MediaManagerService] to ZMessaging.currentGlobal.mediaManager
 
     //Global android services


### PR DESCRIPTION
### Relies on PR https://github.com/wireapp/wire-android/pull/28

Please only review changes in the second commit for this PR and merge the other first

Also renames the CameraPreviewController to the GlobalCameraController, and provides the injectJava method so that the camera can be closed from anywhere in the app - not just through CameraPreviewTextureView instances

### Ticket:
https://wearezeta.atlassian.net/browse/AN-4327

### Test Description:
Click on the cursor video-message button while the camera keyboard is open.

#### APK

[Download build #7279](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7279/artifact/build/artifact/wire-dev-PR29-7279.apk)
[Download build #7304](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7304/artifact/build/artifact/wire-dev-PR29-7304.apk)
[Download build #7311](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7311/artifact/build/artifact/wire-dev-PR29-7311.apk)
[Download build #7314](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7314/artifact/build/artifact/wire-dev-PR29-7314.apk)
[Download build #7315](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7315/artifact/build/artifact/wire-dev-PR29-7315.apk)