### PR TITLE
[AN-5146] Ask to share contacts when opening personal start ui

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
@@ -25,10 +25,13 @@ import java.util.Set;
 
 public interface IUserPreferencesController {
 
-    @IntDef(SEND_LOCATION_MESSAGE)
+    @IntDef({SEND_LOCATION_MESSAGE,
+             LIKED_MESSAGE,
+             DO_NOT_SHOW_SHARE_CONTACTS_DIALOG})
     @interface Action { }
     int SEND_LOCATION_MESSAGE = 0;
     int LIKED_MESSAGE = 1;
+    int DO_NOT_SHOW_SHARE_CONTACTS_DIALOG = 2;
 
     void tearDown();
 

--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
@@ -20,10 +20,8 @@ package com.waz.zclient.controllers.userpreferences;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import com.waz.zclient.R;
 import com.waz.zclient.utils.StringUtils;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -290,7 +288,7 @@ public class UserPreferencesController implements IUserPreferencesController {
 
     @Override
     public boolean hasShareContactsEnabled() {
-        return userPreferences.getBoolean(context.getString(R.string.pref_share_contacts_key), true);
+        return userPreferences.getBoolean(context.getString(R.string.pref_share_contacts_key), false);
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
@@ -509,15 +509,13 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
                 if (fragment == null ||
                     !(fragment instanceof PickUserFragment)) {
                     getControllerFactory().getOnboardingController().incrementPeoplePickerShowCount();
-
-                    PickUserFragment pickUserFragment = PickUserFragment.newInstance(false);
                     getChildFragmentManager()
                         .beginTransaction()
                         .setCustomAnimations(R.anim.slide_in_from_bottom_pick_user,
                                              R.anim.open_new_conversation__thread_list_out,
                                              R.anim.open_new_conversation__thread_list_in,
                                              R.anim.slide_out_to_bottom_pick_user)
-                        .replace(R.id.fl__conversation_list_main, pickUserFragment, PickUserFragment.TAG)
+                        .replace(R.id.fl__conversation_list_main, PickUserFragment.newInstance(false), PickUserFragment.TAG)
                         .addToBackStack(PickUserFragment.TAG)
                         .commit();
                 }

--- a/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
@@ -136,7 +136,7 @@ public class OptionsPreferences extends BasePreferenceFragment<OptionsPreference
             String stringValue = sharedPreferences.getString(key, "");
             boolean wifiOnly = stringValue.equals(getContext().getString(R.string.zms_image_download_value_wifi));
             event = new ChangedImageDownloadPreferenceEvent(wifiOnly);
-        } else if (key.equals(getString(R.string.pref_options_contacts_key))) {
+        } else if (key.equals(getString(R.string.pref_share_contacts_key))) {
             boolean shareContacts = sharedPreferences.getBoolean(key, false);
             event = new ChangedContactsPermissionEvent(shareContacts, true);
             boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
@@ -202,12 +202,13 @@ public class OptionsPreferences extends BasePreferenceFragment<OptionsPreference
 
     @Override
     public void onRequestPermissionsResult(int requestCode, int[] grantResults) {
-        if (requestCode == PermissionUtils.REQUEST_READ_CONTACTS &&
-            grantResults.length > 0 &&
-            grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            boolean oldConfig = getControllerFactory().getUserPreferencesController().hasShareContactsEnabled();
-            getControllerFactory().getUserPreferencesController().setShareContactsEnabled(!oldConfig);
-            getControllerFactory().getUserPreferencesController().setShareContactsEnabled(oldConfig);
+        if (requestCode == PermissionUtils.REQUEST_READ_CONTACTS) {
+            getControllerFactory().getUserPreferencesController().setShareContactsEnabled(false);
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                //Changing the value of the shareContacts seems to be the
+                //only way to trigger a refresh on the sync engine...
+                getControllerFactory().getUserPreferencesController().setShareContactsEnabled(true);
+            }
         }
     }
 }

--- a/app/src/main/res/layout/dialog_checkbox.xml
+++ b/app/src/main/res/layout/dialog_checkbox.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Wire
+  ~ Copyright (C) 2016 Wire Swiss GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see http://www.gnu.org/licenses/.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="fill_parent"
+             android:layout_height="wrap_content" >
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/wire__padding__regular"
+        android:layout_marginEnd="@dimen/wire__padding__regular"
+        android:layout_marginTop="@dimen/wire__padding__small"
+        style="?android:attr/textAppearanceSmall"
+        />
+
+</FrameLayout>

--- a/app/src/main/res/xml/preferences_options.xml
+++ b/app/src/main/res/xml/preferences_options.xml
@@ -24,7 +24,7 @@
 
     <SwitchPreference
         android:defaultValue="true"
-        android:key="@string/pref_options_contacts_key"
+        android:key="@string/pref_share_contacts_key"
         android:title="@string/pref_options_contacts_title"
         android:summary="@string/pref_options_contacts_summary"
         />

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     playServicesVersion = '10.0.1'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '99.1506'
+    zMessagingDevVersionBase = '99.1513'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '99.5.359@aar'

--- a/wire-core/src/main/res/values/strings.xml
+++ b/wire-core/src/main/res/values/strings.xml
@@ -149,6 +149,13 @@
     <string name="people_picker__toolbar_header__one_to_one">Create group</string>
     <string name="people_picker__search_result__expander_title">Show all %1$s ↓</string>
 
+    <!-- start ui / people picker, contacts sharing -->
+    <string name="people_picker__share_contacts__title">Share Contacts</string>
+    <string name="people_picker__share_contacts__message">Wire helps you find your friends if you share your contacts.</string>
+    <string name="people_picker__share_contacts__yay">Allow</string>
+    <string name="people_picker__share_contacts__nah">Deny</string>
+    <string name="people_picker__share_contacts__nevvah">Never ask again</string>
+
     <!-- People you may know -->
     <string name="people_picker__recommended__common_connections__one">Knows %1$s</string>
     <string name="people_picker__recommended__common_connections__two">Knows %1$s and %2$s</string>

--- a/wire-core/src/main/res/values/strings_no_translate.xml
+++ b/wire-core/src/main/res/values/strings_no_translate.xml
@@ -82,7 +82,6 @@
     <string translatable="false" name="pref_account_theme_key">pref_theme_key</string>
     <string translatable="false" name="pref_options_theme_switch_key">pref_theme_switch_key</string>
     <string translatable="false" name="pref_options_cursor_send_button_key">pref_cursor_send_button_key</string>
-    <string translatable="false" name="pref_options_contacts_key">@string/pref_share_contacts_key</string>
     <string translatable="false" name="pref_options_vbr_key">pref_options_vbr_key</string>
     <string translatable="false" name="pref_options_devices_key">pref_privacy_devices_key</string>
     <string translatable="false" name="pref_devices_current_device_category_key">pref_current_device_category_key</string>


### PR DESCRIPTION
Always ask use for permission to sync hashed contact details for user matching. 
For Android  4.x and 5.x we already have permission to access contact details, but we want to explicitly ask user for this. Once user opens start UI a dialog is shown asking for permission to access contacts. For Android 4.x and 5.x we use our own dialog, for Android 6.x and up, we just trigger the default permission dialog.
The dialog will be shown on every start UI launch, until user either says yes to sharing, or ticks the "do not show again" checkbox. 
For existing users that haven't touched the share contacts setting, we will show this dialog. For existing users who have set the share contacts preference to true, we will not show the dialog.
Please see ticket for more details and reasoning for this behaviour. 
#### APK
[Download build #8923](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8923/artifact/build/artifact/wire-dev-PR889-8923.apk)