### PR TITLE
fix: Messages should refresh when likes or quotes change

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
@@ -99,7 +99,7 @@ object MessagesPagedListAdapter {
   val MessageDataDiffCallback: DiffUtil.ItemCallback[MessageAndLikes] = new DiffUtil.ItemCallback[MessageAndLikes] {
     override def areItemsTheSame(o: MessageAndLikes, n: MessageAndLikes): Boolean = n.message.id == o.message.id
     override def areContentsTheSame(o: MessageAndLikes, n: MessageAndLikes): Boolean =
-      areMessageContentsTheSame(o.message, n.message)
+      areMessageAndLikesTheSame(o, n)
   }
 
   def areMessageContentsTheSame(prev: MessageData, updated: MessageData): Boolean = {
@@ -107,5 +107,11 @@ object MessagesPagedListAdapter {
       updated.expired == prev.expired &&
       updated.imageDimensions == prev.imageDimensions &&
       updated.content.find(_.openGraph.nonEmpty) == prev.content.find(_.openGraph.nonEmpty)
+  }
+
+  def areMessageAndLikesTheSame(prev: MessageAndLikes, updated: MessageAndLikes): Boolean = {
+    areMessageContentsTheSame(prev.message, updated.message) &&
+    prev.likes.toSet == updated.likes.toSet &&
+    prev.quote == updated.quote
   }
 }


### PR DESCRIPTION
MessageData doesn't contain information regarding its likes or quotes, meaning that the DiffCallback must use also the information in MessageAndLikes regarding likes and quotes.

fixes: https://github.com/wireapp/android-project/issues/383
fixes: https://github.com/wireapp/android-project/issues/384
fixes: https://github.com/wireapp/android-project/issues/386
#### APK
[Download build #12276](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12276/artifact/build/artifact/wire-dev-PR1963-12276.apk)