### PR TITLE
Only use v3 for outgoing calls

### DIFF
--- a/app/src/candidate/java/com.waz.zclient/PreferenceReceiver.java
+++ b/app/src/candidate/java/com.waz.zclient/PreferenceReceiver.java
@@ -32,10 +32,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
     public static final String ENABLE_GCM_INTENT = "com.waz.zclient.intent.action.ENABLE_GCM";
     public static final String DISABLE_GCM_INTENT = "com.waz.zclient.intent.action.DISABLE_GCM";
 
-    public static final String CALLING_V2_INTENT = "com.waz.zclient.intent.action.CALLING_V2";
-    public static final String CALLING_V3_INTENT = "com.waz.zclient.intent.action.CALLING_V3";
-    public static final String CALLING_BE_SWITCH = "com.waz.zclient.intent.action.CALLING_BE_SWITCH";
-
     @Override
     public void onReceive(Context context, Intent intent) {
         SharedPreferences preferences = context.getSharedPreferences(UserPreferencesController.USER_PREFS_TAG, Context.MODE_PRIVATE);
@@ -55,21 +51,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
             case DISABLE_GCM_INTENT:
                 preferences.edit()
                     .putBoolean(context.getString(R.string.pref_dev_push_enabled_key), false)
-                    .apply();
-                break;
-            case CALLING_V2_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "0")
-                    .apply();
-                break;
-            case CALLING_BE_SWITCH:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "1")
-                    .apply();
-                break;
-            case CALLING_V3_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "2")
                     .apply();
                 break;
         }

--- a/app/src/dev/java/com.waz.zclient/PreferenceReceiver.java
+++ b/app/src/dev/java/com.waz.zclient/PreferenceReceiver.java
@@ -32,10 +32,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
     public static final String ENABLE_GCM_INTENT = "com.waz.zclient.intent.action.ENABLE_GCM";
     public static final String DISABLE_GCM_INTENT = "com.waz.zclient.intent.action.DISABLE_GCM";
 
-    public static final String CALLING_V2_INTENT = "com.waz.zclient.intent.action.CALLING_V2";
-    public static final String CALLING_V3_INTENT = "com.waz.zclient.intent.action.CALLING_V3";
-    public static final String CALLING_BE_SWITCH = "com.waz.zclient.intent.action.CALLING_BE_SWITCH";
-
     @Override
     public void onReceive(Context context, Intent intent) {
         SharedPreferences preferences = context.getSharedPreferences(UserPreferencesController.USER_PREFS_TAG, Context.MODE_PRIVATE);
@@ -55,21 +51,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
             case DISABLE_GCM_INTENT:
                 preferences.edit()
                     .putBoolean(context.getString(R.string.pref_dev_push_enabled_key), false)
-                    .apply();
-                break;
-            case CALLING_V2_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "0")
-                    .apply();
-                break;
-            case CALLING_BE_SWITCH:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "1")
-                    .apply();
-                break;
-            case CALLING_V3_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "2")
                     .apply();
                 break;
         }

--- a/app/src/main/res/xml/preferences_developer.xml
+++ b/app/src/main/res/xml/preferences_developer.xml
@@ -46,16 +46,6 @@
         android:title="@string/pref_dev_version_info_id_title"
         />
 
-    <ListPreference
-        android:key="@string/pref_dev_calling_v3_key"
-        android:title="@string/pref_dev_calling_v3_title"
-        android:defaultValue="2"
-        android:dialogTitle="@string/pref_dev_calling_v3_dialog_title"
-        android:entries="@array/calling_v3_preference_titles"
-        android:entryValues="@array/calling_v3_preferences"
-        android:summary="%s"
-        />
-
     <PreferenceCategory
         android:key="@string/pref_dev_category_notifications_key"
         android:title="@string/pref_dev_category_notifications_title"

--- a/app/src/qa/java/com.waz.zclient/PreferenceReceiver.java
+++ b/app/src/qa/java/com.waz.zclient/PreferenceReceiver.java
@@ -32,9 +32,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
     public static final String ENABLE_GCM_INTENT = "com.waz.zclient.intent.action.ENABLE_GCM";
     public static final String DISABLE_GCM_INTENT = "com.waz.zclient.intent.action.DISABLE_GCM";
 
-    public static final String CALLING_V2_INTENT = "com.waz.zclient.intent.action.CALLING_V2";
-    public static final String CALLING_V3_INTENT = "com.waz.zclient.intent.action.CALLING_V3";
-    public static final String CALLING_BE_SWITCH = "com.waz.zclient.intent.action.CALLING_BE_SWITCH";
     public static final String SILENT_MODE = "com.waz.zclient.intent.action.SILENT_MODE";
 
     @Override
@@ -56,21 +53,6 @@ public class PreferenceReceiver extends BroadcastReceiver {
             case DISABLE_GCM_INTENT:
                 preferences.edit()
                     .putBoolean(context.getString(R.string.pref_dev_push_enabled_key), false)
-                    .apply();
-                break;
-            case CALLING_V2_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "0")
-                    .apply();
-                break;
-            case CALLING_BE_SWITCH:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "1")
-                    .apply();
-                break;
-            case CALLING_V3_INTENT:
-                preferences.edit()
-                    .putString(context.getString(R.string.pref_dev_calling_v3_key), "2")
                     .apply();
                 break;
             case SILENT_MODE:

--- a/wire-core/src/main/res/values/arrays.xml
+++ b/wire-core/src/main/res/values/arrays.xml
@@ -161,16 +161,5 @@
         <item>0</item>
         <item>113</item>
     </integer-array>
-
-    <string-array name="calling_v3_preferences">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
-    <string-array name="calling_v3_preference_titles">
-        <item>Always use calling v2</item>
-        <item>Rely on backend switch</item>
-        <item>Always use calling v3</item>
-    </string-array>
 </resources>
 

--- a/wire-core/src/main/res/values/strings_no_translate.xml
+++ b/wire-core/src/main/res/values/strings_no_translate.xml
@@ -157,9 +157,6 @@
     <string translatable="false" name="pref_dev_otr_only_summary">Send only encrypted messages</string>
     <string translatable="false" name="pref_dev_version_info_id_key">USER_PREFS_DEV_VERSIONS_ID</string>
     <string translatable="false" name="pref_dev_version_info_id_title">Versions</string>
-    <string translatable="false" name="pref_dev_calling_v3_key">@string/zms_calling_v3</string>
-    <string translatable="false" name="pref_dev_calling_v3_title">Calling v3</string>
-    <string translatable="false" name="pref_dev_calling_v3_dialog_title">Select a calling version</string>
     <string translatable="false" name="pref_dev_net_debug_key">USER_PREFS_DEV_NET_DEBUG_ID</string>
     <string translatable="false" name="pref_dev_net_debug_title">Press for network info</string>
     <string translatable="false" name="pref_dev_net_debug_summary">Do it!</string>


### PR DESCRIPTION
All outgoing calls should be made using calling v3. The developer setting for forcing v2 and backend switch has been taken out. 
What is possible: Make calls with v3
What is not possible: Make calls with v2
#### APK
[Download build #8900](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8900/artifact/build/artifact/wire-dev-PR879-8900.apk)
[Download build #8901](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8901/artifact/build/artifact/wire-dev-PR879-8901.apk)
[Download build #8907](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8907/artifact/build/artifact/wire-dev-PR879-8907.apk)