### PR TITLE
Add web socket foreground service preference.

### DIFF
--- a/app/src/main/res/xml/preferences_developer.xml
+++ b/app/src/main/res/xml/preferences_developer.xml
@@ -85,6 +85,13 @@
             android:title="@string/pref_dev_websocket_ping_interval_title"
             />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_dev_ws_foreground_key"
+            android:summary="@string/pref_dev_ws_foreground_summary"
+            android:title="@string/pref_dev_ws_foreground_title"
+        />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
     playServicesVersion = '10.0.1'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '96.1427'
+    zMessagingDevVersionBase = '96.1429'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '96.0.337@aar'

--- a/wire-core/src/main/res/values/strings_no_translate.xml
+++ b/wire-core/src/main/res/values/strings_no_translate.xml
@@ -178,6 +178,9 @@
     <string translatable="false" name="pref_dev_websocket_ping_interval_key">PREF_WEBSOCKET_PING_INTERVAL</string>
     <string translatable="false" name="pref_dev_websocket_ping_interval_summary">Change the frequency of checking the connection to the server. Note that increasing the frequency may have a negative impact on battery life.</string>
     <string translatable="false" name="pref_dev_websocket_ping_interval_title">WebSocket Ping Frequency (ms)</string>
+    <string translatable="false" name="pref_dev_ws_foreground_key">@string/zms_ws_foreground_service_enabled</string>
+    <string translatable="false" name="pref_dev_ws_foreground_summary">Enable to see Web Socket connection status in permanent notification</string>
+    <string translatable="false" name="pref_dev_ws_foreground_title">Web Socket foreground service</string>
 
 </resources>
 


### PR DESCRIPTION
Added dev preference to run websocket service in foreground, ensures that service is not killed by system (at least not too early).

Handling for this preference is added in SE: https://github.com/wireapp/wire-android-sync-engine/pull/95
#### APK
[Download build #8716](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8716/artifact/build/artifact/wire-dev-PR748-8716.apk)