### PR TITLE
chore: corrects the way we update remoteMap in ConversationStorage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
 
-    zMessagingDevVersionBase = '128.2145'
+    zMessagingDevVersionBase = '129.312-PR'
     zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '129.1.489@aar'


### PR DESCRIPTION
https://github.com/wireapp/wire-android-sync-engine/pull/424
#### APK
[Download build #11693](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11693/artifact/build/artifact/wire-dev-PR1792-11693.apk)