### PR TITLE
[AN-4878][AN-4835] Fix click handling for certain view types

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -61,12 +61,15 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
   setClipToPadding(false)
 
   this.onClick {
-    selection.toggleFocused(msgId)
+    if (clickableTypes.contains(msg.msgType))
+      selection.toggleFocused(msgId)
   }
 
   this.onLongClick {
-    performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-    messageActions.showDialog(data)
+    if (longClickableTypes.contains(msg.msgType)) {
+      performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+      messageActions.showDialog(data)
+    } else false
   }
 
   def set(mAndL: MessageAndLikes, prev: Option[MessageData], next: Option[MessageData], opts: MsgBindOptions): Unit = {
@@ -111,7 +114,6 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
         builder.result()
       }
 
-    // don't use margin on message view for spacing, this produces gaps ignoring click events, also margin change forces layout requests
     val (top, bottom) = if (parts.isEmpty) (0, 0) else getMargins(prev.map(_.msgType), next.map(_.msgType), parts.head.tpe, parts.last.tpe, isOneToOne)
     setPadding(0, top, 0, bottom)
     setParts(mAndL, parts, opts)
@@ -177,15 +179,21 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
 
 object MessageView {
 
-  val focusableTypes = Set(
-    Message.Type.TEXT,
-    Message.Type.TEXT_EMOJI_ONLY,
-    Message.Type.ANY_ASSET,
-    Message.Type.ASSET,
-    Message.Type.AUDIO_ASSET,
-    Message.Type.VIDEO_ASSET,
-    Message.Type.LOCATION,
-    Message.Type.RICH_MEDIA
+  import Message.Type._
+
+  val clickableTypes = Set(
+    TEXT,
+    TEXT_EMOJI_ONLY,
+    ANY_ASSET,
+    ASSET,
+    AUDIO_ASSET,
+    VIDEO_ASSET,
+    LOCATION,
+    RICH_MEDIA
+  )
+
+  val longClickableTypes = clickableTypes ++ Set(
+    KNOCK
   )
 
   val GenericMessage = 0
@@ -201,6 +209,7 @@ object MessageView {
   trait MarginRule
 
   case object TextLike extends MarginRule
+  case object SeparatorLike extends MarginRule
   case object ImageLike extends MarginRule
   case object FileLike extends MarginRule
   case object SystemLike extends MarginRule

--- a/app/src/main/scala/com/waz/zclient/messages/parts/PingPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/PingPartView.scala
@@ -24,13 +24,13 @@ import android.widget.{LinearLayout, TextView}
 import com.waz.threading.Threading
 import com.waz.zclient.common.views.ChatheadView
 import com.waz.zclient.messages.UsersController.DisplayName.{Me, Other}
-import com.waz.zclient.messages.{MessageViewPart, MsgPart, UsersController}
+import com.waz.zclient.messages.{ClickableViewPart, MessageViewPart, MsgPart, UsersController}
 import com.waz.zclient.ui.text.{GlyphTextView, TypefaceTextView}
 import com.waz.zclient.ui.utils.TextViewUtils
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
 
-class PingPartView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with MessageViewPart with ViewHelper with EphemeralTextPart {
+class PingPartView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with ClickableViewPart with ViewHelper with EphemeralTextPart {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 


### PR DESCRIPTION
Pings can now be long clicked, and padding around system message view types can't be clicked. The margin rules should ideally be split in half, since now the padding from the view below 'intrudes' into the view above, leading clicks in some types to be passed to what feel like the view below - this is a pretty minor issue though
#### APK
[Download build #8270](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8270/artifact/build/artifact/wire-dev-PR477-8270.apk)