### PR TITLE
[AN-5711] a fix attempt for keyboard flickering by removing the global layout listener

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/globallayout/GlobalLayoutController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/globallayout/GlobalLayoutController.java
@@ -37,7 +37,14 @@ public class GlobalLayoutController implements IGlobalLayoutController {
     private View globalLayout;
     private Activity activity;
 
-    private ViewTreeObserver.OnGlobalLayoutListener globalLayoutListener;
+    private final ViewTreeObserver.OnGlobalLayoutListener globalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+        @Override
+        public void onGlobalLayout() {
+            keyboardListener.onLayoutChange();
+            globalLayout.getViewTreeObserver().removeOnGlobalLayoutListener(globalLayoutListener);
+        }
+    };
+
     private KeyboardVisibilityListener keyboardListener;
 
     private KeyboardVisibilityListener.Callback keyboardCallback = new KeyboardVisibilityListener.Callback() {
@@ -53,12 +60,6 @@ public class GlobalLayoutController implements IGlobalLayoutController {
     };
 
     public GlobalLayoutController() {
-        globalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
-            @Override
-            public void onGlobalLayout() {
-                keyboardListener.onLayoutChange();
-            }
-        };
     }
 
     @Override
@@ -77,7 +78,6 @@ public class GlobalLayoutController implements IGlobalLayoutController {
         globalLayout.getViewTreeObserver().addOnGlobalLayoutListener(globalLayoutListener);
 
         // Listen to layout changes to determine when keyboard becomes visible / hidden
-        // this listener should be set after the global layout listener to avoid keyboard flickering
         keyboardListener = new KeyboardVisibilityListener(view);
         keyboardListener.setCallback(keyboardCallback);
     }

--- a/app/src/main/java/com/waz/zclient/utils/keyboard/KeyboardVisibilityListener.java
+++ b/app/src/main/java/com/waz/zclient/utils/keyboard/KeyboardVisibilityListener.java
@@ -17,10 +17,10 @@
  */
 package com.waz.zclient.utils.keyboard;
 
-import android.graphics.Rect;
-import android.os.Handler;
 import android.view.View;
+import com.waz.zclient.ui.utils.KeyboardUtils;
 import com.waz.zclient.utils.ContextUtils;
+import timber.log.Timber;
 
 public class KeyboardVisibilityListener {
     private final View contentView;
@@ -51,38 +51,20 @@ public class KeyboardVisibilityListener {
     }
 
     public synchronized void onLayoutChange() {
-        if (!layoutChangeInProgress) {
-            layoutChangeInProgress = true;
-            layoutChangeHandler.removeCallbacks(layoutChangeRunnable);
-            layoutChangeHandler.postDelayed(layoutChangeRunnable, 200);
-        }
-    }
+        int newKeyboardHeight = Math.max(0, KeyboardUtils.getKeyboardHeight(contentView) - statusAndNavigationBarHeight);
 
-    private boolean layoutChangeInProgress = false;
+        if (newKeyboardHeight != keyboardHeight) {
+            Timber.i("keyboard height changes from %s to %s", keyboardHeight, newKeyboardHeight);
+            boolean visibilityChanged = keyboardHeight == 0 || newKeyboardHeight == 0;
+            keyboardHeight = newKeyboardHeight;
 
-    private Handler layoutChangeHandler = new Handler();
-
-    private Runnable layoutChangeRunnable = new Runnable() {
-        @Override
-        public void run() {
-            Rect r = new Rect();
-            contentView.getWindowVisibleDisplayFrame(r);
-
-            int newKeyboardHeight = Math.max(0, contentView.getRootView().getHeight() - r.bottom - statusAndNavigationBarHeight);
-
-            if (newKeyboardHeight != keyboardHeight) {
-                boolean visibilityChanged = keyboardHeight == 0 || newKeyboardHeight == 0;
-                keyboardHeight = newKeyboardHeight;
-
-                if (callback != null) {
-                    callback.onKeyboardHeightChanged(newKeyboardHeight);
-                    if (visibilityChanged) {
-                        callback.onKeyboardChanged(newKeyboardHeight > 0, newKeyboardHeight);
-                    }
+            if (callback != null) {
+                callback.onKeyboardHeightChanged(newKeyboardHeight);
+                if (visibilityChanged) {
+                    callback.onKeyboardChanged(newKeyboardHeight > 0, newKeyboardHeight);
                 }
             }
-
-            layoutChangeInProgress = false;
         }
+
     };
 }

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -148,10 +148,8 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
       if (LayoutSpec.isTablet(ctx) && tpe == ExtendedCursorContainer.Type.IMAGES) {
         cameraController.openCamera(CameraContext.MESSAGE)
         keyboard ! KeyboardState.Hidden
-      } else {
-        permissions.withPermissions(keyboardPermissions(tpe): _*) {
-          cursorCallback.foreach(_.openExtendedCursor(tpe))
-        }
+      } else permissions.withPermissions(keyboardPermissions(tpe): _*) {
+        cursorCallback.foreach(_.openExtendedCursor(tpe))
       }
   }
 

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorToolbarContainer.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorToolbarContainer.scala
@@ -43,10 +43,9 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.ViewHelper
-import com.waz.zclient.cursor.CursorController.KeyboardState
 import com.waz.zclient.R
 import com.waz.zclient.ui.animation.interpolators.penner.Expo
-import com.waz.zclient.utils.{ViewUtils, _}
+import com.waz.zclient.utils._
 
 class CursorToolbarContainer(context: Context, attrs: AttributeSet, defStyleAttr: Int)
     extends FrameLayout(context, attrs, defStyleAttr) with ViewHelper {
@@ -57,12 +56,6 @@ class CursorToolbarContainer(context: Context, attrs: AttributeSet, defStyleAttr
   val controller = inject[CursorController]
 
   val heightExpanded = getResources.getDimensionPixelSize(R.dimen.new_cursor_height)
-  val heightShrinked = getResources.getDimensionPixelSize(R.dimen.cursor_height_shrinked)
-
-  val height = controller.keyboard map {
-    case KeyboardState.Hidden => heightExpanded
-    case _ => heightShrinked
-  }
 
   lazy val mainToolbar: View         = findById(R.id.c__cursor__main)
   lazy val secondaryToolbar: View    = findById(R.id.c__cursor__secondary)
@@ -87,10 +80,9 @@ class CursorToolbarContainer(context: Context, attrs: AttributeSet, defStyleAttr
     anim.setInterpolator(new Expo.EaseInOut)
     anim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener {
       override def onAnimationUpdate(animation: ValueAnimator): Unit = {
-        val cursorHeight = height.currentValue.getOrElse(heightExpanded)
         val offset = animation.getAnimatedValue.asInstanceOf[java.lang.Float]
-        mainToolbar.setTranslationY(offset * -cursorHeight)
-        secondaryToolbar.setTranslationY(cursorHeight + offset * -cursorHeight)
+        mainToolbar.setTranslationY(offset * -heightExpanded)
+        secondaryToolbar.setTranslationY(heightExpanded + offset * -heightExpanded)
       }
     })
 
@@ -107,9 +99,8 @@ class CursorToolbarContainer(context: Context, attrs: AttributeSet, defStyleAttr
     anim.setInterpolator(new Expo.EaseInOut)
     anim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener {
       override def onAnimationUpdate(animation: ValueAnimator): Unit = {
-        val cursorHeight = height.currentValue.getOrElse(heightExpanded)
         val offset = animation.getAnimatedValue.asInstanceOf[java.lang.Float]
-        editToolbar.setTranslationY(cursorHeight + offset * -cursorHeight)
+        editToolbar.setTranslationY(heightExpanded + offset * -heightExpanded)
       }
     })
 
@@ -132,11 +123,6 @@ class CursorToolbarContainer(context: Context, attrs: AttributeSet, defStyleAttr
       case false =>
         toolbarSwitchAnimator.cancel()
         toolbarSwitchAnimator.reverse()
-    }
-
-    height.on(Threading.Ui) { h =>
-      ViewUtils.setHeight(this, h)
-      requestLayout()
     }
 
     editVisible.onChanged.on(Threading.Ui) {

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -24,6 +24,7 @@ import android.graphics.drawable.ColorDrawable
 import android.support.v4.content.res.ResourcesCompat
 import android.text.{Editable, TextUtils, TextWatcher}
 import android.util.AttributeSet
+import android.view.View.OnClickListener
 import android.view._
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView.OnEditorActionListener
@@ -125,8 +126,9 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
   emojiButton.onClick {
     controller.keyboard ! KeyboardState.ExtendedCursor(ExtendedCursorContainer.Type.EMOJIS)
   }
+
   keyboardButton.onClick {
-    controller.keyboard ! KeyboardState.Shown
+    notifyKeyboardVisibilityChanged(true)
   }
 
   val cursorHeight = getDimenPx(R.dimen.new_cursor_height)
@@ -148,6 +150,10 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     }
 
     override def beforeTextChanged(charSequence: CharSequence, start: Int, count: Int, after: Int): Unit = ()
+  })
+
+  cursorEditText.setOnClickListener(new OnClickListener {
+    override def onClick(v: View): Unit = notifyKeyboardVisibilityChanged(true)
   })
 
   cursorEditText.setOnEditorActionListener(new OnEditorActionListener {
@@ -250,7 +256,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     cursorEditText.getText.insert(cursorEditText.getSelectionStart, text)
   }
 
-  def notifyKeyboardVisibilityChanged(keyboardIsVisible: Boolean, currentFocus: View): Unit = {
+  def notifyKeyboardVisibilityChanged(keyboardIsVisible: Boolean): Unit = {
     controller.keyboard.mutate {
       case KeyboardState.Shown if !keyboardIsVisible => KeyboardState.Hidden
       case _ if keyboardIsVisible => KeyboardState.Shown

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -694,6 +694,7 @@ class ConversationFragment extends BaseFragment[ConversationFragment.Container] 
     override def onCursorClicked(): Unit = if (!cursorView.isEditingMessage) listView.scrollToBottom()
 
     override def onFocusChange(hasFocus: Boolean): Unit = {
+
       if (hasFocus) getControllerFactory.getFocusController.setFocus(IFocusController.CONVERSATION_CURSOR)
       if (!LayoutSpec.isPhone(getActivity) && getControllerFactory.getPickUserController.isShowingPickUser(IPickUserController.Destination.CONVERSATION_LIST)) {
         // On tablet, apply Page.MESSAGE_STREAM soft input mode when conversation cursor has focus (soft input mode of page gets changed when left startui is open)
@@ -756,7 +757,7 @@ class ConversationFragment extends BaseFragment[ConversationFragment.Container] 
 
   private val keyboardVisibilityObserver = new KeyboardVisibilityObserver {
     override def onKeyboardVisibilityChanged(keyboardIsVisible: Boolean, keyboardHeight: Int, currentFocus: View): Unit =
-      cursorView.notifyKeyboardVisibilityChanged(keyboardIsVisible, currentFocus)
+      cursorView.notifyKeyboardVisibilityChanged(keyboardIsVisible)
   }
 
   private val syncErrorObserver = new SyncErrorObserver {

--- a/wire-ui/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
+++ b/wire-ui/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
@@ -41,16 +41,7 @@ public class KeyboardUtils {
     }
 
     public static boolean keyboardIsVisible(View contentView) {
-        Rect r = new Rect();
-        contentView.getWindowVisibleDisplayFrame(r);
-        int screenHeight = contentView.getRootView().getHeight();
-        int keyboardHeight = screenHeight - r.bottom;
-        return keyboardHeight > 0;
-    }
-
-    public static void hideKeyboard(Context context, IBinder token) {
-        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-        imm.hideSoftInputFromWindow(token, 0);
+        return getKeyboardHeight(contentView) > 0;
     }
 
     public static void hideKeyboard(Activity activity) {
@@ -80,7 +71,6 @@ public class KeyboardUtils {
         }
     }
 
-
     private static InputMethodManager getInputMethodManager(Context context) {
         return (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
     }
@@ -88,7 +78,6 @@ public class KeyboardUtils {
     public static int getKeyboardHeight(View contentView) {
         Rect r = new Rect();
         contentView.getWindowVisibleDisplayFrame(r);
-        int screenHeight = contentView.getRootView().getHeight();
-        return screenHeight - r.bottom;
+        return contentView.getRootView().getHeight() - r.bottom;
     }
 }

--- a/wire-ui/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
+++ b/wire-ui/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
@@ -20,7 +20,6 @@ package com.waz.zclient.ui.utils;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.IBinder;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;


### PR DESCRIPTION
I removed the code changing the toolbar size on keyboard visibility changes, which in turn required the keyboard visibility to be recomputed.
I also followed the advice from these two threads:
https://stackoverflow.com/questions/37116048/android-global-layout-listener-called-repeatedly-in-android
http://android-er.blogspot.de/2014/09/ongloballayoutlistener-called-repeatly.html
and added a line which removes the global layout listener after the computation. The listener is added on `onBaseActivityStart`, and then removed after layout computations. 
#### APK
[Download build #9864](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9864/artifact/build/artifact/wire-dev-PR1297-9864.apk)
[Download build #9876](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9876/artifact/build/artifact/wire-dev-PR1297-9876.apk)
[Download build #9878](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9878/artifact/build/artifact/wire-dev-PR1297-9878.apk)
[Download build #9929](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9929/artifact/build/artifact/wire-dev-PR1297-9929.apk)
[Download build #9930](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9930/artifact/build/artifact/wire-dev-PR1297-9930.apk)
[Download build #9972](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9972/artifact/build/artifact/wire-dev-PR1297-9972.apk)
[Download build #9973](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9973/artifact/build/artifact/wire-dev-PR1297-9973.apk)