### PR TITLE
Fixes AN-5223 and AN-5190. Makes dots visible even if downloading failed

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -31,7 +31,7 @@ import com.waz.zclient.controllers.global.AccentColorController
 import com.waz.zclient.messages.ClickableViewPart
 import com.waz.zclient.messages.MessageView.MsgBindOptions
 import com.waz.zclient.messages.parts.ImagePartView
-import com.waz.zclient.messages.parts.assets.DeliveryState.{Downloading, OtherUploading}
+import com.waz.zclient.messages.parts.assets.DeliveryState.{Downloading, OtherUploading, DownloadFailed}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{StringUtils, _}
 import com.waz.zclient.views.ImageAssetDrawable
@@ -55,10 +55,12 @@ trait AssetPart extends View with ClickableViewPart with ViewHelper { self =>
   val asset = controller.assetSignal(message)
   val deliveryState = DeliveryState(message, asset)
   val completed = deliveryState.map(_ == DeliveryState.Complete)
+  // if the download failed we will retry it after some time, so in practice downloading is always in progress
+  val downloadIndicatorVisible = deliveryState.map(state => state == OtherUploading || state == Downloading || state == DownloadFailed)
   val expired = message map { m => m.isEphemeral && m.expired }
   val accentColorController = inject[AccentColorController]
 
-  val assetBackground = new AssetBackground(deliveryState.map(state => state == OtherUploading || state == Downloading), expired, accentColorController.accentColor)
+  val assetBackground = new AssetBackground(downloadIndicatorVisible, expired, accentColorController.accentColor)
 
   setBackground(assetBackground)
 


### PR DESCRIPTION
Makes dots visible even if downloading failed - we assume the downloading will be retried.
Works best with this PR to SE: https://github.com/wireapp/wire-android-sync-engine/pull/131 but does not depend on it.
#### APK
[Download build #8868](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8868/artifact/build/artifact/wire-dev-PR864-8868.apk)