### PR TITLE
Split logging flags in two

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -205,7 +205,8 @@ android {
                                     sharedUserId           : "",
                                     internal_features      : "true"]
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
 
         candidate {
@@ -217,7 +218,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         prod {
@@ -228,7 +230,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
-            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        "$config.forceEnableLogging"
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         internal {
@@ -240,7 +243,8 @@ android {
                                     internal_features: "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
-            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         experimental {
@@ -252,7 +256,8 @@ android {
                                     internal_features      : "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'FORCE_ENABLE_LOGGING',        'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -84,7 +84,7 @@ import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
-import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendPicker, Callback, ExternalFileSharing, LocalThumbnailCache, SafeLoggingEnabled, UiStorage}
+import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendPicker, Callback, ExternalFileSharing, LocalThumbnailCache, UiStorage}
 import com.waz.zclient.views.DraftMap
 import javax.net.ssl.SSLContext
 import org.threeten.bp.Clock
@@ -341,9 +341,10 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     SafeBase64.setDelegate(new AndroidBase64Delegate)
 
-    if (!SafeLoggingEnabled) {
-      InternalLog.add(new AndroidLogOutput(showSafeOnly = SafeLoggingEnabled))
-      InternalLog.add(new BufferedLogOutput(baseDir = getApplicationContext.getApplicationInfo.dataDir, showSafeOnly = SafeLoggingEnabled))
+    if (BuildConfig.LOGGING_ENABLED) {
+      InternalLog.add(new AndroidLogOutput(showSafeOnly = BuildConfig.SAFE_LOGGING))
+      InternalLog.add(new BufferedLogOutput(baseDir = getApplicationContext.getApplicationInfo.dataDir,
+        showSafeOnly = BuildConfig.SAFE_LOGGING))
     }
 
     verbose("onCreate")

--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -265,8 +265,6 @@ package object utils {
       } mkString " "
   }
 
-  val SafeLoggingEnabled: Boolean = BuildConfig.FORCE_ENABLE_LOGGING
-
   def format(className: String, oneLiner: Boolean, fields: (String, Option[Any])*): String = {
     val fieldsIt = fields.collect { case (key, Some(value)) => key -> value.toString }.toList.iterator
 

--- a/default.json
+++ b/default.json
@@ -20,5 +20,5 @@
       "domain": "*.wire.com",
       "certificate" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreYzBWuvnVKYfgNNX3dVjUnqIVtl4XqQnCcY6m/sWM15TTK0bo9FKnMxNAPtDzB6ViRvpZsKEefX8pi15Jcs4uZiuZ81ISV1bqxtpsjJ56Yjeme99Dca5ck35pThYuK6jZ8vG6pJiY9mRY9nGadid4qWL7uwAeoInx2mOM7HepCCh2NOXd+EjQ4sBsfgb+kWrcVQmBzvLHPUDoykm/m+BvL2eJ1njPNiM/GoeXbmIW1WM3ifucYJoD9g+V5NfHfANrVu2w4YcLDad0C85Nb8U1sgFNkrgOqzhd/1xHok1uOyjoeLTIHHYkryvbBEmdl6v+f2J1EM0+Fj9vseI2TYrQIDAQAB"
   },
-  "forceEnableLogging": false
+  "loggingEnabled": false
 }


### PR DESCRIPTION
# Reason for this pull request

Differentiate between logging enabled and safe logging. These are two different concerns.

This is a follow up to: https://github.com/wireapp/wire-android/pull/1991

# Changes
Add two separate flags
- `LOGGING_ENABLED`, which depends on the configuration JSON
- `SAFE_LOGGING`, which depends on the build flavor. It will always be on for production and candidate.

# Testing
No automated testing. @jspittka will test on the custom build
#### APK
[Download build #12350](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12350/artifact/build/artifact/wire-dev-PR1992-12350.apk)