### PR TITLE
fix: Close the user profile on switching conversations with a deep link

### DIFF
--- a/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
@@ -189,7 +189,7 @@ class IntegrationDetailsFragment extends FragmentHelper {
   //TODO - move navigation logic out of this fragment
   def close(): Boolean =
   if (isRemovingFromConv) {
-    inject[ParticipantsController].onShowAnimations ! true
+    inject[ParticipantsController].onLeaveParticipants ! true
     true
   } else {
     Option(getFragmentManager).foreach { fm =>

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -146,6 +146,7 @@ class MainPhoneFragment extends FragmentHelper
     deepLinkService.deepLink.collect { case Some(result) => result } onUi {
       case OpenDeepLink(UserToken(userId), UserTokenInfo(connected, currentTeamMember)) =>
         pickUserController.hideUserProfile()
+        participantsController.onLeaveParticipants ! true
         if (connected || currentTeamMember) {
           CancellableFuture.delay(750.millis).map { _ =>
             userAccountsController.getOrCreateAndOpenConvFor(userId)
@@ -156,14 +157,18 @@ class MainPhoneFragment extends FragmentHelper
         } else {
           CancellableFuture.delay(getInt(R.integer.framework_animation_duration_medium).millis).map { _ =>
             navigationController.setVisiblePage(Page.CONVERSATION_LIST, MainPhoneFragment.Tag)
-            participantsController.onShowAnimations ! true
             pickUserController.showUserProfile(userId)
           }
         }
         deepLinkService.deepLink ! None
 
       case OpenDeepLink(ConversationToken(convId), _) =>
-        conversationController.switchConversation(convId)
+        pickUserController.hideUserProfile()
+        participantsController.onLeaveParticipants ! true
+        participantsController.selectedParticipant ! None
+        CancellableFuture.delay(750.millis).map { _ =>
+          conversationController.switchConversation(convId)
+        }
         deepLinkService.deepLink ! None
 
       case DoNotOpenDeepLink(Conversation, _) =>

--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -105,7 +105,7 @@ class ConversationManagerFragment extends FragmentHelper
 
         screenController.showMessageDetails ! None
 
-        participantsController.onShowAnimations ! false
+        participantsController.onLeaveParticipants ! false
       } else if (!change.noChange) {
         collectionController.closeCollection()
       }
@@ -129,7 +129,7 @@ class ConversationManagerFragment extends FragmentHelper
       showFragment(ParticipantFragment.newInstance(p.userId, p.fromDeepLink), ParticipantFragment.TAG)
     }
 
-    subs += participantsController.onShowAnimations.onUi { withAnimations =>
+    subs += participantsController.onLeaveParticipants.onUi { withAnimations =>
       navigationController.setRightPage(Page.MESSAGE_STREAM, ConversationManagerFragment.Tag)
 
       if (withAnimations)

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -152,7 +152,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
   private def switchToConversationList() =
     if (!mode.inConversationList) CancellableFuture.delay(getInt(R.integer.framework_animation_duration_medium).millis).map { _ =>
       navController.setVisiblePage(Page.CONVERSATION_LIST, tag)
-      participantsController.onShowAnimations ! true
+      participantsController.onLeaveParticipants ! true
     }
 
   new EventStreamWithAuxSignal(onMenuItemClicked, convState).apply {

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -48,7 +48,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   lazy val selectedParticipant = Signal(Option.empty[UserId])
 
   val onShowParticipants = EventStream[Option[String]]() //Option[String] = fragment tag //TODO use type?
-  val onShowAnimations = EventStream[Boolean]() //Boolean represents with or without animations
+  val onLeaveParticipants = EventStream[Boolean]() //Boolean represents with or without animations
   val onShowParticipantsWithUserId = EventStream[ParticipantRequest]()
 
   val onShowUser = EventStream[Option[UserId]]()

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -152,7 +152,7 @@ class ParticipantFragment extends ManagerFragment
             true
           case Some(f: FragmentHelper) if f.onBackPressed() => true
           case Some(_: FragmentHelper) =>
-            if (getChildFragmentManager.getBackStackEntryCount <= 1) participantsController.onShowAnimations ! true
+            if (getChildFragmentManager.getBackStackEntryCount <= 1) participantsController.onLeaveParticipants ! true
             else getChildFragmentManager.popBackStack()
             true
           case _ =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -99,7 +99,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
 
   private lazy val closeButton = returning(view[TextView](R.id.close_button)) { vh =>
     addingUsers.map(!_).onUi(vis => vh.foreach(_.setVisible(vis)))
-    vh.onClick(_ => participantsController.onShowAnimations ! true)
+    vh.onClick(_ => participantsController.onLeaveParticipants ! true)
   }
 
   private lazy val headerReadOnlyTextView = returning(view[TextView](R.id.participants__header)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -143,7 +143,7 @@ class SingleParticipantFragment extends FragmentHelper {
             case _ =>
           }
           case _ => Future.successful {
-            participantsController.onShowAnimations ! true
+            participantsController.onLeaveParticipants ! true
             participantsController.otherParticipantId.head.foreach {
               case Some(userId) =>
                 inject[IConversationScreenController].hideUser()


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the user looks at another user's profile, then hides the app, and clicks a deep link leading to another conversation, the user's profile does not hide and ends up in an invalid state.

### Causes

The app switches the underlying conversation, but it does not hide the user's profile.

### Solutions

I publish the information that the user's profile should be hidden if it is open. At this point, when opening the app from a deep link, we have no easy way to know that, but if we request closing the user's profile when no profile is opened, nothing will happen.

### Testing

Please recreate the scenario described above.

#### APK
[Download build #12506](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12506/artifact/build/artifact/wire-dev-PR2068-12506.apk)
[Download build #12513](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12513/artifact/build/artifact/wire-dev-PR2068-12513.apk)
[Download build #12514](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12514/artifact/build/artifact/wire-dev-PR2068-12514.apk)