### PR TITLE
fix: Prevent screenshots on conversations with ephemeral messages, but allow otherwise

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
@@ -135,9 +135,9 @@ class MessagesListView(context: Context, attrs: AttributeSet, style: Int) extend
     Option(getContext).foreach {
       case a: Activity =>
         if (hasEphemeral)
-          a.getWindow.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        else
           a.getWindow.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        else
+          a.getWindow.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
       case _ => // not attahced, ignore
     }
   }


### PR DESCRIPTION
fixes https://github.com/wireapp/android-project/issues/333

Changes how `FLAG_SECURE` is set or cleared.
#### APK
[Download build #12115](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12115/artifact/build/artifact/wire-dev-PR1885-12115.apk)