### PR TITLE
Fixes to reopening the SSO Login page and dialog

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -240,6 +240,9 @@ trait FragmentHelper
   def getBooleanArg(key: String, default: Boolean = false): Boolean =
     Option(getArguments).map(_.getBoolean(key, default)).getOrElse(default)
 
+  def getIntArg(key: String): Option[Int] =
+    Option(getArguments).flatMap(a => Option(a.getInt(key)))
+
   override def onBackPressed(): Boolean = {
     verbose(l"onBackPressed")(LogTag(getClass.getSimpleName))
     false

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -149,17 +149,13 @@ class AppEntryActivity extends BaseActivity {
   // If this is the case, in `onResume` we can pop back the stack and show the new fragment.
   override def onResume(): Unit = {
     super.onResume()
-    withFragmentOpt(AppLaunchFragment.Tag) {
-      case Some(f: AppLaunchFragment) =>
-        // if the SSO token is present we use it to log in the user
-        userAccountsController.ssoToken.head.foreach {
-          case Some(_) =>
-            getFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-            showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
-          case _ =>
-        }(Threading.Ui)
+    // if the SSO token is present we use it to log in the user
+    userAccountsController.ssoToken.head.foreach {
+      case Some(_) =>
+        getFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
       case _ =>
-    }
+    }(Threading.Ui)
   }
 
   private def showFragment(): Unit = withFragmentOpt(AppLaunchFragment.Tag) {

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient.appentry
 
+import android.app.FragmentManager
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
@@ -142,12 +143,30 @@ class AppEntryActivity extends BaseActivity {
     }
   }
 
+  // It is possible to open the app through intents with deep links. If that happens, we can't just
+  // show the fragment that was opened previously - we have to take the user to the fragment specified
+  // by the intent (at this point the information about it should be already stored somewhere).
+  // If this is the case, in `onResume` we can pop back the stack and show the new fragment.
+  override def onResume(): Unit = {
+    super.onResume()
+    withFragmentOpt(AppLaunchFragment.Tag) {
+      case Some(f: AppLaunchFragment) =>
+        // if the SSO token is present we use it to log in the user
+        userAccountsController.ssoToken.head.foreach {
+          case Some(_) =>
+            getFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
+          case _ =>
+        }(Threading.Ui)
+      case _ =>
+    }
+  }
+
   private def showFragment(): Unit = withFragmentOpt(AppLaunchFragment.Tag) {
     case Some(_) =>
     case None =>
       userAccountsController.ssoToken.head.foreach {
-        // if the SSO token is present we use it to log in the user
-        case Some(_) =>                    showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
+        case Some(_) => // if the SSO token is present we will handle it in onResume
         case _ =>
           Option(getIntent.getExtras).map(_.getInt(MethodArg)) match {
             case Some(LoginArgVal) =>      showFragment(SignInFragment(), SignInFragment.Tag, animated = false)

--- a/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
@@ -34,7 +34,7 @@ object AppLaunchFragment {
 
 class AppLaunchFragment extends SSOFragment {
 
-  private def activity = getActivity.asInstanceOf[AppEntryActivity]
+  protected def activity = getActivity.asInstanceOf[AppEntryActivity]
 
   private lazy val createTeamButton = view[LinearLayout](R.id.create_team_button)
   private lazy val createAccountButton = view[LinearLayout](R.id.create_account_button)
@@ -54,5 +54,4 @@ class AppLaunchFragment extends SSOFragment {
     loginButton.foreach(_.onClick(activity.showFragment(SignInFragment(SignInMethod(Login, Email)), SignInFragment.Tag)))
   }
 
-  override protected def onSSOConfirm(code: String): Unit = activity.showFragment(SSOWebViewFragment.newInstance(code.toString), SSOWebViewFragment.Tag)
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -18,7 +18,6 @@
 package com.waz.zclient.appentry
 
 import android.app.FragmentManager
-import android.os.Bundle
 import com.waz.api.impl.ErrorResponse
 import com.waz.service.SSOService
 import com.waz.zclient.InputDialog.{Event, OnNegativeBtn, OnPositiveBtn, ValidatorResult}
@@ -38,9 +37,7 @@ trait SSOFragment extends FragmentHelper {
   import SSOFragment._
   import com.waz.threading.Threading.Implicits.Ui
 
-  private lazy val clipboard              = inject[ClipboardUtils]
   private lazy val ssoService             = inject[SSOService]
-  private lazy val spinner                = inject[SpinnerController]
   private lazy val userAccountsController = inject[UserAccountsController]
 
   private lazy val dialogStaff = new InputDialog.Listener with InputDialog.InputValidator {
@@ -54,11 +51,6 @@ trait SSOFragment extends FragmentHelper {
       else ValidatorResult.Invalid()
   }
 
-  override def onCreate(savedInstanceState: Bundle): Unit = {
-    super.onCreate(savedInstanceState)
-    clipboard.primaryClipChanged.onUi { _ => extractTokenAndShowSSODialog() }
-  }
-
   override def onStart(): Unit = {
     super.onStart()
     findChildFragment[InputDialog](SSODialogTag).foreach(_.setListener(dialogStaff).setValidator(dialogStaff))
@@ -67,13 +59,13 @@ trait SSOFragment extends FragmentHelper {
 
   private def extractTokenFromClipboard: Future[Option[String]] = Future {
     for {
-      clipboardText <- clipboard.getPrimaryClipItemsAsText.headOption
+      clipboardText <- inject[ClipboardUtils].getPrimaryClipItemsAsText.headOption
       token         <- ssoService.extractToken(clipboardText.toString)
     } yield token
   }
 
   protected def extractTokenAndShowSSODialog(showIfNoToken: Boolean = false): Unit =
-    userAccountsController.ssoToken.foreach {
+    userAccountsController.ssoToken.head.foreach {
       case Some(token) =>
         userAccountsController.ssoToken ! None
         verifyInput(token)
@@ -82,24 +74,23 @@ trait SSOFragment extends FragmentHelper {
           .filter(_.nonEmpty || showIfNoToken)
           .foreach(showSSODialog)
       case _ =>
-  }
+    }
 
-  protected def showSSODialog(token: Option[String]): Unit = {
-    InputDialog
-      .newInstance(
-        title = R.string.app_entry_sso_dialog_title,
-        message = R.string.app_entry_sso_dialog_message,
-        inputValue = token,
-        inputHint = Some(R.string.app_entry_sso_input_hint),
-        validateInput = true,
-        disablePositiveBtnOnInvalidInput = true,
-        negativeBtn = R.string.app_entry_dialog_cancel,
-        positiveBtn = R.string.app_entry_dialog_log_in
-      )
+  protected def showSSODialog(token: Option[String]): Unit =
+    if (findChildFragment[InputDialog](SSODialogTag).isEmpty)
+      InputDialog.newInstance(
+          title                            = R.string.app_entry_sso_dialog_title,
+          message                          = R.string.app_entry_sso_dialog_message,
+          inputHint                        = Some(R.string.app_entry_sso_input_hint),
+          inputValue                       = token,
+          validateInput                    = true,
+          disablePositiveBtnOnInvalidInput = true,
+          negativeBtn                      = R.string.app_entry_dialog_cancel,
+          positiveBtn                      = R.string.app_entry_dialog_log_in
+        )
       .setListener(dialogStaff)
       .setValidator(dialogStaff)
       .show(getChildFragmentManager, SSODialogTag)
-  }
 
   protected def verifyInput(input: String): Future[Unit] =
     ssoService.extractUUID(input).fold(Future.successful(())) { token =>
@@ -123,6 +114,5 @@ trait SSOFragment extends FragmentHelper {
 
   protected def activity: AppEntryActivity
 
-  protected def onVerifyingToken(verifying: Boolean): Unit = spinner.showSpinner(verifying)
-
+  protected def onVerifyingToken(verifying: Boolean): Unit = inject[SpinnerController].showSpinner(verifying)
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient.appentry
 
+import android.app.FragmentManager
 import android.os.Bundle
 import com.waz.api.impl.ErrorResponse
 import com.waz.service.SSOService
@@ -34,7 +35,6 @@ object SSOFragment {
 }
 
 trait SSOFragment extends FragmentHelper {
-
   import SSOFragment._
   import com.waz.threading.Threading.Implicits.Ui
 
@@ -109,7 +109,8 @@ trait SSOFragment extends FragmentHelper {
         import ErrorResponse._
         result match {
           case Right(true) =>
-            Future.successful(onSSOConfirm(token.toString))
+            getFragmentManager.popBackStack(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            Future.successful(activity.showFragment(SSOWebViewFragment.newInstance(token.toString), SSOWebViewFragment.Tag))
           case Right(false) =>
             showErrorDialog(R.string.sso_signin_wrong_code_title, R.string.sso_signin_wrong_code_message)
           case Left(ErrorResponse(ConnectionErrorCode | TimeoutCode, _, _)) =>
@@ -120,8 +121,7 @@ trait SSOFragment extends FragmentHelper {
       }
     }
 
-
-  protected def onSSOConfirm(code: String): Unit
+  protected def activity: AppEntryActivity
 
   protected def onVerifyingToken(verifying: Boolean): Unit = spinner.showSpinner(verifying)
 

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -33,9 +33,9 @@ import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient._
-import com.waz.zclient.appentry.{AppEntryActivity, SSOFragment, SSOWebViewFragment}
 import com.waz.zclient.appentry.DialogErrorMessage.{EmailError, PhoneError}
 import com.waz.zclient.appentry.fragments.SignInFragment._
+import com.waz.zclient.appentry.{AppEntryActivity, SSOFragment}
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.newreg.fragments.TabPages
 import com.waz.zclient.newreg.fragments.country.{Country, CountryController}
@@ -411,9 +411,7 @@ class SignInFragment
       false
     }
 
-  override protected def onSSOConfirm(code: String): Unit = activity.showFragment(SSOWebViewFragment.newInstance(code.toString), SSOWebViewFragment.Tag)
-
-  def activity = getActivity.asInstanceOf[AppEntryActivity]
+  override protected def activity: AppEntryActivity = getActivity.asInstanceOf[AppEntryActivity]
 }
 
 object SignInFragment {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
@@ -23,7 +23,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import com.waz.zclient._
-import com.waz.zclient.appentry.{CreateTeamFragment, SSOFragment, SSOWebViewFragment}
+import com.waz.zclient.appentry.{CreateTeamFragment, SSOFragment}
 import com.waz.zclient.common.views.InputBox
 import com.waz.zclient.common.views.InputBox.NameValidator
 import com.waz.zclient.ui.utils.KeyboardUtils
@@ -57,8 +57,6 @@ case class TeamNameFragment() extends CreateTeamFragment with SSOFragment {
 
   private def openUrl(id: Int): Unit =
     context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(id))))
-
-  override protected def onSSOConfirm(code: String): Unit = showFragment(SSOWebViewFragment.newInstance(code), SSOWebViewFragment.Tag)
 }
 
 object TeamNameFragment {


### PR DESCRIPTION
### fix: Reopening the SSO Login from an SSO link should reset the page

Until now bringing the app from the background tothe front simply displayed the last screen the user was on. With the introduction of deep links this will have to change. Just as with opening the app from a notification, the app will have to figure out what screen should be displayed.
If the user clicks on an SSO link while the app is in the background and already on the `SSOWebViewFragment`, the fragment should not just be displayed, but it should be reloaded.

fixes https://wearezeta.atlassian.net/browse/AN-6056

### fix: The SSO dialogs should not pile on each other

If the user went back and forth between the Welcome Page and subsequent login/registration pages,
the SSO dialog was sometimes created twice for every page, but when the user clicked `cancel`,
only one was really dismissed. The other didn't appear, but it was also not gone: when the user
went back and forth again and saw the dialog again, now two clicks on `cancel` were required
to dismiss it. Then three, then four, etc.
I fixed the creation of the second dialog, and also changed the way listeners are added and
removed from the dialog (they should be handled in `onStart` and `onStop`).

fixes https://wearezeta.atlassian.net/browse/AN-6086

#### APK
[Download build #12449](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12449/artifact/build/artifact/wire-dev-PR2046-12449.apk)
[Download build #12451](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12451/artifact/build/artifact/wire-dev-PR2046-12451.apk)
[Download build #12454](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12454/artifact/build/artifact/wire-dev-PR2046-12454.apk)
[Download build #12456](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12456/artifact/build/artifact/wire-dev-PR2046-12456.apk)