### PR TITLE
refactor: remove unused ReceivedPushData table

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.805-PR"
+    zMessagingDevVersion = "141.0.810-PR"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -31,7 +31,6 @@ import com.waz.service.ZMessaging
 import com.waz.service.tracking.TrackingService.NoReporting
 import com.waz.service.tracking._
 import com.waz.threading.{SerialDispatchQueue, Threading}
-import com.waz.utils.RichThreetenBPDuration
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient._
 import com.waz.zclient.appentry.fragments.SignInFragment
@@ -40,7 +39,6 @@ import com.waz.zclient.log.LogUI._
 
 import scala.concurrent.Future
 import scala.concurrent.Future._
-import scala.concurrent.duration._
 import scala.util.Try
 
 class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext)
@@ -87,8 +85,6 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
           }
         case e: LoggedOutEvent if e.reason == LoggedOutEvent.InvalidCredentials =>
           //This event type is trigged a lot, so disable for now
-        case e: ReceivedPushEvent if e.p.toFetch.forall(_.asScala < 10.seconds) =>
-        //don't track - there are a lot of these events! We want to keep the event count lower
         case e@ExceptionEvent(_, _, description, Some(throwable)) =>
           error(l"description: ${redactedString(description)}", throwable)(e.tag)
           isTrackingEnabled.head.map {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Remove the unused ReceivedPushData table as this is now being replaced by FCMNotificationsRepository.
#### APK
[Download build #12459](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12459/artifact/build/artifact/wire-dev-PR2049-12459.apk)
[Download build #12462](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12462/artifact/build/artifact/wire-dev-PR2049-12462.apk)