### PR TITLE
fix: ParticipantHeaderFragment should not display both group and username

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -238,7 +238,6 @@ class ParticipantFragment extends ManagerFragment
       isTeamMember <- userAccountsController.isTeamMember(userId).head
     } userOpt match {
       case Some(user) if user.connection == ACCEPTED || user.expiresAt.isDefined || isTeamMember =>
-        participantsController.selectParticipant(userId)
         openUserProfileFragment(SingleParticipantFragment.newInstance(), SingleParticipantFragment.Tag)
 
       case Some(user) if user.connection == PENDING_FROM_OTHER || user.connection == PENDING_FROM_USER || user.connection == IGNORED =>


### PR DESCRIPTION
If the user went from the group chat to the participant details and back, the header displayed both the group name and the user name. That happened because of the invalid intermediate state of a signal controlling the displayed text.

So, the bug with the username appearing next to the group name in the group chat header is a good example that we rely on signals too much, just as @yeryomenkom noted. 
In this particular case, we use a pair of signals and merged them. It looked somehow like that:
`Signal(pageTag, otherParticipant)` 
where the `pageTag` is the view we're on, and the `otherParticipant` is the user we're looking at (it might be `None`). This is because we use the same header for all views, from the conversation, through all the details for the group and users. The header stays displayed and only its contents change.
So, first, when we open a group chat the signal state is something like:
`(Group, None)`
We look at the group chat (or group details - it's the same for us in this case) and no particular user is selected. Then we choose a user in order to go to the user's details and we assume the state of the signal will change to:
`(Single, Some(user))`
And then we press the back button to go back to the group details and we assume that the signal will change back to `(Group, None)`.

The problem is, it's really two signals, and they don't change at once. Every time we switch views, we really go through one more state: either `(Group, Some(user))` or `(Single, None)`, depending on which source signal changes first. Both these states are invalid. 

Until recently, we ignored them and nothing bad happened. But it seems that some of our changes in last weeks affected this logic, and the header started to react to `(Group, Some(user))` and displayed both the group name and the username at once. And then it ignored the valid state of `(Group, None)`.

I changed the logic so that now we rely only on the `pageTag` signal, and if the tag is `Single`, only then we ask for the user data. 

Be careful to cover all cases if you merge signals. Take a moment to think if it's not actually a situation when one of the values is need if and only if the other value is known.

#### APK
[Download build #12414](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12414/artifact/build/artifact/wire-dev-PR2025-12414.apk)
[Download build #12415](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12415/artifact/build/artifact/wire-dev-PR2025-12415.apk)