### PR TITLE
Correct permissions for read receipts

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
@@ -20,7 +20,7 @@ package com.waz.zclient.conversation.creation
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.ShouldCreateFullConversation
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{ConvId, IntegrationId, ProviderId, UserId}
+import com.waz.model._
 import com.waz.service.tracking._
 import com.waz.service.{IntegrationsService, ZMessaging}
 import com.waz.utils.events.{EventContext, EventStream, Signal}
@@ -95,7 +95,7 @@ class CreateConversationController(implicit inj: Injector, ev: EventContext)
           )
         } else Future.successful(userIds)
       teamOnly            <- teamOnly.head
-      readReceipts        <- readReceipts.head
+      readReceipts        <- if(z.teamId.isEmpty) Future.successful(false) else readReceipts.head
       _ = verbose(l"creating conv with  ${userIds.size} users, ${integrationIds.size} bots, shouldFullConv $shouldFullConv, teamOnly $teamOnly and readReceipts $readReceipts")
       conv                <- conversationController.createGroupConversation(Some(name.trim), userIds, teamOnly, readReceipts)
       _                   <- Future.sequence(integrationIds.map { case (pId, iId) => integrationsService.head.flatMap(_.addBotToConversation(conv.id, pId, iId)) })


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR fixes a bug where group conversations created by private users would always have read receipts enabled due to the per-conversation toggle being enabled by default. This was invisible to private users of course, since this option is hidden to them.

Only team users can create teams with read receipts enabled in the conversation settings, so this PR introduces a check for the teamId to ensure this.

Fixes [AN-6088](https://wearezeta.atlassian.net/browse/AN-6088)

### Testing
It was manually tested.

#### APK
[Download build #12541](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12541/artifact/build/artifact/wire-dev-PR2089-12541.apk)