### PR TITLE
fix: Highlight the message even if it is already focused on

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -110,20 +110,20 @@ trait HighlightViewPart extends MessageViewPart with ViewHelper {
 
   private val bgColor = for {
     accent <- accentColorController.accentColor
-    alpha <- animAlpha
+    alpha  <- animAlpha
   } yield
     if (alpha <= 0) Color.TRANSPARENT
     else ColorUtils.injectAlpha(alpha, accent.color)
 
   private val isHighlighted = for {
-    msg <- message
-    focused <- collectionController.focusedItem
-  } yield focused.exists(_.id == msg.id)
+    msg           <- message
+    Some(focused) <- collectionController.focusedItem
+  } yield focused.id == msg.id
 
   bgColor.on(Threading.Ui) { setBackgroundColor }
 
   isHighlighted.on(Threading.Ui) {
-    case true => animator.start()
+    case true  => animator.start()
     case false => animator.end()
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
@@ -107,6 +107,7 @@ class MessagesListView(context: Context, attrs: AttributeSet, style: Int) extend
   }
 
   adapter.onScrollRequested.onUi { case (message, _) =>
+    collectionsController.focusedItem ! None // needed in case we requested a scroll to the same message again
     collectionsController.focusedItem ! Some(message)
   }
 


### PR DESCRIPTION
We highlight a message when we focus on it: either because it was chosen from the search or from a reply. In the case the same message was chosen twice in a row we did nothing, because the message was already "focused".