### PR TITLE
[AN-4448] Adds initial version of toggling between message like descrption, like hint and message time stamp

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
@@ -27,6 +27,7 @@ public interface IUserPreferencesController {
     @IntDef(SEND_LOCATION_MESSAGE)
     @interface Action { }
     int SEND_LOCATION_MESSAGE = 0;
+    int LIKED_MESSAGE = 1;
 
     void tearDown();
 

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/SingleImageMessageFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/SingleImageMessageFragment.java
@@ -68,7 +68,7 @@ public class SingleImageMessageFragment extends SingleImageFragment {
 
     @Override
     protected String getTimeText() {
-        return ZTimeFormatter.getSingleMessageTime(getActivity(), DateTimeUtils.toDate(message.getTime()));
+        return ZTimeFormatter.getSingleMessageTimeAndDate(getActivity(), DateTimeUtils.toDate(message.getTime()));
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/views/row/footer/views/FooterLikeDetailsLayout.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/views/row/footer/views/FooterLikeDetailsLayout.java
@@ -32,7 +32,6 @@ import com.waz.zclient.views.chathead.ChatheadImageView;
 
 public class FooterLikeDetailsLayout extends LinearLayout {
 
-    private User[] users;
     private User firstUser;
     private User secondUser;
 
@@ -91,7 +90,6 @@ public class FooterLikeDetailsLayout extends LinearLayout {
     }
 
     public void setUsers(User[] users) {
-        this.users = users;
         if (users == null || users.length == 0) {
             clearUsers();
             return;
@@ -120,7 +118,7 @@ public class FooterLikeDetailsLayout extends LinearLayout {
     }
 
     private void clearUsers() {
-        ViewUtils.fadeInView(hintArrow);
+        hintArrow.setVisibility(VISIBLE);
         description.setText(R.string.message_footer__tap_to_like);
         descriptionModelObserver.clear();
         firstUser = null;

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/views/row/message/views/TextMessageWithTimestamp.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/views/row/message/views/TextMessageWithTimestamp.java
@@ -89,13 +89,13 @@ public class TextMessageWithTimestamp extends LinearLayout implements AccentColo
             } else if (messageStatus == Message.Status.FAILED) {
                 timestamp = getResources().getString(R.string.content_system_message_timestamp_failure);
             } else if (message.getMessageType() == Message.Type.RECALLED) {
-                String time = ZTimeFormatter.getSingleMessageTime(getContext(), DateTimeUtils.toDate(message.getEditTime()));
+                String time = ZTimeFormatter.getSingleMessageTimeAndDate(getContext(), DateTimeUtils.toDate(message.getEditTime()));
                 timestamp = getContext().getString(R.string.content_system_message_timestamp_deleted, time);
             } else {
                 Instant messageTime = message.isEdited() ?
                                       message.getEditTime() :
                                       message.getTime();
-                timestamp = ZTimeFormatter.getSingleMessageTime(getContext(), DateTimeUtils.toDate(messageTime));
+                timestamp = ZTimeFormatter.getSingleMessageTimeAndDate(getContext(), DateTimeUtils.toDate(messageTime));
             }
 
             timestampTextView.setTransformedText(timestamp);

--- a/app/src/main/java/com/waz/zclient/utils/ZTimeFormatter.java
+++ b/app/src/main/java/com/waz/zclient/utils/ZTimeFormatter.java
@@ -60,7 +60,7 @@ public class ZTimeFormatter {
         return DateTimeFormatter.ofPattern(pattern).format(then.atZone(timeZone));
     }
 
-    public static String getSingleMessageTime(@Nullable Resources resources, LocalDateTime date, boolean is24HourFormat, ZoneId timeZone) {
+    public static String getSingleMessageTimeAndDate(@Nullable Resources resources, LocalDateTime date, boolean is24HourFormat, ZoneId timeZone) {
         if (resources == null) {
             return "";
         }
@@ -70,12 +70,18 @@ public class ZTimeFormatter {
         return formatter.format(date.atZone(timeZone));
     }
 
+    public static String getSingleMessageTimeAndDate(Context context, Date date) {
+        boolean is24HourFormat = DateFormat.is24HourFormat(context);
+        return ZTimeFormatter.getSingleMessageTimeAndDate(context.getResources(),
+                                                          DateConvertUtils.asLocalDateTime(date),
+                                                          is24HourFormat,
+                                                          ZoneId.systemDefault());
+    }
+
     public static String getSingleMessageTime(Context context, Date date) {
         boolean is24HourFormat = DateFormat.is24HourFormat(context);
-        return ZTimeFormatter.getSingleMessageTime(context.getResources(),
-                                                   DateConvertUtils.asLocalDateTime(date),
-                                                   is24HourFormat,
-                                                   ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(getTimeFormatString(context.getResources(), is24HourFormat));
+        return formatter.format(DateConvertUtils.asLocalDateTime(date).atZone(ZoneId.systemDefault()));
     }
 
     private static String getTimeFormatString(@Nullable Resources resources, boolean is24HourFormat) {

--- a/app/src/main/res/layout/row_conversation_footer.xml
+++ b/app/src/main/res/layout/row_conversation_footer.xml
@@ -49,6 +49,7 @@
         />
 
     <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/tv__footer__message_status"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/content__footer__height"
         android:paddingStart="@dimen/content__padding_left"
@@ -56,7 +57,6 @@
         android:gravity="start|center_vertical"
         android:textSize="@dimen/wire__text_size__small"
         app:font="@string/wire__typeface__light"
-        android:visibility="gone"
         />
 
 </FrameLayout>

--- a/app/src/test/java/com/waz/zclient/testutils/MockMessagesList.java
+++ b/app/src/test/java/com/waz/zclient/testutils/MockMessagesList.java
@@ -222,6 +222,11 @@ public class MockMessagesList extends MockObservable implements MessagesList {
         }
 
         @Override
+        public boolean isLastMessageFromSelf() {
+            return false;
+        }
+
+        @Override
         public boolean isUserMentioned() {
             return false;
         }


### PR DESCRIPTION
#### Description
Adds first version of rules for switching between like description, like hint and message time stamp & delivery status

- If message has likes, likes are always shown
- If user taps on received message without likes and has never used like before, a hint "Tap to like" will be visible for 3 seconds after which regular message time stamp is shown
- If user taps on own message without likes, regular message time stamp is shown 

Still missing:
- message sending & delivery status
- tap on message with likes to reveal time stamp and message sending & delivery status
- exceptions for last messages

#### Ticket
https://wearezeta.atlassian.net/browse/AN-4448
#### APK
[Download build #7450](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7450/artifact/build/artifact/wire-dev-PR96-7450.apk)
[Download build #7451](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7451/artifact/build/artifact/wire-dev-PR96-7451.apk)
[Download build #7452](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7452/artifact/build/artifact/wire-dev-PR96-7452.apk)
[Download build #7454](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7454/artifact/build/artifact/wire-dev-PR96-7454.apk)