### PR TITLE
Add call to `ErrorDescription.dismiss()` after showing an alert dialog.

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
@@ -1549,6 +1549,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
                                           R.string.asset_upload_error__not_found__button,
                                           null,
                                           true);
+                errorDescription.dismiss();
                 break;
             case CANNOT_SEND_ASSET_TOO_LARGE:
                 AlertDialog dialog = ViewUtils.showAlertDialog(getActivity(),
@@ -1563,6 +1564,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
                     dialog.setMessage(getString(R.string.asset_upload_error__file_too_large__message, maxFileSize));
                 }
 
+                errorDescription.dismiss();
                 getControllerFactory().getTrackingController().tagEvent(new SelectedTooLargeFileEvent());
                 break;
             case RECORDING_FAILURE:
@@ -1572,6 +1574,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
                                           R.string.alert_dialog__confirmation,
                                           null,
                                           true);
+                errorDescription.dismiss();
 
                 break;
             case CANNOT_SEND_MESSAGE_TO_UNVERIFIED_CONVERSATION:


### PR DESCRIPTION
This is just a quick fix to ensure that error is dismissed when alert is shown.
Ideally error handling should be completely rewritten, with current solution some errors (the ones happening when app is in background) can be missed, or shown to user after a long delay.
Errors should be handled in single place, and checked on every app start.
#### APK
[Download build #7570](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7570/artifact/build/artifact/wire-dev-PR144-7570.apk)
[Download build #7571](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7571/artifact/build/artifact/wire-dev-PR144-7571.apk)
[Download build #7572](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7572/artifact/build/artifact/wire-dev-PR144-7572.apk)