### PR TITLE
Deep links fix go back to conv list

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -45,6 +45,7 @@ import com.waz.zclient.giphy.GiphySharingPreviewFragment
 import com.waz.zclient.log.LogUI
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.UsersController
+import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.pages.main.conversationlist.ConfirmationFragment
 import com.waz.zclient.pages.main.conversationpager.ConversationPagerFragment
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
@@ -143,10 +144,12 @@ class MainPhoneFragment extends FragmentHelper
     confirmationMenu.foreach(_.setVisibility(View.GONE))
     zms.flatMap(_.errors.getErrors).onUi { _.foreach(handleSyncError) }
 
+
     deepLinkService.deepLink.collect { case Some(result) => result } onUi {
       case OpenDeepLink(UserToken(userId), UserTokenInfo(connected, currentTeamMember, self)) =>
         pickUserController.hideUserProfile()
         participantsController.onLeaveParticipants ! true
+
         if (self) {
           startActivity(Intents.OpenSettingsIntent(getContext))
         } else if (connected || currentTeamMember) {
@@ -168,6 +171,8 @@ class MainPhoneFragment extends FragmentHelper
         pickUserController.hideUserProfile()
         participantsController.onLeaveParticipants ! true
         participantsController.selectedParticipant ! None
+        inject[IConversationScreenController].tearDown()
+
         CancellableFuture.delay(750.millis).map { _ =>
           conversationController.switchConversation(convId)
         }

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -45,7 +45,6 @@ import com.waz.zclient.giphy.GiphySharingPreviewFragment
 import com.waz.zclient.log.LogUI
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.UsersController
-import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.pages.main.conversationlist.ConfirmationFragment
 import com.waz.zclient.pages.main.conversationpager.ConversationPagerFragment
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -171,7 +171,6 @@ class MainPhoneFragment extends FragmentHelper
         pickUserController.hideUserProfile()
         participantsController.onLeaveParticipants ! true
         participantsController.selectedParticipant ! None
-        inject[IConversationScreenController].tearDown()
 
         CancellableFuture.delay(750.millis).map { _ =>
           conversationController.switchConversation(convId)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -69,7 +69,7 @@ class ParticipantFragment extends ManagerFragment
   private lazy val userAccountsController = inject[UserAccountsController]
   private lazy val convScreenController   = inject[IConversationScreenController]
 
-  private lazy val headerFragment = ParticipantHeaderFragment.newInstance
+  private lazy val headerFragment = ParticipantHeaderFragment.newInstance(fromDeepLink = getBooleanArg(FromDeepLinkArg))
 
   override def onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation =
     if (nextAnim == 0 || getParentFragment == null)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -22,23 +22,29 @@ import android.os.Bundle
 import android.support.v7.widget.Toolbar
 import android.view._
 import android.widget.TextView
-import com.waz.threading.Threading
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient.ManagerFragment.Page
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.common.controllers.global.AccentColorController
+import com.waz.zclient.controllers.navigation.{INavigationController, Page => NavPage}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.conversation.creation.{AddParticipantsFragment, CreateConversationController}
+import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.utils.ContextUtils.{getColor, getDimenPx, getDrawable}
 import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils}
 import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
 
-class ParticipantHeaderFragment extends FragmentHelper {
+import scala.concurrent.duration._
+
 class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentHelper {
+  import Threading.Implicits.Ui
+
   implicit def cxt: Context = getActivity
 
+  private lazy val navigationController   = inject[INavigationController]
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val themeController        = inject[ThemeController]
   private lazy val newConvController      = inject[CreateConversationController]
@@ -100,7 +106,15 @@ class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentH
 
   private lazy val closeButton = returning(view[TextView](R.id.close_button)) { vh =>
     addingUsers.map(!_).onUi(vis => vh.foreach(_.setVisible(vis)))
-    vh.onClick(_ => participantsController.onLeaveParticipants ! true)
+    vh.onClick { _ =>
+      participantsController.onLeaveParticipants ! true
+
+      // This is a workaround: when dismissing the single participant fragment, we should
+      // go directly back to the conversation list, not the underlying conversation.
+      if (fromDeepLink) CancellableFuture.delay(750.millis).map { _ =>
+        navigationController.setVisiblePage(NavPage.CONVERSATION_LIST, MainPhoneFragment.Tag)
+      }
+    }
   }
 
   private lazy val headerReadOnlyTextView = returning(view[TextView](R.id.participants__header)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -36,6 +36,7 @@ import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils}
 import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
 
 class ParticipantHeaderFragment extends FragmentHelper {
+class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentHelper {
   implicit def cxt: Context = getActivity
 
   private lazy val participantsController = inject[ParticipantsController]
@@ -193,5 +194,6 @@ class ParticipantHeaderFragment extends FragmentHelper {
 object ParticipantHeaderFragment {
   val TAG: String = classOf[ParticipantHeaderFragment].getName
 
-  def newInstance: ParticipantHeaderFragment = new ParticipantHeaderFragment
+  def newInstance(fromDeepLink: Boolean = false): ParticipantHeaderFragment =
+    new ParticipantHeaderFragment(fromDeepLink)
 }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -26,14 +26,16 @@ import android.support.v7.widget.{LinearLayoutManager, RecyclerView}
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.TextView
 import com.waz.service.ZMessaging
-import com.waz.threading.Threading
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils._
 import com.waz.utils.events.{ClockSignal, Signal}
 import com.waz.zclient.common.controllers.{BrowserController, ThemeController, UserAccountsController}
+import com.waz.zclient.controllers.navigation.{INavigationController, Page}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.conversation.creation.CreateConversationController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.UsersController
+import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.participants.{ParticipantOtrDeviceAdapter, ParticipantsController}
 import com.waz.zclient.utils.{ContextUtils, GuestUtils, RichView, StringUtils}
@@ -52,6 +54,7 @@ class SingleParticipantFragment extends FragmentHelper {
 
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val userAccountsController = inject[UserAccountsController]
+  private lazy val navigationController   = inject[INavigationController]
 
   private lazy val fromDeepLink: Boolean = getBooleanArg(FromDeepLink)
 
@@ -286,6 +289,9 @@ class SingleParticipantFragment extends FragmentHelper {
 
   override def onBackPressed(): Boolean = {
     participantsController.selectedParticipant ! None
+    if (fromDeepLink) CancellableFuture.delay(750.millis).map { _ =>
+      navigationController.setVisiblePage(Page.CONVERSATION_LIST, MainPhoneFragment.Tag)
+    }
     super.onBackPressed()
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Dismissing the user info screen from a deep link goes back to the conversation, not the conversation list.

### Causes

We push the conversation for that user before pushing the user info screen.

### Solutions

When dismissing (and we know we came from a deep link), dismiss the conversation too.

## Notes

This is a workaround and should be addressed by decoupling the conversation from the user info screen.

#### APK
[Download build #12522](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12522/artifact/build/artifact/wire-dev-PR2078-12522.apk)
[Download build #12524](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12524/artifact/build/artifact/wire-dev-PR2078-12524.apk)