### PR TITLE
Invite “people” (not “friends”)

### DIFF
--- a/wire-core/src/main/res/values/strings.xml
+++ b/wire-core/src/main/res/values/strings.xml
@@ -567,7 +567,7 @@
     <string name="pref_about_copyright_title">\u00A9 Wire Swiss GmbH</string>
 
     <!-- Pref invite -->
-    <string name="pref_invite_title">Invite friends</string>
+    <string name="pref_invite_title">Invite people</string>
 
     <!-- Preference Account Actions -->
     <string name="pref__account_action__phone_verification__title">Verify phone number</string>


### PR DESCRIPTION
Not all people are “friends”, particularly in a business context.

(Aligning this recently-added string with invitation copy that appears elsewhere in the app.)

Amends 40a9ad3 for AN-4978.