### PR TITLE
[AN-5846] fix keyboard not closing

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversationpager/ConversationPagerFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationpager/ConversationPagerFragment.java
@@ -35,8 +35,8 @@ import com.waz.zclient.controllers.navigation.Page;
 import com.waz.zclient.controllers.navigation.PagerControllerObserver;
 import com.waz.zclient.conversation.ConversationController;
 import com.waz.zclient.collection.controllers.CollectionController;
+import com.waz.zclient.cursor.CursorController;
 import com.waz.zclient.pages.BaseFragment;
-import com.waz.zclient.ui.utils.KeyboardUtils;
 import com.waz.zclient.ui.utils.ResourceUtils;
 import com.waz.zclient.utils.Callback;
 import com.waz.zclient.utils.LayoutSpec;
@@ -159,6 +159,7 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
                     @Override
                     public void run() {
                         conversationPager.setCurrentItem(NavigationController.FIRST_PAGE, false);
+
                     }
                 }, PAGER_DELAY);
                 break;
@@ -249,7 +250,7 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
     public void onPageScrollStateChanged(int state) {
         if (state == ViewPager.SCROLL_STATE_DRAGGING &&
             getControllerFactory().getGlobalLayoutController().isKeyboardVisible()) {
-            KeyboardUtils.hideKeyboard(getActivity());
+            getCursorController().notifyKeyboardVisibilityChanged(false);
         }
     }
 
@@ -262,16 +263,21 @@ public class ConversationPagerFragment extends BaseFragment<ConversationPagerFra
     public void onPageVisible(Page page) {
         if (page == Page.CONVERSATION_LIST) {
             getCollectionController().clearSearch();
-        }
-        if (page == Page.CONVERSATION_LIST &&
-            getControllerFactory().getNavigationController()
-                                  .getPagerPosition() == NavigationController.SECOND_PAGE) {
-            conversationPager.setCurrentItem(NavigationController.FIRST_PAGE);
+            getCursorController().notifyKeyboardVisibilityChanged(false);
+
+            if (getControllerFactory().getNavigationController()
+                    .getPagerPosition() == NavigationController.SECOND_PAGE) {
+                conversationPager.setCurrentItem(NavigationController.FIRST_PAGE);
+            }
         }
     }
 
     private CollectionController getCollectionController() {
         return ((BaseActivity) getActivity()).injectJava(CollectionController.class);
+    }
+
+    private CursorController getCursorController() {
+        return ((BaseActivity) getActivity()).injectJava(CursorController.class);
     }
 
     public interface Container {

--- a/app/src/main/java/com/waz/zclient/pages/main/drawing/DrawingFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/drawing/DrawingFragment.java
@@ -656,6 +656,7 @@ public class DrawingFragment extends BaseFragment<DrawingFragment.Container> imp
                 sketchEditTextView.setBackground(ColorUtils.getTransparentDrawable());
             }
             sketchEditTextView.setVisibility(View.VISIBLE);
+            changeEditTextVisibility();
             showKeyboard();
             hideTip();
         }
@@ -724,6 +725,10 @@ public class DrawingFragment extends BaseFragment<DrawingFragment.Container> imp
         if (!keyboardIsVisible) {
             closeKeyboard();
         }
+        changeEditTextVisibility(keyboardHeight);
+    }
+
+    private void changeEditTextVisibility(int keyboardHeight) {
         if (shouldOpenEditText) {
             shouldOpenEditText = false;
             FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sketchEditTextView.getLayoutParams();
@@ -743,7 +748,13 @@ public class DrawingFragment extends BaseFragment<DrawingFragment.Container> imp
         } else {
             sketchEditTextView.setAlpha(TEXT_ALPHA_VISIBLE);
         }
+    }
 
+    private void changeEditTextVisibility() {
+        View view = ViewUtils.getContentView(getActivity().getWindow());
+        if (view != null) {
+            changeEditTextVisibility(KeyboardUtils.getKeyboardHeight(view));
+        }
     }
 
     private void drawSketchEditText() {

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -70,7 +70,7 @@ class BaseActivity extends AppCompatActivity
       inject[UiLifeCycle].acquireUi()
     }
     getStoreFactory.zMessagingApiStore.getApi.setPermissionProvider(this)
-    val contentView: View = ViewUtils.getView(getWindow.getDecorView, android.R.id.content)
+    val contentView: View = ViewUtils.getContentView(getWindow)
     if (contentView != null) getControllerFactory.setGlobalLayout(contentView)
   }
 

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -141,6 +141,20 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   } yield
     users.nonEmpty
 
+  def notifyKeyboardVisibilityChanged(keyboardIsVisible: Boolean): Unit = {
+    keyboard.mutate {
+      case KeyboardState.Shown if !keyboardIsVisible => KeyboardState.Hidden
+      case _ if keyboardIsVisible => KeyboardState.Shown
+      case state => state
+    }
+
+    if (keyboardIsVisible) editHasFocus.head.foreach { hasFocus =>
+      if (hasFocus) {
+        cursorCallback.foreach(_.onCursorClicked())
+      }
+    }
+  }
+
   keyboard.on(Threading.Ui) {
     case KeyboardState.Shown =>
       cursorCallback.foreach(_.hideExtendedCursor())

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -131,7 +131,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
   }
 
   keyboardButton.onClick {
-    notifyKeyboardVisibilityChanged(true)
+    controller.notifyKeyboardVisibilityChanged(true)
   }
 
   val cursorHeight = getDimenPx(R.dimen.new_cursor_height)
@@ -156,7 +156,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
   })
 
   cursorEditText.setOnClickListener(new OnClickListener {
-    override def onClick(v: View): Unit = notifyKeyboardVisibilityChanged(true)
+    override def onClick(v: View): Unit = controller.notifyKeyboardVisibilityChanged(true)
   })
 
   cursorEditText.setOnEditorActionListener(new OnEditorActionListener {
@@ -270,17 +270,6 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
 
   def insertText(text: String): Unit = {
     cursorEditText.getText.insert(cursorEditText.getSelectionStart, text)
-  }
-
-  def notifyKeyboardVisibilityChanged(keyboardIsVisible: Boolean): Unit = {
-    controller.keyboard.mutate {
-      case KeyboardState.Shown if !keyboardIsVisible => KeyboardState.Hidden
-      case _ if keyboardIsVisible => KeyboardState.Shown
-      case state => state
-    }
-
-    if (keyboardIsVisible && cursorEditText.hasFocus)
-      controller.cursorCallback.foreach(_.onCursorClicked())
   }
 
   def hasText: Boolean = !TextUtils.isEmpty(cursorEditText.getText.toString)

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -56,7 +56,7 @@ import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.conversation.ConversationController.ConversationChange
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.core.stores.inappnotification.SyncErrorObserver
-import com.waz.zclient.cursor.{CursorCallback, CursorView}
+import com.waz.zclient.cursor.{CursorCallback, CursorController, CursorView}
 import com.waz.zclient.messages.MessagesListView
 import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.pages.extendedcursor.ExtendedCursorContainer
@@ -757,7 +757,7 @@ class ConversationFragment extends BaseFragment[ConversationFragment.Container] 
 
   private val keyboardVisibilityObserver = new KeyboardVisibilityObserver {
     override def onKeyboardVisibilityChanged(keyboardIsVisible: Boolean, keyboardHeight: Int, currentFocus: View): Unit =
-      cursorView.notifyKeyboardVisibilityChanged(keyboardIsVisible)
+      inject[CursorController].notifyKeyboardVisibilityChanged(keyboardIsVisible)
   }
 
   private val syncErrorObserver = new SyncErrorObserver {

--- a/wire-core/src/main/java/com/waz/zclient/utils/ViewUtils.java
+++ b/wire-core/src/main/java/com/waz/zclient/utils/ViewUtils.java
@@ -360,6 +360,10 @@ public class ViewUtils {
         return (T) v.findViewById(resId);
     }
 
+    public static <T extends View> T getContentView(@NonNull Window window) {
+        return getView(window.getDecorView(), android.R.id.content);
+    }
+
     @SuppressLint("com.waz.ViewUtils")
     public static <T extends View> T getView(@NonNull Dialog d, @IdRes int resId) {
         return (T) d.findViewById(resId);


### PR DESCRIPTION
I moved `notifyKeyboardVisibilityChanged` from `CursorView` to `CursorController` and call it `ConversationPagerFragment` when the page is switch to the conversation list. The name `notifyKeyboardVisibilityChanged` is misleading right now - it shows/hides the keyboard, not just reacts to the keyboard being already shown/hidden. I focused only on fixing the bug, so I left it as it is. I'd like to come back to it later on.

Also, in the `DrawingFragment`, the text bubble wasn't appearing correctly because it relied on the old listener. I fixed that, but again, I didn't want to remove the listener completely, because I didn't want to risk new bugs. 
#### APK
[Download build #9983](http://192.168.10.18:8080/job/Pull%20Request%20Builder/9983/artifact/build/artifact/wire-dev-PR1334-9983.apk)