### PR TITLE
Readonly profiles

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -192,7 +192,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
 
   //TODO: Replace with flag coming from self
-  private val accountIsLocked = Signal.const(true)
+  private val accountIsLocked = Signal.const(false)
 
   accountIsLocked.onUi { locked =>
     view.setAccountLocked(locked)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -73,6 +73,7 @@ trait AccountView {
   def setPhoneNumberEnabled(enabled: Boolean): Unit
   def setReadReceipt(enabled: Boolean): Unit
   def setResetPasswordEnabled(enabled: Boolean): Unit
+  def setAccountLocked(locked: Boolean): Unit
 }
 
 class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with AccountView with ViewHelper {
@@ -135,6 +136,15 @@ class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   override def setReadReceipt(enabled: Boolean) = readReceiptsSwitch.setChecked(enabled, disableListener = true)
 
   override def setResetPasswordEnabled(enabled: Boolean) = resetPasswordButton.setVisible(enabled)
+
+  override def setAccountLocked(locked: Boolean): Unit = {
+    nameButton.setEnabled(!locked)
+    handleButton.setEnabled(!locked)
+    emailButton.setEnabled(!locked)
+    phoneButton.setEnabled(!locked)
+    pictureButton.setEnabled(!locked)
+    colorButton.setEnabled(!locked)
+  }
 }
 
 case class AccountBackStackKey(args: Bundle = new Bundle()) extends BackStackKey(args) {
@@ -180,6 +190,13 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   } yield sso && (p.isDefined || !isTeam)
 
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
+
+  //TODO: Replace with flag coming from self
+  private val accountIsLocked = Signal.const(true)
+
+  accountIsLocked.onUi { locked =>
+    view.setAccountLocked(locked)
+  }
 
   view.setPictureDrawable(new ImageAssetDrawable(selfPicture, scaleType = ScaleType.CenterInside, request = RequestBuilder.Round))
 


### PR DESCRIPTION
This adds a method to lock the properties on the account page that the user can't edit if their profile is readonly. 

The flag isn't implemented on SE yet so right now the readonly value is mocked.
#### APK
[Download build #12343](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12343/artifact/build/artifact/wire-dev-PR1990-12343.apk)
[Download build #12344](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12344/artifact/build/artifact/wire-dev-PR1990-12344.apk)