### PR TITLE
Addresses Issue #1946 to enable copying sent ephemeral messages

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
@@ -118,7 +118,7 @@ object MessageBottomSheetDialog {
     case object Copy extends MessageAction(R.id.message_bottom_menu_item_copy, R.string.glyph__copy, R.string.message_bottom_menu_action_copy) {
       override def enabled(msg: MessageData, zms: ZMessaging, p: Params): Signal[Boolean] =
         msg.msgType match {
-          case TEXT | TEXT_EMOJI_ONLY | RICH_MEDIA if !msg.isEphemeral => Signal.const(true)
+          case TEXT | TEXT_EMOJI_ONLY | RICH_MEDIA if zms.selfUserId == msg.userId || !msg.isEphemeral => Signal.const(true)
           case _ => Signal.const(false)
         }
     }


### PR DESCRIPTION
## What's new in this PR?
Ability to copy sent ephemeral messages
### Issues

Earlier user wasn't able to copy sent ephemeral messages to clipboard. This PR enables that.  Fixes #1946 

### Solutions

The solution adds a conditional check to see if the message is a sent ephemeral message and then allows copying.

### Testing

The app was run on Emulator(Pixel 2), S9+ and Xiaomi A2 to test. 
