### PR TITLE
Add feature flag for analytics popup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -202,6 +202,7 @@ android {
             buildConfigField 'String',  'FIREBASE_API_KEY',           "\"$config.firebaseApiKey\""
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
+            buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         }
 
         candidate {
@@ -223,6 +224,7 @@ android {
             buildConfigField 'String',  'FIREBASE_API_KEY',           "\"$config.firebaseApiKey\""
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
+            buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         }
 
         prod {
@@ -243,6 +245,7 @@ android {
             buildConfigField 'String',  'FIREBASE_API_KEY',           "\"$config.firebaseApiKey\""
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
+            buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         }
 
         internal {
@@ -264,6 +267,7 @@ android {
             buildConfigField 'String',  'FIREBASE_API_KEY',           "\"$config.firebaseApiKey\""
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
+            buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         }
 
         experimental {
@@ -285,6 +289,7 @@ android {
             buildConfigField 'String',  'FIREBASE_API_KEY',           "\"$config.firebaseApiKey\""
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
+            buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -48,6 +48,7 @@ import com.waz.zclient.tracking.GlobalTrackingController.analyticsPrefKey
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.views.menus.ConfirmationMenu
 import com.waz.zclient.{ErrorsController, FragmentHelper, OnBackPressedListener, R}
+import com.waz.zclient.BuildConfig
 
 import scala.concurrent.Future
 
@@ -84,8 +85,11 @@ class MainPhoneFragment extends FragmentHelper
   lazy val consentDialogFuture = for {
     true <- inject[GlobalModule].prefs(GlobalPreferences.ShowMarketingConsentDialog).apply()
     am   <- am.head
-    analyticsShown <- am.userPrefs(CrashesAndAnalyticsRequestShown).apply()
-    _ <- if (analyticsShown) Future.successful({}) else
+    showAnalyticsPopup <- am.userPrefs(CrashesAndAnalyticsRequestShown).apply().map {
+      previouslyShown => !previouslyShown && BuildConfig.SUBMIT_CRASH_REPORTS
+    }
+    // Show "Help make wire better" popup
+    _ <- if (!showAnalyticsPopup) Future.successful({}) else
       showConfirmationDialog(
         getString(R.string.crashes_and_analytics_request_title),
         getString(R.string.crashes_and_analytics_request_body),
@@ -101,6 +105,7 @@ class MainPhoneFragment extends FragmentHelper
         }
       }
     askMarketingConsentAgain <- am.userPrefs(UserPreferences.AskMarketingConsentAgain).apply()
+    // Show marketing consent popup
     _ <- if (!askMarketingConsentAgain) Future.successful({}) else
       showConfirmationDialogWithNeutralButton(
         R.string.receive_news_and_offers_request_title,

--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
   "firebasePushSenderId": "782078216207",
   "firebaseAppId": "1:782078216207:android:d3db2443512d2055",
   "firebaseApiKey": "AIzaSyBdYVv2f-Y7JJmHVmDNCKgWvX6Isa8rAGA",
+  "submitCrashReports": true,
   "certificatePin" : {
       "domain": "*.wire.com",
       "certificate" : [


### PR DESCRIPTION
# Why

The "Help to make Wire better" popup should be disabled by a feature flag in custom builds

# How

Added a new build config variable, `SUBMIT_CRASH_REPORTS`, loaded from the customization JSON file.

# Testing

No testing coverage for this feature, as this is not easily testable. I manually tested it on device.

# Future improvements needed

- Remove code duplication in the `build.gradle`, so that the common build config fields are only defined once. Will try in a separate PR.
- Test whether the popup should be shown. However at the moment the build config values are hardcoded and can't be edited for testing, and this part of the UI doesn't seem easily testable. Will be addressed as part of a larger architectural change.
#### APK
[Download build #12281](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12281/artifact/build/artifact/wire-dev-PR1964-12281.apk)