### PR TITLE
Fix messages not being tagged as read

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationpager/SecondPageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationpager/SecondPageFragment.scala
@@ -71,21 +71,21 @@ class SecondPageFragment extends FragmentHelper
     } yield (conv.convType, other)).onUi { case (convType, maybeUserId) =>
       info(s"Conversation type: $convType, otherUser: $maybeUserId")
 
-      val (fragment, tag) = (convType, maybeUserId) match {
+      val (fragment, tag, page) = (convType, maybeUserId) match {
         case (Type.INCOMING_CONNECTION, Some(userId)) =>
           import ConnectRequestFragment._
-          (newInstance(userId), FragmentTag)
+          (newInstance(userId), FragmentTag, Page.CONNECT_REQUEST_INBOX)
         case (Type.WAIT_FOR_CONNECTION, Some(userId)) =>
           import PendingConnectRequestManagerFragment._
-          (newInstance(userId, UserRequester.CONVERSATION), Tag)
+          (newInstance(userId, UserRequester.CONVERSATION), Tag, Page.CONNECT_REQUEST_PENDING)
         case _ =>
           import ConversationManagerFragment._
-          (newInstance, Tag)
+          (newInstance, Tag, Page.MESSAGE_STREAM)
       }
 
       def open() = {
-        info(s"openPage $tag")
-        navigationController.setRightPage(Page.CONNECT_REQUEST_INBOX, SecondPageFragment.Tag)
+        info(s"openPage $tag ($page)")
+        navigationController.setRightPage(page, SecondPageFragment.Tag)
 
         val transaction = getChildFragmentManager
           .beginTransaction.replace(R.id.fl__second_page_container, fragment, tag)


### PR DESCRIPTION
The `currentPage` in `NavigationController` was not set to `MESSAGE_STREAM` when the user opened the conversation. That in turn meant that `MessagesController.fullyVisibleMessagesList` stayed as `Signal const None`, instead of changing to the current conversation id. Because no change was happening, the messages in the conversation were not tagged as read. Now that they are:
1. Ephemeral messages are getting counted down properly.
2. The unread messages badge in the conversation list is being cleared.
3. If someone sends a new message to the opened conversation, the notification does not appear.
#### APK
[Download build #10665](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10665/artifact/build/artifact/wire-dev-PR1512-10665.apk)
[Download build #10670](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10670/artifact/build/artifact/wire-dev-PR1512-10670.apk)