### PR TITLE
[AN-5486] Makes MessagesListAdapter and RecyclerCursor rely less on variables

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/IndexWindow.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/IndexWindow.scala
@@ -43,15 +43,15 @@ class IndexWindow(cursor: RecyclerCursor, notifier: RecyclerNotifier, size: Int 
 
   private val ord = implicitly[Ordering[Entry]]
 
-  var data = IndexedSeq.empty[Entry]
-  var totalCount = 0
+  private var data = IndexedSeq.empty[Entry]
+  private var totalCount = 0
 
-  var offset = 0
+  private var offset = 0
 
   def shouldReload(position: Int): Boolean = offset > math.max(0, position - 25) || offset + data.length < math.min(cursor.count, position + 25)
 
   // moves window to specified position, this doesn't generate any notifications, as underlying data didn't really change
-  def reload(c: MessagesCursor, position: Int) = {
+  def reload(c: MessagesCursor, position: Int): Unit = {
     offset = math.max(0, position - 50)
     data = c.getEntries(offset, math.min(cursor.count - offset, 100)).toIndexedSeq
     val size = c.size

--- a/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
@@ -56,7 +56,7 @@ extends RecyclerView.Adapter[QuickReplyContentAdapter.ViewHolder] with Injectabl
   cursor.on(Threading.Ui) { case (c, tpe) =>
     if (!messages.contains(c)) {
       verbose(s"cursor changed: ${c.count}")
-      unreadIndex = c.lastReadIndex() + 1
+      unreadIndex = c.lastReadIndex + 1
       messages.foreach(_.close())
       messages = Some(c)
       convType = tpe
@@ -77,7 +77,7 @@ extends RecyclerView.Adapter[QuickReplyContentAdapter.ViewHolder] with Injectabl
 
     override def notifyDataSetChanged() = {
       messages foreach { c =>
-        unreadIndex = c.lastReadIndex() + 1
+        unreadIndex = c.lastReadIndex + 1
       }
       adapter.notifyDataSetChanged()
     }


### PR DESCRIPTION
This PR is the result of my experiments with MessagesListAdapter and RecyclerCursor. I was not able to reproduce the  bug, but I made the code a little tidier, using vals and signals where possible. The adapter's `positionForMessage` is now working on the UI's thread, instead of Background. The `isLastSelf` flag in the `MsgBindOptions` is now set on `Threading.Ui` as well.
 
If this is not enough (I suspect not) then I would suggest to wait for the conversation refactoring PR and then try to reproduce the bug. 

I made a slight mistake when merging together my temporary commits of this PR and merged one too many: a minor bump commit by Dean. That's why the PR shows Dean as the author.
#### APK
[Download build #9678](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9678/artifact/build/artifact/wire-dev-PR1217-9678.apk)
[Download build #9752](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9752/artifact/build/artifact/wire-dev-PR1217-9752.apk)