### PR TITLE
fix: Opening the participant's details from the dialog should land on the Devices tab

### DIFF
--- a/app/src/main/res/layout/system_message_content.xml
+++ b/app/src/main/res/layout/system_message_content.xml
@@ -29,7 +29,7 @@
         android:id="@+id/gtv__system_message__icon"
         android:layout_marginStart="@dimen/system_margin_start"
         android:layout_marginEnd="@dimen/system_margin_end"
-        android:layout_width="@dimen/content__separator__chathead__size"
+        android:layout_width="@dimen/wire__otr__shield__small_width"
         android:layout_height="@dimen/wire__otr__shield__small_width"
         android:gravity="center"
         android:layout_gravity="center"

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -258,8 +258,11 @@ class SingleParticipantFragment extends FragmentHelper {
 
     footerMenu.foreach(_.setCallback(footerCallback))
 
-    val tab = Option(savedInstanceState).fold[Tab](DetailsTab)(_ => Tab(getStringArg(TabToOpen)))
-    tabs.foreach(_.getTabAt(tab.pos).select())
+    if (Option(savedInstanceState).isEmpty) {
+      val tab = Tab(getStringArg(TabToOpen))
+      visibleTab ! tab
+      tabs.foreach(_.getTabAt(tab.pos).select())
+    }
   }
 
   override def onBackPressed(): Boolean = {

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -770,7 +770,7 @@ class ConversationFragment extends FragmentHelper {
 
         val unverifiedNames = unverifiedUsers.map { u =>
           if (self.map(_.id).contains(u.id)) getString(R.string.conversation_degraded_confirmation__header__you)
-          else u.displayName.str
+          else u.getDisplayName.str
         }
 
         val header =


### PR DESCRIPTION
## What's new in this PR?

A fix to [AN-6094](https://wearezeta.atlassian.net/browse/AN-6094)

### Issues

If a conversation is degraded, a dialog appears and one of the options is to go to the other participant
details to see the unconfirmed device. In that case, the participant's details should automatically
open the Devices tab, but it was opening the Details tab instead. That was fixed.

Also, the dialog didn't always display the other participant's name, and the sorting of users' names
in system messages was broken. I fixed that as well.


#### APK
[Download build #12441](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12441/artifact/build/artifact/wire-dev-PR2040-12441.apk)
[Download build #12443](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12443/artifact/build/artifact/wire-dev-PR2040-12443.apk)