### PR TITLE
Align invitation copy with other clients

### DIFF
--- a/wire-core/src/main/res/values/strings.xml
+++ b/wire-core/src/main/res/values/strings.xml
@@ -160,7 +160,7 @@
     <!-- Should not use newline in the dialog message, not supported by all devices, text will be cut off -->
     <string name="people_picker__invite__share_details_dialog">Share Wire with your friends.</string>
     <string name="people_picker__invite__share_text__header">%1$s wants to connect on Wire</string>
-    <string name="people_picker__invite__share_text__body">I\'m on Wire, search for %1$s or visit get.wire.com.</string>
+    <string name="people_picker__invite__share_text__body">I\'m on Wire, search for %1$s or visit get.wire.com</string>
     <string name="people_picker__invite__message">Hi,\nThanks for the invitation. Let\'s connect.\n%1$s</string>
     <string name="people_picker__invite__sent_feedback">Invitation sent</string>
     <string name="people_picker__contact_list__user_selection_button__label">OPEN</string>


### PR DESCRIPTION
* Drop trailing URL punctuation per YV preference
* https://github.com/wireapp/wire-ios/pull/737