### PR TITLE
fix: The conversation list does not wait for syncing to finish

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -36,7 +36,6 @@ import com.waz.utils.wrappers.URI
 import com.waz.utils.{Serialized, returning, _}
 import com.waz.zclient.calling.controllers.CallStartController
 import com.waz.zclient.conversation.ConversationController.ConversationChange
-import com.waz.zclient.conversationlist.ConversationListAdapter.Normal
 import com.waz.zclient.conversationlist.ConversationListController
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.log.LogUI._
@@ -234,8 +233,8 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
 
   def setCurrentConversationToNext(requester: ConversationChangeRequester): Future[Unit] = {
     def nextConversation(convId: ConvId): Future[Option[ConvId]] =
-      convListController.conversationListData(Normal).head.map {
-        case (_, regular, _) => regular.lift(regular.indexWhere(_.id == convId) + 1).map(_.id)
+      convListController.regularConversationListData.head.map {
+        regular => regular.lift(regular.indexWhere(_.id == convId) + 1).map(_.id)
       } (Threading.Background)
 
     for {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListAdapter.scala
@@ -156,11 +156,6 @@ object ConversationListAdapter {
     override val filter = ConversationListController.IncomingListFilter
   }
 
-  case object Integration extends ListMode {
-    override lazy val nameId = R.string.conversation_list__header__archive_title
-    override val filter = ConversationListController.IntegrationFilter
-  }
-
   trait ConversationRowViewHolder extends RecyclerView.ViewHolder
 
   case class NormalConversationRowViewHolder(view: NormalConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {


### PR DESCRIPTION
This is a partial fix to AN-6149 where the app is stuck on syncing. When something goes wrong during the sync, we should log the error and finish (failed jobs might be rescheduled). The conversation list waits for that and only then the conversations are displayed.
But it is possible that the sync takes longer than usual or - as in the bug case - that it's stuck. Then the conversation list does not appear at all. From the user's perspective it's better for the conversations to appear and the sync should run in the background.

We still don't know what exactly went wrong during the sync, but I think this part of the fix could be applied anyway.

With this PR it is possible that the conversation list will appear and then the order of the displayed conversations will change as the users looks at it. We already had this behaviour some time ago and for some reason we decided it's better to wait for the sync to finish before displaying the conversations. I suggest to have it back: it's not a big thing, certainly much better than making the app unusable with any sync error... and on top of that I think it looks good.

fixes https://wearezeta.atlassian.net/browse/AN-6149 (partially)
#### APK
[Download build #12538](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12538/artifact/build/artifact/wire-dev-PR2086-12538.apk)
[Download build #12542](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12542/artifact/build/artifact/wire-dev-PR2086-12542.apk)