### PR TITLE
checks if the searched person is a team member or is connected

### DIFF
--- a/app/src/main/scala/com/waz/zclient/adapters/PickUsersAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/adapters/PickUsersAdapter.scala
@@ -181,9 +181,9 @@ class PickUsersAdapter(topUsersOnItemTouchListener: SearchResultOnItemTouchListe
         val contactIsSelected = searchUserController.selectedUsers.contains(connectedUser.id)
         holder.asInstanceOf[UserViewHolder].bind(connectedUser, contactIsSelected)
       case UnconnectedUser =>
-        val connectedUser = directoryResults(item.index)
-        val contactIsSelected = searchUserController.selectedUsers.contains(connectedUser.id)
-        holder.asInstanceOf[UserViewHolder].bind(connectedUser, contactIsSelected)
+        val unconnectedUser = directoryResults(item.index)
+        val contactIsSelected = searchUserController.selectedUsers.contains(unconnectedUser.id)
+        holder.asInstanceOf[UserViewHolder].bind(unconnectedUser, contactIsSelected)
       case SectionHeader =>
         holder.asInstanceOf[SectionHeaderViewHolder].bind(item.section, item.name)
       case NameInitialSeparator =>

--- a/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
@@ -48,6 +48,7 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
 
   private var _teamData = Option.empty[TeamData]
   private var _teamId = Option.empty[TeamId]
+  private var _teamMembers = Set.empty[UserId]
 
   val permissions = for {
     zms <- zms
@@ -66,6 +67,13 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
   teamDataSignal { data => _teamData = data }
 
   def teamData = _teamData
+
+  val teamMembersSignal = for {
+    zms <- zms
+    teamMembers <- Signal.future(zms.teams.searchTeamMembers())
+  } yield teamMembers.map(_.id)
+
+  teamMembersSignal { members => _teamMembers = members }
 
   //Things for java
   //TODO hacky mchackerson - needed for the conversation fragment, remove ASAP
@@ -98,6 +106,7 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
 
   def teamId = _teamId
   def isTeamAccount = _teamId.isDefined
+  def isTeamMember(userId: UserId) = _teamMembers.contains(userId)
 
   //TODO should perhaps clean this up a tad
   private def getTeamId(convId: ConvId): Option[TeamId] = zms.currentValue.flatMap(_.convsStorage.conversations.find(_.id == convId).flatMap(_.team))

--- a/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/controllers/UserAccountsController.scala
@@ -107,7 +107,7 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
   def teamId = _teamId
   def isTeamAccount = _teamId.isDefined
   def isTeamMember(userId: UserId) = _teamMembers.contains(userId)
-
+  
   //TODO should perhaps clean this up a tad
   private def getTeamId(convId: ConvId): Option[TeamId] = zms.currentValue.flatMap(_.convsStorage.conversations.find(_.id == convId).flatMap(_.team))
 

--- a/app/src/main/scala/com/waz/zclient/viewholders/SectionHeaderViewHolder.scala
+++ b/app/src/main/scala/com/waz/zclient/viewholders/SectionHeaderViewHolder.scala
@@ -21,29 +21,22 @@ import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.widget.TextView
 import com.waz.zclient.R
-import com.waz.zclient.adapters.PickUsersAdapter
+import com.waz.zclient.adapters.PickUsersAdapter._
 import com.waz.zclient.utils.ViewUtils
+import com.waz.zclient.utils.ContextUtils._
 
 class SectionHeaderViewHolder(val view: View) extends RecyclerView.ViewHolder(view) {
   private val sectionHeaderView: TextView = ViewUtils.getView(view, R.id.ttv_startui_section_header)
+  private implicit val context = sectionHeaderView.getContext
 
   def bind(section: Int, teamName: String): Unit = {
-    val title: String =
-      section match {
-        case PickUsersAdapter.TopUsersSection =>
-          sectionHeaderView.getContext.getResources.getString(R.string.people_picker__top_users_header_title)
-        case PickUsersAdapter.GroupConversationsSection =>
-          if (teamName.isEmpty)
-            sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_conversations_header_title)
-          else
-            sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_team_conversations_header_title, teamName)
-        case PickUsersAdapter.ContactsSection =>
-          sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_connections_header_title)
-        case PickUsersAdapter.DirectorySection =>
-          sectionHeaderView.getContext.getResources.getString(R.string.people_picker__search_result_others_header_title)
-        case PickUsersAdapter.TeamMembersSection =>
-          teamName
-      }
+    val title: String = section match {
+      case TopUsersSection                                => getString(R.string.people_picker__top_users_header_title)
+      case GroupConversationsSection if teamName.isEmpty  => getString(R.string.people_picker__search_result_conversations_header_title)
+      case GroupConversationsSection                      => getString(R.string.people_picker__search_result_team_conversations_header_title, teamName)
+      case ContactsSection                                => getString(R.string.people_picker__search_result_connections_header_title)
+      case DirectorySection                               => getString(R.string.people_picker__search_result_others_header_title)
+    }
     sectionHeaderView.setText(title)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/views/SearchResultUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/views/SearchResultUserRowView.scala
@@ -46,7 +46,8 @@ class SearchResultUserRowView(val context: Context, val attrs: AttributeSet, val
     z <- inject[Signal[ZMessaging]]
     uId <- userId
     isGuest <- z.teams.isGuest(uId)
-  } yield isGuest
+    knownUsers <- z.users.acceptedOrBlockedUsers
+  } yield isGuest && knownUsers.contains(uId)
 
   var userData = Option.empty[UserData]
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '103.1603'
+    zMessagingDevVersionBase = '103.1607'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '103.1.373@aar'


### PR DESCRIPTION
In the search list, if the user clicks on a contact, we now check if this person is a team member, or a contacted user. Only then we open the conversation window. Otherwise we open the connection request window.
Also AN-5435 fix: The "guest" label right to the contact appears now only if the contact is not a team member, but is a contacted user, when using the team account. Uncontacted users do not have this label.
#### APK
[Download build #9209](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9209/artifact/build/artifact/wire-dev-PR1008-9209.apk)
[Download build #9221](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9221/artifact/build/artifact/wire-dev-PR1008-9221.apk)
[Download build #9224](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9224/artifact/build/artifact/wire-dev-PR1008-9224.apk)
[Download build #9227](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9227/artifact/build/artifact/wire-dev-PR1008-9227.apk)
[Download build #9228](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9228/artifact/build/artifact/wire-dev-PR1008-9228.apk)
[Download build #9231](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9231/artifact/build/artifact/wire-dev-PR1008-9231.apk)