### PR TITLE
[AN-5800] Update options menu content when connecting conversation

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
@@ -316,6 +316,7 @@ public class OptionsMenuFragment extends BaseFragment<OptionsMenuFragment.Contai
             public void callback(ConversationData conversationData) {
                 optionsMenu.setTitle(conversationData.displayName());
                 optionsMenu.setConversationDetails(conversationData);
+                onMenuConversationHasChanged(conversationData);
             }
         });
     }


### PR DESCRIPTION
Prevent options menu to open without content when the conversation doesn’t change.