### PR TITLE
[AN-5015] displays Confirmation Menu on each degradation error

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationRequest.java
+++ b/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationRequest.java
@@ -30,6 +30,7 @@ public class ConfirmationRequest {
     public String checkboxLabel;
     public boolean checkboxSelectedByDefault;
     public int headerIconRes;
+    public int backgroundImage;
     public ConfirmationCallback callback;
     public OptionsTheme optionsTheme;
 
@@ -76,6 +77,11 @@ public class ConfirmationRequest {
 
         public Builder withHeaderIcon(@DrawableRes int headerIconRes) {
             confirmationRequest.headerIconRes = headerIconRes;
+            return this;
+        }
+
+        public Builder withBackgroundImage(@DrawableRes int backgroundImage) {
+            confirmationRequest.backgroundImage = backgroundImage;
             return this;
         }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
@@ -1639,7 +1639,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
         if (getControllerFactory().getNavigationController().getCurrentPage() != Page.MESSAGE_STREAM) {
             return;
         }
-        errorDescription.dismiss();
+
         KeyboardUtils.hideKeyboard(getActivity());
 
         final IConversation currentConversation = errorDescription.getConversation();
@@ -1700,6 +1700,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
         final String message = getResources().getQuantityString(R.plurals.conversation__degraded_confirmation__message,
                                                                 messageCount);
 
+
         final ConfirmationCallback callback = new ConfirmationCallback() {
             @Override
             public void positiveButtonClicked(boolean checkboxIsSelected) {
@@ -1707,6 +1708,7 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
                 for (Message message : messages) {
                     message.retry();
                 }
+                errorDescription.dismiss();
             }
 
             @Override
@@ -1742,13 +1744,12 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
             .withNegativeButton(negativeButton)
             .withConfirmationCallback(callback)
             .withCancelButton()
-            .withHeaderIcon(R.drawable.shield_half)
+            .withBackgroundImage(R.drawable.degradation_overlay)
             .withWireTheme(getControllerFactory().getThemeController().getThemeDependentOptionsTheme())
             .build();
 
         getControllerFactory().getConfirmationController().requestConfirmation(request,
                                                                                IConfirmationController.CONVERSATION);
-
     }
 
     private String getConversationTypeString() {

--- a/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
+++ b/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
@@ -41,6 +41,7 @@ import com.waz.zclient.ui.animation.interpolators.penner.Expo;
 import com.waz.zclient.ui.animation.interpolators.penner.Quart;
 import com.waz.zclient.ui.text.GlyphTextView;
 import com.waz.zclient.ui.theme.OptionsTheme;
+import com.waz.zclient.ui.utils.ColorUtils;
 import com.waz.zclient.ui.views.ZetaButton;
 import com.waz.zclient.utils.LayoutSpec;
 import com.waz.zclient.utils.ViewUtils;
@@ -56,6 +57,7 @@ public class ConfirmationMenu extends LinearLayout {
     private String checkboxLabelText;
     private boolean checkboxSelectedByDefault;
     private int headerIconRes;
+    private int backgroundImage;
 
     private TextView headerTextView;
     private TextView contentTextView;
@@ -64,6 +66,7 @@ public class ConfirmationMenu extends LinearLayout {
     private ZetaButton negativeButton;
     private CheckBoxView checkBoxView;
     private ImageView headerIconView;
+    private ImageView backgroundImageView;
     private View backgroundView;
     private View messageContainerView;
     private boolean confirmed;
@@ -130,6 +133,7 @@ public class ConfirmationMenu extends LinearLayout {
         checkboxLabelText = a.getString(R.styleable.ConfirmationMenu_checkboxLabel);
         checkboxSelectedByDefault = a.getBoolean(R.styleable.ConfirmationMenu_checkboxIsSelected, false);
         headerIconRes = a.getResourceId(R.styleable.ConfirmationMenu_headerIcon, 0);
+        backgroundImage = a.getResourceId(R.styleable.ConfirmationMenu_backgroundImage, 0);
         a.recycle();
     }
 
@@ -187,6 +191,8 @@ public class ConfirmationMenu extends LinearLayout {
         if (optionsTheme != null && optionsTheme.getType() == OptionsTheme.Type.LIGHT) {
             negativeButton.setTextColor(color);
         }
+
+        backgroundImageView.setColorFilter(ColorUtils.injectAlpha(0.1f, color));
     }
 
     public void useModalBackground(boolean show) {
@@ -197,6 +203,16 @@ public class ConfirmationMenu extends LinearLayout {
         this.headerIconRes = icon;
         headerIconView.setVisibility(icon == 0 ? GONE : VISIBLE);
         headerIconView.setImageResource(icon);
+    }
+
+    public void setBackgroundImage(@DrawableRes int imageId) {
+        this.backgroundImage = imageId;
+        if (imageId != 0) {
+            backgroundImageView.setImageDrawable(this.getContext().getDrawable(imageId));
+            backgroundImageView.setVisibility(VISIBLE);
+        } else {
+            backgroundImageView.setVisibility(GONE);
+        }
     }
 
     public void animateToShow(boolean show) {
@@ -320,6 +336,9 @@ public class ConfirmationMenu extends LinearLayout {
         headerIconView.setVisibility(headerIconRes == 0 ? GONE : VISIBLE);
         headerIconView.setImageResource(headerIconRes);
 
+        backgroundImageView = ViewUtils.getView(this, R.id.backgroundImage);
+        setBackgroundImage(backgroundImage);
+
         // Consume all touch events
         setOnTouchListener(new OnTouchListener() {
             @Override
@@ -366,6 +385,7 @@ public class ConfirmationMenu extends LinearLayout {
         setNegativeButton(confirmationRequest.negativeButton);
         setCancelVisible(confirmationRequest.cancelVisible);
         setIcon(confirmationRequest.headerIconRes);
+        setBackgroundImage(confirmationRequest.backgroundImage);
         setCheckBox(confirmationRequest.checkboxLabel, confirmationRequest.checkboxSelectedByDefault);
         animateToShow(true);
     }

--- a/app/src/main/res/layout/confirmation_menu_light.xml
+++ b/app/src/main/res/layout/confirmation_menu_light.xml
@@ -31,6 +31,14 @@
         android:background="@color/background_overlay_light"
         />
 
+    <ImageView
+        android:id="@+id/backgroundImage"
+        android:layout_width="@dimen/confirmation_menu__degradation_overlay_width"
+        android:layout_height="@dimen/confirmation_menu__degradation_overlay_height"
+        android:layout_gravity="center"
+        android:gravity="center"
+        />
+
     <LinearLayout
         android:id="@+id/ll__confirmation_dialog__message_container"
         android:layout_width="match_parent"
@@ -136,5 +144,6 @@
         android:textSize="@dimen/wire__icon_button__text_size"
         android:gravity="center"
         />
+
 
 </FrameLayout>

--- a/wire-core/src/main/res/values/attrs.xml
+++ b/wire-core/src/main/res/values/attrs.xml
@@ -83,6 +83,7 @@
         <attr name="checkboxLabel" format="string"/>
         <attr name="checkboxIsSelected" format="boolean"/>
         <attr name="headerIcon" format="reference"/>
+        <attr name="backgroundImage" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="PickUserEditText">

--- a/wire-core/src/main/res/values/dimens.xml
+++ b/wire-core/src/main/res/values/dimens.xml
@@ -485,6 +485,9 @@
     <dimen name="first_time__confirm_email__envelope_padding_bottom">50dp</dimen>
     <dimen name="first_time__confirm_email__text_segment_vertical_padding">20dp</dimen>
 
+    <dimen name="confirmation_menu__degradation_overlay_width">260dp</dimen>
+    <dimen name="confirmation_menu__degradation_overlay_height">260dp</dimen>
+
     <dimen name="profile__guidance__text_margin_top">0dp</dimen>
     <dimen name="profile__edit_container__margin_bottom">64dp</dimen>
     <dimen name="profile__pen_icon__margin_right">64dp</dimen>


### PR DESCRIPTION
This is a fix to the old Java implementation of the confirmation menu displayed when the conversation is degraded. So far it was displayed only on the first message after degradation and if the decision was to cancel message sending, and then another message was sent, the new message did not get the confirmation menu displayed - it was sent anyway. Now the confirmation menu appears every time until "Send Anyway" is clicked.
Also, a shield was added to the background of the confirmation menu.

#### APK
[Download build #8710](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8710/artifact/build/artifact/wire-dev-PR721-8710.apk)
[Download build #8711](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8711/artifact/build/artifact/wire-dev-PR721-8711.apk)
[Download build #8717](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8717/artifact/build/artifact/wire-dev-PR721-8717.apk)
[Download build #8719](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8719/artifact/build/artifact/wire-dev-PR721-8719.apk)