### PR TITLE
chore: SE bump; Batch quote checking in MessageEventProcessor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "133.567-PR@aar"
+    zMessagingDevVersion = "133.578-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '133.0.498@aar'


### PR DESCRIPTION
https://github.com/wireapp/wire-android-sync-engine/pull/451

Testing hints:
* Replies in conversations should work as usual (text, assets, locations)
* Create a group chat, make one of the participants offline, share quotes between the other two (they may also reply to the messages left earlier by the offline user), then put that user back online. The conversation should be updated correctly.
#### APK
[Download build #12096](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12096/artifact/build/artifact/wire-dev-PR1877-12096.apk)
[Download build #12105](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12105/artifact/build/artifact/wire-dev-PR1877-12105.apk)
[Download build #12112](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12112/artifact/build/artifact/wire-dev-PR1877-12112.apk)
[Download build #12122](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12122/artifact/build/artifact/wire-dev-PR1877-12122.apk)