### PR TITLE
Notification display issues

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -84,7 +84,7 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
     if (nots.isEmpty) notManager.cancel(notifId)
     else {
       val notification =
-        if (notifId == ZETA_EPHEMERAL_NOTIFICATION_ID) getEphemeralNotification(nots.size, silent)
+        if (notifId == ZETA_EPHEMERAL_NOTIFICATION_ID) getEphemeralNotification(nots.size, silent, nots.maxBy(_.time).time)
         else if (nots.size == 1) getSingleMessageNotification(nots.head, silent)
         else getMultipleMessagesNotification(nots, silent)
 
@@ -154,7 +154,7 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
     else RingtoneUtils.getUriForRawId(context, returnDefault)
   }
 
-  private def getEphemeralNotification(size: Int, silent: Boolean): Notification = {
+  private def getEphemeralNotification(size: Int, silent: Boolean, displayTime: Instant): Notification = {
     val details = getString(R.string.notification__message__ephemeral_details)
     val title = getQuantityString(R.plurals.notification__message__ephemeral, size, Integer.valueOf(size))
 
@@ -165,6 +165,8 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
     bigTextStyle.bigText(details)
 
     builder
+      .setShowWhen(true)
+      .setWhen(displayTime.toEpochMilli)
       .setSmallIcon(R.drawable.ic_menu_logo)
       .setLargeIcon(getAppIcon)
       .setContentTitle(title)
@@ -196,6 +198,8 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
     builder
       .setSmallIcon(R.drawable.ic_menu_logo)
       .setLargeIcon(getAppIcon)
+      .setShowWhen(true)
+      .setWhen(n.time.toEpochMilli)
       .setContentTitle(title)
       .setContentText(spannableString)
       .setContentIntent(getNotificationAppLaunchIntent(cxt, n.convId.str, requestBase))
@@ -236,6 +240,8 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
       .setBigContentTitle(title)
 
     val builder = new NotificationCompat.Builder(cxt)
+      .setShowWhen(true)
+      .setWhen(ns.maxBy(_.time).time.toEpochMilli)
       .setSmallIcon(R.drawable.ic_menu_logo)
       .setLargeIcon(getAppIcon).setNumber(ns.size)
       .setContentTitle(title)

--- a/app/src/test/scala/com/waz/zclient/notifications/controllers/MessageNotificationsControllerTest.scala
+++ b/app/src/test/scala/com/waz/zclient/notifications/controllers/MessageNotificationsControllerTest.scala
@@ -79,7 +79,7 @@ class MessageNotificationsControllerTest extends JUnitSuite with RobolectricUtil
 
   @Test
   def getMessageForLike(): Unit = {
-    val msg = controller.getMessage(NotificationInfo(NotificationType.LIKE, "", ConvId()), false, true, true)
+    val msg = controller.getMessage(NotificationInfo(NotId(), NotificationType.LIKE, Instant.now, "", ConvId()), false, true, true)
     assertFalse(msg.toString.isEmpty)
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.205.0@aar'
 
-    zMessagingDevVersionBase = '87.1311'
+    zMessagingDevVersionBase = '87.1317'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '87.3.318@aar'


### PR DESCRIPTION
#### Description
This PR fixes:
 * https://wearezeta.atlassian.net/browse/AN-4704
 * The user seeing repeated notifications (this happened if the app was killed in the background and something then re-started it)
 * Notifications appearing with the incorrect timestamp (would happen if a GCM notification is delayed, for some reason)
#### APK
[Download build #8083](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8083/artifact/build/artifact/wire-dev-PR389-8083.apk)
[Download build #8084](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8084/artifact/build/artifact/wire-dev-PR389-8084.apk)
[Download build #8091](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8091/artifact/build/artifact/wire-dev-PR389-8091.apk)