### PR TITLE
[AN-5148] Avoid oom when creating big bitmaps

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/backgroundmain/views/BackgroundDrawable.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/backgroundmain/views/BackgroundDrawable.java
@@ -136,6 +136,9 @@ public class BackgroundDrawable extends Drawable {
     private void createBackgroundShader() {
         if (bitmap == null) {
             bitmap = createBitmap((int) width, (int) height);
+            if (bitmap == null) {
+                return;
+            }
         }
 
         float imageWidth = (float) bitmap.getWidth();
@@ -156,8 +159,10 @@ public class BackgroundDrawable extends Drawable {
             Arrays.fill(colors, DEFAULT_BACKGROUND_COLOR);
             ret = Bitmap.createBitmap(colors, width, height, Bitmap.Config.ARGB_8888);
             return ret;
-        } catch (OutOfMemoryError e){
+        } catch (OutOfMemoryError e) {
             return createBitmap(width / 2, height / 2);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 
@@ -188,6 +193,9 @@ public class BackgroundDrawable extends Drawable {
      * Separate from fullUpdate() to allow for animations without recreating the underlying bitmap.
      */
     private void updateFilter() {
+        if (bitmapShader == null) {
+            return;
+        }
         //New vignette shader must be created here for the animation as the radius changes
         createVignetteShader();
         paint.setShader(new ComposeShader(bitmapShader, vignetteShader, PorterDuff.Mode.DARKEN));

--- a/app/src/main/java/com/waz/zclient/pages/main/backgroundmain/views/BackgroundDrawable.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/backgroundmain/views/BackgroundDrawable.java
@@ -135,9 +135,7 @@ public class BackgroundDrawable extends Drawable {
 
     private void createBackgroundShader() {
         if (bitmap == null) {
-            int[] colors = new int[(int) width * (int) height];
-            Arrays.fill(colors, DEFAULT_BACKGROUND_COLOR);
-            bitmap = Bitmap.createBitmap(colors, (int) width, (int) height, Bitmap.Config.ARGB_8888);
+            bitmap = createBitmap((int) width, (int) height);
         }
 
         float imageWidth = (float) bitmap.getWidth();
@@ -149,6 +147,18 @@ public class BackgroundDrawable extends Drawable {
         matrix.setScale(scale, scale);
         matrix.postTranslate(-(imageWidth * scale - width) / 2f, -(imageHeight * scale - height) / 2f);
         bitmapShader.setLocalMatrix(matrix);
+    }
+
+    private Bitmap createBitmap(int width, int height) {
+        Bitmap ret;
+        try {
+            int[] colors = new int[width * height];
+            Arrays.fill(colors, DEFAULT_BACKGROUND_COLOR);
+            ret = Bitmap.createBitmap(colors, width, height, Bitmap.Config.ARGB_8888);
+            return ret;
+        } catch (OutOfMemoryError e){
+            return createBitmap(width / 2, height / 2);
+        }
     }
 
     private void createVignetteShader() {


### PR DESCRIPTION
This should avoid getting oom with big bitmaps. These should be eventually replaced with the AssetDrawable.
Ticket: https://wearezeta.atlassian.net/browse/AN-5148

#### APK
[Download build #8732](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8732/artifact/build/artifact/wire-dev-PR763-8732.apk)