### PR TITLE
refactor: remove logged try and static tracking methods

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "133.579-PR@aar"
+    zMessagingDevVersion = "133.584-PR@aar"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '133.0.498@aar'

--- a/app/src/main/scala/com/waz/services/gps/GoogleApiImpl.scala
+++ b/app/src/main/scala/com/waz/services/gps/GoogleApiImpl.scala
@@ -25,15 +25,15 @@ import com.google.android.gms.common.ConnectionResult.{SERVICE_VERSION_UPDATE_RE
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.FirebaseApp
 import com.google.firebase.iid.FirebaseInstanceId
-import com.waz.ZLog.{info, warn}
 import com.waz.ZLog.ImplicitTag._
+import com.waz.ZLog.{info, warn}
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.GPSErrorDialogShowCount
 import com.waz.model.PushToken
 import com.waz.service.BackendConfig
 import com.waz.service.BackendConfig.FirebaseOptions
-import com.waz.utils.{LoggedTry, returning}
 import com.waz.utils.events.Signal
+import com.waz.utils.returning
 import com.waz.utils.wrappers.GoogleApi
 
 import scala.util.Try
@@ -85,7 +85,7 @@ object GoogleApiImpl {
   val RequestGooglePlayServices = 7976
   val MaxErrorDialogShowCount = 3
 
-  private[GoogleApiImpl] def initFirebase(context: Context, options: FirebaseOptions) = LoggedTry {
+  private[GoogleApiImpl] def initFirebase(context: Context, options: FirebaseOptions) = Try {
     FirebaseApp.initializeApp(context, new com.google.firebase.FirebaseOptions.Builder()
       .setApplicationId(options.appId)
       .setApiKey(options.apiKey)

--- a/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
@@ -22,6 +22,7 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.EmailAddress
 import com.waz.service.AccountsService
+import com.waz.service.tracking.TrackingService
 import com.waz.service.tracking.TrackingService._
 import com.waz.sync.client.InvitationClient.ConfirmedTeamInvitation
 import com.waz.threading.CancellableFuture
@@ -38,6 +39,7 @@ class InvitationsController(implicit inj: Injector, eventContext: EventContext, 
 
   private lazy val accountsService      = inject[AccountsService]
   private lazy val createTeamController = inject[CreateTeamController]
+  private lazy val tracking             = inject[TrackingService]
 
   var inputEmail = ""
 
@@ -61,7 +63,7 @@ class InvitationsController(implicit inj: Injector, eventContext: EventContext, 
       response match {
         case Left(e) => Left(e)
         case Right(_) =>
-          track(TeamInviteSent(), account.map(_.userId))
+          tracking.track(TeamInviteSent(), account.map(_.userId))
           Right(())
       }
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -26,7 +26,6 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
 import android.view.{LayoutInflater, View, ViewGroup}
-import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.UserId
 import com.waz.permissions.PermissionsService
@@ -34,7 +33,7 @@ import com.waz.service.AccountsService
 import com.waz.service.BackupManager.InvalidMetadata
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.wrappers.{AndroidURIUtil, URI}
-import com.waz.utils.{RichFuture, returning, _}
+import com.waz.utils.{returning, _}
 import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.appentry.fragments.FirstLaunchAfterLoginFragment._
 import com.waz.zclient.pages.main.conversation.AssetIntentsManager
@@ -43,10 +42,10 @@ import com.waz.zclient.ui.views.ZetaButton
 import com.waz.zclient.utils.ViewUtils
 import com.waz.zclient.{FragmentHelper, R, SpinnerController}
 
-import scala.concurrent.duration._
 import scala.async.Async.{async, await}
 import scala.collection.immutable.ListSet
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 object FirstLaunchAfterLoginFragment {
   val Tag: String = classOf[FirstLaunchAfterLoginFragment].getName
@@ -177,7 +176,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
           case _ => activity.onEnterApplication(openSettings = false)
         }
       }
-    } logFailure() recover {
+    }.recover {
       case InvalidMetadata.UserId =>
         spinnerController.showSpinner(false)
         displayError(R.string.backup_import_error_wrong_account_title, R.string.backup_import_error_wrong_account)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -26,8 +26,8 @@ import com.waz.api.EmailCredentials
 import com.waz.content.GlobalPreferences
 import com.waz.model.AccountData.Password
 import com.waz.model.{ConfirmationCode, EmailAddress}
+import com.waz.service.tracking.TrackingService
 import com.waz.service.{AccountsService, GlobalModule}
-import com.waz.service.tracking.TrackingService.track
 import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient._
@@ -76,7 +76,8 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
   implicit val executionContext = Threading.Ui
   implicit lazy val ctx = getContext
 
-  private lazy val accountService     = inject[AccountsService]
+  private lazy val accountService = inject[AccountsService]
+  private lazy val tracking = inject[TrackingService]
 
   private lazy val resendCodeButton = findById[TextView](getView, R.id.ttv__resend_button)
   private lazy val resendCodeTimer = findById[TextView](getView, R.id.ttv__resend_timer)
@@ -195,7 +196,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
         case _ => Future.successful({})
       }
     } yield {
-      track(EnteredCodeEvent(SignInMethod(Register, Email), responseToErrorPair(resp)))
+      tracking.track(EnteredCodeEvent(SignInMethod(Register, Email), responseToErrorPair(resp)))
       resp match {
         case Left(error) =>
           activity.enableProgress(false)
@@ -205,7 +206,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
             phoneConfirmationButton.setState(PhoneConfirmationButton.State.INVALID)
           }
         case _ =>
-          track(RegistrationSuccessfulEvent(SignInFragment.Email))
+          tracking.track(RegistrationSuccessfulEvent(SignInFragment.Email))
           activity.enableProgress(false)
           activity.onEnterApplication(openSettings = false)
       }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -19,16 +19,14 @@ package com.waz.zclient.common.controllers
 
 import android.content.{Context, Intent}
 import android.net.Uri
-import com.waz.ZLog.ImplicitTag._
 import com.waz.api.MessageContent.Location
 import com.waz.model.MessageId
 import com.waz.service.BackendConfig
-import com.waz.utils.LoggedTry
 import com.waz.utils.events.EventStream
 import com.waz.utils.wrappers.{AndroidURIUtil, URI}
-import com.waz.zclient.{Injectable, Injector, R}
-import com.waz.zclient.utils.IntentUtils
 import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.IntentUtils
+import com.waz.zclient.{Injectable, Injector, R}
 
 import scala.util.Try
 
@@ -44,7 +42,7 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
 
   def openUrl(uri: String): Try[Unit] = openUrl(AndroidURIUtil.parse(uri))
 
-  def openUrl(uri: URI): Try[Unit] = LoggedTry {
+  def openUrl(uri: URI): Try[Unit] = Try {
     val intent = new Intent(Intent.ACTION_VIEW, normalizeHttp(AndroidURIUtil.unwrap(uri)))
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     context.startActivity(intent)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -37,7 +37,7 @@ import com.waz.threading.Threading.Implicits.Background
 import com.waz.ui.MemoryImageCache.BitmapRequest.Regular
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.wrappers.{Context, Intent}
-import com.waz.utils.{LoggedTry, _}
+import com.waz.utils._
 import com.waz.zclient.Intents.{CallIntent, OpenCallingScreen}
 import com.waz.zclient._
 import com.waz.zclient.calling.controllers.CallController
@@ -47,6 +47,7 @@ import com.waz.zclient.utils.ContextUtils.{getString, _}
 import com.waz.zclient.utils.RingtoneUtils
 
 import scala.concurrent.Future
+import scala.util.Try
 import scala.util.control.NonFatal
 
 class CallingNotificationsController(implicit cxt: WireContext, eventContext: EventContext, inj: Injector) extends Injectable {
@@ -150,7 +151,7 @@ class CallingNotificationsController(implicit cxt: WireContext, eventContext: Ev
         notificationManager.notify(CallNotificationTag, not.id, builder.build())
       }
 
-      LoggedTry(showNotification()).recover {
+      Try(showNotification()).recover {
         case NonFatal(e) =>
           error(s"Notify failed: try without bitmap", e)
           builder.setLargeIcon(null)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
@@ -28,12 +28,13 @@ import com.waz.service.assets.AssetService.BitmapResult
 import com.waz.service.images.BitmapSignal
 import com.waz.threading.Threading
 import com.waz.ui.MemoryImageCache.BitmapRequest.Single
-import com.waz.utils.LoggedTry
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.wrappers.URI
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.IntentUtils._
 import com.waz.zclient.{Injectable, Injector, R, WireContext}
+
+import scala.util.Try
 
 class ImageNotificationsController(implicit cxt: WireContext, eventContext: EventContext, inj: Injector) extends Injectable {
 
@@ -88,12 +89,12 @@ class ImageNotificationsController(implicit cxt: WireContext, eventContext: Even
 
     def showNotification() = notManager.notify(ZETA_SAVE_IMAGE_NOTIFICATION_ID, builder.build())
 
-    LoggedTry(showNotification()).recover { case e =>
+    Try(showNotification()).recover { case e =>
       error(s"Notify failed: try without bitmap. Error: $e")
       builder.setLargeIcon(null)
       try showNotification()
       catch {
-        case e: Throwable => error("second display attempt failed, aborting")
+        case e: Throwable => error("second display attempt failed, aborting", e)
       }
     }
   }


### PR DESCRIPTION
The LoggedTry class encouraged poor dependency usage WRT the tracking
service, and going forward it doesn't give us enough control over what
gets tracked or not.

The tracking service was also changed so as to only ever be injected
where needed so that we improve testability and modularity of the app.

The next step would actually be to move the tracking service impl
to the Android project and merge it with the GlobalTrackingController there.

**For testers**
 This PR should not change any functionality. It reduces a few crash reports that would be sent if we had a tracking/analytics system, but apart from that, no behavioural changes.


#### APK
[Download build #12127](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12127/artifact/build/artifact/wire-dev-PR1891-12127.apk)