### PR TITLE
[AN-5101] Tracks position of selected search result, group and top user

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/OpenedConversationEvent.java
+++ b/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/OpenedConversationEvent.java
@@ -23,8 +23,22 @@ import com.waz.zclient.core.controllers.tracking.events.Event;
 
 public class OpenedConversationEvent extends Event {
 
-    public OpenedConversationEvent(String conversationType) {
+    public enum Context {
+        SEARCH("search"),
+        OPEN_BUTTON("open_button"),
+        TOPUSER_DOUBLETAP("topuser_doubletap");
+
+        private final String name;
+
+        Context(String tagName) {
+            name = tagName;
+        }
+    }
+
+    public OpenedConversationEvent(String conversationType, Context context, int position) {
         attributes.put(Attribute.TYPE, conversationType);
+        attributes.put(Attribute.CONTEXT, context.toString());
+        attributes.put(Attribute.POSITION, String.valueOf(position));
     }
 
     @NonNull

--- a/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/SelectedTopUser.java
+++ b/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/SelectedTopUser.java
@@ -19,9 +19,14 @@ package com.waz.zclient.controllers.tracking.events.connect;
 
 
 import android.support.annotation.NonNull;
+import com.waz.zclient.core.controllers.tracking.attributes.Attribute;
 import com.waz.zclient.core.controllers.tracking.events.Event;
 
 public class SelectedTopUser extends Event {
+    public SelectedTopUser(int position) {
+        attributes.put(Attribute.POSITION, String.valueOf(position));
+    }
+
     @NonNull
     @Override
     public String getName() {

--- a/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/SelectedUserFromSearchEvent.java
+++ b/app/src/main/java/com/waz/zclient/controllers/tracking/events/connect/SelectedUserFromSearchEvent.java
@@ -23,9 +23,23 @@ import com.waz.zclient.core.controllers.tracking.events.Event;
 
 public class SelectedUserFromSearchEvent extends Event {
 
-    public SelectedUserFromSearchEvent(String userConnectionType, boolean isAddingToGroupConversation) {
+    public enum Section {
+        CONTACTS("contacts"),
+        DIRECTORY("directory");
+
+        private final String name;
+
+        Section(String tagName) {
+            name = tagName;
+        }
+    }
+
+
+    public SelectedUserFromSearchEvent(String userConnectionType, boolean isAddingToGroupConversation, Section section, int position) {
         attributes.put(Attribute.TYPE, userConnectionType);
         attributes.put(Attribute.CONTEXT, isAddingToGroupConversation ? "add_to_conversation" : "startui");
+        attributes.put(Attribute.SECTION, section.toString());
+        attributes.put(Attribute.POSITION, String.valueOf(position));
     }
 
     @NonNull

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
@@ -428,12 +428,16 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
                 getStoreFactory().getConversationStore().setCurrentConversation(conversation,
                                                                                 requester);
             }
-            ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.ONE_TO_ONE_CONVERSATION.name()));
+            ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.ONE_TO_ONE_CONVERSATION.name(),
+                                                                                                                                OpenedConversationEvent.Context.OPEN_BUTTON,
+                                                                                                                                -1));
         } else {
             getStoreFactory().getConversationStore().createGroupConversation(users, requester);
             ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new CreatedGroupConversationEvent(false,
                                                                                                       (users.size() + 1)));
-            ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.GROUP_CONVERSATION.name()));
+            ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.GROUP_CONVERSATION.name(),
+                                                                                                                                OpenedConversationEvent.Context.OPEN_BUTTON,
+                                                                                                                                -1));
         }
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/PickUserFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/PickUserFragment.java
@@ -56,7 +56,6 @@ import com.waz.zclient.controllers.permission.RequestPermissionsObserver;
 import com.waz.zclient.controllers.tracking.events.connect.EnteredSearchEvent;
 import com.waz.zclient.controllers.tracking.events.connect.OpenedConversationEvent;
 import com.waz.zclient.controllers.tracking.events.connect.OpenedGenericInviteMenuEvent;
-import com.waz.zclient.controllers.tracking.events.connect.SelectedTopUser;
 import com.waz.zclient.controllers.tracking.events.connect.SentConnectRequestEvent;
 import com.waz.zclient.controllers.tracking.screens.ApplicationScreen;
 import com.waz.zclient.core.api.scala.ModelObserver;
@@ -748,7 +747,8 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
                                               user,
                                               anchorView instanceof ChatheadWithTextFooter,
                                               isAddingToConversation(),
-                                              searchResultAdapter.getItemViewType(position));
+                                              position,
+                                              searchResultAdapter);
 
         // Selecting user from search results toggles user token and confirmation button
         if (user.getConnectionStatus() == User.ConnectionStatus.ACCEPTED) {
@@ -783,18 +783,21 @@ public class PickUserFragment extends BaseFragment<PickUserFragment.Container> i
             return;
         }
 
-        ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new SelectedTopUser());
-        ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.ONE_TO_ONE_CONVERSATION.name()));
+        ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.ONE_TO_ONE_CONVERSATION.name(),
+                                                                                                                            OpenedConversationEvent.Context.TOPUSER_DOUBLETAP,
+                                                                                                                            (position + 1)));
         getStoreFactory().getConversationStore().setCurrentConversation(user.getConversation(),
                                                                         ConversationChangeRequester.START_CONVERSATION);
     }
 
     @Override
-    public void onConversationClicked(IConversation conversation) {
+    public void onConversationClicked(IConversation conversation, int position) {
         KeyboardUtils.hideKeyboard(getActivity());
+        ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.GROUP_CONVERSATION.name(),
+                                                                                                                            OpenedConversationEvent.Context.SEARCH,
+                                                                                                                            searchResultAdapter.getConversationInternalPosition(position)));
         getStoreFactory().getConversationStore().setCurrentConversation(conversation,
                                                                         ConversationChangeRequester.START_CONVERSATION);
-        ((BaseScalaActivity) getActivity()).injectJava(GlobalTrackingController.class).tagEvent(new OpenedConversationEvent(ConversationType.GROUP_CONVERSATION.name()));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultAdapter.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultAdapter.java
@@ -382,7 +382,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         return conversations != null && getGroupsListLength() > 0;
     }
 
-    private int getConversationInternalPosition(int position) {
+    public int getConversationInternalPosition(int position) {
         if (hasConnectedUsers()) {
             position = position - getContactsSectionLength();
         }
@@ -408,7 +408,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         return position;
     }
 
-    private int getOtherUserInternalPosition(int position) {
+    public int getOtherUserInternalPosition(int position) {
         if (hasConnectedUsers()) {
             position = position - getContactsSectionLength();
         }

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultOnItemTouchListener.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultOnItemTouchListener.java
@@ -52,7 +52,7 @@ public class SearchResultOnItemTouchListener implements RecyclerView.OnItemTouch
                     callback.onUserClicked(((UserRowView) rowView).getUser(), position, rowView);
                 }
                 if (rowView instanceof ConversationRowView) {
-                    callback.onConversationClicked(((ConversationRowView) rowView).getConversation());
+                    callback.onConversationClicked(((ConversationRowView) rowView).getConversation(), position);
                 }
                 return true;
             }
@@ -87,7 +87,7 @@ public class SearchResultOnItemTouchListener implements RecyclerView.OnItemTouch
     public interface Callback {
         void onUserClicked(User user, int position, View anchorView);
 
-        void onConversationClicked(IConversation conversation);
+        void onConversationClicked(IConversation conversation, int position);
 
         void onUserDoubleClicked(User user, int position, View anchorView);
     }

--- a/app/src/main/java/com/waz/zclient/utils/TrackingUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/TrackingUtils.java
@@ -383,16 +383,24 @@ public class TrackingUtils {
                                                User user,
                                                boolean isTopUser,
                                                boolean isAddingToConversation,
-                                               int rowType) {
-
+                                               int position,
+                                               SearchResultAdapter adapter) {
+        int itemType = adapter.getItemViewType(position);
         if (isTopUser) {
-            trackingController.tagEvent(new SelectedTopUser());
+            trackingController.tagEvent(new SelectedTopUser(position + 1));
         } else {
-            switch (rowType) {
+            switch (itemType) {
                 case SearchResultAdapter.ITEM_TYPE_CONNECTED_USER:
+                    trackingController.tagEvent(new SelectedUserFromSearchEvent(user.getConnectionStatus().toString(),
+                                                                                isAddingToConversation,
+                                                                                SelectedUserFromSearchEvent.Section.CONTACTS,
+                                                                                position));
+                    break;
                 case SearchResultAdapter.ITEM_TYPE_OTHER_USER:
                     trackingController.tagEvent(new SelectedUserFromSearchEvent(user.getConnectionStatus().toString(),
-                                                                                isAddingToConversation));
+                                                                                isAddingToConversation,
+                                                                                SelectedUserFromSearchEvent.Section.DIRECTORY,
+                                                                                adapter.getOtherUserInternalPosition(position)));
                     break;
             }
         }

--- a/wire-core/src/main/java/com/waz/zclient/core/controllers/tracking/attributes/Attribute.java
+++ b/wire-core/src/main/java/com/waz/zclient/core/controllers/tracking/attributes/Attribute.java
@@ -80,6 +80,8 @@ public enum Attribute {
     TYPE("type"),
     METHOD("method"),
     OUTCOME("outcome"),
+    SECTION("section"),
+    POSITION("position"),
     ERROR("error"),
     ERROR_MESSAGE("error_message"),
     VALUE("value"),


### PR DESCRIPTION
#### Description

Requested by backend team as a basis for future improvements to search. Adds the following changes:
1) Event **connect.selected_user_from_search**
new attribute "section" (contacts, directory)
new attribute "position" (starts from 1)

2) Event **connect.opened_conversation**
new attribute "context" (search, open_button, topuser_doubletap)
new attribute "position" (starts from 1, only for search)

3) Event **connect.selected_top_user**
new attribute "position" (starts from 1)

#### Ticket
https://wearezeta.atlassian.net/browse/AN-5101
#### APK
[Download build #8664](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8664/artifact/build/artifact/wire-dev-PR712-8664.apk)
[Download build #8665](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8665/artifact/build/artifact/wire-dev-PR712-8665.apk)