### PR TITLE
fix: Open the Okta page directly from the Welcome page

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -148,7 +148,7 @@ class AppEntryActivity extends BaseActivity {
     case None =>
       userAccountsController.ssoToken.head.foreach {
         // if the SSO token is present we use it to log in the user
-        case Some(_) =>                    showFragment(SignInFragment(), SignInFragment.Tag, animated = false)
+        case Some(_) =>                    showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
         case _ =>
           Option(getIntent.getExtras).map(_.getInt(MethodArg)) match {
             case Some(LoginArgVal) =>      showFragment(SignInFragment(), SignInFragment.Tag, animated = false)

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -102,10 +102,6 @@ trait SSOFragment extends FragmentHelper {
       .show(getChildFragmentManager, SSODialogTag)
   }
 
-  protected def cancelSSODialog(): Unit = {
-    findChildFragment[InputDialog](SSODialogTag).foreach(_.dismissAllowingStateLoss())
-  }
-
   protected def verifyInput(input: String): Future[Unit] =
     ssoService.extractUUID(input).fold(Future.successful(())) { token =>
       onVerifyingToken(true)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
@@ -59,7 +59,7 @@ case class TeamNameFragment() extends CreateTeamFragment with SSOFragment {
   private def openUrl(id: Int): Unit =
     context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(id))))
 
-  override protected def onSSOConfirm(code: String): Unit = showFragment(SSOWebViewFragment.newInstance(code.toString), SSOWebViewFragment.Tag)
+  override protected def onSSOConfirm(code: String): Unit = showFragment(SSOWebViewFragment.newInstance(code), SSOWebViewFragment.Tag)
 }
 
 object TeamNameFragment {


### PR DESCRIPTION
Before, we moved to the Registration page first, so when the user clicked "Go back" on the Okta page
they were taken back to registration. By design, it should be the Welcome page.
Also, now "Go back" erases the token, preventing a corner case when the user clicks for the second time on the link, while being on the Okta page already.
#### APK
[Download build #12358](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12358/artifact/build/artifact/wire-dev-PR1998-12358.apk)
[Download build #12419](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12419/artifact/build/artifact/wire-dev-PR1998-12419.apk)