### PR TITLE
Add logic to check if translations are included

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
@@ -72,12 +72,14 @@ class AboutView(context: Context, attrs: AttributeSet, style: Int) extends Linea
 
   def getVersion(implicit context: Context): String = {
     val md = inject[MetaDataService]
+    val translationId = getResources.getIdentifier("wiretranslations_version", "string", context.getPackageName)
+    val translationLibVersion = if(translationId == 0) "n/a" else getString(translationId)
     s"""
       |Version:             ${md.versionName} (${md.appVersion}
       |Sync Engine:         ${ZmsVersion.ZMS_VERSION}
       |AVS:                 ${getString(R.string.avs_version)}
       |Audio-notifications: ${getString(R.string.audio_notifications_version)}
-      |Translations:        ${getString(R.string.wiretranslations_version)}
+      |Translations:        $translationLibVersion
       |Locale:              $getLocale
     """.stripMargin
   }


### PR DESCRIPTION
 - This prevents a crash when making whitelabel builds and the
   translation lib version string can't be found
#### APK
[Download build #12321](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12321/artifact/build/artifact/wire-dev-PR1980-12321.apk)