### PR TITLE
fix: 'via' lowercase in giphy message without search tag

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,7 +741,7 @@
     <!-- Giphy -->
     <string name="giphy_preview__search_hint">Search Giphy</string>
     <string name="giphy_preview__error">NO GIFS FOUND.</string>
-    <string name="giphy_preview__message_via_random_trending">Via giphy.com</string>
+    <string name="giphy_preview__message_via_random_trending">via giphy.com</string>
     <string name="giphy_preview__message_via_search">%s · via giphy.com</string>
     <string name="service_giphy_name">Giphy</string>
 


### PR DESCRIPTION
This PR will
* set the word "via" in a giphy message without giphy search tag to lowercase

Reason:
* Wire for iOS [has it like this](https://github.com/wireapp/wire-ios/blob/99b1762e621318246321072c8762b63633e2f890/Wire-iOS/Resources/Base.lproj/Localizable.strings#L1403)
* The string `{tag} · via giphy.com` is also lowercase