### PR TITLE
[WIP] chore: SE bump and a change to WebLinkPartView to make it work

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
 
-    zMessagingDevVersion = "131.2167"
+    zMessagingDevVersion = "131.491-PR"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '131.1.495@aar'
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
@@ -25,7 +25,6 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.api.Message.Part
 import com.waz.model.GenericContent.LinkPreview
-import com.waz.model.GenericMessage.TextMessage
 import com.waz.model._
 import com.waz.service.messages.MessageAndLikes
 import com.waz.sync.client.OpenGraphClient.OpenGraphData
@@ -64,10 +63,7 @@ class WebLinkPartView(context: Context, attrs: AttributeSet, style: Int) extends
   } yield {
     val index = msg.content.indexOf(ct)
     val linkIndex = msg.content.take(index).count(_.tpe == Part.Type.WEB_LINK)
-    msg.protos.lastOption flatMap {
-      case TextMessage(_, _, previews) if index >= 0 && previews.size > linkIndex => Some(previews(linkIndex))
-      case _ => None
-    }
+    if (index >= 0 && msg.links.size > linkIndex) Some(msg.links(linkIndex)) else None
   }
 
   val image = for {


### PR DESCRIPTION
https://github.com/wireapp/wire-android-sync-engine/pull/444

Adding quotes to text messages in SE broke `WebLinkPartView`.
I added a new method `links` to `MessageData` so `WebLinkPartView` will not have to access them directly.

Please merge this commit only after the work on replies in SE is finished.