### PR TITLE
fix: Always show send button on emoji keyboard

### DIFF
--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -101,7 +101,10 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   val onMessageEdited = EventStream[MessageData]()
   val onEphemeralExpirationSelected = EventStream[Option[FiniteDuration]]()
 
-  val sendButtonEnabled: Signal[Boolean] = zms.map(_.userPrefs).flatMap(_.preference(UserPreferences.SendButtonEnabled).signal)
+  val sendButtonEnabled: Signal[Boolean] = for {
+    sendPref <- zms.map(_.userPrefs).flatMap(_.preference(UserPreferences.SendButtonEnabled).signal)
+    emoji <- emojiKeyboardVisible
+  } yield emoji || sendPref
 
   val enteredTextEmpty = enteredText.map(_._1.isEmpty).orElse(Signal const true)
   val sendButtonVisible = Signal(emojiKeyboardVisible, enteredTextEmpty, sendButtonEnabled, isEditingMessage) map {


### PR DESCRIPTION
## What's new in this PR?

This PR introduces a fix to always show the send button in the emoji keyboard.

### Issues

We must show the send button in the emoji keyboard, even when we have set the show send button preference to false, as otherwise composing messages from the emoji keyboard is impossible. This commit addresses wireapp/android-project#160.

### Testing

Testing was done manually.

#### APK
[Download build #12440](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12440/artifact/build/artifact/wire-dev-PR2039-12440.apk)