### PR TITLE
fix: Typing message event should have priority over mentions

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -367,10 +367,10 @@ object ConversationListRow {
       ConversationBadge.WaitingConnection
     } else if (conversationData.muted) {
       ConversationBadge.Muted
-    } else if (unreadCount.mentions > 0) {
-      ConversationBadge.Mention
     } else if (typing) {
       ConversationBadge.Typing
+    }else if (unreadCount.mentions > 0) {
+      ConversationBadge.Mention
     } else if (conversationData.missedCallMessage.nonEmpty) {
       ConversationBadge.MissedCall
     } else if (conversationData.incomingKnockMessage.nonEmpty) {
@@ -471,8 +471,6 @@ object ConversationListRow {
       val strings = Seq(
         if (mentionsCount > 0)
           context.getResources.getQuantityString(R.plurals.conversation_list__mentions_count, mentionsCount, mentionsCount.toString) else "",
-        if (normalMessageCount > 0)
-          context.getResources.getQuantityString(R.plurals.conversation_list__new_message_count, normalMessageCount, normalMessageCount.toString) else "",
         if (missedCallCount > 0) {
           if (isGroupConv) {
             if (missedCallCount > 1)


### PR DESCRIPTION
I changed the order in choosing the right badge for the conversation in the conv list.
Also, I removed a duplicated new messages count from the summary.
#### APK
[Download build #11783](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11783/artifact/build/artifact/wire-dev-PR1810-11783.apk)
[Download build #11788](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11788/artifact/build/artifact/wire-dev-PR1810-11788.apk)