### PR TITLE
Disable logging on all builds but dev

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -218,8 +218,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
 
         prod {
@@ -230,8 +230,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
 
         internal {
@@ -243,8 +243,8 @@ android {
                                     internal_features: "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
 
         experimental {
@@ -256,7 +256,7 @@ android {
                                     internal_features      : "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
             buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
         }
     }


### PR DESCRIPTION
# Reason for this pull request
This is reverting a previous commit (3012f1e672600b187aea89de0e2103a26cc86c91) because logging causes a crash on all builds but dev. Once the cause of the crash is found, logging will be re-enabled.

# Changes
Disable logging on all builds but dev

#### APK
[Download build #12352](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12352/artifact/build/artifact/wire-dev-PR1993-12352.apk)