### PR TITLE
Update to tidied up preference API on SE

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
@@ -20,12 +20,12 @@ package com.waz.zclient.controllers.userpreferences;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
+
 import com.waz.zclient.R;
 import com.waz.zclient.utils.StringUtils;
+
 import org.json.JSONArray;
 import org.json.JSONException;
-import timber.log.Timber;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -35,9 +35,9 @@ import java.util.UUID;
 
 public class UserPreferencesController implements IUserPreferencesController {
 
-    public static final String USER_PREFS_TAG = "com.waz.zclient.user.preferences";
-    private static final String USER_PREFS_VERSION_ID = "USER_PREFS_VERSION_ID";
+    public static final String USER_PREFS_TAG = "com.wire.preferences";
 
+    //TODO Move these preferences to the UserPreferences service in SE, since a lot of them are user-scoped anyway.
     public static final String USER_PREFS_LAST_ACCENT_COLOR = "USER_PREFS_LAST_ACCENT_COLOR";
     public static final String USER_PREFS_REFERRAL_TOKEN = "USER_PREFS_REFERRAL_TOKEN";
     public static final String USER_PREFS_GENERIC_INVITATION_TOKEN = "USER_PREFS_GENERIC_INVITATION_TOKEN";
@@ -64,25 +64,8 @@ public class UserPreferencesController implements IUserPreferencesController {
     private Context context;
 
     public UserPreferencesController(Context context) {
-        this.context = context;
         userPreferences = context.getSharedPreferences(USER_PREFS_TAG, Context.MODE_PRIVATE);
-
-        // get old version
-        int oldVersion = userPreferences.getInt(USER_PREFS_VERSION_ID, 0);
-        int newVersion = 0;
-        // get new version
-        try {
-            newVersion = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionCode;
-        } catch (PackageManager.NameNotFoundException e) {
-            Timber.e(e, "Failed loading version for UserPreferencesController!");
-        }
-        updateSharedPreferences(oldVersion, newVersion);
-    }
-
-    private void updateSharedPreferences(int oldVersion, int newVersion) {
-        // TODO do something very clever here if old and new version do not match
-        // at the end
-        userPreferences.edit().putInt(USER_PREFS_VERSION_ID, newVersion).apply();
+        this.context = context;
     }
 
     @Override

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -23,7 +23,8 @@ import android.support.multidex.MultiDexApplication
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.verbose
 import com.waz.api.{NetworkMode, ZMessagingApi, ZMessagingApiFactory}
-import com.waz.service.{MediaManagerService, NetworkModeService, PreferenceService, ZMessaging}
+import com.waz.content.GlobalPreferences
+import com.waz.service.{MediaManagerService, NetworkModeService, ZMessaging}
 import com.waz.utils.events.{EventContext, Signal, Subscription}
 import com.waz.zclient.api.scala.ScalaStoreFactory
 import com.waz.zclient.calling.controllers.{CallPermissionsController, CurrentCallController, GlobalCallingController}
@@ -61,7 +62,7 @@ object WireApplication {
     // SE services
     bind [Signal[Option[ZMessaging]]]  to ZMessaging.currentUi.currentZms
     bind [Signal[ZMessaging]]          to inject[Signal[Option[ZMessaging]]].collect { case Some(z) => z }
-    bind [PreferenceService]           to ZMessaging.currentGlobal.prefs
+    bind [GlobalPreferences]           to ZMessaging.currentGlobal.prefs
     bind [NetworkModeService]          to ZMessaging.currentGlobal.network
     bind [MediaManagerService]         to ZMessaging.currentGlobal.mediaManager
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallPermissionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallPermissionsController.scala
@@ -20,6 +20,7 @@ package com.waz.zclient.calling.controllers
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.{info, warn}
 import com.waz.api.{VoiceChannelState, ZmsVersion}
+import com.waz.content.GlobalPreferences.{AutoAnswerCallPrefKey, CallingV3Key}
 import com.waz.model.ConvId
 import com.waz.model.ConversationData.ConversationType
 import com.waz.threading.Threading
@@ -46,8 +47,8 @@ class CallPermissionsController(implicit inj: Injector, cxt: WireContext) extend
   private def useV3(convId: ConvId) = {
     isGroupCall(convId).flatMap {
       case true if !ZmsVersion.DEBUG => Future.successful(false) //Disable v3 group call from non debug builds
-      case _ => {
-        prefs.head.flatMap(p => p.uiPreferenceStringSignal(p.callingV3Key, "1").apply()).flatMap {
+      case _ =>
+        prefs.head.flatMap(_.preference(CallingV3Key).apply()).flatMap {
           case "0" => Future.successful(false) // v2
           case "1" => v3Service.flatMap(_.requestedCallVersion).head.map { v =>
             info(s"Relying on backend switch: using calling version: $v")
@@ -58,7 +59,6 @@ class CallPermissionsController(implicit inj: Injector, cxt: WireContext) extend
             warn("Unexpected calling v3 preference, defaulting to v2")
             Future.successful(false)
         }
-      }
     }
   }
 
@@ -74,7 +74,7 @@ class CallPermissionsController(implicit inj: Injector, cxt: WireContext) extend
       case VoiceChannelState.OTHER_CALLING => true
       case _ => false
     }
-    autoAnswer <- prefs.flatMap(p => p.uiPreferenceBooleanSignal(p.autoAnswerCallPrefKey).signal)
+    autoAnswer <- prefs.flatMap(_.preference(AutoAnswerCallPrefKey).signal)
   } if (incomingCall && autoAnswer) startCall(cId)
 
   /**

--- a/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
@@ -27,6 +27,7 @@ import android.widget.{TextView, Toast}
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.api.{ImageAsset, Message}
+import com.waz.content.Preferences.PrefKey
 import com.waz.model.{AssetData, AssetId, MessageData, Mime}
 import com.waz.service.ZMessaging
 import com.waz.service.assets.GlobalRecordAndPlayService
@@ -67,7 +68,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
   //TODO make a preference controller for handling UI preferences in conjunction with SE preferences
   val downloadOnWifiEnabled = for {
     z <- zms
-    pref <- z.prefs.preference(getString(R.string.pref_options_image_download_key), getString(R.string.zms_image_download_value_always)).signal
+    pref <- z.prefs.preference(PrefKey[String](getString(R.string.pref_options_image_download_key), getString(R.string.zms_image_download_value_always))).signal
   } yield {
     pref == getString(R.string.zms_image_download_value_wifi)
   }

--- a/app/src/main/scala/com/waz/zclient/controllers/global/AccentColorController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/global/AccentColorController.scala
@@ -18,15 +18,17 @@
 package com.waz.zclient.controllers.global
 
 import com.waz.api.impl.{AccentColor, AccentColors}
+import com.waz.content.GlobalPreferences
+import com.waz.content.Preferences.PrefKey
 import com.waz.model.UserData
-import com.waz.service.{PreferenceService, ZMessaging}
+import com.waz.service.ZMessaging
 import com.waz.utils.events.Signal
 import com.waz.zclient.{Injectable, Injector}
 
 import scala.util.Random
 
 class AccentColorController(implicit inj: Injector) extends Injectable {
-  private lazy val prefService = inject[PreferenceService]
+  private lazy val prefs = inject[GlobalPreferences]
 
   private val zms = inject[Signal[Option[ZMessaging]]]
 
@@ -35,7 +37,7 @@ class AccentColorController(implicit inj: Injector) extends Injectable {
     case _ => Signal.const[Option[UserData]](None)
   }
 
-  private val randomColorPref = prefService.intPreference("random_accent_color", defaultValue = Random.nextInt(AccentColors.colors.length))
+  private val randomColorPref = prefs.preference(PrefKey[Int]("random_accent_color", Random.nextInt(AccentColors.colors.length)))
 
   private val userColor = self.map {
     case Some(s) => Some(AccentColor(s.accent))

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -29,6 +29,7 @@ import com.waz.ZLog._
 import com.waz.api.Message.Type._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.{EphemeralExpiration, NetworkMode, Verification}
+import com.waz.content.Preferences.PrefKey
 import com.waz.content.UsersStorage
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.UserData.ConnectionStatus.Blocked
@@ -134,7 +135,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
   }
 
   private def isTrackingEnabled = {
-    val pref = ZMessaging.currentGlobal.prefs.uiPreferences.getBoolean(getString(R.string.pref_advanced_analytics_enabled_key), true)
+    val pref = ZMessaging.currentGlobal.prefs.getFromPref(PrefKey[Boolean](getString(R.string.pref_advanced_analytics_enabled_key), true))
     pref && !BuildConfig.DISABLE_TRACKING_KEEP_LOGGING
   }
 

--- a/app/src/test/scala/com/waz/zclient/messages/parts/footer/FooterViewControllerTest.scala
+++ b/app/src/test/scala/com/waz/zclient/messages/parts/footer/FooterViewControllerTest.scala
@@ -21,10 +21,11 @@ import java.util.concurrent.TimeUnit
 
 import android.content.Context
 import com.waz.api.Message
+import com.waz.content.GlobalPreferences
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model._
+import com.waz.service.ZMessaging
 import com.waz.service.messages.MessageAndLikes
-import com.waz.service.{PreferenceService, ZMessaging}
 import com.waz.testutils.TestUtils.{PrintValues, signalTest}
 import com.waz.testutils.{MockZMessaging, TestWireContext, ViewTestActivity}
 import com.waz.utils.events.{EventContext, Signal}
@@ -80,7 +81,7 @@ class FooterViewControllerTest extends JUnitSuite {
     bind[Context] to context
     bind[Signal[ZMessaging]] to Signal.const(zMessaging)
     bind[Signal[Option[ZMessaging]]] to Signal.const(Some(zMessaging))
-    bind[PreferenceService] to zMessaging.prefs
+    bind[GlobalPreferences] to zMessaging.prefs
     bind[AccentColorController] to new AccentColorController
     bind[SelectionController] to new SelectionController
     bind[UsersController] to new UsersController

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
     playServicesVersion = '10.0.1'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '98.1476'
+    zMessagingDevVersionBase = '98.1477'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '98.2.345@aar'


### PR DESCRIPTION
Necessary to work with https://github.com/wireapp/wire-android-sync-engine/pull/124

This merges the more commonly used user and zms preferences into one file to simplify the preference API on SE. 

The next step would be to move the Preference objects to Scala and get rid of the `UserPreferenceController` entirely.

### To test
Please install a previous build, update your preferences, change a few things around, install the new build (without clearing the data) and make sure there are no crashes or preferences that were not carried across properly. 
#### APK
[Download build #8857](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8857/artifact/build/artifact/wire-dev-PR848-8857.apk)
[Download build #8859](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8859/artifact/build/artifact/wire-dev-PR848-8859.apk)
[Download build #8860](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8860/artifact/build/artifact/wire-dev-PR848-8860.apk)