### PR TITLE
fix: stop saving bitmap in onSavedInstanceState

### DIFF
--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -319,12 +319,6 @@ class DrawingFragment extends FragmentHelper
     sensorManager.registerListener(shakeEventListener, sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER), SensorManager.SENSOR_DELAY_NORMAL)
   }
 
-  override def onSaveInstanceState(outState: Bundle): Unit = {
-    getBitmapDrawing.foreach(outState.putParcelable(SAVED_INSTANCE_BITMAP, _))
-    assetIntentsManager.onSaveInstanceState(outState)
-    super.onSaveInstanceState(outState)
-  }
-
   override def onStop(): Unit = {
     sensorManager.unregisterListener(shakeEventListener)
     super.onStop()


### PR DESCRIPTION
  It seems as though when targeting Android version >=24
  the system now throws a android.os.TransactionTooLargeException
  when the SavedInstanceState bundle is greater than 1MB
  (previously the system would log a warning).

  The DrawingFragment, upon being minimised, saves the entire bitmap to
  the outState bundle, which is often much more than 1MB.

  This PR stops saving the bitmap to the outstate.

  This now means that if the Activity is killed in the background, the
  bitmap the user was drawing will be lost. On most devices with
  Android 7 though (assuming they're relatively high-end devices) it
  will take some time for the activity to be killed, and so the user
  can still minimise the app without losing their sketch immediately.

  This commit potentially fixes: https://github.com/wireapp/android-project/issues/268
  (however we should monitor this in the coming release)

  The ideal solution would be to persist the bitmap to the file system
  on fragment stop. I have created a ticket for future work:
  https://github.com/wireapp/android-project/issues/269
#### APK
[Download build #11692](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11692/artifact/build/artifact/wire-dev-PR1790-11692.apk)