### PR TITLE
[AN-4890] Fix weblink preview issue

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -82,8 +82,15 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
     val isOneToOne = ConversationType.isOneToOne(opts.convType)
 
     val contentParts = {
-      if (msg.msgType != Message.Type.RICH_MEDIA) Seq(PartDesc(MsgPart(msg.msgType, isOneToOne)))
-      else msg.content map { content => PartDesc(MsgPart(content.tpe), Some(content)) }
+      if (msg.msgType == Message.Type.RICH_MEDIA){
+        if (msg.content.size > 1){
+          Seq(PartDesc(MsgPart(Message.Type.TEXT, isOneToOne))) ++ (msg.content map { content => PartDesc(MsgPart(content.tpe), Some(content)) }).filter(_.tpe == WebLink)
+        } else {
+          msg.content map { content => PartDesc(MsgPart(content.tpe), Some(content)) }
+        }
+      }
+      else
+        Seq(PartDesc(MsgPart(msg.msgType, isOneToOne)))
     } .filter(_.tpe != MsgPart.Empty)
 
     val parts =


### PR DESCRIPTION
If there was text surrounding the link, the preview would replace the
link in the middle of the text. Now it adds it only at the end of the
message view.
Ticket: https://wearezeta.atlassian.net/projects/AN/issues/AN-4890
#### APK
[Download build #8308](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8308/artifact/build/artifact/wire-dev-PR503-8308.apk)
[Download build #8313](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8313/artifact/build/artifact/wire-dev-PR503-8313.apk)
[Download build #8314](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8314/artifact/build/artifact/wire-dev-PR503-8314.apk)