### PR TITLE
Forces user detail view update on common connections change

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.java
@@ -288,7 +288,7 @@ public class BlockedUserProfileFragment extends BaseFragment<BlockedUserProfileF
 
     @Override
     public void onCommonConnectionsUpdated(CommonConnections commonConnections) {
-
+        userDetailsView.refresh();
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/connect/PendingConnectRequestFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/connect/PendingConnectRequestFragment.java
@@ -414,7 +414,7 @@ public class PendingConnectRequestFragment extends BaseFragment<PendingConnectRe
 
     @Override
     public void onCommonConnectionsUpdated(CommonConnections commonConnections) {
-        // do nothing
+        userDetailsView.refresh();
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/connect/SendConnectRequestFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/connect/SendConnectRequestFragment.java
@@ -309,7 +309,7 @@ public class SendConnectRequestFragment extends BaseFragment<SendConnectRequestF
 
     @Override
     public void onCommonConnectionsUpdated(CommonConnections commonConnections) {
-
+        userDetailsView.refresh();
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantHeaderFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantHeaderFragment.java
@@ -541,7 +541,7 @@ public class ParticipantHeaderFragment extends BaseFragment<ParticipantHeaderFra
 
     @Override
     public void onCommonConnectionsUpdated(CommonConnections commonConnections) {
-
+        userDetailsView.refresh();
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/dialogs/ChangeUsernamePreferenceDialogFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/dialogs/ChangeUsernamePreferenceDialogFragment.java
@@ -105,7 +105,11 @@ public class ChangeUsernamePreferenceDialogFragment extends BaseDialogFragment<C
 
         @Override
         public void onUpdateFailed(int code, String message, String label) {
-            usernameInputLayout.setError(getString(R.string.pref__account_action__dialog__change_username__error_unknown));
+            if (code == 409) {
+                usernameInputLayout.setError(getString(R.string.pref__account_action__dialog__change_username__error_already_taken));
+            } else {
+                usernameInputLayout.setError(getString(R.string.pref__account_action__dialog__change_username__error_unknown));
+            }
             enableEditing();
         }
     };

--- a/wire-ui/src/main/java/com/waz/zclient/ui/views/UserDetailsView.java
+++ b/wire-ui/src/main/java/com/waz/zclient/ui/views/UserDetailsView.java
@@ -113,6 +113,10 @@ public class UserDetailsView extends LinearLayout {
         user = null;
     }
 
+    public void refresh() {
+        userModelObserver.forceUpdate();
+    }
+
     private void init() {
         LayoutInflater.from(getContext()).inflate(R.layout.user__details, this, true);
         userNameTextView = ViewUtils.getView(this, R.id.ttv__user_details__user_name);


### PR DESCRIPTION
Since the user model observer doesn’t update itself for common
connections.