### PR TITLE
[AN-5819] Re-enable spinner for sync jobs in ConversationListFragment

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationlist/ConversationListManagerFragment.java
@@ -294,9 +294,8 @@ public class ConversationListManagerFragment extends BaseFragment<ConversationLi
         switch (syncState) {
             case SYNCING:
             case WAITING:
-                //TODO: There seems to be a problem with the sync state right now, remove after resolved
-                //listLoadingIndicatorView.show(animationType);
-                //return;
+                listLoadingIndicatorView.show(animationType);
+                return;
             case COMPLETED:
                 listLoadingIndicatorView.hide();
                 break;

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -180,7 +180,6 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
     zms.head.flatMap { _.convsUi.createGroupConversation(localId, users) }
 
   // TODO: remove when not used anymore
-
   def iConv(id: ConvId): IConversation = convStore.getConversation(id.str)
   def iCurrentConv: IConversation = currentConvId.currentValue.map(iConv).orNull
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '114.1770'
+    zMessagingDevVersionBase = '114.1771'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '112.2.409@aar'


### PR DESCRIPTION
Depends on:
https://github.com/wireapp/wire-android-sync-engine/pull/278

Local build including SE:
https://drive.google.com/open?id=19MmZ_GbQdi2-tI3aAo8k38ALvT19jOy4

**Note:** Please also double check trying to login to accounts with maximum devices.
#### APK
[Download build #9906](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9906/artifact/build/artifact/wire-dev-PR1312-9906.apk)