### PR TITLE
Sync generic registration error strings

### DIFF
--- a/wire-core/src/main/res/values/strings.xml
+++ b/wire-core/src/main/res/values/strings.xml
@@ -64,8 +64,8 @@
     <string name="new_reg_email_exists_message">@string/sign_up__account_creation_error__duplicate_email_message</string>
     <string name="new_reg_email_invalid_header">Invalid email address</string>
     <string name="new_reg_email_invalid_message">Please enter a valid email address.</string>
-    <string name="new_reg_email_generic_error_header">Invalid email address</string>
-    <string name="new_reg_email_generic_error_message">Please enter a valid email address.</string>
+    <string name="new_reg_email_generic_error_header">Something went wrong</string>
+    <string name="new_reg_email_generic_error_message">Please try to register again.</string>
     <string name="new_reg_email_register_generic_error_header">Invalid information</string>
     <string name="new_reg_email_register_generic_error_message">Please enter your full name and a valid email address and password.</string>
     <string name="new_reg_email_invalid_login_credentials_header">Invalid information</string>


### PR DESCRIPTION
Align with copy from phone registration variants:
* `new_reg_phone_generic_error_header`
* `new_reg_phone_generic_error_message`

Closes #530.
#### APK
[Download build #8350](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8350/artifact/build/artifact/wire-dev-PR540-8350.apk)