### PR TITLE
Clarify GVC limitation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1407,6 +1407,6 @@
     <string name="backup_import_error_wrong_account">You cannot restore history from a different account.</string>
     <string name="video_paused">Video paused</string>
     <string name="calling_degraded_title">New device</string>
-    <string name="call_info_text">Up to 128 people can join a group conversation. Video calls work in groups of 4 or less.</string>
+    <string name="call_info_text">Up to 128 people can join a group conversation. Video calls work with up to 3 other people and you.</string>
     <string name="too_many_people_video_toast">Video calls only work in groups of 4 or less.</string>
 </resources>


### PR DESCRIPTION
Since the number of participants shown in the conversation does not include the current user, we need to change this copy to prevent confusion when the conversation shows “4 people” and the Video Call icon is not available.