### PR TITLE
Updated SE 77.0.285/77.1173

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,10 @@ ext {
     playServicesVersion = '7.8.+'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.195.0@aar'
-    zMessagingDevVersionBase = '77.1171'
+    zMessagingDevVersionBase = '77.1173'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
-    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '77.0.284@aar'
+    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '77.0.285@aar'
 
     avsVersion = '2.8.4@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal


### PR DESCRIPTION
Fixes message edit when offline, if user edits a message before it's actually sent to backend then current SE will only send edit message and receiver will ignore it (message lost)
#### APK
[Download build #7408](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7408/artifact/build/artifact/wire-dev-PR70-7408.apk)