### PR TITLE
Invalidate StyleSheet when text size or color changes

### DIFF
--- a/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
+++ b/app/src/main/java/com/waz/zclient/markdown/MarkdownTextView.java
@@ -53,6 +53,22 @@ public class MarkdownTextView extends TypefaceTextView implements ViewHelper {
 
     private StyleSheet mStyleSheet;
 
+    @Override
+    public void setTextSize(int unit, float size) {
+        super.setTextSize(unit, size);
+        invalidateStyleSheet();
+    }
+
+    @Override
+    public void setTextColor(int color) {
+        super.setTextColor(color);
+        invalidateStyleSheet();
+    }
+
+    private void invalidateStyleSheet() {
+        mStyleSheet = null;
+    }
+
     /**
      * Configures the style sheet used for rendering.
      */


### PR DESCRIPTION
# What's in this PR?
This PR addresses an issue where some messages were randomly displayed with large font.

## Cause
The `StyleSheet` used to render markdown is created once for each text view and uses the text size and color of this view to configure its base font. It could happen that some stylesheets received the standard font size, while others received a larger font size (for emoji only messages). When these text views were being recycled, their associated style sheets were not updated for the new messages. As a result, some messages were rendered with outdated style sheets.

## Solution
Whenever the font size or color is changed of a text view is changed, create the stylesheet again.