### PR TITLE
Handle null pointer returned by File.listFiles in WireApplication.clearOldVideoFiles

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient
 
+import java.io.File
 import java.util.Calendar
 
 import android.app.{Activity, ActivityManager, NotificationManager}
@@ -216,14 +217,17 @@ object WireApplication {
   protected def clearOldVideoFiles(context: Context): Unit = {
     val oneWeekAgo = Calendar.getInstance
     oneWeekAgo.add(Calendar.DAY_OF_YEAR, -7)
-    Option(context.getExternalCacheDir).foreach { _.listFiles().foreach { file =>
-      val fileName = file.getName
-      val fileModified = Calendar.getInstance()
-      fileModified.setTimeInMillis(file.lastModified)
-      if (fileName.startsWith("VID_") && fileName.endsWith(".mp4") && fileModified.before(oneWeekAgo)) {
-        file.delete()
+    Option(context.getExternalCacheDir).foreach { dir =>
+      Option(dir.listFiles).fold[List[File]](Nil)(_.toList).foreach { file =>
+        val fileName = file.getName
+        val fileModified = Calendar.getInstance()
+        fileModified.setTimeInMillis(file.lastModified)
+        if (fileName.startsWith("VID_") &&
+            fileName.endsWith(".mp4") &&
+            fileModified.before(oneWeekAgo)
+        ) file.delete()
       }
-    }}
+    }
   }
 }
 


### PR DESCRIPTION
`File.listFiles` returns `null` if it's not possible to read from the directory or the path is invalid for some reason. It's a very rare case of a very ugly Java way of doing things. I wrapped the result in an `Option`.