### PR TITLE
fix: Delete edited message which consist now only of whitespace chars

### DIFF
--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -219,7 +219,7 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
       msg = m.get
       (CursorText(text, mentions), _) <- enteredText.head
     } {
-      if (text.isEmpty) {
+      if (text.trim.isEmpty) {
         cs.recallMessage(cId, msg.id)
         Toast.makeText(ctx, R.string.conversation__message_action__delete__confirmation, Toast.LENGTH_SHORT).show()
       } else {


### PR DESCRIPTION
If the user edits a message and deletes its contents, the message is going to be deleted. This fix makes the same thing happen if the user leaves only whitespace character in the contents. We assume that was the original reason of the edit, and the user simply didn't see that there is more whitespace characters to delete.

fixes: https://github.com/wireapp/android-project/issues/284

#### APK
[Download build #11819](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11819/artifact/build/artifact/wire-dev-PR1822-11819.apk)
[Download build #11820](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11820/artifact/build/artifact/wire-dev-PR1822-11820.apk)