### PR TITLE
chore: SE bump for fixing unarchivisation events

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "133.567-PR@aar"
+    zMessagingDevVersion = "133.579-PR@aar"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '133.0.498@aar'


### PR DESCRIPTION
https://github.com/wireapp/wire-android-sync-engine/pull/452

fixes https://github.com/wireapp/android-project/issues/336

Testing hints:
The bug caused archived "mentions-only" conversations to be unarchived when any reply was sent to the conversation, no matter who was the author of the original message. Now a "mentions-only" conversation should be unarchived only in the case if the original message is from the current user.
I refactored how mentions are checked as well, so you can also test if conversations are being unarchived correctly in the case of mentions.
#### APK
[Download build #12110](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12110/artifact/build/artifact/wire-dev-PR1882-12110.apk)
[Download build #12111](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12111/artifact/build/artifact/wire-dev-PR1882-12111.apk)
[Download build #12114](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12114/artifact/build/artifact/wire-dev-PR1882-12114.apk)