### PR TITLE
fix: Back press on a send connect request screen should return to the Start UI

### DIFF
--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -40,6 +40,7 @@ import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.pages.main.connect.UserProfileContainer
 import com.waz.zclient.pages.main.participants.ProfileAnimation
+import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.paintcode.GuestIcon
 import com.waz.zclient.participants.UserRequester
 import com.waz.zclient.ui.text.TypefaceTextView
@@ -216,6 +217,11 @@ class SendConnectRequestFragment extends BaseFragment[SendConnectRequestFragment
       connectButton.setVisibility(View.VISIBLE)
       connectButton.fadeIn(FiniteDuration(getInt(R.integer.framework_animation_duration_long), MILLISECONDS))
     }
+  }
+
+  override def onBackPressed(): Boolean = {
+    inject[IPickUserController].hideUserProfile()
+    true
   }
 }
 


### PR DESCRIPTION
## What's new in this PR?

A fix for a bug in Start (Search) UI

### Issues

If we find a person through the Search and open the profile page to send the connect request, but cancel it by clicking the back button, we are taken to the conversation list instead of back to the Search.

### Causes
The conversation list is the default `onBackPressed` destination. Its functionality has to be overloaded in order to allow for other results. The method was not overloaded for `SendConnectRquestFragment`.

### Solutions

I overloaded the above-mentioned method, so that it hides the user profile - revealing the underling Search - but it does not return the user to the conversation list.

### Testing

Find a new connection, open the user profile, click the back button.

#### APK
[Download build #12429](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12429/artifact/build/artifact/wire-dev-PR2032-12429.apk)