### PR TITLE
fix: Don't crop photos taken with the internal camera

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/ImageAssetDrawable.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/ImageAssetDrawable.scala
@@ -244,7 +244,7 @@ object ImageAssetDrawable {
     val asset = AssetData.newImageAsset(tag = Medium).copy(sizeInBytes = imageData.length, data = Some(imageData))
     new ImageAssetDrawable(
       Signal.const(DataImage(asset)),
-      scaleType = ScaleType.CenterCrop,
+      scaleType = ScaleType.CenterInside,
       request = if (isMirrored) RequestBuilder.RegularMirrored else RequestBuilder.Regular
     )
   }


### PR DESCRIPTION
fixes https://github.com/wireapp/android-project/issues/258

When taking a photo, we choose from the list of possible resolutions the format which is equal, or only a bit bigger in height than `ImageAssetGenerator.MediumSize`. Usually it means a resolution with ratio 16:9, but in some cases the chosen one was 4:3 or even 1:1. As a result, even though the user saw a 16:9 picture on the screen, the photo taken was taken in the chosen resolution's ratio.
This PR fixes that by preferring 16:9 resolutions. Only if there is none, a different resolution will be chosen. 
Also, the preview will show all the photo, scaled down to fit the screen. Until now the photo was cropped instead, showing only the center part.
#### APK
[Download build #11884](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11884/artifact/build/artifact/wire-dev-PR1845-11884.apk)
[Download build #11885](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11885/artifact/build/artifact/wire-dev-PR1845-11885.apk)
[Download build #11949](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11949/artifact/build/artifact/wire-dev-PR1845-11949.apk)
[Download build #11989](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11989/artifact/build/artifact/wire-dev-PR1845-11989.apk)
[Download build #12005](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12005/artifact/build/artifact/wire-dev-PR1845-12005.apk)