### PR TITLE
[AN-4520] Removes icon for dark theme setting

### DIFF
--- a/app/src/main/res/xml/preferences_options.xml
+++ b/app/src/main/res/xml/preferences_options.xml
@@ -93,7 +93,6 @@
         <SwitchPreference
             android:key="@string/pref_options_theme_switch_key"
             android:title="@string/pref_options_dark_theme_title"
-            android:icon="@drawable/ic_action_theme"
             />
 
         <SwitchPreference


### PR DESCRIPTION
#### Description
As requested by @Yorgos-V, removing icon for dark theme setting. 

#### Ticket: https://wearezeta.atlassian.net/browse/AN-4520
#### APK
[Download build #7666](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7666/artifact/build/artifact/wire-dev-PR209-7666.apk)
[Download build #7669](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7669/artifact/build/artifact/wire-dev-PR209-7669.apk)