### PR TITLE
Messages in notifications should not be reversed

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -288,7 +288,7 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
 
     val messages = ns.map(n => getMessage(n, multiple = true, singleConversationInBatch = isSingleConv, singleUserInBatch = users.size == 1 && isSingleConv)).takeRight(5)
     builder.setContentText(messages.last) //the collapsed notification should have the last message
-    messages.reverse.foreach(inboxStyle.addLine)//the expanded notification should have the most recent at the top (reversed)
+    messages.foreach(inboxStyle.addLine)
 
     builder.build
   }


### PR DESCRIPTION
The order of the messages should be chronological, with top=oldest and bottom=most recent.
The default SMS app by google on my nexus 5X does the same. Here is a screenshot after receiving "A", "B", "C"
![wire 2017-02-21 at 9 48 58](https://cloud.githubusercontent.com/assets/21009625/23157491/c40adbf4-f81b-11e6-881f-e2567365260b.png)

#### APK
[Download build #8501](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8501/artifact/build/artifact/wire-dev-PR629-8501.apk)