### PR TITLE
chore: SE bump for fixing a bug in sending a typing indicator event

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "138.2214"
+    zMessagingDevVersion = "139.690-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '139.0.510@aar'


### PR DESCRIPTION
SE: https://github.com/wireapp/wire-android-sync-engine/pull/480

fixes: https://github.com/wireapp/android-project/issues/392

How to test:
* Type something.
* Check on another device (not necessarily with this patch) that you see the typing indicator
#### APK
[Download build #12289](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12289/artifact/build/artifact/wire-dev-PR1972-12289.apk)