### PR TITLE
[AN-5416] all connected non-team users are guests

### DIFF
--- a/app/src/main/scala/com/waz/zclient/adapters/PickUsersAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/adapters/PickUsersAdapter.scala
@@ -57,7 +57,7 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
   }
 
   private var topUsers = Seq[UserData]()
-  private var teamMembersAndGuests = Seq[UserData]()
+  private var teamMembers = Seq[UserData]()
   private var conversations = Seq[ConversationData]()
   private var connectedUsers = Seq[UserData]()
   private var contacts = Seq[Contact]()
@@ -65,9 +65,9 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
   private var currentUser = Option.empty[UserData]
 
   searchUserController.allDataSignal.throttle(500.millis).on(Threading.Ui) {
-    case (newTopUsers, newTeamMembersAndGuests, newConversations, newConnectedUsers, newContacts, newDirectoryResults) =>
+    case (newTopUsers, newTeamMembers, newConversations, newConnectedUsers, newContacts, newDirectoryResults) =>
       topUsers = newTopUsers
-      teamMembersAndGuests = newTeamMembersAndGuests
+      teamMembers = newTeamMembers
       conversations = newConversations
       connectedUsers = newConnectedUsers
       contacts = newContacts
@@ -92,11 +92,11 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
       }
     }
 
-    def addTeamMembersAndGuests(): Unit = {
-      if (teamMembersAndGuests.nonEmpty) {
-        mergedResult = mergedResult ++ Seq(SearchResult(SectionHeader, TeamMembersAndGuestsSection, 0, teamName))
-        mergedResult = mergedResult ++ teamMembersAndGuests.indices.map { i =>
-          SearchResult(ConnectedUser, TeamMembersAndGuestsSection, i, teamMembersAndGuests(i).id.str.hashCode)
+    def addTeamMembers(): Unit = {
+      if (teamMembers.nonEmpty) {
+        mergedResult = mergedResult ++ Seq(SearchResult(SectionHeader, TeamMembersSection, 0, teamName))
+        mergedResult = mergedResult ++ teamMembers.indices.map { i =>
+          SearchResult(ConnectedUser, TeamMembersSection, i, teamMembers(i).id.str.hashCode)
         }
       }
     }
@@ -151,7 +151,7 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
     }
 
     if (userAccountsController.isTeamAccount) {
-      addTeamMembersAndGuests()
+      addTeamMembers()
       addGroupConversations()
       addContacts()
     } else {
@@ -177,11 +177,7 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
         val conversation = conversations(item.index)
         holder.asInstanceOf[ConversationViewHolder].bind(conversation)
       case ConnectedUser =>
-        val connectedUser =
-          if (item.section == TeamMembersAndGuestsSection)
-            teamMembersAndGuests(item.index)
-          else
-            connectedUsers(item.index)
+        val connectedUser = if (item.section == TeamMembersSection) teamMembers(item.index) else connectedUsers(item.index)
         val contactIsSelected = searchUserController.selectedUsers.contains(connectedUser.id)
         holder.asInstanceOf[UserViewHolder].bind(connectedUser, contactIsSelected)
       case UnconnectedUser =>
@@ -196,11 +192,7 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
         val contact  = contacts(item.index)
         holder.asInstanceOf[AddressBookContactViewHolder].bind(contact, contactsCallback)
       case Expand =>
-        val itemCount =
-          if (item.section == ContactsSection)
-            contacts.size + connectedUsers.size
-          else
-            conversations.size
+        val itemCount = if (item.section == ContactsSection) contacts.size + connectedUsers.size else conversations.size
         holder.asInstanceOf[SectionExpanderViewHolder].bind(itemCount, new View.OnClickListener() {
           def onClick(v: View): Unit = {
             if (item.section == ContactsSection) expandContacts() else expandGroups()
@@ -268,7 +260,7 @@ object PickUsersAdapter {
 
   //Sections
   val TopUsersSection = 0
-  val TeamMembersAndGuestsSection = 1
+  val TeamMembersSection = 1
   val GroupConversationsSection = 2
   val ContactsSection = 3
   val DirectorySection = 4

--- a/app/src/main/scala/com/waz/zclient/viewholders/SectionHeaderViewHolder.scala
+++ b/app/src/main/scala/com/waz/zclient/viewholders/SectionHeaderViewHolder.scala
@@ -41,7 +41,7 @@ class SectionHeaderViewHolder(val view: View) extends RecyclerView.ViewHolder(vi
           sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_connections_header_title)
         case PickUsersAdapter.DirectorySection =>
           sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_others_header_title)
-        case PickUsersAdapter.TeamMembersAndGuestsSection =>
+        case PickUsersAdapter.TeamMembersSection =>
           teamName
       }
     sectionHeaderView.setText(title)


### PR DESCRIPTION
* Initial search shows team members and connected users. Connected users which are not team members have a "guest" tag.
* Searching team conversations for non-team members is still in the SE code, but is not used in the UI
* A bit of refactoring: `IndexedSeq.empty` instead of `IndexedSeq()`. 
* Users already in the conversation are filtered out
#### APK
[Download build #9197](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9197/artifact/build/artifact/wire-dev-PR1003-9197.apk)
[Download build #9198](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9198/artifact/build/artifact/wire-dev-PR1003-9198.apk)
[Download build #9201](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9201/artifact/build/artifact/wire-dev-PR1003-9201.apk)
[Download build #9202](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9202/artifact/build/artifact/wire-dev-PR1003-9202.apk)
[Download build #9204](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9204/artifact/build/artifact/wire-dev-PR1003-9204.apk)