### PR TITLE
fix: A partner should be treated as a guest when displaying the bottom bar

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -171,12 +171,14 @@ class SingleParticipantFragment extends FragmentHelper {
   }
 
   private lazy val footerMenu = returning( view[FooterMenu](R.id.fm__footer) ) { vh =>
+    // TODO: merge this logic with ConversationOptionsMenuController
     (for {
       createPerm <- userAccountsController.hasCreateConvPermission
       convId     <- participantsController.conv.map(_.id)
       remPerm    <- userAccountsController.hasRemoveConversationMemberPermission(convId)
       isGuest    <- participantsController.isCurrentUserGuest
-    } yield (createPerm || remPerm) && !isGuest).map {
+      isPartner  <- userAccountsController.isPartner
+    } yield (createPerm || remPerm) && !isGuest && !isPartner).map {
       case true => R.string.glyph__more
       case _    => R.string.empty_string
     }.map(getString).onUi(text => vh.foreach(_.setRightActionText(text)))


### PR DESCRIPTION
Fixes a bug when the user (who is a partner, not a guest) opens group conversations' details and from there goes to a single participant details. The only possible action for a partner on this screen should be "Open Conversation" which appers on the left button. The right button ("...") should be invisible.
Because of the bug it was visible, but when clicked, no options appeared.
#### APK
[Download build #12407](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12407/artifact/build/artifact/wire-dev-PR2020-12407.apk)