### PR TITLE
fix: delay starting WebSocketService on app launch

### DIFF
--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -30,6 +30,7 @@ import com.waz.permissions.PermissionsService
 import com.waz.permissions.PermissionsService.{Permission, PermissionProvider}
 import com.waz.service.{UiLifeCycle, ZMessaging}
 import com.waz.services.websocket.WebSocketService
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.IControllerFactory
@@ -38,6 +39,7 @@ import com.waz.zclient.utils.ViewUtils
 
 import scala.collection.breakOut
 import scala.collection.immutable.ListSet
+import scala.concurrent.duration._
 
 
 class BaseActivity extends AppCompatActivity
@@ -80,7 +82,9 @@ class BaseActivity extends AppCompatActivity
   }
 
   def onBaseActivityResume(): Unit =
-    WebSocketService(this)
+    CancellableFuture.delay(150.millis).foreach { _ =>
+      WebSocketService(this)
+    } (Threading.Ui)
 
   override protected def onResumeFragments(): Unit = {
     verbose("onResumeFragments")


### PR DESCRIPTION
This is a hack to avoid a bug on Android 9, where sometimes the system
doesn't think the app is in the foreground before starting the service,
leading to a significant number of IllegalStateExceptions. Once we
target Android 9, we should be able to use this logic just on this
version

fixes: https://github.com/wireapp/android-project/issues/303
#### APK
[Download build #11873](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11873/artifact/build/artifact/wire-dev-PR1840-11873.apk)