### PR TITLE
Align microcopy for timed message settings

### DIFF
--- a/wire-core/src/main/res/values/strings.xml
+++ b/wire-core/src/main/res/values/strings.xml
@@ -1025,7 +1025,7 @@
     <string name="message_footer__status__deleted">%1$s \u30FB Deleted</string>
     <string name="message_footer__status__ephemeral">%1$s \u30FB _%2$ds left_</string>
 
-    <string name="ephemeral_message__timeout_selection_info">SET A TIMER FOR TIMED MESSAGES</string>
+    <string name="ephemeral_message__timeout_selection_info">SET A TIMER FOR TEMPORARY MESSAGES</string>
 
     <string name="ephemeral_message__timeout__off">Off</string>
     <string name="ephemeral_message__timeout__5_sec">5 seconds</string>


### PR DESCRIPTION
This commit aligns the timer setting copy with other platforms to avoid redundant usage of “timer/timed”, and explain that timed messages are temporary _(rather than scheduled)_.