### PR TITLE
Fix/missing phone number

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -177,7 +177,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
     p      <- phone
     isTeam <- isTeam
     sso    <- accounts.isActiveAccountSSO
-  } yield sso && (p.isDefined || !isTeam)
+  } yield !sso && (p.isDefined || !isTeam)
 
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -173,9 +173,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   val phone = self.map(_.phone)
   val email = self.map(_.email)
 
-  val isPhoneNumberEnabled = for {
-    isTeam <- isTeam
-  } yield !isTeam
+  val isPhoneNumberEnabled = isTeam.map(!_)
 
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -174,10 +174,8 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   val email = self.map(_.email)
 
   val isPhoneNumberEnabled = for {
-    p      <- phone
     isTeam <- isTeam
-    sso    <- accounts.isActiveAccountSSO
-  } yield !sso && (p.isDefined || !isTeam)
+  } yield !isTeam
 
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
 


### PR DESCRIPTION
# Reason for this pull request

There was no option anymore to change or add the phone in the account settings. This was a regression. The intended behavior is:

| User type | Add/change phone |
|----|--------------|
|Personal account|✅|
|Team user|❌|
|SSO user (*)|❌|

(*) currently only team users can be SSO users, so the distinction is irrelevant, but it was present in the code before.

# Changes

Changed the condition for deciding whether to show the phone number field. Team users won't show the phone field (regardless of whether the user is a SSO user or not).

# Testing

This has been manually tested on device with:
- a personal account
- a non-SSO team account
- an SSO account

In all cases, the field is present/not present in the account settings as expected.