### PR TITLE
Feature flag to disable changing email in account

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,6 +197,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
             buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
+            buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
         }
 
         candidate {
@@ -220,6 +221,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
             buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
+            buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
         }
 
         prod {
@@ -242,6 +244,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
             buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
+            buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
         }
 
         internal {
@@ -265,6 +268,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
             buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
+            buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
         }
 
         experimental {
@@ -288,6 +292,7 @@ android {
             buildConfigField 'String',  'CERTIFICATE_PIN_BYTES',      "\"$certPinBytes\""
             buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
             buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
+            buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -226,7 +226,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
     } (Threading.Ui)
   }
 
-  view.onEmailClick.onUi { _ =>
+  view.onEmailClick.filter( _ => BuildConfig.ALLOW_CHANGE_OF_EMAIL).onUi { _ =>
     import Threading.Implicits.Ui
     accounts.activeAccountManager.head.map(_.foreach(_.hasPassword().foreach {
       case Left(ex) => val (h, b) = DialogErrorMessage.genericError(ex.code)

--- a/default.json
+++ b/default.json
@@ -13,6 +13,7 @@
   "firebaseApiKey": "AIzaSyBdYVv2f-Y7JJmHVmDNCKgWvX6Isa8rAGA",
   "submitCrashReports": true,
   "allowMarketingCommunication": true,
+  "allowChangeOfEmail": true,
   "certificatePin" : {
       "domain": "*.wire.com",
       "certificate" : [


### PR DESCRIPTION
# Reason for this pull request

Add a feature flag `ALLOW_CHANGE_OF_EMAIL` to disable changing email in account settings

# Changes

Added a feature flag and ignore taps on the email label. It's still a button, but it won't do anything.

# Testing

Manually tested on device (both on and off)

# Limitations
See https://github.com/wireapp/wire-android/pull/1967 for limitations
#### APK
[Download build #12300](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12300/artifact/build/artifact/wire-dev-PR1975-12300.apk)