### PR TITLE
Bump AVS to 3.6.28. Includes refactor of CBR.

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -466,12 +466,12 @@ class MainActivity extends BaseActivity
         getString(R.string.group_calling_cancel),
         new DialogInterface.OnClickListener() {
           def onClick(dialog: DialogInterface, which: Int) = {
-            callPermissionController.startCall(new ConvId(c.getId), withVideo, getControllerFactory.getUserPreferencesController.isVariableBitRateEnabled)
+            callPermissionController.startCall(new ConvId(c.getId), withVideo)
           }
       }, null)
 
     case c =>
-      callPermissionController.startCall(new ConvId(c.getId), withVideo, getControllerFactory.getUserPreferencesController.isVariableBitRateEnabled)
+      callPermissionController.startCall(new ConvId(c.getId), withVideo)
   }
 
   private def cannotStartGSM() =

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallPermissionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallPermissionsController.scala
@@ -53,18 +53,13 @@ class CallPermissionsController(implicit inj: Injector, cxt: WireContext) extend
     * already an ongoing call, the withVideo and variableBitRate flags will be ignored by the
     * underlying service
     */
-  def startCall(convId: ConvId, withVideo: Boolean = false, variableBitRate: Boolean = false): Unit = {
+  def startCall(convId: ConvId, withVideo: Boolean = false): Unit = {
     convIdOpt.head.map(_.isDefined).map { incoming =>
       permissionsController.requiring(if (withVideo) Set(CameraPermission, RecordAudioPermission) else Set(RecordAudioPermission)) {
-        if (!incoming) setVariableBitRateMode(variableBitRate)
         callingService.head.map(_.startCall(convId, withVideo))
       }(R.string.calling__cannot_start__title, if (withVideo) R.string.calling__cannot_start__no_video_permission__message else R.string.calling__cannot_start__no_permission__message,
         if (incoming) callingService.head.map(_.endCall(convId)))
     }
   }
 
-  def setVariableBitRateMode(enabled: Boolean): Unit = {
-    val cbrOn = if(enabled) 0 else 1 // in SE it's reversed: we DISABLE cbr instead of enabling vbr and vice versa
-    callingService.head.map(_.setAudioConstantBitRateEnabled(cbrOn))
-  }
 }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CurrentCallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CurrentCallController.scala
@@ -199,10 +199,9 @@ class CurrentCallController(implicit inj: Injector, cxt: WireContext) extends In
       case (s, cId) => s.setVideoSendActive(cId, if(state == SEND) false else true)
     }
   }
-
-  val vbrEnabled: Signal[String] = callingService.flatMap(_.otherSideCBR).map {
+  val cbrEnabled: Signal[String] = callingService.flatMap(_.currentCall.map(_.fold(false)(_.isCbrEnabled))).map {
     case false => ""
-    case true => "" // TODO re-enable CBR when avs is fixed cxt.getString(R.string.audio_message__constant_bit_rate)
+    case true => cxt.getString(R.string.audio_message__constant_bit_rate)
   }
 
   val speakerButton = ButtonSignal(zms.map(_.mediamanager), zms.flatMap(_.mediamanager.isSpeakerOn)) {

--- a/app/src/main/scala/com/waz/zclient/calling/views/HeaderLayoutVideo.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/HeaderLayoutVideo.scala
@@ -45,7 +45,7 @@ class HeaderLayoutAudio(val context: Context, val attrs: AttributeSet, val defSt
 
   controller.glob.conversationName.on(Threading.Ui)(nameView.setText)
 
-  controller.vbrEnabled.on(Threading.Ui)(bitRateModeView.setText)
+  controller.cbrEnabled.on(Threading.Ui)(bitRateModeView.setText)
 
 }
 

--- a/app/src/main/scala/com/waz/zclient/pages/main/profile/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/profile/preferences/pages/OptionsView.scala
@@ -88,7 +88,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   contactsSwitch.setPreference(ShareContacts)
   darkThemeSwitch.setPreference(DarkTheme)
   downloadImagesSwitch.setPreference(DownloadImagesAlways)
-// TODO re-enable CBR after avs fix: vbrSwitch.setPreference(VBREnabled)
+  // TODO re-enable CBR after avs fix: vbrSwitch.setPreference(VBREnabled)
   vbrSwitch.setChecked(true) //true for vbr
   vbrSwitch.setDisabled(true)
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,10 +76,10 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '109.1728'
+    zMessagingDevVersionBase = '111.1731'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
-    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '110.0.403@aar'
+    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '111.1.405@aar'
 
     avsVersion = '3.4.100@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
@@ -87,7 +87,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '3.6.17@aar'
+    customAvsVersion = '3.6.36@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
Relevant API changes:

1. New parameters in wcall_create:
- wcall_video_state_change_h
- wcall_audio_cbr_change_h

2. wcall_set_video_state_handler and wcall_set_audio_cbr_enabled_handler removed (use wcall_create params instead)

3. audio_cbr parameter added to wcall_start and wcall_answer. The audio_cbr parameter needs to be provided from the respective account setting for every call. Group calls will also set CBR but it will never be displayed on screen as there is no knowledge about CBR settings between remote participants.