### PR TITLE
Use doLast as leftShift is deprecated

### DIFF
--- a/lintlib/build.gradle
+++ b/lintlib/build.gradle
@@ -25,7 +25,7 @@ android {
 project.afterEvaluate {
     def compileLintTask = project.tasks.find {it.name == 'compileLint'}
     compileLintTask.dependsOn ':lintrules:jar'
-    compileLintTask << {
+    compileLintTask.doLast {
         copy {
             from '../lintrules/build/libs'
             into 'build/intermediates/lint'


### PR DESCRIPTION
Fixes a deprecation warning in Gradle's output:

```
> Configure project :lintlib
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_djolk5zcqhqkffnr2dmemcova$_run_closure2.doCall(/home/calum/code/wire-android/lintlib/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```