### PR TITLE
Fix CreateConversationSettings UI elements not reacting to events

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -42,14 +42,10 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
   private lazy val userAccountsController       = inject[UserAccountsController]
 
   private lazy val inputBox = view[InputBox](R.id.input_box)
-
-  private lazy val guestsToggle = returning(view[SwitchCompat](R.id.guest_toggle)) { vh =>
-    findById[ImageView](R.id.allow_guests_icon).setImageDrawable(GuestIconWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
-    createConversationController.teamOnly.currentValue.foreach(teamOnly => vh.foreach(_.setChecked(!teamOnly)))
-    vh.foreach(_.setOnCheckedChangeListener(new OnCheckedChangeListener {
-      override def onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean): Unit = createConversationController.teamOnly ! !isChecked
-    }))
-  }
+  private lazy val guestsToggle = view[SwitchCompat](R.id.guest_toggle)
+  private lazy val convOptions = view[View](R.id.create_conv_options)
+  private lazy val convOptionsArrow = view[ImageView](R.id.create_conv_options_icon)
+  private lazy val callInfo = view[TextView](R.id.call_info)
 
   private lazy val readReceiptsToggle  = returning(view[SwitchCompat](R.id.read_receipts_toggle)) { vh =>
     findById[ImageView](R.id.read_receipts_icon).setImageDrawable(ViewWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
@@ -77,21 +73,6 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
   private val optionsVisible = Signal(false)
 
-  private lazy val convOptions = returning(view[View](R.id.create_conv_options)) { vh =>
-    userAccountsController.isTeam.onUi(vis => vh.foreach(_.setVisible(vis)))
-    vh.foreach(_.onClick {
-      optionsVisible.mutate(!_)
-    })
-  }
-
-  private lazy val convOptionsArrow = returning(view[ImageView](R.id.create_conv_options_icon)) { vh =>
-    vh.foreach(_.setImageDrawable(ForwardNavigationIcon(R.color.light_graphite_40)))
-    optionsVisible.map(if (_) -1.0f else 1.0f).onUi(turn => vh.foreach(_.setRotation(turn * 90.0f)))
-  }
-
-  private lazy val callInfo = returning(view[TextView](R.id.call_info)){ vh =>
-    userAccountsController.isTeam.onUi(vis => vh.foreach(_.setVisible(vis)))
-  }
 
   private lazy val guestsToggleRow = returning(view[View](R.id.guest_toggle_row)) { vh =>
     Signal(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
@@ -114,7 +95,9 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
   override def onViewCreated(v: View, savedInstanceState: Bundle): Unit = {
 
-    callInfo
+    callInfo.foreach { view =>
+        userAccountsController.isTeam.onUi(vis => view.setVisible(vis))
+    }
     guestsToggleRow
     guestsToggleDesc
     readReceiptsToggleRow
@@ -128,11 +111,27 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
       box.errorLayout.setVisible(false)
     }
 
-    guestsToggle
+    guestsToggle.foreach { view =>
+      findById[ImageView](R.id.allow_guests_icon).setImageDrawable(GuestIconWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
+      createConversationController.teamOnly.currentValue.foreach(teamOnly => view.setChecked(!teamOnly))
+      view.setOnCheckedChangeListener(new OnCheckedChangeListener {
+        override def onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean): Unit = createConversationController.teamOnly ! !isChecked
+      })
+    }
     readReceiptsToggle
 
-    convOptions
-    convOptionsArrow
+    convOptions.foreach { view =>
+      userAccountsController.isTeam.onUi(vis => view.setVisible(vis))
+      view.onClick {
+        optionsVisible.mutate(!_)
+      }
+    }
+
+    convOptionsArrow.foreach { view =>
+      view.setImageDrawable(ForwardNavigationIcon(R.color.light_graphite_40))
+      optionsVisible.map(if (_) -1.0f else 1.0f).onUi(turn => view.setRotation(turn * 90.0f))
+    }
+
     convOptionsSubtitle
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -95,9 +95,7 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
   override def onViewCreated(v: View, savedInstanceState: Bundle): Unit = {
 
-    callInfo.foreach { view =>
-        userAccountsController.isTeam.onUi(vis => view.setVisible(vis))
-    }
+    callInfo
     guestsToggleRow
     guestsToggleDesc
     readReceiptsToggleRow
@@ -121,7 +119,6 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
     readReceiptsToggle
 
     convOptions.foreach { view =>
-      userAccountsController.isTeam.onUi(vis => view.setVisible(vis))
       view.onClick {
         optionsVisible.mutate(!_)
       }
@@ -129,7 +126,6 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
     convOptionsArrow.foreach { view =>
       view.setImageDrawable(ForwardNavigationIcon(R.color.light_graphite_40))
-      optionsVisible.map(if (_) -1.0f else 1.0f).onUi(turn => view.setRotation(turn * 90.0f))
     }
 
     convOptionsSubtitle
@@ -140,6 +136,9 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
     optionsVisible.onChanged.onUi { _ =>
       inject[KeyboardController].hideKeyboardIfVisible()
     }
+    userAccountsController.isTeam.onUi(vis => convOptions.foreach(_.setVisible(vis)))
+    optionsVisible.map(if (_) -1.0f else 1.0f).onUi(turn => convOptionsArrow.foreach(_.setRotation(turn * 90.0f)))
+    userAccountsController.isTeam.onUi(vis => callInfo.foreach(_.setVisible(vis)))
   }
 }
 


### PR DESCRIPTION
# Reason for this pull request
Many UI elements in the "create conversation" screen were not responsive to user event after switching to another fragment and coming back.

In particular, the "show/hide" arrow for settings would be visible only the first time the fragment is opened, and the list of users would not update after switching guests on/off if going back and forth between fragments.

# Changes

This was caused by calling `viewHolder.foreach` in the body of a `returning(... viewholder ...)`. With this code, the foreach would be called only once when the fragment is created. If the view is then destroyed and re-created, the new view inside the viewholder would not have been "visited" by the foreach.

The fix is to call the `viewholder.foreach` in the `onCreateView` method, which is called again every time the view is re-created (and the new individual views are already available in the view holder).

# Testing
Tested manually on device, before and after the fix. Steps:
- log in as team user
- open create conversation flow
- enter conversation name
- leave option as: allow guests
- click next (go to user selections)
- click back to previous screen
- issue 1: you can't expand/collapse the options anymore
- switch off "allow guest"
- click next
- issue 2: guests are still in the list

Both issues are fixed with this PR

#### APK
[Download build #12361](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12361/artifact/build/artifact/wire-dev-PR2000-12361.apk)
[Download build #12365](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12365/artifact/build/artifact/wire-dev-PR2000-12365.apk)