### PR TITLE
fix: prevent websocket notification from flickering.

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -33,6 +33,8 @@ import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient._
 
+import scala.concurrent.duration._
+
 class WebSocketController(implicit inj: Injector) extends Injectable {
   private lazy val global   = inject[GlobalModule]
   private lazy val accounts = inject[AccountsService]
@@ -132,7 +134,7 @@ class WebSocketService extends ServiceHelper {
     }
 
   private lazy val appInForegroundSubscription =
-    controller.notificationTitleRes {
+    controller.notificationTitleRes.throttle(500.millis) {
       case None =>
         verbose("stopForeground")
         stopForeground(true)


### PR DESCRIPTION
  It seems as though the signal for deciding to show the ws notification
  can flicker very quickly to true before it is then set back to false
  when the app is minimised (for those users where the WebSocketService
  should be not active).

  This commit throttles the signal to prevent this flicker.

  fixes: https://github.com/wireapp/android-project/issues/262
#### APK
[Download build #11670](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11670/artifact/build/artifact/wire-dev-PR1786-11670.apk)