### PR TITLE
feat: Use user permissions (a partner, a team member) in searching

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "140.2235"
+    zMessagingDevVersion = "141.0.2247-DEV"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.518@aar'

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -30,7 +30,7 @@ import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.UserPreferences
 import com.waz.model.otr.Client
-import com.waz.model.{AccentColor, AccountDataOld, Availability}
+import com.waz.model.{AccentColor, Availability, UserPermissions}
 import com.waz.service.tracking.TrackingService
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
@@ -48,7 +48,6 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.Time.TimeStamp
 import com.waz.zclient.utils.{BackStackKey, BackStackNavigator, RichView, StringUtils, UiStorage, UserSignal}
 import com.waz.zclient.views.AvailabilityView
-
 import ProfileViewController.MaxAccountsCount
 import BuildConfig.ACCOUNT_CREATION_ENABLED
 
@@ -309,7 +308,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   }
 
   usersAccounts.selfPermissions
-    .map(_.contains(AccountDataOld.Permission.AddTeamMember))
+    .map(_.contains(UserPermissions.Permission.AddTeamMember))
     .onUi(view.setManageTeamEnabled)
 
 

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -74,7 +74,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
   lazy val searchUserOrServices: Signal[SearchUserListState] = {
     import SearchUserListState._
     for {
-      filter  <- filter
+      filter  <- filter.throttle(500.millis)
       tab     <- tab
       res     <- tab match {
         case Tab.People =>
@@ -83,10 +83,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
             results     <- search.search(filter)
           } yield
           //TODO make isEmpty method on SE?
-            if (results.convs.isEmpty &&
-              results.local.isEmpty &&
-              results.top.isEmpty &&
-              results.dir.isEmpty)
+            if (results.isEmpty)
               if (filter.isEmpty) NoUsers else NoUsersFound
             else Users(results)
         case Tab.Services =>

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -162,11 +162,11 @@ class SearchUIFragment extends BaseFragment[SearchUIFragment.Container]
   private lazy val emptyListButton = returning(view[RelativeLayout](R.id.empty_list_button)) { v =>
     (for {
       zms <- zms
-      permissions <- userAccountsController.selfPermissions.orElse(Signal.const(Set.empty[AccountDataOld.Permission]))
+      permissions <- userAccountsController.selfPermissions.orElse(Signal.const(Set.empty[UserPermissions.Permission]))
       members <- zms.teams.searchTeamMembers().orElse(Signal.const(Set.empty[UserData]))
       searching <- adapter.filter.map(_.nonEmpty)
      } yield
-       zms.teamId.nonEmpty && permissions(AccountDataOld.Permission.AddTeamMember) && !members.exists(_.id != zms.selfUserId) && !searching
+       zms.teamId.nonEmpty && permissions(UserPermissions.Permission.AddTeamMember) && !members.exists(_.id != zms.selfUserId) && !searching
     ).onUi(visible => v.foreach(_.setVisible(visible)))
   }
 


### PR DESCRIPTION
## What's new in this PR?

The functionality for filtering out from the user search results which should not be visible for partners. The results visible for standard team members are also slightly changed, taking into account that some of the results are partners.

For details please refer to the documentation:
https://github.com/wearezeta/documentation/blob/master/topics/teams/use%20cases/clients/101-search-for-partners.md

#### APK
[Download build #12435](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12435/artifact/build/artifact/wire-dev-PR2035-12435.apk)
[Download build #12436](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12436/artifact/build/artifact/wire-dev-PR2035-12436.apk)
[Download build #12437](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12437/artifact/build/artifact/wire-dev-PR2035-12437.apk)