### PR TITLE
Updated avs version to 2.8.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
     avsGroup = 'com.wire.avs'
 
     // proprietary avs artifact config
-    customAvsVersion = '2.8.7@aar'
+    customAvsVersion = '2.8.8@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
Build server had issues with avs version numbers. This one has correct avs version number in avs logs
#### APK
[Download build #7426](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7426/artifact/build/artifact/wire-dev-PR77-7426.apk)