### PR TITLE
fix: Avoid black stripe when there is no navigation bar (#249)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/BackgroundImageView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/BackgroundImageView.scala
@@ -25,7 +25,7 @@ import com.waz.model.Dim2
 import com.waz.service.ZMessaging
 import com.waz.utils.events.Signal
 import com.waz.zclient.common.views.ImageController.{ImageSource, WireImage}
-import com.waz.zclient.utils.ContextUtils.getColor
+import com.waz.zclient.utils.ContextUtils.{getColor, getNavigationBarHeight}
 import com.waz.zclient.utils.ViewUtils
 import com.waz.zclient.{R, ViewHelper}
 
@@ -41,6 +41,6 @@ class BackgroundImageView(val context: Context, val attrs: AttributeSet, val def
   } yield WireImage(picture)
 
   private val configuration = context.getResources.getConfiguration
-  setBackground(new BackgroundDrawable(pictureId, getContext, Dim2(ViewUtils.toPx(context, configuration.screenWidthDp), ViewUtils.toPx(context, configuration.screenHeightDp))))
+  setBackground(new BackgroundDrawable(pictureId, getContext, Dim2(ViewUtils.toPx(context, configuration.screenWidthDp), ViewUtils.toPx(context, configuration.screenHeightDp + getNavigationBarHeight))))
   setImageDrawable(new ColorDrawable(getColor(R.color.black_58)))
 }


### PR DESCRIPTION
Some phones hide their navigation bar so it's better to account for it all the time when rendering the background.
fixes https://github.com/wireapp/android-project/issues/249
#### APK
[Download build #11838](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11838/artifact/build/artifact/wire-dev-PR1829-11838.apk)