### PR TITLE
fix: deep link generic error

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -172,9 +172,9 @@ class MainActivity extends BaseActivity
           .map { _ => startFirstFragment() }
         deepLinkService.deepLink ! None
 
-      case Some(DeepLinkNotFound) =>
+      case Some(DeepLinkUnknown) =>
         verbose(l"received unrecognized deep link")
-        val ok = showErrorDialog(
+        showErrorDialog(
           R.string.deep_link_generic_error_title,
           R.string.deep_link_generic_error_message)
           .map { _ => startFirstFragment() }

--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLink.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLink.scala
@@ -62,6 +62,8 @@ object DeepLinkParser {
     case DeepLink.Access => "access"
   }
 
+  def isDeepLink(str: String): Boolean = str.startsWith(s"$Scheme://")
+
   def parseLink(str: String): Option[(DeepLink, RawToken)] = {
     getAll.view
       .map { link =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

The generic error for deep links was being shown after every sign in with a custom backend.

### Causes

The error was shown if the result of deep link parsing was `DeepLinkNotFound`. This however gets returned not only when the deep link is not recognized, but also when there is no data in the intent being checked. (In `MainActivity`, we always check the intent for a deep link, though the intent may not have anything to do with the deep link).

### Solutions

Create a new checking result `DeepLinkUnknown` that is specifically for the case where a deep link has been extracted from the intent (it starts with the correct scheme) but doesn't contain a recognized link type (sso, conversation, user, access). `DeepLinkNotFound` is therefore only for cases where the intent has no deep link at all.

### Testing

Manually tested.
#### APK
[Download build #12587](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12587/artifact/build/artifact/wire-dev-PR2112-12587.apk)