### PR TITLE
Changed wifi download pref check.

### DIFF
--- a/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
@@ -63,6 +63,16 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
   lazy val singleImage              = inject[ISingleImageController]
   lazy val drawingController        = inject[IDrawingController]
 
+  //TODO make a preference controller for handling UI preferences in conjunction with SE preferences
+  val downloadOnWifiEnabled = for {
+    z <- zms
+    pref <- z.prefs.preference(getString(R.string.pref_options_image_download_key), getString(R.string.zms_image_download_value_always)).signal
+  } yield {
+    pref == getString(R.string.zms_image_download_value_wifi)
+  }
+  downloadOnWifiEnabled.disableAutowiring()
+
+
   val onFileOpened = EventStream[AssetData]()
   val onFileSaved = EventStream[AssetData]()
   val onVideoPlayed = EventStream[AssetData]()

--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -24,10 +24,9 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{Dim2, MessageData, MessageId}
-import com.waz.service.ZMessaging
 import com.waz.service.messages.MessageAndLikes
 import com.waz.utils.RichOption
-import com.waz.utils.events.Signal
+import com.waz.zclient.controllers.AssetsController
 import com.waz.zclient.controllers.global.SelectionController
 import com.waz.zclient.messages.MessageViewLayout.PartDesc
 import com.waz.zclient.messages.MsgPart._
@@ -50,6 +49,7 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
   protected val factory = inject[MessageViewFactory]
   private val selection = inject[SelectionController].messages
   private lazy val messageActions = inject[MessageActionsController]
+  private lazy val assetsController = inject[AssetsController]
 
   private var msgId: MessageId = _
   private var msg: MessageData = MessageData.Empty
@@ -132,10 +132,7 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
       }
   }
 
-  //TODO make a preference controller for handling UI preferences in conjunction with SE preferences
-  def isDownloadOnWifiEnabled = inject[Signal[ZMessaging]]
-    .flatMap(_.prefs.preference(getString(R.string.pref_options_image_download_key), getString(R.string.zms_image_download_value_always)).signal)
-    .currentValue.contains(getString(R.string.zms_image_download_value_wifi))
+  def isDownloadOnWifiEnabled = assetsController.downloadOnWifiEnabled.currentValue.contains(true)
 
   def isFooterHiding = !hasFooter && getFooter.isDefined
 


### PR DESCRIPTION
Moved preference access logic to a val in 'AssetsController' and disabled
autowiring for that signal, this way value will be precomputed.

Calling `Signal.currentValue` on freshly created signal will often fail,
most of the time signals will be initially empty. In this case preference
is loaded in background, so it would only work if value is already cached.

We should pay more attention to warning logs generated in `Signal.currentValue`, 
calling that on unwired signal is a bit risky. 
Actually `currentValue` should be avoided whenever possible, use `Signal.head` instead.
#### APK
[Download build #8324](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8324/artifact/build/artifact/wire-dev-PR519-8324.apk)