### PR TITLE
feat: Add a broadcast intent to set the staging backend by default

### DIFF
--- a/app/src/candidate/AndroidManifest.xml
+++ b/app/src/candidate/AndroidManifest.xml
@@ -38,6 +38,7 @@
                 <action android:name="${applicationId}.intent.action.DISABLE_TRACKING" />
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
+                <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -40,6 +40,7 @@
                 <action android:name="${applicationId}.intent.action.DISABLE_TRACKING" />
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
+                <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
             </intent-filter>
         </receiver>
 

--- a/app/src/experimental/AndroidManifest.xml
+++ b/app/src/experimental/AndroidManifest.xml
@@ -40,6 +40,7 @@
                 <action android:name="${applicationId}.intent.action.DISABLE_TRACKING" />
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
+                <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -40,6 +40,7 @@
                 <action android:name="${applicationId}.intent.action.DISABLE_TRACKING" />
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
+                <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/com/waz/zclient/utils/BackendPicker.java
+++ b/app/src/main/java/com/waz/zclient/utils/BackendPicker.java
@@ -36,7 +36,7 @@ import java.util.NoSuchElementException;
 
 public class BackendPicker {
 
-    private static final String CUSTOM_BACKEND_PREFERENCE = "custom_backend_pref";
+    public static final String CUSTOM_BACKEND_PREFERENCE = "custom_backend_pref";
     private final Context context;
 
     public BackendPicker(Context context) {
@@ -47,7 +47,7 @@ public class BackendPicker {
         if (shouldShowBackendPicker()) {
             showDialog(prodBackend, activity, callback);
         } else {
-            callback.callback(prodBackend);
+            callback.callback(getBackendConfig(prodBackend));
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -20,6 +20,7 @@ package com.waz.zclient.qa
 
 import android.app.Activity
 import android.content.{BroadcastReceiver, Context, Intent}
+import android.preference.PreferenceManager
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.verbose
 import com.waz.content.GlobalPreferences._
@@ -31,7 +32,8 @@ import com.waz.zclient.controllers.userpreferences.IUserPreferencesController._
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController._
 import com.waz.zclient.tracking.GlobalTrackingController
-import com.waz.zclient.{BuildConfig, WireApplication}
+import com.waz.zclient.utils.BackendPicker
+import com.waz.zclient.{Backend, BuildConfig, WireApplication}
 
 /**
   * to test, fire an intent using:
@@ -93,6 +95,11 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver {
             setResultData("")
             setResultCode(Activity.RESULT_CANCELED)
         }
+      case SELECT_STAGING_BE =>
+        PreferenceManager.getDefaultSharedPreferences(context)
+          .edit
+          .putString(BackendPicker.CUSTOM_BACKEND_PREFERENCE, Backend.StagingBackend.environment)
+          .commit
       case _ =>
         setResultData("Unknown Intent!")
         setResultCode(Activity.RESULT_CANCELED)
@@ -116,6 +123,7 @@ object AbstractPreferenceReceiver {
   private val TRACKING_ID_INTENT       = packageName + ".intent.action.TRACKING_ID"
   private val FULL_CONVERSATION_INTENT = packageName + ".intent.action.FULL_CONVERSATION_INTENT"
   private val HIDE_GDPR_POPUPS         = packageName + ".intent.action.HIDE_GDPR_POPUPS"
+  private val SELECT_STAGING_BE        = packageName + ".intent.action.SELECT_STAGING_BE"
 
   private lazy val DeveloperAnalyticsEnabled = PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
 }


### PR DESCRIPTION
# Reason for this pull request
Automation has a lot of issues with the backend picker at start up. We can improve it by selecting automatically on dev and experimental builds.

# Changes
* Enable receiving a broadcast intent to set the staging backend by default

# Testing
* Manually tested on device
#### APK
[Download build #12378](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12378/artifact/build/artifact/wire-dev-PR2007-12378.apk)
[Download build #12379](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12379/artifact/build/artifact/wire-dev-PR2007-12379.apk)
[Download build #12385](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12385/artifact/build/artifact/wire-dev-PR2007-12385.apk)