### PR TITLE
fix: use Signal#publish method correctly

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -77,15 +77,9 @@ class SharingController(implicit injector: Injector, wContext: WireContext, even
   }
 
   private def resetContent() = {
-    sharableContent.publish(None, dispatcher)
-    targetConvs.publish(Seq.empty, dispatcher)
-    ephemeralExpiration.publish(None, dispatcher)
-  }
-
-  def clearSharingFor(convId: ConvId) = if (convId != null) {
-    targetConvs.currentValue.foreach { convs =>
-      if (convs.contains(convId)) resetContent()
-    }
+    sharableContent     ! None
+    targetConvs         ! Seq.empty
+    ephemeralExpiration ! None
   }
 
   def publishTextContent(text: String): Unit =

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -172,19 +172,19 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     name <- conversationName
     Some(convId) <- conversationId
     av <- controller.availability(convId)
-  } yield (name, av)).on(Threading.Ui) { case (name, av) =>
+  } yield (name, av)).onUi { case (name, av) =>
     title.setText(name)
     AvailabilityView.displayLeftOfText(title, av, title.getCurrentTextColor, pushDown = true)
   }
 
-  subtitleText.on(Threading.Ui) {
+  subtitleText.onUi {
     case (convId, text) if conversationData.forall(_.id == convId) =>
       setSubtitle(text)
     case _ =>
       verbose("Outdated conversation subtitle")
     }
 
-  badgeInfo.on(Threading.Ui) {
+  badgeInfo.onUi {
     case (convId, status) if conversationData.forall(_.id == convId) =>
       badge.setStatus(status)
     case _ =>
@@ -202,7 +202,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     case _ =>
       verbose("Outdated avatar info")
   }
-  avatarInfo.on(Threading.Ui){
+  avatarInfo.onUi{
     case (convId, convType, members, alpha) if conversationData.forall(_.id == convId) =>
       if (convType == ConversationType.Group && members.size == 1 && conversationData.exists(_.team.nonEmpty)) {
         avatar.setConversationType(ConversationType.OneToOne)
@@ -242,7 +242,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     avatar.setConversationType(conversationData.convType)
     avatar.clearImages()
     avatar.setAlpha(getResourceFloat(R.dimen.conversation_avatar_alpha_active))
-    conversationId.publish(Some(conversationData.id), Threading.Background)
+    conversationId.publish(Some(conversationData.id), Threading.Ui)
     closeImmediate()
   }
 


### PR DESCRIPTION
It turns out that the currentContext parameter in the Signal#publish
method is exactly that, a hint to what the currentContext is, in which
publish is called. This is then used to avoid posting a future to the
Signal's subscription later on down the chain so that the subscription
can then be executed synchronously.

Previously, we thought that the publish method was there to specify an
execution context on which the subscriptions should be executed. This
assumption has proven to be false and this PR fixes the areas where these
false assumptions where made.

Luckly there were no serious side-effects to this mistake, and hence no
ticket to link here...
#### APK
[Download build #12036](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12036/artifact/build/artifact/wire-dev-PR1862-12036.apk)