### PR TITLE
Adapt code to changes in SE search API

### DIFF
--- a/app/src/debug/java/com/waz/zclient/core/stores/stub/StubZMessagingApiStore.java
+++ b/app/src/debug/java/com/waz/zclient/core/stores/stub/StubZMessagingApiStore.java
@@ -37,7 +37,6 @@ import com.waz.api.Logging;
 import com.waz.api.LoginListener;
 import com.waz.api.PermissionProvider;
 import com.waz.api.Search;
-import com.waz.api.SearchQuery;
 import com.waz.api.Self;
 import com.waz.api.Spotify;
 import com.waz.api.TrackingData;
@@ -144,11 +143,6 @@ public class StubZMessagingApiStore implements IZMessagingApiStore {
                                           KindOfVerification kindOfVerification,
                                           ZMessagingApi.PhoneNumberVerificationListener phoneNumberVerificationListener) {
 
-            }
-
-            @Override
-            public SearchQuery searchQuery() {
-                return null;
             }
 
             @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/PickUserFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/PickUserFragment.java
@@ -41,7 +41,7 @@ import com.waz.api.Contacts;
 import com.waz.api.IConversation;
 import com.waz.api.NetworkMode;
 import com.waz.api.User;
-import com.waz.api.UsersSearchResult;
+import com.waz.api.UserSearchResult;
 import com.waz.zclient.OnBackPressedListener;
 import com.waz.zclient.R;
 import com.waz.zclient.controllers.accentcolor.AccentColorObserver;
@@ -106,6 +106,7 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
 
     public static final int NUM_SEARCH_RESULTS_LIST = 30;
     public static final int NUM_SEARCH_RESULTS_TOP_USERS = 24;
+    public static final int NUM_SEARCH_RESULTS_ADD_TO_CONV = 1000;
 
     private static final int DEFAULT_SELECTED_INVITE_METHOD = 0;
     private static final int SHOW_KEYBOARD_THRETHOLD = 10;
@@ -169,13 +170,13 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
         }
     };
 
-    private final ModelObserver<UsersSearchResult> usersSearchModelObserver = new ModelObserver<UsersSearchResult>() {
+    private final ModelObserver<UserSearchResult> usersSearchModelObserver = new ModelObserver<UserSearchResult>() {
         @Override
-        public void updated(UsersSearchResult model) {
+        public void updated(UserSearchResult model) {
             if (getContainer() != null) {
                 getContainer().getLoadingViewIndicator().hide();
             }
-            if (model.getContacts() == null || model.getContacts().length == 0) {
+            if (model.getAll().length == 0) {
                 PickUserDataState dataState = getDataState(getControllerFactory().getPickUserController().hasSelectedUsers());
                 if (dataState == PickUserDataState.SHOW_ALL_USERS_TO_ADD_TO_CONVERSATION) {
                     handleEmptySearchResult(getString(R.string.people_picker__error_message__no_users_to_add_to_conversation), "", false);
@@ -184,7 +185,7 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
                 }
             } else {
                 hideErrorMessage();
-                searchResultAdapter.setSearchResult(model.getContacts(), null, null);
+                searchResultAdapter.setSearchResult(model.getAll(), null, null);
             }
         }
     };
@@ -480,11 +481,6 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
                 getStoreFactory().getPickUserStore().loadContacts();
                 break;
         }
-    }
-
-    @Override
-    public void onRecommendedUsersUpdated(User[] users) {
-
     }
 
     @Override
@@ -928,10 +924,10 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
                 filter = "";
             case SHOW_SEARCH_RESULTS_TO_ADD_TO_CONVERSATION:
                 String[] excludedUsers = getStoreFactory().getPickUserStore().getExcludedUsers();
-                UsersSearchResult usersSearchResult = getStoreFactory().getZMessagingApiStore()
+                UserSearchResult usersSearchResult = getStoreFactory().getZMessagingApiStore()
                                                                        .getApi()
                                                                        .search()
-                                                                       .getConnections(filter, excludedUsers);
+                                                                       .getConnections(filter, NUM_SEARCH_RESULTS_ADD_TO_CONV, excludedUsers, false);
                 usersSearchModelObserver.setAndUpdate(usersSearchResult);
                 break;
             case SHOW_SEARCH_RESULTS:

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
     playServicesVersion = '7.8.+'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.195.0@aar'
-    zMessagingDevVersionBase = '77.1173'
+    zMessagingDevVersionBase = '77.1175'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '77.0.287@aar'

--- a/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/IPickUserStore.java
+++ b/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/IPickUserStore.java
@@ -30,8 +30,6 @@ public interface IPickUserStore extends IStore {
 
     void loadTopUserList(int numberOfResults, boolean excludeUsers);
 
-    void loadRecommendedUsers(int numberOfResults);
-
     void loadSearchByFilter(String filter, int numberOfResults, boolean excludeUsers);
 
     void loadContacts();

--- a/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/PickUserStore.java
+++ b/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/PickUserStore.java
@@ -44,12 +44,6 @@ public abstract class PickUserStore implements IPickUserStore {
         }
     }
 
-    protected void notifyRecommendedUsersUpdated(User[] users) {
-        for (PickUserStoreObserver pickUserStoreObserver : pickUserStoreObservers) {
-            pickUserStoreObserver.onRecommendedUsersUpdated(users);
-        }
-    }
-
     protected void notifySearchResultsUpdated(User[] contacts, User[] otherUsers, IConversation[] conversations) {
         for (PickUserStoreObserver pickUserStoreObserver : pickUserStoreObservers) {
             pickUserStoreObserver.onSearchResultsUpdated(contacts, otherUsers, conversations);

--- a/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/PickUserStoreObserver.java
+++ b/wire-core/src/main/java/com/waz/zclient/core/stores/pickuser/PickUserStoreObserver.java
@@ -24,8 +24,6 @@ import com.waz.api.User;
 public interface PickUserStoreObserver {
     void onTopUsersUpdated(User[] users);
 
-    void onRecommendedUsersUpdated(User[] users);
-
     void onSearchResultsUpdated(User[] contacts, User[] otherUsers, IConversation[] conversations);
 
     void onContactsUpdated(Contacts contacts);


### PR DESCRIPTION
As a result of CM-444, the SE implementation of searching changed quite a bit which caused the surface API to change a bit as well.

User search and group conversation search are now both done on client side. Only top people and recommendation search is done via backend. The only change noticeable for end users should be that connected users whose name starts with an emoji are now found correctly.

#### APK
[Download build #7417](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7417/artifact/build/artifact/wire-dev-PR75-7417.apk)
[Download build #7421](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7421/artifact/build/artifact/wire-dev-PR75-7421.apk)
[Download build #7424](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7424/artifact/build/artifact/wire-dev-PR75-7424.apk)
[Download build #7425](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7425/artifact/build/artifact/wire-dev-PR75-7425.apk)