### PR TITLE
Re-enable logging and fix logging crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -218,8 +218,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         prod {
@@ -230,8 +230,8 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        "true"
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         internal {
@@ -243,8 +243,8 @@ android {
                                     internal_features: "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 
         experimental {
@@ -256,8 +256,8 @@ android {
                                     internal_features      : "true"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'false'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
     }
 

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -21,8 +21,9 @@
    *** get*();
 }
 
--keep class scala.collection.SeqLike { public java.lang.String toString(); }
+# Needed for logging
 -keepclassmembers class * { public java.lang.String toString(); }
+
 -keep class scala.concurrent.forkjoin.** { *; }
 -keep class org.webrtc.** { *; }
 -keep class com.waz.call.FlowManager { *; }

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -22,6 +22,7 @@
 }
 
 -keep class scala.collection.SeqLike { public java.lang.String toString(); }
+-keepclassmembers class * { public java.lang.String toString(); }
 -keep class scala.concurrent.forkjoin.** { *; }
 -keep class org.webrtc.** { *; }
 -keep class com.waz.call.FlowManager { *; }


### PR DESCRIPTION
# Reason for this pull request

Logs were disabled on all build but devs because logs would crash due to `java.lang.Object.toString` not being available.

# Changes

This commit reverts e5969077a4c251437f35eb0e11bb9c62c158e56c, effectivelly re-applying 3012f1e672600b187aea89de0e2103a26cc86c91.

The real fix is to make sure that the `toString` method is not stripped for any object by proguard.

# Testing

I build a experimental release build locally before and after the fix. Before the fix, I would see the exception in the logs at every start. After the fix, the exception is gone.
#### APK
[Download build #12353](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12353/artifact/build/artifact/wire-dev-PR1994-12353.apk)
[Download build #12354](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12354/artifact/build/artifact/wire-dev-PR1994-12354.apk)