### PR TITLE
[AN-5398] share contacts disabled when on a team account

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
@@ -57,6 +57,7 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
     private RingtonePreference textTonePreference;
     private RingtonePreference pingPreference;
     private SwitchPreference themePreference;
+    private SwitchPreference shareContactsPreference;
 
     public static OptionsPreferences newInstance(String rootKey, Bundle extras) {
         OptionsPreferences f = new OptionsPreferences();
@@ -78,6 +79,10 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
         textTonePreference.setShowSilent(true);
         pingPreference.setShowSilent(true);
         setDefaultRingtones();
+
+        shareContactsPreference = (SwitchPreference) findPreference(getString(R.string.pref_share_contacts_key));
+        UserAccountsController ctrl = injectJava(UserAccountsController.class);
+        shareContactsPreference.setVisible(!ctrl.isTeamAccount());
 
         bindPreferenceSummaryToValue(ringtonePreference);
         bindPreferenceSummaryToValue(textTonePreference);
@@ -138,14 +143,11 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
             boolean wifiOnly = stringValue.equals(getContext().getString(R.string.zms_image_download_value_wifi));
             event = new ChangedImageDownloadPreferenceEvent(wifiOnly);
         } else if (key.equals(getString(R.string.pref_share_contacts_key))) {
-            UserAccountsController ctrl = injectJava(UserAccountsController.class);
-            if (ctrl != null && !ctrl.isTeamAccount()) {
-                boolean shareContacts = sharedPreferences.getBoolean(key, false);
-                event = new ChangedContactsPermissionEvent(shareContacts, true);
-                boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
-                if (shareContacts && !hasContactsReadPermission) {
-                    ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
-                }
+            boolean shareContacts = sharedPreferences.getBoolean(key, false);
+            event = new ChangedContactsPermissionEvent(shareContacts, true);
+            boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
+            if (shareContacts && !hasContactsReadPermission) {
+                ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
             }
         } else if (key.equals(getString(R.string.pref_options_theme_switch_key))) {
             getControllerFactory().getThemeController().toggleThemePending(true);

--- a/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
@@ -82,8 +82,10 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
 
         shareContactsPreference = (SwitchPreference) findPreference(getString(R.string.pref_share_contacts_key));
         UserAccountsController ctrl = injectJava(UserAccountsController.class);
-        shareContactsPreference.setVisible(!ctrl.isTeamAccount());
-
+        if (ctrl != null) {
+            shareContactsPreference.setVisible(!ctrl.isTeamAccount());
+        }
+        
         bindPreferenceSummaryToValue(ringtonePreference);
         bindPreferenceSummaryToValue(textTonePreference);
         bindPreferenceSummaryToValue(pingPreference);
@@ -143,11 +145,14 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
             boolean wifiOnly = stringValue.equals(getContext().getString(R.string.zms_image_download_value_wifi));
             event = new ChangedImageDownloadPreferenceEvent(wifiOnly);
         } else if (key.equals(getString(R.string.pref_share_contacts_key))) {
-            boolean shareContacts = sharedPreferences.getBoolean(key, false);
-            event = new ChangedContactsPermissionEvent(shareContacts, true);
-            boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
-            if (shareContacts && !hasContactsReadPermission) {
-                ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
+            UserAccountsController ctrl = injectJava(UserAccountsController.class);
+            if (ctrl != null && !ctrl.isTeamAccount()) {
+                boolean shareContacts = sharedPreferences.getBoolean(key, false);
+                event = new ChangedContactsPermissionEvent(shareContacts, true);
+                boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
+                if (shareContacts && !hasContactsReadPermission) {
+                    ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
+                }
             }
         } else if (key.equals(getString(R.string.pref_options_theme_switch_key))) {
             getControllerFactory().getThemeController().toggleThemePending(true);

--- a/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/preferences/OptionsPreferences.java
@@ -30,6 +30,7 @@ import android.support.v7.preference.PreferenceCategory;
 import com.waz.zclient.BaseActivity;
 import com.waz.zclient.R;
 import com.waz.zclient.calling.controllers.CallPermissionsController;
+import com.waz.zclient.controllers.UserAccountsController;
 import com.waz.zclient.controllers.permission.RequestPermissionsObserver;
 import com.waz.zclient.core.controllers.tracking.events.Event;
 import com.waz.zclient.core.controllers.tracking.events.settings.ChangedBitRateModeEvent;
@@ -137,11 +138,14 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
             boolean wifiOnly = stringValue.equals(getContext().getString(R.string.zms_image_download_value_wifi));
             event = new ChangedImageDownloadPreferenceEvent(wifiOnly);
         } else if (key.equals(getString(R.string.pref_share_contacts_key))) {
-            boolean shareContacts = sharedPreferences.getBoolean(key, false);
-            event = new ChangedContactsPermissionEvent(shareContacts, true);
-            boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
-            if (shareContacts && !hasContactsReadPermission) {
-                ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
+            UserAccountsController ctrl = injectJava(UserAccountsController.class);
+            if (ctrl != null && !ctrl.isTeamAccount()) {
+                boolean shareContacts = sharedPreferences.getBoolean(key, false);
+                event = new ChangedContactsPermissionEvent(shareContacts, true);
+                boolean hasContactsReadPermission = PermissionUtils.hasSelfPermissions(getContext(), Manifest.permission.READ_CONTACTS);
+                if (shareContacts && !hasContactsReadPermission) {
+                    ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_CONTACTS}, PermissionUtils.REQUEST_READ_CONTACTS);
+                }
             }
         } else if (key.equals(getString(R.string.pref_options_theme_switch_key))) {
             getControllerFactory().getThemeController().toggleThemePending(true);
@@ -201,7 +205,8 @@ public class OptionsPreferences extends BasePreferenceFragment implements Shared
     public void onRequestPermissionsResult(int requestCode, int[] grantResults) {
         if (requestCode == PermissionUtils.REQUEST_READ_CONTACTS) {
             getControllerFactory().getUserPreferencesController().setShareContactsEnabled(false);
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            UserAccountsController ctrl = injectJava(UserAccountsController.class);
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && !ctrl.isTeamAccount()) {
                 //Changing the value of the shareContacts seems to be the
                 //only way to trigger a refresh on the sync engine...
                 getControllerFactory().getUserPreferencesController().setShareContactsEnabled(true);

--- a/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
@@ -27,6 +27,7 @@ import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.utils.Callback
 import com.waz.zclient.{BaseActivity, Injectable, Injector}
+import timber.log.Timber
 
 import scala.concurrent.Future
 
@@ -84,4 +85,5 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
   def hasCreateConversationPermission: Boolean = !isTeamAccount || _permissions(AccountData.Permission.CreateConversation)
   def hasRemoveConversationMemberPermission(convId: ConvId): Boolean = !isTeamAccount || _permissions(AccountData.Permission.RemoveConversationMember)
   def hasAddConversationMemberPermission(convId: ConvId): Boolean = !isTeamAccount || _permissions(AccountData.Permission.AddConversationMember)
+
 }

--- a/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
@@ -27,7 +27,6 @@ import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.utils.Callback
 import com.waz.zclient.{BaseActivity, Injectable, Injector}
-import timber.log.Timber
 
 import scala.concurrent.Future
 

--- a/app/src/main/scala/com/waz/zclient/fragments/PickUserFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/fragments/PickUserFragment.scala
@@ -823,7 +823,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
   }
 
   override def onRequestPermissionsResult(requestCode: Int, grantResults: Array[Int]): Unit = {
-    if (requestCode == PermissionUtils.REQUEST_READ_CONTACTS) {
+    if (requestCode == PermissionUtils.REQUEST_READ_CONTACTS && !userAccountsController.isTeamAccount) {
       getControllerFactory.getUserPreferencesController.setShareContactsEnabled(false)
       if (grantResults.length > 0) {
         if (grantResults(0) == PackageManager.PERMISSION_GRANTED) {
@@ -881,9 +881,10 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
   }
 
   private def requestShareContactsPermissions(): Unit = {
-    if (getControllerFactory == null || getControllerFactory.isTornDown) {
+    if (getControllerFactory == null || getControllerFactory.isTornDown || userAccountsController.isTeamAccount) {
       return
     }
+
     if (PermissionUtils.hasSelfPermissions(getContext, Manifest.permission.READ_CONTACTS)) {
       getControllerFactory.getUserPreferencesController.setShareContactsEnabled(true)
     }


### PR DESCRIPTION
If the user is on a team account, the app should not ask her about sharing contacts and any try to do so should be disabled.

The switch in Options was not removed, as that was not decided yet. The user can switch it manually, but if she's on the team account, it doesn't do anything.
#### APK
[Download build #9142](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9142/artifact/build/artifact/wire-dev-PR982-9142.apk)
[Download build #9144](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9144/artifact/build/artifact/wire-dev-PR982-9144.apk)
[Download build #9153](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9153/artifact/build/artifact/wire-dev-PR982-9153.apk)
[Download build #9155](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9155/artifact/build/artifact/wire-dev-PR982-9155.apk)