### PR TITLE
fix: The displayed timestamp of the quote should switch between time and date/time

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
@@ -19,6 +19,7 @@ package com.waz.zclient.messages.parts
 
 import android.content.Context
 import android.graphics.Typeface
+import android.text.format.DateFormat
 import android.util.{AttributeSet, TypedValue}
 import android.view.{View, ViewGroup}
 import android.widget.{LinearLayout, TextView}
@@ -38,9 +39,11 @@ import com.waz.zclient.paintcode.WireStyleKit
 import com.waz.zclient.ui.text.{GlyphTextView, LinkTextView, TypefaceTextView}
 import com.waz.zclient.ui.utils.TypefaceUtils
 import com.waz.zclient.utils.ContextUtils.{getString, getStyledColor}
-import com.waz.zclient.utils.{DateConvertUtils, RichTextView, ZTimeFormatter}
+import com.waz.zclient.utils.{DateConvertUtils, RichTextView}
 import com.waz.zclient.{R, ViewHelper}
 import com.waz.zclient.utils.RichView
+import com.waz.zclient.utils.ZTimeFormatter.getSeparatorTime
+import org.threeten.bp.{LocalDateTime, ZoneId}
 
 abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with ViewHelper with EphemeralPartView {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
@@ -99,7 +102,10 @@ abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int) 
   quotedMessage
     .map(_.time.instant)
     .map(DateConvertUtils.asLocalDateTime)
-    .map(t => ZTimeFormatter.getSingleMessageTime(getContext, t))
+    .map { t =>
+      val context = getContext
+      getSeparatorTime(context, LocalDateTime.now, t, DateFormat.is24HourFormat(context), ZoneId.systemDefault, true)
+    }
     .map(getString(R.string.quote_timestamp_message, _))
     .onUi(timestamp.setText)
 


### PR DESCRIPTION
Currently the quotes show only the time. The way date/time is displayed should be consistent with how we display it in other places in the Android app (eg. in separators between messages in the conversation view).

Testing hints:
Check how the date and time of the quote is displayed in replies from today and previous days.
#### APK
[Download build #12113](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12113/artifact/build/artifact/wire-dev-PR1884-12113.apk)
[Download build #12124](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12124/artifact/build/artifact/wire-dev-PR1884-12124.apk)
[Download build #12136](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12136/artifact/build/artifact/wire-dev-PR1884-12136.apk)