### PR TITLE
fix: reduce the number of possible events that trigger loading new PagedList

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "133.584-PR@aar"
+    zMessagingDevVersion = "133.596-PR@aar"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '133.0.498@aar'

--- a/app/src/main/scala/com/waz/zclient/conversation/LikesListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/LikesListFragment.scala
@@ -20,7 +20,7 @@ package com.waz.zclient.conversation
 import android.os.Bundle
 import android.support.v7.widget.{LinearLayoutManager, RecyclerView, Toolbar}
 import android.view.{LayoutInflater, View, ViewGroup}
-import com.waz.model.{Liking, MessageId}
+import com.waz.model.MessageId
 import com.waz.service.ZMessaging
 import com.waz.threading.CancellableFuture
 import com.waz.utils.events.{RefreshingSignal, Signal}
@@ -28,7 +28,6 @@ import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ScreenController
 import com.waz.zclient.pages.main.conversation.ConversationManagerFragment
 import com.waz.zclient.{FragmentHelper, R}
-import com.waz.content.Likes
 
 class LikesListFragment extends FragmentHelper {
 
@@ -38,10 +37,7 @@ class LikesListFragment extends FragmentHelper {
   private lazy val likersListView = view[RecyclerView](R.id.rv__likes_list)
   private lazy val likesAdapter   = returning(new LikesAdapter(getContext)) { adapter =>
     def getLikes(zms: ZMessaging, messageId: MessageId) =
-      new RefreshingSignal[Likes, Seq[Liking]](
-        CancellableFuture.lift(zms.reactionsStorage.getLikes(messageId)),
-        zms.reactionsStorage.onChanged.map(_.filter(_.message == messageId))
-      )
+      new RefreshingSignal(CancellableFuture.lift(zms.reactionsStorage.getLikes(messageId)), zms.reactionsStorage.onChanged.map(_.filter(_.message == messageId)))
 
     (for {
       z               <- inject[Signal[ZMessaging]]

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
@@ -98,6 +98,13 @@ class MessagesPagedListAdapter()(implicit ec: EventContext, inj: Injector) exten
 object MessagesPagedListAdapter {
   val MessageDataDiffCallback: DiffUtil.ItemCallback[MessageAndLikes] = new DiffUtil.ItemCallback[MessageAndLikes] {
     override def areItemsTheSame(o: MessageAndLikes, n: MessageAndLikes): Boolean = n.message.id == o.message.id
-    override def areContentsTheSame(o: MessageAndLikes, n: MessageAndLikes): Boolean = o == n
+    override def areContentsTheSame(o: MessageAndLikes, n: MessageAndLikes): Boolean =
+      areMessageContentsTheSame(o.message, n.message)
+  }
+
+  def areMessageContentsTheSame(prev: MessageData, updated: MessageData): Boolean = {
+    updated.contentString != prev.contentString &&
+      updated.expired != prev.expired &&
+      updated.imageDimensions != prev.imageDimensions
   }
 }


### PR DESCRIPTION
This commit attempts to limit the number of events that would lead to
a refresh of the cursor and to the creation of a new PagedList in the
MessagePagedListController. Every event stream is checked against the
current active convId and we only care about a subset of updates to the
message data (really anything that can change the height or position
of a message)
#### APK
[Download build #12146](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12146/artifact/build/artifact/wire-dev-PR1907-12146.apk)