### PR TITLE
fix: add job for checking registered PushToken

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,7 @@ ext {
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
 
-    zMessagingDevVersionBase = '131.2165'
-    zMessagingDevVersion = "${zMessagingDevVersionBase}@aar"
+    zMessagingDevVersion = "131.413-PR@aar"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '131.1.495@aar'
 
@@ -232,7 +231,7 @@ dependencies {
 
     //    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.scala-lang:scala-library:$scalaVersion"
-    compileOnly "org.scala-lang:scala-reflect:$scalaVersion"
+    implementation "org.scala-lang:scala-reflect:$scalaVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     //wire libraries:
@@ -285,8 +284,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:17.3.0'
 
     //third party libraries
-    implementation 'com.evernote:android-job:1.3.0-alpha06'
-    implementation 'android.arch.work:work-runtime:1.0.0-alpha07'
+    implementation 'com.evernote:android-job:1.2.6'
     implementation 'com.jakewharton.timber:timber:4.7.0'
     implementation 'net.hockeyapp.android:HockeySDK:4.1.4'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.0'
@@ -300,11 +298,6 @@ dependencies {
 
     // Test dependencies
     testImplementation 'junit:junit:4.12'
-    testImplementation("com.wire:testutils:$zMessagingDevVersionBase") {
-        exclude module: 'aspectjrt'
-        exclude module: 'isoparser'
-        exclude module: 'zmessaging-android'
-    }
     testImplementation("org.scalatest:scalatest_$scalaMajorVersion:2.2.6") {
         exclude module: 'scala-library'
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -252,12 +252,11 @@
             </intent-filter>
         </service>
 
-        <receiver android:name="com.waz.services.websocket.WebSocketBroadcastReceiver">
+        <receiver android:name="com.waz.services.websocket.OnBootAndUpdateBroadcastReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
-                <action android:name="android.intent.action.PACKAGE_DATA_CLEARED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/res/layout/preferences_dev_layout.xml
+++ b/app/src/main/res/layout/preferences_dev_layout.xml
@@ -50,34 +50,6 @@
                 app:title="@string/pref_dev_version_info_id_title"
                 />
 
-            <com.waz.zclient.ui.text.TypefaceTextView
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/preference_button_height"
-                android:text="@string/pref_dev_category_notifications_title"
-                android:gravity="center_vertical"
-                android:paddingStart="@dimen/wire__padding__16"
-                android:paddingEnd="@dimen/wire__padding__16"
-                android:textColor="@color/accent_blue"
-                />
-
-            <com.waz.zclient.preferences.views.SwitchPreference
-                android:id="@+id/preferences_dev_gcm"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:title="@string/pref_dev_push_enabled_title"
-                app:subtitle="@string/pref_dev_push_enabled_summary"
-                app:key="@string/pref_dev_push_enabled_key"
-                />
-
-            <com.waz.zclient.preferences.views.TextButton
-                android:id="@+id/preferences_dev_websocket_freq"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/wire__padding__20"
-                app:title="@string/pref_dev_websocket_ping_interval_title"
-                app:subtitle="@string/pref_dev_websocket_ping_interval_summary"
-                />
-
             <com.waz.zclient.preferences.views.TextButton
                 android:id="@+id/preferences_dev_slow_sync"
                 android:layout_width="match_parent"
@@ -113,7 +85,45 @@
                 app:subtitle="@string/pref_dev_full_conv_summary"
                 app:title="@string/pref_dev_full_conv_title"
                 app:key="@string/pref_dev_full_conv_key"
+            />
+
+            <com.waz.zclient.ui.text.TypefaceTextView
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                android:text="@string/pref_dev_category_notifications_title"
+                android:gravity="center_vertical"
+                android:paddingStart="@dimen/wire__padding__16"
+                android:paddingEnd="@dimen/wire__padding__16"
+                android:textColor="@color/accent_blue"
                 />
+
+            <com.waz.zclient.preferences.views.SwitchPreference
+                android:id="@+id/preferences_dev_gcm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:title="@string/pref_dev_push_enabled_title"
+                app:subtitle="@string/pref_dev_push_enabled_summary"
+                app:key="@string/pref_dev_push_enabled_key"
+                />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_dev_websocket_freq"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
+                app:title="@string/pref_dev_websocket_ping_interval_title"
+                app:subtitle="@string/pref_dev_websocket_ping_interval_summary"
+                />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_dev_check_push_tokens"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
+                android:layout_marginBottom="@dimen/wire__padding__20"
+                app:title="@string/pref_dev_check_push_token_title"
+                app:subtitle="@string/pref_dev_check_push_token_summary"
+            />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -167,6 +167,9 @@
     <string translatable="false" name="pref_dev_full_conv_title">Create full conversation</string>
     <string translatable="false" name="prefs__username_change__username_at">\@</string>
 
+    <string translatable="false" name="pref_dev_check_push_token_title">Check Registered Push Token</string>
+    <string translatable="false" name="pref_dev_check_push_token_summary">Trigger a job to compare the push token registered for the current user on the backend with the token we have stored locally</string>
+
     <!--Account preferences-->
     <string translatable="false" name="pref_dev_category_sign_in_account_key">PREF_ACCOUNTS_SIGN_IN</string>
     <string translatable="false" name="pref_dev_category_sign_in_account_title">Sign into account</string>

--- a/app/src/main/scala/com/waz/jobs/PushTokenCheckJob.scala
+++ b/app/src/main/scala/com/waz/jobs/PushTokenCheckJob.scala
@@ -15,17 +15,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.waz.services.fcm
+package com.waz.jobs
 
 import com.evernote.android.job.Job.Result
 import com.evernote.android.job.util.support.PersistableBundleCompat
-import com.evernote.android.job.{Job, JobManager, JobRequest}
+import com.evernote.android.job._
 import com.waz.ZLog.{error, verbose}
-import com.waz.ZLog.ImplicitTag._
-import com.waz.model.{Uid, UserId}
-import com.waz.service.AccountsService.InBackground
+import com.waz.ZLog.ImplicitTag.implicitLogTag
+import com.waz.model.UserId
 import com.waz.service.ZMessaging
-import com.waz.service.push.PushService.FetchFromJob
+import com.waz.services.fcm.FetchJob
 import com.waz.threading.Threading
 import com.waz.utils.returning
 
@@ -34,52 +33,56 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
 
-class FetchJob extends Job {
+class PushTokenCheckJob extends Job {
 
-  import FetchJob._
+  import PushTokenCheckJob._
   import Threading.Implicits.Background
 
-  override def onRunJob(params: Job.Params) = {
-    val account = Option(params.getExtras.getString(AccountExtra, null)).map(UserId)
-    val notification = Option(params.getExtras.getString(NotificationExtra, null)).map(Uid(_))
-    verbose(s"onStartJob, account: $account")
-    def syncAccount(userId: UserId, nId: Option[Uid]): Future[Unit] =
-      for {
-        Some(zms) <- ZMessaging.accountsService.flatMap(_.getZms(userId))
-        _ <- zms.push.syncHistory(FetchFromJob(nId), withRetries = false)
-      } yield {}
+  override def onRunJob(params: Job.Params): Job.Result = {
+    Option(params.getExtras.getString(AccountExtra, null)).map(UserId) match {
+      case Some(acc) =>
+        val res = ZMessaging.currentGlobal.accountsService.getZms(acc).flatMap {
+          case Some(zms) =>
+            zms.pushToken.checkCurrentUserTokens().map {
+              case Right(performFetch) =>
+                //trigger a fetch in case we missed any notifications
+                //TODO, this is a bit rigid - we should chain the work with WorkManager and provide and interface so that
+                //TODO the SE can decide this for itself
+                if (performFetch)
+                  FetchJob(acc, nId = None)
 
-    val result = account.fold(Future.successful({})) { id =>
-      ZMessaging.accountsService.flatMap(_.accountState(id).head).flatMap {
-        case InBackground => syncAccount(id, notification)
-        case _            =>
-          verbose("account active, no point in executing fetch job")
-          Future.successful({})
-      }
-    }
+                Result.SUCCESS
+              case Left(err) => if (err.isFatal) Result.FAILURE else Result.RESCHEDULE
+            }
+          case _ => Future.successful(Result.FAILURE)
+        }
+        try {
+          Await.result(res, 1.minute) //Give the job a long time to complete
+        } catch {
+          case NonFatal(e) =>
+            error("PushTokenCheckJob failed", e)
+            Result.RESCHEDULE
+        }
 
-    try {
-      Await.result(result, 1.minute) //Give the job a long time to complete
-      Result.SUCCESS
-    } catch {
-      case NonFatal(e) =>
-        error("FetchJob failed", e)
-        Result.RESCHEDULE
+      case None => Result.FAILURE
     }
   }
 }
 
-object FetchJob {
-
-  val Tag = "FetchJob"
+object PushTokenCheckJob {
+  val Tag = "PushTokenCheckJob"
   val AccountExtra = "accounts"
-  val NotificationExtra = "notification"
 
   val MinExecutionDelay = 1.millis //must be greater than 0
   val MaxExecutionDelay = 15.seconds
   val InitialBackoffDelay = 500.millis
 
-  def apply(userId: UserId, nId: Option[Uid]): Unit = {
+  def apply(): Unit =
+    ZMessaging.currentGlobal.accountsService.zmsInstances.head.foreach { zs =>
+      zs.map(_.selfUserId).foreach(PushTokenCheckJob(_))
+    }(Threading.Background)
+
+  def apply(userId: UserId): Unit = {
     val tag = s"$Tag#${userId.str}"
 
     val manager = JobManager.instance()
@@ -88,14 +91,13 @@ object FetchJob {
       verbose(s"currentJob: $j")
     }
 
-    val hasPendingRequest = returning(JobManager.instance().getAllJobRequestsForTag(tag).asScala.toSet) { v =>
+    val hasPendingRequest = returning(manager.getAllJobRequestsForTag(tag).asScala.toSet) { v =>
       if (v.size > 1) error(s"Shouldn't be more than one fetch job for account: $userId")
     }.nonEmpty
 
     if (!(hasPendingRequest || currentJob.isDefined)) {
       val args = returning(new PersistableBundleCompat()) { b =>
         b.putString(AccountExtra, userId.str)
-        b.putString(NotificationExtra, nId.map(_.str).orNull)
       }
 
       new JobRequest.Builder(tag)

--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -26,6 +26,7 @@ import android.support.v4.app.NotificationCompat
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.content.GlobalPreferences.{PushEnabledKey, WsForegroundKey}
+import com.waz.jobs.PushTokenCheckJob
 import com.waz.service.AccountsService.InForeground
 import com.waz.service.{AccountsService, GlobalModule, ZMessaging}
 import com.waz.threading.Threading
@@ -77,7 +78,7 @@ class WebSocketController(implicit inj: Injector) extends Injectable {
 /**
   * Receiver called on boot or when app is updated.
   */
-class WebSocketBroadcastReceiver extends BroadcastReceiver {
+class OnBootAndUpdateBroadcastReceiver extends BroadcastReceiver {
 
   private var context: Context = _
 
@@ -87,9 +88,17 @@ class WebSocketBroadcastReceiver extends BroadcastReceiver {
   private lazy val controller =
     injector.binding[WebSocketController].getOrElse(throw new Exception(s"Failed to load WebSocketController")).apply()
 
+  private lazy val accounts =
+    injector.binding[AccountsService].getOrElse(throw new Exception(s"Failed to load AccountsService")).apply()
+
   override def onReceive(context: Context, intent: Intent): Unit = {
     this.context = context
     verbose(s"onReceive $intent")
+
+    accounts.zmsInstances.head.foreach { zs =>
+      zs.map(_.selfUserId).foreach(PushTokenCheckJob(_))
+    } (Threading.Background)
+
 
     controller.serviceInForeground.head.foreach {
       case true =>

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -35,6 +35,7 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.verbose
 import com.waz.api.NetworkMode
 import com.waz.content._
+import com.waz.jobs.PushTokenCheckJob
 import com.waz.log.InternalLog
 import com.waz.model.{AccentColor, ConversationData, TeamId, UserId}
 import com.waz.permissions.PermissionsService
@@ -331,8 +332,9 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     JobManager.create(this).addJobCreator(new JobCreator {
       override def create(tag: String) =
-        if (tag.contains(FetchJob.Tag)) new FetchJob
-        else null
+        if      (tag.contains(FetchJob.Tag))          new FetchJob
+        else if (tag.contains(PushTokenCheckJob.Tag)) new PushTokenCheckJob
+        else    null
     })
 
     val prefs = GlobalPreferences(this)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -23,11 +23,12 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.GlobalPreferences._
 import com.waz.content.UserPreferences.LastStableNotification
+import com.waz.jobs.PushTokenCheckJob
 import com.waz.model.AccountData.Password
 import com.waz.model.Uid
-import com.waz.ZLog.ImplicitTag._
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
 import com.waz.service.{AccountManager, ZMessaging}
 import com.waz.utils.events.Signal
@@ -78,6 +79,10 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int) ext
 
   val createFullConversationSwitch = returning(findById[SwitchPreference](R.id.preferences_dev_full_conv)) { v =>
     v.setPreference(ShouldCreateFullConversation, global = true)
+  }
+
+  val checkPushTokenButton = returning(findById[TextButton](R.id.preferences_dev_check_push_tokens)) { v =>
+    v.onClickEvent(_ => PushTokenCheckJob())
   }
 
   private def registerClient(v: View, password: Option[Password] = None): Future[Unit] = {


### PR DESCRIPTION
This commit provides an Evernote Job for, and executes, the check to see
if the current user has a correctly registered push token.

The evernote job handles scheduling, back-off and rescheduling of the
work, while the job itself will be triggered from inside the
WebSocketBroadcastReceiver (which I will now rename to
StartAndUpgradeBroadcastReceiver). This should be sufficient to
ensure that anyone with the bug will be re-registered the next time
they start the app after upgrading, and every device restart should
be a regular enough check to make sure the token is still valid.

partly fixes: https://github.com/wireapp/android-project/issues/263
#### APK
[Download build #11868](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11868/artifact/build/artifact/wire-dev-PR1837-11868.apk)
[Download build #11872](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11872/artifact/build/artifact/wire-dev-PR1837-11872.apk)