### PR TITLE
[AN-4564] Fixes tab selection in emoji keyboard in RTL layout

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/emoji/EmojiKeyboardLayout.java
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/emoji/EmojiKeyboardLayout.java
@@ -21,6 +21,7 @@ package com.waz.zclient.pages.extendedcursor.emoji;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -122,6 +123,11 @@ public class EmojiKeyboardLayout extends LinearLayout {
         tapIndicatorLayout.setCallback(new TabIndicatorLayout.Callback() {
             @Override
             public void onItemSelected(int pos) {
+                if (ViewCompat.getLayoutDirection(EmojiKeyboardLayout.this) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+                    // Revert tab position for RTL layout
+                    pos = (TAB_COUNT - 1) - pos;
+                }
+
                 if (pos == TAB_COUNT - 1) {
                     Threading.Background().execute(new Runnable() {
                         @Override


### PR DESCRIPTION
#### Description
Currently, selecting a tab in emoji keyboard will make tab from opposite direction selected in RTL layout.

#### Ticket
https://wearezeta.atlassian.net/browse/AN-4564
#### APK
[Download build #7678](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7678/artifact/build/artifact/wire-dev-PR218-7678.apk)