### PR TITLE
Assets v3

### DIFF
--- a/app/src/main/java/com/waz/zclient/utils/BackendPicker.java
+++ b/app/src/main/java/com/waz/zclient/utils/BackendPicker.java
@@ -38,8 +38,7 @@ public class BackendPicker {
     private final Context context;
 
     private final String[] backends = new String[] {
-            BackendConfig.EdgeBackend().environment(),
-            BackendConfig.DevBackend().environment(),
+            BackendConfig.StagingBackend().environment(),
             BackendConfig.ProdBackend().environment()
     };
 

--- a/app/src/main/java/com/waz/zclient/utils/BuildConfigUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/BuildConfigUtils.java
@@ -104,10 +104,8 @@ public class BuildConfigUtils {
     }
 
     public static BackendConfig defaultBackend() {
-        if (BuildConfig.USE_EDGE_BACKEND) {
-            return BackendConfig.EdgeBackend();
-        } else if (BuildConfig.USE_STAGING_BACKEND) {
-            return BackendConfig.DevBackend();
+        if (BuildConfig.USE_STAGING_BACKEND) {
+            return BackendConfig.StagingBackend();
         } else {
             return BackendConfig.ProdBackend();
         }

--- a/app/src/main/res/xml/preferences_developer.xml
+++ b/app/src/main/res/xml/preferences_developer.xml
@@ -53,4 +53,10 @@
         android:title="@string/pref_dev_version_info_id_title"
         />
 
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="@string/pref_dev_assets_v3_key"
+        android:title="@string/pref_dev_assets_v3_title"
+        />
+
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
     playServicesVersion = '7.8.+'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.205.0@aar'
-    zMessagingDevVersionBase = '84.1257'
+    zMessagingDevVersionBase = '84.1265'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '84.1.308@aar'

--- a/wire-core/src/main/res/values/strings_no_translate.xml
+++ b/wire-core/src/main/res/values/strings_no_translate.xml
@@ -159,6 +159,8 @@
     <string translatable="false" name="pref_dev_otr_only_summary">Send only encrypted messages</string>
     <string translatable="false" name="pref_dev_version_info_id_key">USER_PREFS_DEV_VERSIONS_ID</string>
     <string translatable="false" name="pref_dev_version_info_id_title">Versions</string>
+    <string translatable="false" name="pref_dev_assets_v3_key">@string/zms_assets_v3</string>
+    <string translatable="false" name="pref_dev_assets_v3_title">Send assets using API v3</string>
 
 </resources>
 


### PR DESCRIPTION
### Currently working on better fix
I'll just leave this PR here as it provides a build that mostly works

Includes the latest SE with Assets v3 sending and receiving. By default, v3 is enabled, but in developer preferences there is an option to turn it off and send with v2. 

Note, currently rendering of images is broken on the sender side and will be included in a future SE version. For now they are very scaled up and might appear off-colour of distorted. 

Gifs are also broken

Does not include scoped plan for profile pictures 
#### APK
[Download build #7815](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7815/artifact/build/artifact/wire-dev-PR282-7815.apk)
[Download build #7820](http://192.168.10.18:8080/job/Pull%20Request%20Builder/7820/artifact/build/artifact/wire-dev-PR282-7820.apk)