### PR TITLE
WorkManager sync service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,9 +21,8 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "133.2178"
+    zMessagingDevVersion = "133.2179@aar"
     paging_version = "1.0.0"
-
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '133.0.498@aar'
 
@@ -58,7 +57,7 @@ android {
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
         versionName majorVersion + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.waz.background.TestRunner"
     }
 
     packagingOptions {
@@ -253,12 +252,10 @@ dependencies {
     }
 
     // For using local files in app/libs
-
     //implementation (name:'avs', ext:'aar')
-
     //implementation (name:'audio-notifications', ext:'aar')
-
     //implementation (name:'zmessaging-android', ext:'aar')
+
     implementation "$avsGroup:$avsName:${internal ? avsInternalVersion : avsVersion}"
     implementation("com.wire:zmessaging-android:${internal ? zMessagingDevVersion : zMessagingReleaseVersion}") {
         transitive = true
@@ -286,6 +283,11 @@ dependencies {
     implementation "com.google.android.gms:play-services-gcm:$playServicesVersion"
     implementation 'com.google.firebase:firebase-messaging:17.3.0'
 
+    //WorkManager
+    def work_version = "1.0.0-alpha10"
+    implementation "android.arch.work:work-runtime:$work_version"
+    implementation "android.arch.work:work-firebase:$work_version"
+
     //third party libraries
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'com.jakewharton.timber:timber:4.7.0'
@@ -310,6 +312,17 @@ dependencies {
     testImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
     testImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
     testImplementation "android.arch.paging:common:$paging_version"
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+
+    //The dexmaker stuff is needed for Mockito to work completely
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
+    androidTestImplementation "android.arch.work:work-testing:$work_version"
 
     ScalaCompileOptions.metaClass.daemonServer = true
     ScalaCompileOptions.metaClass.fork = true

--- a/app/src/androidTest/scala/com/waz/background/WorkManagerSyncRequestServiceSpec.scala
+++ b/app/src/androidTest/scala/com/waz/background/WorkManagerSyncRequestServiceSpec.scala
@@ -1,0 +1,160 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.background
+
+import java.util.UUID
+
+import android.app.Application
+import android.arch.lifecycle.MutableLiveData
+import android.content.Context
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.{AndroidJUnit4, AndroidJUnitRunner}
+import androidx.work.test.WorkManagerTestInitHelper
+import com.waz.ZLog.ImplicitTag._
+import com.waz.api.{NetworkMode, SyncState}
+import com.waz.log.{AndroidLogOutput, InternalLog}
+import com.waz.model.sync.SyncRequest
+import com.waz.model.sync.SyncRequest.SyncSelf
+import com.waz.model.{SyncId, UserId}
+import com.waz.service.NetworkModeService
+import com.waz.service.tracking.TrackingService
+import com.waz.sync.{SyncHandler, SyncResult}
+import com.waz.threading.Threading
+import com.waz.utils.events.{EventContext, Signal}
+import com.waz.zclient.{Injector, Module, WireContext}
+import org.junit.runner.RunWith
+import org.junit.{Before, Test}
+import org.mockito.Matchers._
+import org.mockito.Mockito
+import org.threeten.bp.Clock
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+
+@RunWith(classOf[AndroidJUnit4])
+class WorkManagerSyncRequestServiceSpec {
+
+  implicit val ec: ExecutionContext = Threading.Background
+
+  val account = UserId("account")
+  val network = Signal(NetworkMode.WIFI)
+
+  implicit var context: Context = _
+  implicit var app: TestApplication = _
+  implicit def injector: Injector = app.injector
+  implicit def eventContext: EventContext = app.eventContext
+
+  private var networkService  = Mockito.mock(classOf[NetworkModeService], "networkModeService")
+  private var syncHandler     = Mockito.mock(classOf[SyncHandler], "syncHandler")
+  private var tracking        = Mockito.mock(classOf[TrackingService], "trackingService")
+
+  @Before
+  def beforeAll(): Unit = {
+    context  = InstrumentationRegistry.getTargetContext
+    app      = context.getApplicationContext.asInstanceOf[TestApplication]
+
+    app.testModule = new Module {
+      bind[WorkManagerSyncRequestService] to new WorkManagerSyncRequestService()(injector, context, eventContext)
+      bind[Clock]                         to Clock.systemUTC()
+      bind[NetworkModeService]            to networkService
+      bind[SyncHandler]                   to syncHandler
+      bind[TrackingService]               to tracking
+    }
+
+    WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    Mockito.when(networkService.networkMode).thenReturn(network)
+  }
+
+  @Test
+  def liveDataSignal(): Unit = {
+    val liveData = new MutableLiveData[Int]()
+    val signal = new LiveDataSignal(liveData)
+    assert(signal.currentValue.isEmpty)
+    liveData.postValue(1)
+    assert(Await.result(signal.collect { case s if s == 1 => true }.head, 3.seconds))
+  }
+
+  @Test
+  def awaitRecentlyScheduledSyncJob(): Unit = {
+
+    val service = injector[WorkManagerSyncRequestService]()
+    val testDriver = WorkManagerTestInitHelper.getTestDriver
+
+    val jobFinishedPromise = Promise[SyncResult]()
+    Mockito.when(syncHandler.apply(any(), any())(any())).thenReturn(jobFinishedPromise.future)
+
+    val id  = Await.result(service.addRequest(account, SyncSelf), 3.seconds)
+    val res = service.await(id)
+
+    setConstraintsMet(id)
+    jobFinishedPromise.trySuccess(SyncResult.Success)
+
+    assert(Await.result(res, 3.seconds) == SyncResult.Success)
+  }
+
+  @Test
+  def testObservingSyncState(): Unit = {
+
+    val service = injector[WorkManagerSyncRequestService]()
+
+    val jobFinishedPromise = Promise[SyncResult]()
+    Mockito.when(syncHandler.apply(any(), any())(any())).thenReturn(jobFinishedPromise.future)
+
+    val id  = service.addRequest(account, SyncRequest.SyncSelf)
+    val state = service.syncState(account, Seq(SyncSelf.cmd))
+
+    val passed = for {
+      id <- id
+      _ <- state.filter(_ == SyncState.WAITING).head
+      _ = setConstraintsMet(id)
+      _ <- state.filter(_ == SyncState.SYNCING).head
+      _ = jobFinishedPromise.trySuccess(SyncResult.Success)
+      _ <- state.filter(_ == SyncState.COMPLETED).head
+    } yield true
+
+    assert(Await.result(passed, 5.seconds))
+  }
+
+  /**
+    * setAllConstraintsMet on the test driver synchronously blocks until the Worker#doWork implementation completes.
+    * This is just a wrapper to post the method on the background thread, so that the test can continue and we can
+    * complete the work later.
+    */
+  def setConstraintsMet(id: SyncId): Unit = {
+    Future(WorkManagerTestInitHelper.getTestDriver.setAllConstraintsMet(UUID.fromString(id.str)))(Threading.Background)
+  }
+}
+
+class TestApplication extends Application with WireContext {
+  override def eventContext: EventContext = EventContext.Global
+
+  var testModule: Module = _
+
+  override implicit def injector: Injector = testModule
+
+  override def onCreate(): Unit = {
+    super.onCreate()
+    InternalLog.add(new AndroidLogOutput)
+  }
+}
+
+
+class TestRunner extends AndroidJUnitRunner {
+  override def newApplication(cl: ClassLoader, className: String, context: Context): Application =
+    super.newApplication(cl, classOf[TestApplication].getName, context)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -903,6 +903,7 @@
         <item quantity="other">%1$d people</item>
     </plurals>
     <string name="message_footer__status__sending">Sending…</string>
+    <string name="message_footer__status__waiting_for_connection">Waiting for connection…</string>
     <string name="message_footer__status__sent">%1$s \u30FB Sent</string>
     <string name="message_footer__status__delivered">%1$s \u30FB Delivered</string>
     <string name="message_footer__status__failed">Sending failed. _Resend_</string>

--- a/app/src/main/scala/com/waz/background/WorkManagerSyncRequestService.scala
+++ b/app/src/main/scala/com/waz/background/WorkManagerSyncRequestService.scala
@@ -1,0 +1,276 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.background
+
+import java.util.UUID
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
+import android.arch.lifecycle.{LiveData, Observer}
+import android.content.Context
+import androidx.work._
+import com.waz.ZLog._
+import com.waz.api.SyncState
+import com.waz.api.impl.ErrorResponse
+import com.waz.api.impl.ErrorResponse.internalError
+import com.waz.model.sync.SyncJob.Priority
+import com.waz.model.sync.{SyncCommand, SyncRequest}
+import com.waz.model.{SyncId, UserId}
+import com.waz.service.NetworkModeService
+import com.waz.service.tracking.TrackingService
+import com.waz.sync.SyncHandler.RequestInfo
+import com.waz.sync.{SyncHandler, SyncRequestService, SyncResult}
+import com.waz.threading.Threading
+import com.waz.utils.events.{EventContext, Signal}
+import com.waz.utils.{RichInstant, returning}
+import com.waz.zclient.{Injectable, Injector, WireContext}
+import org.json.JSONObject
+import org.threeten.bp.{Clock, Instant}
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.util.control.{NoStackTrace, NonFatal}
+
+class WorkManagerSyncRequestService (implicit inj: Injector, cxt: Context, eventContext: EventContext) extends SyncRequestService with Injectable {
+
+  import WorkManagerSyncRequestService._
+  import com.waz.threading.Threading.Implicits.Background
+
+  private lazy val wm = WorkManager.getInstance()
+
+  override def addRequest(account:    UserId,
+                          req:        SyncRequest,
+                          priority:   Int            = Priority.Normal,
+                          dependsOn:  Seq[SyncId]    = Nil,
+                          forceRetry: Boolean        = false,
+                          delay:      FiniteDuration = Duration.Zero) = {
+
+    val work = new OneTimeWorkRequest.Builder(classOf[SyncJobWorker])
+      .setConstraints(
+        new Constraints.Builder()
+          .setRequiredNetworkType(NetworkType.CONNECTED)
+          .build())
+      .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+      .setInitialDelay(delay.toMillis, TimeUnit.MILLISECONDS)
+      .setInputData(
+        new Data.Builder()
+          .putString(AccountId, account.str)
+          .putString(SyncRequestCmd, req.cmd.name)
+          .putString(Json, SyncRequest.Encoder(req).toString)
+          .putLong(ScheduledTime, (inject[Clock].instant() + delay).toEpochMilli)
+          .build())
+      .addTag(account.str)
+      .addTag(req.cmd.name)
+      .build()
+
+    import SyncRequest._
+    val uniqueGroupName = req match {
+      case r: RequestForConversation with Serialized => Some(r.convId.str)
+      case r: RequestForUser         with Serialized => Some(r.userId.str)
+      case _ => None
+    }
+
+    implicit val logTag: LogTag = jobLogTag(account)
+    val commandTag = commandId(req.cmd, work.getId)
+    verbose(s"$commandTag scheduling...")
+
+    Future {
+      (uniqueGroupName.map(n => s"${account.str}--$n") match {
+        case Some(n) => wm.beginUniqueWork(n, ExistingWorkPolicy.APPEND, work).enqueue()
+        case None    => wm.enqueue(work)
+      }).get()
+      verbose(s"$commandTag scheduled successfully")
+      SyncId(work.getId.toString)
+    }
+  }
+
+  override def await(ids: Set[SyncId]): Future[Set[SyncResult]] =
+    Future.sequence(ids.map(await))
+
+  override def await(id: SyncId): Future[SyncResult] = {
+    implicit val logTag: LogTag = "WorkManager#await"
+    new LiveDataSignal(wm.getStatusByIdLiveData(UUID.fromString(id.str)))
+      .collect { case status if status.getState.isFinished =>
+        import androidx.work.State._
+        status.getState match {
+          case SUCCEEDED =>
+            decodeError(status.getOutputData) match {
+              case Some(e) => SyncResult.Failure(e)
+              case _       => SyncResult.Success
+            }
+          case CANCELLED => SyncResult.Failure(ErrorResponse.Cancelled)
+          case _         => SyncResult.Failure("unexpected failure!")
+        }
+      }.head
+  }
+
+  override def syncState(account: UserId, matchers: Seq[SyncCommand]): Signal[SyncState] = {
+    implicit val logTag: LogTag = "WorkManager#syncState"
+    new LiveDataSignal(wm.getStatusesByTagLiveData(account.str))
+      .map(_.filter(_.getTags.exists(tag => matchers.map(_.name).toSet.contains(tag))))
+      .map { statuses =>
+        returning {
+          if (statuses.isEmpty) SyncState.COMPLETED
+          else statuses.map { s =>
+            import State._
+            s.getState match {
+              case ENQUEUED |
+                   BLOCKED =>
+                SyncState.WAITING
+
+              case RUNNING =>
+                SyncState.SYNCING
+
+              case FAILED |
+                   SUCCEEDED if s.getOutputData.getBoolean(Failure, false) =>
+                SyncState.FAILED
+
+              case SUCCEEDED |
+                   CANCELLED =>
+                SyncState.COMPLETED
+            }
+          }.minBy(_.ordinal())
+        }(s => verbose(s"matchers: $matchers => state: $s"))
+      }
+  }
+}
+
+object WorkManagerSyncRequestService {
+
+  def jobLogTag(acc: UserId): LogTag = s"WorkManager:${acc.str.take(8)}"
+  def commandId(cmd: SyncCommand, id: UUID): String = commandId(cmd.name, id)
+  def commandId(cmdName: String, id: UUID): String = s"$cmdName (jobId: ${id.toString.take(8)}...) =>"
+
+  def decodeError(d: Data): Option[ErrorResponse] =
+    if (d.getBoolean(Failure, false)) {
+      val code  = d.getInt(ErrorCode, ErrorResponse.InternalErrorCode)
+      val msg   = d.getString(ErrorMessage)
+      val label = d.getString(ErrorMessage)
+      Some(ErrorResponse(code, msg, label))
+    } else None
+
+  //Inputs
+  val SyncRequestCmd = "SyncRequestCmd"
+  val AccountId      = "AccountId"
+  val ScheduledTime  = "ScheduledTime"
+  val Json           = "Json"
+
+  //Outputs
+  val Failure      = "Failure"
+  val ErrorCode    = "ErrorCode"
+  val ErrorMessage = "ErrorMessage"
+  val ErrorLabel   = "ErrorLabel"
+
+  val MaxSyncAttempts = 20
+  val SyncJobTimeout  = 10.minutes
+
+  class SyncJobWorker(context: Context, params: WorkerParameters) extends Worker(context, params) with Injectable {
+
+    implicit val wireContext = WireContext(context)
+    implicit val injector    = wireContext.injector
+
+    lazy val tracking = inject[TrackingService]
+    lazy val clock    = inject[Clock]
+    lazy val network  = inject[NetworkModeService].networkMode
+
+    override def doWork(): ListenableWorker.Result = {
+
+      import ListenableWorker._
+      val input         = getInputData
+      val account       = UserId(input.getString(AccountId))
+      val cmd           = input.getString(SyncRequestCmd)
+      val scheduledTime = input.getLong(ScheduledTime, 0)
+      val request       = SyncRequest.Decoder(new JSONObject(input.getString(Json)))
+
+      implicit val logTag: LogTag = jobLogTag(account)
+      val commandTag = commandId(cmd, getId)
+      verbose(s"$commandTag doWork")
+
+      val syncHandler = inject[SyncHandler]
+      val requestInfo = RequestInfo(getRunAttemptCount, Instant.ofEpochMilli(scheduledTime), network.currentValue)
+
+      def onFailure(err: ErrorResponse) = {
+        setOutputData(new Data.Builder()
+            .putBoolean(Failure, true)
+            .putInt(ErrorCode, err.code)
+            .putString(ErrorMessage, err.message)
+            .putString(ErrorLabel, err.label)
+            .build()
+        )
+        //we need to return the SUCCESS code so as not to block appended unique work
+        Result.SUCCESS
+      }
+
+      try {
+        Await.result(syncHandler(account, request)(requestInfo), SyncJobTimeout) match {
+          case SyncResult.Success =>
+            verbose(s"$commandTag completed successfully")
+            Result.SUCCESS
+
+          case SyncResult.Failure(error) =>
+            warn(s"$commandTag failed permanently with error: $error")
+            if (error.shouldReportError) {
+              tracking.exception(new RuntimeException(s"$commandTag failed permanently with error: $error") with NoStackTrace, s"Got fatal error, dropping request: ${request.cmd}\n error: $error")
+            }
+            onFailure(error)
+
+          case SyncResult.Retry(error) if getRunAttemptCount > MaxSyncAttempts =>
+            warn(s"$commandTag failed more than the maximum $MaxSyncAttempts times, final time was with error: $error")
+            tracking.exception(new RuntimeException(s"$commandTag failed more than the maximum $MaxSyncAttempts times, final time was with error: $error") with NoStackTrace, s"$MaxSyncAttempts attempts exceeded, dropping request: ${request.cmd}\n error: $error")
+            onFailure(error)
+
+          case SyncResult.Retry(error) =>
+            warn(s"$commandTag failed non-fatally with $error, retrying...")
+            Result.RETRY
+        }
+      } catch {
+        case e: TimeoutException =>
+          error(s"$commandTag doWork timed out after $SyncJobTimeout, the job seems to be blocked", e)
+          tracking.exception(e, s"$commandTag timed out after $SyncJobTimeout")
+          onFailure(ErrorResponse.timeout(s"$logTag $commandTag timed out after $SyncJobTimeout, aborting"))
+
+        case NonFatal(e) =>
+          error(s"$commandTag failed unexpectedly", e)
+          tracking.exception(e, s"$commandTag failed unexpectedly")
+          onFailure(internalError(e.getMessage))
+      }
+    }
+  }
+}
+
+class LiveDataSignal[T](liveData: LiveData[T]) extends Signal[T] {
+
+  private val observer = new Observer[T] {
+    override def onChanged(t: T): Unit =
+      set(Option(t), Some(Threading.Ui))
+  }
+
+  override protected def onWire(): Unit =
+    Threading.Ui {
+      liveData.observeForever(observer)
+      set(Option(liveData.getValue), Some(Threading.Ui))
+    }
+
+
+  override protected def onUnwire(): Unit =
+    Threading.Ui {
+      liveData.removeObserver(observer)
+      value = None
+    }
+}
+

--- a/app/src/main/scala/com/waz/zclient/Injectable.scala
+++ b/app/src/main/scala/com/waz/zclient/Injectable.scala
@@ -19,8 +19,8 @@ package com.waz.zclient
 
 
 trait Injectable {
-  def inject[T: reflect.Manifest](implicit inj: Injector) =
-    inj.binding[T].getOrElse(throw new Exception(s"No binding for: ${implicitly[reflect.Manifest[T]].runtimeClass.getName} in $inj")).apply()
+  def inject[T: reflect.Manifest](implicit inj: Injector): T =
+    inj.apply[T]()
 }
 
 case class Provider[T](fn: () => T) extends (() => T) {
@@ -33,6 +33,9 @@ case class Singleton[T](fn: () => T) extends (() => T) {
 
 trait Injector { self =>
   def binding[T: reflect.Manifest]: Option[() => T]
+
+  def apply[T: reflect.Manifest](): T =
+    binding[T].getOrElse(throw new Exception(s"No binding for: ${implicitly[reflect.Manifest[T]].runtimeClass.getName} in $this")).apply()
 
   private[zclient] val head = self
   private[zclient] val tail = self

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -55,9 +55,10 @@ trait WireContext extends Context {
 
   def eventContext: EventContext
 
-  implicit lazy val injector: Injector = {
+  private lazy val _injector =
     WireApplication.APP_INSTANCE.contextModule(this) :: getApplicationContext.asInstanceOf[WireApplication].module
-  }
+
+  implicit def injector: Injector = _injector
 }
 
 trait ViewFinder {

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -92,7 +92,7 @@ class ClientsController(implicit inj: Injector) extends Injectable {
         case _ => userAccounts.getConversationId(userId)
       }
       syncId <- z.otrService.resetSession(convId, userId, clientId)
-      resp   <- z.syncRequests.scheduler.await(syncId)
+      resp   <- z.syncRequests.await(syncId)
     } yield resp)
       .recover {
         case e: Throwable => SyncResult.failed()

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -86,7 +86,7 @@ class ClientsController(implicit inj: Injector) extends Injectable {
 
   def resetSession(userId: UserId, clientId: ClientId): Future[SyncResult] = {
     (for {
-      z    <- zms.head
+      z      <- zms.head
       convId <- inject[Signal[Option[ConvId]]].head.flatMap {
         case Some(id) => Future.successful(id)
         case _ => userAccounts.getConversationId(userId)
@@ -95,7 +95,7 @@ class ClientsController(implicit inj: Injector) extends Injectable {
       resp   <- z.syncRequests.await(syncId)
     } yield resp)
       .recover {
-        case e: Throwable => SyncResult.failed()
+        case e: Throwable => SyncResult(e)
       }
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -28,7 +28,6 @@ import com.waz.api.SyncState._
 import com.waz.model._
 import com.waz.model.sync.SyncCommand._
 import com.waz.service.ZMessaging
-import com.waz.sync.SyncRequestServiceImpl.SyncMatcher
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
@@ -157,7 +156,7 @@ class ConversationListManagerFragment extends Fragment
 
       (for {
         z        <- zms
-        syncSate <- z.syncRequests.syncState(SyncMatchers).map(_.state)
+        syncSate <- z.syncRequests.syncState(z.selfUserId, SyncMatchers)
         animType <- animationType
       } yield (syncSate, animType)).onUi { case (state, animType) =>
         state match {
@@ -420,7 +419,7 @@ class ConversationListManagerFragment extends Fragment
 }
 
 object ConversationListManagerFragment {
-  lazy val SyncMatchers = Seq(SyncConversations, SyncSelf, SyncConnections).map(SyncMatcher(_, None))
+  lazy val SyncMatchers = Seq(SyncConversations, SyncSelf, SyncConnections)
 
   lazy val ConvListUpdateThrottling = 250.millis
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
@@ -119,7 +119,7 @@ class FooterPartView(context: Context, attrs: AttributeSet, style: Int) extends 
   likeButton.init(controller)
   likeDetails.init(controller)
 
-  controller.timestampText.zip(controller.linkColor).on(Threading.Ui) { case (string, color) =>
+  controller.timestampText.zip(controller.linkColor).onUi { case (string, color) =>
     timeStampAndStatus.setText(string)
     if (string.contains('_')) {
       TextViewUtils.linkifyText(timeStampAndStatus, color, false, controller.linkCallback)
@@ -128,7 +128,7 @@ class FooterPartView(context: Context, attrs: AttributeSet, style: Int) extends 
 
   private var lastShow = false
   private var lastMsgId = MessageId()
-  controller.showTimestamp.on(Threading.Ui) { st =>
+  controller.showTimestamp.onUi { st =>
     switchAnim.cancel()
 
     val msgId = message.currentValue.fold(lastMsgId)(_.id)
@@ -146,7 +146,7 @@ class FooterPartView(context: Context, attrs: AttributeSet, style: Int) extends 
     lastMsgId = msgId
   }
 
-  controller.expiring.on(Threading.Ui)(likeButton.setGone)
+  controller.expiring.onUi(likeButton.setGone)
 
   override def onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int): Unit = {
     super.onLayout(changed, left, top, right, bottom)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -21,10 +21,12 @@ import android.content.{ClipData, ClipboardManager, Context, DialogInterface}
 import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{CompoundButton, TextView}
+import com.waz.ZLog.ImplicitTag._
+import com.waz.ZLog.error
 import com.waz.api.Verification
 import com.waz.model.UserId
 import com.waz.model.otr.ClientId
-import com.waz.sync.SyncResult
+import com.waz.sync.SyncResult._
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
@@ -179,13 +181,13 @@ class SingleOtrClientFragment extends FragmentHelper {
       clientsController.resetSession(uId, cId).map { res =>
         resetSessionButton.foreach(_.setEnabled(true))
         res match {
-          case SyncResult.Success =>
+          case Success =>
             ViewUtils.showAlertDialog(
               getActivity,
               R.string.empty_string,
               R.string.otr__reset_session__message_ok,
               R.string.otr__reset_session__button_ok, null, true)
-          case SyncResult.Failure(_, _) =>
+          case Failure(_) =>
             ViewUtils.showAlertDialog(
               getActivity,
               R.string.empty_string,
@@ -198,6 +200,8 @@ class SingleOtrClientFragment extends FragmentHelper {
                   resetSession()
                 }
               })
+          case Retry(_) =>
+            error("Awaiting a sync job should not return Retry")//TODO return ErrorOr[Unit] from await?
         }
       } (Threading.Ui)
     case _ =>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -223,7 +223,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
   private def resetSession(): Unit = {
     zms.head.flatMap { zms =>
       zms.selectedConv.selectedConvIdPref() flatMap { conv =>
-        zms.otrService.resetSession(conv.getOrElse(ConvId(zms.selfUserId.str)), zms.selfUserId, clientId) flatMap zms.syncRequests.scheduler.await
+        zms.otrService.resetSession(conv.getOrElse(ConvId(zms.selfUserId.str)), zms.selfUserId, clientId) flatMap zms.syncRequests.await
       }
     }.recover {
       case e: Throwable => SyncResult.failed()

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -226,12 +226,14 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
         zms.otrService.resetSession(conv.getOrElse(ConvId(zms.selfUserId.str)), zms.selfUserId, clientId) flatMap zms.syncRequests.await
       }
     }.recover {
-      case e: Throwable => SyncResult.failed()
+      case e: Throwable => SyncResult(e)
     }.map {
-      case SyncResult.Success => view.showToast(R.string.otr__reset_session__message_ok)
-      case SyncResult.Failure(err, _) =>
+      case SyncResult.Success      => view.showToast(R.string.otr__reset_session__message_ok)
+      case SyncResult.Failure(err) =>
         warn(s"session reset failed: $err")
         view.showDialog(R.string.otr__reset_session__message_fail, R.string.otr__reset_session__button_ok, R.string.otr__reset_session__button_fail, onPos = resetSession())
+      case SyncResult.Retry(err)   =>
+        error(s"Await sync result shouldn't return retry: $err")
     }(Threading.Ui)
   }
 


### PR DESCRIPTION
### To do: 
* remove Evernote Sync job and use WorkManager directly (separate PR)

### Tested so far:
* login and initial sync (this also tests the await method)
* sending messages and assets
* creating groups
* search
* all of the above on slow and flaky network
* ensure that failed message sending does not block sending of further messages
* sending large asset (or on flaky network) and minimising/swiping away application on Android >= 8 should not cause crash in background
* last read time
* Try sending a message in offline mode, try cancelling sending that message, try another one, then go back online 

### To Test:
* Performance on Android < 5.0 or on devices w/o GPS
* Upgrade with old sync jobs in database

### Current limitations:
* Sending asset blocks other messages into the same conversation until asset is sent (fix depends on assets refactoring)
#### APK
[Download build #12012](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12012/artifact/build/artifact/wire-dev-PR1857-12012.apk)
[Download build #12014](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12014/artifact/build/artifact/wire-dev-PR1857-12014.apk)
[Download build #12016](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12016/artifact/build/artifact/wire-dev-PR1857-12016.apk)
[Download build #12024](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12024/artifact/build/artifact/wire-dev-PR1857-12024.apk)
[Download build #12055](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12055/artifact/build/artifact/wire-dev-PR1857-12055.apk)
[Download build #12063](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12063/artifact/build/artifact/wire-dev-PR1857-12063.apk)
[Download build #12080](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12080/artifact/build/artifact/wire-dev-PR1857-12080.apk)
[Download build #12082](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12082/artifact/build/artifact/wire-dev-PR1857-12082.apk)