### PR TITLE
chore: Remove a duplicated entry for CallWakeService in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -242,9 +242,6 @@
 
         <meta-data android:name="com.mixpanel.android.MPConfig.MinimumSessionDuration" android:value="2000" />
 
-        <service android:name="com.waz.services.calling.CallWakeService"
-                 android:exported="true"/>
-
         <service
             android:name="com.waz.services.fcm.FCMHandlerService">
             <intent-filter>


### PR DESCRIPTION
There were two entries for `<service android:name="com.waz.services.calling.CallWakeService">` in `src/main/AndroidManifest.xml` and Android Studio failed to run tasks because of that.
#### APK
[Download build #11870](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11870/artifact/build/artifact/wire-dev-PR1839-11870.apk)