### PR TITLE
Fix all compiler warnings and enable fatal warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -298,7 +298,14 @@ dependencies {
 }
 
 tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = ["-feature", "-target:jvm-1.7", "-Xfuture", "-deprecation", "-Yinline-warnings", "-Ywarn-unused-import", "-encoding", "UTF-8"]
+    scalaCompileOptions.additionalParameters = [
+        "-feature",
+        "-Xfuture",
+        "-Xfatal-warnings",
+        "-deprecation",
+        "-Ywarn-unused-import",
+        "-encoding",
+        "UTF-8"]
 }
 
 def getDate() {

--- a/app/src/main/java/com/waz/zclient/utils/AutoFocusCallbackDeprecation.java
+++ b/app/src/main/java/com/waz/zclient/utils/AutoFocusCallbackDeprecation.java
@@ -1,0 +1,22 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+public interface AutoFocusCallbackDeprecation {
+    void onAutoFocus(Boolean s, CameraWrapper cam);
+}

--- a/app/src/main/java/com/waz/zclient/utils/CameraParamsWrapper.java
+++ b/app/src/main/java/com/waz/zclient/utils/CameraParamsWrapper.java
@@ -1,0 +1,33 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+import android.hardware.Camera;
+
+public class CameraParamsWrapper {
+
+    private final Camera.Parameters params;
+
+    public CameraParamsWrapper(Camera.Parameters params) {
+        this.params = params;
+    }
+
+    public Camera.Parameters get() {
+        return params;
+    }
+}

--- a/app/src/main/java/com/waz/zclient/utils/CameraSizeWrapper.java
+++ b/app/src/main/java/com/waz/zclient/utils/CameraSizeWrapper.java
@@ -1,0 +1,41 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+import android.hardware.Camera;
+
+public class CameraSizeWrapper {
+
+    private final Camera.Size size;
+
+    public CameraSizeWrapper(Camera.Size size) {
+        this.size = size;
+    }
+
+    public Camera.Size get() {
+        return size;
+    }
+
+    public int width() {
+        return size.width;
+    }
+
+    public int height() {
+        return size.height;
+    }
+}

--- a/app/src/main/java/com/waz/zclient/utils/CameraWrapper.java
+++ b/app/src/main/java/com/waz/zclient/utils/CameraWrapper.java
@@ -1,0 +1,33 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+import android.hardware.Camera;
+
+public class CameraWrapper {
+
+    private final Camera camera;
+
+    public CameraWrapper(Camera camera) {
+        this.camera = camera;
+    }
+
+    public Camera get() {
+        return camera;
+    }
+}

--- a/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
@@ -1,0 +1,172 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+
+import android.app.Notification;
+import android.content.Context;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.hardware.Camera;
+import android.hardware.Camera.Area;
+import android.hardware.Camera.AutoFocusCallback;
+import android.hardware.Camera.CameraInfo;
+import android.hardware.Camera.Parameters;
+import android.hardware.Camera.PictureCallback;
+import android.hardware.Camera.ShutterCallback;
+import android.os.Build;
+import android.os.PowerManager;
+import android.os.Vibrator;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.view.ViewCompat;
+import android.telephony.PhoneNumberUtils;
+import android.text.Html;
+import android.text.Spanned;
+import android.view.View;
+import android.view.WindowManager;
+
+import net.hockeyapp.android.CrashManagerListener;
+import net.hockeyapp.android.ExceptionHandler;
+
+import java.util.Locale;
+
+import static android.hardware.Camera.getNumberOfCameras;
+
+@SuppressWarnings("Deprecation")
+/*
+ This class exists to facilitate fine-grained warning deprecation, not possible in Scala
+ TODO(AN-5975): rewrite this class in Scala once we can include the silencer plugin
+ */
+public class DeprecationUtils {
+
+    public static int PRIORITY_MAX = Notification.PRIORITY_MAX;
+
+    public static int WAKE_LOCK_OPTIONS = PowerManager.SCREEN_BRIGHT_WAKE_LOCK |
+                                          PowerManager.FULL_WAKE_LOCK          |
+                                          PowerManager.ACQUIRE_CAUSES_WAKEUP;
+
+    public static int FLAG_DISMISS_KEYGUARD = WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD;
+
+    public static final int NUMBER_OF_CAMERAS = getNumberOfCameras();
+
+    public static Locale getDefaultLocale(Context context) {
+        return context.getResources().getConfiguration().locale;
+    }
+
+    public static Drawable getDrawable(Context context, int resId) {
+        return context.getResources().getDrawable(resId);
+    }
+
+    public static void saveException(Throwable t, CrashManagerListener l) {
+        ExceptionHandler.saveException(t, l);
+    }
+
+    public static String formatNumber(String s) {
+        return PhoneNumberUtils.formatNumber(s);
+    }
+
+    public static float getAlpha(View v) {
+        return ViewCompat.getAlpha(v);
+    }
+
+    public static void setAlpha(View v, float f) {
+        ViewCompat.setAlpha(v, f);
+    }
+
+    public static NotificationCompat.Builder getBuilder(Context context) {
+        return new NotificationCompat.Builder(context);
+    }
+
+    public static void setPriority(Notification not, int priority) {
+        not.priority = priority;
+    }
+
+    //maybe we can get rid of this one?
+    public static void vibrate(Vibrator v, long[] pattern, int repeat) {
+        v.vibrate(pattern, repeat);
+    }
+
+    public static void setParams(Camera c, CameraWrap cw) {
+        if (c != null) {
+            Parameters params = c.getParameters();
+            cw.f(new CameraParamsWrapper(params));
+            c.setParameters(params);
+        }
+    }
+
+    public static void setAutoFocusCallback(Camera c, final AutoFocusCallbackDeprecation af) {
+        c.autoFocus(new AutoFocusCallback() {
+            @Override
+            public void onAutoFocus(boolean success, Camera camera) {
+                af.onAutoFocus(success, new CameraWrapper(camera));
+            }
+        });
+    }
+
+    public static Area Area(Rect r, int focusWeight) {
+        return new Area(r, focusWeight);
+    }
+
+    public static ShutterCallback shutterCallback(final ShutterCallbackDeprecated scd) {
+        return new ShutterCallback() {
+            @Override
+            public void onShutter() {
+                scd.onShutter();
+            }
+        };
+    }
+
+    public static void getCameraInfo(int cameraId, CameraInfo info) {
+        Camera.getCameraInfo(cameraId, info);
+    }
+
+    public static CameraInfo CameraInfoFactory() {
+        return new CameraInfo();
+    }
+
+    public static PictureCallback pictureCallback(final PictureCallbackDeprecated pcd) {
+        return new PictureCallback() {
+            @Override
+            public void onPictureTaken(byte[] data, Camera camera) {
+                pcd.onPictureTaken(data, new CameraWrapper(camera));
+            }
+        };
+    }
+
+    /**
+     * This function is taken from this Stackoverflow answer:
+     * https://stackoverflow.com/a/39841101/158703
+     */
+    public static Spanned fromHtml(String source) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            return Html.fromHtml(source);
+        }
+    }
+
+    /**
+     * We need to use an interface as Java doesn't have first class functions.
+     * We need CameraParamsWrapper so we can instantiate this interface in Scala code
+     * without writing the type "Params" as this gives a deprecation warning
+     */
+    public interface CameraWrap {
+        void f(CameraParamsWrapper wrapper);
+    }
+}
+

--- a/app/src/main/java/com/waz/zclient/utils/PictureCallbackDeprecated.java
+++ b/app/src/main/java/com/waz/zclient/utils/PictureCallbackDeprecated.java
@@ -1,0 +1,22 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+public interface PictureCallbackDeprecated {
+    void onPictureTaken(byte[] data, CameraWrapper camera);
+}

--- a/app/src/main/java/com/waz/zclient/utils/ShutterCallbackDeprecated.java
+++ b/app/src/main/java/com/waz/zclient/utils/ShutterCallbackDeprecated.java
@@ -1,0 +1,22 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils;
+
+public interface ShutterCallbackDeprecated {
+    void onShutter();
+}

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -145,11 +145,7 @@ class SignInFragment extends BaseFragment[Container] with FragmentHelper with Vi
         pos match  {
           case TabPages.CREATE_ACCOUNT =>
             tabSelector.setSelected(TabPages.CREATE_ACCOUNT)
-            signInController.uiSignInState.mutate {
-              case _ => SignInMethod(Register, Phone) //TODO: remove to enable register by email
-              case SignInMethod(Login, x) => SignInMethod(Register, x)
-              case other => other
-            }
+            signInController.uiSignInState.mutate(_ => SignInMethod(Register, Phone))
           case TabPages.SIGN_IN =>
             tabSelector.setSelected(TabPages.SIGN_IN)
             signInController.uiSignInState.mutate {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
@@ -19,7 +19,7 @@ package com.waz.zclient.appentry.fragments
 
 import android.os.{Build, Bundle, Handler}
 import android.support.v4.content.ContextCompat
-import android.text.{Editable, Html, TextWatcher}
+import android.text.{Editable, TextWatcher}
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{TextView, Toast}
 import com.waz.service.ZMessaging
@@ -34,6 +34,7 @@ import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.ui.text.TypefaceEditText
 import com.waz.zclient.ui.utils.KeyboardUtils
+import com.waz.zclient.utils.DeprecationUtils
 
 object VerifyPhoneFragment {
   val TAG: String = classOf[VerifyPhoneFragment].getName
@@ -149,12 +150,7 @@ class VerifyPhoneFragment extends BaseFragment[VerifyPhoneFragment.Container] wi
 
   private def onPhoneNumberLoaded(phone: String): Unit = {
     val text = String.format(getResources.getString(R.string.activation_code_info_manual), phone)
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
-      //noinspection ScalaDeprecation
-      textViewInfo.setText(Html.fromHtml(text))
-    else
-      textViewInfo.setText(Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY))
-
+    textViewInfo.setText(DeprecationUtils.fromHtml(text))
   }
 
   private def requestCode(shouldCall: Boolean) = {

--- a/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
@@ -29,7 +29,7 @@ import com.waz.threading.Threading
 import com.waz.zclient._
 import com.waz.zclient.calling.controllers.GlobalCallingController
 import com.waz.zclient.calling.views.VideoCallingView
-import com.waz.zclient.utils.RichView
+import com.waz.zclient.utils.{DeprecationUtils, RichView}
 
 class CallingActivity extends BaseActivity {
   import CallingActivity._
@@ -86,7 +86,7 @@ class CallingActivity extends BaseActivity {
         WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
         WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON |
         WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-        WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+        DeprecationUtils.FLAG_DISMISS_KEYGUARD
     )
   }
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CurrentCallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CurrentCallController.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.calling.controllers
 
-import _root_.com.waz.zclient.utils.LayoutSpec
+import _root_.com.waz.zclient.utils.{DeprecationUtils, LayoutSpec}
 import android.media.AudioManager
 import android.os.Vibrator
 import com.waz.ZLog.ImplicitTag._
@@ -179,13 +179,14 @@ class CurrentCallController(implicit inj: Injector, cxt: WireContext) extends In
   }
 
   def vibrate(): Unit = {
+    import com.waz.zclient.utils.ContextUtils._
     val audioManager = Option(inject[AudioManager])
     val vibrator = Option(inject[Vibrator])
 
     val disableRepeat = -1
     (audioManager, vibrator) match {
       case (Some(am), Some(vib)) if am.getRingerMode != AudioManager.RINGER_MODE_SILENT =>
-        vib.vibrate(cxt.getResources.getIntArray(R.array.call_control_enter).map(_.toLong), disableRepeat)
+        DeprecationUtils.vibrate(vib, getIntArray(R.array.call_control_enter).map(_.toLong), disableRepeat)
       case _ =>
     }
   }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/GlobalCallingController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/GlobalCallingController.scala
@@ -32,6 +32,7 @@ import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.calling.CallingActivity
 import com.waz.zclient.common.controllers.SoundController
 import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.DeprecationUtils
 import com.waz.zclient.{Injectable, Injector, R, WireContext}
 
 class GlobalCallingController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext) extends Injectable {
@@ -275,7 +276,7 @@ private class ScreenManager(implicit injector: Injector) extends Injectable {
 
   private def createWakeLock() = {
     val flags = if (stayAwake)
-      PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP
+      DeprecationUtils.WAKE_LOCK_OPTIONS
     else PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK
     releaseWakeLock()
     wakeLock = powerManager.map(_.newWakeLock(flags, TAG))

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
@@ -30,7 +30,7 @@ import com.waz.media.manager.context.IntensityLevel
 import com.waz.service.ZMessaging
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.RingtoneUtils
+import com.waz.zclient.utils.{DeprecationUtils, RingtoneUtils}
 import com.waz.zclient.utils.RingtoneUtils.{getUriForRawId, isDefaultValue}
 import com.waz.zclient.{R, _}
 
@@ -138,7 +138,7 @@ class SoundController(implicit inj: Injector, cxt: Context) extends Injectable {
     (audioManager, vibrator) match {
       case (Some(am), Some(vib)) if play && am.getRingerMode != AudioManager.RINGER_MODE_SILENT && isVibrationEnabled =>
         vib.cancel() // cancel any current vibrations
-        vib.vibrate(getIntArray(patternId).map(_.toLong), if (loop) 0 else -1)
+        DeprecationUtils.vibrate(vib, getIntArray(patternId).map(_.toLong), if (loop) 0 else -1)
       case (_, Some(vib)) => vib.cancel()
       case _ =>
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -48,7 +48,6 @@ import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.main.connect.{BlockedUserProfileFragment, ConnectRequestLoadMode, PendingConnectRequestManagerFragment, SendConnectRequestFragment}
 import com.waz.zclient.pages.main.conversation.controller.{ConversationScreenControllerObserver, IConversationScreenController}
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController.Destination
-import com.waz.zclient.pages.main.pickuser.controller.IPickUserController.Destination._
 import com.waz.zclient.pages.main.pickuser.controller.{IPickUserController, PickUserControllerScreenObserver}
 import com.waz.zclient.participants.OptionsMenuFragment
 import com.waz.zclient.ui.animation.interpolators.penner.{Expo, Quart}
@@ -103,6 +102,8 @@ class ConversationListManagerFragment extends Fragment
 
   lazy val hasConvs = convListController.establishedConversations.map(_.nonEmpty)
 
+  import pickUserController._
+
   lazy val animationType = {
     import LoadingIndicatorView._
     hasConvs.map {
@@ -141,14 +142,14 @@ class ConversationListManagerFragment extends Fragment
         v.resetFullScreenPadding()
       }
 
+
       if (savedInstanceState == null) {
         val fm = getChildFragmentManager
-        import pickUserController._
         // When re-starting app to open into specific page, child fragments may exist despite savedInstanceState == null
         if (isShowingUserProfile) hideUserProfile()
-        if (isShowingPickUser(CONVERSATION_LIST)) {
-          hidePickUser(CONVERSATION_LIST)
-          Option(fm.findFragmentByTag(SearchUIFragment.TAG)).foreach { f =>
+        if (isShowingPickUser(Destination.CONVERSATION_LIST)) {
+          hidePickUser(Destination.CONVERSATION_LIST)
+          Option(fm.findFragmentByTag(SearchUIFragment.TAG)).foreach { _ =>
             fm.popBackStack(SearchUIFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
           }
         }
@@ -171,23 +172,19 @@ class ConversationListManagerFragment extends Fragment
         }
       }
 
-      convController.convChanged.map(_.requester).onUi { req =>
-        import ConversationChangeRequester._
+      convController.convChanged.map(_.requester).onUi {
+        case ConversationChangeRequester.START_CONVERSATION |
+             ConversationChangeRequester.START_CONVERSATION_FOR_CALL |
+             ConversationChangeRequester.START_CONVERSATION_FOR_VIDEO_CALL |
+             ConversationChangeRequester.START_CONVERSATION_FOR_CAMERA |
+             ConversationChangeRequester.INTENT =>
+          stripToConversationList()
 
-        req match {
-          case START_CONVERSATION |
-               START_CONVERSATION_FOR_CALL |
-               START_CONVERSATION_FOR_VIDEO_CALL |
-               START_CONVERSATION_FOR_CAMERA |
-               INTENT =>
-            stripToConversationList()
+        case ConversationChangeRequester.INCOMING_CALL =>
+          stripToConversationList()
+          animateOnIncomingCall()
 
-          case INCOMING_CALL =>
-            stripToConversationList()
-            animateOnIncomingCall()
-
-          case _ => //
-        }
+        case _ => //
       }
 
       accentColor.accentColor.onUi { c =>

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -36,6 +36,7 @@ import com.waz.zclient.calling.controllers.GlobalCallingController
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.common.views.ImageController
 import com.waz.zclient._
+import com.waz.zclient.utils.DeprecationUtils
 import com.waz.zms.CallWakeService
 
 class CallingNotificationsController(implicit cxt: WireContext, eventContext: EventContext, inj: Injector) extends Injectable {
@@ -81,7 +82,7 @@ class CallingNotificationsController(implicit cxt: WireContext, eventContext: Ev
       val message = getCallStateMessage(state, video)
       val title = if (group) getString(R.string.system_notification__group_call_title, callerName, conv.displayName) else conv.displayName
 
-      val builder = new NotificationCompat.Builder(cxt)
+      val builder = DeprecationUtils.getBuilder(cxt)
         .setSmallIcon(R.drawable.ic_menu_logo)
         .setLargeIcon(bmp.orNull)
         .setContentTitle(title)
@@ -111,7 +112,7 @@ class CallingNotificationsController(implicit cxt: WireContext, eventContext: Ev
 
       def buildNotification = {
         val notification = builder.build
-        notification.priority = Notification.PRIORITY_MAX
+        DeprecationUtils.setPriority(notification, DeprecationUtils.PRIORITY_MAX)
         if (state != OtherCalling) notification.flags |= Notification.FLAG_NO_CLEAR
         notification
       }

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
@@ -32,6 +32,7 @@ import com.waz.utils.LoggedTry
 import com.waz.utils.wrappers.URI
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.DeprecationUtils
 import com.waz.zclient.utils.IntentUtils._
 import com.waz.zclient.{Injectable, Injector, R, WireContext}
 
@@ -77,7 +78,7 @@ class ImageNotificationsController(implicit cxt: WireContext, eventContext: Even
       .bigPicture(bitmap)
       .setSummaryText(summaryText)
 
-    val builder = new NotificationCompat.Builder(cxt)
+    val builder = DeprecationUtils.getBuilder(cxt)
       .setContentTitle(notificationTitle)
       .setContentText(summaryText)
       .setSmallIcon(R.drawable.ic_menu_save_image_gallery)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -49,7 +49,7 @@ import com.waz.zclient.controllers.userpreferences.UserPreferencesController
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.controllers.NavigationController
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.{RingtoneUtils, ViewUtils}
+import com.waz.zclient.utils.{DeprecationUtils, RingtoneUtils, ViewUtils}
 import com.waz.zms.NotificationsAndroidService
 import org.threeten.bp.Instant
 
@@ -180,7 +180,7 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
 
       val inboxStyle = new NotificationCompat.InboxStyle()
 
-      val builder = new NotificationCompat.Builder(cxt)
+      val builder = DeprecationUtils.getBuilder(cxt)
         .setWhen(nots.minBy(_.time).time.toEpochMilli)
         .setShowWhen(true)
         .setCategory(NotificationCompat.CATEGORY_MESSAGE)
@@ -294,7 +294,7 @@ class MessageNotificationsController(implicit inj: Injector, cxt: Context, event
   }
 
   private def commonBuilder(accountId: AccountId, title: CharSequence, displayTime: Instant, style: NotificationCompat.Style, silent: Boolean) = {
-    val builder = new NotificationCompat.Builder(cxt)
+    val builder = DeprecationUtils.getBuilder(cxt)
       .setShowWhen(true)
       .setCategory(NotificationCompat.CATEGORY_MESSAGE)
       .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/app/src/main/scala/com/waz/zclient/participants/OptionsMenuFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/OptionsMenuFragment.scala
@@ -139,13 +139,12 @@ class OptionsMenu(val context: Context, val attrs: AttributeSet, val defStyleAtt
         val item = items(itemNumber)
 
         row.addView(returning(LayoutInflater.from(getContext).inflate(R.layout.options_menu__item, this, false)) { container =>
-          import OptionsTheme.Type._
           returning(getView[FrameLayout](container, R.id.fl_options_menu_button)) { v =>
             val drawable = (item.isToggled, theme.getType) match {
-              case (true,  DARK) => R.drawable.selector__icon_button__background__dark_toggled
-              case (true,  _)    => R.drawable.selector__icon_button__background__light_toggled
-              case (false, DARK) => R.drawable.selector__icon_button__background__dark
-              case (false, _)    => R.drawable.selector__icon_button__background__light
+              case (true,  OptionsTheme.Type.DARK) => R.drawable.selector__icon_button__background__dark_toggled
+              case (true,  _)                      => R.drawable.selector__icon_button__background__light_toggled
+              case (false, OptionsTheme.Type.DARK) => R.drawable.selector__icon_button__background__dark
+              case (false, _)                      => R.drawable.selector__icon_button__background__light
             }
             v.setBackground(getDrawable(drawable))
           }
@@ -153,9 +152,9 @@ class OptionsMenu(val context: Context, val attrs: AttributeSet, val defStyleAtt
           returning(getView[GlyphTextView](container, R.id.gtv__options_menu_button__glyph)) { v =>
             v.setText(item.resGlyphId)
             val inverted = (item.isToggled, theme.getType) match {
-              case (true,  DARK) => ctrl.themes.optionsLightTheme
-              case (true,  _)    => ctrl.themes.optionsDarkTheme
-              case (false, _)    => theme
+              case (true,  OptionsTheme.Type.DARK) => ctrl.themes.optionsLightTheme
+              case (true,  _)                      => ctrl.themes.optionsDarkTheme
+              case (false, _)                      => theme
             }
             v.setTextColor(inverted.getTextColorPrimarySelector)
           }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -24,16 +24,13 @@ import android.support.v7.widget.Toolbar
 import android.view._
 import android.view.animation.{AlphaAnimation, Animation}
 import android.widget.TextView
-import com.waz.api.Verification
-import com.waz.model.UserData
-import com.waz.utils.events.{Signal, Subscription}
+import com.waz.utils.events.Subscription
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.utils.{RichView, ViewUtils}
-import com.waz.zclient.views.e2ee.ShieldView
 import com.waz.zclient.{FragmentHelper, R}
 
 class ParticipantHeaderFragment extends BaseFragment[ParticipantHeaderFragment.Container] with FragmentHelper {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangePhoneDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangePhoneDialog.scala
@@ -50,7 +50,7 @@ import com.waz.zclient.appentry.{GenericRegisterPhoneError, PhoneExistsError}
 import com.waz.zclient.controllers.deviceuser.IDeviceUserController
 import com.waz.zclient.newreg.fragments.country.{Country, CountryController}
 import com.waz.zclient.ui.utils.{DrawableUtils, MathUtils}
-import com.waz.zclient.utils.{RichView, ViewUtils}
+import com.waz.zclient.utils.{DeprecationUtils, RichView, ViewUtils}
 import com.waz.ZLog.ImplicitTag._
 
 import scala.concurrent.Future
@@ -222,7 +222,7 @@ class ChangePhoneDialog extends DialogFragment with FragmentHelper with CountryC
       errorView.setText(error)
       errorView.setVisible(true)
       if (animate) {
-        if (MathUtils.floatEqual(ViewCompat.getAlpha(errorView), 1f)) ViewCompat.setAlpha(errorView, 0f)
+        if (MathUtils.floatEqual(DeprecationUtils.getAlpha(errorView), 1f)) DeprecationUtils.setAlpha(errorView, 0f)
         ViewCompat.animate(errorView).alpha(1f).setDuration(AnimationDuration).setInterpolator(LINEAR_OUT_SLOW_IN_INTERPOLATOR).setListener(new ViewPropertyAnimatorListenerAdapter() {
           override def onAnimationStart(view: View) = view.setVisible(true)
         }).start()

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyPhoneFragment.scala
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.support.design.widget.TextInputLayout
 import android.support.v4.app.DialogFragment
 import android.support.v4.app.DialogFragment.STYLE_NO_FRAME
-import android.telephony.PhoneNumberUtils
 import android.text.{Editable, TextUtils}
 import android.view.View.OnKeyListener
 import android.view.WindowManager.LayoutParams.{SOFT_INPUT_ADJUST_RESIZE, SOFT_INPUT_STATE_ALWAYS_HIDDEN}
@@ -36,7 +35,7 @@ import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.pages.main.profile.views.OnTextChangedListener
 import com.waz.zclient.ui.utils.TypefaceUtils
-import com.waz.zclient.utils.RichView
+import com.waz.zclient.utils.{DeprecationUtils, RichView}
 import com.waz.zclient.{FragmentHelper, R}
 
 class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
@@ -61,7 +60,7 @@ class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View = {
 
-    val phonNumber = PhoneNumber(PhoneNumberUtils.formatNumber(getArguments.getString(ArgPhone, "")))
+    val phoneNumber = PhoneNumber(DeprecationUtils.formatNumber(getArguments.getString(ArgPhone, "")))
 
     val view = inflater.inflate(R.layout.fragment_preference_phone_number_verification, container, false)
 
@@ -73,7 +72,7 @@ class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
       v.setEnabled(false)
       v.onClick {
         ZMessaging.accountsService.flatMap {
-          _.verifyPhoneNumber(PhoneCredentials(phonNumber, Option(ConfirmationCode(new String(verificationCode)))), KindOfVerification.VERIFY_ON_UPDATE).map {
+          _.verifyPhoneNumber(PhoneCredentials(phoneNumber, Option(ConfirmationCode(new String(verificationCode)))), KindOfVerification.VERIFY_ON_UPDATE).map {
             case Right(()) => dismiss()
             case _         => verificationCodeInputLayout.setError(getString(R.string.new_reg_phone_generic_error_header))
           } (Threading.Ui)
@@ -89,7 +88,7 @@ class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
         v.animate.alpha(0f).start()
 
         ZMessaging.accountsService.flatMap {
-          _.requestPhoneConfirmationCode(phonNumber, KindOfAccess.REGISTRATION).map {
+          _.requestPhoneConfirmationCode(phoneNumber, KindOfAccess.REGISTRATION).map {
             case ActivateResult.Success =>
               v.animate.alpha(1f).start()
             case _ =>
@@ -102,7 +101,7 @@ class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
     }
 
     returning(findById[TextView](view, R.id.tv__verification_description)) {
-      _.setText(getString(R.string.pref__account_action__phone_verification__description, phonNumber.str))
+      _.setText(getString(R.string.pref__account_action__phone_verification__description, phoneNumber.str))
     }
 
     textBoxes = Seq(

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -35,7 +35,8 @@ import com.waz.zclient._
 import com.waz.zclient.appentry.EntryError
 import com.waz.zclient.appentry.controllers.SignInController.{InputType, SignInMethod}
 import com.waz.zclient.tracking.AddPhotoOnRegistrationEvent.Source
-import net.hockeyapp.android.{CrashManagerListener, ExceptionHandler}
+import com.waz.zclient.utils.DeprecationUtils
+import net.hockeyapp.android.CrashManagerListener
 import org.json.JSONObject
 
 import scala.collection.JavaConverters._
@@ -214,7 +215,7 @@ object GlobalTrackingController {
     t match {
       case _: RSRuntimeException => //
       case _ =>
-        ExceptionHandler.saveException(t, new CrashManagerListener {
+        DeprecationUtils.saveException(t, new CrashManagerListener {
           override def shouldAutoUploadCrashes: Boolean = true
           override def getUserID: String = Try(ZMessaging.context.getSharedPreferences("zprefs", Context.MODE_PRIVATE).getString("com.waz.device.id", "???")).getOrElse("????")
           override def getDescription: String = s"zmessaging - $tag - $description"

--- a/app/src/main/scala/com/waz/zclient/tracking/MixpanelGuard.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/MixpanelGuard.scala
@@ -27,7 +27,6 @@ import com.waz.zclient.{BuildConfig, WireContext}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.language.{implicitConversions, reflectiveCalls}
 
 object MixpanelGuard {
 

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -59,8 +59,7 @@ object ContextUtils {
 
   def getDrawable(resId: Int, theme: Option[Resources#Theme] = None)(implicit context: Context): Drawable = {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      //noinspection ScalaDeprecation
-      context.getResources.getDrawable(resId)
+      DeprecationUtils.getDrawable(context, resId)
     } else
       context.getResources.getDrawable(resId, theme.orNull)
   }
@@ -74,8 +73,7 @@ object ContextUtils {
 
   def getLocale(implicit context: Context) = {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      //noinspection ScalaDeprecation
-      context.getResources.getConfiguration.locale
+      DeprecationUtils.getDefaultLocale(context)
     } else {
       context.getResources.getConfiguration.getLocales.get(0)
     }

--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -23,7 +23,6 @@ import android.graphics.LightingColorFilter
 import android.graphics.drawable.LayerDrawable
 import android.support.v7.preference.Preference
 import android.support.v7.preference.Preference.{OnPreferenceChangeListener, OnPreferenceClickListener}
-import android.support.v7.widget.SwitchCompat
 import android.text.{Editable, TextWatcher}
 import android.view.View._
 import android.view.ViewGroup.LayoutParams

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     targetSdkVersion = 23
     buildToolsVersion = '26.0.1'
     scalaMajorVersion = '2.11'
-    scalaVersion = scalaMajorVersion + '.8'
+    scalaVersion = scalaMajorVersion + '.12'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
     preDexLibs = !project.hasProperty('disablePreDex')

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,18 @@ scalaVersion in Global := "2.11.8"
 
 compileOrder in Global := CompileOrder.Mixed
 
-javacOptions in Global ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions in Global ++= Seq("-source", "1.7", "-target", "-Werror" , "1.7")
 
-scalacOptions in Global ++= Seq("-feature", "-target:jvm-1.7", "-Xfuture", "-deprecation", "-Yinline-warnings", "-Ywarn-unused-import", "-encoding", "UTF-8")
+scalacOptions in Global ++= Seq(
+    "-feature",
+    "-target:jvm-1.7",
+    "-Xfuture",
+    "-Xfatal-warnings" ,
+    "-deprecation",
+    "-Yinline-warnings",
+    "-Ywarn-unused-import",
+    "-encoding",
+    "UTF-8")
 
 resolvers in Global ++= Seq (
   "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val app = Project("zclient-app", file("app"))
     dexMaxHeap := "6144M",
     minSdkVersion := "17",
     libraryDependencies ++= Seq (multidex, supportannotations, supportdesign, audioNotifications, cardview,
-      spotifyAuth, spotifyPlayer, nineoldandroids, localytics, psBase, psGcm, psMaps, psLocation, mp4parser,
+      nineoldandroids, localytics, psBase, psGcm, psMaps, psLocation, mp4parser,
       "com.jakewharton.hugo" % "hugo-annotations" % "1.2.1" % "provided",
       "com.wire" % "testutils" % zmsDevVersion % Test,
       "com.geteit" %% "robotest" % "0.7" % Test exclude("org.scalatest", "scalatest"),

--- a/macrosupport/build.gradle
+++ b/macrosupport/build.gradle
@@ -26,7 +26,3 @@ dependencies {
     provided deps.scalaReflect
 
 }
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = ["-feature", "-target:jvm-1.7", "-Xfuture", "-deprecation", "-Yinline-warnings", "-Ywarn-unused-import", "-encoding", "UTF-8"]
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += "android team nexus snapshots" at "http://192.168.10.18:8081/nexus/content/repositories/snapshots"
 
-addSbtPlugin("org.scala-android" % "sbt-android" % "1.7.2")
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.7.10")


### PR DESCRIPTION
This commit should help us keep the number of warnings to a minimum in future. I've created a Java class which implements any code which has to contain deprecations. It's a big ugly at times, and would be cleaner in Scala. However, the scala compiler plugin doesn't support the [Gradle Scala Plugin](https://github.com/ghik/silencer/issues/6) at the moment, and our migration to SBT for wire-ui is still a ways off.
#### APK
[Download build #10361](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10361/artifact/build/artifact/wire-dev-PR1431-10361.apk)
[Download build #10362](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10362/artifact/build/artifact/wire-dev-PR1431-10362.apk)
[Download build #10365](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10365/artifact/build/artifact/wire-dev-PR1431-10365.apk)
[Download build #10401](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10401/artifact/build/artifact/wire-dev-PR1431-10401.apk)
[Download build #10402](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10402/artifact/build/artifact/wire-dev-PR1431-10402.apk)
[Download build #10405](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10405/artifact/build/artifact/wire-dev-PR1431-10405.apk)
[Download build #10409](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10409/artifact/build/artifact/wire-dev-PR1431-10409.apk)
[Download build #10411](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10411/artifact/build/artifact/wire-dev-PR1431-10411.apk)