### PR TITLE
[AN-5259] More versatile colors in Sketch

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -126,9 +126,9 @@ private class IncomingControlsView(val context: Context, val attrs: AttributeSet
 
   private val leftButtonGlyphString = getResources.getString(R.string.glyph__end_call)
   private val leftButtonColor = ContextCompat.getColor(getContext, R.color.accent_red)
-  private val leftButtonPressedColor = ContextCompat.getColor(getContext, R.color.draw_light_red)
+  private val leftButtonPressedColor = ContextCompat.getColor(getContext, R.color.light_red)
   private val rightButtonColor = ContextCompat.getColor(getContext, R.color.accent_green)
-  private val rightButtonPressedColor = ContextCompat.getColor(getContext, R.color.draw_light_green)
+  private val rightButtonPressedColor = ContextCompat.getColor(getContext, R.color.light_green)
 
   private val array = context.getTheme.obtainStyledAttributes(attrs, R.styleable.IncomingControlsLayout, 0, 0)
   private val buttonRadius = array.getDimensionPixelSize(R.styleable.IncomingControlsLayout_buttonDiameter, 0) / 2

--- a/wire-core/src/main/res/values/arrays.xml
+++ b/wire-core/src/main/res/values/arrays.xml
@@ -48,14 +48,14 @@
         <item>@color/accent_orange</item>
         <item>@color/accent_pink</item>
         <item>@color/accent_magenta</item>
-        <item>@color/draw_light_blue</item>
-        <item>@color/draw_light_green</item>
-        <item>@color/draw_light_yellow</item>
-        <item>@color/draw_light_red</item>
-        <item>@color/draw_light_orange</item>
-        <item>@color/draw_light_pink</item>
-        <item>@color/draw_light_purple</item>
-        <item>@color/draw_light_grey</item>
+        <item>@color/draw_mocha</item>
+        <item>@color/draw_brown</item>
+        <item>@color/draw_mustard</item>
+        <item>@color/draw_strawberry</item>
+        <item>@color/draw_maroon</item>
+        <item>@color/draw_sky</item>
+        <item>@color/draw_olive</item>
+        <item>@color/draw_grey</item>
     </array>
 
     <array name="list_unread_indicator_radiuses">

--- a/wire-core/src/main/res/values/colors.xml
+++ b/wire-core/src/main/res/values/colors.xml
@@ -82,15 +82,18 @@
     <!--Sketch color picker-->
     <color name="draw_white">@color/white</color>
     <color name="draw_black">@color/black</color>
-    <color name="draw_light_blue">#96BED6</color>
-    <color name="draw_light_green">#A3EBA3</color>
-    <color name="draw_light_yellow">#FEE7A3</color>
-    <color name="draw_light_red">#FDA5A5</color>
-    <color name="draw_light_orange">#FFD4A3</color>
-    <color name="draw_light_pink">#FEC4E7</color>
-    <color name="draw_light_purple">#DBA3FE</color>
-    <color name="draw_light_grey">#A3A3A3</color>
+    <color name="draw_mocha">#B05701</color>
+    <color name="draw_brown">#613102</color>
+    <color name="draw_mustard">#E4BC46</color>
+    <color name="draw_strawberry">#E75177</color>
+    <color name="draw_maroon">#941751</color>
+    <color name="draw_sky">#6EA6BF</color>
+    <color name="draw_olive">#999647</color>
+    <color name="draw_grey">#707070</color>
     <color name="draw_disabled">@color/light_graphite</color>
+
+    <color name="light_green">#A3EBA3</color>
+    <color name="light_red">#FDA5A5</color>
 
     <color name="yorgos">#FF4A4A4A</color>
 

--- a/wire-ui/src/main/res/drawable/selector__icon_button__background__green.xml
+++ b/wire-ui/src/main/res/drawable/selector__icon_button__background__green.xml
@@ -22,7 +22,7 @@
 
     <item android:state_pressed="true">
         <shape android:shape="oval">
-            <solid android:color="@color/draw_light_green" />
+            <solid android:color="@color/light_green" />
         </shape>
     </item>
     <item>

--- a/wire-ui/src/main/res/drawable/selector__icon_button__background__red.xml
+++ b/wire-ui/src/main/res/drawable/selector__icon_button__background__red.xml
@@ -22,7 +22,7 @@
 
     <item android:state_pressed="true">
         <shape android:shape="oval">
-            <solid android:color="@color/draw_light_red" />
+            <solid android:color="@color/light_red" />
         </shape>
     </item>
     <item>


### PR DESCRIPTION
Changed available colours in Sketch. Please update automation tests to check for the new colours!

### Removed colours:
* draw_light_blue
* draw_light_green
* draw_light_yellow
* draw_light_red
* draw_light_orange
* draw_light_pink
* draw_light_purple
* draw_light_grey

### Added colours:
* mocha
* brown
* mustard
* strawberry
* maroon
* sky
* olive
* grey

### Full list of available colours:
* black 0, 0, 0, 1
* white 1, 1, 1, 1
* blue 0.137, 0.568, 0.827, 1
* green 0, 0.784, 0, 1
* yellow 0.996, 0.749, 0.007, 1
* red 0.984, 0.031, 0.027, 1
* orange 1, 0.537, 0, 1
* pink 0.996, 0.368, 0.741, 1
* purple 0.611, 0, 0.996, 1
* mocha 0.688, 0.342, 0.002, 1
* brown 0.381, 0.192, 0.006, 1
* mustard 0.894, 0.735, 0.274, 1
* strawberry 0.905, 0.317, 0.466, 1
* maroon 0.58, 0.088, 0.318, 1
* sky 0.431, 0.65, 0.749, 1
* olive 0.6, 0.588, 0.278, 1
* grey 0.44, 0.44, 0.44, 1
#### APK
[Download build #8902](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8902/artifact/build/artifact/wire-dev-PR880-8902.apk)
[Download build #8904](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8904/artifact/build/artifact/wire-dev-PR880-8904.apk)