### PR TITLE
feature: customize URL schema

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,6 +112,7 @@ android {
         versionName majorVersion + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
+        manifestPlaceholders = [customURLScheme: config.custom_url_scheme]
 
         buildConfigField 'Integer', 'MAX_ACCOUNTS',               "$config.maxAccounts"
         buildConfigField 'String',  'BACKEND_URL',                "\"$config.backendUrl\""

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,7 +92,7 @@
             <intent-filter>
                 <data
                     android:host="password-reset-successful"
-                    android:scheme="wire"
+                    android:scheme="${customURLScheme}"
                     />
 
                 <action android:name="android.intent.action.VIEW" />
@@ -105,7 +105,7 @@
             <intent-filter>
                 <data
                     android:host="start-sso"
-                    android:scheme="wire"
+                    android:scheme="${customURLScheme}"
                     />
 
                 <action android:name="android.intent.action.VIEW" />
@@ -179,7 +179,7 @@
 
             <intent-filter>
                 <data android:host="email-verified"
-                      android:scheme="wire" />
+                      android:scheme="${customURLScheme}" />
 
                 <action android:name="android.intent.action.VIEW" />
 
@@ -191,7 +191,7 @@
             <intent-filter>
                 <data
                     android:host="connect"
-                    android:scheme="wire"
+                    android:scheme="${customURLScheme}"
                     />
 
                 <action android:name="android.intent.action.VIEW" />

--- a/default.json
+++ b/default.json
@@ -20,5 +20,6 @@
       "domain": "*.wire.com",
       "certificate" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreYzBWuvnVKYfgNNX3dVjUnqIVtl4XqQnCcY6m/sWM15TTK0bo9FKnMxNAPtDzB6ViRvpZsKEefX8pi15Jcs4uZiuZ81ISV1bqxtpsjJ56Yjeme99Dca5ck35pThYuK6jZ8vG6pJiY9mRY9nGadid4qWL7uwAeoInx2mOM7HepCCh2NOXd+EjQ4sBsfgb+kWrcVQmBzvLHPUDoykm/m+BvL2eJ1njPNiM/GoeXbmIW1WM3ifucYJoD9g+V5NfHfANrVu2w4YcLDad0C85Nb8U1sgFNkrgOqzhd/1xHok1uOyjoeLTIHHYkryvbBEmdl6v+f2J1EM0+Fj9vseI2TYrQIDAQAB"
   },
-  "loggingEnabled": false
+  "loggingEnabled": false,
+  "custom_url_scheme": "wire"
 }


### PR DESCRIPTION
## What's new in this PR?
Ability to customize the URL schema that is registered for the app, via JSON

### Reason
This is used to open SSO links. In case there are multiple flavors (customer-customized) of the build on one device, it's necessary to distinguish which flavor gets opened by a link. This is done with each flavor having a separate schema registered.

### Testing
I created a build with a custom schema and verified on device that links with that custom schema cause the app to open.

#### APK
[Download build #12427](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12427/artifact/build/artifact/wire-dev-PR2031-12427.apk)