### PR TITLE
feat: Display email from UserData as a field in the rich profile

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingDevVersion = "141.0.2263-DEV"
+    zMessagingDevVersion = "141.0.2265"
     paging_version = "1.0.0"
     // Release version number must be like this X.0(.Y)
     zMessagingReleaseVersion = System.getenv("ZMESSAGING_VERSION") ?: '141.0.2263@aar'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -823,6 +823,8 @@
     <string name="otr__reset_session__button_ok">OK</string>
     <string name="otr__reset_session__button_fail">Try again</string>
 
+    <string name="user_profile_email_field_name">Email</string>
+
     <string name="advanced_image_download_wifi_info">The picture will appear when you are on Wi-Fi again</string>
     <string name="change_settings">Change Settings</string>
     <string name="conversation_list__action_join_call">JOIN</string>


### PR DESCRIPTION
If the field `email` in `UserData` is not `None`, it should be displayed on the single user profile as the first of user fields. with the name "Email". It is up to the backend to decide if the email should be displayed or hidden (if it's going to be hidden, the backend should simply not send this data). To make it consistent, the app should should request a full user sync after on the first login after updating  to the version with this feature.

SE part: https://github.com/wireapp/wire-android-sync-engine/pull/531
#### APK
[Download build #12545](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12545/artifact/build/artifact/wire-dev-PR2094-12545.apk)
[Download build #12547](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12547/artifact/build/artifact/wire-dev-PR2094-12547.apk)
[Download build #12553](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12553/artifact/build/artifact/wire-dev-PR2094-12553.apk)
[Download build #12557](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12557/artifact/build/artifact/wire-dev-PR2094-12557.apk)