### PR TITLE
Feature/usernames takeover screen fix

### DIFF
--- a/app/src/debug/java/com/waz/zclient/controllers/stubs/StubUsernamesController.java
+++ b/app/src/debug/java/com/waz/zclient/controllers/stubs/StubUsernamesController.java
@@ -54,7 +54,17 @@ public class StubUsernamesController implements IUsernamesController {
     }
 
     @Override
+    public void addUsernamesObserverAndUpdate(UsernamesControllerObserver usernamesControllerObserver) {
+
+    }
+
+    @Override
     public void removeUsernamesObserver(UsernamesControllerObserver usernamesControllerObserver) {
+
+    }
+
+    @Override
+    public void closeFirstAssignUsernameScreen() {
 
     }
 

--- a/app/src/main/java/com/waz/zclient/controllers/usernames/IUsernamesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/usernames/IUsernamesController.java
@@ -37,6 +37,10 @@ public interface IUsernamesController {
 
     void removeUsernamesObserver(UsernamesControllerObserver usernamesControllerObserver);
 
+    void addUsernamesObserverAndUpdate(UsernamesControllerObserver usernamesControllerObserver);
+
+    void closeFirstAssignUsernameScreen();
+
     void logout();
 
     void tearDown();

--- a/app/src/main/java/com/waz/zclient/controllers/usernames/UsernamesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/usernames/UsernamesController.java
@@ -115,11 +115,16 @@ public class UsernamesController implements IUsernamesController {
     @Override
     public void addUsernamesObserver(UsernamesControllerObserver usernamesControllerObserver) {
         usernamesControllerObservers.add(usernamesControllerObserver);
+    }
+
+    @Override
+    public void addUsernamesObserverAndUpdate(UsernamesControllerObserver usernamesControllerObserver) {
+        addUsernamesObserver(usernamesControllerObserver);
         if (hasGeneratedUsername()) {
             if (generatedUsername.isValid()) {
-                notifyObserversValidUsernameGenerated(generatedUsername.searchedName, generatedUsername.username);
+                usernamesControllerObserver.onValidUsernameGenerated(generatedUsername.searchedName, generatedUsername.username);
             } else {
-                notifyObserversAttemptsExhausted(generatedUsername.searchedName);
+                usernamesControllerObserver.onUsernameAttemptsExhausted(generatedUsername.searchedName);
             }
         } else {
             userModelObserver.forceUpdate();
@@ -129,6 +134,13 @@ public class UsernamesController implements IUsernamesController {
     @Override
     public void removeUsernamesObserver(UsernamesControllerObserver usernamesControllerObserver) {
         usernamesControllerObservers.remove(usernamesControllerObserver);
+    }
+
+    @Override
+    public void closeFirstAssignUsernameScreen() {
+        for (UsernamesControllerObserver observer : usernamesControllerObservers) {
+            observer.onCloseFirstAssignUsernameScreen();
+        }
     }
 
     private void notifyObserversValidUsernameGenerated(String name, String generatedUsername) {

--- a/app/src/main/java/com/waz/zclient/controllers/usernames/UsernamesControllerObserver.java
+++ b/app/src/main/java/com/waz/zclient/controllers/usernames/UsernamesControllerObserver.java
@@ -20,4 +20,5 @@ package com.waz.zclient.controllers.usernames;
 public interface UsernamesControllerObserver {
     void onValidUsernameGenerated(String name, String generatedUsername);
     void onUsernameAttemptsExhausted(String name);
+    void onCloseFirstAssignUsernameScreen();
 }

--- a/app/src/main/java/com/waz/zclient/pages/main/MainTabletFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/MainTabletFragment.java
@@ -39,7 +39,6 @@ import com.waz.zclient.controllers.confirmation.ConfirmationRequest;
 import com.waz.zclient.controllers.confirmation.IConfirmationController;
 import com.waz.zclient.controllers.navigation.Page;
 import com.waz.zclient.controllers.singleimage.SingleImageObserver;
-import com.waz.zclient.controllers.usernames.UsernamesControllerObserver;
 import com.waz.zclient.core.controllers.tracking.attributes.RangedAttribute;
 import com.waz.zclient.pages.BaseFragment;
 import com.waz.zclient.pages.main.backgroundmain.views.BackgroundFrameLayout;
@@ -53,14 +52,13 @@ import com.waz.zclient.views.menus.ConfirmationMenu;
 
 
 public class MainTabletFragment extends BaseFragment<MainTabletFragment.Container> implements
-        OnBackPressedListener,
-        InAppNotificationFragment.Container,
-        RootFragment.Container,
-        SingleImageObserver,
-        SingleImageFragment.Container,
-        ConfirmationObserver,
-        AccentColorObserver,
-        UsernamesControllerObserver {
+                                                                                   OnBackPressedListener,
+                                                                                   InAppNotificationFragment.Container,
+                                                                                   RootFragment.Container,
+                                                                                   SingleImageObserver,
+                                                                                   SingleImageFragment.Container,
+                                                                                   ConfirmationObserver,
+                                                                                   AccentColorObserver {
 
     public static final String TAG = MainTabletFragment.class.getName();
     private static final String ARG_LOCK_EXPANDED = "ARG_LOCK_EXPANDED";
@@ -124,7 +122,6 @@ public class MainTabletFragment extends BaseFragment<MainTabletFragment.Containe
         getControllerFactory().getAccentColorController().addAccentColorObserver(this);
         getControllerFactory().getAccentColorController().addAccentColorObserver(backgroundLayout);
         getControllerFactory().getBackgroundController().addBackgroundObserver(backgroundLayout);
-        getControllerFactory().getUsernameController().addUsernamesObserver(this);
     }
 
     @Override
@@ -134,7 +131,6 @@ public class MainTabletFragment extends BaseFragment<MainTabletFragment.Containe
         getControllerFactory().getSingleImageController().removeSingleImageObserver(this);
         getControllerFactory().getAccentColorController().removeAccentColorObserver(backgroundLayout);
         getControllerFactory().getBackgroundController().removeBackgroundObserver(backgroundLayout);
-        getControllerFactory().getUsernameController().removeUsernamesObserver(this);
         super.onStop();
     }
 
@@ -263,28 +259,6 @@ public class MainTabletFragment extends BaseFragment<MainTabletFragment.Containe
     @Override
     public void onAccentColorHasChanged(Object sender, int color) {
         confirmationMenu.setButtonColor(color);
-    }
-
-    //////////////////////////////////////////////////////////////////////////////////////////
-    //
-    //  UsernamesObserver
-    //
-    //////////////////////////////////////////////////////////////////////////////////////////
-
-    @Override
-    public void onValidUsernameGenerated(String name, String generatedUsername) {
-        RootFragment fragment = (RootFragment) getChildFragmentManager().findFragmentByTag(RootFragment.TAG);
-        if (fragment != null) {
-            fragment.showFirstTimeAssignUsername(name, generatedUsername);
-        }
-    }
-
-    @Override
-    public void onUsernameAttemptsExhausted(String name) {
-        RootFragment fragment = (RootFragment) getChildFragmentManager().findFragmentByTag(RootFragment.TAG);
-        if (fragment != null) {
-            fragment.showFirstTimeAssignUsername(name, "");
-        }
     }
 
     public interface Container {

--- a/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
@@ -51,6 +51,7 @@ import com.waz.zclient.controllers.giphy.GiphyObserver;
 import com.waz.zclient.controllers.location.LocationObserver;
 import com.waz.zclient.controllers.navigation.Page;
 import com.waz.zclient.controllers.navigation.PagerControllerObserver;
+import com.waz.zclient.controllers.usernames.UsernamesControllerObserver;
 import com.waz.zclient.core.api.scala.ModelObserver;
 import com.waz.zclient.core.controllers.tracking.events.media.SentPictureEvent;
 import com.waz.zclient.core.stores.connect.IConnectStore;
@@ -103,6 +104,7 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
                                                                        DrawingObserver,
                                                                        LocationObserver,
                                                                        ParticipantsStoreObserver,
+                                                                       UsernamesControllerObserver,
                                                                        ConversationFragment.Container,
                                                                        ConversationListManagerFragment.Container {
     public static final String TAG = RootFragment.class.getName();
@@ -234,6 +236,7 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         getControllerFactory().getCameraController().addCameraActionObserver(this);
         getControllerFactory().getPickUserController().addPickUserScreenControllerObserver(this);
         getControllerFactory().getGiphyController().addObserver(this);
+        getControllerFactory().getUsernameController().addUsernamesObserverAndUpdate(this);
         getControllerFactory().getDrawingController().addDrawingObserver(this);
         getStoreFactory().getParticipantsStore().addParticipantsStoreObserver(this);
         getControllerFactory().getLocationController().addObserver(this);
@@ -248,6 +251,7 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         getControllerFactory().getConversationScreenController().removeConversationControllerObservers(this);
         getControllerFactory().getSlidingPaneController().removeObserver(this);
         getControllerFactory().getCameraController().removeCameraActionObserver(this);
+        getControllerFactory().getUsernameController().removeUsernamesObserver(this);
         getControllerFactory().getNavigationController().removePagerControllerObserver(this);
         getStoreFactory().getConversationStore().removeConversationStoreObserver(this);
         getControllerFactory().getPickUserController().removePickUserScreenControllerObserver(this);
@@ -899,27 +903,22 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         getChildFragmentManager().popBackStack(LocationFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
 
-    public void showBlankFragment() {
+    @Override
+    public void onValidUsernameGenerated(String name, String generatedUsername) {
         rightSideShouldBeBlank = true;
         openMessageStream(Page.NONE, BlankFragment.newInstance(), BlankFragment.TAG);
     }
 
-    public void hideBlankFragment() {
-        rightSideShouldBeBlank = false;
-        conversationModelObserver.forceUpdate();
-    }
-
-    public void showFirstTimeAssignUsername(String name, String suggestedUsername) {
-        ConversationListManagerFragment fragment = (ConversationListManagerFragment) getChildFragmentManager().findFragmentByTag(ConversationListManagerFragment.TAG);
-        if (fragment != null) {
-            fragment.showFirstAssignUsernameScreen(name, suggestedUsername);
-            showBlankFragment();
-        }
+    @Override
+    public void onUsernameAttemptsExhausted(String name) {
+        rightSideShouldBeBlank = true;
+        openMessageStream(Page.NONE, BlankFragment.newInstance(), BlankFragment.TAG);
     }
 
     @Override
-    public void closeFirstAssignUsernameScreen() {
-        hideBlankFragment();
+    public void onCloseFirstAssignUsernameScreen() {
+        rightSideShouldBeBlank = false;
+        conversationModelObserver.forceUpdate();
     }
 
     public interface Container {

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationpager/FirstPageFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationpager/FirstPageFragment.java
@@ -26,7 +26,6 @@ import android.view.ViewGroup;
 import com.waz.zclient.OnBackPressedListener;
 import com.waz.zclient.R;
 import com.waz.zclient.pages.BaseFragment;
-import com.waz.zclient.pages.main.RootFragment;
 import com.waz.zclient.pages.main.conversationlist.ConfirmationFragment;
 import com.waz.zclient.pages.main.conversationlist.ConversationListManagerFragment;
 import timber.log.Timber;
@@ -124,14 +123,6 @@ public class FirstPageFragment extends BaseFragment<FirstPageFragment.Container>
     @Override
     public void onOpenUrl(String url) {
         getContainer().onOpenUrl(url);
-    }
-
-    @Override
-    public void closeFirstAssignUsernameScreen() {
-        RootFragment fragment = (RootFragment) getChildFragmentManager().findFragmentByTag(RootFragment.TAG);
-        if (fragment != null) {
-            fragment.hideBlankFragment();
-        }
     }
 
     public interface Container {


### PR DESCRIPTION
#### Description
Refactors triggering and closing of take over screen for user names to not go through via `MainPhoneFragment` and `MainTabletFragment`

#### APK
[Download build #8095](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8095/artifact/build/artifact/wire-dev-PR392-8095.apk)
[Download build #8099](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8099/artifact/build/artifact/wire-dev-PR392-8099.apk)
[Download build #8101](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8101/artifact/build/artifact/wire-dev-PR392-8101.apk)
[Download build #8106](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8106/artifact/build/artifact/wire-dev-PR392-8106.apk)