### PR TITLE
[AN-5463] Conversation view is opening after I switch accounts

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
@@ -726,7 +726,6 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
 
     @Override
     public boolean onBackPressed() {
-
         Fragment fragment = getChildFragmentManager().findFragmentByTag(ParticipantsDialogFragment.TAG);
         if (fragment instanceof OnBackPressedListener &&
             ((OnBackPressedListener) fragment).onBackPressed()) {

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/ConversationFragment.java
@@ -455,55 +455,55 @@ public class ConversationFragment extends BaseFragment<ConversationFragment.Cont
         typingIndicatorView = ViewUtils.getView(view, R.id.tiv_typing_indicator_view);
         typingIndicatorView.setCallback(this);
         listView = ViewUtils.getView(view, R.id.messages_list_view);
-            toolbar.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    getControllerFactory().getConversationScreenController().showParticipants(toolbar, false);
-                }
-            });
-            toolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
-                @Override
-                public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_audio_call:
-                            getControllerFactory().getCallingController().startCall(false);
-                            cursorLayout.closeEditMessage(false);
-                            return true;
-                        case R.id.action_video_call:
-                            getControllerFactory().getCallingController().startCall(true);
-                            cursorLayout.closeEditMessage(false);
-                            return true;
-                    }
-                    return false;
-                }
-            });
-            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (cursorLayout == null) {
-                        return;
-                    }
-
+        toolbar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                getControllerFactory().getConversationScreenController().showParticipants(toolbar, false);
+            }
+        });
+        toolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+            switch (item.getItemId()) {
+                case R.id.action_audio_call:
+                    getControllerFactory().getCallingController().startCall(false);
                     cursorLayout.closeEditMessage(false);
-                    getActivity().onBackPressed();
-                    KeyboardUtils.closeKeyboardIfShown(getActivity());
-                }
-            });
+                    return true;
+                case R.id.action_video_call:
+                    getControllerFactory().getCallingController().startCall(true);
+                    cursorLayout.closeEditMessage(false);
+                    return true;
+            }
+            return false;
+            }
+        });
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+            if (cursorLayout == null) {
+                return;
+            }
 
-            leftMenu.setOnMenuItemClickListener(new ActionMenuView.OnMenuItemClickListener() {
-                @Override
-                public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_collection:
-                            getCollectionController().openCollection();
-                            return true;
-                    }
-                    return false;
-                }
-            });
+            cursorLayout.closeEditMessage(false);
+            getActivity().onBackPressed();
+            KeyboardUtils.closeKeyboardIfShown(getActivity());
+            }
+        });
 
-            if (LayoutSpec.isTablet(getContext()) && ViewUtils.isInLandscape(getContext())) {
-                toolbar.setNavigationIcon(null);
+        leftMenu.setOnMenuItemClickListener(new ActionMenuView.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+            switch (item.getItemId()) {
+                case R.id.action_collection:
+                    getCollectionController().openCollection();
+                    return true;
+            }
+            return false;
+            }
+        });
+
+        if (LayoutSpec.isTablet(getContext()) && ViewUtils.isInLandscape(getContext())) {
+            toolbar.setNavigationIcon(null);
         }
 
         conversationLoadingIndicatorViewView = ViewUtils.getView(view, R.id.lbv__conversation__loading_indicator);

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
@@ -117,6 +117,7 @@ public class OptionsMenuFragment extends BaseFragment<OptionsMenuFragment.Contai
         getStoreFactory().getConversationStore().addConversationStoreObserver(this);
 
         String conversationId = getArguments().getString(ARGUMENT_CONVERSATION_ID);
+
         if (!TextUtils.isEmpty(conversationId)) {
             getStoreFactory()
                 .getZMessagingApiStore()

--- a/wire-core/src/main/java/com/waz/zclient/core/api/scala/ScalaConversationStore.java
+++ b/wire-core/src/main/java/com/waz/zclient/core/api/scala/ScalaConversationStore.java
@@ -160,6 +160,7 @@ public class ScalaConversationStore implements IConversationStore {
 
         if (conversationsList != null) {
             conversationsList.removeUpdateListener(conversationListUpdateListener);
+            conversationsList.setSelectedConversation(null);
             conversationsList = null;
         }
 
@@ -240,18 +241,18 @@ public class ScalaConversationStore implements IConversationStore {
 
     @Override
     public void setCurrentConversationToNext(ConversationChangeRequester requester) {
-        if (getNextConversation() == null) {
-            return;
+        IConversation nextConv = getNextConversation();
+        if (nextConv != null) {
+            setCurrentConversation(nextConv, requester);
         }
-        setCurrentConversation(getNextConversation(), requester);
     }
 
     @Override
     public IConversation getNextConversation() {
-        if (conversationsList == null ||
-            conversationsList.size() == 0) {
+        if (conversationsList == null || conversationsList.size() == 0) {
             return null;
         }
+
         for (int i = 0; i < conversationsList.size(); i++) {
             IConversation previousConversation = i >= 1 ? conversationsList.get(i - 1) : null;
             IConversation conversation = conversationsList.get(i);
@@ -493,7 +494,6 @@ public class ScalaConversationStore implements IConversationStore {
     protected void notifyCurrentConversationHasChanged(IConversation fromConversation,
                                                        IConversation toConversation,
                                                        ConversationChangeRequester conversationChangerSender) {
-
         for (ConversationStoreObserver conversationStoreObserver : conversationStoreObservers) {
             conversationStoreObserver.onCurrentConversationHasChanged(fromConversation,
                                                                       toConversation,
@@ -521,15 +521,9 @@ public class ScalaConversationStore implements IConversationStore {
                     }
                 }
             }
-
-            // TODO: AN-2974
-            if (conversationsList.size() > 0) {
-                setCurrentConversation(conversationsList.get(0), ConversationChangeRequester.FIRST_LOAD);
-                return;
-            }
+        } else {
+            setCurrentConversation(selectedConversation, ConversationChangeRequester.FIRST_LOAD);
         }
-
-        setCurrentConversation(selectedConversation, ConversationChangeRequester.FIRST_LOAD);
     }
 
     private boolean isPendingIncomingConnectRequest(IConversation conversation) {


### PR DESCRIPTION
Removed the old fix to AN-2974 - seems to be not longer necessary. Thus decreased the number of calls to `ScalaConversationStore.setCurrentConversation` with the `selectedConversation` other than `null`.

In the near future it would be nice to rewrite `ScalaConversationStore` to Scala and then remove unnecessary code from `Conversations` and `ConversationsList` in SE.

Also fixed indentation in `ConversationFragment`.
#### APK
[Download build #9249](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9249/artifact/build/artifact/wire-dev-PR1020-9249.apk)
[Download build #9264](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9264/artifact/build/artifact/wire-dev-PR1020-9264.apk)