### PR TITLE
fix: Increasing the distance between the handle and the avatar on the user profile

### DIFF
--- a/app/src/main/res/layout/fragment_participants_single_tabbed.xml
+++ b/app/src/main/res/layout/fragment_participants_single_tabbed.xml
@@ -36,6 +36,7 @@
         app:w_font="@string/wire__typeface__light"
         android:gravity="center"
         android:background="?wireBackgroundColor"
+        android:paddingBottom="@dimen/wire__padding__regular"
         />
 
     <FrameLayout

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -36,7 +36,7 @@ import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.participants.{ParticipantOtrDeviceAdapter, ParticipantsController}
-import com.waz.zclient.utils.{GuestUtils, RichView, StringUtils}
+import com.waz.zclient.utils.{ContextUtils, GuestUtils, RichView, StringUtils}
 import com.waz.zclient.views.menus.{FooterMenu, FooterMenuCallback}
 import com.waz.zclient.{FragmentHelper, R}
 import org.threeten.bp.Instant
@@ -119,6 +119,11 @@ class SingleParticipantFragment extends FragmentHelper {
     visibleTab.onUi {
       case DetailsTab => vh.foreach(_.setVisible(true))
       case _          => vh.foreach(_.setVisible(false))
+    }
+
+    if (fromDeepLink) {
+      verbose(l"DEEP details view, setting the top margin")
+      vh.foreach(_.setMarginTop(ContextUtils.getDimenPx(R.dimen.wire__padding__50)))
     }
   }
 


### PR DESCRIPTION
Small changes discussed with the Design team:

1. The bottom padding of the handle is increased in both cases - with visible tabs and without.
2. If the tabs are invisible, the top margin between the border and the avatar is increased.
#### APK
[Download build #12520](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12520/artifact/build/artifact/wire-dev-PR2076-12520.apk)