### PR TITLE
fix: crash when switching accounts

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -416,7 +416,13 @@ class ViewHolder[T <: View](id: Int, finder: ViewFinder) {
   def get: T = view.getOrElse { returning(finder.findById[T](id)) { t => view = Some(t) } }
 
   @inline
-  def opt: Option[T] = Option(get)
+  def opt: Option[T] = view match {
+    case t@Some(_) => t
+    case None =>
+      if (finder != null) {
+        returning(Option(finder.findById[T](id))) { view = _}
+      } else None
+  }
 
   def clear() =
     view = Option.empty

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -416,13 +416,9 @@ class ViewHolder[T <: View](id: Int, finder: ViewFinder) {
   def get: T = view.getOrElse { returning(finder.findById[T](id)) { t => view = Some(t) } }
 
   @inline
-  def opt: Option[T] = view match {
-    case t@Some(_) => t
-    case None =>
-      if (finder != null) {
-        returning(Option(finder.findById[T](id))) { view = _}
-      } else None
-  }
+  def opt: Option[T] =
+    if(finder != null) Option(get)
+    else None
 
   def clear() =
     view = Option.empty

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -310,10 +310,10 @@ class NormalConversationFragment extends ConversationListFragment {
       }
     }
     listActionsView.foreach(_.animate().alpha(1f).setDuration(500))
-    loadingListView.foreach(_.animate().alpha(0f).setDuration(500).withEndAction(new Runnable {
+    loadingListView.foreach(v => v.animate().alpha(0f).setDuration(500).withEndAction(new Runnable {
       override def run() = {
         if (NormalConversationFragment.this != null)
-          loadingListView.foreach(_.setVisibility(GONE))
+          v.setVisibility(GONE)
       }
     }))
 


### PR DESCRIPTION
 - This commit changes the reference used to match the one used
   outside the closure in NormalConversationFragment
 - I've changed the definition of opt in ViewHolder to be safer, never invoking findById on a null finder, this should help cut down on crashes of this type in future, although there still exist race conditions I think. We should think about a proper fix for this issue.
#### APK
[Download build #12416](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12416/artifact/build/artifact/wire-dev-PR2026-12416.apk)
[Download build #12417](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12417/artifact/build/artifact/wire-dev-PR2026-12417.apk)
[Download build #12418](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12418/artifact/build/artifact/wire-dev-PR2026-12418.apk)