### PR TITLE
Don't include translations for whitelabel builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -326,7 +326,10 @@ dependencies {
 
     //wire libraries:
     implementation "com.wire:audio-notifications:$audioVersion"
-    implementation 'com.wire:wiretranslations:1.+'
+    //don't include wire translations for custom builds
+    if (customRepository.isEmpty() || token.isEmpty()) {
+        implementation 'com.wire:wiretranslations:1.+'
+    }
 
     // TODO  Nasty hack to be able to build add only one wire-core flavor to the build
 


### PR DESCRIPTION
This is necessary to facilitate copying custom translations over.
#### APK
[Download build #12288](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12288/artifact/build/artifact/wire-dev-PR1969-12288.apk)