### PR TITLE
[DO NOT MERGE] A very hacky example how Scala and Kotlin can interact via a Java facade 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -267,6 +267,10 @@ android {
 
 
     sourceSets {
+        main {
+            scala.srcDirs += ['src/main/scala', 'src/main/java']
+            java.srcDirs = []
+        }
         androidTest {
             java.srcDirs += ['build/generated/source/apt/androidTest/dev/debug']
             java.srcDirs += ['src/androidTest/kotlin']

--- a/app/src/main/java/com/waz/zclient/FooJavaClass.java
+++ b/app/src/main/java/com/waz/zclient/FooJavaClass.java
@@ -1,0 +1,32 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient;
+
+import timber.log.Timber;
+
+public class FooJavaClass {
+    public FooJavaClass(String foo) {
+        this.foo = foo;
+    }
+
+    private String foo = "";
+
+    public void foofoo() {
+        Timber.i("" + foo);
+    }
+}

--- a/app/src/main/java/com/waz/zclient/ScalaFacade.java
+++ b/app/src/main/java/com/waz/zclient/ScalaFacade.java
@@ -1,0 +1,34 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient;
+
+public class ScalaFacade {
+    private static final ScalaFacade ourInstance = new ScalaFacade();
+
+    public static ScalaFacade getInstance() {
+        return ourInstance;
+    }
+
+    private ScalaFacade() {
+    }
+
+    public static FooJavaClass foo() {
+       FooClass fooScala = WireApplication$.MODULE$.foo();
+       return new FooJavaClass(fooScala.foo());
+    }
+}

--- a/app/src/main/java/com/waz/zclient/markdown/Markdown.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/Markdown.kt
@@ -18,6 +18,8 @@
 package com.waz.zclient.markdown
 
 import android.text.SpannableString
+import com.waz.zclient.ScalaFacade
+import com.waz.zclient.FooJavaClass
 import com.waz.zclient.markdown.visitors.SpanRenderer
 import org.commonmark.parser.Parser
 
@@ -28,6 +30,8 @@ class Markdown {
             val document = Parser.builder().build().parse(input)
             val renderer = SpanRenderer(style ?: StyleSheet())
             document.accept(renderer)
+            val foo: FooJavaClass = ScalaFacade.foo()
+            foo.foofoo()
             return renderer.spannableString
         }
     }

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -93,6 +93,10 @@ import org.threeten.bp.Clock
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
+case class FooClass(foo: String = "Foo!") extends DerivedLogTag {
+  def foofoo(): Unit = info(l"${showString(foo)}")
+}
+
 object WireApplication extends DerivedLogTag {
   var APP_INSTANCE: WireApplication = _
 
@@ -101,6 +105,8 @@ object WireApplication extends DerivedLogTag {
   type AccountToUsersStorage = (UserId) => Future[Option[UsersStorage]]
   type AccountToConvsStorage = (UserId) => Future[Option[ConversationStorage]]
   type AccountToConvsService = (UserId) => Future[Option[ConversationsService]]
+
+  def foo(): FooClass = FooClass()
 
   lazy val Global = new Module {
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         classpath 'com.google.gms:google-services:3.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'org.ajoberstar.grgit:grgit-core:3.0.0'
+        classpath "jp.leafytree.gradle:gradle-android-scala-plugin:1.4"
     }
 }
 


### PR DESCRIPTION
The changes in gradle files might not be necessary. I did them to match what I saw at https://github.com/saturday06/gradle-android-scala-plugin

It seems at the moment that Kotlin can't access Scala classes directly, although it should be possible to call a method in a Scala `object` from Kotlin if we don't care about the results and if arguments to that method are good for both languages. Otherwise, we need to create a facade in Java to enable interaction.