### PR TITLE
[AN-5422] stops filtering out old team conversations

### DIFF
--- a/app/src/main/scala/com/waz/zclient/controllers/SearchUserController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/SearchUserController.scala
@@ -98,7 +98,7 @@ class SearchUserController(initialState: SearchState)(implicit injector: Injecto
   } yield convs.filter{ conv =>
     searchState.teamId match {
       case Some(tId) => conv.team.contains(tId)
-      case _ => conv.team.isEmpty
+      case _ => true
     }
   }.distinct
 


### PR DESCRIPTION
A single line change that should be enough to stop filtering out team conversations in private space. However, due to another bug, currently it's quite difficult for me to create a group team conversation and test it. I'll come back to it later.
If you already have an old team conversation, feel free to test it.
#### APK
[Download build #9188](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9188/artifact/build/artifact/wire-dev-PR998-9188.apk)