### PR TITLE
Update “Full house” copy

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1481,10 +1481,7 @@
 
     <string name="max_participants_alert_title">The group is full</string>
     <string name="max_participants_create_alert_message">Up to 300 people can join a conversation.</string>
-    <plurals name="max_participants_add_alert_message">
-        <item quantity="one">Up to 300 people can join a conversation. Currently there is only room for %1$s more.</item>
-        <item quantity="other">Up to 300 people can join a conversation. Currently there is only room for %1$s more.</item>
-    </plurals>
+    <string name="max_participants_add_alert_message">Up to 300 people can join a conversation. Currently there is only room for %1$s more.</string>
     <string name="sso_signin_button">Company log in</string>
 
     <string name="sso_signin_error_title">Something went wrong</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1479,7 +1479,7 @@
     <string name="markdown_link_dialog_confirmation">OK</string>
     <string name="markdown_link_dialog_cancel">CANCEL</string>
 
-    <string name="max_participants_alert_title">Full house</string>
+    <string name="max_participants_alert_title">The group is full</string>
     <string name="max_participants_create_alert_message">Up to 300 people can join a conversation.</string>
     <plurals name="max_participants_add_alert_message">
         <item quantity="one">Up to 300 people can join a conversation. Currently there is only room for %1$s more person.</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1482,8 +1482,8 @@
     <string name="max_participants_alert_title">The group is full</string>
     <string name="max_participants_create_alert_message">Up to 300 people can join a conversation.</string>
     <plurals name="max_participants_add_alert_message">
-        <item quantity="one">Up to 300 people can join a conversation. Currently there is only room for %1$s more person.</item>
-        <item quantity="other">Up to 300 people can join a conversation. Currently there is only room for %1$s more people.</item>
+        <item quantity="one">Up to 300 people can join a conversation. Currently there is only room for %1$s more.</item>
+        <item quantity="other">Up to 300 people can join a conversation. Currently there is only room for %1$s more.</item>
     </plurals>
     <string name="sso_signin_button">Company log in</string>
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.support.v7.widget.Toolbar
 import android.view._
 import android.widget.TextView
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient.ManagerFragment.Page
@@ -31,10 +32,8 @@ import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.conversation.creation.{AddParticipantsFragment, CreateConversationController}
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.utils.ContextUtils.getColor
-import com.waz.zclient.utils.{RichView, ViewUtils}
+import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils}
 import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
-import com.waz.ZLog.ImplicitTag._
-import com.waz.zclient.utils.ContextUtils._
 
 class ParticipantHeaderFragment extends FragmentHelper {
   implicit def cxt: Context = getActivity
@@ -132,7 +131,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
           val remaining = ConversationController.MaxParticipants - others - 1
           ViewUtils.showAlertDialog(getContext,
             getString(R.string.max_participants_alert_title),
-            getQuantityString(R.plurals.max_participants_add_alert_message, remaining, remaining.toString),
+            ContextUtils.getString(R.plurals.max_participants_add_alert_message, remaining.toString),
             getString(android.R.string.ok), null, true)
         }
       case _ =>


### PR DESCRIPTION
The “Full house” dialog title that appears when a conversation reaches the maximum number of participants is a remnant of our earlier informal tone. 

This should be revised to adapt to our recent B2B tone per https://github.com/wireapp/copywriting/issues/37.

⚠️ Other platforms do not distinguish between singular and plural variants here, so 7867774 changes both to agree with what other clients show. If time allows, code could be refactored to use a single string, as both variants are now identical.