### PR TITLE
Degradation popup should appear for self

### DIFF
--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -762,7 +762,7 @@ class ConversationFragment extends FragmentHelper {
       (for {
         self <- inject[UserAccountsController].currentUser.head
         members <- convController.loadMembers(convId)
-        unverifiedUsers = (members ++ self.map(Seq(_)).getOrElse(Nil)).filter { !_.isVerified }
+        unverifiedUsers = members.filter { !_.isVerified }
         unverifiedDevices <-
           if (unverifiedUsers.size == 1) Future.sequence(unverifiedUsers.map(u => convController.loadClients(u.id).map(_.filter(!_.isVerified)))).map(_.flatten.size)
           else Future.successful(0) // in other cases we don't need this number
@@ -770,14 +770,14 @@ class ConversationFragment extends FragmentHelper {
 
         val unverifiedNames = unverifiedUsers.map { u =>
           if (self.map(_.id).contains(u.id)) getString(R.string.conversation_degraded_confirmation__header__you)
-          else u.displayName
+          else u.displayName.str
         }
 
         val header =
           if (unverifiedUsers.isEmpty) getString(R.string.conversation__degraded_confirmation__header__someone)
           else if (unverifiedUsers.size == 1)
             getQuantityString(R.plurals.conversation__degraded_confirmation__header__single_user, unverifiedDevices, unverifiedNames.head)
-          else getString(R.string.conversation__degraded_confirmation__header__multiple_user, unverifiedNames.mkString(","))
+          else getString(R.string.conversation__degraded_confirmation__header__multiple_user, unverifiedNames.tail.mkString(","), unverifiedNames.head)
 
         val onlySelfChanged = unverifiedUsers.size == 1 && self.map(_.id).contains(unverifiedUsers.head.id)
 


### PR DESCRIPTION
# Reason for this pull request
When you add a device and send a message to a verified conversation, the conversation degrades but the popup to confirm the sending wasn't showing preventing the user from sending more messages.

fixes: https://github.com/wireapp/android-project/issues/35

# Changes
* Remove duplication of self on the unverified users (`loadMembers` should return self already)
* The names sequence should have type `Seq[String]` not `Seq[Serializable]`
* The string `R.string.conversation__degraded_confirmation__header__multiple_user` has two parameters but only one was being added. This was causing a crash.

# Testing
* Manually tested on the device
#### APK
[Download build #12391](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12391/artifact/build/artifact/wire-dev-PR2015-12391.apk)
[Download build #12392](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12392/artifact/build/artifact/wire-dev-PR2015-12392.apk)