### PR TITLE
Propagate deep link argument to SingleParticipantFragment

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -52,6 +52,7 @@ import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.pages.startup.UpdateFragment
 import com.waz.zclient.participants.ParticipantsController
+import com.waz.zclient.participants.ParticipantsController.ParticipantRequest
 import com.waz.zclient.preferences.PreferencesActivity
 import com.waz.zclient.preferences.dialogs.ChangeHandleFragment
 import com.waz.zclient.tracking.UiTrackingController
@@ -183,7 +184,7 @@ class MainActivity extends BaseActivity
           CancellableFuture.delay(750.millis).map { _ =>
             userAccountsController.getOrCreateAndOpenConvFor(userId)
               .foreach { _ =>
-                participantsController.onShowParticipantsWithUserId ! userId
+                participantsController.onShowParticipantsWithUserId ! ParticipantRequest(userId, fromDeepLink = true)
               }
           }
         } else {

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MentionsViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MentionsViewPart.scala
@@ -28,6 +28,7 @@ import com.waz.zclient.messages.{MessageView, MessageViewPart}
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.ui.utils.ColorUtils
 import com.waz.utils.returning
+import com.waz.zclient.participants.ParticipantsController.ParticipantRequest
 import com.waz.zclient.utils.ContextUtils._
 
 trait MentionsViewPart extends MessageViewPart with ViewHelper {
@@ -66,7 +67,7 @@ trait MentionsViewPart extends MessageViewPart with ViewHelper {
         new ClickableSpan {
           override def onClick(widget: View): Unit = {
             mention.userId match {
-              case Some(uId) => participantsController.onShowParticipantsWithUserId ! uId
+              case Some(uId) => participantsController.onShowParticipantsWithUserId ! ParticipantRequest(uId)
               case _ => participantsController.onShowParticipants ! None
             }
           }

--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -122,11 +122,11 @@ class ConversationManagerFragment extends FragmentHelper
       showFragment(ParticipantFragment.newInstance(childTag), ParticipantFragment.TAG)
     }
 
-    subs += participantsController.onShowParticipantsWithUserId.onUi { user =>
+    subs += participantsController.onShowParticipantsWithUserId.onUi { p =>
       keyboard.hideKeyboardIfVisible()
       navigationController.setRightPage(Page.PARTICIPANT, ConversationManagerFragment.Tag)
-      participantsController.selectParticipant(user)
-      showFragment(ParticipantFragment.newInstance(user), ParticipantFragment.TAG)
+      participantsController.selectParticipant(p.userId)
+      showFragment(ParticipantFragment.newInstance(p.userId, p.fromDeepLink), ParticipantFragment.TAG)
     }
 
     subs += participantsController.onShowAnimations.onUi { withAnimations =>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -27,6 +27,7 @@ import com.waz.zclient.common.controllers.{SoundController, ThemeController}
 import com.waz.zclient.controllers.confirmation.{ConfirmationRequest, IConfirmationController, TwoButtonConfirmationCallback}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
+import com.waz.zclient.participants.ParticipantsController.ParticipantRequest
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{UiStorage, UserSignal}
 import com.waz.zclient.{Injectable, Injector, R}
@@ -48,7 +49,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
 
   val onShowParticipants = EventStream[Option[String]]() //Option[String] = fragment tag //TODO use type?
   val onShowAnimations = EventStream[Boolean]() //Boolean represents with or without animations
-  val onShowParticipantsWithUserId = EventStream[UserId]()
+  val onShowParticipantsWithUserId = EventStream[ParticipantRequest]()
 
   val onShowUser = EventStream[Option[UserId]]()
 
@@ -142,4 +143,8 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
       inject[SoundController].playAlert()
     case _ =>
   }(Threading.Ui)
+}
+
+object ParticipantsController {
+  case class ParticipantRequest(userId: UserId, fromDeepLink: Boolean = false)
 }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -104,7 +104,7 @@ class ParticipantFragment extends ManagerFragment
               case true if getStringArg(UserToOpenArg).isEmpty =>
                 (GroupParticipantsFragment.newInstance(), GroupParticipantsFragment.Tag)
               case _ =>
-                (SingleParticipantFragment.newInstance(), SingleParticipantFragment.Tag)
+                (SingleParticipantFragment.newInstance(fromDeepLink = getBooleanArg(FromDeepLinkArg)), SingleParticipantFragment.Tag)
             }
         }).map {
           case (f, tag) =>
@@ -291,6 +291,7 @@ object ParticipantFragment {
   val TAG: String = classOf[ParticipantFragment].getName
   private val PageToOpenArg = "ARG__FIRST__PAGE"
   private val UserToOpenArg = "ARG__USER"
+  private val FromDeepLinkArg = "ARG__FROM__DEEP__LINK"
 
   def newInstance(page: Option[String]): ParticipantFragment =
     returning(new ParticipantFragment) { f =>
@@ -299,9 +300,12 @@ object ParticipantFragment {
       }
     }
 
-  def newInstance(userId: UserId): ParticipantFragment =
+  def newInstance(userId: UserId, fromDeepLink: Boolean = false): ParticipantFragment =
     returning(new ParticipantFragment) { f =>
-      f.setArguments(returning(new Bundle)(_.putString(UserToOpenArg, userId.str)))
+      f.setArguments(returning(new Bundle) { b =>
+        b.putString(UserToOpenArg, userId.str)
+        b.putBoolean(FromDeepLinkArg, fromDeepLink)
+      })
     }
 
 }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -297,13 +297,13 @@ object SingleParticipantFragment {
   }
 
   private val TabToOpen: String = "TAB_TO_OPEN"
+  private val FromDeepLink: String = "FROM_DEEP_LINK"
 
-  def newInstance(tabToOpen: Option[String] = None): SingleParticipantFragment =
+  def newInstance(tabToOpen: Option[String] = None, fromDeepLink: Boolean = false): SingleParticipantFragment =
     returning(new SingleParticipantFragment) { f =>
-      tabToOpen.foreach { t =>
-        f.setArguments(returning(new Bundle){
-          _.putString(TabToOpen, t)
-        })
-      }
+      val args = new Bundle()
+      args.putBoolean(FromDeepLink, fromDeepLink)
+      tabToOpen.foreach { t => args.putString(TabToOpen, t)}
+      f.setArguments(args)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The user profile screen needs to know whether it was opened via a deep link.

### Solutions

Simply propagate a boolean argument from the point we react to the deep link until we open the `SingleParticipantFragment`.

## Notes

This is in preparation for changing the footer of the user profile, which will happen in a separate PR.
#### APK
[Download build #12498](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12498/artifact/build/artifact/wire-dev-PR2064-12498.apk)