### PR TITLE
fix: remove analytics library from dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -350,7 +350,10 @@ dependencies {
     implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
     implementation "com.google.android.gms:play-services-location:$playServicesVersion"
     implementation "com.google.android.gms:play-services-gcm:$playServicesVersion"
-    implementation 'com.google.firebase:firebase-messaging:17.3.0'
+    implementation ('com.google.firebase:firebase-messaging:17.3.0') {
+        exclude group: 'com.google.firebase', module: 'firebase-analytics'
+        exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
+    }
 
     //WorkManager
     def work_version = "1.0.0-alpha13"


### PR DESCRIPTION
## What's new in this PR?
Removing some warning about tracking libraries by excluding those libraries completely.

### Issues
Wire tests positive for trackers on the Exodus detection tool/website. See https://github.com/wireapp/wire-android/issues/1986

### Causes
The Firebase library (which we use for FCM) also includes some tracking libraries. Even if we don't use them, they are still included and this will trigger a warning.

### Solutions
I used the suggestion from https://github.com/wireapp/wire-android/issues/1986#issuecomment-465808522 and excluded those libraries manually from the Firebase import package.

### Testing

There are two concerns here:
1. Will this change remove the warning?
1. Will this change affect negatively the behavior of notifications for the user?

For the warning, I manually checked a local build on device with _ClassyShark3xodus_ as suggested in https://github.com/wireapp/wire-android/issues/1986#issuecomment-474808790

_ClassyShark3xodus_ reported trackers before the fix, and no trackers after the fix. ✅

For the notification behavior, this is not so straightforward to test as in general it's hard to test absence of bugs, and notification is a complex system. In agreement with @AnastasiiaWire we decided to let this build run on internal apps for a couple of weeks before releasing, and gather feedback from internal users. We will merge this PR only when the current release is done, then test it internally and if no problem is detected, it will go public with the following release.