### PR TITLE
fix: on start conversation action menu was empty

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -125,7 +125,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit inj
         } else {
           if (teamMember || connectStatus.contains(ACCEPTED) || isBot) {
             builder ++= Set(notifications, Delete)
-            if (currentConv.isDefined && !teamMember && connectStatus.contains(ACCEPTED)) builder += Block
+            if (!mode.inConversationList && !teamMember && connectStatus.contains(ACCEPTED)) builder += Block
           }
           else if (connectStatus.contains(PENDING_FROM_USER)) builder += Block
         }

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -97,8 +97,8 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   lazy val isCurrentUserGuest: Signal[Boolean] = for {
     z           <- zms
     currentUser <- UserSignal(z.selfUserId)
-    currentConv <- conv
-  } yield currentConv.team.isDefined && currentConv.team != currentUser.teamId
+    currentConvTeam <- convController.currentConvOpt.map(_.flatMap(_.team))
+  } yield currentConvTeam.isDefined && currentConvTeam != currentUser.teamId
 
   lazy val currentUserBelongsToConversationTeam: Signal[Boolean] = for {
     z           <- zms

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -97,8 +97,8 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   lazy val isCurrentUserGuest: Signal[Boolean] = for {
     z           <- zms
     currentUser <- UserSignal(z.selfUserId)
-    currentConvTeam <- convController.currentConvOpt.map(_.flatMap(_.team))
-  } yield currentConvTeam.isDefined && currentConvTeam != currentUser.teamId
+    currentConv <- conv
+  } yield currentConv.team.isDefined && currentConv.team != currentUser.teamId
 
   lazy val currentUserBelongsToConversationTeam: Signal[Boolean] = for {
     z           <- zms


### PR DESCRIPTION
 - This was due to currentConv being an empty signal, so this commit
   changes things to use currentConvOpt instead. A long term fix is to
   use a separate Controller for the conversationListManager and the
   conversation details tab.
#### APK
[Download build #12409](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12409/artifact/build/artifact/wire-dev-PR2021-12409.apk)
[Download build #12411](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12411/artifact/build/artifact/wire-dev-PR2021-12411.apk)
[Download build #12412](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12412/artifact/build/artifact/wire-dev-PR2021-12412.apk)