### PR TITLE
feat: Move mute notification settings to conv options

### DIFF
--- a/app/src/main/java/com/waz/zclient/paintcode/WireDrawable.scala
+++ b/app/src/main/java/com/waz/zclient/paintcode/WireDrawable.scala
@@ -145,6 +145,11 @@ case class ConversationIcon(colorRes: Int)(implicit context: Context) extends Wi
   override def draw(canvas: Canvas) = drawConversation(canvas, getDrawingRect, ResizingBehavior.AspectFit, paint.getColor)
 }
 
+case class NotificationsIcon(color: Int)(implicit context: Context) extends WireDrawable {
+  setColor(color)
+  override def draw(canvas: Canvas) = drawAlerts(canvas, getDrawingRect, ResizingBehavior.AspectFit, paint.getColor)
+}
+
 case class EphemeralIcon(color: Int, timeUnit: TimeUnit)(implicit context: Context) extends WireDrawable {
   setColor(color)
   import com.waz.model.EphemeralDuration._

--- a/app/src/main/res/layout/list_options_button_with_value_label.xml
+++ b/app/src/main/res/layout/list_options_button_with_value_label.xml
@@ -56,15 +56,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:orientation="horizontal"
+            android:orientation="vertical"
             android:layout_toEndOf="@id/icon"
             android:layout_toStartOf="@id/next_indicator">
 
             <com.waz.zclient.ui.text.TypefaceTextView
                 android:id="@+id/name_text"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:drawablePadding="@dimen/wire__padding__6"
@@ -74,11 +73,11 @@
 
             <com.waz.zclient.ui.text.TypefaceTextView
                 android:id="@+id/value_text"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="1"
-                android:textSize="@dimen/wire__text_size__regular"
+                android:textSize="@dimen/wire__text_size__small"
                 android:textColor="@color/light_graphite_40"
                 android:drawablePadding="@dimen/wire__padding__6"
                 app:w_font="@string/wire__typeface__light"

--- a/app/src/main/res/layout/notifications_options_fragment.xml
+++ b/app/src/main/res/layout/notifications_options_fragment.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Wire
+    Copyright (C) 2018 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?wireBackgroundCollection">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:id="@+id/notifications_options_list_view">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/participants_options_button_margin_top"
+            android:orientation="vertical"
+            style="?wireBackground"
+            android:id="@+id/list_view">
+        </LinearLayout>
+
+        <com.waz.zclient.ui.text.TypefaceTextView
+            android:id="@+id/notifications_explanation_text"
+            android:text="@string/notifications_explanation_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/wire__padding__regular"
+            android:layout_marginBottom="@dimen/wire__padding__regular"
+            android:paddingStart="@dimen/wire__padding__regular"
+            android:paddingEnd="@dimen/wire__padding__regular"
+            android:textColor="?wireSecondaryTextColor"
+            app:w_font="@string/wire__typeface__regular"
+            android:textSize="@dimen/wire__text_size__small"
+            />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/single_participant_tab_details.xml
+++ b/app/src/main/res/layout/single_participant_tab_details.xml
@@ -95,6 +95,72 @@
             android:layout_marginTop="@dimen/wire__padding__8"
             android:visibility="gone"/>
 
+       <RelativeLayout
+            android:id="@+id/notifications_button"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/menu_item_height"
+            android:clickable="true"
+            android:focusable="true"
+            android:visibility="gone"
+            style="?wireBackground">
+
+            <com.waz.zclient.ui.text.GlyphTextView
+                android:id="@+id/notifications_button_icon"
+                android:layout_width="@dimen/guest_options_icon_size"
+                android:layout_height="@dimen/guest_options_icon_size"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="@dimen/wire__padding__big"
+                android:layout_marginEnd="@dimen/wire__padding__big"
+                android:scaleType="centerInside"
+                android:text="@string/glyph__notify"
+                />
+
+            <ImageView
+                android:id="@+id/notifications_button_next_indicator"
+                android:layout_width="@dimen/next_indicator_size"
+                android:layout_height="@dimen/next_indicator_size"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/wire__padding__regular"
+                android:layout_marginEnd="@dimen/wire__padding__regular"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:orientation="vertical"
+                android:layout_toEndOf="@id/notifications_button_icon"
+                android:layout_toStartOf="@id/notifications_button_next_indicator">
+
+                <com.waz.zclient.ui.text.TypefaceTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:drawablePadding="@dimen/wire__padding__6"
+                    app:w_font="@string/wire__typeface__light"
+                    style="?startUiUserRowLabel"
+                    android:layout_gravity="start"
+                    android:text="@string/notifications_options_title"/>
+
+                <com.waz.zclient.ui.text.TypefaceTextView
+                    android:id="@+id/notifications_button_value_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textSize="@dimen/wire__text_size__small"
+                    android:textColor="@color/light_graphite_40"
+                    android:drawablePadding="@dimen/wire__padding__6"
+                    app:w_font="@string/wire__typeface__light"
+                    android:layout_gravity="end"/>
+            </LinearLayout>
+
+        </RelativeLayout>
+
     </LinearLayout>
 
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -61,6 +61,7 @@
     <item name="services_section" type="id" />
     <item name="guest_options" type="id" />
     <item name="timed_messages_options" type="id" />
+    <item name="notifications_options" type="id" />
 
     <item name="create_group_button" type="id"/>
     <item name="create_guest_room_button" type="id"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="conversation__action__delete_only">\tDelete content</string>
 
     <string name="conversation__action__notifications_everything">Everything</string>
-    <string name="conversation__action__notifications_mentions_only">Only mentions</string>
+    <string name="conversation__action__notifications_mentions_and_replies">Mentions and Replies</string>
     <string name="conversation__action__notifications_nothing">Nothing</string>
     <string name="conversation__action__notifications_title">Notify me about:</string>
 
@@ -1131,7 +1131,9 @@
     <string name="allow_guests">Allow guests and services</string>
     <string name="guest_options_title">Guests and services</string>
     <string name="ephemeral_options_title">Timed messages</string>
+    <string name="notifications_options_title">Notifications</string>
     <string name="ephemeral_explanation_text">Timed messages will be turned on for all the participants in this conversation</string>
+    <string name="notifications_explanation_text">You can be notified about everything (including audio and video calls) or only when you are mentioned.</string>
     <string name="show_all_participants">Show all (%1$s)</string>
 
     <string name="allow_guests_error_title">Something went wrong</string>

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -216,6 +216,17 @@ trait FragmentHelper extends Fragment with OnBackPressedListener with ViewFinder
     h
   }
 
+  def slideFragmentInFromRight(f: Fragment, tag: String): Unit =
+    getFragmentManager.beginTransaction
+      .setCustomAnimations(
+        R.anim.fragment_animation_second_page_slide_in_from_right,
+        R.anim.fragment_animation_second_page_slide_out_to_left,
+        R.anim.fragment_animation_second_page_slide_in_from_left,
+        R.anim.fragment_animation_second_page_slide_out_to_right)
+      .replace(R.id.fl__participant__container, f, tag)
+      .addToBackStack(tag)
+      .commit
+
   def getStringArg(key: String): Option[String] =
     Option(getArguments).flatMap(a => Option(a.getString(key)))
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -324,4 +324,11 @@ object ConversationController {
     }
   }
 
+  lazy val MuteSets = Seq(MuteSet.AllAllowed, MuteSet.OnlyMentionsAllowed, MuteSet.AllMuted)
+
+  def muteSetDisplayStringId(muteSet: MuteSet): Int = muteSet match {
+    case MuteSet.AllMuted            => R.string.conversation__action__notifications_nothing
+    case MuteSet.OnlyMentionsAllowed => R.string.conversation__action__notifications_mentions_and_replies
+    case _                           => R.string.conversation__action__notifications_everything
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -102,7 +102,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit inj
       case Mode.Normal(_) =>
 
         def notifications: MenuItem =
-          if (zms.teamId.isDefined)
+          if (zms.teamId.isDefined && mode.inConversationList)
             Notifications
           else if (conv.muted.isAllAllowed)
             Mute
@@ -110,15 +110,15 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit inj
             Unmute
 
         builder += (if (conv.archived) Unarchive else Archive)
+
         if (isGroup) {
-          if (conv.isActive) {
-            builder ++= Set(notifications, Leave)
-          }
+          if (conv.isActive) builder += Leave
+          if (mode.inConversationList || zms.teamId.isEmpty) builder += notifications
           builder += Delete
         } else {
           if (teamMember || connectStatus.contains(ACCEPTED) || isBot) {
             builder ++= Set(notifications, Delete)
-            if (!teamMember && connectStatus.contains(ACCEPTED)) builder ++= Set(Block)
+            if (!teamMember && connectStatus.contains(ACCEPTED)) builder += Block
           }
           else if (connectStatus.contains(PENDING_FROM_USER)) builder += Block
         }

--- a/app/src/main/scala/com/waz/zclient/participants/TabbedParticipantPagerAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/TabbedParticipantPagerAdapter.scala
@@ -29,14 +29,14 @@ import com.waz.zclient.utils.RichView
 import com.waz.zclient.views.menus.FooterMenuCallback
 import com.waz.zclient.{Injectable, Injector, R}
 
-class TabbedParticipantPagerAdapter(participantOtrDeviceAdapter: ParticipantOtrDeviceAdapter, footerCallback: FooterMenuCallback)(implicit context: Context, injector: Injector, eventContext: EventContext)
+class TabbedParticipantPagerAdapter(participantOtrDeviceAdapter: ParticipantOtrDeviceAdapter, footerCallback: FooterMenuCallback, navButtonCallback: () => Unit)(implicit context: Context, injector: Injector, eventContext: EventContext)
   extends PagerAdapter with Injectable {
   import TabbedParticipantPagerAdapter._
 
   override def instantiateItem(container: ViewGroup, position: Int): java.lang.Object = returning(
     tabs(position) match {
       case tab@ParticipantTab('details, _) =>
-        returning( new ParticipantDetailsTab(context, footerCallback) ) {
+        returning( new ParticipantDetailsTab(context, footerCallback, navButtonCallback) ) {
           _.setTag(tab)
         }
       case ParticipantTab('devices, _) =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
@@ -21,7 +21,6 @@ package com.waz.zclient.participants.fragments
 import android.content.Context
 import android.os.Bundle
 import android.support.annotation.Nullable
-import android.support.v4.app.Fragment
 import android.support.v7.widget.{LinearLayoutManager, RecyclerView}
 import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.ZLog.ImplicitTag._
@@ -104,23 +103,16 @@ class GroupParticipantsFragment extends FragmentHelper {
       case _ =>
     }
 
-    def slideFragmentInFromRight(f: Fragment, tag: String) =
-      getFragmentManager.beginTransaction
-        .setCustomAnimations(
-          R.anim.fragment_animation_second_page_slide_in_from_right,
-          R.anim.fragment_animation_second_page_slide_out_to_left,
-          R.anim.fragment_animation_second_page_slide_in_from_left,
-          R.anim.fragment_animation_second_page_slide_out_to_right)
-        .replace(R.id.fl__participant__container, f, tag)
-        .addToBackStack(tag)
-        .commit
-
     adapter.onGuestOptionsClick.onUi { _ =>
       slideFragmentInFromRight(new GuestOptionsFragment(), GuestOptionsFragment.Tag)
     }
 
     adapter.onEphemeralOptionsClick.onUi { _ =>
       slideFragmentInFromRight(new EphemeralOptionsFragment(), EphemeralOptionsFragment.Tag)
+    }
+
+    adapter.onNotificationsClick.onUi { _ =>
+      slideFragmentInFromRight(new NotificationsOptionsFragment(), NotificationsOptionsFragment.Tag)
     }
 
     adapter.onShowAllParticipantsClick.onUi { _ =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/NotificationsOptionsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/NotificationsOptionsFragment.scala
@@ -1,0 +1,84 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.participants.fragments
+
+import android.os.Bundle
+import android.view.{LayoutInflater, View, ViewGroup}
+import android.widget.{LinearLayout, RelativeLayout, TextView}
+import com.waz.ZLog.ImplicitTag._
+import com.waz.model.MuteSet
+import com.waz.service.ZMessaging
+import com.waz.utils.events.Signal
+import com.waz.utils.returning
+import com.waz.zclient.conversation.ConversationController
+import com.waz.zclient.participants.NotificationsOptionsMenuController
+import com.waz.zclient.ui.text.GlyphTextView
+import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.RichView
+import com.waz.zclient.{FragmentHelper, R, SpinnerController}
+
+class NotificationsOptionsFragment extends FragmentHelper {
+  import com.waz.threading.Threading.Implicits.Ui
+
+  private lazy val convController = inject[ConversationController]
+
+  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) =
+    inflater.inflate(R.layout.notifications_options_fragment, container, false)
+
+  private lazy val optionsListLayout = returning(view[LinearLayout](R.id.list_view)) { _ =>
+    convController.currentConv.map(_.muted).onUi(setValue)
+  }
+
+  private def setValue(e: MuteSet): Unit = optionsListLayout.foreach { layout =>
+    layout.removeAllViews()
+    ConversationController.MuteSets.zipWithIndex.map { case (muteSet, index) =>
+      getLayoutInflater.inflate(R.layout.conversation_option_item, layout, true)
+      (muteSet, layout.getChildAt(index).asInstanceOf[RelativeLayout], index != ConversationController.MuteSets.size - 1)
+    }.foreach { case (muteSet, r, separatorVisible) =>
+      findById[TextView](r, R.id.text).setText(getString(NotificationsOptionsMenuController.menuItem(muteSet).titleId))
+      findById[GlyphTextView](r, R.id.glyph).setVisible(e.equals(muteSet))
+      findById[View](r, R.id.separator).setVisible(separatorVisible)
+
+      r.onClick {
+        if (e != muteSet) {
+          val spinner = inject[SpinnerController]
+          spinner.showSpinner(true)
+
+          (for {
+            z      <- inject[Signal[ZMessaging]].head
+            convId <- convController.currentConvId.head
+            _      <- convController.setMuted(convId, muteSet)
+          } yield {}).onComplete { res =>
+            if (res.isFailure) showToast(getString(R.string.generic_error_message))
+            spinner.showSpinner(false)
+            this.getFragmentManager.popBackStack()
+          }
+        }
+      }
+    }
+  }
+
+  override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
+    super.onViewCreated(view, savedInstanceState)
+    optionsListLayout
+  }
+}
+
+object NotificationsOptionsFragment {
+  val Tag = implicitLogTag
+}


### PR DESCRIPTION
fixes https://github.com/wireapp/android-project/issues/301

In case of group conversations the notifications options (all allowed / mentions only / all muted) should appear on the group participants view, and they should work just as "Timed messages" options. The entry from the bottom popup menu should be removed. In case of one-to-one conversations the notifications options should stay in the bottom popup menu.

Note: We are waiting for the WireStyleKit notification icon from the Design. Right now I use the "Mute" icon instead. The code can be reviewed and tested as it is.
#### APK
[Download build #11879](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11879/artifact/build/artifact/wire-dev-PR1841-11879.apk)
[Download build #11880](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11880/artifact/build/artifact/wire-dev-PR1841-11880.apk)
[Download build #11886](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11886/artifact/build/artifact/wire-dev-PR1841-11886.apk)
[Download build #11887](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11887/artifact/build/artifact/wire-dev-PR1841-11887.apk)
[Download build #11985](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11985/artifact/build/artifact/wire-dev-PR1841-11985.apk)
[Download build #11986](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11986/artifact/build/artifact/wire-dev-PR1841-11986.apk)
[Download build #11999](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11999/artifact/build/artifact/wire-dev-PR1841-11999.apk)
[Download build #12034](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12034/artifact/build/artifact/wire-dev-PR1841-12034.apk)