### PR TITLE
Markdown Fixes

### DIFF
--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
@@ -104,7 +104,7 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_BlockQuote() {
         // given
-        val sut = BlockQuoteSpan(Color.BLUE, 4, 8, 16, 8)
+        val sut = BlockQuoteSpan(Color.BLUE, Color.GREEN, 4, 8, 16, 8)
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
@@ -115,7 +115,7 @@ class GroupSpanTest {
         for (span in spans) {
             when (span) {
                 is CustomQuoteSpan -> {
-                    assertEquals(Color.BLUE, span.color)
+                    assertEquals(Color.GREEN, span.color)
                     assertEquals(4, span.stripeWidth)
                     assertEquals(8, span.gapWidth)
                 }

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
@@ -165,11 +165,22 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_ListItem() {
         // given
-        val sut = ListItemSpan()
+        val sut = ListItemSpan(8, 16)
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
-        assertTrue(sut.spans.isEmpty())
+        assertEquals(1, sut.spans.size)
+
+        val span = sut.spans.first()
+
+        when (span) {
+            is ParagraphSpacingSpan -> {
+                assertEquals(8, span.before)
+                assertEquals(16, span.after)
+            }
+            else -> fail()
+        }
+
         assertTrue(sut.toNode() is ListItem)
     }
 

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
@@ -176,13 +176,13 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_FencedCodeBlock() {
         // given
-        val sut = FencedCodeBlockSpan(Color.RED, 16)
+        val sut = FencedCodeBlockSpan(Color.RED, 16, 8, 20)
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
 
         val spans = sut.spans
-        assertEquals(3, spans.size)
+        assertEquals(4, spans.size)
 
         for (span in spans) {
             when (span) {
@@ -195,6 +195,10 @@ class GroupSpanTest {
                 }
                 is ForegroundColorSpan -> {
                     assertEquals(Color.RED, span.foregroundColor)
+                }
+                is ParagraphSpacingSpan -> {
+                    assertEquals(8, span.before)
+                    assertEquals(20, span.after)
                 }
                 else -> fail()
             }
@@ -212,13 +216,13 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_IndentedCodeBlock() {
         // given
-        val sut = IndentedCodeBlockSpan(Color.YELLOW, 20)
+        val sut = IndentedCodeBlockSpan(Color.YELLOW, 20, 8, 16)
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
 
         val spans = sut.spans
-        assertEquals(3, spans.size)
+        assertEquals(4, spans.size)
 
         for (span in spans) {
             when (span) {
@@ -232,6 +236,10 @@ class GroupSpanTest {
                 is ForegroundColorSpan -> {
                     assertEquals(Color.YELLOW, span.foregroundColor)
                 }
+                is ParagraphSpacingSpan -> {
+                    assertEquals(8, span.before)
+                    assertEquals(16, span.after)
+                }
                 else -> fail()
             }
         }
@@ -244,13 +252,13 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_HtmlBlock() {
         // given
-        val sut = HtmlBlockSpan(Color.GREEN, 8)
+        val sut = HtmlBlockSpan(Color.GREEN, 8, 16, 20)
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
 
         val spans = sut.spans
-        assertEquals(3, spans.size)
+        assertEquals(4, spans.size)
 
         for (span in spans) {
             when (span) {
@@ -263,6 +271,10 @@ class GroupSpanTest {
                 }
                 is ForegroundColorSpan -> {
                     assertEquals(Color.GREEN, span.foregroundColor)
+                }
+                is ParagraphSpacingSpan -> {
+                    assertEquals(16, span.before)
+                    assertEquals(20, span.after)
                 }
                 else -> fail()
             }

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
@@ -165,21 +165,11 @@ class GroupSpanTest {
     @Test
     fun testThatItConfiguresSpansAndNode_ListItem() {
         // given
-        val sut = ListItemSpan(8, 16)
+        val sut = ListItemSpan()
 
         // then
         assertEquals(GroupSpan.Priority.MEDIUM, sut.priority)
-        assertEquals(1, sut.spans.size)
-
-        val span = sut.spans.first()
-
-        when (span) {
-            is ParagraphSpacingSpan -> {
-                assertEquals(8, span.before)
-                assertEquals(16, span.after)
-            }
-            else -> fail()
-        }
+        assertTrue(sut.spans.isEmpty())
 
         assertTrue(sut.toNode() is ListItem)
     }

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/SpanRendererTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/SpanRendererTest.kt
@@ -24,6 +24,7 @@ import android.text.style.TabStopSpan
 import com.waz.zclient.markdown.spans.GroupSpan
 import com.waz.zclient.markdown.spans.commonmark.*
 import com.waz.zclient.markdown.spans.custom.ListPrefixSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import com.waz.zclient.markdown.visitors.SpanRenderer
 import org.commonmark.node.Node
 import org.commonmark.parser.Parser
@@ -959,9 +960,18 @@ class SpanRendererTest {
             assertEquals( stylesheet.listItemContentMargin, tabStopSpans.first().tabStop)
         }
 
-        // finally check that each prefix has a span
+        // check that each prefix has a span
         val prefixResults = result.spanResults(ListPrefixSpan::class.java)
         check(prefixResults, "1.", "2.", "3.", "•", "•")
+
+        // lastly, check for paragraph spacing spans on each item. These ranges represent
+        // each item (excluding nested lists from items)
+        for (range in listOf(0..13, 13..26, 26..38, 38..50, 50..64)) {
+            val spacingSpans = result.spansInRange(range, ParagraphSpacingSpan::class.java)
+            assertEquals(1, spacingSpans.size)
+            assertEquals(stylesheet.listItemSpacingBefore, spacingSpans.first().before)
+            assertEquals(stylesheet.listItemSpacingAfter, spacingSpans.first().after)
+        }
     }
 
     @Test
@@ -1060,9 +1070,18 @@ class SpanRendererTest {
             assertEquals( stylesheet.listItemContentMargin, tabStopSpans.first().tabStop)
         }
 
-        // finally check that each prefix has a span
+        // check that each prefix has a span
         val prefixResults = result.spanResults(ListPrefixSpan::class.java)
         check(prefixResults, "1.", "2.", "•", "•", "•")
+
+        // lastly, check for paragraph spacing spans on each item. These ranges represent
+        // each item (excluding nested lists from items)
+        for (range in listOf(0..12, 12..24, 24..37, 37..50, 50..63)) {
+            val spacingSpans = result.spansInRange(range, ParagraphSpacingSpan::class.java)
+            assertEquals(1, spacingSpans.size)
+            assertEquals(stylesheet.listItemSpacingBefore, spacingSpans.first().before)
+            assertEquals(stylesheet.listItemSpacingAfter, spacingSpans.first().after)
+        }
     }
 
     @Test
@@ -1267,6 +1286,15 @@ class SpanRendererTest {
         // it should have indentation for the all lines
         assertEquals(stylesheet.listItemContentMargin, spans.first().getLeadingMargin(true))
         assertEquals(stylesheet.listItemContentMargin, spans.first().getLeadingMargin(false))
+
+        // lastly, check for paragraph spacing spans on each item. These ranges represent
+        // each item (excluding nested lists from items)
+        for (range in listOf(0..12, 12..41, 42..65, 65..87, 87..99)) {
+            val spacingSpans = result.spansInRange(range, ParagraphSpacingSpan::class.java)
+            assertEquals(1, spacingSpans.size)
+            assertEquals(stylesheet.listItemSpacingBefore, spacingSpans.first().before)
+            assertEquals(stylesheet.listItemSpacingAfter, spacingSpans.first().after)
+        }
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
@@ -99,6 +99,7 @@ class StyleSheetTest {
         val span = result as BlockQuoteSpan
 
         assertEquals(sut.quoteColor, span.color)
+        assertEquals(sut.quoteStripeColor, span.stripeColor)
         assertEquals(sut.quoteStripeWidth, span.stripeWidth)
         assertEquals(sut.quoteGapWidth, span.gapWidth)
         assertEquals(sut.quoteSpacingBefore, span.beforeSpacing)

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
@@ -143,10 +143,6 @@ class StyleSheetTest {
 
         // then
         assertTrue(result is ListItemSpan)
-        val span = result as ListItemSpan
-
-        assertEquals(sut.listItemSpacingBefore, span.beforeSpacing)
-        assertEquals(sut.listItemSpacingAfter, span.afterSpacing)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
@@ -143,6 +143,10 @@ class StyleSheetTest {
 
         // then
         assertTrue(result is ListItemSpan)
+        val span = result as ListItemSpan
+
+        assertEquals(sut.listItemSpacingBefore, span.beforeSpacing)
+        assertEquals(sut.listItemSpacingAfter, span.afterSpacing)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
@@ -159,6 +159,8 @@ class StyleSheetTest {
 
         assertEquals(sut.codeColor, span.color)
         assertEquals((sut.codeBlockIndentation * sut.screenDensity).toInt(), span.indentation)
+        assertEquals(sut.paragraphSpacingBefore, span.beforeSpacing)
+        assertEquals(sut.paragraphSpacingAfter, span.afterSpacing)
     }
 
     @Test
@@ -175,6 +177,8 @@ class StyleSheetTest {
 
         assertEquals(sut.codeColor, span.color)
         assertEquals((sut.codeBlockIndentation * sut.screenDensity).toInt(), span.indentation)
+        assertEquals(sut.paragraphSpacingBefore, span.beforeSpacing)
+        assertEquals(sut.paragraphSpacingAfter, span.afterSpacing)
     }
 
     @Test
@@ -191,6 +195,8 @@ class StyleSheetTest {
 
         assertEquals(sut.codeColor, span.color)
         assertEquals((sut.codeBlockIndentation * sut.screenDensity).toInt(), span.indentation)
+        assertEquals(sut.paragraphSpacingBefore, span.beforeSpacing)
+        assertEquals(sut.paragraphSpacingAfter, span.afterSpacing)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/StyleSheetTest.kt
@@ -101,8 +101,8 @@ class StyleSheetTest {
         assertEquals(sut.quoteColor, span.color)
         assertEquals(sut.quoteStripeWidth, span.stripeWidth)
         assertEquals(sut.quoteGapWidth, span.gapWidth)
-        assertEquals(sut.paragraphSpacingBefore, span.beforeSpacing)
-        assertEquals(sut.paragraphSpacingAfter, span.afterSpacing)
+        assertEquals(sut.quoteSpacingBefore, span.beforeSpacing)
+        assertEquals(sut.quoteSpacingAfter, span.afterSpacing)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/spans/ParagraphSpacingSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/spans/ParagraphSpacingSpanTest.kt
@@ -20,20 +20,31 @@ package com.waz.zclient.markdown.spans
 import android.graphics.Paint
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.TextPaint
 import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.mock
 
 class ParagraphSpacingSpanTest {
 
+    private val paint = mock(TextPaint::class.java)
     private val text = SpannableString("while she was able to see, her eyes were on mine.")
 
+    @Before
+    fun setup() {
+        // this span is density sensitive
+        paint.density = 2f
+    }
+
     fun check(fm: Paint.FontMetricsInt, ascent: Int, top: Int, descent: Int, bottom: Int, leading: Int) {
-        assertEquals(ascent, fm.ascent)
-        assertEquals(top, fm.top)
-        assertEquals(descent, fm.descent)
-        assertEquals(bottom, fm.bottom)
-        assertEquals(leading, fm.leading)
+        val scale = { v: Int -> (paint.density * v).toInt() }
+        assertEquals(scale(ascent), fm.ascent)
+        assertEquals(scale(top), fm.top)
+        assertEquals(scale(descent), fm.descent)
+        assertEquals(scale(bottom), fm.bottom)
+        assertEquals(scale(leading), fm.leading)
     }
 
     @Test
@@ -46,7 +57,7 @@ class ParagraphSpacingSpanTest {
         val fm = Paint.FontMetricsInt()
 
         // when first line chooses height: 'while she was '
-        sut.chooseHeight(text, 0, text.length, 0, 0, fm)
+        sut.chooseHeight(text, 0, text.length, 0, 0, fm, paint)
 
         // then the top of the line is 8pts higher and the bottom of the line is 16pts lower
         check(fm, -8, -8, 16, 16, 0)
@@ -62,19 +73,19 @@ class ParagraphSpacingSpanTest {
         val fm = Paint.FontMetricsInt()
 
         // when first line chooses height: 'while she was '
-        sut.chooseHeight(text, 0, 14, 0, 0, fm)
+        sut.chooseHeight(text, 0, 14, 0, 0, fm, paint)
 
         // then the top of the line is 8pts higher
         check(fm, -8, -8, 0, 0, 0)
 
         // when second line chooses height: 'able to see, '
-        sut.chooseHeight(text, 14, 27, 0, 0, fm)
+        sut.chooseHeight(text, 14, 27, 0, 0, fm, paint)
 
         // then original fm is used
         check(fm, 0, 0, 0, 0, 0)
 
         // when last line chooses height: 'her eyes were on mine.'
-        sut.chooseHeight(text, 27, 49, 0, 0, fm)
+        sut.chooseHeight(text, 27, 49, 0, 0, fm, paint)
 
         // then the bottom of the last line is 16pts lower
         check(fm, 0, 0, 16, 16, 0)
@@ -89,7 +100,7 @@ class ParagraphSpacingSpanTest {
         val fm = Paint.FontMetricsInt()
 
         // when first line chooses height: 'while she was '
-        sut.chooseHeight(text, 0, text.length, 0, 0, fm)
+        sut.chooseHeight(text, 0, text.length, 0, 0, fm, paint)
 
         // then the fm is unchanged
         check(fm, 0, 0, 0, 0, 0)

--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -18,14 +18,22 @@
 package com.waz.zclient.markdown;
 
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.v4.content.ContextCompat;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 
+import com.waz.zclient.R;
+import com.waz.zclient.controllers.accentcolor.AccentColorController;
 import com.waz.zclient.markdown.spans.GroupSpan;
 import com.waz.zclient.markdown.spans.commonmark.ImageSpan;
 import com.waz.zclient.markdown.spans.commonmark.LinkSpan;
 import com.waz.zclient.ui.text.TypefaceTextView;
+import com.waz.zclient.utils.ContextUtils;
+import com.waz.zclient.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,17 +52,39 @@ public class MarkdownTextView extends TypefaceTextView {
         super(context);
     }
 
+    private StyleSheet mStyleSheet;
+
+
+    /**
+     * Configures the style sheet used for rendering.
+     */
+    private void configureStyleSheet() {
+        mStyleSheet = new StyleSheet();
+
+        mStyleSheet.setBaseFontColor(getCurrentTextColor());
+        mStyleSheet.setBaseFontSize((int) getTextSize());
+
+        mStyleSheet.setCodeColor(ContextUtils.getStyledColor(R.attr.codeColor, context()));
+        mStyleSheet.setQuoteColor(ContextUtils.getStyledColor(R.attr.quoteColor, context()));
+        mStyleSheet.setListPrefixColor(ContextUtils.getStyledColor(R.attr.listPrefixColor, context()));
+
+        // TODO: this should be users accent color
+        mStyleSheet.setLinkColor(ContextCompat.getColor(context(), R.color.accent_blue));
+
+        // to make links clickable
+        mStyleSheet.configureLinkHandler(context());
+        setMovementMethod(LinkMovementMethod.getInstance());
+    }
+
+
     /**
      * Mark down the text currently in the buffer.
      */
     public void markdown() {
-        StyleSheet ss = StyleSheet.Companion.styleFor(this);
-
-        // to make links clickable
-        setMovementMethod(LinkMovementMethod.getInstance());
+        if (mStyleSheet == null) { configureStyleSheet(); }
 
         String text = getText().toString();
-        SpannableString result = Markdown.parse(text, ss);
+        SpannableString result = Markdown.parse(text, mStyleSheet);
         setText(result);
     }
 

--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -18,22 +18,17 @@
 package com.waz.zclient.markdown;
 
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.net.Uri;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 
 import com.waz.zclient.R;
-import com.waz.zclient.controllers.accentcolor.AccentColorController;
 import com.waz.zclient.markdown.spans.GroupSpan;
 import com.waz.zclient.markdown.spans.commonmark.ImageSpan;
 import com.waz.zclient.markdown.spans.commonmark.LinkSpan;
 import com.waz.zclient.ui.text.TypefaceTextView;
 import com.waz.zclient.utils.ContextUtils;
-import com.waz.zclient.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -49,7 +49,6 @@ public class MarkdownTextView extends TypefaceTextView {
 
     private StyleSheet mStyleSheet;
 
-
     /**
      * Configures the style sheet used for rendering.
      */
@@ -71,13 +70,11 @@ public class MarkdownTextView extends TypefaceTextView {
         setLineSpacing(0f, 1.1f);
     }
 
-
     /**
      * Mark down the text currently in the buffer.
      */
     public void markdown() {
         if (mStyleSheet == null) { configureStyleSheet(); }
-
         String text = getText().toString();
         SpannableString result = Markdown.parse(text, mStyleSheet);
         setText(result);

--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -58,6 +58,7 @@ public class MarkdownTextView extends TypefaceTextView {
         mStyleSheet.setBaseFontSize((int) getTextSize());
         mStyleSheet.setCodeColor(ContextUtils.getStyledColor(R.attr.codeColor, context()));
         mStyleSheet.setQuoteColor(ContextUtils.getStyledColor(R.attr.quoteColor, context()));
+        mStyleSheet.setQuoteStripeColor(ContextUtils.getStyledColor(R.attr.quoteStripeColor, context()));
         mStyleSheet.setListPrefixColor(ContextUtils.getStyledColor(R.attr.listPrefixColor, context()));
 
         // TODO: this should be users accent color

--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -55,10 +55,8 @@ public class MarkdownTextView extends TypefaceTextView {
      */
     private void configureStyleSheet() {
         mStyleSheet = new StyleSheet();
-
         mStyleSheet.setBaseFontColor(getCurrentTextColor());
         mStyleSheet.setBaseFontSize((int) getTextSize());
-
         mStyleSheet.setCodeColor(ContextUtils.getStyledColor(R.attr.codeColor, context()));
         mStyleSheet.setQuoteColor(ContextUtils.getStyledColor(R.attr.quoteColor, context()));
         mStyleSheet.setListPrefixColor(ContextUtils.getStyledColor(R.attr.listPrefixColor, context()));
@@ -69,6 +67,8 @@ public class MarkdownTextView extends TypefaceTextView {
         // to make links clickable
         mStyleSheet.configureLinkHandler(context());
         setMovementMethod(LinkMovementMethod.getInstance());
+
+        setLineSpacing(0f, 1.1f);
     }
 
 

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -204,7 +204,7 @@ public class StyleSheet {
                 return BulletListSpan(node.bulletMarker)
             }
             is ListItem -> {
-                return ListItemSpan(listItemSpacingBefore, listItemSpacingAfter)
+                return ListItemSpan()
             }
             is FencedCodeBlock -> {
                 return FencedCodeBlockSpan(

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -127,7 +127,7 @@ public class StyleSheet {
     /**
      * The indentation (in points) from the leading margin of all code blocks.
      */
-    public var codeBlockIndentation: Int = 24
+    public var codeBlockIndentation: Int = 0
 
     /**
      * The color of links.

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -81,6 +81,16 @@ public class StyleSheet {
     public var quoteGapWidth: Int = 16
 
     /**
+     * The amount of spacing (in points) before a quote.
+     */
+    public var quoteSpacingBefore: Int = 16
+
+    /**
+     * The amount of spacing (in points) after a quote.
+     */
+    public var quoteSpacingAfter: Int = 16
+
+    /**
      * The color of list prefixes
      */
     public var listPrefixColor: Int = Color.GRAY
@@ -184,8 +194,8 @@ public class StyleSheet {
                     quoteColor,
                     quoteStripeWidth,
                     quoteGapWidth,
-                    paragraphSpacingBefore,
-                    paragraphSpacingAfter,
+                    quoteSpacingBefore,
+                    quoteSpacingAfter,
                     screenDensity
                 )
             }

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -197,13 +197,28 @@ public class StyleSheet {
                 return ListItemSpan()
             }
             is FencedCodeBlock -> {
-                return FencedCodeBlockSpan(codeColor, codeBlockIndentation.scaled)
+                return FencedCodeBlockSpan(
+                    codeColor,
+                    codeBlockIndentation.scaled,
+                    paragraphSpacingBefore,
+                    paragraphSpacingAfter
+                )
             }
             is IndentedCodeBlock -> {
-                return IndentedCodeBlockSpan(codeColor, codeBlockIndentation.scaled)
+                return IndentedCodeBlockSpan(
+                    codeColor,
+                    codeBlockIndentation.scaled,
+                    paragraphSpacingBefore,
+                    paragraphSpacingAfter
+                )
             }
             is HtmlBlock -> {
-                return HtmlBlockSpan(codeColor, codeBlockIndentation.scaled)
+                return HtmlBlockSpan(
+                    codeColor,
+                    codeBlockIndentation.scaled,
+                    paragraphSpacingBefore,
+                    paragraphSpacingAfter
+                )
             }
             is Link -> {
                 return LinkSpan(node.destination, linkColor, onClickLink)

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -52,12 +52,12 @@ public class StyleSheet {
     /**
      * The amount of spacing (in points) before a paragraph.
      */
-    public var paragraphSpacingBefore: Int = 16
+    public var paragraphSpacingBefore: Int = 6
 
     /**
      * The amount of spacing (in points) after a paragraph.
      */
-    public var paragraphSpacingAfter: Int = 16
+    public var paragraphSpacingAfter: Int = 6
 
     /**
      * The relative font size multiplers (values) for the various header levels (keys).
@@ -93,12 +93,12 @@ public class StyleSheet {
     /**
      * The amount of spacing (in points) before a list item.
      */
-    public var listItemSpacingBefore: Int = 16
+    public var listItemSpacingBefore: Int = 6
 
     /**
      * The amount of spacing (in points) after a list item.
      */
-    public var listItemSpacingAfter: Int = 16
+    public var listItemSpacingAfter: Int = 6
 
     /**
      * The color of all monospace code text.

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -17,15 +17,14 @@
  */
 package com.waz.zclient.markdown
 
+import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.Paint
 import android.net.Uri
-import android.support.v4.content.ContextCompat
 import android.support.v4.content.ContextCompat.startActivity
-import android.widget.TextView
 import com.waz.zclient.R
 import com.waz.zclient.markdown.spans.GroupSpan
 import com.waz.zclient.markdown.spans.commonmark.*
@@ -39,34 +38,6 @@ import org.commonmark.node.*
  * syntax tree constructed from a marked down document.
  */
 public class StyleSheet {
-
-    companion object {
-        fun styleFor(textView: TextView): StyleSheet {
-            val context = textView.context
-            val style = StyleSheet()
-
-            style.baseFontColor = textView.currentTextColor
-            style.baseFontSize = textView.textSize.toInt()
-            style.linkColor = ContextCompat.getColor(context, R.color.accent_blue)
-
-            style.onClickLink = { url: String ->
-                // show dialog to confirm if url should be open
-                ViewUtils.showAlertDialog(context,
-                    context.getString(R.string.markdown_link_dialog_title),
-                    context.getString(R.string.markdown_link_dialog_message, url),
-                    context.getString(R.string.markdown_link_dialog_confirmation),
-                    context.getString(R.string.markdown_link_dialog_cancel),
-                    DialogInterface.OnClickListener { _, _ ->
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                        startActivity(context, intent, null)
-                    },
-                    null
-                )
-            }
-
-            return style
-        }
-    }
 
     /**
      * The base font size (in pixels) used for all markdown units unless otherwise specified.
@@ -167,6 +138,27 @@ public class StyleSheet {
     }
 
     private val Int.scaled: Int get() = (this * screenDensity).toInt()
+
+    /**
+     * Configures the handler when a markdown link is clicked by presenting a confirmation
+     * dialog from the given context.
+     */
+    fun configureLinkHandler(context: Context) {
+        onClickLink = { url: String ->
+            // show dialog to confirm if url should be open
+            ViewUtils.showAlertDialog(context,
+                context.getString(R.string.markdown_link_dialog_title),
+                context.getString(R.string.markdown_link_dialog_message, url),
+                context.getString(R.string.markdown_link_dialog_confirmation),
+                context.getString(R.string.markdown_link_dialog_cancel),
+                DialogInterface.OnClickListener { _, _ ->
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                    startActivity(context, intent, null)
+                },
+                null
+            )
+        }
+    }
 
     /**
      * Returns the configured `GroupSpan` for the given node, depending on the node type.

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -66,9 +66,14 @@ public class StyleSheet {
     public var headingSizeMultipliers = mapOf(1 to 1.7f, 2 to 1.5f, 3 to 1.25f, 4 to 1.25f, 5 to 1.25f, 6 to 1.25f)
 
     /**
-     * The color of a quote (including stripe).
+     * The color of a quote text.
      */
     public var quoteColor: Int = Color.GRAY
+
+    /**
+     * The color of a quote stripe.
+     */
+    public var quoteStripeColor: Int = Color.GRAY
 
     /**
      * The width (in points) of the quote stripe.
@@ -192,6 +197,7 @@ public class StyleSheet {
             is BlockQuote -> {
                 return BlockQuoteSpan(
                     quoteColor,
+                    quoteStripeColor,
                     quoteStripeWidth,
                     quoteGapWidth,
                     quoteSpacingBefore,

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -93,12 +93,12 @@ public class StyleSheet {
     /**
      * The amount of spacing (in points) before a list item.
      */
-    public var listItemSpacingBefore: Int = 6
+    public var listItemSpacingBefore: Int = 4
 
     /**
      * The amount of spacing (in points) after a list item.
      */
-    public var listItemSpacingAfter: Int = 6
+    public var listItemSpacingAfter: Int = 4
 
     /**
      * The color of all monospace code text.

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -120,6 +120,16 @@ public class StyleSheet {
     public var listPrefixGapWidth: Int = 8
 
     /**
+     * The amount of spacing (in points) before a list item.
+     */
+    public var listItemSpacingBefore: Int = 16
+
+    /**
+     * The amount of spacing (in points) after a list item.
+     */
+    public var listItemSpacingAfter: Int = 16
+
+    /**
      * The color of all monospace code text.
      */
     public var codeColor: Int = Color.GRAY
@@ -194,7 +204,7 @@ public class StyleSheet {
                 return BulletListSpan(node.bulletMarker)
             }
             is ListItem -> {
-                return ListItemSpan()
+                return ListItemSpan(listItemSpacingBefore, listItemSpacingAfter)
             }
             is FencedCodeBlock -> {
                 return FencedCodeBlockSpan(

--- a/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/StyleSheet.kt
@@ -102,7 +102,7 @@ public class StyleSheet {
     /**
      * The width (in points) of the quote stripe.
      */
-    public var quoteStripeWidth: Int = 4
+    public var quoteStripeWidth: Int = 2
 
     /**
      * The gap width (in points) between the quote stripe and the quote content text.

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/BlockQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/BlockQuoteSpan.kt
@@ -37,7 +37,7 @@ class BlockQuoteSpan(
 ) : BlockSpan() {
 
     init {
-        add(CustomQuoteSpan(color, stripeWidth, gapWidth, density))
+        add(CustomQuoteSpan(color, stripeWidth, gapWidth, density, beforeSpacing, afterSpacing))
         add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
         add(ForegroundColorSpan(color))
     }

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/BlockQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/BlockQuoteSpan.kt
@@ -29,6 +29,7 @@ import org.commonmark.node.Node
  */
 class BlockQuoteSpan(
     val color: Int,
+    val stripeColor: Int,
     val stripeWidth: Int,
     val gapWidth: Int,
     val beforeSpacing: Int,
@@ -37,7 +38,7 @@ class BlockQuoteSpan(
 ) : BlockSpan() {
 
     init {
-        add(CustomQuoteSpan(color, stripeWidth, gapWidth, density, beforeSpacing, afterSpacing))
+        add(CustomQuoteSpan(stripeColor, stripeWidth, gapWidth, density, beforeSpacing, afterSpacing))
         add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
         add(ForegroundColorSpan(color))
     }

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/FencedCodeBlockSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/FencedCodeBlockSpan.kt
@@ -21,18 +21,25 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.TypefaceSpan
 import com.waz.zclient.markdown.spans.BlockSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.commonmark.node.FencedCodeBlock
 import org.commonmark.node.Node
 
 /**
  * The span corresponding to the Commonmark "FencedCodeBlock" node.
  */
-class FencedCodeBlockSpan(val color: Int, val indentation: Int) : BlockSpan() {
+class FencedCodeBlockSpan(
+    val color: Int,
+    val indentation: Int,
+    val beforeSpacing: Int,
+    val afterSpacing: Int
+) : BlockSpan() {
 
     init {
         add(TypefaceSpan("monospace"))
         add(LeadingMarginSpan.Standard(indentation))
         add(ForegroundColorSpan(color))
+        add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
     }
 
     override fun toNode(literal: String?): Node {

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/HtmlBlockSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/HtmlBlockSpan.kt
@@ -21,18 +21,25 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.TypefaceSpan
 import com.waz.zclient.markdown.spans.BlockSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.commonmark.node.HtmlBlock
 import org.commonmark.node.Node
 
 /**
  * The span corresponding to the markdown "HtmlBlock" unit.
  */
-class HtmlBlockSpan(val color: Int, val indentation: Int) : BlockSpan() {
+class HtmlBlockSpan(
+    val color: Int,
+    val indentation: Int,
+    val beforeSpacing: Int,
+    val afterSpacing: Int
+) : BlockSpan() {
 
     init {
         add(TypefaceSpan("monospace"))
         add(LeadingMarginSpan.Standard(indentation))
         add(ForegroundColorSpan(color))
+        add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
     }
 
     override fun toNode(literal: String?): Node {

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/IndentedCodeBlockSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/IndentedCodeBlockSpan.kt
@@ -21,18 +21,25 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.TypefaceSpan
 import com.waz.zclient.markdown.spans.BlockSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.commonmark.node.IndentedCodeBlock
 import org.commonmark.node.Node
 
 /**
  * The span corresponding to the markdown "IndentedCode" unit.
  */
-class IndentedCodeBlockSpan(val color: Int, val indentation: Int) : BlockSpan() {
+class IndentedCodeBlockSpan(
+    val color: Int,
+    val indentation: Int,
+    val beforeSpacing: Int,
+    val afterSpacing: Int
+) : BlockSpan() {
 
     init {
         add(TypefaceSpan("monospace"))
         add(LeadingMarginSpan.Standard(indentation))
         add(ForegroundColorSpan(color))
+        add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
     }
 
     override fun toNode(literal: String?): Node {

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/ListItemSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/ListItemSpan.kt
@@ -18,13 +18,18 @@
 package com.waz.zclient.markdown.spans.commonmark
 
 import com.waz.zclient.markdown.spans.BlockSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.commonmark.node.ListItem
 import org.commonmark.node.Node
 
 /**
  * The span corresponding to the markdown "ListItem" unit.
  */
-class ListItemSpan : BlockSpan() {
+class ListItemSpan(val beforeSpacing: Int, val afterSpacing: Int) : BlockSpan() {
+
+    init {
+        add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
+    }
 
     override fun toNode(literal: String?): Node = ListItem()
 }

--- a/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/ListItemSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/commonmark/ListItemSpan.kt
@@ -18,18 +18,13 @@
 package com.waz.zclient.markdown.spans.commonmark
 
 import com.waz.zclient.markdown.spans.BlockSpan
-import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import org.commonmark.node.ListItem
 import org.commonmark.node.Node
 
 /**
  * The span corresponding to the markdown "ListItem" unit.
  */
-class ListItemSpan(val beforeSpacing: Int, val afterSpacing: Int) : BlockSpan() {
-
-    init {
-        add(ParagraphSpacingSpan(beforeSpacing, afterSpacing))
-    }
+class ListItemSpan() : BlockSpan() {
 
     override fun toNode(literal: String?): Node = ListItem()
 }

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
@@ -31,7 +31,9 @@ class CustomQuoteSpan(
     color: Int,
     val stripeWidth: Int,
     val gapWidth: Int,
-    private val density: Float = 1f
+    private val density: Float = 1f,
+    val beforeSpacing: Int = 0,
+    val afterSpacing: Int = 0
 ) : QuoteSpan(color) {
 
     override fun getLeadingMargin(first: Boolean): Int {
@@ -42,11 +44,21 @@ class CustomQuoteSpan(
         c: Canvas?, p: Paint?, x: Int, dir: Int, top: Int, baseline: Int, bottom: Int,
         text: CharSequence?, start: Int, end: Int, first: Boolean, layout: Layout?
     ) {
-        // ensure this span is attached to the text
         val spanned = text as Spanned
-        if (!(spanned.getSpanStart(this) <= start && spanned.getSpanEnd(this) >= end)) return
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
 
+        // ensure this span is attached to the text
+        if (!(spanStart <= start && spanEnd >= end)) return
         if (c == null || p == null) return
+
+        // we want to top and bottom of the stripe to align with the top and bottom of the text.
+        // if there is before and after spacing applied, then we must counter it by offsetting
+        // 'top' and 'bottom'.
+        var topOffset = 0f
+        var bottomOffset = 0f
+        if (spanStart == start) { topOffset += beforeSpacing * density }
+        if (spanEnd == end + 1) { bottomOffset -= afterSpacing * density }
 
         // save paint state
         val style = p.style
@@ -54,7 +66,7 @@ class CustomQuoteSpan(
 
         p.style = Paint.Style.FILL
         p.color = this.color
-        c.drawRect(x.toFloat(), top.toFloat(), (x + dir * stripeWidth * density).toFloat(), bottom.toFloat(), p)
+        c.drawRect(x.toFloat(), top.toFloat() + topOffset, (x + dir * stripeWidth * density), bottom.toFloat() + bottomOffset, p)
 
         // reset paint
         p.style = style

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
@@ -44,7 +44,7 @@ class CustomQuoteSpan(
     ) {
         // ensure this span is attached to the text
         val spanned = text as Spanned
-        if (!(spanned.getSpanStart(this) == start && spanned.getSpanEnd(this) == end)) return
+        if (!(spanned.getSpanStart(this) <= start && spanned.getSpanEnd(this) >= end)) return
 
         if (c == null || p == null) return
 

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/ListPrefixSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/ListPrefixSpan.kt
@@ -40,11 +40,11 @@ class ListPrefixSpan(
     }
 
     override fun draw(canvas: Canvas?, text: CharSequence?, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint?) {
+        if (canvas == null || text == null || paint == null) return
+
         // ensure this span is attached to the text
         val spanned = text as Spanned
         if (!(spanned.getSpanStart(this) == start && spanned.getSpanEnd(this) == end)) return
-
-        if (canvas == null || text == null || paint == null) return
 
         // the list prefix
         val prefix = text.subSequence(start until end)

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/ParagraphSpacingSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/ParagraphSpacingSpan.kt
@@ -43,6 +43,8 @@ class ParagraphSpacingSpan(val before: Int, val after: Int) : LineHeightSpan.Wit
     ) {
         if (text !is Spanned) return
 
+        val density = paint?.density ?: 1f
+
         // store the initial values
         if (firstTime && fm != null) {
             firstTime = false
@@ -65,16 +67,16 @@ class ParagraphSpacingSpan(val before: Int, val after: Int) : LineHeightSpan.Wit
         // if first line
         if (spanStart == start) {
             fm?.let {
-                fm.ascent -= before
-                fm.top -= before
+                fm.ascent -= (density * before).toInt()
+                fm.top -= (density * before).toInt()
             }
         }
 
         // if last line
         if (spanEnd == end) {
             fm?.let {
-                fm.descent += after
-                fm.bottom += after
+                fm.descent += (density * after).toInt()
+                fm.bottom += (density * after).toInt()
             }
         }
     }

--- a/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
@@ -40,7 +40,6 @@ import org.commonmark.renderer.NodeRenderer
  */
 class SpanRenderer(private val styleSheet: StyleSheet) : AbstractVisitor(), NodeRenderer {
 
-    // TODO: make this an option
     val softBreaksAsHardBreaks = true
     val spannableString: SpannableString get() = writer.spannableString.trim() as SpannableString
 

--- a/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
@@ -308,7 +308,6 @@ class SpanRenderer(private val styleSheet: StyleSheet) : AbstractVisitor(), Node
 
     override fun visit(image: Image?) {
         if (image == null) return
-        // TODO: write raw input b/c this is unsupported
         writer.saveCursor()
         visitChildren(image)
         writer.set(styleSheet.spanFor(image), writer.retrieveCursor())
@@ -376,8 +375,7 @@ class SpanRenderer(private val styleSheet: StyleSheet) : AbstractVisitor(), Node
             is Paragraph -> if (!node.isOuterMost) return
             else -> { }
         }
-
-        // TODO: we might want to prohibit adding newline if it is the last node
+        
         writer.lineIfNeeded()
     }
 }

--- a/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
@@ -296,6 +296,7 @@ class SpanRenderer(private val styleSheet: StyleSheet) : AbstractVisitor(), Node
         if (htmlBlock == null) return
         writer.saveCursor()
         writer.write(htmlBlock.literal)
+        writeLineIfNeeded(htmlBlock)
         writer.set(styleSheet.spanFor(htmlBlock), writer.retrieveCursor())
     }
 

--- a/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/visitors/SpanRenderer.kt
@@ -23,6 +23,7 @@ import android.text.style.LeadingMarginSpan
 import android.text.style.TabStopSpan
 import com.waz.zclient.markdown.StyleSheet
 import com.waz.zclient.markdown.spans.custom.ListPrefixSpan
+import com.waz.zclient.markdown.spans.custom.ParagraphSpacingSpan
 import com.waz.zclient.markdown.utils.*
 import org.commonmark.internal.renderer.text.BulletListHolder
 import org.commonmark.internal.renderer.text.ListHolder
@@ -273,6 +274,9 @@ class SpanRenderer(private val styleSheet: StyleSheet) : AbstractVisitor(), Node
             // indentation for second paragraph up to nested list or item end
             writer.set(LeadingMarginSpan.Standard(indentation + standardPrefixWidth), b1, b2)
         }
+
+        // before and after spacing, from item start up to nested list or item end
+        writer.set(ParagraphSpacingSpan(styleSheet.listItemSpacingBefore, styleSheet.listItemSpacingAfter), start, b2 ?: b1)
 
         // finally, the span for the whole item
         writer.set(styleSheet.spanFor(listItem), start)

--- a/app/src/main/res/values/theme_attrs.xml
+++ b/app/src/main/res/values/theme_attrs.xml
@@ -155,4 +155,9 @@
     <!-- Teams -->
     <attr name="roundBackgroundDrawable" format="reference" />
 
+    <!-- Markdown -->
+    <attr name="codeColor" format="reference" />
+    <attr name="quoteColor" format="reference" />
+    <attr name="listPrefixColor" format="reference" />
+
 </resources>

--- a/app/src/main/res/values/theme_attrs.xml
+++ b/app/src/main/res/values/theme_attrs.xml
@@ -158,6 +158,7 @@
     <!-- Markdown -->
     <attr name="codeColor" format="reference" />
     <attr name="quoteColor" format="reference" />
+    <attr name="quoteStripeColor" format="reference" />
     <attr name="listPrefixColor" format="reference" />
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -178,6 +178,11 @@
         <!-- Teams -->
         <item name="roundBackgroundDrawable">@drawable/rounded_corner_background_dark</item>
 
+        <!-- Markdown -->
+        <item name="codeColor">@color/white_64</item>
+        <item name="quoteColor">@color/white_64</item>
+        <item name="listPrefixColor">@color/white_64</item>
+
     </style>
 
     <style name="Theme.Light" parent="@style/Theme.Design.Light.NoActionBar">
@@ -336,6 +341,11 @@
 
         <!-- Teams -->
         <item name="roundBackgroundDrawable">@drawable/rounded_corner_background_light</item>
+
+        <!-- Markdown -->
+        <item name="codeColor">@color/graphite_64</item>
+        <item name="quoteColor">@color/graphite_64</item>
+        <item name="listPrefixColor">@color/graphite_64</item>
 
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -181,6 +181,7 @@
         <!-- Markdown -->
         <item name="codeColor">@color/white_64</item>
         <item name="quoteColor">@color/white_64</item>
+        <item name="quoteStripeColor">@color/white_24</item>
         <item name="listPrefixColor">@color/white_64</item>
 
     </style>
@@ -345,6 +346,7 @@
         <!-- Markdown -->
         <item name="codeColor">@color/graphite_64</item>
         <item name="quoteColor">@color/graphite_64</item>
+        <item name="quoteStripeColor">@color/graphite_24</item>
         <item name="listPrefixColor">@color/graphite_64</item>
 
     </style>

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/AccentColorController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/AccentColorController.scala
@@ -22,7 +22,7 @@ import com.waz.content.GlobalPreferences
 import com.waz.content.Preferences.PrefKey
 import com.waz.service.ZMessaging
 import com.waz.utils.crypto.ZSecureRandom
-import com.waz.utils.events.Signal
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.{Injectable, Injector}
 
 class AccentColorController(implicit inj: Injector) extends Injectable {
@@ -53,4 +53,12 @@ class AccentColorController(implicit inj: Injector) extends Injectable {
       AccentColors.colors(_)
     }
   }
+
+  def accentColorForJava(callback: AccentColorCallback, ec: EventContext): Unit = {
+    accentColor.onUi(callback.color)(ec)
+  }
+}
+
+trait AccentColorCallback {
+  def color(color: com.waz.api.AccentColor): Unit
 }


### PR DESCRIPTION
# What's in this PR?
This PR contains mostly design tweaks but also some leftover todos from the previous run.

**Design fixes include:**
- Definitions of colors for code, list prefix and quotes (both in light and dark mode).
- The color of links should be the user's chosen accent color.
- If the user changes accent color (on any device), the link color should update accordingly.
- The quote stripe should be thinner and appear the same color as the quoted text.
- Increase paragraph spacing around list items and quotes.
- Code blocks should not be indented.
- Increase line-height of all text slightly.

**Bug fixes:**
- The paragraph spacing was not respecting screen density (on low-density devices, it was too large).
- HTML blocks were missing a trailing newline.
- Quotes were not rendering on multiple lines

## Note
These changes have already been shown to the design team.