### PR TITLE
Handle connection requests fragments

### DIFF
--- a/app/src/main/scala/com/waz/zclient/connect/ConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/ConnectRequestFragment.scala
@@ -55,28 +55,21 @@ class ConnectRequestFragment extends BaseFragment[Container] with FragmentHelper
     (for {
       Some(u) <- scrollToOnOpen
       req     <- adapter.incomingRequests
-    } yield if (req.contains(u)) Some(u) else None).onUi {
-      case Some(u) =>
-        adapter.findPosition(u).foreach { p =>
-          recyclerView.scrollToPosition(p)
-          scrollToOnOpen ! None
-        }
-      case _ => //
+    } yield (u, req)).collect { case (u, req) if req.contains(u) => u } .onUi { u =>
+      adapter.findPosition(u).foreach { p =>
+        recyclerView.scrollToPosition(p)
+        scrollToOnOpen ! None
+      }
     }
 
     scrollToOnOpen ! Try(getArguments.getString(SelectedUser)).toOption.map(UserId)
 
     rootView
   }
-
-  //FIXME - sometimes this is not called by the SecondPageFragment, so the position setting is lost.
-  def setVisibleConnectRequest(userId: UserId) =
-    scrollToOnOpen ! Some(userId)
 }
 
 object ConnectRequestFragment {
-
-  val FragmentTag = classOf[ConnectRequestFragment].getName
+  val Tag = classOf[ConnectRequestFragment].getName
   val SelectedUser = "ARG_SELECTED_USER"
 
   trait Container {


### PR DESCRIPTION
Fix for: https://github.com/wireapp/android-project/projects/6#card-8372703

The other member of the conversation which is in the pending connection state (both incoming and outgoing) is not an active member of the conversation. Trying to get her id like that resulted in opening the standard conversation fragment instead.

Conversation in the pending connection states are all true 1:1 conversations, so I decided to use here the old trick of converting the `convId` to `userId` directly. It would be even better to give all pending connection fragments ability to handle this directly instead of passing the id as a parameter. But right now this should be sufficient.
#### APK
[Download build #10731](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10731/artifact/build/artifact/wire-dev-PR1530-10731.apk)
[Download build #10732](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10732/artifact/build/artifact/wire-dev-PR1530-10732.apk)
[Download build #10753](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10753/artifact/build/artifact/wire-dev-PR1530-10753.apk)
[Download build #10756](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10756/artifact/build/artifact/wire-dev-PR1530-10756.apk)
[Download build #10785](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10785/artifact/build/artifact/wire-dev-PR1530-10785.apk)
[Download build #10800](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10800/artifact/build/artifact/wire-dev-PR1530-10800.apk)
[Download build #10801](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10801/artifact/build/artifact/wire-dev-PR1530-10801.apk)