### PR TITLE
fixes callbacks in ConversationController

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/RootFragment.java
@@ -209,6 +209,13 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         }
     }
 
+    private final Callback callback = new Callback<ConversationController.ConversationChange>() {
+        @Override
+        public void callback(ConversationController.ConversationChange conversationChange) {
+            onCurrentConversationHasChanged(conversationChange);
+        }
+    };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -220,12 +227,7 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         getControllerFactory().getConversationScreenController().addConversationControllerObservers(this);
         getControllerFactory().getNavigationController().addPagerControllerObserver(this);
 
-        inject(ConversationController.class).onConvChanged(new Callback<ConversationController.ConversationChange>() {
-            @Override
-            public void callback(ConversationController.ConversationChange conversationChange) {
-                onCurrentConversationHasChanged(conversationChange);
-            }
-        });
+        inject(ConversationController.class).addConvChangedCallback(callback);
 
         getControllerFactory().getCameraController().addCameraActionObserver(this);
         getControllerFactory().getPickUserController().addPickUserScreenControllerObserver(this);
@@ -250,6 +252,9 @@ public class RootFragment extends BaseFragment<RootFragment.Container> implement
         getControllerFactory().getGiphyController().removeObserver(this);
         getControllerFactory().getDrawingController().removeDrawingObserver(this);
         getCollectionController().removeObserver(this);
+
+        inject(ConversationController.class).removeConvChangedCallback(callback);
+
         super.onStop();
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/LocationFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/LocationFragment.java
@@ -264,6 +264,20 @@ public class LocationFragment extends BaseFragment<LocationFragment.Container> i
         mapView.onSaveInstanceState(outState);
     }
 
+    private final Callback callback = new Callback<ConversationController.ConversationChange>() {
+        @Override
+        public void callback(ConversationController.ConversationChange change) {
+            if (change.toConvId() != null) {
+                inject(ConversationController.class).withConvLoaded(change.toConvId(), new Callback<ConversationData>() {
+                    @Override
+                    public void callback(ConversationData conversationData) {
+                        toolbarTitle.setText(conversationData.displayName());
+                    }
+                });
+            }
+        }
+    };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -281,20 +295,7 @@ public class LocationFragment extends BaseFragment<LocationFragment.Container> i
             requestCurrentLocationButton.setVisibility(View.GONE);
         }
 
-        final ConversationController ctrl = inject(ConversationController.class);
-        ctrl.onConvChanged(new Callback<ConversationController.ConversationChange>() {
-            @Override
-            public void callback(ConversationController.ConversationChange change) {
-                if (change.toConvId() != null) {
-                    ctrl.withConvLoaded(change.toConvId(), new Callback<ConversationData>() {
-                        @Override
-                        public void callback(ConversationData conversationData) {
-                            toolbarTitle.setText(conversationData.displayName());
-                        }
-                    });
-                }
-            }
-        });
+        inject(ConversationController.class).addConvChangedCallback(callback);
     }
 
     @Override
@@ -337,6 +338,7 @@ public class LocationFragment extends BaseFragment<LocationFragment.Container> i
     public void onStop() {
         getControllerFactory().getRequestPermissionsController().removeObserver(this);
         getControllerFactory().getAccentColorController().removeAccentColorObserver(this);
+        inject(ConversationController.class).removeConvChangedCallback(callback);
         super.onStop();
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
@@ -176,6 +176,13 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
         return view;
     }
 
+    private final Callback callback = new Callback<ConversationController.ConversationChange>() {
+        @Override
+        public void callback(ConversationController.ConversationChange conversationChange) {
+            onCurrentConversationHasChanged(conversationChange);
+        }
+    };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -187,12 +194,7 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
         getControllerFactory().getNavigationController().addNavigationControllerObserver(this);
         getControllerFactory().getConfirmationController().addConfirmationObserver(this);
 
-        inject(ConversationController.class).onConvChanged(new Callback<ConversationController.ConversationChange>() {
-            @Override
-            public void callback(ConversationController.ConversationChange conversationChange) {
-                onCurrentConversationHasChanged(conversationChange);
-            }
-        });
+        inject(ConversationController.class).addConvChangedCallback(callback);
     }
 
     @Override
@@ -210,6 +212,8 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
         getControllerFactory().getConversationScreenController().removeConversationControllerObservers(this);
         getControllerFactory().getNavigationController().removeNavigationControllerObserver(this);
         getControllerFactory().getConfirmationController().removeConfirmationObserver(this);
+
+        inject(ConversationController.class).removeConvChangedCallback(callback);
 
         super.onStop();
     }

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationpager/ConversationPagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationpager/ConversationPagerFragment.java
@@ -91,6 +91,13 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
         return conversationPager;
     }
 
+    private final Callback callback = new Callback<ConversationController.ConversationChange>() {
+        @Override
+        public void callback(ConversationController.ConversationChange change) {
+            onCurrentConversationHasChanged(change);
+        }
+    };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -102,12 +109,7 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
         getControllerFactory().getNavigationController().addPagerControllerObserver(this);
         getControllerFactory().getNavigationController().addNavigationControllerObserver(this);
 
-        inject(ConversationController.class).onConvChanged(new Callback<ConversationController.ConversationChange>() {
-            @Override
-            public void callback(ConversationController.ConversationChange change) {
-                onCurrentConversationHasChanged(change);
-            }
-        });
+        inject(ConversationController.class).addConvChangedCallback(callback);
     }
 
     @Override
@@ -115,6 +117,7 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
         getControllerFactory().getNavigationController().removePagerControllerObserver(this);
         getControllerFactory().getNavigationController().removeNavigationControllerObserver(this);
         conversationPager.setOnPageChangeListener(null);
+        inject(ConversationController.class).removeConvChangedCallback(callback);
         super.onStop();
     }
 

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantFragment.java
@@ -253,6 +253,14 @@ public class ParticipantFragment extends BaseFragment<ParticipantFragment.Contai
 
     }
 
+    private Callback callback = new Callback<ConversationController.ConversationChange>() {
+        @Override
+        public void callback(ConversationController.ConversationChange change) {
+            onCurrentConversationHasChanged(change);
+            onConversationLoaded(change.toConvId());
+        }
+    };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -270,13 +278,7 @@ public class ParticipantFragment extends BaseFragment<ParticipantFragment.Contai
         }
         getControllerFactory().getPickUserController().addPickUserScreenControllerObserver(this);
 
-        convController.onConvChanged(new Callback<ConversationController.ConversationChange>() {
-            @Override
-            public void callback(ConversationController.ConversationChange change) {
-                onCurrentConversationHasChanged(change);
-                onConversationLoaded(change.toConvId());
-            }
-        });
+        convController.addConvChangedCallback(callback);
     }
 
     @Override
@@ -287,6 +289,8 @@ public class ParticipantFragment extends BaseFragment<ParticipantFragment.Contai
         }
         getStoreFactory().participantsStore().removeParticipantsStoreObserver(this);
         getControllerFactory().getPickUserController().removePickUserScreenControllerObserver(this);
+
+        convController.removeConvChangedCallback(callback);
 
         super.onStop();
     }


### PR DESCRIPTION
Changes to how `*Fragments` written in Java register callbacks in `ConversationController` in order to listen to conversation changes. The old way resulted in too many callbacks being registered and that may actually contributed to delays, freezes, etc.
#### APK
[Download build #9855](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9855/artifact/build/artifact/wire-dev-PR1295-9855.apk)