### PR TITLE
Fix exit animation for SingleParticipantFragment

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
@@ -163,18 +163,18 @@ class GroupParticipantsFragment extends FragmentHelper {
     }
   }
 
-  override def onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation = {
-    val parent = getParentFragment
-    // Apply the workaround only if this is a child fragment, and the parent is being removed.
-    if (!enter && parent != null && parent.isRemoving) {
-      // This is a workaround for the bug where child fragments disappear when
-      // the parent is removed (as all children are first removed from the parent)
-      // See https://code.google.com/p/android/issues/detail?id=55228
-      returning(new AlphaAnimation(1, 1)) {
-        _.setDuration(ViewUtils.getNextAnimationDuration(parent))
-      }
-    } else super.onCreateAnimation(transit, enter, nextAnim)
-  }
+  // This is a workaround for the bug where child fragments disappear when
+  // the parent is removed (as all children are first removed from the parent)
+  // See https://code.google.com/p/android/issues/detail?id=55228
+  // Apply the workaround only if this is a child fragment, and the parent is being removed.
+  override def onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation =
+    Option(getParentFragment) match {
+      case Some(parent) if !enter && parent.isRemoving =>
+        returning(new AlphaAnimation(1, 1)) {
+          _.setDuration(ViewUtils.getNextAnimationDuration(parent))
+        }
+      case _ => super.onCreateAnimation(transit, enter, nextAnim)
+    }
 
   override def onCreateView(inflater: LayoutInflater, viewGroup: ViewGroup, savedInstanceState: Bundle): View =
     inflater.inflate(R.layout.fragment_group_participant, viewGroup, false)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -105,12 +105,6 @@ class ParticipantFragment extends BaseFragment[ParticipantFragment.Container] wi
     if (Option(savedInstanceState).isEmpty)
       participantsController.isGroupOrBot.head.foreach { groupOrBot =>
         getChildFragmentManager.beginTransaction
-        .setCustomAnimations(
-          R.anim.open_new_conversation__thread_list_in,
-          R.anim.open_new_conversation__thread_list_out,
-          R.anim.open_new_conversation__thread_list_in,
-          R.anim.open_new_conversation__thread_list_out
-        )
         .replace(
           R.id.fl__participant__header__container,
           headerFragment,

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -20,7 +20,6 @@ package com.waz.zclient.participants.fragments
 import android.content.Context
 import android.os.Bundle
 import android.support.annotation.Nullable
-import android.support.v4.app.Fragment
 import android.support.v4.view.ViewPager
 import android.view.animation.{AlphaAnimation, Animation}
 import android.view.{LayoutInflater, View, ViewGroup}
@@ -121,9 +120,10 @@ class SingleParticipantFragment extends FragmentHelper {
   // Apply the workaround only if this is a child fragment, and the parent is being removed.
   override def onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation =
     Option(getParentFragment) match {
-      case Some(parent: Fragment) if enter && parent.isRemoving => returning(new AlphaAnimation(1, 1)){
-        _.setDuration(ViewUtils.getNextAnimationDuration(parent))
-      }
+      case Some(parent) if !enter && parent.isRemoving =>
+        returning(new AlphaAnimation(1, 1)) {
+          _.setDuration(ViewUtils.getNextAnimationDuration(parent))
+        }
       case _ => super.onCreateAnimation(transit, enter, nextAnim)
     }
 


### PR DESCRIPTION
Setting custom animations in `ParticipantFragment` was redundant, and there was a typo in `SingleParticipantFragment.onCreateAnimation`  - the dummy animation should be used when `enter` was false, not true. 
#### APK
[Download build #10431](http://192.168.10.18:8080/job/Pull%20Request%20Builder/10431/artifact/build/artifact/wire-dev-PR1445-10431.apk)