### PR TITLE
Make the call participants list use the correct zms

### DIFF
--- a/app/src/main/res/layout/calling_middle_layout.xml
+++ b/app/src/main/res/layout/calling_middle_layout.xml
@@ -44,7 +44,7 @@
     <com.waz.zclient.calling.views.CallParticipantsView
         android:id="@+id/call_participants"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="top|start"
         android:visibility="gone"
         app:isScrollable="false"

--- a/app/src/main/scala/com/waz/zclient/calling/CallParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallParticipantsAdapter.scala
@@ -22,6 +22,7 @@ import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.RecyclerView.ViewHolder
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.ImageView
+import com.waz.ZLog.ImplicitTag.implicitLogTag
 import com.waz.utils.events._
 import com.waz.zclient.ViewHelper.inflate
 import com.waz.zclient.calling.controllers.CallController
@@ -34,7 +35,6 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils.{getColor, getDrawable, getString, getStyledColor}
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{Injectable, Injector, R}
-import com.waz.ZLog.ImplicitTag.implicitLogTag
 
 class CallParticipantsAdapter(implicit context: Context, eventContext: EventContext, inj: Injector) extends RecyclerView.Adapter[ViewHolder] with Injectable {
 
@@ -58,7 +58,9 @@ class CallParticipantsAdapter(implicit context: Context, eventContext: EventCont
     notifyDataSetChanged()
   }
 
-  callController.participantInfos(maxRows.map(_ - 1)).onUi { v =>
+  callController.participantInfos(
+    if (maxRows.exists(_ < numOfParticipants)) maxRows.map(_ - 1) else maxRows
+  ).onUi { v =>
     items = v
     notifyDataSetChanged()
   }
@@ -74,7 +76,7 @@ class CallParticipantsAdapter(implicit context: Context, eventContext: EventCont
   }
 
   override def getItemViewType(position: Int): Int =
-    if (maxRows.contains(position + 1)) ShowAll
+    if (maxRows.contains(position + 1) && maxRows.exists(_ < numOfParticipants)) ShowAll
     else UserRow
 
   override def getItemCount: Int = maxRows match {
@@ -83,7 +85,7 @@ class CallParticipantsAdapter(implicit context: Context, eventContext: EventCont
   }
 
   override def getItemId(position: Int): Long =
-    if (maxRows.contains(position + 1)) 0
+    if (maxRows.contains(position) && maxRows.exists(_ < numOfParticipants)) 0
     else items(position).userId.hashCode()
 
   setHasStableIds(true)

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -77,7 +77,8 @@ abstract class UserVideoView(context: Context, val userId: UserId) extends Frame
 
   override def onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int): Unit = {
     super.onLayout(changed, left, top, right, bottom)
-    if (changed) imageView.setBackground(new BackgroundDrawable(pictureId, getContext, Dim2(right - left, bottom - top)))
+    if (changed)
+      imageView.setBackground(new BackgroundDrawable(pictureId, getContext, Dim2(right - left, bottom - top)))
   }
 
   val videoView: View
@@ -110,11 +111,10 @@ class OtherVideoView(context: Context, userId: UserId) extends UserVideoView(con
 
 class CallingFragment extends FragmentHelper {
 
+  private lazy val controller       = inject[CallController]
+  private lazy val themeController  = inject[ThemeController]
   private lazy val controlsFragment = ControlsFragment.newInstance
-
-  private lazy val controller = inject[CallController]
-  private lazy val themeController = inject[ThemeController]
-  private lazy val previewCardView = view[CardView](R.id.preview_card_view)
+  private lazy val previewCardView  = view[CardView](R.id.preview_card_view)
 
   private var viewMap = Map[UserId, UserVideoView]()
 
@@ -144,7 +144,12 @@ class CallingFragment extends FragmentHelper {
               verbose("Showing card preview")
               cardView.removeAllViews()
               v.removeView(selfView)
-              selfView.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+              selfView.setLayoutParams(
+                new FrameLayout.LayoutParams(
+                  ViewGroup.LayoutParams.MATCH_PARENT,
+                  ViewGroup.LayoutParams.MATCH_PARENT
+                )
+              )
               cardView.addView(selfView)
               cardView.setVisibility(View.VISIBLE)
             } else {
@@ -161,38 +166,35 @@ class CallingFragment extends FragmentHelper {
           case _ => true
         }.sortWith {
           case (_:SelfVideoView, _) => true
-          case (v1, v2) => v1.userId.str.hashCode > v2.userId.str.hashCode
+          case (v1, v2)             => v1.userId.str.hashCode > v2.userId.str.hashCode
         }
 
         gridViews.zipWithIndex.foreach { case (r, index) =>
           val (row, col, span) = index match {
             case 0 if !isVideoBeingSent && gridViews.size == 2 => (0, 0, 2)
-            case 0 => (0, 0, 1)
+            case 0                                             => (0, 0, 1)
             case 1 if !isVideoBeingSent && gridViews.size == 2 => (1, 0, 2)
-            case 1 => (0, 1, 1)
-            case 2 if gridViews.size == 3 => (1, 0, 2)
-            case 2 => (1, 0, 1)
-            case 3 => (1, 1, 1)
+            case 1                                             => (0, 1, 1)
+            case 2 if gridViews.size == 3                      => (1, 0, 2)
+            case 2                                             => (1, 0, 1)
+            case 3                                             => (1, 1, 1)
           }
           verbose(s"Span sizes: ($row, $col, $span)")
-          val params = new GridLayout.LayoutParams()
-          params.width = 0
-          params.height = 0
-          params.rowSpec = GridLayout.spec(row, 1, GridLayout.FILL, 1f)
-          params.columnSpec = GridLayout.spec(col, span, GridLayout.FILL, 1f)
-          r.setLayoutParams(params)
+          r.setLayoutParams(returning(new GridLayout.LayoutParams()) { params =>
+            params.width      = 0
+            params.height     = 0
+            params.rowSpec    = GridLayout.spec(row, 1, GridLayout.FILL, 1f)
+            params.columnSpec = GridLayout.spec(col, span, GridLayout.FILL, 1f)
+          })
 
-          if (r.getParent == null)
-            v.addView(r)
+          if (r.getParent == null) v.addView(r)
         }
 
         val viewsToRemove = viewMap.filter {
           case (uid, selfView) if uid == selfId => !gridViews.contains(selfView)
-          case (uId, _) => !videoUsers.contains(uId)
+          case (uId, _)                         => !videoUsers.contains(uId)
         }
-        viewsToRemove.foreach { case (_, view) =>
-          v.removeView(view)
-        }
+        viewsToRemove.foreach { case (_, view) => v.removeView(view) }
         viewMap = viewMap.filter { case (uId, _) => videoUsers.contains(uId) }
       }
     }
@@ -213,7 +215,8 @@ class CallingFragment extends FragmentHelper {
 
     videoGrid
 
-    getChildFragmentManager.beginTransaction
+    getChildFragmentManager
+      .beginTransaction
       .replace(R.id.controls_layout, controlsFragment, ControlsFragment.Tag)
       .commit
   }

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -43,8 +43,9 @@ class ControlsFragment extends FragmentHelper {
 
   private lazy val callingHeader = view[CallingHeader](R.id.calling_header)
 
-  private lazy val callingMiddle = view[CallingMiddleLayout](R.id.calling_middle)
+  private lazy val callingMiddle   = view[CallingMiddleLayout](R.id.calling_middle)
   private lazy val callingControls = view[ControlsView](R.id.controls_grid)
+
   private var subs = Set[Subscription]()
 
   override def onCreate(savedInstanceState: Bundle): Unit = {
@@ -62,8 +63,7 @@ class ControlsFragment extends FragmentHelper {
     super.onViewCreated(v, savedInstanceState)
 
     callingControls
-
-    callingMiddle // initializing it later than header and controls to reduce the number of height recalculations
+    callingMiddle // initializing it later than the header and controls to reduce the number of height recalculations
 
     controller.isCallActive.onUi {
       case false =>
@@ -73,23 +73,28 @@ class ControlsFragment extends FragmentHelper {
     }
 
     (for {
-      state <- controller.callState
-      incoming = state == CallState.SelfJoining || state == CallState.OtherCalling
+      state                 <- controller.callState
+      incoming              =  state == CallState.SelfJoining || state == CallState.OtherCalling
       Some(degradationText) <- controller.degradationWarningText
     } yield (incoming, degradationText)).onUi { case (incoming, degradationText) =>
-      val builder = new AlertDialog.Builder(getActivity)
-      builder
+      new AlertDialog.Builder(getActivity)
         .setTitle(R.string.calling_degraded_title)
         .setMessage(degradationText)
         .setCancelable(false)
-        .setPositiveButton(if (incoming) android.R.string.ok else R.string.calling_ongoing_call_start_anyway, new DialogInterface.OnClickListener {
-          override def onClick(dialog: DialogInterface, which: Int): Unit = controller.continueDegradedCall()
-        })
-        .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener {
-          override def onClick(dialog: DialogInterface, which: Int): Unit = controller.leaveCall()
-        })
-
-      builder.create().show()
+        .setPositiveButton(
+          if (incoming) android.R.string.ok else R.string.calling_ongoing_call_start_anyway,
+          new DialogInterface.OnClickListener {
+            override def onClick(dialog: DialogInterface, which: Int): Unit = controller.continueDegradedCall()
+          }
+        )
+        .setNegativeButton(
+          android.R.string.cancel,
+          new DialogInterface.OnClickListener {
+            override def onClick(dialog: DialogInterface, which: Int): Unit = controller.leaveCall()
+          }
+        )
+        .create()
+        .show()
     }
 
     callingHeader.foreach {
@@ -119,7 +124,7 @@ class ControlsFragment extends FragmentHelper {
 
     //we need to listen to clicks on the outer layout, so that we can set this.getView to gone.
     getView.getParent.asInstanceOf[View].onClick {
-      Option(getView).map(_.getVisibility != View.VISIBLE).foreach(controller.controlsClick)
+      Option(getView).map(!_.isVisible).foreach(controller.controlsClick)
     }
 
     callingMiddle.foreach(vh => subs += vh.onShowAllClicked.onUi { _ =>

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallParticipantsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallParticipantsView.scala
@@ -21,6 +21,7 @@ import android.content.Context
 import android.support.v7.widget.LinearLayoutManager.VERTICAL
 import android.support.v7.widget.{LinearLayoutManager, RecyclerView}
 import android.util.AttributeSet
+import com.waz.utils.events.EventStream
 import com.waz.zclient.calling.CallParticipantsAdapter
 import com.waz.zclient.{R, ViewHelper}
 
@@ -29,24 +30,25 @@ class CallParticipantsView(val context: Context, val attrs: AttributeSet, val de
   def this(context: Context) = this(context, null)
 
   private val adapter = new CallParticipantsAdapter()
-  val onShowAllClicked = adapter.onShowAllClicked
+
+  val onShowAllClicked: EventStream[Unit] = adapter.onShowAllClicked
 
   private val isScrollable =
-    context.getTheme
+    context
+      .getTheme
       .obtainStyledAttributes(attrs, R.styleable.CallParticipantsView, 0, 0)
       .getBoolean(R.styleable.CallParticipantsView_isScrollable, true)
 
   private val layoutManager =
-    if (isScrollable) {
+    if (isScrollable)
       new LinearLayoutManager(context, VERTICAL, false)
-    } else {
+    else
       new LinearLayoutManager(context, VERTICAL, false) {
         override def canScrollVertically: Boolean = false
       }
-    }
 
   setLayoutManager(layoutManager)
   setAdapter(adapter)
 
-  def setMaxRows(maxRows: Int) = adapter.setMaxRows(maxRows)
+  def setMaxRows(maxRows: Int): Unit = adapter.setMaxRows(maxRows)
 }

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -32,11 +32,11 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
 
   private val controller = inject[CallController]
 
-  lazy val nameView        = findById[TextView](R.id.ttv__calling__header__name)
-  lazy val subtitleView    = findById[TextView](R.id.ttv__calling__header__subtitle)
-  lazy val bitRateModeView = findById[TextView](R.id.ttv__calling__header__bitrate)
+  private lazy val nameView        = findById[TextView](R.id.ttv__calling__header__name)
+  private lazy val subtitleView    = findById[TextView](R.id.ttv__calling__header__subtitle)
+  private lazy val bitRateModeView = findById[TextView](R.id.ttv__calling__header__bitrate)
 
-  lazy val closeButton = findById[GlyphButton](R.id.calling_header_close)
+  lazy val closeButton: GlyphButton = findById[GlyphButton](R.id.calling_header_close)
 
   inflate(R.layout.calling_header, this)
 
@@ -44,7 +44,7 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
   controller.conversationName.onUi(nameView.setText)
 
   controller.cbrEnabled.map {
-    case true => getString(R.string.audio_message__constant_bit_rate)
+    case true  => getString(R.string.audio_message__constant_bit_rate)
     case false => ""
   }.onUi(bitRateModeView.setText)
 

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -24,6 +24,7 @@ import android.util.AttributeSet
 import android.view.{Gravity, View, ViewGroup}
 import android.view.View.OnClickListener
 import android.widget.{CompoundButton, ImageView, LinearLayout, RelativeLayout}
+import com.waz.ZLog.ImplicitTag.implicitLogTag
 import com.waz.model.{Availability, IntegrationData, TeamId, UserData}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
@@ -86,7 +87,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int) exten
   def showArrow(show: Boolean): Unit = nextIndicator.setVisibility(if (show) View.VISIBLE else View.GONE)
 
   def setCallParticipantInfo(user: CallParticipantInfo): Unit = {
-    chathead.setUserId(user.userId)
+    chathead.setUserId(user.userId, user.zms)
     setTitle(user.displayName)
     setVerified(user.isVerified)
     subtitleView.setVisibility(View.GONE)

--- a/app/src/main/scala/com/waz/zclient/conversation/ParticipantDetailsTab.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ParticipantDetailsTab.scala
@@ -30,11 +30,12 @@ import com.waz.zclient.paintcode.GuestIcon
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.{GuestUtils, RichView, UiStorage}
+import com.waz.zclient.utils.{GuestUtils, RichView}
 import com.waz.zclient.views.ShowAvailabilityView
 import com.waz.zclient.views.menus.{FooterMenu, FooterMenuCallback}
 import com.waz.zclient.{R, ViewHelper}
 import org.threeten.bp.Instant
+
 import scala.concurrent.duration._
 
 class ParticipantDetailsTab(val context: Context, callback: FooterMenuCallback) extends LinearLayout(context, null, 0) with ViewHelper {
@@ -42,7 +43,6 @@ class ParticipantDetailsTab(val context: Context, callback: FooterMenuCallback) 
   inflate(R.layout.single_participant_tab_details)
   setOrientation(LinearLayout.VERTICAL)
 
-  private implicit val uiStorage     = inject[UiStorage]
   private val zms                    = inject[Signal[ZMessaging]]
   private val usersController        = inject[UsersController]
   private val participantsController = inject[ParticipantsController]
@@ -65,8 +65,8 @@ class ParticipantDetailsTab(val context: Context, callback: FooterMenuCallback) 
   } yield !user.isWireBot && user.isGuest(teamId)
 
   private val leftActionStrings = for {
-    isWireless <- participantsController.otherParticipant.map(_.expiresAt.isDefined)
-    isGroupOrBot <- participantsController.isGroupOrBot
+    isWireless     <- participantsController.otherParticipant.map(_.expiresAt.isDefined)
+    isGroupOrBot   <- participantsController.isGroupOrBot
     hasPermissions <- userAccountsController.hasCreateConvPermission
   } yield if (isWireless) {
     (R.string.empty_string, R.string.empty_string)
@@ -87,14 +87,14 @@ class ParticipantDetailsTab(val context: Context, callback: FooterMenuCallback) 
 
   (for {
     expires <- participantsController.otherParticipant.map(_.expiresAt)
-    clock <- if (expires.isDefined) ClockSignal(5.minutes) else Signal.const(Instant.EPOCH)
+    clock   <- if (expires.isDefined) ClockSignal(5.minutes) else Signal.const(Instant.EPOCH)
   } yield expires match {
     case Some(expiresAt) => GuestUtils.timeRemainingString(expiresAt, clock)
     case _ => ""
   }).onUi(guestIndicatorTimer.setText)
 
   Signal(participantsController.otherParticipant.map(_.expiresAt.isDefined), usersController.availabilityVisible).map {
-    case (true, _) => false
+    case (true, _)         => false
     case (_, isTeamMember) => isTeamMember
   }.onUi { userAvailability.setVisible }
 

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -207,9 +207,9 @@ object ContextUtils {
     p.future
   }
 
-  def showPermissionsErrorDialog(titleRes: Int, msgRes: Int, ackRes: Int = android.R.string.ok)(implicit cxt: Context) = {
+  def showPermissionsErrorDialog(titleRes: Int, msgRes: Int, ackRes: Int = android.R.string.ok)(implicit cxt: Context): Future[Unit] = {
     val p = Promise[Unit]()
-    val dialog = new AlertDialog.Builder(cxt)
+    new AlertDialog.Builder(cxt)
       .setTitle(titleRes)
       .setMessage(msgRes)
       .setPositiveButton(ackRes, null)
@@ -221,7 +221,7 @@ object ContextUtils {
         override def onDismiss(dialog: DialogInterface) = p.complete(Success({}))
       })
       .create
-    dialog.show()
+      .show()
     p.future
   }
 


### PR DESCRIPTION
1. Fixed a bug in the call participants list - if the call was from another account, the list was unable to show all participants due to using the current zms instead of the calling zms. Also required changes to the chathead view, which also tried to use the current zms to display the chathead.
2. Fixed a bug in the short call participants list - if the max rows was N and the number of participants was N, the "Show All" button was displayed as the last element, even though we could display the last participant instead and have no need for the button.
3. Fixed a bug returning 0 as the number of members of the call's conversation if the call was from the other account. Required for determining if the participant is allowed to turn on video.
4. Made the code more readable. 

#### APK
[Download build #10993](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10993/artifact/build/artifact/wire-dev-PR1579-10993.apk)
[Download build #10994](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10994/artifact/build/artifact/wire-dev-PR1579-10994.apk)
[Download build #10996](http://192.168.120.33:8080/job/Pull%20Request%20Builder/10996/artifact/build/artifact/wire-dev-PR1579-10996.apk)
[Download build #11002](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11002/artifact/build/artifact/wire-dev-PR1579-11002.apk)
[Download build #11003](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11003/artifact/build/artifact/wire-dev-PR1579-11003.apk)
[Download build #11006](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11006/artifact/build/artifact/wire-dev-PR1579-11006.apk)
[Download build #11028](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11028/artifact/build/artifact/wire-dev-PR1579-11028.apk)
[Download build #11029](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11029/artifact/build/artifact/wire-dev-PR1579-11029.apk)