### PR TITLE
Fix sorting of likes

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
@@ -37,7 +37,7 @@ class LikeDetailsView(context: Context, attrs: AttributeSet, style: Int) extends
   private val description: TextView = findById(R.id.like__description)
 
   def init(controller: FooterViewController): Unit = {
-    val likedBy = controller.messageAndLikes.map(_.likes.sortBy(_.str))
+    val likedBy = controller.messageAndLikes.map(_.likes)
 
     def getDisplayNameString(ids: Seq[UserId]): Signal[String] = {
       if (ids.size > 3)


### PR DESCRIPTION
# Reason for this pull request

Users that liked a message are displayed under the message in the wrong order. According to specs, they should be sorted by time of like.

# Changes

There was an unnecessary resorting of likes that was sorting them by user ID. The likes are already passed in the correct order from sync engine.

# Testing

Manual testing on device with a message with three "likers", before the fix and after the fix. Behave as expected.

#### APK
[Download build #12338](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12338/artifact/build/artifact/wire-dev-PR1988-12338.apk)