### PR TITLE
Event-based notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "135.2190"
+    zMessagingDevVersion = "135.625-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '134.1.500@aar'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -310,6 +310,7 @@
 
         <service android:name="com.waz.services.calling.CallingNotificationsService" />
         <service android:name="com.waz.services.calling.CallWakeService" android:exported="true" />
+        <service android:name="com.waz.services.notifications.NotificationsHandlerService" />
 
     </application>
 

--- a/app/src/main/scala/com/waz/services/FutureService.scala
+++ b/app/src/main/scala/com/waz/services/FutureService.scala
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.services
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.support.v4.content.WakefulBroadcastReceiver
+import com.waz.ZLog.ImplicitTag._
+import com.waz.ZLog._
+import com.waz.model.UserId
+import com.waz.service.ZMessaging
+import com.waz.threading.Threading
+import com.waz.utils.WakeLockImpl
+
+import scala.concurrent.Future
+import scala.util.control.NoStackTrace
+
+abstract class FutureService extends Service {
+
+  protected lazy val wakeLock = new WakeLockImpl(getApplicationContext)
+
+  override def onBind(intent: Intent): IBinder = null
+
+  override def onStartCommand(intent: Intent, flags: Int, startId: Int): Int = wakeLock {
+    debug(s"onStartCommand: $startId, intent: $intent")
+    Option(intent) foreach WakefulBroadcastReceiver.completeWakefulIntent
+
+    val future =
+      if (intent == null) Future.successful({})
+      else wakeLock async {
+        onIntent(intent, startId).recover { case ex => error("onIntent failed", ex) } (Threading.Background)
+      }
+    future.onComplete { _ => onComplete(startId) }(Threading.Ui)
+
+    Service.START_REDELIVER_INTENT
+  }
+
+  protected def onIntent(intent: Intent, id: Int): Future[Any]
+
+  protected def onComplete(startId: Int): Unit = {
+    debug(s"onCompleted: $startId")
+    stopSelf(startId)
+  }
+}
+
+trait ZMessagingService extends Service {
+  import Threading.Implicits.Background
+  import ZMessagingService._
+
+  private def accounts = ZMessaging.currentAccounts
+
+  def onZmsIntent[Result](intent: Intent)(execute: ZMessaging => Future[Result]): Future[Result] =
+    if (intent != null && intent.hasExtra(ZmsUserIdExtra)) {
+      val userId = UserId(intent.getStringExtra(ZmsUserIdExtra))
+      accounts.getZms(userId) flatMap {
+        case Some(acc) => execute(acc)
+        case None =>
+          error(s"zmessaging not available")
+          Future.failed(NoAccountException(userId))
+      }
+    } else {
+      error("intent has no ZUserId extra")
+      Future.failed(InvalidIntentException)
+    }
+}
+
+object ZMessagingService {
+  val ZmsUserIdExtra = "zms_user_id"
+
+  case object InvalidIntentException extends Exception(s"Invalid ZMessagingService intent") with NoStackTrace
+  case class NoZMessagingException(id: UserId) extends Exception(s"ZMessaging instance not available with id: $id") with NoStackTrace
+  case class NoAccountException(id: UserId) extends Exception(s"AccountService instance not available with id: $id") with NoStackTrace
+}

--- a/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
@@ -22,10 +22,10 @@ import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.model.{ConvId, UserId}
 import com.waz.service.ZMessaging
+import com.waz.services.{FutureService, ZMessagingService}
 import com.waz.utils.events.EventContext
 import com.waz.utils.returning
 import com.waz.utils.wrappers.Intent
-import com.waz.zms.{FutureService, ZMessagingService}
 
 import scala.concurrent.Future
 

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -26,9 +26,9 @@ import com.waz.service.ZMessaging.clock
 import com.waz.service.push.PushService.FetchFromIdle
 import com.waz.service.push.{PushService, ReceivedPushData, ReceivedPushStorage}
 import com.waz.service.{AccountsService, NetworkModeService, ZMessaging}
+import com.waz.services.ZMessagingService
 import com.waz.threading.Threading
 import com.waz.utils.{JsonDecoder, RichInstant, Serialized}
-import com.waz.zms.ZMessagingService
 import org.json
 import org.threeten.bp.Instant
 
@@ -48,7 +48,7 @@ class FCMHandlerService extends FirebaseMessagingService with ZMessagingService 
 
   override def onNewToken(s: String): Unit = {
     ZMessaging.globalModule.map {
-      info(s"onNewToken()")
+      info(s"onNewToken: $s")
       _.tokenService.setNewToken()
     } (Threading.Background)
   }

--- a/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
@@ -20,8 +20,8 @@ package com.waz.services.fcm
 import com.evernote.android.job.Job.Result
 import com.evernote.android.job.util.support.PersistableBundleCompat
 import com.evernote.android.job.{Job, JobManager, JobRequest}
-import com.waz.ZLog.{error, verbose}
 import com.waz.ZLog.ImplicitTag._
+import com.waz.ZLog.{error, verbose}
 import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InBackground
 import com.waz.service.ZMessaging
@@ -76,7 +76,7 @@ object FetchJob {
   val NotificationExtra = "notification"
 
   val MinExecutionDelay = 1.millis //must be greater than 0
-  val MaxExecutionDelay = 15.seconds
+  val MaxExecutionDelay = 2.seconds
   val InitialBackoffDelay = 500.millis
 
   def apply(userId: UserId, nId: Option[Uid]): Unit = {

--- a/app/src/main/scala/com/waz/services/notifications/NotificationsHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/notifications/NotificationsHandlerService.scala
@@ -1,0 +1,109 @@
+/**
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.services.notifications
+
+import android.app.{NotificationManager, PendingIntent}
+import android.content.{Context, Intent}
+import android.support.v4.app.RemoteInput
+import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
+import com.waz.model.{ConvId, UserId}
+import com.waz.service.ZMessaging
+import com.waz.services.FutureService
+import com.waz.threading.Threading
+import com.waz.utils.{TimedWakeLock, returning}
+import com.waz.zclient.ServiceHelper
+import com.waz.zclient.notifications.controllers.MessageNotificationsController.toNotificationConvId
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class NotificationsHandlerService extends FutureService with ServiceHelper {
+
+  import NotificationsHandlerService._
+  import Threading.Implicits.Background
+
+  override protected lazy val wakeLock = new TimedWakeLock(getApplicationContext, 2.seconds)
+
+  override protected def onIntent(intent: Intent, id: Int): Future[Any] = wakeLock.async {
+
+    val account = Option(intent.getStringExtra(ExtraAccountId)).map(UserId)
+    val conversation = Option(intent.getStringExtra(ExtraConvId)).map(ConvId)
+    val instantReplyContent = Option(RemoteInput.getResultsFromIntent(intent)).map(_.getCharSequence(InstantReplyKey))
+
+    Option(ZMessaging.currentAccounts) match {
+      case Some(accs) =>
+        account match {
+          case Some(acc) => accs.getZms(acc).flatMap {
+            case Some(zms) if ActionClear == intent.getAction =>
+              verbose(l"Clearing notifications for account: $acc and conversation:$conversation")
+              zms.notifications.dismissNotifications(conversation.map(Set(_)))
+            case Some(zms) if ActionQuickReply == intent.getAction =>
+              (instantReplyContent, conversation) match {
+                case (Some(content), Some(convId)) =>
+                  zms.convsUi.sendTextMessage(convId, content.toString, exp = Some(None)).map { _ =>
+                    inject[NotificationManager].cancel(toNotificationConvId(acc, convId))
+                  }
+                case _ =>
+                  Future.successful({})
+              }
+            case _ =>
+              Future.successful({})
+          }
+          case None =>
+            warn(l"No account id passed on intent")
+            Future.successful({})
+        }
+      case None =>
+        warn(l"No AccountsService available")
+        Future.successful({})
+    }
+  }
+}
+
+  object NotificationsHandlerService {
+    val ActionClear = "com.wire.CLEAR_NOTIFICATIONS"
+    val ActionQuickReply = "com.wire.QUICK_REPLY"
+    val ExtraAccountId = "account_id"
+    val ExtraConvId = "conv_id"
+
+    val InstantReplyKey = "instant_reply_key"
+
+    def clearNotificationsIntent(userId: UserId, convId: Option[ConvId] = None)(implicit context: Context): PendingIntent = {
+      PendingIntent.getService(
+        context,
+        userId.str.hashCode + convId.map(_.str.hashCode).getOrElse(0),
+        returning(
+          new Intent(context, classOf[NotificationsHandlerService])
+            .setAction(ActionClear)
+            .putExtra(ExtraAccountId, userId.str)) { intent =>
+          convId.foreach(c => intent.putExtra(ExtraConvId, c.str))
+        },
+        PendingIntent.FLAG_UPDATE_CURRENT)
+    }
+
+    def quickReplyIntent(userId: UserId, convId: ConvId)(implicit context: Context): PendingIntent =
+      PendingIntent.getService(
+        context,
+        (userId.str + convId.str).hashCode,
+        new Intent(context, classOf[NotificationsHandlerService])
+          .setAction(ActionQuickReply)
+          .putExtra(ExtraAccountId, userId.str)
+          .putExtra(ExtraConvId, convId.str),
+        PendingIntent.FLAG_ONE_SHOT)
+  }

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -45,7 +45,6 @@ import com.waz.service.call.GlobalCallingService
 import com.waz.service.conversation.{ConversationsService, ConversationsUiService, SelectedConversationService}
 import com.waz.service.images.ImageLoader
 import com.waz.service.messages.MessagesService
-import com.waz.service.push.GlobalNotificationsService
 import com.waz.service.tracking.TrackingService
 import com.waz.services.fcm.FetchJob
 import com.waz.services.gps.GoogleApiImpl
@@ -77,14 +76,14 @@ import com.waz.zclient.cursor.CursorController
 import com.waz.zclient.messages.controllers.{MessageActionsController, NavigationController}
 import com.waz.zclient.messages.{LikesController, MessagePagedListController, MessageViewFactory, MessagesController, UsersController}
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.AndroidNotificationsManager
-import com.waz.zclient.notifications.controllers.{CallingNotificationsController, ImageNotificationsController, MessageNotificationsController, NotificationManagerWrapper}
+import com.waz.zclient.notifications.controllers._
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.pages.main.conversationpager.controller.ISlidingPaneController
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
-import com.waz.zclient.utils.{BackStackNavigator, BackendPicker, Callback, ExternalFileSharing, LocalThumbnailCache, SafeLoggingEnabled, UiStorage, AndroidBase64}
+import com.waz.zclient.utils.{AndroidBase64, BackStackNavigator, BackendPicker, Callback, ExternalFileSharing, LocalThumbnailCache, SafeLoggingEnabled, UiStorage}
 import com.waz.zclient.views.DraftMap
 import javax.net.ssl.SSLContext
 import org.threeten.bp.Clock
@@ -97,6 +96,9 @@ object WireApplication {
 
   type AccountToImageLoader = (UserId) => Future[Option[ImageLoader]]
   type AccountToAssetsStorage = (UserId) => Future[Option[AssetsStorage]]
+  type AccountToUsersStorage = (UserId) => Future[Option[UsersStorage]]
+  type AccountToConvsStorage = (UserId) => Future[Option[ConversationStorage]]
+  type AccountToConvsService = (UserId) => Future[Option[ConversationsService]]
 
   lazy val Global = new Module {
 
@@ -123,11 +125,11 @@ object WireApplication {
     //SE Services
     bind [GlobalModule]                   to ZMessaging.currentGlobal
     bind [AccountsService]                to ZMessaging.currentAccounts
+    bind [Signal[AccountsService]]        to Signal.future(ZMessaging.accountsService) //use for early-initialised classes
     bind [BackendConfig]                  to inject[GlobalModule].backend
     bind [AccountStorage]                 to inject[GlobalModule].accountsStorage
     bind [TeamsStorage]                   to inject[GlobalModule].teamsStorage
     bind [SSOService]                     to inject[GlobalModule].ssoService
-    bind [GlobalNotificationsService]     to inject[GlobalModule].notifications
     bind [GoogleApi]                      to inject[GlobalModule].googleApi
     bind [GlobalCallingService]           to inject[GlobalModule].calling
     bind [SyncHandler]                    to inject[GlobalModule].syncHandler
@@ -147,9 +149,12 @@ object WireApplication {
     import com.waz.threading.Threading.Implicits.Background
     bind [AccountToImageLoader]   to (userId => inject[AccountsService].getZms(userId).map(_.map(_.imageLoader)))
     bind [AccountToAssetsStorage] to (userId => inject[AccountsService].getZms(userId).map(_.map(_.assetsStorage)))
+    bind [AccountToUsersStorage]  to (userId => inject[AccountsService].getZms(userId).map(_.map(_.usersStorage)))
+    bind [AccountToConvsStorage]  to (userId => inject[AccountsService].getZms(userId).map(_.map(_.convsStorage)))
+    bind [AccountToConvsService]  to (userId => inject[AccountsService].getZms(userId).map(_.map(_.conversations)))
 
     // the current user's id
-    bind [Signal[Option[UserId]]] to ZMessaging.currentUi.currentZms.map(_.map(_.selfUserId))
+    bind [Signal[Option[UserId]]] to inject[Signal[AccountsService]].flatMap(_.activeAccountId)
     bind [Signal[UserId]]         to inject[Signal[ZMessaging]].map(_.selfUserId)
     bind [Signal[Option[TeamId]]] to inject[Signal[ZMessaging]].map(_.teamId)
 
@@ -161,7 +166,6 @@ object WireApplication {
     bind [Signal[UserService]]                   to inject[Signal[ZMessaging]].map(_.users)
     bind [Signal[UserSearchService]]             to inject[Signal[ZMessaging]].map(_.userSearch)
     bind [Signal[ConversationStorage]]           to inject[Signal[ZMessaging]].map(_.convsStorage)
-    bind [Signal[NotificationStorage]]           to inject[Signal[ZMessaging]].map(_.notifStorage)
     bind [Signal[UsersStorage]]                  to inject[Signal[ZMessaging]].map(_.usersStorage)
     bind [Signal[MembersStorage]]                to inject[Signal[ZMessaging]].map(_.membersStorage)
     bind [Signal[OtrClientsStorage]]             to inject[Signal[ZMessaging]].map(_.otrClientsStorage)
@@ -360,7 +364,15 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     val googleApi = GoogleApiImpl(this, backend, prefs)
     val base64 = new AndroidBase64()
 
-    ZMessaging.onCreate(this, backend, prefs, googleApi, base64, inject[WorkManagerSyncRequestService])
+    ZMessaging.onCreate(
+      this,
+      backend,
+      prefs,
+      googleApi,
+      base64,
+      inject[WorkManagerSyncRequestService],
+      inject[MessageNotificationsController]
+    )
 
     inject[NotificationManagerWrapper]
     inject[ImageNotificationsController]

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -1,67 +1,66 @@
 /**
-  * Wire
-  * Copyright (C) 2018 Wire Swiss GmbH
-  *
-  * This program is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  */
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.waz.zclient.notifications.controllers
 
 import android.annotation.TargetApi
 import android.content.Context
-import android.graphics._
+import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.support.annotation.RawRes
 import android.support.v4.app.NotificationCompat
 import android.text.TextUtils
-import com.waz.ZLog.ImplicitTag.implicitLogTag
-import com.waz.ZLog.verbose
+import com.waz.log.ZLog2._
+import com.waz.ZLog.ImplicitTag._
+import com.waz.api.NotificationsHandler.NotificationType
 import com.waz.api.NotificationsHandler.NotificationType._
 import com.waz.bitmap.BitmapUtils
-import com.waz.content.{AssetsStorage, ConversationStorage, TeamsStorage, UsersStorage}
+import com.waz.content._
 import com.waz.model._
 import com.waz.service.images.ImageLoader
-import com.waz.service.push.GlobalNotificationsService
-import com.waz.service.push.NotificationService.NotificationInfo
+import com.waz.service.push.NotificationUiController
 import com.waz.service.{AccountsService, UiLifeCycle}
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.ui.MemoryImageCache.BitmapRequest
-import com.waz.utils._
-import com.waz.utils.events.{EventContext, EventStream, Signal}
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.wrappers.Bitmap
-import com.waz.zclient.WireApplication.{AccountToAssetsStorage, AccountToImageLoader}
-import com.waz.zclient._
+import com.waz.zclient.WireApplication._
 import com.waz.zclient.common.controllers.SoundController
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.controllers.navigation.Page
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.controllers.NavigationController
-import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.ContextUtils.{getInt, getIntArray, toPx}
 import com.waz.zclient.utils.{ResString, RingtoneUtils}
+import com.waz.zclient.{BuildConfig, Injectable, Injector, R}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_INT > Build.VERSION_CODES.M,
                                      applicationId: String = BuildConfig.APPLICATION_ID)
-                                    (implicit inj: Injector, cxt: Context, eventContext: EventContext) extends Injectable { self =>
+                                    (implicit inj: Injector, cxt: Context, eventContext: EventContext) extends Injectable with NotificationUiController {
 
   import MessageNotificationsController._
   import Threading.Implicits.Background
 
-  private lazy val notificationsService  = inject[GlobalNotificationsService]
-  private lazy val accounts              = inject[AccountsService]
+  private lazy val notificationManager   = inject[NotificationManagerWrapper]
+
   private lazy val selfId                = inject[Signal[UserId]]
   private lazy val soundController       = inject[SoundController]
   private lazy val navigationController  = inject[NavigationController]
@@ -70,66 +69,39 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
   private lazy val userStorage           = inject[Signal[UsersStorage]]
   private lazy val teamsStorage          = inject[TeamsStorage]
 
-  val notificationsToCancel = EventStream[Set[Int]]()
-  val notificationToBuild   = EventStream[(Int, NotificationProps)]()
-
-  private var accentColors = Map[UserId, Int]()
-
-  inject[AccentColorController].colors { cs =>
-    accentColors = cs.map { case (userId, color) => userId -> color.color }
-  }
-
-  private val newNotifications =
+  override val notificationsSourceVisible: Signal[Map[UserId, Set[ConvId]]] =
     for {
-      notifications <- notificationsService.groupedNotifications.map(_.toSeq.sortBy(_._1.str.hashCode))
-      _             =  verbose(s"grouped notifications: ${notifications.map {case (userId, (_, nots)) => userId -> nots.size}}")
-      tn            <- Signal.future(Future.sequence(notifications.map { case (userId, _) => fetchTeamName(userId) }))
-      teamNames     =  tn.toMap
-    } yield notifications.map {
-      case (userId, (shouldBeSilent, nots)) => (userId, shouldBeSilent, nots, teamNames(userId))
-    }
+      accs     <- inject[Signal[AccountsService]].flatMap(_.accountsWithManagers)
+      uiActive <- inject[UiLifeCycle].uiActive
+      selfId   <- selfId
+      convId   <- convController.currentConvIdOpt
+      convs    <- convsStorage.flatMap(_.contents.map(_.keySet))
+      page     <- navigationController.visiblePage
+    } yield
+      accs.map { accId =>
+        accId ->
+          (if (selfId != accId || !uiActive) Set.empty[ConvId]
+          else page match {
+            case Page.CONVERSATION_LIST => convs
+            case Page.MESSAGE_STREAM    => Set(convId).flatten
+            case _                      => Set.empty[ConvId]
+          })
+      }.toMap
 
-  newNotifications.onUi {
-    _.foreach {
-      case (userId, shouldBeSilent, nots, teamName) if nots.nonEmpty =>
-        createConvNotifications(userId, shouldBeSilent, nots, teamName)
-      case (userId, _, _, _) =>
-        notificationsToCancel ! Set(toNotificationGroupId(userId), toEphemeralNotificationGroupId(userId))
-    }
-  }
-
-  newNotifications { notifications =>
-    if (bundleEnabled) {
-      val notIdSet = notifications.flatMap { case (userId, _, nots, _) =>
-        nots.flatMap(n => Seq(toNotificationConvId(userId, n.convId), toEphemeralNotificationConvId(userId, n.convId))) ++ Seq(toNotificationGroupId(userId))
-      }.toSet
-
-      val activeIds = inject[NotificationManagerWrapper].getActiveNotificationIds.toSet
-
-      val toCancel = activeIds -- notIdSet
-      if (toCancel.nonEmpty) notificationsToCancel ! toCancel
-    }
-  }
-
-  (for {
-    accs     <- accounts.accountsWithManagers
-    uiActive <- inject[UiLifeCycle].uiActive
-    selfId   <- selfId
-    convId   <- convController.currentConvIdOpt
-    storage  <- convsStorage
-    convs    <- Signal.future(storage.list())
-    page     <- navigationController.visiblePage
-  } yield
-    accs.map { accId =>
-      accId ->
-        (if (selfId != accId || !uiActive) Set.empty[ConvId]
-        else page match {
-          case Page.CONVERSATION_LIST => convs.map(_.id).toSet
-          case Page.MESSAGE_STREAM    => Set(convId).flatten
-          case _                      => Set.empty[ConvId]
-        })
-    }.toMap) { displayedConversations =>
-    notificationsService.notificationsSourceVisible ! displayedConversations
+  override def onNotificationsChanged(accountId: UserId, nots: Set[NotificationData]): Future[Unit] = {
+    verbose(l"onNotificationsChanged: $accountId, nots: $nots")
+    for {
+      teamName  <- fetchTeamName(accountId)
+      summaries <- createSummaryNotificationProps(accountId, nots, teamName).map(_.map(p => (toNotificationGroupId(accountId), p)))
+      convNots  <- createConvNotifications(accountId, nots, teamName).map(_.toMap)
+      _         <- Threading.Ui {
+        val nots = convNots ++ summaries
+        if (nots.isEmpty)
+          notificationManager.cancelNotifications(Set(toNotificationGroupId(accountId), toEphemeralNotificationGroupId(accountId)))
+        else
+          nots.foreach { case (id, props) => notificationManager.showNotification(id, props) }
+      }.future
+    } yield {}
   }
 
   private def fetchTeamName(userId: UserId) =
@@ -140,174 +112,278 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
         case Some(teamId) => teamsStorage.get(teamId)
         case _            => Future.successful(Option.empty[TeamData])
       }
-    } yield userId -> team.map(_.name)
+    } yield team.map(_.name)
 
-  private def getPictureForNotifications(userId: UserId, nots: Seq[NotificationInfo]): Future[Option[Bitmap]] =
-    if (nots.exists(_.isEphemeral)) Future.successful(None)
-    else {
-      val pictures  = nots.flatMap(_.userPicture).distinct
-      val assetId   = if (pictures.size == 1) pictures.headOption else None
+  private def createSummaryNotificationProps(userId: UserId, nots: Set[NotificationData], teamName: Option[Name]) = {
+    verbose(l"createSummaryNotificationProps: $userId, ${nots.size}")
+    if (nots.nonEmpty && bundleEnabled)
+      notificationColor(userId).map { color =>
+        Some(NotificationProps (userId,
+          when                     = Some(nots.minBy(_.time.instant).time.instant.toEpochMilli),
+          showWhen                 = Some(true),
+          category                 = Some(NotificationCompat.CATEGORY_MESSAGE),
+          priority                 = Some(NotificationCompat.PRIORITY_HIGH),
+          smallIcon                = Some(R.drawable.ic_menu_logo),
+          groupSummary             = Some(true),
+          group                    = Some(userId),
+          openAccountIntent        = Some(userId),
+          contentInfo              = teamName.map(_.str),
+          color                    = color
+        ))
+    } else Future.successful(None)
+  }
 
-      verbose(s"getPictureForNotifications, assetId: $assetId")
+  private def createConvNotifications(accountId: UserId, nots: Set[NotificationData], teamName: Option[Name]) = {
+    verbose(l"createConvNotifications: $accountId, ${nots.size}")
+    if (nots.nonEmpty) {
+      val (ephemeral, normal) = nots.toSeq.sortBy(_.time).partition(_.ephemeral)
 
-      val imageLoader   = inject[AccountToImageLoader]
-      val assetsStorage = inject[AccountToAssetsStorage]
+      val groupedConvs =
+        if (bundleEnabled)
+          normal.groupBy(_.conv).map {
+            case (convId, ns) => toNotificationConvId(accountId, convId) -> ns
+          } ++ ephemeral.groupBy(_.conv).map {
+            case (convId, ns) => toEphemeralNotificationConvId(accountId, convId) -> ns
+          }
+        else
+          Map(toNotificationGroupId(accountId) -> normal, toEphemeralNotificationGroupId(accountId) -> ephemeral)
 
-      Future.sequence(List(imageLoader(userId), assetsStorage(userId))).flatMap {
-        case Some(imageLoader: ImageLoader) :: Some(assetsStorage: AssetsStorage) :: Nil =>
+      val teamNameOpt = if (groupedConvs.keys.size > 1) None else teamName
+
+      Future.sequence(groupedConvs.filter(_._2.nonEmpty).map {
+        case (notId, ns) =>
           for {
-            assetData <- assetId.fold(Future.successful(Option.empty[AssetData]))(assetsStorage.get)
-            bmp       <- assetData.fold(Future.successful(Option.empty[Bitmap])){ ad =>
-              imageLoader.loadBitmap(ad, BitmapRequest.Single(toPx(64)), forceDownload = false).map(Option(_)).withTimeout(500.millis).recoverWith {
-                case _ : Throwable => CancellableFuture.successful(None)
-              }.future
+            commonProps   <- commonNotificationProperties(ns, accountId)
+            specificProps <-
+              if (ns.size == 1) singleNotificationProperties(commonProps, accountId, ns.head, teamNameOpt)
+              else              multipleNotificationProperties(commonProps, accountId, ns, teamNameOpt)
+          } yield notId -> specificProps
+      })
+    } else Future.successful(Iterable.empty)
+  }
+
+  private def commonNotificationProperties(ns: Seq[NotificationData], userId: UserId) =
+    for {
+      color <- notificationColor(userId)
+      pic   <- getPictureForNotifications(userId, ns)
+    } yield {
+      NotificationProps(userId,
+        showWhen      = Some(true),
+        category      = Some(NotificationCompat.CATEGORY_MESSAGE),
+        priority      = Some(NotificationCompat.PRIORITY_HIGH),
+        smallIcon     = Some(R.drawable.ic_menu_logo),
+        vibrate       = if (soundController.isVibrationEnabled(userId)) Some(getIntArray(R.array.new_message_gcm).map(_.toLong)) else Some(Array(0l,0l)),
+        autoCancel    = Some(true),
+        sound         = getSound(ns),
+        onlyAlertOnce = Some(ns.forall(_.hasBeenDisplayed)),
+        group         = Some(userId),
+        when          = Some(ns.maxBy(_.time.instant).time.instant.toEpochMilli),
+        largeIcon     = pic,
+        lights        = Some(color.getOrElse(Color.WHITE), getInt(R.integer.notifications__system__led_on), getInt(R.integer.notifications__system__led_off)),
+        color         = color,
+        lastIsPing    = ns.map(_.msgType).lastOption.map(_ == KNOCK)
+      )
+    }
+
+  private def notificationColor(userId: UserId) =
+    applicationId match {
+      case "com.wire.internal"   => Future.successful(Some(Color.GREEN))
+      case "com.waz.zclient.dev" => inject[AccentColorController].colors.head.map(_.get(userId).map(_.color))
+      case "com.wire.x"          => Future.successful(Some(Color.RED))
+      case "com.wire.qa"         => Future.successful(Some(Color.BLUE))
+      case _                     => Future.successful(None)
+    }
+
+  private def singleNotificationProperties(props: NotificationProps, account: UserId, n: NotificationData, teamName: Option[Name]) = {
+    verbose(l"singleNotificationProperties: $account, $n, $teamName")
+    for {
+      title <- getMessageTitle(account, n, None).map(t => SpannableWrapper(t, List(Span(Span.StyleSpanBold, Span.HeaderRange))))
+      body  <- getMessage(account, n, singleConversationInBatch = true)
+    } yield {
+      val requestBase  = System.currentTimeMillis.toInt
+      val bigTextStyle = StyleBuilder(StyleBuilder.BigText, title = title, summaryText = teamName.map(_.str), bigText = Some(body))
+      val specProps = props.copy(
+        contentTitle             = Some(title),
+        contentText              = Some(body),
+        style                    = Some(bigTextStyle),
+        openConvIntent           = Some((account, n.conv, requestBase)),
+        clearNotificationsIntent = Some((account, Some(n.conv)))
+      )
+      if (n.msgType != NotificationType.CONNECT_REQUEST)
+        specProps.copy(
+          action1 = Some((account, n.conv, requestBase + 1, bundleEnabled)),
+          action2 = Some((account, n.conv, requestBase + 2, bundleEnabled))
+        )
+      else specProps
+    }
+  }
+
+  private def getMessageTitle(account: UserId, n: NotificationData, teamName: Option[String]) = {
+    if (n.ephemeral)
+      Future.successful(ResString(R.string.notification__message__ephemeral_someone))
+    else {
+      getConvName(account, n).map(_.getOrElse(Name.Empty)).map { convName =>
+        teamName match {
+          case Some(name) =>
+            ResString(R.string.notification__message__group__prefix__other, convName, name)
+          case None =>
+            ResString(convName)
+        }
+      }
+    }
+  }
+
+  private def getConvName(account: UserId, n: NotificationData) =
+    inject[AccountToConvsStorage].apply(account).flatMap {
+      case Some(st) =>
+        st.get(n.conv).map(_.map(_.displayName))
+      case None =>
+        Future.successful(Option.empty[Name])
+    }
+
+  private def getUserName(account: UserId, n: NotificationData) =
+    inject[AccountToUsersStorage].apply(account).flatMap {
+      case Some(st) =>
+        st.get(n.user).map(_.map(_.getDisplayName))
+      case None =>
+        Future.successful(Option.empty[Name])
+    }
+
+  private def isGroupConv(account: UserId, n: NotificationData) =
+    inject[AccountToConvsService].apply(account).flatMap {
+      case Some(service) => service.isGroupConversation(n.conv)
+      case _ => Future.successful(false)
+    }
+
+  private def getMessage(account: UserId, n: NotificationData, singleConversationInBatch: Boolean): Future[SpannableWrapper] = {
+    val message = n.msg.replaceAll("\\r\\n|\\r|\\n", " ")
+
+    for {
+      header <- n.msgType match {
+        case CONNECT_ACCEPTED => Future.successful(ResString.Empty)
+        case _ => getDefaultNotificationMessageLineHeader(account, n, singleConversationInBatch)
+      }
+      convName <- getConvName(account, n).map(_.getOrElse(Name.Empty))
+      userName <- getUserName(account, n).map(_.getOrElse(Name.Empty))
+    } yield {
+      val body = n.msgType match {
+        case _ if n.ephemeral && n.isSelfMentioned => ResString(R.string.notification__message_with_mention__ephemeral)
+        case _ if n.ephemeral && n.isReply => ResString(R.string.notification__message_with_quote__ephemeral)
+        case _ if n.ephemeral => ResString(R.string.notification__message__ephemeral)
+        case TEXT             => ResString(message)
+        case MISSED_CALL      => ResString(R.string.notification__message__one_to_one__wanted_to_talk)
+        case KNOCK            => ResString(R.string.notification__message__one_to_one__pinged)
+        case ANY_ASSET        => ResString(R.string.notification__message__one_to_one__shared_file)
+        case ASSET            => ResString(R.string.notification__message__one_to_one__shared_picture)
+        case VIDEO_ASSET      => ResString(R.string.notification__message__one_to_one__shared_video)
+        case AUDIO_ASSET      => ResString(R.string.notification__message__one_to_one__shared_audio)
+        case LOCATION         => ResString(R.string.notification__message__one_to_one__shared_location)
+        case RENAME           => ResString(R.string.notification__message__group__renamed_conversation, convName)
+        case MEMBER_LEAVE     => ResString(R.string.notification__message__group__remove)
+        case MEMBER_JOIN      => ResString(R.string.notification__message__group__add)
+        case LIKE if n.likedContent.nonEmpty =>
+          n.likedContent.collect {
+            case LikedContent.PICTURE =>
+              ResString(R.string.notification__message__liked_picture)
+            case LikedContent.TEXT_OR_URL =>
+              ResString(R.string.notification__message__liked, n.msg)
+          }.getOrElse(ResString(R.string.notification__message__liked_message))
+        case CONNECT_ACCEPTED       => ResString(R.string.notification__message__single__accept_request, userName)
+        case CONNECT_REQUEST        => ResString(R.string.people_picker__invite__share_text__header, userName)
+        case MESSAGE_SENDING_FAILED => ResString(R.string.notification__message__send_failed)
+        case _ => ResString.Empty
+      }
+
+      getMessageSpannable(header, body, n.msgType == TEXT)
+    }
+  }
+
+  private def getDefaultNotificationMessageLineHeader(account: UserId, n: NotificationData, singleConversationInBatch: Boolean) =
+    for {
+      convName <- getConvName(account, n)
+      userName <- getUserName(account, n).map(_.getOrElse(Name.Empty))
+      isGroup  <- isGroupConv(account, n)
+    } yield {
+      if (n.ephemeral) ResString.Empty
+      else {
+        val prefixId =
+          if (!singleConversationInBatch && isGroup)
+            if (n.isSelfMentioned)
+              R.string.notification__message_with_mention__group__prefix__text
+            else if (n.isReply)
+              R.string.notification__message_with_quote__group__prefix__text
+            else
+              R.string.notification__message__group__prefix__text
+          else if (!singleConversationInBatch && !isGroup || singleConversationInBatch && isGroup)
+            if (n.isSelfMentioned)
+              R.string.notification__message_with_mention__name__prefix__text
+            else if (n.isReply)
+              R.string.notification__message_with_quote__name__prefix__text
+            else
+              R.string.notification__message__name__prefix__text
+          else if (singleConversationInBatch && isGroup && n.isReply)
+            R.string.notification__message_with_quote__name__prefix__text_one2one
+          else 0
+        if (prefixId > 0) {
+          convName match {
+            case Some(cn) => ResString(prefixId, userName, cn)
+            case None => ResString(prefixId, List(ResString(userName), ResString(R.string.notification__message__group__default_conversation_name)))
+          }
+        }
+        else ResString.Empty
+      }
+    }
+
+  @TargetApi(21)
+  private def getMessageSpannable(header: ResString, body: ResString, isTextMessage: Boolean) = {
+    val spans = Span(Span.ForegroundColorSpanBlack, Span.HeaderRange) ::
+      (if (!isTextMessage) List(Span(Span.StyleSpanItalic, Span.BodyRange)) else Nil)
+    SpannableWrapper(header = header, body = body, spans = spans, separator = "")
+  }
+
+  private def getPictureForNotifications(userId: UserId, nots: Seq[NotificationData]): Future[Option[Bitmap]] =
+    if (nots.exists(_.ephemeral)) Future.successful(None)
+    else {
+      inject[AccountToUsersStorage].apply(userId).flatMap {
+        case Some(st) =>
+          for {
+            //TODO if a user doesn't have a picture, should we default to some bitmap?
+            assetId <- st.getAll(nots.map(_.user).toSet).map(_.flatten.flatMap(_.picture)).map { pictures =>
+              if (pictures.size == 1) pictures.headOption else None
             }
-          } yield
-            bmp.map { original => Bitmap.fromAndroid(BitmapUtils.createRoundBitmap(original, toPx(64), 0, Color.TRANSPARENT)) }
+            bitmap <- {
+              val imageLoader   = inject[AccountToImageLoader]
+              val assetsStorage = inject[AccountToAssetsStorage]
+
+              Future.sequence(List(imageLoader(userId), assetsStorage(userId))).flatMap {
+                case Some(imageLoader: ImageLoader) :: Some(assetsStorage: AssetsStorage) :: Nil =>
+                  for {
+                    assetData <- assetId.fold(Future.successful(Option.empty[AssetData]))(assetsStorage.get)
+                    bmp       <- assetData.fold(Future.successful(Option.empty[Bitmap])){ ad =>
+                      imageLoader.loadBitmap(ad, BitmapRequest.Single(toPx(64)), forceDownload = false).map(Option(_)).withTimeout(500.millis).recoverWith {
+                        case _ : Throwable => CancellableFuture.successful(None)
+                      }.future
+                    }
+                  } yield
+                    bmp.map { original => Bitmap.fromAndroid(BitmapUtils.createRoundBitmap(original, toPx(64), 0, Color.TRANSPARENT)) }
+                case _ => Future.successful(None)
+              }
+            }
+          } yield bitmap
         case _ => Future.successful(None)
       }
     }
 
-  private def createSummaryNotificationProps(userId: UserId, silent: Boolean, nots: Seq[NotificationInfo], teamName: Option[Name]) =
-    NotificationProps (userId,
-      when                     = Some(nots.minBy(_.time.instant).time.instant.toEpochMilli),
-      showWhen                 = Some(true),
-      category                 = Some(NotificationCompat.CATEGORY_MESSAGE),
-      priority                 = Some(NotificationCompat.PRIORITY_HIGH),
-      smallIcon                = Some(R.drawable.ic_menu_logo),
-      groupSummary             = Some(true),
-      group                    = Some(userId),
-      openAccountIntent        = Some(userId),
-      clearNotificationsIntent = Some((userId, None)),
-      contentInfo              = teamName.map(_.str),
-      color                    = notificationColor(userId)
-    )
-
-  private def createConvNotifications(userId: UserId, silent: Boolean, nots: Seq[NotificationInfo], teamName: Option[Name]): Unit = {
-      if (bundleEnabled) {
-        val summary = createSummaryNotificationProps(userId, silent, nots, teamName)
-        notificationToBuild ! (toNotificationGroupId(userId), summary)
-      }
-
-      val (ephemeral, normal) = nots.partition(_.isEphemeral)
-      verbose(s"createConvNotifications($userId, ${normal.map(_.convId)}, ${ephemeral.map(_.convId)})")
-
-      val groupedConvs =
-        if (bundleEnabled)
-          normal.groupBy(_.convId).map {
-            case (convId, ns) => toNotificationConvId(userId, convId) -> ns
-          } ++ ephemeral.groupBy(_.convId).map {
-              case (convId, ns) => toEphemeralNotificationConvId(userId, convId) -> ns
-            }
-        else
-          Map(toNotificationGroupId(userId) -> normal, toEphemeralNotificationGroupId(userId) -> ephemeral)
-
-      val teamNameOpt = if (groupedConvs.keys.size > 1) None else teamName
-
-      val notFutures = groupedConvs.map { case (notId, ns) =>
-        getPictureForNotifications(userId, ns).map { pic =>
-          val commonProps   = commonNotificationProperties(ns, userId, silent, pic)
-          val specificProps =
-            if (ns.size == 1) singleNotificationProperties(commonProps, userId, ns.head, teamNameOpt)
-            else              multipleNotificationProperties(commonProps, userId, ns, teamNameOpt)
-
-          notId -> (specificProps, ns.map(_.id))
-        }
-      }
-
-      Future.sequence(notFutures.map {
-        _.map { case (notId, (props, notsDisplayed)) =>
-          verbose(s"a notification to build: $notId -> $props")
-          notificationToBuild ! (notId, props)
-          notsDisplayed
-        }
-      }).foreach { notsDisplayed =>
-        val ids = notsDisplayed.flatten.toSeq
-        verbose(s"notifications marked as displayed: $ids")
-        notificationsService.markAsDisplayed(userId, ids)
-      } (Threading.Ui)
+  private def getSound(ns: Seq[NotificationData]) = {
+    if (soundController.soundIntensityNone) None
+    else if (!soundController.soundIntensityFull && (ns.size > 1 && ns.lastOption.forall(_.msgType != KNOCK))) None
+    else ns.map(_.msgType).lastOption.fold(Option.empty[Uri]) {
+      case ASSET | ANY_ASSET | VIDEO_ASSET | AUDIO_ASSET |
+           LOCATION | TEXT | CONNECT_ACCEPTED | CONNECT_REQUEST | RENAME |
+           LIKE  => Option(getSelectedSoundUri(soundController.currentTonePrefs._2, R.raw.new_message_gcm))
+      case KNOCK => Option(getSelectedSoundUri(soundController.currentTonePrefs._3, R.raw.ping_from_them))
+      case _     => None
     }
-
-  private def singleNotificationProperties(props: NotificationProps, userId: UserId, n: NotificationInfo, teamName: Option[Name]): NotificationProps = {
-    val title        = SpannableWrapper(getMessageTitle(n, None), List(Span(Span.StyleSpanBold, Span.HeaderRange)))
-    val body         = getMessage(n, singleConversationInBatch = true)
-    val requestBase  = System.currentTimeMillis.toInt
-    val bigTextStyle = StyleBuilder(StyleBuilder.BigText, title = title, summaryText = teamName.map(_.str), bigText = Some(body))
-
-    val specProps = props.copy(
-      contentTitle             = Some(title),
-      contentText              = Some(body),
-      style                    = Some(bigTextStyle),
-      openConvIntent           = Some((userId, n.convId, requestBase)),
-      clearNotificationsIntent = Some((userId, Some(n.convId)))
-    )
-
-    if (n.tpe != CONNECT_REQUEST)
-      specProps.copy(
-        action1 = Some((userId, n.convId, requestBase + 1, bundleEnabled)),
-        action2 = Some((userId, n.convId, requestBase + 2, bundleEnabled))
-      )
-    else specProps
-  }
-
-  private def multipleNotificationProperties(props: NotificationProps, userId: UserId, ns: Seq[NotificationInfo], teamName: Option[Name]): NotificationProps = {
-    val convIds = ns.map(_.convId).toSet
-    val isSingleConv = convIds.size == 1
-
-    val header =
-      if (isSingleConv) {
-        if (ns.exists(_.isEphemeral))
-          ResString(R.string.notification__message__ephemeral_someone)
-        else if (ns.head.isGroupConv)
-          ns.head.convName.map(_.str).map(ResString(_)).getOrElse(ResString.Empty)
-        else
-          ns.head.convName.orElse(ns.head.userName).map(_.str).map(ResString(_)).getOrElse(ResString.Empty)
-      }
-      else
-        ResString(R.plurals.notification__new_messages__multiple, convIds.size, ns.size)
-
-    val separator = " • "
-
-    val title =
-      if (isSingleConv && ns.size > 5)
-        SpannableWrapper(
-          header = header,
-          body = ResString(R.plurals.conversation_list__new_message_count, ns.size),
-          spans = List(
-            Span(Span.StyleSpanBold, Span.HeaderRange),
-            Span(Span.StyleSpanItalic, Span.BodyRange, separator.length),
-            Span(Span.ForegroundColorSpanGray, Span.BodyRange)
-          ),
-          separator = separator
-        )
-      else
-        SpannableWrapper(
-          header = header,
-          spans = List(Span(Span.StyleSpanBold, Span.HeaderRange))
-        )
-
-    val requestBase = System.currentTimeMillis.toInt
-    val messages    = ns.sortBy(_.time.instant).map(n => getMessage(n, singleConversationInBatch = isSingleConv)).takeRight(5).toList
-    val inboxStyle  = StyleBuilder(StyleBuilder.Inbox, title = title, summaryText = (if (bundleEnabled) teamName else None).map(_.str), lines = messages)
-
-    val specProps = props.copy(
-      contentTitle = Some(title),
-      contentText  = Some(messages.last),
-      style        = Some(inboxStyle)
-    )
-
-    if (isSingleConv)
-      specProps.copy(
-        openConvIntent           = Some((userId, convIds.head, requestBase)),
-        clearNotificationsIntent = Some((userId, Some(convIds.head))),
-        action1                  = Some((userId, convIds.head, requestBase + 1, bundleEnabled)),
-        action2                  = Some((userId, convIds.head, requestBase + 2, bundleEnabled))
-      )
-    else
-      specProps.copy(
-        openAccountIntent        = Some(userId),
-        clearNotificationsIntent = Some((userId, None))
-      )
   }
 
   private def getSelectedSoundUri(value: String, @RawRes defaultResId: Int): Uri =
@@ -318,136 +394,68 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
     else RingtoneUtils.getUriForRawId(cxt, returnDefault)
   }
 
-  private def commonNotificationProperties(ns: Seq[NotificationInfo], userId: UserId, silent: Boolean, pic: Option[Bitmap]) = {
-    val color = notificationColor(userId)
-    NotificationProps(userId,
-      showWhen      = Some(true),
-      category      = Some(NotificationCompat.CATEGORY_MESSAGE),
-      priority      = Some(NotificationCompat.PRIORITY_HIGH),
-      smallIcon     = Some(R.drawable.ic_menu_logo),
-      vibrate       = if (!silent && soundController.isVibrationEnabled(userId)) Some(getIntArray(R.array.new_message_gcm).map(_.toLong)) else Some(Array(0l,0l)),
-      autoCancel    = Some(true),
-      sound         = getSound(ns, silent),
-      onlyAlertOnce = Some(ns.forall(_.hasBeenDisplayed)),
-      group         = Some(userId),
-      when          = Some(ns.maxBy(_.time.instant).time.instant.toEpochMilli),
-      largeIcon     = pic,
-      lights        = Some(color.getOrElse(Color.WHITE), getInt(R.integer.notifications__system__led_on), getInt(R.integer.notifications__system__led_off)),
-      color         = color,
-      lastIsPing    = ns.map(_.tpe).lastOption.map(_ == KNOCK)
-    )
-  }
+  private def multipleNotificationProperties(props: NotificationProps, account: UserId, ns: Seq[NotificationData], teamName: Option[Name]): Future[NotificationProps] = {
+    verbose(l"multipleNotificationProperties: $account, $ns, $teamName")
+    val convIds = ns.map(_.conv).toSet
+    val isSingleConv = convIds.size == 1
 
-  private def getSound(ns: Seq[NotificationInfo], silent: Boolean) = {
-    if (soundController.soundIntensityNone || silent) None
-    else if (!soundController.soundIntensityFull && (ns.size > 1 && ns.lastOption.forall(_.tpe != KNOCK))) None
-    else ns.map(_.tpe).lastOption.fold(Option.empty[Uri]) {
-      case ASSET | ANY_ASSET | VIDEO_ASSET | AUDIO_ASSET |
-           LOCATION | TEXT | CONNECT_ACCEPTED | CONNECT_REQUEST | RENAME |
-           LIKE  => Option(getSelectedSoundUri(soundController.currentTonePrefs._2, R.raw.new_message_gcm))
-      case KNOCK => Option(getSelectedSoundUri(soundController.currentTonePrefs._3, R.raw.ping_from_them))
-      case _     => None
-    }
-  }
+    val n = ns.head
 
-  private[notifications] def getMessage(n: NotificationInfo, singleConversationInBatch: Boolean): SpannableWrapper = {
-    val message = n.message.replaceAll("\\r\\n|\\r|\\n", " ")
-    val header  = n.tpe match {
-      case CONNECT_ACCEPTED => ResString.Empty
-      case _                => getDefaultNotificationMessageLineHeader(n, singleConversationInBatch)
-    }
-
-    val body = n.tpe match {
-      case _ if n.isEphemeral && n.isUserMentioned => ResString(R.string.notification__message_with_mention__ephemeral)
-      case _ if n.isEphemeral && n.isQuote => ResString(R.string.notification__message_with_quote__ephemeral)
-      case _ if n.isEphemeral => ResString(R.string.notification__message__ephemeral)
-      case TEXT               => ResString(message)
-      case MISSED_CALL        => ResString(R.string.notification__message__one_to_one__wanted_to_talk)
-      case KNOCK              => ResString(R.string.notification__message__one_to_one__pinged)
-      case ANY_ASSET          => ResString(R.string.notification__message__one_to_one__shared_file)
-      case ASSET              => ResString(R.string.notification__message__one_to_one__shared_picture)
-      case VIDEO_ASSET        => ResString(R.string.notification__message__one_to_one__shared_video)
-      case AUDIO_ASSET        => ResString(R.string.notification__message__one_to_one__shared_audio)
-      case LOCATION           => ResString(R.string.notification__message__one_to_one__shared_location)
-      case RENAME             => ResString(R.string.notification__message__group__renamed_conversation, n.convName.getOrElse(Name.Empty))
-      case MEMBER_LEAVE       => ResString(R.string.notification__message__group__remove)
-      case MEMBER_JOIN        => ResString(R.string.notification__message__group__add)
-      case LIKE if n.likedContent.nonEmpty =>
-        n.likedContent.collect {
-          case LikedContent.PICTURE =>
-            ResString(R.string.notification__message__liked_picture)
-          case LikedContent.TEXT_OR_URL =>
-            ResString(R.string.notification__message__liked, n.message)
-        }.getOrElse(ResString(R.string.notification__message__liked_message))
-      case CONNECT_ACCEPTED       => ResString(R.string.notification__message__single__accept_request, n.userName.getOrElse(Name.Empty))
-      case CONNECT_REQUEST        => ResString(R.string.people_picker__invite__share_text__header, n.userName.getOrElse(Name.Empty))
-      case MESSAGE_SENDING_FAILED => ResString(R.string.notification__message__send_failed)
-      case _ => ResString.Empty
-    }
-
-    getMessageSpannable(header, body, n.tpe == TEXT)
-  }
-
-  private def getMessageTitle(n: NotificationInfo, teamName: Option[String]): ResString = {
-    if (n.isEphemeral)
-      ResString(R.string.notification__message__ephemeral_someone)
-    else {
-      val convName = n.convName.orElse(n.userName).getOrElse(Name.Empty)
-      teamName match {
-        case Some(name) =>
-          ResString(R.string.notification__message__group__prefix__other, convName, name)
-        case None =>
-          ResString(convName)
-      }
-    }
-  }
-
-  @TargetApi(21)
-  private def getMessageSpannable(header: ResString, body: ResString, isTextMessage: Boolean) = {
-    val spans = Span(Span.ForegroundColorSpanBlack, Span.HeaderRange) ::
-      (if (!isTextMessage) List(Span(Span.StyleSpanItalic, Span.BodyRange)) else Nil)
-    SpannableWrapper(header = header, body = body, spans = spans, separator = "")
-  }
-
-  private def getDefaultNotificationMessageLineHeader(n: NotificationInfo, singleConversationInBatch: Boolean): ResString =
-    if (n.isEphemeral) ResString.Empty
-    else {
-      val prefixId =
-        if (!singleConversationInBatch && n.isGroupConv)
-          if (n.isUserMentioned)
-            R.string.notification__message_with_mention__group__prefix__text
-          else if (n.isQuote)
-            R.string.notification__message_with_quote__group__prefix__text
-          else
-            R.string.notification__message__group__prefix__text
-        else if (!singleConversationInBatch && !n.isGroupConv || singleConversationInBatch && n.isGroupConv)
-          if (n.isUserMentioned)
-            R.string.notification__message_with_mention__name__prefix__text
-          else if (n.isQuote)
-            R.string.notification__message_with_quote__name__prefix__text
-          else
-            R.string.notification__message__name__prefix__text
-        else if (singleConversationInBatch && !n.isGroupConv && n.isQuote)
-            R.string.notification__message_with_quote__name__prefix__text_one2one
-        else 0
-      if (prefixId > 0) {
-        val userName = n.userName.getOrElse(Name.Empty)
-        n.convName match {
-          case Some(convName) => ResString(prefixId, userName, convName)
-          case None           => ResString(prefixId, List(ResString(userName), ResString(R.string.notification__message__group__default_conversation_name)))
+    for {
+      convName <- getConvName(account, n).map(_.getOrElse(Name.Empty))
+      messages <- Future.sequence(ns.sortBy(_.time.instant).map(n => getMessage(account, n, singleConversationInBatch = isSingleConv)).takeRight(5).toList)
+    } yield {
+      val header =
+        if (isSingleConv) {
+          if (ns.exists(_.ephemeral)) ResString(R.string.notification__message__ephemeral_someone)
+          else ResString(convName.str)
         }
-      }
-      else ResString.Empty
+        else
+          ResString(R.plurals.notification__new_messages__multiple, convIds.size, ns.size)
+
+      val separator = " • "
+
+      val title =
+        if (isSingleConv && ns.size > 5)
+          SpannableWrapper(
+            header = header,
+            body = ResString(R.plurals.conversation_list__new_message_count, ns.size),
+            spans = List(
+              Span(Span.StyleSpanBold, Span.HeaderRange),
+              Span(Span.StyleSpanItalic, Span.BodyRange, separator.length),
+              Span(Span.ForegroundColorSpanGray, Span.BodyRange)
+            ),
+            separator = separator
+          )
+        else
+          SpannableWrapper(
+            header = header,
+            spans = List(Span(Span.StyleSpanBold, Span.HeaderRange))
+          )
+
+      val requestBase = System.currentTimeMillis.toInt
+      val inboxStyle  = StyleBuilder(StyleBuilder.Inbox, title = title, summaryText = (if (bundleEnabled) teamName else None).map(_.str), lines = messages)
+
+      val specProps = props.copy(
+        contentTitle = Some(title),
+        contentText  = Some(messages.last),
+        style        = Some(inboxStyle)
+      )
+
+      if (isSingleConv)
+        specProps.copy(
+          openConvIntent           = Some((account, n.conv, requestBase)),
+          clearNotificationsIntent = Some((account, Some(n.conv))),
+          action1                  = Some((account, n.conv, requestBase + 1, bundleEnabled)),
+          action2                  = Some((account, n.conv, requestBase + 2, bundleEnabled))
+        )
+      else
+        specProps.copy(
+          openAccountIntent        = Some(account),
+          clearNotificationsIntent = Some((account, None))
+        )
     }
-
-  private def notificationColor(userId: UserId) = applicationId match {
-    case "com.wire.internal"   => Some(Color.GREEN)
-    case "com.waz.zclient.dev" => accentColors.get(userId)
-    case "com.wire.x"          => Some(Color.RED)
-    case "com.wire.qa"         => Some(Color.BLUE)
-    case _                     => None
   }
-
 }
 
 object MessageNotificationsController {
@@ -459,4 +467,5 @@ object MessageNotificationsController {
 
   val ZETA_MESSAGE_NOTIFICATION_ID: Int = 1339272
   val ZETA_EPHEMERAL_NOTIFICATION_ID: Int = 1339279
+
 }


### PR DESCRIPTION
Notifications are now generated directly from events in the pipeline in a couple of event `Stage`s rather than from `EventStream`s from the various storage classes. This then means that the generation of notifications happens within the `Future` that represents the pipeline and so it shouldn't any longer be possible for the system to kill the app before notifications are generated. 

In order to work with this new approach, the UI is now also future - rather than signal - based. The SE will, upon receiving new events, group together any existing notifications and add to them the newly generated notifications, and push all of them to the UI. The UI is then responsible for displaying those notifications within a `Future[Unit]` on completion of which the pipeline can continue. This, in a sense, makes the notification generation and displaying much more functional, pushing all side-effects back as far as possible. 

### Testing: 
This work is mostly concerned with the persisting, generation and displaying of notifications. Receiving notifications and interacting with them (e.g., quick replies, opening target conversation etc.) shouldn't be affected. Note that notifications should batch a lot more nicely now too!

**Note:** all tests need to be carried out on both Android versions that support channels and those that don't. Probably not a bad idea to check out <5.0 devices as well!

* [x] Receive message from some other user, have other user edit or delete their messages
* [x] Have the other user like your messages, unlike them
* [x] Have another user reply to your messages - should say "Reply: text"
* [x] Have another user mention you in a conversation
* [x] Receive a connection request from another user (when you accept that request from another device, you should see "you are now connected with xyz")
* [x] Have another user accept your connect request
* [x] **pre-channels:** Receive messages into many different conversations in one account: clicking on the notification should open the account
* [x] **channels:** Receive messages into many different conversations in one account: there should be a bundle for every conversation and clicking on the bundle should open its conversation
* [x] Receive messages into just one conversation: clicking on the notification should open its conversation.
* [x] Group creation events
* [x] User added/removed events
* [x] Conversation state change events (rename etc.)
* [ ] ~~After reading a message from another device, any new incoming notifications on the Android device should *not* make a sound for the next minute. After that minute, any unread notifications will then make a sound~~
 > Decided not to re-implement this, since I don't currently have a good solution for Android >= 8.0 (the alarm manager probably won't work) 
* [x] currently, notifications are always silent
* [x] Multiple accounts: each account should have its own notification or channels
* [x] 1:1 conversations in team accounts should show user name, not conversation name
* [x] messages into group conversations currently do not show user who sent message
* [x] test updating from old version of app to this new logic (is db migration necessary?) - it seems as though some message types may not work properly (replies etc.) but a migration shouldn't be necessary since notifications are pretty temporary



#### APK
[Download build #12176](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12176/artifact/build/artifact/wire-dev-PR1912-12176.apk)
[Download build #12180](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12180/artifact/build/artifact/wire-dev-PR1912-12180.apk)
[Download build #12182](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12182/artifact/build/artifact/wire-dev-PR1912-12182.apk)
[Download build #12184](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12184/artifact/build/artifact/wire-dev-PR1912-12184.apk)
[Download build #12189](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12189/artifact/build/artifact/wire-dev-PR1912-12189.apk)
[Download build #12194](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12194/artifact/build/artifact/wire-dev-PR1912-12194.apk)