### PR TITLE
Stop unnecessary binding of ConversationNameViewHolder

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -42,6 +42,7 @@ import com.waz.zclient.ui.text.{GlyphTextView, TypefaceEditText}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils}
 import com.waz.zclient.{Injectable, Injector, R}
+
 import scala.concurrent.duration._
 
 class ParticipantsAdapter(numOfColumns: Int)(implicit context: Context, injector: Injector, eventContext: EventContext)
@@ -251,12 +252,13 @@ object ParticipantsAdapter {
     })
 
     def bind(id: ConvId, displayName: String, verified: Boolean): Unit = {
-      convId = Some(id)
-      convName = Some(displayName)
-
-      editText.setText(displayName)
-      Selection.removeSelection(editText.getText)
-      verifiedShield.setVisible(verified)
+      if (!convId.contains(id)) convId = Some(id)
+      if (verifiedShield.isVisible != verified) verifiedShield.setVisible(verified)
+      if (!convName.contains(displayName)) {
+        convName = Some(displayName)
+        editText.setText(displayName)
+        Selection.removeSelection(editText.getText)
+      }
     }
 
     def onBackPressed(): Boolean =


### PR DESCRIPTION
Calls to the `bind` method were resetting the conversation name while editing.
#### APK
[Download build #10718](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10718/artifact/build/artifact/wire-dev-PR1527-10718.apk)
[Download build #10719](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10719/artifact/build/artifact/wire-dev-PR1527-10719.apk)