### PR TITLE
Fix sticky calling notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '126.2100'
+    zMessagingDevVersionBase = '126.2101'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '126.0.472@aar'


### PR DESCRIPTION
The actual bug was in SE in `Preferences` - deserializing of an empty set was failing. The fix was a simple one-liner, so I just merged it to `develop` and bumbed the SE version in UI.
https://github.com/wireapp/wire-android-sync-engine/commit/5d0882816ec2253a4394048e58bf57879a5bb122

When that was fixed, it became unnecessary to handle deserialization failures in `CallingNotificationController`.

fixes https://github.com/wireapp/android-project/issues/161
fixes https://github.com/wireapp/wire-android/issues/1683