### PR TITLE
[AN-4300] Show infinite loading bar when there is no server connectivity

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/connectivity/ConnectivityIndicatorView.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/connectivity/ConnectivityIndicatorView.java
@@ -22,14 +22,11 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.widget.TextView;
 import com.waz.zclient.R;
-import com.waz.zclient.utils.ViewUtils;
 
 public class ConnectivityIndicatorView extends FrameLayout {
 
     private View contentView;
-    private TextView errorMessageView;
     private float removedPosition;
     private float collapsedPosition;
 
@@ -57,8 +54,6 @@ public class ConnectivityIndicatorView extends FrameLayout {
     private void init() {
         LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         contentView = inflater.inflate(R.layout.connectivity_indicator, this, true);
-        errorMessageView = ViewUtils.getView(contentView, R.id.ttv__network_indicator__error_message);
-
         removedPosition = -getContext().getResources().getDimension(R.dimen.network_indicator__expanded_height);
         collapsedPosition = -getContext().getResources().getDimension(R.dimen.network_indicator__collapse_position);
 
@@ -82,14 +77,6 @@ public class ConnectivityIndicatorView extends FrameLayout {
                        }
                    })
                    .start();
-    }
-
-    public void setIsServerError(boolean isServerError) {
-        if (isServerError) {
-            errorMessageView.setText(R.string.system_status__no_server_connection);
-        } else {
-            errorMessageView.setText(R.string.system_status__no_internet);
-        }
     }
 
     public void hide() {

--- a/app/src/main/res/layout/connectivity_indicator.xml
+++ b/app/src/main/res/layout/connectivity_indicator.xml
@@ -34,7 +34,6 @@
         />
 
     <com.waz.zclient.ui.text.TypefaceTextView
-        android:id="@+id/ttv__network_indicator__error_message"
         android:layout_width="match_parent"
         android:layout_height="@dimen/network_indicator__visible_height"
         android:gravity="center"

--- a/app/src/main/res/layout/fragment_connectivity.xml
+++ b/app/src/main/res/layout/fragment_connectivity.xml
@@ -29,6 +29,13 @@
         android:layout_height="wrap_content"
         />
 
+    <com.waz.zclient.views.LoadingIndicatorView
+        android:id="@+id/liv__server_connecting_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        />
+
     <ImageView
         android:id="@+id/iv__connectivity_foreground"
         android:layout_width="match_parent"


### PR DESCRIPTION
#### Ticket:
https://wearezeta.atlassian.net/browse/AN-4300

#### Test description:
Pro tip, try and connect to hm-wifi-guest to trick your device into thinking it has internet, but to prevent it from being able to connect to the servers. Then you can test both use cases.
#### APK
[Download build #7388](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7388/artifact/build/artifact/wire-dev-PR58-7388.apk)