### PR TITLE
fix: Unable to open SearchUI after opening a connect request from a deep link

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/IPickUserController.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/IPickUserController.java
@@ -39,7 +39,7 @@ public interface IPickUserController {
 
     boolean isShowingPickUser();
 
-    void showUserProfile(UserId userId);
+    void showUserProfile(UserId userId, boolean fromDeepLink);
 
     void hideUserProfile();
 

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/PickUserController.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/PickUserController.java
@@ -97,9 +97,9 @@ public class PickUserController implements IPickUserController {
     }
 
     @Override
-    public void showUserProfile(UserId userId) {
+    public void showUserProfile(UserId userId, boolean fromDeepLink) {
         for (PickUserControllerScreenObserver pickUserControllerScreenObserver : pickUserControllerScreenObservers) {
-            pickUserControllerScreenObserver.onShowUserProfile(userId);
+            pickUserControllerScreenObserver.onShowUserProfile(userId, fromDeepLink);
         }
         isShowingUserProfile = true;
     }

--- a/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/PickUserControllerScreenObserver.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/pickuser/controller/PickUserControllerScreenObserver.java
@@ -25,7 +25,7 @@ public interface PickUserControllerScreenObserver {
 
     void onHidePickUser();
 
-    void onShowUserProfile(UserId userId);
+    void onShowUserProfile(UserId userId, boolean fromDeepLink);
 
     void onHideUserProfile();
 }

--- a/app/src/main/java/com/waz/zclient/participants/UserRequester.java
+++ b/app/src/main/java/com/waz/zclient/participants/UserRequester.java
@@ -18,5 +18,5 @@
 package com.waz.zclient.participants;
 
 public enum UserRequester {
-    SEARCH, CONVERSATION, PARTICIPANTS, INVITE, POPOVER, CALL
+    SEARCH, CONVERSATION, PARTICIPANTS, INVITE, POPOVER, CALL, DEEP_LINK
 }

--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -34,6 +34,7 @@ import com.waz.zclient.common.views.ImageAssetDrawable
 import com.waz.zclient.common.views.ImageAssetDrawable.{RequestBuilder, ScaleType}
 import com.waz.zclient.common.views.ImageController.WireImage
 import com.waz.zclient.connect.PendingConnectRequestFragment.ArgUserRequester
+import com.waz.zclient.controllers.navigation.{INavigationController, Page}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.BaseFragment
@@ -71,6 +72,7 @@ class SendConnectRequestFragment
   private lazy val accentColorController = inject[AccentColorController]
   private lazy val zms = inject[Signal[ZMessaging]]
   private lazy val themeController = inject[ThemeController]
+  private lazy val navController = inject[INavigationController]
 
   private lazy val user = usersController.user(userToConnectId)
 
@@ -79,11 +81,18 @@ class SendConnectRequestFragment
     permission <- userAccountsController.hasRemoveConversationMemberPermission(convId)
   } yield permission && userRequester == UserRequester.PARTICIPANTS
 
+  private lazy val returnPage =
+    if (userRequester == UserRequester.PARTICIPANTS || userRequester == UserRequester.DEEP_LINK)
+      Page.CONVERSATION_LIST
+    else
+      Page.PICK_USER
+
   private lazy val connectButton = returning(view[ZetaButton](R.id.zb__send_connect_request__connect_button)) { vh =>
     accentColorController.accentColor.map(_.color).onUi { color => vh.foreach(_.setAccentColor(color)) }
     vh.onClick { _ =>
       usersController.connectToUser(userToConnectId).foreach(_.foreach { _ =>
         keyboardController.hideKeyboardIfVisible()
+        navController.setLeftPage(returnPage, SendConnectRequestFragment.Tag)
         getContainer.onConnectRequestWasSentToUser()
       })
     }
@@ -199,7 +208,7 @@ class SendConnectRequestFragment
 
       override def onRightActionClicked(): Unit = removeConvMemberFeatureEnabled.head.foreach {
         case true =>
-          inject[ConversationController].currentConv.head.foreach { conv =>
+          conversationController.currentConv.head.foreach { conv =>
             if (conv.isActive)
               inject[IConversationScreenController].showConversationMenu(false, conv.id)
           }
@@ -223,6 +232,7 @@ class SendConnectRequestFragment
   }
 
   override def onBackPressed(): Boolean = {
+    navController.setLeftPage(returnPage, SendConnectRequestFragment.Tag)
     inject[IPickUserController].hideUserProfile()
     true
   }

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -157,7 +157,7 @@ class MainPhoneFragment extends FragmentHelper
         } else {
           CancellableFuture.delay(getInt(R.integer.framework_animation_duration_medium).millis).map { _ =>
             navigationController.setVisiblePage(Page.CONVERSATION_LIST, MainPhoneFragment.Tag)
-            pickUserController.showUserProfile(userId)
+            pickUserController.showUserProfile(userId, true)
           }
         }
         deepLinkService.deepLink ! None

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -338,7 +338,7 @@ class SearchUIFragment extends BaseFragment[SearchUIFragment.Container]
             Future { user.connection match {
               case PendingFromUser | Blocked | Ignored | Cancelled | Unconnected =>
                 convScreenController.setPopoverLaunchedMode(DialogLaunchMode.SEARCH)
-                pickUserController.showUserProfile(userId)
+                pickUserController.showUserProfile(userId, false)
               case ConnectionStatus.PendingFromOther =>
                 getContainer.showIncomingPendingConnectRequest(ConvId(userId.str))
               case _ =>


### PR DESCRIPTION
## What's new in this PR?

`SendConnectRequestFragment` is now receiving information that it was opened from a deep link, so after it is closed we will go back to the conversation list, not SearchUI. Note that the transfer was already implemented - only setting the information about it in the navigation controller was missing.

### Causes

Until now opening connect requests was possible only from the SearchUI, so when we got back from it (either by sending the request or by pressing the back button) we assumed that we always go back to SearchUI. And if we are on SearchUI then opening SearchUI should do nothing.

fixes https://wearezeta.atlassian.net/browse/AN-6139

I also decided to clean up `ConversationListManagerFragment` a little bit: Some injected controllers were not used, other were used only once, so could be inlined.

#### APK
[Download build #12516](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12516/artifact/build/artifact/wire-dev-PR2074-12516.apk)
[Download build #12517](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12517/artifact/build/artifact/wire-dev-PR2074-12517.apk)
[Download build #12518](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12518/artifact/build/artifact/wire-dev-PR2074-12518.apk)