### PR TITLE
Ensure that asset part views have a valid content tag and are inflated in the right order

### DIFF
--- a/app/src/main/res/layout/message_image_content.xml
+++ b/app/src/main/res/layout/message_image_content.xml
@@ -19,7 +19,6 @@
 
 -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-             android:id="@+id/content"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
     >

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
@@ -38,7 +38,10 @@ class ImagePartView(context: Context, attrs: AttributeSet, style: Int) extends F
 
   override val tpe: MsgPart = MsgPart.Image
 
-  override def inflate(): Unit = inflate(R.layout.message_image_content)
+  override lazy val contentLayoutId = {
+    setId(R.id.content) //ensure outer view has content id set - this doesn't seem to work with merge tags
+    R.layout.message_image_content
+  }
 
   private val selection = inject[SelectionController].messages
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -27,7 +27,7 @@ import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient.controllers.AssetsController
 import com.waz.zclient.messages.MessageView.MsgBindOptions
-import com.waz.zclient.messages.{ClickableViewPart, MessageViewPart}
+import com.waz.zclient.messages.ClickableViewPart
 import com.waz.zclient.messages.parts.assets.DeliveryState.OtherUploading
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{StringUtils, _}
@@ -38,6 +38,11 @@ import org.threeten.bp.Duration
 
 trait AssetPart extends View with ClickableViewPart with ViewHelper {
   val controller = inject[AssetsController]
+
+  def contentLayoutId: Int
+  inflate(contentLayoutId)
+
+  private lazy val content: View = findById[View](R.id.content)
 
   val message = Signal[MessageData]()
   val asset = controller.assetSignal(message)
@@ -50,14 +55,6 @@ trait AssetPart extends View with ClickableViewPart with ViewHelper {
   override def set(msg: MessageData, part: Option[MessageContent], opts: MsgBindOptions): Unit = {
     message ! msg
   }
-}
-
-
-trait ContentAssetPart extends AssetPart {
-  def inflate(): Unit
-
-  inflate()
-  private val content: View = findById(R.id.content)
 
   //toggle content visibility to show only progress dot background if other side is uploading asset
   deliveryState.map {
@@ -66,8 +63,7 @@ trait ContentAssetPart extends AssetPart {
   }.on(Threading.Ui)(content.setVisible)
 }
 
-
-trait ActionableAssetPart extends ContentAssetPart {
+trait ActionableAssetPart extends AssetPart {
   protected val assetActionButton: AssetActionButton = findById(R.id.action_button)
 
   override def set(msg: MessageData, part: Option[MessageContent], opts: MsgBindOptions): Unit = {
@@ -91,7 +87,7 @@ trait PlayableAsset extends ActionableAssetPart {
 }
 
 
-trait ImageLayoutAssetPart extends ContentAssetPart {
+trait ImageLayoutAssetPart extends AssetPart {
   import ImageLayoutAssetPart._
 
   protected val imageDim = message map { _.imageDimensions.getOrElse(Dim2(1, 1)) }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
@@ -35,7 +35,7 @@ class AudioAssetPartView(context: Context, attrs: AttributeSet, style: Int) exte
 
   override val tpe: MsgPart = MsgPart.AudioAsset
 
-  override def inflate() = inflate(R.layout.message_audio_asset_content)
+  override lazy val contentLayoutId = R.layout.message_audio_asset_content
 
   private val progressBar: SeekBar = findById(R.id.progress)
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/FileAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/FileAssetPartView.scala
@@ -38,7 +38,7 @@ class FileAssetPartView(context: Context, attrs: AttributeSet, style: Int) exten
 
   override val tpe: MsgPart = MsgPart.FileAsset
 
-  override def inflate() = inflate(R.layout.message_file_asset_content)
+  override lazy val contentLayoutId = R.layout.message_file_asset_content
 
   private val downloadedIndicator: GlyphTextView = findById(R.id.done_indicator)
   private val fileNameView: TextView = findById(R.id.file_name)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
@@ -38,7 +38,10 @@ class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int) exte
 
   override val tpe: MsgPart = MsgPart.VideoAsset
 
-  override def inflate() = inflate(R.layout.message_video_asset_content)
+  override lazy val contentLayoutId = {
+    setId(R.id.content) //ensure outer view has content id set - this doens't seem to work with merge tags
+    R.layout.message_video_asset_content
+  }
 
   private val controls = Seq(
     findById[View](R.id.action_button),

--- a/wire-core/src/main/res/values/ids.xml
+++ b/wire-core/src/main/res/values/ids.xml
@@ -50,4 +50,6 @@
     <item name="video_calling_view" type="id" />
 
     <item name="emoji_keyboard_item" type="id" />
+
+    <item name="content" type="id"/>
 </resources>


### PR DESCRIPTION
This should fix the crashes we've been seeing...
#### APK
[Download build #8184](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8184/artifact/build/artifact/wire-dev-PR448-8184.apk)