### PR TITLE
Add flag to control logging on custom builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,6 @@ android {
         buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
-        buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
     }
 
     packagingOptions {
@@ -206,6 +205,7 @@ android {
                                     sharedUserId           : "",
                                     internal_features      : "true"]
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
+            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
         }
 
         candidate {
@@ -217,6 +217,7 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
+            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
         }
 
         prod {
@@ -227,6 +228,7 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
+            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
         }
 
         internal {
@@ -238,6 +240,7 @@ android {
                                     internal_features: "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
+            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
         }
 
         experimental {
@@ -249,6 +252,7 @@ android {
                                     internal_features      : "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
+            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ android {
         buildConfigField 'boolean',  'SUBMIT_CRASH_REPORTS',      "$config.submitCrashReports"
         buildConfigField 'boolean',  'ALLOW_MARKETING_COMMUNICATION',      "$config.allowMarketingCommunication"
         buildConfigField 'boolean', 'ALLOW_CHANGE_OF_EMAIL',      "$config.allowChangeOfEmail"
+        buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -271,8 +271,8 @@ package object utils {
   val InternalId     = "com.wire.internal"
   val ExperimentalId = "com.wire.x"
 
-  val IsProd: Boolean = Set(ProdId, CandidateId).exists(BuildConfig.APPLICATION_ID.contains)
-  val SafeLoggingEnabled: Boolean = Set(ProdId, CandidateId, InternalId).exists(BuildConfig.APPLICATION_ID.contains)
+  val SafeLoggingEnabled: Boolean = BuildConfig.FORCE_ENABLE_LOGGING ||
+    Set(ProdId, CandidateId, InternalId).contains(BuildConfig.APPLICATION_ID)
 
   def format(className: String, oneLiner: Boolean, fields: (String, Option[Any])*): String = {
     val fieldsIt = fields.collect { case (key, Some(value)) => key -> value.toString }.toList.iterator

--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -265,14 +265,7 @@ package object utils {
       } mkString " "
   }
 
-  val DevId          = "com.waz.zclient.dev"
-  val CandidateId    = "com.wire.candidate"
-  val ProdId         = "com.wire"
-  val InternalId     = "com.wire.internal"
-  val ExperimentalId = "com.wire.x"
-
-  val SafeLoggingEnabled: Boolean = BuildConfig.FORCE_ENABLE_LOGGING ||
-    Set(ProdId, CandidateId, InternalId).contains(BuildConfig.APPLICATION_ID)
+  val SafeLoggingEnabled: Boolean = BuildConfig.FORCE_ENABLE_LOGGING
 
   def format(className: String, oneLiner: Boolean, fields: (String, Option[Any])*): String = {
     val fieldsIt = fields.collect { case (key, Some(value)) => key -> value.toString }.toList.iterator

--- a/default.json
+++ b/default.json
@@ -19,5 +19,6 @@
   "certificatePin" : {
       "domain": "*.wire.com",
       "certificate" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreYzBWuvnVKYfgNNX3dVjUnqIVtl4XqQnCcY6m/sWM15TTK0bo9FKnMxNAPtDzB6ViRvpZsKEefX8pi15Jcs4uZiuZ81ISV1bqxtpsjJ56Yjeme99Dca5ck35pThYuK6jZ8vG6pJiY9mRY9nGadid4qWL7uwAeoInx2mOM7HepCCh2NOXd+EjQ4sBsfgb+kWrcVQmBzvLHPUDoykm/m+BvL2eJ1njPNiM/GoeXbmIW1WM3ifucYJoD9g+V5NfHfANrVu2w4YcLDad0C85Nb8U1sgFNkrgOqzhd/1xHok1uOyjoeLTIHHYkryvbBEmdl6v+f2J1EM0+Fj9vseI2TYrQIDAQAB"
-  }
+  },
+  "forceEnableLogging": false
 }


### PR DESCRIPTION
# Reason for this pull request

On custom builds, logs were disabled. We want to enable them to debug.

# Changes
- Added a new flag to force logging to be enabled, regardless of the application ID. Since the application ID is personalized for custom applications, we can't hardcode any application ID to test against
- Removed this line as it was unused: https://github.com/wireapp/wire-android/blob/ec206db070964ba7e7f9cba95c1921c0e59abd48/app/src/main/scala/com/waz/zclient/utils/package.scala#L274

# Testing
Will be tested by @jspittka on a custom build.

#### APK
[Download build #12345](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12345/artifact/build/artifact/wire-dev-PR1991-12345.apk)
[Download build #12347](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12347/artifact/build/artifact/wire-dev-PR1991-12347.apk)