### PR TITLE
Fix: Always set up logs service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,10 +22,10 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.2260"
+    zMessagingDevVersion = "141.0.2261-DEV"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
-    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'
+    zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2261@aar'
 
     avsVersion = '4.9.170@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.2259"
+    zMessagingDevVersion = "141.0.0-SNAPSHOT"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2253@aar'

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -349,12 +349,12 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     SafeBase64.setDelegate(new AndroidBase64Delegate)
 
     ZMessaging.globalReady.future.onSuccess {
-      case _ => if (BuildConfig.LOGGING_ENABLED) {
+      case _ =>
         InternalLog.setLogsService(inject[LogsService])
         InternalLog.add(new AndroidLogOutput(showSafeOnly = BuildConfig.SAFE_LOGGING))
-        InternalLog.add(new BufferedLogOutput(baseDir = getApplicationContext.getApplicationInfo.dataDir,
+        InternalLog.add(new BufferedLogOutput(
+          baseDir = getApplicationContext.getApplicationInfo.dataDir,
           showSafeOnly = BuildConfig.SAFE_LOGGING))
-      }
     }
 
     verbose(l"onCreate")


### PR DESCRIPTION
## What's new in this PR?

### Issues

In order to enabled logging by default for `DEBUG` builds, we need to always set up the logs service. The config flag `LOGGING_ENABLED` is redundant after introducing `GlobalPreferences.LogsEnabled` in SE.

### Solutions

Always create the logs service.

### Needs Release With

- [x] https://github.com/wireapp/wire-android-sync-engine/pull/524
#### APK
[Download build #12529](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12529/artifact/build/artifact/wire-dev-PR2073-12529.apk)