### PR TITLE
fix: Go back to the conv list after leaving a group

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -83,11 +83,6 @@ class ConversationListController(implicit inj: Injector, ec: EventContext) exten
     val incoming = if (listMode == Normal) (incomingConvs, members.flatten) else (Seq(), Seq())
     (z.selfUserId, regular, incoming)
   }
-
-  def nextConversation(convId: ConvId): Future[Option[ConvId]] =
-    conversationListData(Normal).head.map {
-      case (_, regular, _) => regular.lift(regular.indexWhere(_.id == convId) + 1).map(_.id)
-    } (Threading.Background)
 }
 
 object ConversationListController {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the user chose to leave a group from the participants menu, the app didn't go back to the conversation screen. The user had to do it manually.

### Causes

Lack of the call to a method which opened the conversation list.
Strangely enough, it was implemented for the "Archive" action, so I simply had to use the same code.

### Solutions

Explained above.

### Testing

Create a group. Leave it. 
Create a group. Delete it + leave it.
If you create a group and delete it without leaving, you should not be taken back to the conversation list.

#### APK
[Download build #12426](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12426/artifact/build/artifact/wire-dev-PR2030-12426.apk)
[Download build #12428](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12428/artifact/build/artifact/wire-dev-PR2030-12428.apk)