### PR TITLE
[AN-4387] Fixed bug where giphy button is visible after closing edit message with empty input

### DIFF
--- a/wire-ui/src/main/java/com/waz/zclient/ui/cursor/CursorLayout.java
+++ b/wire-ui/src/main/java/com/waz/zclient/ui/cursor/CursorLayout.java
@@ -289,10 +289,10 @@ public class CursorLayout extends FrameLayout implements
             return;
         }
         giphyEnabled = enable;
-        if (isEditingMessage()) {
-            return;
-        }
         if (enable) {
+            if (isEditingMessage()) {
+                return;
+            }
             int duration = getResources().getInteger(R.integer.animation_duration_medium);
             giphyButton.setVisibility(View.VISIBLE);
             giphyButton.setAlpha(0);
@@ -505,7 +505,7 @@ public class CursorLayout extends FrameLayout implements
         newCursorEditText.setSelection(newCursorEditText.getText().length());
 
         if (giphyEnabled) {
-            giphyButton.setVisibility(GONE);
+            enableGiphyButton(false);
         }
         setBackgroundColor(ContextCompat.getColor(getContext(), R.color.white));
         ViewUtils.fadeInView(editMessageBackgroundView);
@@ -531,9 +531,6 @@ public class CursorLayout extends FrameLayout implements
             editMessageCursorToolbar.setVisibility(GONE);
             editMessageBackgroundView.setVisibility(GONE);
             resetMainAndSecondaryToolbars();
-        }
-        if (giphyEnabled) {
-            giphyButton.setVisibility(VISIBLE);
         }
 
         setBackgroundColor(ContextCompat.getColor(getContext(), R.color.transparent));


### PR DESCRIPTION
#### Description
Fixes issue:
- Type something into text field
- Long press a message to trigger message editing
- Removed edited message so edit text field is empty
- Close edit message
-> Regular text field is empty and giphy button is visible

#### Ticket
https://wearezeta.atlassian.net/browse/AN-4387
#### APK
[Download build #7404](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7404/artifact/build/artifact/wire-dev-PR64-7404.apk)