### PR TITLE
Fix crash on Backend Picker when pausing app

### DIFF
--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -71,7 +71,7 @@ class BaseActivity extends AppCompatActivity
     getControllerFactory.setActivity(this)
     ZMessaging.currentUi.onStart()
     inject[UiLifeCycle].acquireUi()
-    if (!this.isInstanceOf[LaunchActivity]) permissions.registerProvider(this)
+    permissions.registerProvider(this)
     Option(ViewUtils.getContentView(getWindow)).foreach(getControllerFactory.setGlobalLayout)
   }
 

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -19,6 +19,7 @@
 package com.waz.zclient
 
 import android.content.Intent
+import android.support.v7.app.AppCompatActivity
 import com.waz.ZLog.ImplicitTag._
 import com.waz.service.{AccountsService, BackendConfig}
 import com.waz.threading.Threading
@@ -26,14 +27,13 @@ import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.utils.{BackendPicker, Callback}
 
 
-class LaunchActivity extends BaseActivity {
-  override def getBaseTheme = R.style.Theme_Dark
+class LaunchActivity extends AppCompatActivity with ActivityHelper {
 
-  override def onBaseActivityStart() = {
+  override def onStart() = {
+    super.onStart()
     new BackendPicker(getApplicationContext).withBackend(this, new Callback[BackendConfig]() {
       override def callback(be: BackendConfig) = {
         getApplication.asInstanceOf[WireApplication].ensureInitialized(be)
-        superOnBaseActivityStart()
 
         //TODO - could this be racing with setting the active account?
         inject[AccountsService].activeAccountId.head.map {
@@ -43,12 +43,6 @@ class LaunchActivity extends BaseActivity {
       }
     }, Backend.ProdBackend)
   }
-
-  //Can't call super from within anonymous class
-  private def superOnBaseActivityStart() = super.onBaseActivityStart()
-
-  //No need for onBaseActivityResume in this instance of Activity
-  override def onBaseActivityResume(): Unit = {}
 
   override protected def onNewIntent(intent: Intent) = {
     super.onNewIntent(intent)


### PR DESCRIPTION
# Reason for this pull request
Bug: When we pause/go to background in the backend selection dialog, the app crashes.

This can be annoying for QA since their automation tools might pause the app after starting.

# Changes
* `LaunchActivity` is only used to display the dialog and guide the user to the correct Activity depending on their account state. There is no need for it to extend `BaseActivity` since none of the services `BaseActivity` depends on are instantiated yet.

# Testing
Manually tested on the device
#### APK
[Download build #12394](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12394/artifact/build/artifact/wire-dev-PR2017-12394.apk)