### PR TITLE
Let conversation names be clickable

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ShareToMultipleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ShareToMultipleFragment.scala
@@ -203,6 +203,8 @@ class SelectableConversationRow(context: Context, checkBoxListener: CompoundButt
   val checkBox = ViewUtils.getView(this, R.id.rb__conversation_selected).asInstanceOf[CheckBox]
 
   checkBox.setOnCheckedChangeListener(checkBoxListener)
+  nameView.setOnClickListener(new OnClickListener() {
+    override def onClick(v: View) : Unit = checkBox.toggle()})
 }
 
 object ShareToMultipleFragment {

--- a/app/src/main/scala/com/waz/zclient/conversation/ShareToMultipleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ShareToMultipleFragment.scala
@@ -204,7 +204,8 @@ class SelectableConversationRow(context: Context, checkBoxListener: CompoundButt
 
   checkBox.setOnCheckedChangeListener(checkBoxListener)
   nameView.setOnClickListener(new OnClickListener() {
-    override def onClick(v: View) : Unit = checkBox.toggle()})
+    override def onClick(v: View): Unit = checkBox.toggle()
+  })
 }
 
 object ShareToMultipleFragment {


### PR DESCRIPTION
In the sharing fragment it's now possible to click on the name of a conversation to select it; before this commit you had to tap the checkbox area which is too small, and people are lazy.
#### APK
[Download build #8422](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8422/artifact/build/artifact/wire-dev-PR579-8422.apk)