### PR TITLE
Update play services verification dialog

### DIFF
--- a/app/src/main/java/com/waz/zclient/MainActivity.java
+++ b/app/src/main/java/com/waz/zclient/MainActivity.java
@@ -370,9 +370,7 @@ public class MainActivity extends BaseActivity implements MainPhoneFragment.Cont
 
     private void verifyGooglePlayServicesStatus() {
         int deviceGooglePlayServicesState = GooglePlayServicesUtil.isGooglePlayServicesAvailable(getApplicationContext());
-        if (deviceGooglePlayServicesState == ConnectionResult.SERVICE_MISSING ||
-            deviceGooglePlayServicesState == ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED ||
-            deviceGooglePlayServicesState == ConnectionResult.SERVICE_DISABLED) {
+        if (deviceGooglePlayServicesState == ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED) {
             GooglePlayServicesUtil.getErrorDialog(deviceGooglePlayServicesState,
                                                   this,
                                                   REQUEST_CODE_GOOGLE_PLAY_SERVICES_DIALOG)


### PR DESCRIPTION
Changed to not display error dialog if play services are missing or disabled.
Most of the time this means that user doesn't want or can't run Play Services.
We don't want to bother those users with a dialog. 
Alternative solution would be to show a dialog with 'never again' checkbox, 
but it seems like too much work for a small gain.
#### APK
[Download build #7350](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7350/artifact/build/artifact/wire-dev-PR45-7350.apk)