### PR TITLE
treat group chats with 1 other person as 1:1, but not when it's a bot

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/controller/ConversationScreenController.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/controller/ConversationScreenController.java
@@ -29,6 +29,7 @@ import com.waz.zclient.pages.main.participants.dialog.DialogLaunchMode;
 import java.util.HashSet;
 import java.util.Set;
 
+
 public class ConversationScreenController implements IConversationScreenController {
     private Set<ConversationScreenControllerObserver> conversationScreenControllerObservers = new HashSet<>();
 

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/OptionsMenuFragment.java
@@ -166,47 +166,53 @@ public class OptionsMenuFragment extends BaseFragment<OptionsMenuFragment.Contai
     }
 
 
-    public void onMenuConversationHasChanged(ConversationData conv) {
-        List<OptionsMenuItem> items = new ArrayList<>();
+    public void onMenuConversationHasChanged(final ConversationData conv) {
+        ConversationController conversationController = inject(ConversationController.class);
+        conversationController.isGroup(conv.id(), new Callback<Boolean>() {
+            @Override public void callback(Boolean isGroup) {
+                List<OptionsMenuItem> items = new ArrayList<>();
 
-        if (conv.convType() == IConversation.Type.GROUP) {
-            if (conv.isActive()) {
-                // silence/unsilence
-                if (conv.muted()) {
-                    items.add(OptionsMenuItem.UNSILENCE);
-                } else {
-                    items.add(OptionsMenuItem.SILENCE);
-                }
+                if (isGroup) {
+                    if (conv.isActive()) {
+                        // silence/unsilence
+                        if (conv.muted()) {
+                            items.add(OptionsMenuItem.UNSILENCE);
+                        } else {
+                            items.add(OptionsMenuItem.SILENCE);
+                        }
 
-                if (inConversationList) {
+                        if (inConversationList) {
+                            items.add(OptionsMenuItem.CALL);
+                            items.add(OptionsMenuItem.PICTURE);
+                        } else { //in ParticipantsFragment
+                            items.add(OptionsMenuItem.RENAME);
+                        }
+                    }
+
+                    // archive
+                    if (conv.archived()) {
+                        items.add(OptionsMenuItem.UNARCHIVE);
+                    } else {
+                        items.add(OptionsMenuItem.ARCHIVE);
+                    }
+
+                    items.add(OptionsMenuItem.DELETE);
+
+                    // leave
+                    if (conv.isActive()) {
+                        items.add(OptionsMenuItem.LEAVE);
+                    }
+                    optionsMenu.setMenuItems(items, optionsTheme);
+                } else if (conv.convType() == IConversation.Type.ONE_TO_ONE) {
                     items.add(OptionsMenuItem.CALL);
                     items.add(OptionsMenuItem.PICTURE);
-                } else { //in ParticipantsFragment
-                    items.add(OptionsMenuItem.RENAME);
+                    connectUser(ConversationController.getOtherParticipantForOneToOneConv(conv));
+                } else if (conv.convType() == IConversation.Type.WAIT_FOR_CONNECTION) {
+                    connectUser(ConversationController.getOtherParticipantForOneToOneConv(conv));
                 }
             }
+        });
 
-            // archive
-            if (conv.archived()) {
-                items.add(OptionsMenuItem.UNARCHIVE);
-            } else {
-                items.add(OptionsMenuItem.ARCHIVE);
-            }
-
-            items.add(OptionsMenuItem.DELETE);
-
-            // leave
-            if (conv.isActive()) {
-                items.add(OptionsMenuItem.LEAVE);
-            }
-            optionsMenu.setMenuItems(items, optionsTheme);
-        } else if (conv.convType() == IConversation.Type.ONE_TO_ONE) {
-            items.add(OptionsMenuItem.CALL);
-            items.add(OptionsMenuItem.PICTURE);
-            connectUser(ConversationController.getOtherParticipantForOneToOneConv(conv));
-        } else if (conv.convType() == IConversation.Type.WAIT_FOR_CONNECTION) {
-            connectUser(ConversationController.getOtherParticipantForOneToOneConv(conv));
-        }
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantHeaderFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/ParticipantHeaderFragment.java
@@ -231,33 +231,51 @@ public class ParticipantHeaderFragment extends BaseFragment<ParticipantHeaderFra
     }
 
     @Override
-    public void conversationUpdated(IConversation conversation) {
-        if (conversation == null) {
+    public void conversationUpdated(final IConversation iConv) {
+        if (iConv == null) {
             return;
         }
-        isGroupConversation = conversation.getType() == IConversation.Type.GROUP;
-        if (isGroupConversation) {
-            membersCountTextView.setVisibility(View.VISIBLE);
-            userDetailsView.setVisibility(View.GONE);
-            headerReadOnlyTextView.setText(conversation.getName());
-            if (conversation.isMemberOfConversation()) {
-                headerEditText.setText(conversation.getName());
-                headerEditText.setVisibility(View.VISIBLE);
-            } else {
-                headerEditText.setVisibility(View.GONE);
+
+        final ConversationController ctrl = inject(ConversationController.class);
+        final ConvId convId = new ConvId(iConv.getId());
+
+        ctrl.isGroup(convId, new Callback<Boolean>() {
+            @Override
+            public void callback(final Boolean isGroup) {
+                ctrl.isWithBot(convId, new Callback<Boolean>() {
+                    @Override
+                    public void callback(final Boolean isWithBot) {
+                        if (isGroup || isWithBot) {
+                            membersCountTextView.setVisibility(View.VISIBLE);
+                            userDetailsView.setVisibility(View.GONE);
+                            headerReadOnlyTextView.setText(iConv.getName());
+                            if (iConv.isMemberOfConversation()) {
+                                headerEditText.setText(iConv.getName());
+                                headerEditText.setVisibility(View.VISIBLE);
+                            } else {
+                                headerEditText.setVisibility(View.GONE);
+                            }
+
+                            shieldView.setVisibility(View.GONE);
+                            penIcon.setVisibility(View.VISIBLE);
+
+                        } else {
+                            membersCountTextView.setVisibility(View.GONE);
+                            userDetailsView.setVisibility(View.VISIBLE);
+                            headerEditText.setVisibility(View.GONE);
+                            penIcon.setVisibility(View.GONE);
+                            ctrl.isVerified(convId, new Callback<Boolean>() {
+                                @Override
+                                public void callback(Boolean isVerified) {
+                                    shieldView.setVisibility(isVerified ? View.VISIBLE : View.GONE);
+                                }
+                            });
+                        }
+                    }
+                });
             }
+        });
 
-            shieldView.setVisibility(View.GONE);
-            penIcon.setVisibility(View.VISIBLE);
-
-        } else {
-            membersCountTextView.setVisibility(View.GONE);
-            userDetailsView.setVisibility(View.VISIBLE);
-            headerEditText.setVisibility(View.GONE);
-            penIcon.setVisibility(View.GONE);
-            shieldView.setVisibility(conversation.getOtherParticipant().getVerified() == Verification.VERIFIED ?
-                                     View.VISIBLE : View.GONE);
-        }
     }
 
     @Override

--- a/app/src/main/java/com/waz/zclient/pages/main/participants/dialog/ParticipantsDialogFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/participants/dialog/ParticipantsDialogFragment.java
@@ -364,12 +364,13 @@ public class ParticipantsDialogFragment extends BaseFragment<ParticipantsDialogF
                     user = getStoreFactory().pickUserStore().getUser(userId);
                 }
             }
+
+
             if (getArguments().getBoolean(ARG__ADD_TO_CONVERSATION)) {
-                transaction.replace(R.id.fl__participant_dialog__main__container,
-                                    PickUserFragment.newInstance(true,
-                                                                 getArguments().getBoolean(ARG__GROUP_CONVERSATION),
-                                                                 inject(ConversationController.class).getCurrentConvId().str()),
-                                    PickUserFragment.TAG());
+                ConvId convId = inject(ConversationController.class).getCurrentConvId();
+                if (convId != null) transaction.replace(R.id.fl__participant_dialog__main__container,
+                                                        PickUserFragment.newInstance(true, convId.str()),
+                                                        PickUserFragment.TAG());
 
             } else if (getControllerFactory().getConversationScreenController().getPopoverLaunchMode() == DialogLaunchMode.PARTICIPANT_BUTTON ||
                 getControllerFactory().getConversationScreenController().getPopoverLaunchMode() == DialogLaunchMode.CONVERSATION_TOOLBAR) {
@@ -727,10 +728,10 @@ public class ParticipantsDialogFragment extends BaseFragment<ParticipantsDialogF
         if (convId == null) {
             getControllerFactory().getDialogBackgroundImageController().setImageAsset(null, false);
         } else {
-            inject(ConversationController.class).withCurrentConvType(new Callback<IConversation.Type>() {
+            inject(ConversationController.class).isGroup(convId, new Callback<Boolean>() {
                 @Override
-                public void callback(IConversation.Type convType) {
-                    boolean blurred = convType == IConversation.Type.GROUP &&
+                public void callback(Boolean isGroup) {
+                    boolean blurred = isGroup &&
                         getControllerFactory().getConversationScreenController().getPopoverLaunchMode() == DialogLaunchMode.PARTICIPANT_BUTTON;
                     getControllerFactory().getDialogBackgroundImageController().setImageAsset(ConversationController.emptyImageAsset(), blurred);
                 }
@@ -752,6 +753,7 @@ public class ParticipantsDialogFragment extends BaseFragment<ParticipantsDialogF
             requester != IConversationScreenController.CONVERSATION_DETAILS) {
             return;
         }
+
         Fragment fragment = getChildFragmentManager().findFragmentByTag(ParticipantFragment.TAG);
         if (fragment instanceof ConversationScreenControllerObserver) {
             ((ConversationScreenControllerObserver) fragment).onShowConversationMenu(requester,

--- a/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsSummaryFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsSummaryFragment.scala
@@ -34,6 +34,7 @@ import com.waz.zclient.common.controllers.IntegrationsController
 import com.waz.zclient.utils.ContextUtils.showToast
 
 import scala.concurrent.Future
+import com.waz.ZLog.ImplicitTag._
 
 class IntegrationDetailsSummaryFragment extends Fragment with FragmentHelper {
 
@@ -56,7 +57,7 @@ class IntegrationDetailsSummaryFragment extends Fragment with FragmentHelper {
     } else super.onCreateAnimation(transit, enter, nextAnim)
   }
 
-  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View ={
+  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View = {
     val localInflater =
       if (integrationDetailsViewController.addingToConversation.isEmpty && integrationDetailsViewController.removingFromConversation.isEmpty)
         inflater.cloneInContext(new ContextThemeWrapper(getActivity, R.style.Theme_Dark))

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsChatheadAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsChatheadAdapter.scala
@@ -54,16 +54,10 @@ class ParticipantsChatheadAdapter(numOfColumns: Int)(implicit context: Context, 
     val (verified, unverified) = people.partition(_.isVerified)
 
     unverified.map(data => Left(data.id)) :::
-      (if (verified.nonEmpty)
-        Right(SEPARATOR_VERIFIED) :: verified.map(data => Left(data.id))
-       else
-        List.empty[Either[UserId, Int]]
-      ) :::
-      (if (bots.nonEmpty)
-        Right(SEPARATOR_BOTS) :: bots.map(data => Left(data.id))
-       else
-        List.empty[Either[UserId, Int]]
-      )
+      (if (unverified.nonEmpty && verified.nonEmpty) List(Right(SEPARATOR_VERIFIED)) else Nil) :::
+      verified.map(data => Left(data.id)) :::
+      (if (bots.nonEmpty && (unverified.nonEmpty || verified.nonEmpty)) List(Right(SEPARATOR_BOTS)) else Nil) :::
+      bots.map(data => Left(data.id))
   }
 
   positions.onUi { list =>

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -369,7 +369,10 @@ class ConversationFragment extends BaseFragment[ConversationFragment.Container] 
       audioMessageRecordingView.hide()
     }
 
-    getControllerFactory.getConversationScreenController.setSingleConversation(toConv.convType == IConversation.Type.ONE_TO_ONE)
+    convController.isGroup(toConv).foreach { b =>
+      verbose(s"BOTS updateConv, conv is group: $b")
+      getControllerFactory.getConversationScreenController.setSingleConversation(!b)
+    }
     // TODO: ConversationScreenController should listen to this signal and do it itself
     extendedCursorContainer.close(true)
   }


### PR DESCRIPTION
Mostly refactoring. A group conversation with only one other person is treated as a 1-to-1 conversation. Except, when this "other person" is a bot. Then we show a list of users just as in the group conversation, and a button "Add People" at the bottom (not: "Create Group"). 

I already see one bug: In case of a fake 1-to-1 conversation, the header of the TabbedParticipantBodyFragment is not set. 
#### APK
[Download build #10146](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10146/artifact/build/artifact/wire-dev-PR1389-10146.apk)