### PR TITLE
fix: Don't show the reads tab on non-team accounts; read receipts switch in 'create conv' always on

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -24,9 +24,7 @@ import android.text.InputFilter.LengthFilter
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{CompoundButton, ImageView, TextView}
 import android.widget.CompoundButton.OnCheckedChangeListener
-import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
-import com.waz.service.ZMessaging
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.UserAccountsController
@@ -42,7 +40,6 @@ import com.waz.zclient.utils.RichView
 class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
   private lazy val createConversationController = inject[CreateConversationController]
   private lazy val userAccountsController       = inject[UserAccountsController]
-  private lazy val zms                          = inject[Signal[ZMessaging]]
 
   private lazy val inputBox = view[InputBox](R.id.input_box)
 
@@ -56,10 +53,7 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
   private lazy val readReceiptsToggle  = returning(view[SwitchCompat](R.id.read_receipts_toggle)) { vh =>
     findById[ImageView](R.id.read_receipts_icon).setImageDrawable(ViewWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
-    zms.flatMap(_.propertiesService.readReceiptsEnabled).onUi { readReceiptsEnabled =>
-      createConversationController.readReceipts ! readReceiptsEnabled
-      vh.foreach(_.setChecked(readReceiptsEnabled))
-    }
+    vh.foreach(_.setChecked(true))
 
     vh.foreach(_.setOnCheckedChangeListener(new OnCheckedChangeListener {
       override def onCheckedChanged(buttonView: CompoundButton, readReceiptsEnabled: Boolean): Unit =
@@ -151,5 +145,5 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 }
 
 object CreateConversationSettingsFragment {
-  val Tag = ZLog.ImplicitTag.implicitLogTag
+  val Tag = implicitLogTag
 }

--- a/app/src/main/scala/com/waz/zclient/messages/LikesController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/LikesController.scala
@@ -24,6 +24,7 @@ import com.waz.utils.events.{EventContext, EventStream, Signal}
 import com.waz.zclient.{Injectable, Injector}
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message.Type._
+import com.waz.model.MessageData
 
 class LikesController(implicit ec: EventContext, injector: Injector) extends Injectable {
 
@@ -49,4 +50,6 @@ class LikesController(implicit ec: EventContext, injector: Injector) extends Inj
 
 object LikesController {
   val LikeableMessages = Set(TEXT, TEXT_EMOJI_ONLY, ASSET, ANY_ASSET, VIDEO_ASSET, AUDIO_ASSET, RICH_MEDIA, LOCATION)
+
+  def isLikeable(m: MessageData): Boolean = LikeableMessages.contains(m.msgType)
 }


### PR DESCRIPTION
If the user is not on a team account, the message details should not display read receipts even if the message was sent by that user. It also means that if the message is ephemeral (or not-likeable for another reason) neither of the tabs is going to be displayed. In such case, the message details should not be opened at all.

The 'read receipts' switch on the create conversation screen should be always on. It should not depend on the user choice for sending read receipts.
#### APK
[Download build #12196](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12196/artifact/build/artifact/wire-dev-PR1917-12196.apk)
[Download build #12197](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12197/artifact/build/artifact/wire-dev-PR1917-12197.apk)
[Download build #12199](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12199/artifact/build/artifact/wire-dev-PR1917-12199.apk)