### PR TITLE
remove consp1racy repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,6 @@ allprojects {
         maven { url "https://dl.bintray.com/wire-android/releases" }
         maven { url "https://dl.bintray.com/wire-android/snapshots" }
         maven { url "https://dl.bintray.com/wire-android/third-party" }
-        maven { url "http://dl.bintray.com/consp1racy/maven" }
         maven { url "http://maven.localytics.com/public" }
         mavenCentral()
     }


### PR DESCRIPTION
The net.xpece.android dependencies are found on jcenter now,
so the http://dl.bintray.com/consp1racy/maven repository can be removed.
#### APK
[Download build #8138](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8138/artifact/build/artifact/wire-dev-PR410-8138.apk)