### PR TITLE
[AN-4873] Fix MatchError in AudioAssetPartView.

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
@@ -51,7 +51,8 @@ class AudioAssetPartView(context: Context, attrs: AttributeSet, style: Int) exte
     pl <- isPlaying
     a <- asset
   } yield (pl, a)).onChanged {
-    case (pl, (a, _)) if pl => controller.onAudioPlayed ! a
+    case (pl, (a, _)) =>
+      if (pl) controller.onAudioPlayed ! a
   }
 
   assetActionButton.onClicked.filter(_ == DeliveryState.Complete) { _ =>


### PR DESCRIPTION
Events subscriber can not be a partial function, it has to be exhaustive (handle all cases).