### PR TITLE
Fix/deep link user info

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1294,6 +1294,9 @@
     <string name="deep_link_conversation_error_title">Wire cannot open this conversation.</string>
     <string name="deep_link_conversation_error_message">This account may not have access or the conversation may not exist.</string>
 
+    <string name="deep_link_user_error_title">Wire can\'t find this person.</string>
+    <string name="deep_link_user_error_message">You may not have permission with this account or it no longer exists.</string>
+
     <!--Two identical strings are needed for German translation-->
     <string name="quote_timestamp_message_time">Original message from %s</string>
     <string name="quote_timestamp_message_date">Original message from %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1291,8 +1291,8 @@
     <string name="reply_message_type_asset">ATTACHMENT</string>
     <string name="reply_message_type_unknown">You cannot see this message.</string>
 
-    <string name="deep_link_conversation_error_title">Wire cannot open this conversation.</string>
-    <string name="deep_link_conversation_error_message">This account may not have access or the conversation may not exist.</string>
+    <string name="deep_link_conversation_error_title">Wire can\'t open this conversation.</string>
+    <string name="deep_link_conversation_error_message">You may not have permission with this account or the person may not be on Wire.</string>
 
     <string name="deep_link_user_error_title">Wire can\'t find this person.</string>
     <string name="deep_link_user_error_message">You may not have permission with this account or it no longer exists.</string>

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -42,7 +42,8 @@ import com.waz.zclient.{Injectable, Injector, R}
 
 import scala.concurrent.duration._
 
-class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit injector: Injector, context: Context, ec: EventContext)
+class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink: Boolean = false)
+                                       (implicit injector: Injector, context: Context, ec: EventContext)
   extends OptionsMenuController
     with Injectable
     with DerivedLogTag {
@@ -106,10 +107,17 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode)(implicit inj
     mode match {
       case Mode.Leaving(_) =>
         builder ++= Set(LeaveOnly, LeaveAndDelete)
+
       case Mode.Deleting(_) =>
         builder ++= Set(DeleteOnly, DeleteAndLeave)
+
+      case Mode.Normal(false) if fromDeepLink =>
+        if (connectStatus.contains(ACCEPTED) || connectStatus.contains(PENDING_FROM_USER)) builder += Block
+        else if (connectStatus.contains(BLOCKED)) builder += Unblock
+
       case Mode.Normal(false) if isGroup && selectedParticipant.isDefined =>
         if (removePerm && !isGuest) builder += RemoveMember
+
       case Mode.Normal(_) =>
 
         def notifications: MenuItem =

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -163,7 +163,11 @@ class ParticipantFragment extends ManagerFragment
   }
 
   override def onShowConversationMenu(inConvList: Boolean, convId: ConvId): Unit =
-    if (!inConvList) OptionsMenu(getContext, new ConversationOptionsMenuController(convId, Mode.Normal(inConvList))).show()
+    if (!inConvList) {
+      val fromDeepLink = getBooleanArg(FromDeepLinkArg)
+      val controller = new ConversationOptionsMenuController(convId, Mode.Normal(inConvList), fromDeepLink)
+      OptionsMenu(getContext, controller).show()
+    }
 
   def showOtrClient(userId: UserId, clientId: ClientId): Unit =
     getChildFragmentManager

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -179,12 +179,14 @@ class SingleParticipantFragment extends FragmentHelper {
     // TODO: merge this logic with ConversationOptionsMenuController
     (for {
       createPerm <- userAccountsController.hasCreateConvPermission
-      convId     <- participantsController.conv.map(_.id)
-      remPerm    <- userAccountsController.hasRemoveConversationMemberPermission(convId)
+      conv       <- participantsController.conv
+      remPerm    <- userAccountsController.hasRemoveConversationMemberPermission(conv.id)
       isGuest    <- participantsController.isCurrentUserGuest
       isGroup    <- participantsController.isGroup
       isPartner  <- userAccountsController.isPartner
-    } yield (createPerm || remPerm) && !isGuest && (!isGroup || !isPartner)).map {
+      other      <- participantsController.otherParticipant
+      otherIsGuest = other.isGuest(conv.team)
+    } yield (!fromDeepLink || otherIsGuest) && (createPerm || remPerm) && !isGuest && (!isGroup || !isPartner)).map {
       case true => R.string.glyph__more
       case _    => R.string.empty_string
     }.map(getString).onUi(text => vh.foreach(_.setRightActionText(text)))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -53,6 +53,9 @@ class SingleParticipantFragment extends FragmentHelper {
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val userAccountsController = inject[UserAccountsController]
 
+//  private lazy val fromDeepLink: Boolean = getBooleanArg(FromDeepLink)
+  private lazy val fromDeepLink: Boolean = true
+
   private val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
 
   private lazy val tabs = returning(view[TabLayout](R.id.details_and_devices_tabs)) {
@@ -131,7 +134,7 @@ class SingleParticipantFragment extends FragmentHelper {
     override def onLeftActionClicked(): Unit =
       participantsController.otherParticipant.map(_.expiresAt.isDefined).head.foreach {
         case false => participantsController.isGroup.head.flatMap {
-          case false => userAccountsController.hasCreateConvPermission.head.map {
+          case false if !fromDeepLink => userAccountsController.hasCreateConvPermission.head.map {
             case true => inject[CreateConversationController].onShowCreateConversation ! true
             case _ =>
           }
@@ -162,6 +165,8 @@ class SingleParticipantFragment extends FragmentHelper {
     isPartner      <- userAccountsController.isPartner
   } yield if (isWireless) {
     (R.string.empty_string, R.string.empty_string)
+  } else if (fromDeepLink) {
+    (R.string.glyph__conversation, R.string.conversation__action__open_conversation)
   } else if (!isPartner && !isGroupOrBot && canCreateConv) {
     (R.string.glyph__add_people, R.string.conversation__action__create_group)
   } else if (isPartner && !isGroupOrBot) {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -58,15 +58,20 @@ class SingleParticipantFragment extends FragmentHelper {
   private val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
 
   private lazy val tabs = returning(view[TabLayout](R.id.details_and_devices_tabs)) {
-    _.foreach {
-      _.addOnTabSelectedListener(new OnTabSelectedListener {
-        override def onTabSelected(tab: TabLayout.Tab): Unit = {
-          visibleTab ! SingleParticipantFragment.Tab.tabs.find(_.pos == tab.getPosition).getOrElse(DetailsTab)
-        }
+    _.foreach { layout =>
 
-        override def onTabUnselected(tab: TabLayout.Tab): Unit = {}
-        override def onTabReselected(tab: TabLayout.Tab): Unit = {}
-      })
+      if (fromDeepLink)
+        layout.setVisibility(View.GONE)
+      else {
+        layout.addOnTabSelectedListener(new OnTabSelectedListener {
+          override def onTabSelected(tab: TabLayout.Tab): Unit = {
+            visibleTab ! SingleParticipantFragment.Tab.tabs.find(_.pos == tab.getPosition).getOrElse(DetailsTab)
+          }
+
+          override def onTabUnselected(tab: TabLayout.Tab): Unit = {}
+          override def onTabReselected(tab: TabLayout.Tab): Unit = {}
+        })
+      }
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -53,8 +53,7 @@ class SingleParticipantFragment extends FragmentHelper {
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val userAccountsController = inject[UserAccountsController]
 
-//  private lazy val fromDeepLink: Boolean = getBooleanArg(FromDeepLink)
-  private lazy val fromDeepLink: Boolean = true
+  private lazy val fromDeepLink: Boolean = true // TODO: getBooleanArg(FromDeepLink)
 
   private val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -53,7 +53,7 @@ class SingleParticipantFragment extends FragmentHelper {
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val userAccountsController = inject[UserAccountsController]
 
-  private lazy val fromDeepLink: Boolean = true // TODO: getBooleanArg(FromDeepLink)
+  private lazy val fromDeepLink: Boolean = getBooleanArg(FromDeepLink)
 
   private val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

- Left footer action was displaying _Create group_ instead of _Open conversation_.
- Right footer action menu visible/showing incorrect menu items

### Causes

The `SingleParticipantFragment` is not aware of whether it was opened by a deep link.

### Solutions

Check if coming from a deep link and update the footer according to the spec.

### Known Bug

When opening user profile for a connected guest user, open the menu and block, then unblock the user. The menu icon disappears, but reappears after a few seconds.

#### APK
[Download build #12503](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12503/artifact/build/artifact/wire-dev-PR2066-12503.apk)
[Download build #12504](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12504/artifact/build/artifact/wire-dev-PR2066-12504.apk)
[Download build #12509](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12509/artifact/build/artifact/wire-dev-PR2066-12509.apk)
[Download build #12511](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12511/artifact/build/artifact/wire-dev-PR2066-12511.apk)