### PR TITLE
Avoid array oob when getting the view type for an invalid position

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultAdapter.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/SearchResultAdapter.java
@@ -272,6 +272,9 @@ public class SearchResultAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     @Override
     public @ItemType int getItemViewType(int position) {
         @ItemType int type = -1;
+        if (position < 0) {
+            return type;
+        }
         if (showSearch) {
             if (hasConnectedUsers() &&
                 position < getContactsSectionLength()) {

--- a/app/src/main/java/com/waz/zclient/utils/TrackingUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/TrackingUtils.java
@@ -386,6 +386,9 @@ public class TrackingUtils {
                                                int position,
                                                SearchResultAdapter adapter) {
         int itemType = adapter.getItemViewType(position);
+        if (itemType < 0) {
+            return;
+        }
         if (isTopUser) {
             trackingController.tagEvent(new SelectedTopUser(position + 1));
         } else {


### PR DESCRIPTION
The position and the user seem to be decoupled and there is the possibility of having a valid user and an invalid position.
#### APK
[Download build #8700](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8700/artifact/build/artifact/wire-dev-PR738-8700.apk)