### PR TITLE
[AN-4647] Adds missing referral to Localytics broadcast receiver

### DIFF
--- a/app/src/main/java/com/waz/zclient/broadcast/ReferralBroadcastReceiver.java
+++ b/app/src/main/java/com/waz/zclient/broadcast/ReferralBroadcastReceiver.java
@@ -21,6 +21,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import com.localytics.android.ReferralReceiver;
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController;
 import timber.log.Timber;
 
@@ -30,6 +31,9 @@ public class ReferralBroadcastReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        ReferralReceiver localyticsReferralReceiver = new ReferralReceiver();
+        localyticsReferralReceiver.onReceive(context, intent);
+
         try {
             if (intent.hasExtra("referrer")) {
                 String token = intent.getStringExtra("referrer");


### PR DESCRIPTION
#### Description
Since the app is already using a `BroadcastReceiver`, this adds Localytics as one referral receiver according to the documentation:
https://docs.localytics.com/dev/android.html#modify-androidmanifest-v3-android
https://docs.localytics.com/dev/android.html#multiple-referral-receivers-android

#### Ticket
https://wearezeta.atlassian.net/browse/AN-4647
#### APK
[Download build #8149](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8149/artifact/build/artifact/wire-dev-PR425-8149.apk)