### PR TITLE
feat: track latency of notifications in new table

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.2253-DEV"
+    zMessagingDevVersion = "141.0.0-SNAPSHOT"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.0-SNAPSHOT"
+    zMessagingDevVersion = "141.0.805-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -148,13 +148,14 @@ object FCMHandlerService {
               idle
             )).map(_ => {})
         }
-        _ <- nId.fold(Future.successful({})) { nId =>
-          fcmPushes.insert(
+        _ <- nId match {
+          case Some(n) => fcmPushes.insert(
             FCMNotification(
-              nId,
+              n,
               now,
               FCMNotification.Pushed
             )).map(_ => {})
+          case _ => Future.successful(())
         }
 
         /**

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -149,12 +149,7 @@ object FCMHandlerService {
             )).map(_ => {})
         }
         _ <- nId match {
-          case Some(n) => fcmPushes.insert(
-            FCMNotification(
-              n,
-              now,
-              FCMNotification.Pushed
-            )).map(_ => {})
+          case Some(n) => fcmPushes.insert(FCMNotification(n, now, FCMNotification.Pushed))
           case _ => Future.successful(())
         }
 

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -23,7 +23,7 @@ import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InForeground
 import com.waz.service.ZMessaging.clock
 import com.waz.service.push.PushService.FetchFromIdle
-import com.waz.service.push.{PushService, ReceivedPushData, ReceivedPushStorage}
+import com.waz.service.push._
 import com.waz.service.{AccountsService, NetworkModeService, ZMessaging}
 import com.waz.services.ZMessagingService
 import com.waz.threading.Threading
@@ -114,6 +114,7 @@ object FCMHandlerService {
                    push:           PushService,
                    network:        NetworkModeService,
                    receivedPushes: ReceivedPushStorage,
+                   fcmPushes:      FCMNotificationsRepository,
                    sentTime:       Instant) extends DerivedLogTag {
 
     import com.waz.threading.Threading.Implicits.Background
@@ -147,6 +148,14 @@ object FCMHandlerService {
               idle
             )).map(_ => {})
         }
+        _ <- nId.fold(Future.successful({})) { nId =>
+          fcmPushes.insert(
+            FCMNotification(
+              nId,
+              now,
+              FCMNotification.Pushed
+            )).map(_ => {})
+        }
 
         /**
           * Warning: Here we want to trigger a direct fetch if we are in doze mode - when we get an FCM in doze mode, it is
@@ -163,7 +172,8 @@ object FCMHandlerService {
 
   object FCMHandler {
     def apply(zms: ZMessaging, data: Map[String, String], sentTime: Instant): Future[Unit] =
-      new FCMHandler(zms.selfUserId, zms.accounts, zms.push, zms.network, zms.receivedPushStorage, sentTime).handleMessage(data)
+      new FCMHandler(zms.selfUserId, zms.accounts, zms.push, zms.network, zms.receivedPushStorage,
+        zms.fcmNotifications, sentTime).handleMessage(data)
   }
 
   val DataKey = "data"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Add first table for notification tracking. This is the first stage, where we store all notifications received over FCM into a table.
#### APK
[Download build #12455](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12455/artifact/build/artifact/wire-dev-PR2048-12455.apk)
[Download build #12458](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12458/artifact/build/artifact/wire-dev-PR2048-12458.apk)
[Download build #12461](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12461/artifact/build/artifact/wire-dev-PR2048-12461.apk)