### PR TITLE
fix: Conversations being displayed should rely on a signal

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -60,11 +60,13 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
 
   private var lastConvId = Option.empty[ConvId]
 
+  val currentConvIdOpt: Signal[Option[ConvId]] = convsStats.flatMap(_.selectedConversationId)
+
   val currentConvId: Signal[ConvId] =
     convsStats.flatMap(_.selectedConversationId).collect { case Some(convId) => convId }
 
   val currentConvOpt: Signal[Option[ConversationData]] =
-    currentConvId.flatMap(conversationData) // updates on every change of the conversation data, not only on switching
+    currentConvIdOpt.flatMap(_.fold(Signal.const(Option.empty[ConversationData]))(conversationData)) // updates on every change of the conversation data, not only on switching
 
   val currentConv: Signal[ConversationData] =
     currentConvOpt.collect { case Some(conv) => conv }

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -46,6 +46,7 @@ import com.waz.zclient.common.controllers.SoundController
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.controllers.navigation.Page
 import com.waz.zclient.conversation.ConversationController
+import com.waz.zclient.conversationlist.ConversationListAdapter
 import com.waz.zclient.messages.controllers.NavigationController
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{ResString, RingtoneUtils}
@@ -115,15 +116,15 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
     accs     <- accounts.accountsWithManagers
     uiActive <- inject[UiLifeCycle].uiActive
     selfId   <- selfId
-    convId   <- convController.currentConvId.map(Option(_)).orElse(Signal.const(Option.empty[ConvId]))
-    convs    <- convsStorage.map(_.conversations)
+    convId   <- convController.currentConvIdOpt
+    convs    <- convsStorage.flatMap(_.convsSignal.map(_.conversations.filter(ConversationListAdapter.Normal.filter).map(_.id).toSet))
     page     <- navigationController.visiblePage
   } yield
     accs.map { accId =>
       accId ->
         (if (selfId != accId || !uiActive) Set.empty[ConvId]
         else page match {
-          case Page.CONVERSATION_LIST => convs.map(_.id).toSet
+          case Page.CONVERSATION_LIST => convs
           case Page.MESSAGE_STREAM    => Set(convId).flatten
           case _                      => Set.empty[ConvId]
         })


### PR DESCRIPTION
Previously it was relying on a static list and it wouldn't get updated when new conversations appear. Also fixed ConversationController util Signals so that the optional gets triggered when empty.
fixes: https://github.com/wireapp/android-project/issues/325

## Steps to reproduce

Receive a message in a newly installed/logged in account before any conversation has been selected yet. 
#### APK
[Download build #11987](http://192.168.120.33:8080/job/Pull%20Request%20Builder/11987/artifact/build/artifact/wire-dev-PR1850-11987.apk)