### PR TITLE
Fix/tablet crashes

### DIFF
--- a/app/src/main/res/layout-sw600dp/single_input_box.xml
+++ b/app/src/main/res/layout-sw600dp/single_input_box.xml
@@ -105,9 +105,12 @@
             android:layout_gravity="center_horizontal|top"/>
 
         <com.waz.zclient.ui.text.TypefaceTextView
-            android:id="@+id/empty_search_message"
+            android:id="@+id/error_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/wire__padding__8"
+            android:layout_marginStart="@dimen/wire__padding__16"
+            android:layout_marginEnd="@dimen/wire__padding__16"
             android:textSize="@dimen/wire__text_size__small"
             android:textColor="@color/teams_error_red"
             android:gravity="center"

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
@@ -62,7 +62,7 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
       // We need to adjust the behaviour of the error text view: It should always be visible,
       // but it will become red when validation fails.
       inputField.errorText.setGravity(Gravity.START)
-      inputField.errorText.setTextColor(context.getColor(R.color.teams_placeholder_text))
+      inputField.errorText.setTextColor(ContextUtils.getColor(R.color.teams_placeholder_text))
       inputField.setShouldDisableOnClick(false)
       inputField.setShouldClearErrorOnClick(false)
       inputField.setShouldClearErrorOnTyping(false)
@@ -72,7 +72,7 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
 
       inputField.editText.addTextListener { text =>
         createTeamController.password = text
-        inputField.errorText.setTextColor(context.getColor(R.color.teams_placeholder_text))
+        inputField.errorText.setTextColor(ContextUtils.getColor(R.color.teams_placeholder_text))
       }
 
       inputField.editText.requestFocus()
@@ -80,7 +80,7 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
 
       inputField.setOnClick( text =>
         if (!validator.isValidPassword(text)) {
-          inputField.errorText.setTextColor(context.getColor(R.color.teams_error_red))
+          inputField.errorText.setTextColor(ContextUtils.getColor(R.color.teams_error_red))
           Future.successful(Some(getString(R.string.password_policy_hint, passwordMinLength)))
         } else {
           AppEntryDialogs.showTermsAndConditions(context).flatMap {


### PR DESCRIPTION
## What's new in this PR?

### Issues

On the tablet:

1. Entering the create team flow crashed the app
2. Tapping on "create group" in profile of a user crashed the app.
3. Setting team password crashed the app.

### Causes

1. We changed the id of the error text field in `InputBox` to be something more meaningful. Unfortunately, `InputBox` has two layout files (the other one for the tablet), and the id was not updated in both. Trying to access the error text field on tablet resulted in a null exception.
2. Same reason.
3. We were getting colors using a method that doesn't exist on older APIs.  

### Solutions

1. Sync the changes in both layout files.
2. Same solution.
3. Use the `ContextUtils` helper object to get colors. 

#### APK
[Download build #12568](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12568/artifact/build/artifact/wire-dev-PR2106-12568.apk)