### PR TITLE
fix: log switch using default.json

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,7 +230,7 @@ android {
                                     internal_features      : "false"]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        "true"
+            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$config.loggingEnabled"
             buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
         }
 


### PR DESCRIPTION
## What's new in this PR?
The log switch was hardcoded to true for production but should read the value from the custom JSON config.

### Testing
I manually verified that the `BuildConfig` generated after this commit has the right value of the log switch.
#### APK
[Download build #12425](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12425/artifact/build/artifact/wire-dev-PR2029-12425.apk)