### PR TITLE
fix: SendConnectRequestFragment should show "..." instead of "-" 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -39,6 +39,7 @@ import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.pages.main.connect.UserProfileContainer
+import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.pages.main.participants.ProfileAnimation
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.paintcode.GuestIcon
@@ -99,7 +100,7 @@ class SendConnectRequestFragment extends BaseFragment[SendConnectRequestFragment
       }
     }
     removeConvMemberFeatureEnabled.map {
-      case true => getString(R.string.glyph__minus)
+      case true => getString(R.string.glyph__more)
       case _ => ""
     }.onUi(text => vh.foreach(_.setRightActionText(text)))
   }
@@ -197,9 +198,12 @@ class SendConnectRequestFragment extends BaseFragment[SendConnectRequestFragment
         case _ =>
       }
 
-      override def onRightActionClicked(): Unit = removeConvMemberFeatureEnabled.head foreach {
+      override def onRightActionClicked(): Unit = removeConvMemberFeatureEnabled.head.foreach {
         case true =>
-          getContainer.showRemoveConfirmation(userToConnectId)
+          inject[ConversationController].currentConv.head.foreach { conv =>
+            if (conv.isActive)
+              inject[IConversationScreenController].showConversationMenu(false, conv.id)
+          }
         case _ =>
       }
     }))


### PR DESCRIPTION
`SendConnectRequestFragment` is used both for sending requests and as a screen the user when they open an unconnected chat group member details. In the second case, the right button on the footer menu is visible.
Until now it was the "-" icon, indicating the possibility to remove the user from the group. Now, because of changes of how we display the footer menu, this is changed to the universal "..." icon. Clicking on it opens the bottom popup menu and from there the user may remove the other person from the group.

fixes https://wearezeta.atlassian.net/browse/AN-6077

#### APK
[Download build #12446](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12446/artifact/build/artifact/wire-dev-PR2043-12446.apk)