### PR TITLE
Bump upload file size to 100MB

### DIFF
--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -24,14 +24,13 @@ import android.provider.MediaStore
 import android.support.annotation.Nullable
 import android.support.v7.widget.{ActionMenuView, Toolbar}
 import android.text.TextUtils
-import android.text.format.Formatter
 import android.view._
 import android.view.animation.Animation
 import android.widget.{AbsListView, FrameLayout, TextView}
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.model.AccentColor
-import com.waz.api.{AssetFactory, AudioAssetForUpload, AudioEffect, ErrorType}
+import com.waz.api.{AudioAssetForUpload, AudioEffect, ErrorType}
 import com.waz.content.GlobalPreferences
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{MessageContent => _, _}
@@ -671,8 +670,7 @@ class ConversationFragment extends FragmentHelper {
       )
       errorsController.dismissSyncError(err.id)
     case ErrorType.CANNOT_SEND_ASSET_TOO_LARGE =>
-      val maxAllowedSizeInBytes = AssetFactory.getMaxAllowedAssetSizeInBytes
-      if (maxAllowedSizeInBytes > 0) {
+      accountsController.isTeam.head.foreach { isTeam =>
         val dialog = ViewUtils.showAlertDialog(
           getActivity,
           R.string.asset_upload_error__file_too_large__title,
@@ -681,9 +679,9 @@ class ConversationFragment extends FragmentHelper {
           null,
           true
         )
-        dialog.setMessage(getString(R.string.asset_upload_error__file_too_large__message, Formatter.formatShortFileSize(getContext, maxAllowedSizeInBytes)))
+        dialog.setMessage(getString(R.string.asset_upload_error__file_too_large__message, s"${AssetData.maxAssetSizeInBytes(isTeam) / (1024 * 1024)}MB"))
+        errorsController.dismissSyncError(err.id)
       }
-      errorsController.dismissSyncError(err.id)
     case ErrorType.RECORDING_FAILURE =>
       ViewUtils.showAlertDialog(
         getActivity,

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
     playServicesVersion = '11.0.0'
 
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-    zMessagingDevVersionBase = '127.2129'
+    zMessagingDevVersionBase = '127.263-PR'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '127.3.480@aar'


### PR DESCRIPTION
Requires https://github.com/wireapp/wire-android-sync-engine/pull/394
I replaced the call to `Formatter.formatShortFileSize` with a simple string interpolation, because the former treats a megabyte as a million of bytes, while in SE we define it as 2^20 (1024 * 1024) bytes. As a result, the 100 * 1024 * 1024 bytes limit was rounded up back to megabytes as 105MB.  
#### APK
[Download build #11388](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11388/artifact/build/artifact/wire-dev-PR1693-11388.apk)
[Download build #11413](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11413/artifact/build/artifact/wire-dev-PR1693-11413.apk)
[Download build #11528](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11528/artifact/build/artifact/wire-dev-PR1693-11528.apk)