### PR TITLE
Set max execution delay for fetch jobs, bump up Android Job, fix a few problems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -281,10 +281,12 @@ dependencies {
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
     implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
     implementation "com.google.android.gms:play-services-location:$playServicesVersion"
-    implementation 'com.google.firebase:firebase-messaging:17.1.0'
+    implementation "com.google.android.gms:play-services-gcm:$playServicesVersion"
+    implementation 'com.google.firebase:firebase-messaging:17.3.0'
 
     //third party libraries
-    implementation 'com.evernote:android-job:1.2.0'
+    implementation 'com.evernote:android-job:1.3.0-alpha06'
+    implementation 'android.arch.work:work-runtime:1.0.0-alpha07'
     implementation 'com.jakewharton.timber:timber:4.7.0'
     implementation 'net.hockeyapp.android:HockeySDK:4.1.4'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.0.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -240,7 +240,8 @@
         <!--For Evernote Background jobs-->
         <service
             android:name="com.evernote.android.job.gcm.PlatformGcmService"
-            android:enabled="false"
+            android:enabled="true"
+            tools:replace="android:enabled"
             android:exported="true"
             android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE">
             <intent-filter>

--- a/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
@@ -75,7 +75,7 @@ object FetchJob {
   val AccountExtra = "accounts"
   val NotificationExtra = "notification"
 
-  val MaxExecutionDelay = 30.seconds
+  val MaxExecutionDelay = 15.seconds
   val InitialBackoffDelay = 500.millis
 
   def apply(userId: UserId, nId: Option[Uid]): Unit = {
@@ -99,6 +99,7 @@ object FetchJob {
 
       new JobRequest.Builder(tag)
         .setBackoffCriteria(InitialBackoffDelay.toMillis, JobRequest.BackoffPolicy.EXPONENTIAL)
+        .setExecutionWindow(9L, MaxExecutionDelay.toMillis)
         .setExtras(args)
         .startNow()
         .build()

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -326,7 +326,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     })
 
     val prefs = GlobalPreferences(this)
-    val googleApi = new GoogleApiImpl(this, backend, prefs)
+    val googleApi = GoogleApiImpl(this, backend, prefs)
 
     ZMessaging.onCreate(this, backend, prefs, googleApi)
 


### PR DESCRIPTION
I decided to close https://github.com/wireapp/wire-android/pull/1750 and approach the problem from scratch. Here are the results.

1. We set the max delay cap in fetch jobs to 15 seconds.
2. Android Job is updated to 1.3.0-alpha06, using internally WorkManager 1.0.0-alpha07.
3. I ensured that `GoogleApiImpl` is instantiated only once (otherwise we got an error that firebaseApp is already initialized).
4. I made some changes to how notifications in Android 8+ uses channel, to ensure they're displayed properly.

All in all, these changes should deal with a few bugs I encountered while testing notifications on Android 8 and let us focus on the main issue.
#### APK
[Download build #11566](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11566/artifact/build/artifact/wire-dev-PR1758-11566.apk)
[Download build #11568](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11568/artifact/build/artifact/wire-dev-PR1758-11568.apk)
[Download build #11574](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11574/artifact/build/artifact/wire-dev-PR1758-11574.apk)