### PR TITLE
[AN-5785] Opening Wire from a notification sometimes leads to a wrong conversation

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
@@ -85,6 +85,7 @@ import com.waz.zclient.utils.LayoutSpec;
 import com.waz.zclient.utils.ViewUtils;
 import com.waz.zclient.views.LoadingIndicatorView;
 import com.waz.zclient.views.menus.ConfirmationMenu;
+import timber.log.Timber;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -351,6 +352,7 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
     @Override
     public void showIncomingPendingConnectRequest(IConversation conversation) {
         getControllerFactory().getPickUserController().hidePickUser(getCurrentPickerDestination(), false);
+        Timber.i("showIncomingPendingConnectRequest %s", conversation.getId());
         inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.INBOX);
     }
 
@@ -368,6 +370,7 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
             User user = users.get(0);
             IConversation conversation = user.getConversation();
             if (conversation != null) {
+                Timber.i("onSelectedUsers %s", conversation.getId());
                 inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), requester);
             }
         } else {
@@ -549,11 +552,13 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
 
     @Override
     public void onAcceptedConnectRequest(IConversation conversation) {
+        Timber.i("onAcceptedConnectRequest %s", conversation.getId());
         inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.START_CONVERSATION);
     }
 
     @Override
     public void onAcceptedPendingOutgoingConnectRequest(IConversation conversation) {
+        Timber.i("onAcceptedPendingOutgoingConnectRequest %s", conversation.getId());
         inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.CONNECT_REQUEST_ACCEPTED);
     }
 
@@ -566,6 +571,7 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
     @Override
     public void onUnblockedUser(IConversation restoredConversationWithUser) {
         getControllerFactory().getPickUserController().hideUserProfile();
+        Timber.i("onUnblockedUser %s", restoredConversationWithUser.getId());
         inject(ConversationController.class).selectConv(new ConvId(restoredConversationWithUser.getId()), ConversationChangeRequester.START_CONVERSATION);
     }
 
@@ -965,11 +971,13 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
     }
 
     public void callConversation(ConvId convId) {
+        Timber.i("callConversation %s", convId.str());
         inject(ConversationController.class).selectConv(convId, ConversationChangeRequester.CONVERSATION_LIST);
         getControllerFactory().getCallingController().startCall(false);
     }
 
     public void sendPictureToConversation(ConvId convId) {
+        Timber.i("endPictureToConversation %s", convId.str());
         inject(ConversationController.class).selectConv(convId, ConversationChangeRequester.CONVERSATION_LIST);
         getControllerFactory().getCameraController().openCamera(CameraContext.MESSAGE);
     }

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationpager/SecondPageFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationpager/SecondPageFragment.java
@@ -273,11 +273,13 @@ public class SecondPageFragment extends BaseFragment<SecondPageFragment.Containe
 
     @Override
     public void onAcceptedConnectRequest(IConversation conversation) {
+        Timber.i("onAcceptedConnectRequest %s", conversation.getId());
         inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.CONVERSATION_LIST);
     }
 
     @Override
     public void onAcceptedPendingOutgoingConnectRequest(IConversation conversation) {
+        Timber.i("onAcceptedPendingOutgoingConnectRequest %s", conversation.getId());
         inject(ConversationController.class).selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.CONNECT_REQUEST_ACCEPTED);
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantBodyFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantBodyFragment.java
@@ -65,6 +65,7 @@ import com.waz.zclient.utils.ViewUtils;
 import com.waz.zclient.views.images.ImageAssetImageView;
 import com.waz.zclient.views.menus.FooterMenu;
 import com.waz.zclient.views.menus.FooterMenuCallback;
+import timber.log.Timber;
 
 public class ParticipantBodyFragment extends BaseFragment<ParticipantBodyFragment.Container> implements
                                                                                    ConversationScreenControllerObserver,
@@ -353,6 +354,7 @@ public class ParticipantBodyFragment extends BaseFragment<ParticipantBodyFragmen
 
                         // Go to conversation with this user
                         getControllerFactory().getPickUserController().hidePickUserWithoutAnimations(getContainer().getCurrentPickerDestination());
+                        Timber.i("conversationUpdated.onLeftActionClicked %s", user.getConversation().getId());
                         inject(ConversationController.class).selectConv(new ConvId(user.getConversation().getId()), ConversationChangeRequester.CONVERSATION_LIST);
                         return;
                     }
@@ -567,6 +569,7 @@ public class ParticipantBodyFragment extends BaseFragment<ParticipantBodyFragmen
 
                             // Go to conversation with this user
                             getControllerFactory().getPickUserController().hidePickUserWithoutAnimations(getContainer().getCurrentPickerDestination());
+                            Timber.i("onConnectUserUpdated.onLeftActionClicked %s", user.getConversation().getId());
                             inject(ConversationController.class).selectConv(new ConvId(user.getConversation().getId()), ConversationChangeRequester.CONVERSATION_LIST);
                         } else {
                             getControllerFactory().getConversationScreenController().addPeopleToConversation();

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantFragment.java
@@ -82,6 +82,7 @@ import com.waz.zclient.utils.LayoutSpec;
 import com.waz.zclient.utils.ViewUtils;
 import com.waz.zclient.views.DefaultPageTransitionAnimation;
 import com.waz.zclient.views.LoadingIndicatorView;
+import timber.log.Timber;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -943,6 +944,7 @@ public class ParticipantFragment extends BaseFragment<ParticipantFragment.Contai
     @Override
     public void onAcceptedConnectRequest(final IConversation conversation) {
         getControllerFactory().getConversationScreenController().hideUser();
+        Timber.i("onAcceptedConnectRequest %s", conversation.getId());
         convController.selectConv(new ConvId(conversation.getId()), ConversationChangeRequester.START_CONVERSATION);
     }
 
@@ -955,6 +957,7 @@ public class ParticipantFragment extends BaseFragment<ParticipantFragment.Contai
     @Override
     public void onUnblockedUser(IConversation restoredConversationWithUser) {
         getControllerFactory().getConversationScreenController().hideUser();
+        Timber.i("onUnblockedUser %s", restoredConversationWithUser.getId());
         convController.selectConv(new ConvId(restoredConversationWithUser.getId()), ConversationChangeRequester.START_CONVERSATION);
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/SingleParticipantFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/SingleParticipantFragment.java
@@ -59,6 +59,7 @@ import com.waz.zclient.views.e2ee.ShieldView;
 import com.waz.zclient.views.images.ImageAssetImageView;
 import com.waz.zclient.views.menus.FooterMenu;
 import com.waz.zclient.views.menus.FooterMenuCallback;
+import timber.log.Timber;
 
 public class SingleParticipantFragment extends BaseFragment<SingleParticipantFragment.Container> implements
                                                                                                  UserProfile,
@@ -312,6 +313,7 @@ public class SingleParticipantFragment extends BaseFragment<SingleParticipantFra
                     // Go to conversation with this user
                     goToConversationWithUser = true;
                     getContainer().dismissUserProfile();
+                    Timber.i("onUserUpdated %s", user.getConversation().getId());
                     inject(ConversationController.class).selectConv(new ConvId(user.getConversation().getId()), ConversationChangeRequester.START_CONVERSATION);
                 }
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -28,7 +28,7 @@ import android.support.v4.app.Fragment
 import android.text.TextUtils
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.{error, info, verbose}
-import com.waz.api.{NetworkMode, _}
+import com.waz.api.{NetworkMode, User, _}
 import com.waz.model.{AccountId, ConvId, ConversationData}
 import com.waz.service.ZMessaging
 import com.waz.service.ZMessaging.clock
@@ -314,6 +314,7 @@ class MainActivity extends BaseActivity
 
     intent match {
       case NotificationIntent(accountId, convId, startCall) =>
+        verbose(s"notification intent, accountId=$accountId, convId=$convId")
         val switchAccount = {
           val accounts = ZMessaging.currentAccounts
           accounts.activeAccount.head.flatMap {
@@ -406,10 +407,12 @@ class MainActivity extends BaseActivity
     getControllerFactory.getNavigationController.setPagerSettingForPage(page)
   }
 
-  def onConnectUserUpdated(user: User, usertype: IConnectStore.UserRequester) = ()
+  def onConnectUserUpdated(user: User, userRequester: IConnectStore.UserRequester): Unit = {}
 
-  def onInviteRequestSent(conversation: IConversation) =
+  def onInviteRequestSent(conversation: IConversation) = {
+    info(s"onInviteRequestSent(${conversation.getId})")
     conversationController.selectConv(Option(new ConvId(conversation.getId)), ConversationChangeRequester.INVITE)
+  }
 
   def onOpenUrl(url: String) = {
     try {

--- a/app/src/main/scala/com/waz/zclient/fragments/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/fragments/ConversationListFragment.scala
@@ -49,6 +49,9 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
 import com.waz.zclient.views.conversationlist.{ArchiveTopToolbar, ConversationListTopToolbar, NormalTopToolbar}
 
+import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
+
 import com.waz.zclient.{FragmentHelper, OnBackPressedListener, R}
 
 abstract class ConversationListFragment extends BaseFragment[ConversationListFragment.Container] with FragmentHelper {
@@ -97,6 +100,7 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
   private def handleItemClick(conversationData: ConversationData): Unit = {
     import Threading.Implicits.Background
+    verbose(s"handleItemClick, switching conv to ${conversationData.id}")
     conversationController.selectConv(Option(conversationData.id), ConversationChangeRequester.CONVERSATION_LIST).map { _ =>
       conversationController.archive(conversationData.id, archive = false)
     }

--- a/app/src/main/scala/com/waz/zclient/fragments/PickUserFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/fragments/PickUserFragment.scala
@@ -32,7 +32,7 @@ import android.view.animation.Animation
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView.OnEditorActionListener
 import android.widget._
-import com.waz.ZLog
+import com.waz.ZLog._
 import com.waz.api._
 import com.waz.content.UserPreferences
 import com.waz.model.UserData.ConnectionStatus
@@ -144,7 +144,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
   private var teamPermissions = Set[AccountData.Permission]()
 
   private implicit lazy val uiStorage = inject[UiStorage]
-  private implicit lazy val logTag = ZLog.logTagFor[PickUserFragment]
+  private implicit lazy val logTag = logTagFor[PickUserFragment]
   private implicit lazy val context = getContext
   private lazy val zms = inject[Signal[ZMessaging]]
   private lazy val self = zms.flatMap(z => UserSignal(z.selfUserId))
@@ -563,6 +563,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
     Option(getUser(userId)) match {
       case Some(user) if !user.isMe && user.getConnectionStatus == User.ConnectionStatus.ACCEPTED =>
        conversationController.getOrCreateConv(userId).flatMap { conv =>
+         verbose(s"onConversationClicked(${conv.id})")
           conversationController.selectConv(Some(conv.id), ConversationChangeRequester.START_CONVERSATION)
         }(Threading.Ui)
       case _ => Future.successful({})
@@ -571,6 +572,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
 
   override def onConversationClicked(conversationData: ConversationData, position: Int): Unit = {
     KeyboardUtils.hideKeyboard(getActivity)
+    verbose(s"onConversationClicked(${conversationData.id})")
     conversationController.selectConv(Some(conversationData.id), ConversationChangeRequester.START_CONVERSATION)
   }
 
@@ -706,6 +708,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
           val conversation: IConversation = user.getConversation
           if (conversation != null) {
             KeyboardUtils.hideKeyboard(getActivity)
+            verbose(s"showUser ${conversation.getId}")
             conversationController.selectConv(new ConvId(conversation.getId), ConversationChangeRequester.START_CONVERSATION)
           }
         }

--- a/wire-core/src/main/scala/com/waz/zclient/core/stores/conversation/IConversationStore.scala
+++ b/wire-core/src/main/scala/com/waz/zclient/core/stores/conversation/IConversationStore.scala
@@ -17,13 +17,8 @@
  */
 package com.waz.zclient.core.stores.conversation
 
-import com.waz.api.AssetForUpload
-import com.waz.api.AudioAssetForUpload
 import com.waz.api.IConversation
-import com.waz.api.ImageAsset
-import com.waz.api.MessageContent
 import com.waz.api.SyncState
-import com.waz.api.User
 import com.waz.model.ConvId
 import com.waz.zclient.core.stores.IStore
 


### PR DESCRIPTION
Couldn't reproduce the bug, but from the description and testing it looked like the problem lies in a race condition between setting the current conversation from an Intent and opening the current conversation in the conversation fragment. I put `ConversationController` on a `SerialDispatchQueue` and removed unnecessary code while tracking paths leading to  `ConversationController.selectConv`.

Needs more testing.
#### APK
[Download build #9810](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9810/artifact/build/artifact/wire-dev-PR1276-9810.apk)
[Download build #9813](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9813/artifact/build/artifact/wire-dev-PR1276-9813.apk)
[Download build #9814](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9814/artifact/build/artifact/wire-dev-PR1276-9814.apk)
[Download build #9816](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9816/artifact/build/artifact/wire-dev-PR1276-9816.apk)
[Download build #9818](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9818/artifact/build/artifact/wire-dev-PR1276-9818.apk)
[Download build #9819](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9819/artifact/build/artifact/wire-dev-PR1276-9819.apk)
[Download build #9820](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9820/artifact/build/artifact/wire-dev-PR1276-9820.apk)
[Download build #9828](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9828/artifact/build/artifact/wire-dev-PR1276-9828.apk)
[Download build #9835](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9835/artifact/build/artifact/wire-dev-PR1276-9835.apk)