### PR TITLE
fix: Restore the Block button in the bottom menu in the conv list

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -125,7 +125,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit inj
         } else {
           if (teamMember || connectStatus.contains(ACCEPTED) || isBot) {
             builder ++= Set(notifications, Delete)
-            if (!mode.inConversationList && !teamMember && connectStatus.contains(ACCEPTED)) builder += Block
+            if (!teamMember && connectStatus.contains(ACCEPTED)) builder += Block
           }
           else if (connectStatus.contains(PENDING_FROM_USER)) builder += Block
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues
After the recent changes the "conversation actions" menu stopped displaying the Block button when opened by a long tap from the conversation list. The same menu opened from the participant's details displays the Block button correctly.

### Causes
The buttons displayed in the menu are controlled by a multitude of conditions. It's very easy to introduce a minor bug like that when we change something in the code. 

### Solutions

A condition was introduced by mistake that prevented the Block button form appearing. I removed it.

### Testing

Go to the conversation list. Tap long on a 1:1 conversation. The bottom menu will open. The Block button should be among the options.


#### APK
[Download build #12424](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12424/artifact/build/artifact/wire-dev-PR2028-12424.apk)