### PR TITLE
feat: force readonly profile for sso users

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "139.2224"
+    zMessagingDevVersion = "139.725-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '139.0.510@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "139.725-PR"
+    zMessagingDevVersion = "139.2227"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '139.0.510@aar'

--- a/app/src/main/res/layout/preferences_account_layout.xml
+++ b/app/src/main/res/layout/preferences_account_layout.xml
@@ -73,6 +73,7 @@
                 />
 
             <com.waz.zclient.ui.text.TypefaceTextView
+                android:id="@+id/preferences_account_appearance_header"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"
                 android:text="@string/pref_account_appearance_category_title"

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -95,6 +95,7 @@ class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   val dataUsageButton     = findById[TextButton](R.id.preferences_data_usage_permissions)
   val readReceiptsSwitch  = findById[SwitchPreference](R.id.preferences_account_read_receipts)
   val personalInformationHeaderLabel = findById[TypefaceTextView](R.id.preference_personal_information_header)
+  val appearanceHeader = findById[TypefaceTextView](R.id.preferences_account_appearance_header)
 
   // Hide data usage section if there is nothing to show in there
   val showPersonalInformationSection = BuildConfig.SUBMIT_CRASH_REPORTS || BuildConfig.ALLOW_MARKETING_COMMUNICATION
@@ -144,6 +145,9 @@ class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     phoneButton.setEnabled(!locked)
     pictureButton.setEnabled(!locked)
     colorButton.setEnabled(!locked)
+    appearanceHeader.setVisible(!locked)
+    pictureButton.setVisible(!locked)
+    colorButton.setVisible(!locked)
   }
 }
 
@@ -187,8 +191,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
 
   val selfPicture: Signal[ImageSource] = self.map(_.picture).collect{case Some(pic) => WireImage(pic)}
 
-  //TODO: Replace with flag coming from self
-  private val accountIsLocked = Signal.const(false)
+  private val accountIsLocked: Signal[Boolean] = self.map(_.isReadOnlyProfile)
 
   accountIsLocked.onUi { locked =>
     view.setAccountLocked(locked)


### PR DESCRIPTION
 - This PR includes some UI changes to prevent users from editing their
   profile if they are being managed by sso/scim

I've tested in on both sso and normal team accounts and it works as expected
#### APK
[Download build #12357](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12357/artifact/build/artifact/wire-dev-PR1997-12357.apk)