### PR TITLE
fix: Properly initialize the app before handling conversation and profile deep links

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -145,7 +145,7 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
           for {
             Some(acc) <- account.map(_.map(_.userId)).head
             _         <- callStart.startCall(acc, convId)
-          } yield {}
+          } yield ()
       }
     } (Threading.Ui).future
 

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -25,32 +25,38 @@ import com.waz.content.UserPreferences.CrashesAndAnalyticsRequestShown
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.model.{ErrorData, Uid}
 import com.waz.service.{AccountManager, GlobalModule, ZMessaging}
-import com.waz.threading.Threading
-import com.waz.utils.events.Signal
+import com.waz.threading.{CancellableFuture, Threading}
+import com.waz.utils.events.{Signal, Subscription}
 import com.waz.utils.returning
+import com.waz.zclient._
 import com.waz.zclient.collection.controllers.CollectionController
 import com.waz.zclient.collection.fragments.CollectionFragment
-import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.controllers.global.{AccentColorController, KeyboardController}
+import com.waz.zclient.common.controllers.{BrowserController, UserAccountsController}
 import com.waz.zclient.controllers.collections.CollectionsObserver
 import com.waz.zclient.controllers.confirmation.{ConfirmationObserver, ConfirmationRequest, IConfirmationController}
 import com.waz.zclient.controllers.navigation.{INavigationController, Page}
 import com.waz.zclient.controllers.singleimage.{ISingleImageController, SingleImageObserver}
 import com.waz.zclient.conversation.{ConversationController, ImageFragment}
+import com.waz.zclient.deeplinks.{DeepLink, DeepLinkService}
 import com.waz.zclient.giphy.GiphySharingPreviewFragment
 import com.waz.zclient.log.LogUI
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.main.conversationlist.ConfirmationFragment
 import com.waz.zclient.pages.main.conversationpager.ConversationPagerFragment
+import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
+import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.tracking.GlobalTrackingController.analyticsPrefKey
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.views.menus.ConfirmationMenu
-import com.waz.zclient.{ErrorsController, FragmentHelper, OnBackPressedListener, R}
-import com.waz.zclient.BuildConfig
+import DeepLink.{logTag => _, _}
+import DeepLinkService._
 
+import scala.collection.mutable
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class MainPhoneFragment extends FragmentHelper
   with OnBackPressedListener
@@ -72,11 +78,14 @@ class MainPhoneFragment extends FragmentHelper
   private lazy val collectionController   = inject[CollectionController]
   private lazy val browserController      = inject[BrowserController]
   private lazy val errorsController       = inject[ErrorsController]
-
   private lazy val navigationController   = inject[INavigationController]
   private lazy val singleImageController  = inject[ISingleImageController]
   private lazy val confirmationController = inject[IConfirmationController]
   private lazy val keyboardController     = inject[KeyboardController]
+  private lazy val deepLinkService        = inject[DeepLinkService]
+  private lazy val participantsController = inject[ParticipantsController]
+  private lazy val userAccountsController = inject[UserAccountsController]
+  private lazy val pickUserController     = inject[IPickUserController]
 
   private lazy val confirmationMenu = returning(view[ConfirmationMenu](R.id.cm__confirm_action_light)) { vh =>
     accentColorController.accentColor.map(_.color).onUi(color => vh.foreach(_.setButtonColor(color)))
@@ -135,6 +144,8 @@ class MainPhoneFragment extends FragmentHelper
     zms.flatMap(_.errors.getErrors).onUi { _.foreach(handleSyncError) }
   }
 
+  private val subs = mutable.HashSet.empty[Subscription]
+
   override def onStart(): Unit = {
     super.onStart()
     singleImageController.addSingleImageObserver(this)
@@ -142,9 +153,35 @@ class MainPhoneFragment extends FragmentHelper
     collectionController.addObserver(this)
 
     consentDialogFuture
+
+    subs += deepLinkService.deepLink.onUi {
+      case Some(OpenDeepLink(UserToken(userId), UserTokenInfo(connected, currentTeamMember))) =>
+        pickUserController.hideUserProfile()
+        if (connected || currentTeamMember) {
+          CancellableFuture.delay(750.millis).map { _ =>
+            userAccountsController.getOrCreateAndOpenConvFor(userId)
+              .foreach { _ =>
+                participantsController.onShowParticipantsWithUserId ! userId
+              }
+          }
+        } else {
+          CancellableFuture.delay(getInt(R.integer.framework_animation_duration_medium).millis).map { _ =>
+            navigationController.setVisiblePage(Page.CONVERSATION_LIST, MainPhoneFragment.Tag)
+            participantsController.onShowAnimations ! true
+            pickUserController.showUserProfile(userId)
+          }
+        }
+
+      case Some(OpenDeepLink(ConversationToken(convId), _)) =>
+        conversationController.switchConversation(convId)
+
+      case _ =>
+    }
   }
 
   override def onStop(): Unit = {
+    subs.foreach(_.unsubscribe())
+    subs.clear()
     singleImageController.removeSingleImageObserver(this)
     confirmationController.removeConfirmationObserver(this)
     collectionController.removeObserver(this)

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -49,6 +49,7 @@ import com.waz.zclient.pages.main.conversationlist.ConfirmationFragment
 import com.waz.zclient.pages.main.conversationpager.ConversationPagerFragment
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
+import com.waz.zclient.participants.ParticipantsController.ParticipantRequest
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.tracking.GlobalTrackingController.analyticsPrefKey
 import com.waz.zclient.utils.ContextUtils._
@@ -149,7 +150,7 @@ class MainPhoneFragment extends FragmentHelper
           CancellableFuture.delay(750.millis).map { _ =>
             userAccountsController.getOrCreateAndOpenConvFor(userId)
               .foreach { _ =>
-                participantsController.onShowParticipantsWithUserId ! userId
+                participantsController.onShowParticipantsWithUserId ! ParticipantRequest(userId, fromDeepLink = true)
               }
           }
         } else {


### PR DESCRIPTION
Currently deep links work only if the app was previous opened and now works in the background.
This is because we handle all deep links in `MainActivity`. If the app is not initialized already,
we try to switch the conversation or open a profile before `MainPhoneFragment` is set up.
This PR delays handling of these two types of deep links, moving them to the `onStart` method
of `MainPhoneFragment`.

#### APK
[Download build #12494](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12494/artifact/build/artifact/wire-dev-PR2062-12494.apk)
[Download build #12495](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12495/artifact/build/artifact/wire-dev-PR2062-12495.apk)
[Download build #12496](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12496/artifact/build/artifact/wire-dev-PR2062-12496.apk)
[Download build #12500](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12500/artifact/build/artifact/wire-dev-PR2062-12500.apk)
[Download build #12501](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12501/artifact/build/artifact/wire-dev-PR2062-12501.apk)
[Download build #12502](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12502/artifact/build/artifact/wire-dev-PR2062-12502.apk)