### PR TITLE
[AN-5315] ephemeral images visible in fullscreen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/AssetsController.scala
@@ -126,11 +126,11 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
       observer.clear()
       imObserver.clear()
     }
-    p.future foreach { m =>
+    p.future.foreach( m => if (!(m.isEphemeral && m.isExpired)) {
       verbose(s"message loaded, opening single image for $m")
       singleImage.setViewReferences(container)
       singleImage.showSingleImage(m)
-    }
+    })
   }
 
   //FIXME: don't use java api

--- a/app/src/main/scala/com/waz/zclient/fragments/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/fragments/ImageFragment.scala
@@ -190,6 +190,7 @@ class ImageFragment extends BaseFragment[ImageFragment.Container] with FragmentH
   }
 
   override def onBackPressed() = {
+    collectionController.focusedItem ! None
     false
   }
 


### PR DESCRIPTION
When you tap an ephemeral image, it opens in fullscreen but the app does not allow the user to swipe to see other images, as is the case with non-ephemeral photos.
When the time is out and the image is obfuscated (turns into a blue rectangle) tapping does not work anymore (but a long tap still opens the menu).
#### APK
[Download build #8982](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8982/artifact/build/artifact/wire-dev-PR916-8982.apk)
[Download build #8993](http://192.168.10.18:8080/job/Pull%20Request%20Builder/8993/artifact/build/artifact/wire-dev-PR916-8993.apk)
[Download build #9000](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9000/artifact/build/artifact/wire-dev-PR916-9000.apk)