### PR TITLE
fix: Likers in the message footer should be displayed chronologically

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
@@ -46,9 +46,9 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     replies     <- replyData
     Some(msgId) <- conversationController.currentConvId.map(replies.get)
     Some(msg)   <- messagesController.getMessage(msgId)
-    sender      <- usersController.displayNameStringIncludingSelf(msg.userId)
+    sender      <- usersController.user(msg.userId)
     asset       <- assetsController.assetSignal(msg.assetId).map(a => Option(a._1)).orElse(Signal.const(Option.empty[AssetData]))
-  } yield Option(ReplyContent(msg, asset, sender))).orElse(Signal.const(None))
+  } yield Option(ReplyContent(msg, asset, sender.getDisplayName))).orElse(Signal.const(None))
 
   messagesService.flatMap(ms => Signal.wrap(ms.msgEdited)) { case (from, to) =>
     replyData.mutate { data =>

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -56,12 +56,6 @@ class UsersController(implicit injector: Injector, context: Context) extends Inj
     user <- userId.fold(Signal.const(Option.empty[UserData]))(uId => user(uId).map(Some(_)))
   } yield user
 
-  def displayNameStringIncludingSelf(id: UserId): Signal[String] =
-    for {
-      zms <- zMessaging
-      user <- user(id)
-    } yield user.getDisplayName
-
   def displayName(id: UserId): Signal[DisplayName] = zMessaging.flatMap { zms =>
     if (zms.selfUserId == id) Signal const Me
     else user(id).map(u => Other(if (u.deleted) getString(R.string.default_deleted_username) else u.getDisplayName))

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
@@ -21,13 +21,13 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.{LinearLayout, TextView}
 import com.waz.ZLog.ImplicitTag._
-import com.waz.model.UserId
+import com.waz.content.{ReactionsStorage, UsersStorage}
+import com.waz.service.messages.MessageAndLikes
 import com.waz.utils.events.Signal
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
 
 class LikeDetailsView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with ViewHelper {
-
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
@@ -36,22 +36,19 @@ class LikeDetailsView(context: Context, attrs: AttributeSet, style: Int) extends
 
   private val description: TextView = findById(R.id.like__description)
 
-  def init(controller: FooterViewController): Unit = {
-    val likedBy = controller.messageAndLikes.map(_.likes)
-
-    def getDisplayNameString(ids: Seq[UserId]): Signal[String] = {
-      if (ids.size > 3)
-        Signal.const(getQuantityString(R.plurals.message_footer__number_of_likes, ids.size, Integer.valueOf(ids.size)))
-      else
-        Signal.sequence(ids map { controller.signals.displayNameStringIncludingSelf } :_*).map { names =>
-          if (names.isEmpty) getString(R.string.message_footer__tap_to_like)
-          else names.mkString(", ")
-        }
-    }
-
-    val displayText = likedBy.flatMap(getDisplayNameString)
-
-    displayText.onUi(description.setText)
-  }
+  def init(controller: FooterViewController): Unit =
+    controller.messageAndLikes.flatMap {
+        case MessageAndLikes(_, likes, _, _) if likes.isEmpty =>
+          Signal.const(getString(R.string.message_footer__tap_to_like))
+        case MessageAndLikes(_, likes, _, _) if likes.size > 3 =>
+          Signal.const(getQuantityString(R.plurals.message_footer__number_of_likes, likes.size, Integer.valueOf(likes.size)))
+        case MessageAndLikes(msg, _, _, _) =>
+          for {
+            reactionsStorage <- inject[Signal[ReactionsStorage]]
+            likers           <- reactionsStorage.likes(msg.id).map(_.likers)
+            usersStorage     <- inject[Signal[UsersStorage]]
+            users            <- usersStorage.listSignal(likers.keys)
+          } yield users.sortBy(u => likers(u.id)).map(_.getDisplayName).mkString(", ")
+    }.onUi(description.setText)
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Until now, the order of likers in the message footer depended on the order of userIds in `MessageAndLikes`. That order was chronological, but sometimes it got mixed up.

### Causes

While searching for usernames we transform the sequence of ids in to a set. It means that the order is destroyed and sometimes the returned names were in different order than the ids of the users.

### Solutions

One way to avoid it is to maintain ids as a sequence, but we try to use sets instead wherever possible - they make operations much easier (searching, addition, substraction, etc). Instead, I decided to directly ask for timestamps of likes from `ReactionStorage` and sort the names according to them. We use this functionality only if the number of likes <= 3, so it shouldn't be expensive.

### Testing
Create a group with three members. Send a message. Like the message using two or three of the users, unlike it, like it again. The order of user names should change chronologically, ie. new likes should appear at the end of the list.


#### APK
[Download build #12430](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12430/artifact/build/artifact/wire-dev-PR2033-12430.apk)