### PR TITLE
Add feature flag for "data permission" options in account

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,6 +196,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
+            buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         }
 
         candidate {
@@ -218,6 +219,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
+            buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         }
 
         prod {
@@ -239,6 +241,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
+            buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         }
 
         internal {
@@ -261,6 +264,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
+            buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         }
 
         experimental {
@@ -283,6 +287,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_DOMAIN',     "\"$config.certificatePin.domain\""
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
+            buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         }
     }
 

--- a/app/src/main/res/layout/preferences_account_layout.xml
+++ b/app/src/main/res/layout/preferences_account_layout.xml
@@ -117,6 +117,7 @@
                 />
 
             <com.waz.zclient.ui.text.TypefaceTextView
+                android:id="@+id/preference_personal_information_header"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"
                 android:text="@string/pref_account_personal_information_category_title"

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -86,7 +86,8 @@ class MainPhoneFragment extends FragmentHelper
     true <- inject[GlobalModule].prefs(GlobalPreferences.ShowMarketingConsentDialog).apply()
     am   <- am.head
     showAnalyticsPopup <- am.userPrefs(CrashesAndAnalyticsRequestShown).apply().map {
-      previouslyShown => !previouslyShown && BuildConfig.SUBMIT_CRASH_REPORTS
+      previouslyShown =>
+        !previouslyShown && BuildConfig.SUBMIT_CRASH_REPORTS
     }
     // Show "Help make wire better" popup
     _ <- if (!showAnalyticsPopup) Future.successful({}) else

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -42,9 +42,11 @@ import com.waz.zclient.common.views.ImageController.{ImageSource, WireImage}
 import com.waz.zclient.preferences.dialogs._
 import com.waz.zclient.preferences.views.{EditNameDialog, PictureTextButton, SwitchPreference, TextButton}
 import com.waz.zclient.ui.utils.TextViewUtils._
+import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.ViewUtils._
 import com.waz.zclient.utils.{BackStackKey, BackStackNavigator, RichView, StringUtils, UiStorage}
+import com.waz.zclient.BuildConfig
 
 trait AccountView {
   val onNameClick:          EventStream[Unit]
@@ -91,6 +93,13 @@ class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   val backupButton        = findById[TextButton](R.id.preferences_backup)
   val dataUsageButton     = findById[TextButton](R.id.preferences_data_usage_permissions)
   val readReceiptsSwitch  = findById[SwitchPreference](R.id.preferences_account_read_receipts)
+  val personalInformationHeaderLabel = findById[TypefaceTextView](R.id.preference_personal_information_header)
+
+  // Hide data usage section if there is nothing to show in there
+  val showPersonalInformationSection = BuildConfig.SUBMIT_CRASH_REPORTS || BuildConfig.ALLOW_MARKETING_COMMUNICATION
+  dataUsageButton.setVisible(showPersonalInformationSection)
+  personalInformationHeaderLabel.setVisible(showPersonalInformationSection)
+
 
   override val onNameClick          = nameButton.onClickEvent.map(_ => ())
   override val onHandleClick        = handleButton.onClickEvent.map(_ => ())

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
@@ -75,11 +75,9 @@ class DataUsagePermissionsView(context: Context, attrs: AttributeSet, style: Int
         v.onCheckedChange.onUi { set =>
           setReceivingNewsAndOffersSwitchEnabled(false)
           am.head.flatMap(_.setMarketingConsent(Some(set))).foreach { resp =>
-            resp match {
-              case Right(_) => //
-              case Left(_)  =>
-                v.setChecked(!set, disableListener = true) //set switch back to whatever it was
-                ContextUtils.showGenericErrorDialog()
+            if (resp.isLeft) {
+              v.setChecked(!set, disableListener = true) //set switch back to whatever it was
+              ContextUtils.showGenericErrorDialog()
             }
             setReceivingNewsAndOffersSwitchEnabled(true)
           }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
@@ -23,7 +23,6 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
-import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
 import com.waz.service.AccountManager
 import com.waz.threading.Threading

--- a/default.json
+++ b/default.json
@@ -12,6 +12,7 @@
   "firebaseAppId": "1:782078216207:android:d3db2443512d2055",
   "firebaseApiKey": "AIzaSyBdYVv2f-Y7JJmHVmDNCKgWvX6Isa8rAGA",
   "submitCrashReports": true,
+  "allowMarketingCommunication": true,
   "certificatePin" : {
       "domain": "*.wire.com",
       "certificate" : [


### PR DESCRIPTION
# Reason for this pull request

Need to add feature flags for some options in the data permission settings, namely:
- Send anonymous crash reports
- Allow marketing communication

We want to hide those options completely when the feature flag is removed.

# Changes

Removed the to individual options if the flags are false, and also removed the main "data permission" setting button if both flags are false, as there is no point in having an empty section.

# Testing
See the issue with testing in https://github.com/wireapp/wire-android/pull/1964
#### APK
[Download build #12292](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12292/artifact/build/artifact/wire-dev-PR1967-12292.apk)