### PR TITLE
[AN-TESTING-GALLERY] Testing Gallery 5.0

### DIFF
--- a/testing_gallery/build.gradle
+++ b/testing_gallery/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.wire.testinggallery"
         minSdkVersion 19
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
     }
     buildTypes {
         release {

--- a/testing_gallery/src/main/AndroidManifest.xml
+++ b/testing_gallery/src/main/AndroidManifest.xml
@@ -31,6 +31,14 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         >
+
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".CaptureImageActivity"
             android:label="@string/app_name"

--- a/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
@@ -41,6 +41,10 @@ public class DocumentResolver {
         return query(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, null);
     }
 
+    public Uri getAudioPath() {
+        return query(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, null);
+    }
+
     public Uri getImagePath() {
         return query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null);
     }

--- a/testing_gallery/src/main/java/com/wire/testinggallery/MainActivity.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/MainActivity.java
@@ -1,0 +1,109 @@
+/**
+ * Wire
+ * Copyright (C) 2017 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wire.testinggallery;
+
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.support.v4.app.ShareCompat;
+import android.support.v7.app.AppCompatActivity;
+
+public class MainActivity extends AppCompatActivity {
+    private static final String COMMAND = "command";
+    private static final String PACKAGE_NAME = "package";
+    private static final String COMMAND_SHARE_TEXT = "share_text";
+    private static final String COMMAND_SHARE_IMAGE = "share_image";
+    private static final String COMMAND_SHARE_VIDEO = "share_video";
+    private static final String COMMAND_SHARE_AUDIO = "share_audio";
+    private static final String COMMAND_SHARE_FILE = "share_file";
+    private static final String COMMAND_CHECK_NOTIFICATION_ACCESS = "check_notification_access";
+    private static final String DEFAULT_TEST_TEXT = "QA AUTOMATION TEST";
+    private static final String DEFAULT_PACKAGE_NAME = "com.wire.candidate";
+
+    @Override
+    protected void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        registerReceiver(broadcastReceiver, new IntentFilter("com.wire.testinggallery.main.receiver"));
+    }
+
+    BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Intent shareIntent;
+            String command = intent.getStringExtra(COMMAND);
+            String packageName = intent.getStringExtra(PACKAGE_NAME) == null ?
+                DEFAULT_PACKAGE_NAME : intent.getStringExtra(PACKAGE_NAME);
+            if (command.startsWith("share")) {
+                if (command.equals(COMMAND_SHARE_TEXT)) {
+                    shareIntent = ShareCompat.IntentBuilder.from(MainActivity.this)
+                        .setType("text/plain")
+                        .setText(DEFAULT_TEST_TEXT)
+                        .getIntent();
+                } else {
+                    Uri uri = getLatestAssetUriByCommand(command);
+                    shareIntent = ShareCompat.IntentBuilder.from(MainActivity.this)
+                        .setType(getContentResolver().getType(uri))
+                        .setStream(uri)
+                        .getIntent();
+                }
+                shareIntent.setPackage(packageName);
+                startActivity(shareIntent);
+            } else {
+                switch (command) {
+                    case COMMAND_CHECK_NOTIFICATION_ACCESS:
+                        if (Settings.Secure.getString(getContentResolver(), "enabled_notification_listeners").contains(getApplicationContext().getPackageName())) {
+                            setResultData("VERIFIED");
+                        } else {
+                            setResultData("UNVERIFIED");
+                        }
+                        break;
+                    default:
+                        throw new RuntimeException(String.format("Cannot identify your command [%s]", command));
+                }
+            }
+        }
+    };
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        unregisterReceiver(broadcastReceiver);
+    }
+
+    private Uri getLatestAssetUriByCommand(String command) {
+        DocumentResolver resolver = new DocumentResolver(getContentResolver());
+        switch (command) {
+            case COMMAND_SHARE_FILE:
+                return resolver.getDocumentPath();
+            case COMMAND_SHARE_IMAGE:
+                return resolver.getImagePath();
+            case COMMAND_SHARE_VIDEO:
+                return resolver.getVideoPath();
+            case COMMAND_SHARE_AUDIO:
+                return resolver.getAudioPath();
+            default:
+                throw new RuntimeException(String.format("Cannot identify the command : %s", command));
+        }
+    }
+
+}

--- a/testing_gallery/src/main/java/com/wire/testinggallery/store/NotificationMessage.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/store/NotificationMessage.java
@@ -18,6 +18,8 @@
 package com.wire.testinggallery.store;
 
 
+import android.app.Notification;
+
 import com.google.gson.Gson;
 
 public class NotificationMessage {
@@ -25,11 +27,13 @@ public class NotificationMessage {
     private String title;
     private String text;
     private String[] textLines;
+    private transient Notification notification;
 
-    public NotificationMessage(int id, String title, String text, CharSequence[] textLinesSequence) {
+    public NotificationMessage(int id, String title, String text, CharSequence[] textLinesSequence, Notification notification) {
         this.id = id;
         this.title = title;
         this.text = text;
+        this.notification = notification;
         if (textLinesSequence != null) {
             textLines = new String[textLinesSequence.length];
             for (int i = 0; i < textLinesSequence.length; i++) {
@@ -52,6 +56,10 @@ public class NotificationMessage {
 
     public String[] getTextLines() {
         return textLines;
+    }
+
+    public Notification getNotification() {
+        return notification;
     }
 
     public String toJsonString() {


### PR DESCRIPTION
## Notification button
Enable testing gallery to support send pending intent of "Reply" and "Call" which are generated by Wire.

Example:
```bash
adb shell am broadcast -a com.wire.testinggallery.notification --es command reply
adb shell am broadcast -a com.wire.testinggallery.notification --es command call
```

## Check Notification Access
```bash
# Return : Broadcast completed: result=0, data="VERIFIED" 
# Or : Broadcast completed: result=0, data="UNVERIFIED"
adb shell am broadcast -a com.wire.testinggallery.main.receiver --es command check_notification_access
```

## Share
Enable testing gallery to share everything into Wire, to check Share page

```bash
# Launch Testing Gallery Main activity
adb shell am start -n com.wire.testinggallery/.MainActivity
# Share everything
# --es command: which could be share_text/share_image/share_video/share_audio/share_file
#   when it share text, it will share "QA AUTOMATION TEST"
#   when it share asset, it will return latest download files
# --es package: which specified the sharing destination build,  
#   such as com.wire.x, by default, it will use com.wire.candidate
adb shell am broadcast -a com.wire.testinggallery.main.receiver --es command share_text --es package com.wire.x
```

> Be careful notification command and share command use different receiver.

> Version: 4.0 => 5.0

#### APK
[Download build #8425](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8425/artifact/build/artifact/wire-dev-PR582-8425.apk)
[Download build #8435](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8435/artifact/build/artifact/wire-dev-PR582-8435.apk)
[Download build #8437](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8437/artifact/build/artifact/wire-dev-PR582-8437.apk)