### PR TITLE
[AN-4897] Ensure that members changed chatheads view can wrap to second line

### DIFF
--- a/app/src/main/res/layout/message_member_change_content.xml
+++ b/app/src/main/res/layout/message_member_change_content.xml
@@ -33,7 +33,7 @@
         android:layout_marginBottom="@dimen/wire__padding__small" />
 
     <com.waz.zclient.messages.parts.MembersGridView
-        android:id="@+id/rv__row_conversation__people_changed__grid"
+        android:id="@+id/people_changed_grid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/content__padding_left"


### PR DESCRIPTION
The MembersGridView now needs to handle it's recycling in a more specific way, so it can't really make use of the generic ChatheadsRecyclerView. I'll leave that trait in place though, in case we need other lists in the future