### PR TITLE
[AN-5331] Internal Log

### DIFF
--- a/app/src/main/java/com/waz/zclient/WireUncaughtExceptionHandler.java
+++ b/app/src/main/java/com/waz/zclient/WireUncaughtExceptionHandler.java
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient;
 
+import com.waz.log.InternalLog;
 import com.waz.zclient.controllers.IControllerFactory;
 
 class WireUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
@@ -49,5 +50,6 @@ class WireUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
         if (defaultUncaughtExceptionHandler != null) {
             defaultUncaughtExceptionHandler.uncaughtException(thread, throwable);
         }
+        InternalLog.flush();
     }
 }

--- a/app/src/main/java/com/waz/zclient/ZApplication.java
+++ b/app/src/main/java/com/waz/zclient/ZApplication.java
@@ -24,7 +24,7 @@ import android.support.annotation.Nullable;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 import com.localytics.android.Localytics;
 import com.localytics.android.LocalyticsActivityLifecycleCallbacks;
-import com.waz.api.LogLevel;
+import com.waz.api.impl.LogLevel;
 import com.waz.api.impl.AccentColors;
 import com.waz.zclient.controllers.IControllerFactory;
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController;
@@ -120,7 +120,7 @@ public class ZApplication extends WireApplication implements ServiceContainer {
                                        .getBoolean(context.getString(R.string.pref_force_verbose_key), false);
         if (com.waz.zclient.BuildConfig.DEBUG || forceVerbose) {
             Timber.plant(new Timber.DebugTree());
-            LogLevel.setMinimumLogLevel(LogLevel.VERBOSE);
+            LogLevel.setMinimumLogLevel(android.util.Log.VERBOSE);
         } else {
             Timber.plant(new WireLoggerTree());
             LogLevel.setMinimumLogLevel(BuildConfigUtils.getLogLevelSE(context));

--- a/app/src/main/java/com/waz/zclient/utils/BuildConfigUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/BuildConfigUtils.java
@@ -23,7 +23,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Environment;
 import com.waz.api.AvsLogLevel;
-import com.waz.api.LogLevel;
 import com.waz.zclient.BuildConfig;
 import com.waz.zclient.R;
 import timber.log.Timber;
@@ -60,26 +59,26 @@ public class BuildConfigUtils {
         return false;
     }
 
-    public static LogLevel getLogLevelSE(Context context) {
+    public static int getLogLevelSE(Context context) {
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_supress)) {
-            return LogLevel.SUPPRESS;
+            return Integer.MAX_VALUE;
         }
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_verbose)) {
-            return LogLevel.VERBOSE;
+            return android.util.Log.VERBOSE;
         }
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_debug)) {
-            return LogLevel.DEBUG;
+            return android.util.Log.DEBUG;
         }
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_info)) {
-            return LogLevel.INFO;
+            return android.util.Log.INFO;
         }
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_warn)) {
-            return LogLevel.WARN;
+            return android.util.Log.WARN;
         }
         if (BuildConfig.LOG_LEVEL_SE == context.getResources().getInteger(R.integer.log_level_error)) {
-            return LogLevel.ERROR;
+            return android.util.Log.ERROR;
         }
-        return LogLevel.ASSERT;
+        return android.util.Log.ASSERT;
 
     }
 

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -25,6 +25,7 @@ import android.support.annotation.NonNull
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import com.waz.api.{Permission, PermissionProvider}
+import com.waz.log.InternalLog
 import com.waz.zclient.common.controllers.PermissionActivity
 import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.core.stores.IStoreFactory
@@ -76,6 +77,7 @@ class BaseActivity extends AppCompatActivity
       started = false
     }
     getStoreFactory.getZMessagingApiStore.getApi.removePermissionProvider(this)
+    InternalLog.flush()
     super.onStop()
   }
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -21,9 +21,11 @@ import android.os.Build
 import android.renderscript.RenderScript
 import android.support.multidex.MultiDexApplication
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.verbose
-import com.waz.api.{NetworkMode, ZMessagingApi, ZMessagingApiFactory}
+import com.waz.ZLog.{debug, verbose}
+import com.waz.api
+import com.waz.api.{NetworkMode, ZMessagingApi, ZMessagingApiFactory, ZmsVersion}
 import com.waz.content.GlobalPreferences
+import com.waz.log.InternalLog
 import com.waz.service.{MediaManagerService, NetworkModeService, ZMessaging}
 import com.waz.utils.events.{EventContext, Signal, Subscription}
 import com.waz.zclient.api.scala.ScalaStoreFactory
@@ -149,6 +151,11 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
   override def onCreate(): Unit = {
     super.onCreate()
+
+    if (ZmsVersion.DEBUG) {
+      InternalLog.init(getApplicationContext.getApplicationInfo.dataDir)
+    }
+
     verbose("onCreate")
     controllerFactory = new DefaultControllerFactory(getApplicationContext)
 
@@ -183,6 +190,9 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     } else {
       inject[RenderScript].destroy()
     }
+
+    InternalLog.flush()
+
     super.onTerminate()
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '101.1558'
+    zMessagingDevVersionBase = '101.1560'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '101.2.370@aar'


### PR DESCRIPTION
* Needs https://github.com/wireapp/wire-android-sync-engine/pull/160
* Initializes InternalLog on WireApplication onCreate
* Flushes in WireApplication.onTerminate, BaseActivity.onStop, and WireUncaughtExceptionHandler
* com.waz.api.LogLevel is deleted
I didn't add a flush in HockeyCrashReporting, but maybe it would be a good idea too.
#### APK
[Download build #9051](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9051/artifact/build/artifact/wire-dev-PR939-9051.apk)
[Download build #9052](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9052/artifact/build/artifact/wire-dev-PR939-9052.apk)
[Download build #9053](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9053/artifact/build/artifact/wire-dev-PR939-9053.apk)