### PR TITLE
Fix a non-exhaustive match in DrawingFragment

### DIFF
--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -285,6 +285,7 @@ class DrawingFragment extends FragmentHelper
                 v.setLayoutParams(params)
               case MotionEvent.ACTION_UP =>
                 closeKeyboard()
+              case _ =>
             }
           drawingCanvasView.exists(_.onTouchEvent(event))
         }


### PR DESCRIPTION
fixes https://github.com/wireapp/android-project/issues/244

There's a non-exhaustive match of motion events in `DrawingFragment`, causing crashes if one of the unhandles events is intercepted (very unlikely). Adding the default case should be enough to fix it.
#### APK
[Download build #11584](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11584/artifact/build/artifact/wire-dev-PR1765-11584.apk)
[Download build #11586](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11586/artifact/build/artifact/wire-dev-PR1765-11586.apk)