### PR TITLE
Feature/logs setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.825-PR"
+    zMessagingDevVersion = "141.0.2257"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'

--- a/app/src/main/res/layout/preferences_advanced_layout.xml
+++ b/app/src/main/res/layout/preferences_advanced_layout.xml
@@ -35,10 +35,20 @@
             android:orientation="vertical"
             >
 
+            <com.waz.zclient.preferences.views.SwitchPreference
+                android:id="@+id/preferences_enable_logs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
+                app:title="@string/pref_advanced_enable_logs_title"
+                app:subtitle="@string/pref_advanced_enable_logs_subtitle"
+                />
+
             <com.waz.zclient.preferences.views.TextButton
                 android:id="@+id/preferences_debug_report"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
                 app:subtitle="@string/pref_advanced_debug_report_summary"
                 app:title="@string/pref_advanced_debug_report_title"
                 />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,8 +493,10 @@
 
     <!-- Advanced -->
     <string name="pref_advanced_screen_title">Advanced</string>
-    <string name="pref_advanced_debug_report_title">Submit debug report</string>
-    <string name="pref_advanced_debug_report_summary">This helps Wire Support diagnose problems.</string>
+    <string name="pref_advanced_enable_logs_title">Collect usage data</string>
+    <string name="pref_advanced_enable_logs_subtitle">This stores troubleshooting information locally. Disabling this option will delete all local logs.</string>
+    <string name="pref_advanced_debug_report_title">Create debug report</string>
+    <string name="pref_advanced_debug_report_summary">You can submit this to Wire Support to help diagnose problems.</string>
     <string name="pref_advanced_reset_push_title">Reset push notifications token</string>
     <string name="pref_advanced_reset_push_summary">If you experience problems with push notifications, Wire Support may ask you to reset this token.</string>
     <string name="pref_advanced_reset_push_completed">Push token has been reset</string>

--- a/app/src/main/scala/com/waz/services/FutureService.scala
+++ b/app/src/main/scala/com/waz/services/FutureService.scala
@@ -27,6 +27,7 @@ import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.waz.utils.WakeLockImpl
 import com.waz.zclient.log.LogUI._
+import com.waz.zclient.Intents.RichIntent
 
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
@@ -38,7 +39,7 @@ abstract class FutureService extends Service with DerivedLogTag {
   override def onBind(intent: Intent): IBinder = null
 
   override def onStartCommand(intent: Intent, flags: Int, startId: Int): Int = wakeLock {
-    debug(l"onStartCommand: $startId, intent: $intent")
+    debug(l"onStartCommand: $startId, intent: ${RichIntent(intent)}")
     Option(intent) foreach WakefulBroadcastReceiver.completeWakefulIntent
 
     val future =

--- a/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
@@ -34,10 +34,11 @@ import scala.concurrent.Future
   */
 class CallWakeService extends FutureService with ZMessagingService with DerivedLogTag {
   import CallWakeService._
+  import com.waz.zclient.Intents.RichIntent
   implicit val ec = EventContext.Global
 
   override protected def onIntent(intent: AIntent, id: Int): Future[Any] = onZmsIntent(intent) { implicit zms =>
-    debug(l"onIntent $intent")
+    debug(l"onIntent ${RichIntent(intent)}")
     if (intent != null && intent.hasExtra(ConvIdExtra)) {
       implicit val convId = ConvId(intent.getStringExtra(ConvIdExtra))
       debug(l"convId: $convId")

--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -32,6 +32,7 @@ import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient._
+import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.log.LogUI._
 
 class WebSocketController(implicit inj: Injector) extends Injectable {
@@ -93,7 +94,7 @@ class OnBootAndUpdateBroadcastReceiver extends BroadcastReceiver with DerivedLog
 
   override def onReceive(context: Context, intent: Intent): Unit = {
     this.context = context
-    verbose(l"onReceive $intent")
+    verbose(l"onReceive ${RichIntent(intent)}")
 
     accounts.zmsInstances.head.foreach { zs =>
       zs.map(_.selfUserId).foreach(PushTokenCheckJob(_))
@@ -165,7 +166,7 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
   override def onBind(intent: content.Intent): IBinder = null
 
   override def onStartCommand(intent: Intent, flags: Int, startId: Int): Int = {
-    verbose(l"onStartCommand($intent, $startId)")
+    verbose(l"onStartCommand(${RichIntent(intent)}, $startId)")
     webSocketActiveSubscription
     appInForegroundSubscription
 

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -31,6 +31,7 @@ import com.waz.service.{UiLifeCycle, ZMessaging}
 import com.waz.services.websocket.WebSocketService
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.returning
+import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.tracking.GlobalTrackingController
@@ -99,7 +100,7 @@ class BaseActivity extends AppCompatActivity
   def getBaseTheme: Int = themeController.forceLoadDarkTheme
 
   override protected def onActivityResult(requestCode: Int, resultCode: Int, data: Intent) = {
-    verbose(l"onActivityResult: requestCode: $requestCode, resultCode: $resultCode, data: $data")
+    verbose(l"onActivityResult: requestCode: $requestCode, resultCode: $resultCode, data: ${RichIntent(data)}")
     super.onActivityResult(requestCode, resultCode, data)
     permissions.registerProvider(this)
   }

--- a/app/src/main/scala/com/waz/zclient/ShareActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/ShareActivity.scala
@@ -38,6 +38,7 @@ import com.waz.zclient.common.controllers.SharingController
 import com.waz.zclient.common.controllers.SharingController.{FileContent, ImageContent}
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.controllers.confirmation.TwoButtonConfirmationCallback
+import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.sharing.ShareToMultipleFragment
 import com.waz.zclient.views.menus.ConfirmationMenu
@@ -92,7 +93,7 @@ class ShareActivity extends BaseActivity with ActivityHelper {
     inject[PermissionsService].requestAllPermissions(ListSet(READ_EXTERNAL_STORAGE)).map {
       case true =>
         val intent = getIntent
-        verbose(l"$intent")
+        verbose(l"${RichIntent(intent)}")
         val ir = ShareCompat.IntentReader.from(this)
         if (!ir.isShareIntent) finish()
         else {

--- a/app/src/main/scala/com/waz/zclient/log/LogShowInstancesUI.scala
+++ b/app/src/main/scala/com/waz/zclient/log/LogShowInstancesUI.scala
@@ -23,8 +23,6 @@ import com.waz.log.LogShow
 import com.waz.service.tracking.TrackingEvent
 import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.collection.controllers.CollectionController.ContentType
-import com.waz.zclient.deeplinks.DeepLink
-import com.waz.zclient.deeplinks.DeepLinkService.CheckingResult
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.MessageView.MsgBindOptions
 import com.waz.zclient.messages.UsersController.DisplayName
@@ -104,7 +102,5 @@ trait LogShowInstancesUI {
     LogShow.createFrom { t =>
       l"ContentType(msgTypes: ${t.msgTypes}, typeFilter: ${t.typeFilter})"
     }
-
-  implicit val DeepLinkLogShow: LogShow[DeepLink] = LogShow.logShowWithHash
 
 }

--- a/app/src/main/scala/com/waz/zclient/log/LogShowInstancesUI.scala
+++ b/app/src/main/scala/com/waz/zclient/log/LogShowInstancesUI.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.zclient.log
 
-import android.content.Intent
 import com.evernote.android.job.Job
 import com.waz.avs.VideoPreview
 import com.waz.log.LogShow
@@ -38,27 +37,22 @@ trait LogShowInstancesUI {
   
   implicit val JobLogShow: LogShow[Job] = LogShow.logShowWithHash
 
-  implicit val IntentLogShow: LogShow[Intent] = LogShow.create(_ => "intent")
-
-  implicit val RichIntentLogShow: LogShow[RichIntent] = LogShow.create(_ => "rich intent")
-//    LogShow.createFrom { i =>
-//      l"""
-//         |Intent(
-//         |  action:           ${redactedString(i.intent.getAction)}
-//         |  flags:            ${redactedString(i.intent.getFlags.toString)}
-//         |  extras:           ${redactedString(i.intent.getExtras.toString)}
-//         |  categories:       ${redactedString(i.intent.getCategories.toString)}
-//         |  data:             ${redactedString(i.intent.getDataString)}
-//         |  fromNotification: ${i.fromNotification}
-//         |  fromSharing:      ${i.intent.fromSharing}
-//         |  startCall:        ${i.intent.startCall}
-//         |  accountId:        ${i.accountId}
-//         |  convId:           ${i.convId}
-//         |  page:             ${i.page.map(redactedString)})
-//       """.stripMargin
-//    }
-
-  implicit val DeepLinkCheckingResultLogShow: LogShow[CheckingResult] = LogShow.logShowWithHash
+  implicit val RichIntentLogShow: LogShow[RichIntent] =
+    LogShow.createFrom { i =>
+      l"""
+         |Intent(
+         |  action:           ${i.getAction.map(redactedString)},
+         |  flags:            ${redactedString(i.getFlags.toString)},
+         |  extras:           ${i.getExtras.map(e => redactedString(e.toString))},
+         |  data:             ${i.getDataString.map(redactedString)},
+         |  fromNotification: ${i.fromNotification},
+         |  fromSharing:      ${i.fromSharing},
+         |  startCall:        ${i.startCall},
+         |  accountId:        ${i.accountId},
+         |  convId:           ${i.convId},
+         |  page:             ${i.page.map(redactedString)})
+        """.stripMargin
+  }
 
   implicit val SearchUserListStateLogShow: LogShow[SearchUserListState] =
     LogShow.createFrom {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
@@ -24,6 +24,8 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.{LinearLayout, Toast}
 import com.waz.content.GlobalPreferences.WsForegroundKey
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.log.LogsService
 import com.waz.service.ZMessaging
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.returning
@@ -34,38 +36,57 @@ import com.waz.zclient.utils.{BackStackKey, DebugUtils}
 import com.waz.zclient.{R, ViewHelper}
 
 import scala.concurrent.duration._
+
 trait AdvancedView
 
-class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with AdvancedView with ViewHelper {
+class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int)
+  extends LinearLayout(context, attrs, style)
+    with AdvancedView
+    with ViewHelper
+    with DerivedLogTag {
+
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
   inflate(R.layout.preferences_advanced_layout)
 
+  private val logsService = inject[LogsService]
+  private val initialLogsEnabled = logsService.logsEnabledGlobally.currentValue.getOrElse(false)
 
-  val submitReport = returning(findById[TextButton](R.id.preferences_debug_report)) { v =>
+  val submitLogs = returning(findById[TextButton](R.id.preferences_debug_report)) { v =>
+    setButtonEnabled(v, initialLogsEnabled)
+
     v.onClickEvent { _ =>
       DebugUtils.sendDebugReport(context.asInstanceOf[Activity])
     }
   }
 
-  val resetPush = returning(findById[TextButton](R.id.preferences_reset_push)) { v =>
-    def setResetEnabled(enabled: Boolean): Unit = {
-      v.setEnabled(enabled)
-      v.setAlpha(if (enabled) 1.0f else 0.5f)
-    }
+  val loggingSwitch = returning(findById[SwitchPreference](R.id.preferences_enable_logs)) { v =>
+    v.setChecked(initialLogsEnabled)
 
+    v.onCheckedChange { enabled =>
+      logsService.setLogsEnabled(enabled)
+      setButtonEnabled(submitLogs, enabled)
+    }
+  }
+
+  val resetPush = returning(findById[TextButton](R.id.preferences_reset_push)) { v =>
     v.onClickEvent { _ =>
       ZMessaging.currentGlobal.tokenService.resetGlobalToken()
       Toast.makeText(getContext, getString(R.string.pref_advanced_reset_push_completed)(getContext), Toast.LENGTH_LONG).show()
-      setResetEnabled(false)
-      CancellableFuture.delay(5.seconds).map(_ => setResetEnabled(true))(Threading.Ui)
+      setButtonEnabled(v, enabled = false)
+      CancellableFuture.delay(5.seconds).map(_ => setButtonEnabled(v, enabled = true))(Threading.Ui)
     }
   }
 
   val webSocketForegroundServiceSwitch = returning(findById[SwitchPreference](R.id.preferences_websocket_service)) { v =>
     inject[GoogleApi].isGooglePlayServicesAvailable.map(if (_) View.GONE else View.VISIBLE).onUi(v.setVisibility)
     v.setPreference(WsForegroundKey, global = true)
+  }
+
+  def setButtonEnabled(button: TextButton, enabled: Boolean): Unit = {
+    button.setEnabled(enabled)
+    button.setAlpha(if (enabled) 1f else .5f)
   }
 }
 


### PR DESCRIPTION
## What's new in this PR?

This PR introduces a new global preference to enable/disable logs:

- The switch preference is the first item in _Settings -> Advanced_.
- It is disabled by default.
- The _Create debug report_ button is only enabled if the switch is enabled.
- Disabling the switch will delete all existing logcat and internal logs.

There were also some issues with logging `Intent`; in some cases either the intent was `null`, or some of its methods that were used in the log returned `null`. To overcome this, I removed `LogShow[Intent]`, added some helper methods to `RichIntent` and used `LogShow[RichIntent]` instead.

## Needs Release With
- [x] https://github.com/wireapp/wire-android-sync-engine/pull/516/files
#### APK
[Download build #12493](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12493/artifact/build/artifact/wire-dev-PR2050-12493.apk)
[Download build #12499](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12499/artifact/build/artifact/wire-dev-PR2050-12499.apk)