### PR TITLE
Prevent crash on opening WebSocketService on app start

### DIFF
--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -36,8 +36,8 @@ import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.ViewUtils
 
-import scala.collection.immutable.ListSet
 import scala.collection.breakOut
+import scala.collection.immutable.ListSet
 
 
 class BaseActivity extends AppCompatActivity
@@ -53,21 +53,16 @@ class BaseActivity extends AppCompatActivity
 
   def injectJava[T](cls: Class[T]) = inject[T](reflect.Manifest.classType(cls), injector)
 
-  override def onCreate(savedInstanceState: Bundle) = {
+  override protected def onCreate(savedInstanceState: Bundle) = {
+    verbose(s"onCreate")
     super.onCreate(savedInstanceState)
     setTheme(getBaseTheme)
   }
 
   override def onStart(): Unit = {
+    verbose(s"onStart")
     super.onStart()
     onBaseActivityStart()
-  }
-
-  def getBaseTheme: Int = themeController.forceLoadDarkTheme
-
-  override protected def onActivityResult(requestCode: Int, resultCode: Int, data: Intent) = {
-    super.onActivityResult(requestCode, resultCode, data)
-    permissions.registerProvider(this)
   }
 
   def onBaseActivityStart(): Unit = {
@@ -79,7 +74,41 @@ class BaseActivity extends AppCompatActivity
     WebSocketService(this)
   }
 
+  override protected def onResume(): Unit = {
+    verbose(s"onResume")
+    super.onResume()
+  }
+
+
+  override protected def onResumeFragments(): Unit = {
+    verbose("onResumeFragments")
+    super.onResumeFragments()
+  }
+
+  override def onWindowFocusChanged(hasFocus: Boolean): Unit = {
+    verbose(s"onWindowFocusChanged: $hasFocus")
+  }
+
+  def getBaseTheme: Int = themeController.forceLoadDarkTheme
+
+  override protected def onActivityResult(requestCode: Int, resultCode: Int, data: Intent) = {
+    verbose(s"onActivityResult: requestCode: $requestCode, resultCode: $resultCode, data: $data")
+    super.onActivityResult(requestCode, resultCode, data)
+    permissions.registerProvider(this)
+  }
+
+  override protected def onPause(): Unit = {
+    verbose(s"onPause")
+    super.onPause()
+  }
+
+  override protected def onSaveInstanceState(outState: Bundle): Unit = {
+    verbose("onSaveInstanceState")
+    super.onSaveInstanceState(outState)
+  }
+
   override def onStop() = {
+    verbose(s"onStop")
     ZMessaging.currentUi.onPause()
     inject[UiLifeCycle].releaseUi()
     InternalLog.flush()
@@ -87,6 +116,7 @@ class BaseActivity extends AppCompatActivity
   }
 
   override def onDestroy() = {
+    verbose(s"onDestroy")
     globalTrackingController.flushEvents()
     permissions.unregisterProvider(this)
     super.onDestroy()

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -71,14 +71,16 @@ class BaseActivity extends AppCompatActivity
     inject[UiLifeCycle].acquireUi()
     if (!this.isInstanceOf[LaunchActivity]) permissions.registerProvider(this)
     Option(ViewUtils.getContentView(getWindow)).foreach(getControllerFactory.setGlobalLayout)
-    WebSocketService(this)
   }
 
   override protected def onResume(): Unit = {
     verbose(s"onResume")
     super.onResume()
+    onBaseActivityResume()
   }
 
+  def onBaseActivityResume(): Unit =
+    WebSocketService(this)
 
   override protected def onResumeFragments(): Unit = {
     verbose("onResumeFragments")

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -46,6 +46,9 @@ class LaunchActivity extends BaseActivity {
   //Can't call super from within anonymous class
   private def superOnBaseActivityStart() = super.onBaseActivityStart()
 
+  //No need for onBaseActivityResume in this instance of Activity
+  override def onBaseActivityResume(): Unit = {}
+
   override protected def onNewIntent(intent: Intent) = {
     super.onNewIntent(intent)
     setIntent(intent)

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -88,8 +88,6 @@ class MainActivity extends BaseActivity
   }
 
   override def onCreate(savedInstanceState: Bundle) = {
-    info("onCreate")
-
     Option(getActionBar).foreach(_.hide())
     super.onCreate(savedInstanceState)
 
@@ -159,13 +157,7 @@ class MainActivity extends BaseActivity
 
   }
 
-  override protected def onResumeFragments() = {
-    info("onResumeFragments")
-    super.onResumeFragments()
-  }
-
   override def onStart() = {
-    info("onStart")
     getControllerFactory.getNavigationController.addNavigationControllerObserver(this)
     inject[NavigationController].mainActivityActive.mutate(_ + 1)
 
@@ -178,7 +170,6 @@ class MainActivity extends BaseActivity
   }
 
   override protected def onResume() = {
-    info("onResume")
     super.onResume()
 
     Option(ZMessaging.currentGlobal).foreach(_.googleApi.checkGooglePlayServicesAvailable(this))
@@ -291,20 +282,13 @@ class MainActivity extends BaseActivity
     transaction.commit
   }
 
-  override protected def onPause() = {
-    info("onPause")
-    super.onPause()
-  }
-
   override protected def onSaveInstanceState(outState: Bundle) = {
-    info("onSaveInstanceState")
     getControllerFactory.getNavigationController.onSaveInstanceState(outState)
     super.onSaveInstanceState(outState)
   }
 
   override def onStop() = {
     super.onStop()
-    info("onStop")
     getControllerFactory.getNavigationController.removeNavigationControllerObserver(this)
     inject[NavigationController].mainActivityActive.mutate(_ - 1)
   }
@@ -317,7 +301,6 @@ class MainActivity extends BaseActivity
   }
 
   override protected def onActivityResult(requestCode: Int, resultCode: Int, data: Intent) = {
-    info(s"OnActivity requestCode: $requestCode, resultCode: $resultCode")
     super.onActivityResult(requestCode, resultCode, data)
     Option(ZMessaging.currentGlobal).foreach(_.googleApi.onActivityResult(requestCode, resultCode))
     Option(getSupportFragmentManager.findFragmentById(R.id.fl_main_content)).foreach(_.onActivityResult(requestCode, resultCode, data))


### PR DESCRIPTION
It seems as though Activity#onStart() may be called before the Activity
  is technically in the foreground as defined in the
  [Android 8 restrictions on background services](https://developer.android.com/about/versions/oreo/background)

  This PR then delays starting the WebSocketService to the onResume
  method, in the hopes that this will be late enough. According to
  [this post on stack overflow](https://stackoverflow.com/questions/4414171/how-to-detect-when-an-android-app-goes-to-the-background-and-come-back-to-the-fo)
  even onResume may be called before we are technically in the foreground

  This also begs the question that perhaps our definition of UiActive
  is not correct, however this commit will not change this logic for now.
  Here is a ticket for this future work:
  wireapp/android-project#265

  fixes: https://github.com/wireapp/android-project/issues/264
#### APK
[Download build #11672](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11672/artifact/build/artifact/wire-dev-PR1788-11672.apk)
[Download build #11674](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11674/artifact/build/artifact/wire-dev-PR1788-11674.apk)
[Download build #11675](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11675/artifact/build/artifact/wire-dev-PR1788-11675.apk)
[Download build #11678](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11678/artifact/build/artifact/wire-dev-PR1788-11678.apk)