### PR TITLE
fix showing the profile for unconnected and blocked users

### DIFF
--- a/app/src/main/scala/com/waz/zclient/usersearch/PickUserFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/PickUserFragment.scala
@@ -317,7 +317,7 @@ class PickUserFragment extends BaseFragment[PickUserFragment.Container]
         case Some(user) =>
           import ConnectionStatus._
           keyboard.hideKeyboardIfVisible()
-          if (z.teamId.isDefined || user.connection == Accepted)
+          if (user.connection == Accepted || (user.connection == Unconnected && z.teamId.isDefined && z.teamId == user.teamId))
             userAccountsController.getConversation(Set(userId)).map(_.id).map { convId =>
               conversationController.selectConv(convId, ConversationChangeRequester.START_CONVERSATION)
             }


### PR DESCRIPTION
1. Go to the StartUI while on a team account.
2. Click on a blocked user. The app should show the user's profile with the "Unblock" button, but instead it tries to start the conversation and fails. 
3. Click on an unconnected user. The app should show the user's profile with the "Connect" button, but instead it tries to start the conversation and fails. 
Fixed.
#### APK
[Download build #10286](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10286/artifact/build/artifact/wire-dev-PR1418-10286.apk)