### PR TITLE
fix: cleared convs should show after being opened

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -92,7 +92,7 @@ class ConversationListController(implicit inj: Injector, ec: EventContext) exten
 
 object ConversationListController {
 
-  lazy val RegularListFilter: (ConversationData => Boolean) = { c => Set(ConversationType.OneToOne, ConversationType.Group, ConversationType.WaitForConnection).contains(c.convType) && !c.hidden && !c.archived && !c.completelyCleared }
+  lazy val RegularListFilter: (ConversationData => Boolean) = { c => Set(ConversationType.OneToOne, ConversationType.Group, ConversationType.WaitForConnection).contains(c.convType) && !c.hidden && !c.archived}
   lazy val IncomingListFilter: (ConversationData => Boolean) = { c => !c.hidden && !c.archived && c.convType == ConversationType.Incoming }
   lazy val ArchivedListFilter: (ConversationData => Boolean) = { c => Set(ConversationType.OneToOne, ConversationType.Group, ConversationType.Incoming, ConversationType.WaitForConnection).contains(c.convType) && !c.hidden && c.archived && !c.completelyCleared }
   lazy val EstablishedListFilter: (ConversationData => Boolean) = { c => RegularListFilter(c) && c.convType != ConversationType.WaitForConnection }


### PR DESCRIPTION
 - This commit ensures that cleared conversations that have been opened
   since being cleared are shown in the conversation list again.
   We archive cleared conversations which shouldn't be shown, so we use
   the archive flag to determine what should be shown.
 - This ensures parity with iOS.
 - Fixes wireapp/android-project#391
#### APK
[Download build #12332](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12332/artifact/build/artifact/wire-dev-PR1987-12332.apk)