### PR TITLE
Allow the setting of prod backend from intent

### DIFF
--- a/app/src/candidate/AndroidManifest.xml
+++ b/app/src/candidate/AndroidManifest.xml
@@ -39,6 +39,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>
 

--- a/app/src/experimental/AndroidManifest.xml
+++ b/app/src/experimental/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -100,6 +100,11 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
           .edit
           .putString(BackendPicker.CUSTOM_BACKEND_PREFERENCE, Backend.StagingBackend.environment)
           .commit
+      case SELECT_PROD_BE =>
+        PreferenceManager.getDefaultSharedPreferences(context)
+          .edit
+          .putString(BackendPicker.CUSTOM_BACKEND_PREFERENCE, Backend.ProdBackend.environment)
+          .commit
       case _ =>
         setResultData("Unknown Intent!")
         setResultCode(Activity.RESULT_CANCELED)
@@ -124,6 +129,7 @@ object AbstractPreferenceReceiver {
   private val FULL_CONVERSATION_INTENT = packageName + ".intent.action.FULL_CONVERSATION_INTENT"
   private val HIDE_GDPR_POPUPS         = packageName + ".intent.action.HIDE_GDPR_POPUPS"
   private val SELECT_STAGING_BE        = packageName + ".intent.action.SELECT_STAGING_BE"
+  private val SELECT_PROD_BE           = packageName + ".intent.action.SELECT_PROD_BE"
 
   private lazy val DeveloperAnalyticsEnabled = PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
 }


### PR DESCRIPTION
This is required by QA to test the custom backend feature

## What's new in this PR?

### Issues

Due to difficulties on the backed test infrastructure, it will be easier to test the custom backend feature using our production backend. This commit adds the ability to set the production backend from an Intent, the same way we currently support setting the staging backend.

### Causes

Dev builds ask the user to pick a backend, so we can't simply rely on the default being production.
#### APK
[Download build #12558](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12558/artifact/build/artifact/wire-dev-PR2099-12558.apk)