### PR TITLE
feat: Allow log in with an SSO id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "137.2197"
+    zMessagingDevVersion = "137.633-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '137.1.508@aar'

--- a/app/src/main/res/layout/remove_otr_device_dialog.xml
+++ b/app/src/main/res/layout/remove_otr_device_dialog.xml
@@ -30,9 +30,10 @@
     >
 
     <ScrollView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:overScrollMode="ifContentScrolls"
+        android:id="@+id/remove_otr_device_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:overScrollMode="ifContentScrolls"
         >
 
         <android.support.design.widget.TextInputLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -782,6 +782,7 @@
     <!-- OTR -->
     <string name="otr__remove_device__title">Remove %1$s</string>
     <string name="otr__remove_device__message">Enter your password</string>
+    <string name="otr__remove_device__are_you_sure">Are you sure?</string>
     <string name="otr__remove_device__default">device</string>
     <string name="otr__remove_device__button_delete">OK</string>
     <string name="otr__remove_device__button_cancel">Cancel</string>

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -51,6 +51,7 @@ trait SSOFragment extends FragmentHelper {
       case OnPositiveBtn(input) =>
         ssoService.extractUUID(input).foreach(uuid => verifyCode(uuid))
     }
+
     override def isInputInvalid(input: String): ValidatorResult =
       if (ssoService.isTokenValid(input.trim)) ValidatorResult.Valid
       else ValidatorResult.Invalid()

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -70,9 +70,9 @@ class SSOWebViewFragment extends FragmentHelper {
               activity.showFragment(FirstLaunchAfterLoginFragment(userId, ssoHadDB = hadDB), FirstLaunchAfterLoginFragment.Tag)
             case _ =>
               for {
-                am <- accountsService.accountManagers.head.map(_.find(_.userId == userId))
+                am      <- accountsService.accountManagers.head.map(_.find(_.userId == userId))
                 clState <- am.fold2(Future.successful(None), _.getOrRegisterClient().map(_.fold(_ => None, Some(_))))
-                _ <- accountsService.setAccount(Some(userId))
+                _       <- accountsService.setAccount(Some(userId))
               } getActivity.asInstanceOf[AppEntryActivity].onEnterApplication(openSettings = false, clState)
           }
         case Left(error) => showSSOError(error)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -176,10 +176,7 @@ class SignInFragment extends SSOFragment
     confirmationButton.foreach(_.setAccentColor(Color.WHITE))
     setConfirmationButtonActive(isValid.currentValue.getOrElse(false))
     forgotPasswordButton.foreach(_.setOnClickListener(this))
-    companyLoginButton.foreach { btn =>
-      if (IsProd) btn.setVisibility(View.GONE)
-      else btn.setOnClickListener(this)
-    }
+    companyLoginButton.foreach(_.setOnClickListener(this))
   }
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View =

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -23,6 +23,8 @@ import com.waz.service.{AccountsService, GlobalModule}
 import com.waz.threading.Threading
 import com.waz.zclient.{Injectable, Injector}
 
+import scala.concurrent.Future
+
 class PasswordController(implicit inj: Injector) extends Injectable {
   import Threading.Implicits.Background
 
@@ -32,10 +34,10 @@ class PasswordController(implicit inj: Injector) extends Injectable {
 
   //The password is never saved in the database, this will just update the in-memory version of the current account
   //so that the password is globally correct.
-  def setPassword(p: Password) =
+  def setPassword(p: Password): Future[Unit] =
     for {
       Some(accountData) <- accounts.activeAccount.head
-      _ <- global.accountsStorage.update(accountData.id, _.copy(password = Some(p)))
+      _                 <- global.accountsStorage.update(accountData.id, _.copy(password = Some(p)))
     } yield {}
 
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -43,19 +43,21 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
   import RemoveDeviceDialog._
   import Threading.Implicits.Ui
 
-  val onDelete = EventStream[Password]()
+  val onDelete = EventStream[Option[Password]]()
 
   private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.remove_otr_device_dialog, null)
 
-  private def providePassword(pwd: String): Unit = {
-    onDelete ! Password(pwd)
-    for {
-      zms         <- inject[Signal[ZMessaging]].head
-      Some(am)    <- zms.accounts.activeAccountManager.head
-      self        <- am.getSelf
-      Some(email) = self.email
-      _           <- zms.auth.onPasswordReset(Option(EmailCredentials(email, Password(pwd))))
-    } yield ()
+  private def providePassword(password: Option[Password]): Unit = {
+    onDelete ! password
+    password.foreach { pwd =>
+      for {
+        zms         <- inject[Signal[ZMessaging]].head
+        Some(am)    <- zms.accounts.activeAccountManager.head
+        self        <- am.getSelf
+        Some(email) = self.email
+        _           <- zms.auth.onPasswordReset(Option(EmailCredentials(email, pwd)))
+      } yield ()
+    }
     dismiss()
   }
 
@@ -64,7 +66,7 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
       def onEditorAction(v: TextView, actionId: Int, event: KeyEvent) =
         actionId match {
           case EditorInfo.IME_ACTION_DONE =>
-            providePassword(v.getText.toString)
+            providePassword(Some(Password(v.getText.toString)))
             true
           case _ => false
         }
@@ -77,15 +79,21 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
     _.onClick(inject[BrowserController].openForgotPasswordPage())
   }
 
+  private var isSSO = false
+
   override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
-    passwordEditText
-    textInputLayout
-    forgotPasswordButton
+    isSSO = getArguments.getBoolean(IsSSOARG)
+    if(isSSO){
+      findById[View](root, R.id.remove_otr_device_scrollview).setVisible(false)
+    }
+    passwordEditText.setVisible(!isSSO)
+    textInputLayout.setVisible(!isSSO)
+    forgotPasswordButton.setVisible(!isSSO)
     Option(getArguments.getString(ErrorArg)).foreach(textInputLayout.setError)
     new AlertDialog.Builder(getActivity)
       .setView(root)
       .setTitle(getString(R.string.otr__remove_device__title, getArguments.getString(NameArg, getString(R.string.otr__remove_device__default))))
-      .setMessage(R.string.otr__remove_device__message)
+      .setMessage(if (isSSO) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message)
       .setPositiveButton(R.string.otr__remove_device__button_delete, null)
       .setNegativeButton(R.string.otr__remove_device__button_cancel, null)
       .create
@@ -95,7 +103,8 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
     super.onStart()
     Try(getDialog.asInstanceOf[AlertDialog]).toOption.foreach { d =>
       d.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-        def onClick(v: View) = providePassword(passwordEditText.getText.toString)
+        def onClick(v: View) =
+          providePassword(if (isSSO) None else Some(Password(passwordEditText.getText.toString)))
       })
     }
   }
@@ -110,12 +119,14 @@ object RemoveDeviceDialog {
   val FragmentTag = RemoveDeviceDialog.getClass.getSimpleName
   private val NameArg  = "ARG_NAME"
   private val ErrorArg = "ARG_ERROR"
+  private val IsSSOARG = "ARG_IS_SSO"
 
-  def newInstance(deviceName: String, error: Option[String]): RemoveDeviceDialog =
+  def newInstance(deviceName: String, error: Option[String], isSSO: Boolean): RemoveDeviceDialog =
     returning(new RemoveDeviceDialog) {
       _.setArguments(returning(new Bundle()) { b =>
         b.putString(NameArg, deviceName)
         error.foreach(b.putString(ErrorArg, _))
+        b.putBoolean(IsSSOARG, isSSO)
       })
     }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -233,12 +233,12 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
 
   view.onDeviceRemoved { _ =>
     passwordController.password.head.map {
-      case Some(p) => removeDevice(p)
-      case _ => showRemoveDeviceDialog()
+      case Some(p)       => removeDevice(Some(p))
+      case _                => showRemoveDeviceDialog()
     }
   }
 
-  private def removeDevice(password: Password): Unit = {
+  private def removeDevice(password: Option[Password] = None): Unit = {
     spinnerController.showDimmedSpinner(show = true)
     for {
       am           <- accountManager.head
@@ -246,10 +246,10 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
         case LimitReached => true
         case _ => false
       }
-      _ <- am.deleteClient(clientId, password).map { //TODO use password instead of str
+      _ <- am.deleteClient(clientId, password).map {
         case Right(_) =>
           for {
-            _ <- passwordController.setPassword(password)
+            _ <- password.fold(Future.successful({}))(passwordController.setPassword)
             _ <- if (limitReached) am.getOrRegisterClient() else Future.successful({})
             _ <- Threading.Ui {
               spinnerController.showSpinner(false)
@@ -266,8 +266,8 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
   }
 
   private def showRemoveDeviceDialog(error: Option[String] = None): Unit = {
-    model.head.map { n =>
-      val fragment = returning(RemoveDeviceDialog.newInstance(n, error))(_.onDelete(removeDevice))
+    Signal(accounts.isActiveAccountSSO, model).head.foreach { case (isSSO, name) =>
+      val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onDelete(removeDevice))
       context.asInstanceOf[BaseActivity]
         .getSupportFragmentManager
         .beginTransaction


### PR DESCRIPTION
SSO login ("Company login") is now enabled on production.
If the user is logged in via SSO, it overrides email, phone, and password - wherever these three are requested, if SSO Id is present, they are not needed anymore.
In case of removing a client we still want the user to confirm that this is what they want, since a client removed by accident might be a bad mistake. In that case, `RemoveDeviceDialog` shows only "Are you sure?" and no edit box for the password.

SE: https://github.com/wireapp/wire-android-sync-engine/pull/460