### PR TITLE
Bump AVS to 3.2.34.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '3.2.30@aar'
+    customAvsVersion = '3.2.34@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
Includes fix for https://github.com/wireapp/wire-android/issues/680
#### APK
[Download build #8575](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8575/artifact/build/artifact/wire-dev-PR684-8575.apk)
[Download build #8580](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8580/artifact/build/artifact/wire-dev-PR684-8580.apk)