### PR TITLE
Contribution to issue #233

### DIFF
--- a/app/opensource.txt
+++ b/app/opensource.txt
@@ -1,7 +1,5 @@
 Image Filters from http://www.jhlabs.com - Apache 2.0
-Localytics SDK - http://www.localytics.com/docs/sdks-integration-guides/sdks/
 Android Wheel Control - https://code.google.com/p/android-wheel/ - Apache 2.0
-WebRTC 
 Commons IO - http://commons.apache.org/proper/commons-io/ - Apache 2.0
 Gson - https://code.google.com/p/google-gson/ - Apache 2.0
 Hockeyapp SDK - http://support.hockeyapp.net/kb/client-integration-android-other-platforms/hockeyapp-for-android-sdk
@@ -14,9 +12,8 @@ ListViewAnimations - https://github.com/nhaarman/ListViewAnimations - Apache 2.0
 NineOldAndroids - https://github.com/JakeWharton/NineOldAndroids/ - Apache 2.0
 Timber - https://github.com/JakeWharton/timber - Apache 2.0
 Spotify Authentication Library - https://developer.spotify.com/technologies/spotify-android-sdk/android-sdk-api-reference/ - Apache License, Version 2.0
-Spotify Player Library - https://developer.spotify.com/technologies/spotify-android-sdk/android-sdk-api-reference/ - Apache License, Version 2.0
 Retrofit - https://github.com/square/retrofit - Apache License, Version 2.0
 OkHttp - https://github.com/square/okhttp - Apache License, Version 2.0
 Spotify Web API for Android - https://github.com/kaaes/spotify-web-api-android - MIT
 Material Preference - https://github.com/consp1racy/android-support-preference - Apache 2.0
-https://github.com/iPaulPro/aFileChooser - Apache License, Version 2.0
+aFileChooser - https://github.com/iPaulPro/aFileChooser - Apache License, Version 2.0

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -181,10 +181,6 @@
             </intent-filter>
         </activity>
         <activity android:name=".controllers.notifications.ShareSavedImageActivity" />
-        <!-- Needed for LoginActivity to work -->
-        <activity
-            android:name="com.spotify.sdk.android.authentication.LoginActivity"
-            android:theme="@android:style/Theme.Holo.Light.NoActionBar.Fullscreen"/>
 
         <activity
             android:name=".LaunchActivity"

--- a/app/src/main/java/com/waz/zclient/controllers/spotify/SpotifyController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/spotify/SpotifyController.java
@@ -79,7 +79,6 @@ public class SpotifyController implements ISpotifyController {
 
     @Override
     public void logout() {
-        AuthenticationClient.clearCookies(context);
         spotify.disconnect();
         reset();
         notifyLogout();

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ ext {
             supportpreferences   : 'net.xpece.android:support-preference:0.8.1',
 
             // For spotify
-            spotifyAuth          : 'com.wire:spotify-auth:1.0.0-beta13@aar',
+            spotifyAuth          : 'com.spotify.android:auth:1.0.0-alpha',
 
             // Internal
             audioNotifications   : "com.wire:audio-notifications:$audioVersion",

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -70,7 +70,7 @@ object Deps {
   lazy val rebound = "com.facebook.rebound" % "rebound" % "0.3.8"
   lazy val supportpreferences = "net.xpece.android" % "support-preference" % "0.8.1"
 
-  lazy val spotifyAuth = "com.wire" % "spotify-auth" % "1.0.0-beta13"
+  lazy val spotifyAuth = "com.spotify.android" % "auth" % "1.0.0-alpha"
   lazy val spotifyPlayer = "com.wire" % "spotify-player" % "1.0.0-beta13"
 
   lazy val audioNotifications = "com.wearezeta.avs" % "audio-notifications" % audioVersion


### PR DESCRIPTION
This pull request together with https://github.com/wireapp/wire-android-sync-engine/pull/101 replaces the spotifyAuth dependency from Wire's 3rd party repo with a stock version.

Also proprietary dependencies are removed from the opensource.txt file.