### PR TITLE
fix: disable FCM analytics

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -231,6 +231,10 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
+        <!--Disable tracking in the FCM core-->
+        <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
         <!-- Internal features from SE -->
         <meta-data android:name="INTERNAL" android:value="${internal_features}"/>


### PR DESCRIPTION
It seems as though the core FCM library (which would probably be a transient
dependancy of the FCM notifications library) seems to also include the
analytics logic of FCM.

This commit explicity disables analytics, just in case.

fixes: https://github.com/wireapp/wire-android/issues/1835