### PR TITLE
Fix/custom backend

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = "141.0.0-SNAPSHOT"//System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
+    zMessagingDevVersion = "141.0.882-PR"//System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.2266"
+    zMessagingVersion = "141.0.2267"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'
@@ -36,7 +36,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = "141.0.882-PR"//System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
+    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
+    zMessagingDevVersion = "141.0.0-SNAPSHOT"//System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,7 +518,6 @@
     <string name="pref_about_tos_title">Terms of Use</string>
     <string name="pref_about_privacy_policy_title">Privacy Policy</string>
     <string name="pref_about_licenses_title">License information</string>
-    <string name="pref_about_licenses_url">@string/url_third_party_licences</string>
     <string name="pref_about_version_title">Version %s</string>
     <string name="pref_about_copyright_title">\u00A9 Wire Swiss GmbH</string>
 

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -175,36 +175,36 @@
     <string translatable="false" name="pref_dev_category_sign_in_account_title">Sign into account</string>
     <string translatable="false" name="pref_dev_category_sign_in_account_summary">Sign into another account and switch to that one</string>
 
-    <string translatable="false" name="pref_manage_team_url">https://teams.wire.com/login/?utm_source=client_settings&amp;utm_term=android</string>
+    <!--
+    The prefixes ACCOUNTS, TEAMS, and WEBSITE are placeholders for hosts. These are
+    replaced at runtime with corresponding endpoints defined in the BackendConfig.
+    Custom whitelabel versions can overwrite these with urls (without prefixes of course).
+    -->
 
-    <string translatable="false" name="pick_user_manage_team_url">https://teams.wire.com/login/?utm_source=client_landing&amp;utm_term=android</string>
+    <string translatable="false" name="url_password_reset">ACCOUNTS/forgot/</string>
 
-    <string translatable="false" name="invalid_email_help">https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-</string>
-    <string translatable="false" name="teams_set_email_about_url">https://support.wire.com/hc/en-us/articles/115004082129</string>
+    <string translatable="false" name="pref_manage_team_url">TEAMS/login/?utm_source=client_settings&amp;utm_term=android</string>
+    <string translatable="false" name="pick_user_manage_team_url">TEAMS/login/?utm_source=client_landing&amp;utm_term=android</string>
+    <string translatable="false" name="url_manage_services">TEAMS/services</string>
 
-    <string translatable="false" name="url_home">https://wire.com</string>
-    <string translatable="false" name="url_terms_of_service_personal">https://wire.com/legal/terms/personal/</string>
-    <string translatable="false" name="url_terms_of_service_teams">https://wire.com/legal/terms/teams/</string>
-    <string translatable="false" name="url_privacy_policy">https://wire.com/legal/privacy/embed/</string>
-    <string translatable="false" name="url__help">https://support.wire.com</string>
+    <string translatable="false" name="url_home">WEBSITE</string>
+    <string translatable="false" name="url_terms_of_service_personal">WEBSITE/legal/terms/personal/</string>
+    <string translatable="false" name="url_terms_of_service_teams">WEBSITE/legal/terms/teams/</string>
+    <string translatable="false" name="url_privacy_policy">WEBSITE/legal/privacy/embed/</string>
+    <string translatable="false" name="url_third_party_licences">WEBSITE/legal/#licenses</string>
+    <string translatable="false" name="url_otr_learn_why">WEBSITE/privacy/why</string>
+    <string translatable="false" name="url_otr_learn_how">WEBSITE/privacy/how</string>
+    <string translatable="false" name="url_otr_decryption_error_1">WEBSITE/privacy/error-1</string>
+    <string translatable="false" name="url_otr_decryption_error_2">WEBSITE/privacy/error-2</string>
+    <string translatable="false" name="url_about_teams">WEBSITE/products/pro-secure-team-collaboration/</string>
+    <string translatable="false" name="usernames__learn_more__link">WEBSITE/support/username/</string>
+    <string translatable="false" name="pref_about_website_url">WEBSITE</string>
 
-    <string translatable="false" name="url_password_reset">https://account.wire.com/forgot/</string>
-    <string translatable="false" name="url_password_reset_staging">https://wire-account-staging.zinfra.io/forgot/</string>
-
-    <string translatable="false" name="url_third_party_licences">https://wire.com/legal/#licenses</string>
-    <string translatable="false" name="url_otr_learn_why">https://wire.com/privacy/why</string>
-    <string translatable="false" name="url_otr_learn_how">https://wire.com/privacy/how</string>
-    <string translatable="false" name="url_otr_decryption_error_1">https://wire.com/privacy/error-1</string>
-    <string translatable="false" name="url_otr_decryption_error_2">https://wire.com/privacy/error-2</string>
-    <string translatable="false" name="url_about_teams">https://wire.com/products/pro-secure-team-collaboration/</string>
-
-    <string translatable="false" name="url_manage_services">https://teams.wire.com/</string>
-    <string translatable="false" name="url_manage_services_staging">https://wire-admin-dev.zinfra.io/services/</string>
-    <string translatable="false" name="usernames__learn_more__link">https://wire.com/support/username/</string>
     <string translatable="false" name="pref_support_website_url">https://support.wire.com</string>
     <string translatable="false" name="pref_support_contact_url">https://support.wire.com/hc/requests/new</string>
-    <string translatable="false" name="pref_about_website_url">https://wire.com</string>
-
+    <string translatable="false" name="url__help">https://support.wire.com</string>
+    <string translatable="false" name="invalid_email_help">https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-</string>
+    <string translatable="false" name="teams_set_email_about_url">https://support.wire.com/hc/en-us/articles/115004082129</string>
 
 </resources>
 

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -181,13 +181,16 @@
     Custom whitelabel versions can overwrite these with urls (without prefixes of course).
     -->
 
-    <string translatable="false" name="url_password_reset">|ACCOUNTS|/forgot/</string>
+    <string translatable="false" name="url_password_forgot">|ACCOUNTS|/forgot/</string>
 
-    <string translatable="false" name="pref_manage_team_url">|TEAMS|/login/?utm_source=client_settings&amp;utm_term=android</string>
-    <string translatable="false" name="pick_user_manage_team_url">|TEAMS|/login/?utm_source=client_landing&amp;utm_term=android</string>
+    <string translatable="false" name="url_pref_manage_team">|TEAMS|/login/?utm_source=client_settings&amp;utm_term=android</string>
+    <string translatable="false" name="url_start_ui_manage_team">|TEAMS|/login/?utm_source=client_landing&amp;utm_term=android</string>
     <string translatable="false" name="url_manage_services">|TEAMS|/services</string>
 
     <string translatable="false" name="url_home">|WEBSITE|</string>
+    <string translatable="false" name="url_about_website">|WEBSITE|</string>
+    <string translatable="false" name="url_about_teams">|WEBSITE|/products/pro-secure-team-collaboration/</string>
+    <string translatable="false" name="url_usernames_learn_more">|WEBSITE|/support/username/</string>
     <string translatable="false" name="url_terms_of_service_personal">|WEBSITE|/legal/terms/personal/</string>
     <string translatable="false" name="url_terms_of_service_teams">|WEBSITE|/legal/terms/teams/</string>
     <string translatable="false" name="url_privacy_policy">|WEBSITE|/legal/privacy/embed/</string>
@@ -196,15 +199,12 @@
     <string translatable="false" name="url_otr_learn_how">|WEBSITE|/privacy/how</string>
     <string translatable="false" name="url_otr_decryption_error_1">|WEBSITE|/privacy/error-1</string>
     <string translatable="false" name="url_otr_decryption_error_2">|WEBSITE|/privacy/error-2</string>
-    <string translatable="false" name="url_about_teams">|WEBSITE|/products/pro-secure-team-collaboration/</string>
-    <string translatable="false" name="usernames__learn_more__link">|WEBSITE|/support/username/</string>
-    <string translatable="false" name="pref_about_website_url">|WEBSITE|</string>
 
-    <string translatable="false" name="pref_support_website_url">https://support.wire.com</string>
-    <string translatable="false" name="pref_support_contact_url">https://support.wire.com/hc/requests/new</string>
-    <string translatable="false" name="url__help">https://support.wire.com</string>
-    <string translatable="false" name="invalid_email_help">https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-</string>
-    <string translatable="false" name="teams_set_email_about_url">https://support.wire.com/hc/en-us/articles/115004082129</string>
+    <string translatable="false" name="url_help">https://support.wire.com</string>
+    <string translatable="false" name="url_support_website">https://support.wire.com</string>
+    <string translatable="false" name="url_contact_support">https://support.wire.com/hc/requests/new</string>
+    <string translatable="false" name="url_invalid_email_help">https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-</string>
+    <string translatable="false" name="url_teams_set_email_about">https://support.wire.com/hc/en-us/articles/115004082129</string>
 
 </resources>
 

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -176,29 +176,29 @@
     <string translatable="false" name="pref_dev_category_sign_in_account_summary">Sign into another account and switch to that one</string>
 
     <!--
-    The prefixes ACCOUNTS, TEAMS, and WEBSITE are placeholders for hosts. These are
+    The prefixes |ACCOUNTS|, |TEAMS|, and |WEBSITE| are placeholders for hosts. These are
     replaced at runtime with corresponding endpoints defined in the BackendConfig.
     Custom whitelabel versions can overwrite these with urls (without prefixes of course).
     -->
 
-    <string translatable="false" name="url_password_reset">ACCOUNTS/forgot/</string>
+    <string translatable="false" name="url_password_reset">|ACCOUNTS|/forgot/</string>
 
-    <string translatable="false" name="pref_manage_team_url">TEAMS/login/?utm_source=client_settings&amp;utm_term=android</string>
-    <string translatable="false" name="pick_user_manage_team_url">TEAMS/login/?utm_source=client_landing&amp;utm_term=android</string>
-    <string translatable="false" name="url_manage_services">TEAMS/services</string>
+    <string translatable="false" name="pref_manage_team_url">|TEAMS|/login/?utm_source=client_settings&amp;utm_term=android</string>
+    <string translatable="false" name="pick_user_manage_team_url">|TEAMS|/login/?utm_source=client_landing&amp;utm_term=android</string>
+    <string translatable="false" name="url_manage_services">|TEAMS|/services</string>
 
-    <string translatable="false" name="url_home">WEBSITE</string>
-    <string translatable="false" name="url_terms_of_service_personal">WEBSITE/legal/terms/personal/</string>
-    <string translatable="false" name="url_terms_of_service_teams">WEBSITE/legal/terms/teams/</string>
-    <string translatable="false" name="url_privacy_policy">WEBSITE/legal/privacy/embed/</string>
-    <string translatable="false" name="url_third_party_licences">WEBSITE/legal/#licenses</string>
-    <string translatable="false" name="url_otr_learn_why">WEBSITE/privacy/why</string>
-    <string translatable="false" name="url_otr_learn_how">WEBSITE/privacy/how</string>
-    <string translatable="false" name="url_otr_decryption_error_1">WEBSITE/privacy/error-1</string>
-    <string translatable="false" name="url_otr_decryption_error_2">WEBSITE/privacy/error-2</string>
-    <string translatable="false" name="url_about_teams">WEBSITE/products/pro-secure-team-collaboration/</string>
-    <string translatable="false" name="usernames__learn_more__link">WEBSITE/support/username/</string>
-    <string translatable="false" name="pref_about_website_url">WEBSITE</string>
+    <string translatable="false" name="url_home">|WEBSITE|</string>
+    <string translatable="false" name="url_terms_of_service_personal">|WEBSITE|/legal/terms/personal/</string>
+    <string translatable="false" name="url_terms_of_service_teams">|WEBSITE|/legal/terms/teams/</string>
+    <string translatable="false" name="url_privacy_policy">|WEBSITE|/legal/privacy/embed/</string>
+    <string translatable="false" name="url_third_party_licences">|WEBSITE|/legal/#licenses</string>
+    <string translatable="false" name="url_otr_learn_why">|WEBSITE|/privacy/why</string>
+    <string translatable="false" name="url_otr_learn_how">|WEBSITE|/privacy/how</string>
+    <string translatable="false" name="url_otr_decryption_error_1">|WEBSITE|/privacy/error-1</string>
+    <string translatable="false" name="url_otr_decryption_error_2">|WEBSITE|/privacy/error-2</string>
+    <string translatable="false" name="url_about_teams">|WEBSITE|/products/pro-secure-team-collaboration/</string>
+    <string translatable="false" name="usernames__learn_more__link">|WEBSITE|/support/username/</string>
+    <string translatable="false" name="pref_about_website_url">|WEBSITE|</string>
 
     <string translatable="false" name="pref_support_website_url">https://support.wire.com</string>
     <string translatable="false" name="pref_support_contact_url">https://support.wire.com/hc/requests/new</string>

--- a/app/src/main/scala/com/waz/zclient/Backend.scala
+++ b/app/src/main/scala/com/waz/zclient/Backend.scala
@@ -45,6 +45,9 @@ object Backend {
     baseUrl = "https://staging-nginz-https.zinfra.io",
     websocketUrl = "https://staging-nginz-ssl.zinfra.io/await",
     blacklistHost = s"https://clientblacklist.wire.com/staging/android",
+    teamsUrl = "https://wire-teams-staging.zinfra.io",
+    accountsUrl = "https://wire-account-staging.zinfra.io",
+    websiteUrl = "https://wire.com",
     StagingFirebaseOptions,
     certPin)
 
@@ -53,6 +56,9 @@ object Backend {
     BuildConfig.BACKEND_URL,
     BuildConfig.WEBSOCKET_URL,
     BuildConfig.BLACKLIST_HOST,
+    teamsUrl = "https://teams.wire.com",
+    accountsUrl = "https://account.wire.com",
+    websiteUrl = "https://wire.com",
     ProdFirebaseOptions,
     certPin)
 }

--- a/app/src/main/scala/com/waz/zclient/CredentialsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/CredentialsFragment.scala
@@ -374,7 +374,7 @@ class SetOrRequestPasswordFragment extends CredentialsFragment {
     confirmationButton.foreach(_.setAccentColor(Color.WHITE))
 
     Option(findById[View](R.id.ttv_signin_forgot_password)).foreach { forgotPw =>
-      forgotPw.onClick(inject[BrowserController].openForgotPasswordPage())
+      forgotPw.onClick(inject[BrowserController].openForgotPassword())
       forgotPw.setVisibility(if (hasPw) View.VISIBLE else View.INVISIBLE)
     }
 

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -26,14 +26,14 @@ import com.waz.service.AccountsService
 import com.waz.threading.Threading
 import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.utils.BackendSelector
+import com.waz.zclient.utils.BackendController
 
 class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
 
   override def onStart() = {
     super.onStart()
 
-    new BackendSelector()(this).selectBackend { be =>
+    BackendController()(this).selectBackend { be =>
       getApplication.asInstanceOf[WireApplication].ensureInitialized(be)
       inject[AccountsService].activeAccountId.head(LogTag("BackendSelector")).map {
         case Some(_) => startMain()

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -18,11 +18,12 @@
 
 package com.waz.zclient
 
-import android.content.Intent
+import android.app.AlertDialog
+import android.content.{DialogInterface, Intent}
 import android.support.v7.app.AppCompatActivity
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.service.AccountsService
+import com.waz.service.{AccountsService, BackendConfig}
 import com.waz.threading.Threading
 import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.log.LogUI._
@@ -30,16 +31,46 @@ import com.waz.zclient.utils.BackendController
 
 class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
 
+  private lazy val backendController = inject[BackendController]
+
   override def onStart() = {
     super.onStart()
 
-    BackendController()(this).selectBackend { be =>
+    val callback: BackendConfig => Unit = { be =>
       getApplication.asInstanceOf[WireApplication].ensureInitialized(be)
       inject[AccountsService].activeAccountId.head(LogTag("BackendSelector")).map {
         case Some(_) => startMain()
         case _ => startSignUp()
       }(Threading.Ui)
     }
+
+    if (backendController.shouldShowBackendSelector) showDialog(callback)
+    else callback(backendController.getStoredBackendConfig.getOrElse(Backend.ProdBackend))
+  }
+
+  /// Presents a dialog to select backend.
+  private def showDialog(callback: BackendConfig => Unit): Unit = {
+    val environments = Backend.byName
+    val items: Array[CharSequence] = environments.keys.toArray
+
+    val builder = new AlertDialog.Builder(this)
+    builder.setTitle("Select Backend")
+
+    builder.setItems(items, new DialogInterface.OnClickListener {
+      override def onClick(dialog: DialogInterface, which: Int): Unit = {
+        val choice = items.apply(which).toString
+        val config = environments.apply(choice)
+        backendController.setStoredBackendConfig(config)
+        callback(config)
+      }
+    })
+
+    builder.setCancelable(false)
+    builder.create().show()
+
+    // QA needs to be able to switch backends via intents. Any changes to the backend
+    // preference while the dialog is open will be treated as a user selection.
+    backendController.onPreferenceSet(callback)
   }
 
   override protected def onNewIntent(intent: Intent) = {

--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -111,7 +111,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
     summaryTextView.foreach { summaryTextView =>
       TextViewUtils.linkifyText(summaryTextView, Color.WHITE, R.string.wire__typeface__light, false, new Runnable() {
-        def run(): Unit = browser.openUrl(getString(R.string.usernames__learn_more__link))
+        def run(): Unit = browser.openUserNamesLearnMore()
       })
     }
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -86,7 +86,7 @@ import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
-import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendSelector, ExternalFileSharing, LocalThumbnailCache, UiStorage}
+import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendController, ExternalFileSharing, LocalThumbnailCache, UiStorage}
 import com.waz.zclient.views.DraftMap
 import javax.net.ssl.SSLContext
 import org.threeten.bp.Clock
@@ -366,7 +366,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     controllerFactory = new ControllerFactory(getApplicationContext)
 
-    new BackendSelector()(this).getStoredBackendConfig.foreach { be =>
+    BackendController()(this).getStoredBackendConfig.foreach { be =>
       ensureInitialized(be)
     }
   }

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -201,6 +201,7 @@ object WireApplication extends DerivedLogTag {
     bind [IConfirmationController]       toProvider controllerFactory.getConfirmationController
 
     // global controllers
+    bind [BackendController]       to new BackendController()
     bind [WebSocketController]     to new WebSocketController
     bind [CrashController]         to new CrashController
     bind [AccentColorController]   to new AccentColorController()
@@ -366,7 +367,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     controllerFactory = new ControllerFactory(getApplicationContext)
 
-    BackendController()(this).getStoredBackendConfig.foreach { be =>
+    inject[BackendController].getStoredBackendConfig.foreach { be =>
       ensureInitialized(be)
     }
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -189,7 +189,7 @@ class AppEntryActivity extends BaseActivity {
                 verbose(l"got config response: $config")
                 enableProgress(false)
 
-                BackendController().switchBackend(inject[GlobalModule], config, configUrl)
+                inject[BackendController].switchBackend(inject[GlobalModule], config, configUrl)
                 verbose(l"switched backend")
 
                 // re-present fragment for updated ui.

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -46,7 +46,7 @@ import com.waz.zclient.newreg.fragments.country.CountryController
 import com.waz.zclient.ui.text.{GlyphTextView, TypefaceTextView}
 import com.waz.zclient.ui.utils.KeyboardUtils
 import com.waz.zclient.utils.ContextUtils.{showConfirmationDialog, showErrorDialog}
-import com.waz.zclient.utils.{BackendSelector, ContextUtils, RichView, ViewUtils}
+import com.waz.zclient.utils.{BackendController, ContextUtils, RichView, ViewUtils}
 import com.waz.zclient.views.LoadingIndicatorView
 
 import scala.collection.JavaConverters._
@@ -189,7 +189,7 @@ class AppEntryActivity extends BaseActivity {
                 verbose(l"got config response: $config")
                 enableProgress(false)
 
-                new BackendSelector().switchBackend(inject[GlobalModule], config, configUrl)
+                BackendController().switchBackend(inject[GlobalModule], config, configUrl)
                 verbose(l"switched backend")
 
                 // re-present fragment for updated ui.

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryDialogs.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryDialogs.scala
@@ -18,19 +18,16 @@
 package com.waz.zclient.appentry
 
 import android.content.DialogInterface.OnDismissListener
-import android.content.Intent.{ACTION_VIEW, FLAG_ACTIVITY_NEW_TASK}
-import android.content.{Context, DialogInterface, Intent}
-import android.net.Uri
+import android.content.{Context, DialogInterface}
 import android.support.v7.app.AlertDialog
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.utils.returning
 import com.waz.zclient.R
-import com.waz.zclient.log.LogUI._
+import com.waz.zclient.common.controllers.BrowserController
 
 import scala.concurrent.{Future, Promise}
 
 object AppEntryDialogs extends DerivedLogTag {
-  def showTermsAndConditions(context: Context): Future[Boolean] = {
+  def showTermsAndConditions(context: Context, browser: BrowserController): Future[Boolean] = {
     val dialogResult = Promise[Boolean]()
     val dialog = new AlertDialog.Builder(context)
       .setPositiveButton(R.string.app_entry_dialog_accept, new DialogInterface.OnClickListener {
@@ -41,7 +38,7 @@ object AppEntryDialogs extends DerivedLogTag {
       })
       .setNeutralButton(R.string.app_entry_dialog_view, new DialogInterface.OnClickListener {
         override def onClick(dialog: DialogInterface, which: Int): Unit = {
-          onOpenUrl(context, context.getString(R.string.url_terms_of_service_teams))
+          browser.openTeamsTermsOfService()
           dialogResult.trySuccess(false)
         }
       })
@@ -54,7 +51,7 @@ object AppEntryDialogs extends DerivedLogTag {
     dialogResult.future
   }
 
-  def showNotificationsWarning(context: Context): Future[Boolean] = {
+  def showNotificationsWarning(context: Context, browser: BrowserController): Future[Boolean] = {
     val dialogResult = Promise[Boolean]()
     val dialog = new AlertDialog.Builder(context)
       .setPositiveButton(R.string.app_entry_dialog_accept, new DialogInterface.OnClickListener {
@@ -65,7 +62,7 @@ object AppEntryDialogs extends DerivedLogTag {
       })
       .setNeutralButton(R.string.app_entry_dialog_view, new DialogInterface.OnClickListener {
         override def onClick(dialog: DialogInterface, which: Int): Unit = {
-          onOpenUrl(context, context.getString(R.string.url_privacy_policy))
+          browser.openPrivacyPolicy()
           dialogResult.trySuccess(false)
         }
       })
@@ -76,16 +73,5 @@ object AppEntryDialogs extends DerivedLogTag {
       })
     dialog.show()
     dialogResult.future
-  }
-
-  private def onOpenUrl(context: Context, url: String) = {
-    try {
-      val normUrl = Uri.parse(if (!url.startsWith("http://") && !url.startsWith("https://")) s"http://$url" else url)
-      val browserIntent = returning(new Intent(ACTION_VIEW, normUrl))(_.addFlags(FLAG_ACTIVITY_NEW_TASK))
-      context.startActivity(browserIntent)
-    }
-    catch {
-      case _: Exception => error(l"Failed to open URL: ${redactedString(url)}")
-    }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
@@ -26,7 +26,7 @@ import com.waz.zclient.appentry.fragments.SignInFragment._
 import com.waz.zclient.appentry.fragments.{SignInFragment, TeamNameFragment}
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils.showInfoDialog
-import com.waz.zclient.utils.{BackendSelector, LayoutSpec, RichView}
+import com.waz.zclient.utils.{BackendController, LayoutSpec, RichView}
 
 object AppLaunchFragment {
 
@@ -55,17 +55,17 @@ class AppLaunchFragment extends SSOFragment {
     inflater.inflate(R.layout.app_entry_scene, container, false)
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    val backendSelector = new BackendSelector()
-    val hasCustomBackend = backendSelector.hasCustomBackend
+    val backendController = BackendController()
+    val hasCustomBackend = backendController.hasCustomBackend
 
     if (hasCustomBackend) {
       logo.foreach(_.setVisible(false))
       backendInfo.foreach(_.setVisible(true))
 
-      val name = backendSelector.getStoredBackendConfig.map(_.environment).getOrElse("N/A")
+      val name = backendController.getStoredBackendConfig.map(_.environment).getOrElse("N/A")
       backendTitle.foreach(_.setText(getString(R.string.custom_backend_info_title, name)))
 
-      val configUrl = backendSelector.customBackendConfigUrl.getOrElse("N/A").toUpperCase
+      val configUrl = backendController.customBackendConfigUrl.getOrElse("N/A").toUpperCase
       backendSubtitle.foreach(_.setText(configUrl))
 
       backendShowMoreButton.foreach(_.setOnTouchListener(new OnTouchListener {

--- a/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppLaunchFragment.scala
@@ -55,7 +55,7 @@ class AppLaunchFragment extends SSOFragment {
     inflater.inflate(R.layout.app_entry_scene, container, false)
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    val backendController = BackendController()
+    val backendController = inject[BackendController]
     val hasCustomBackend = backendController.hasCustomBackend
 
     if (hasCustomBackend) {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/InviteToTeamFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/InviteToTeamFragment.scala
@@ -28,7 +28,6 @@ import com.waz.api.impl.ErrorResponse.{ConnectionErrorCode, Forbidden, InternalE
 import com.waz.model.EmailAddress
 import com.waz.threading.Threading
 import com.waz.utils.returning
-import com.waz.utils.wrappers.AndroidURIUtil
 import com.waz.zclient.R
 import com.waz.zclient.appentry.controllers.InvitationsController
 import com.waz.zclient.appentry.{CreateTeamFragment, InvitesAdapter}
@@ -53,7 +52,7 @@ case class InviteToTeamFragment() extends CreateTeamFragment {
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
     super.onViewCreated(view, savedInstanceState)
-    learnMoreButton.foreach(_.onClick(browser.openUrl(AndroidURIUtil.parse(context.getString(R.string.invalid_email_help)))))
+    learnMoreButton.foreach(_.onClick(browser.openInvalidEmailHelp()))
     inputField.foreach { inputField =>
       inputField.setShouldDisableOnClick(false)
       inputField.setShouldClearErrorOnClick(true)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamEmailFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamEmailFragment.scala
@@ -18,8 +18,6 @@
 package com.waz.zclient.appentry.fragments
 
 import android.app.Activity
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.text.InputType
 import android.view.View
@@ -29,6 +27,7 @@ import com.waz.zclient._
 import com.waz.zclient.appentry.CreateTeamFragment
 import com.waz.zclient.appentry.DialogErrorMessage.EmailError
 import com.waz.zclient.appentry.fragments.SetTeamEmailFragment._
+import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views.InputBox
 import com.waz.zclient.common.views.InputBox.EmailValidator
 import com.waz.zclient.ui.text.TypefaceTextView
@@ -64,11 +63,7 @@ case class SetTeamEmailFragment() extends CreateTeamFragment {
         }(Threading.Ui)
       }
     }
-    aboutButton.foreach(_.onClick(openUrl(R.string.teams_set_email_about_url)))
-  }
-
-  private def openUrl(id: Int): Unit ={
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(id))))
+    aboutButton.foreach(_.onClick(inject[BrowserController].openAboutSetTeamEmail()))
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
@@ -30,6 +30,7 @@ import com.waz.utils.PasswordValidator
 import com.waz.zclient._
 import com.waz.zclient.appentry.DialogErrorMessage.EmailError
 import com.waz.zclient.appentry.{AppEntryDialogs, CreateTeamFragment}
+import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views.InputBox
 import com.waz.zclient.common.views.InputBox.SimpleValidator
 import com.waz.zclient.tracking.TeamAcceptedTerms
@@ -83,7 +84,7 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
           inputField.errorText.setTextColor(context.getColor(R.color.teams_error_red))
           Future.successful(Some(getString(R.string.password_policy_hint, passwordMinLength)))
         } else {
-          AppEntryDialogs.showTermsAndConditions(context).flatMap {
+          AppEntryDialogs.showTermsAndConditions(context, inject[BrowserController]).flatMap {
             case true =>
               tracking.track(TeamAcceptedTerms(TeamAcceptedTerms.AfterPassword))
               val credentials = EmailCredentials(EmailAddress(createTeamController.teamEmail), Password(text), Some(ConfirmationCode(createTeamController.code)))

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -198,7 +198,7 @@ class SignInFragment
 
     termsOfService.foreach { text =>
       TextViewUtils.linkifyText(text, getColor(R.color.white), true, new Runnable {
-        override def run(): Unit = browserController.openUrl(getString(R.string.url_terms_of_service_personal))
+        override def run(): Unit = browserController.openPersonalTermsOfService()
       })
     }
     countryButton.foreach(_.setOnClickListener(this))
@@ -414,7 +414,7 @@ class SignInFragment
         }
 
       case R.id.ttv_signin_forgot_password =>
-        browserController.openForgotPasswordPage()
+        browserController.openForgotPassword()
       case R.id.close_button =>
         activity.abortAddAccount()
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/TeamNameFragment.scala
@@ -18,12 +18,11 @@
 package com.waz.zclient.appentry.fragments
 
 import android.app.Activity
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import com.waz.zclient._
 import com.waz.zclient.appentry.{CreateTeamFragment, SSOFragment}
+import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views.InputBox
 import com.waz.zclient.common.views.InputBox.NameValidator
 import com.waz.zclient.ui.utils.KeyboardUtils
@@ -52,11 +51,8 @@ case class TeamNameFragment() extends CreateTeamFragment with SSOFragment {
         }
       )
     }
-    about.foreach(_.onClick(openUrl(R.string.url_about_teams)))
+    about.foreach(_.onClick(inject[BrowserController].openAboutTeams()))
   }
-
-  private def openUrl(id: Int): Unit =
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(id))))
 }
 
 object TeamNameFragment {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -191,7 +191,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
               R.string.app_entry_dialog_no_thanks
             )).map { consent =>
             am.setMarketingConsent(consent)
-            if (consent.isEmpty) inject[BrowserController].openUrl(getString(R.string.url_privacy_policy))
+            if (consent.isEmpty) inject[BrowserController].openPrivacyPolicy()
           }
         case _ => Future.successful({})
       }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyTeamEmailFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyTeamEmailFragment.scala
@@ -82,7 +82,7 @@ case class VerifyTeamEmailFragment() extends CreateTeamFragment{
               createTeamController.receiveNewsAndOffers = confirmed
               createTeamController.code = code
               showFragment(SetNameFragment(), SetNameFragment.Tag)
-              if (confirmed.isEmpty) inject[BrowserController].openUrl(getString(R.string.url_privacy_policy))
+              if (confirmed.isEmpty) inject[BrowserController].openPrivacyPolicy()
               None
             }
         }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -129,8 +129,8 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
 }
 
 object BrowserController {
-  val Accounts = "ACCOUNTS"
-  val Teams = "TEAMS"
-  val Website = "WEBSITE"
+  val Accounts = "|ACCOUNTS|"
+  val Teams = "|TEAMS|"
+  val Website = "|WEBSITE|"
 
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -20,22 +20,23 @@ package com.waz.zclient.common.controllers
 import android.content.{Context, Intent}
 import android.net.Uri
 import com.waz.api.MessageContent.Location
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.MessageId
 import com.waz.service.BackendConfig
-import com.waz.zclient.Backend.StagingBackend
-import com.waz.utils.events.EventStream
+import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.wrappers.{AndroidURIUtil, URI}
-import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.zclient.utils.IntentUtils
 import com.waz.zclient.{Injectable, Injector, R}
 
 import scala.util.Try
 
-class BrowserController(implicit context: Context, injector: Injector) extends Injectable {
+class BrowserController(implicit context: Context, injector: Injector) extends Injectable with DerivedLogTag {
+  import BrowserController._
 
-  private val beConfig = inject[BackendConfig]
+  private lazy val config = inject[BackendConfig]
 
-  val onYoutubeLinkOpened = EventStream[MessageId]()
+  val onYoutubeLinkOpened: SourceStream[MessageId] = EventStream[MessageId]()
 
   private def normalizeHttp(uri: Uri) =
     if (uri.getScheme == null) uri.buildUpon().scheme("http").build()
@@ -50,12 +51,86 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
   }
 
   def openLocation(location: Location): Unit =
-    Option(IntentUtils.getGoogleMapsIntent(context, location.getLatitude, location.getLongitude, location.getZoom, location.getName)) foreach { context.startActivity }
+    Option(IntentUtils.getGoogleMapsIntent(
+      context,
+      location.getLatitude,
+      location.getLongitude,
+      location.getZoom,
+      location.getName)) foreach { context.startActivity }
 
-  def openForgotPasswordPage(): Try[Unit] =
-    openUrl(getString(if (beConfig == StagingBackend) R.string.url_password_reset_staging else R.string.url_password_reset))
+  // Accounts
 
-  def openManageTeamsPage(): Try[Unit] =
-    openUrl(getString(if (beConfig == StagingBackend) R.string.url_manage_services_staging else R.string.url_manage_services))
+  def openForgotPassword(): Try[Unit] =
+    openUrl(getString(R.string.url_password_reset).replaceFirst(Accounts, config.accountsUrl.toString))
+
+  // Teams
+
+  def openPrefsManageTeam(): Try[Unit] =
+    openUrl(getString(R.string.pref_manage_team_url).replaceFirst(Teams, config.teamsUrl.toString))
+
+  def openStartUIManageTeam(): Try[Unit] =
+    openUrl(getString(R.string.pick_user_manage_team_url).replaceFirst(Teams, config.teamsUrl.toString))
+
+  def openManageServices(): Try[Unit] =
+    openUrl(getString(R.string.url_manage_services).replaceFirst(Teams, config.teamsUrl.toString))
+
+  // Website
+
+  def openHomePage(): Try[Unit] =
+    openUrl(getString(R.string.url_home).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openAboutWebsite(): Try[Unit] =
+    openUrl(getString(R.string.pref_about_website_url).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openAboutTeams(): Try[Unit] =
+    openUrl(getString(R.string.url_about_teams).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openUserNamesLearnMore(): Try[Unit] =
+    openUrl(getString(R.string.usernames__learn_more__link).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openPrivacyPolicy(): Try[Unit] =
+    openUrl(getString(R.string.url_privacy_policy).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openPersonalTermsOfService(): Try[Unit] =
+    openUrl(getString(R.string.url_terms_of_service_personal).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openTeamsTermsOfService(): Try[Unit] =
+    openUrl(getString(R.string.url_terms_of_service_teams).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openThirdPartyLicenses(): Try[Unit] =
+    openUrl(getString(R.string.url_third_party_licences).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openOtrLearnWhy(): Try[Unit] =
+    openUrl(getString(R.string.url_otr_learn_why).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openOtrLearnHow(): Try[Unit] =
+    openUrl(getString(R.string.url_otr_learn_how).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openDecryptionError1(): Try[Unit] =
+    openUrl(getString(R.string.url_otr_decryption_error_1).replaceFirst(Website, config.websiteUrl.toString))
+
+  def openDecryptionError2(): Try[Unit] =
+    openUrl(getString(R.string.url_otr_decryption_error_2).replaceFirst(Website, config.websiteUrl.toString))
+
+  // Support
+
+  // Custom backend configs don't include endpoints for a support website, so just use the
+  // resources strings as they are.
+
+  def openHelp(): Try[Unit] = openUrl(getString(R.string.url__help))
+
+  def openSupportPage(): Try[Unit] = openUrl(getString(R.string.pref_support_website_url))
+
+  def openContactSupport(): Try[Unit] = openUrl(getString(R.string.pref_support_contact_url))
+
+  def openInvalidEmailHelp(): Try[Unit] = openUrl(getString(R.string.invalid_email_help))
+
+  def openAboutSetTeamEmail(): Try[Unit] = openUrl(getString(R.string.teams_set_email_about_url))
+}
+
+object BrowserController {
+  val Accounts = "ACCOUNTS"
+  val Teams = "TEAMS"
+  val Website = "WEBSITE"
 
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -61,15 +61,15 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
   // Accounts
 
   def openForgotPassword(): Try[Unit] =
-    openUrl(getString(R.string.url_password_reset).replaceFirst(Accounts, config.accountsUrl.toString))
+    openUrl(getString(R.string.url_password_forgot).replaceFirst(Accounts, config.accountsUrl.toString))
 
   // Teams
 
   def openPrefsManageTeam(): Try[Unit] =
-    openUrl(getString(R.string.pref_manage_team_url).replaceFirst(Teams, config.teamsUrl.toString))
+    openUrl(getString(R.string.url_pref_manage_team).replaceFirst(Teams, config.teamsUrl.toString))
 
   def openStartUIManageTeam(): Try[Unit] =
-    openUrl(getString(R.string.pick_user_manage_team_url).replaceFirst(Teams, config.teamsUrl.toString))
+    openUrl(getString(R.string.url_start_ui_manage_team).replaceFirst(Teams, config.teamsUrl.toString))
 
   def openManageServices(): Try[Unit] =
     openUrl(getString(R.string.url_manage_services).replaceFirst(Teams, config.teamsUrl.toString))
@@ -80,13 +80,13 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
     openUrl(getString(R.string.url_home).replaceFirst(Website, config.websiteUrl.toString))
 
   def openAboutWebsite(): Try[Unit] =
-    openUrl(getString(R.string.pref_about_website_url).replaceFirst(Website, config.websiteUrl.toString))
+    openUrl(getString(R.string.url_about_website).replaceFirst(Website, config.websiteUrl.toString))
 
   def openAboutTeams(): Try[Unit] =
     openUrl(getString(R.string.url_about_teams).replaceFirst(Website, config.websiteUrl.toString))
 
   def openUserNamesLearnMore(): Try[Unit] =
-    openUrl(getString(R.string.usernames__learn_more__link).replaceFirst(Website, config.websiteUrl.toString))
+    openUrl(getString(R.string.url_usernames_learn_more).replaceFirst(Website, config.websiteUrl.toString))
 
   def openPrivacyPolicy(): Try[Unit] =
     openUrl(getString(R.string.url_privacy_policy).replaceFirst(Website, config.websiteUrl.toString))
@@ -117,20 +117,19 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
   // Custom backend configs don't include endpoints for a support website, so just use the
   // resources strings as they are.
 
-  def openHelp(): Try[Unit] = openUrl(getString(R.string.url__help))
+  def openHelp(): Try[Unit] = openUrl(getString(R.string.url_help))
 
-  def openSupportPage(): Try[Unit] = openUrl(getString(R.string.pref_support_website_url))
+  def openSupportPage(): Try[Unit] = openUrl(getString(R.string.url_support_website))
 
-  def openContactSupport(): Try[Unit] = openUrl(getString(R.string.pref_support_contact_url))
+  def openContactSupport(): Try[Unit] = openUrl(getString(R.string.url_contact_support))
 
-  def openInvalidEmailHelp(): Try[Unit] = openUrl(getString(R.string.invalid_email_help))
+  def openInvalidEmailHelp(): Try[Unit] = openUrl(getString(R.string.url_invalid_email_help))
 
-  def openAboutSetTeamEmail(): Try[Unit] = openUrl(getString(R.string.teams_set_email_about_url))
+  def openAboutSetTeamEmail(): Try[Unit] = openUrl(getString(R.string.url_teams_set_email_about))
 }
 
 object BrowserController {
   val Accounts = "\\|ACCOUNTS\\|"
   val Teams = "\\|TEAMS\\|"
   val Website = "\\|WEBSITE\\|"
-
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -129,8 +129,8 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
 }
 
 object BrowserController {
-  val Accounts = "|ACCOUNTS|"
-  val Teams = "|TEAMS|"
-  val Website = "|WEBSITE|"
+  val Accounts = "\\|ACCOUNTS\\|"
+  val Teams = "\\|TEAMS\\|"
+  val Website = "\\|WEBSITE\\|"
 
 }

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -134,7 +134,7 @@ class AddParticipantsFragment extends FragmentHelper {
       case _ => View.GONE
     }).onUi(vis => vh.foreach(_.setVisibility(vis)))
 
-    vh.onClick(_ => browserController.openManageTeamsPage())
+    vh.onClick(_ => browserController.openManageServices())
   }
 
   private lazy val errorText = returning(view[TypefaceTextView](R.id.empty_search_message)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
@@ -24,7 +24,6 @@ import com.waz.model.{UserData, UserId}
 import com.waz.service.IntegrationsService
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
-import com.waz.utils.wrappers.AndroidURIUtil
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views._
 import com.waz.zclient.messages.{MessageViewPart, MsgPart, UsersController}
@@ -86,7 +85,7 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
     case (true, _) =>
       label.setText(R.string.content__message__connect_request__auto_connect__footer)
       TextViewUtils.linkifyText(label, getStyledColor(R.attr.wirePrimaryTextColor), true, true, new Runnable() {
-        override def run() = browser.openUrl(AndroidURIUtil parse getString(R.string.url__help))
+        override def run() = browser.openHelp()
       })
     case (false, false) =>
       label.setTextColor(getStyledColor(R.attr.wirePrimaryTextColor))

--- a/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
@@ -22,7 +22,6 @@ import android.util.AttributeSet
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
 import com.waz.utils.events.Signal
-import com.waz.utils.wrappers.AndroidURIUtil
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.common.controllers.{BrowserController, ScreenController}
 import com.waz.zclient.log.LogUI._
@@ -114,8 +113,8 @@ class OtrMsgPartView(context: Context, attrs: AttributeSet, style: Int)
         case (OTR_UNVERIFIED | OTR_DEVICE_ADDED | OTR_MEMBER_ADDED, true)  => screenController.openOtrDevicePreferences()
         case (OTR_UNVERIFIED | OTR_DEVICE_ADDED | OTR_MEMBER_ADDED, false) => participantsController.onShowParticipants ! Some(SingleParticipantFragment.DevicesTab.str)
         case (STARTED_USING_DEVICE, _)                  => screenController.openOtrDevicePreferences()
-        case (OTR_ERROR, _)                             => browserController.openUrl(AndroidURIUtil parse getString(R.string.url_otr_decryption_error_1))
-        case (OTR_IDENTITY_CHANGED, _)                  => browserController.openUrl(AndroidURIUtil parse getString(R.string.url_otr_decryption_error_2))
+        case (OTR_ERROR, _)                             => browserController.openDecryptionError1()
+        case (OTR_IDENTITY_CHANGED, _)                  => browserController.openDecryptionError2()
         case _ =>
           info(l"unhandled help link click for $msg")
       }

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -125,7 +125,7 @@ class MainPhoneFragment extends FragmentHelper
         R.string.app_entry_dialog_not_now
       ).map { confirmed =>
         am.setMarketingConsent(confirmed)
-        if (confirmed.isEmpty) inject[BrowserController].openUrl(getString(R.string.url_privacy_policy))
+        if (confirmed.isEmpty) inject[BrowserController].openPrivacyPolicy()
       }
   } yield {}
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -102,7 +102,7 @@ class SingleOtrClientFragment extends FragmentHelper {
     accentColor
       .map(c => getHighlightText(getActivity, getString(R.string.otr__participant__single_device__how_to_link), c, false))
       .onUi(t => vh.foreach(_.setText(t)))
-    vh.onClick(_ => inject[BrowserController].openUrl(getString(R.string.url_otr_learn_how)))
+    vh.onClick(_ => inject[BrowserController].openOtrLearnHow())
     vh.foreach(_.setVisible(userId.isDefined))
   }
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -268,9 +268,7 @@ class SingleParticipantFragment extends FragmentHelper {
           }
         }
 
-        adapter.onHeaderClick {
-          _ => inject[BrowserController].openUrl(getString(R.string.url_otr_learn_why))
-        }
+        adapter.onHeaderClick { _ => inject[BrowserController].openOtrLearnWhy() }
       }
       view.setLayoutManager(new LinearLayoutManager(ctx))
       view.setHasFixedSize(true)

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -75,7 +75,7 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
   private lazy val textInputLayout = findById[TextInputLayout](root, R.id.til__remove_otr_device)
 
   private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.device_forgot_password)) {
-    _.onClick(inject[BrowserController].openForgotPasswordPage())
+    _.onClick(inject[BrowserController].openForgotPassword())
   }
 
   private lazy val isSSO = getArguments.getBoolean(IsSSOARG)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -21,7 +21,6 @@ import android.app.Activity
 import android.content.{Context, DialogInterface, Intent}
 import android.graphics.drawable.Drawable
 import android.graphics.{Canvas, ColorFilter, Paint, PixelFormat}
-import android.net.Uri
 import android.os.{Bundle, Parcel, Parcelable}
 import android.support.v4.app.{Fragment, FragmentTransaction}
 import android.util.AttributeSet
@@ -47,7 +46,7 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.ViewUtils._
 import com.waz.zclient.utils.{BackStackKey, BackStackNavigator, RichView, StringUtils, UiStorage}
 import com.waz.zclient.BuildConfig
-import com.waz.zclient.common.controllers.UserAccountsController
+import com.waz.zclient.common.controllers.{BrowserController, UserAccountsController}
 
 trait AccountView {
   val onNameClick:          EventStream[Unit]
@@ -302,9 +301,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
     }(Threading.Ui)
   }
 
-  view.onPasswordResetClick.onUi { _ =>
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_password_reset))))
-  }
+  view.onPasswordResetClick.onUi { _ => inject[BrowserController].openForgotPassword() }
 
   view.onLogoutClick.onUi { _ =>
     showAlertDialog(context, null,

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -20,7 +20,6 @@ package com.waz.zclient.preferences.pages
 import android.app.AlertDialog
 import android.content.{Context, DialogInterface, Intent}
 import android.graphics.drawable.Drawable
-import android.net.Uri
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
@@ -34,7 +33,7 @@ import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, EventStream, Signal}
 import com.waz.zclient._
-import com.waz.zclient.common.controllers.UserAccountsController
+import com.waz.zclient.common.controllers.{BrowserController, UserAccountsController}
 import com.waz.zclient.common.views.ImageAssetDrawable
 import com.waz.zclient.common.views.ImageAssetDrawable.{RequestBuilder, ScaleType}
 import com.waz.zclient.common.views.ImageController.{ImageSource, WireImage}
@@ -92,8 +91,7 @@ class ProfileViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
 
   private var dialog = Option.empty[AlertDialog]
 
-  teamButton.onClickEvent.on(Threading.Ui) { _ =>
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.pref_manage_team_url)))) }
+  teamButton.onClickEvent.on(Threading.Ui) { _ => inject[BrowserController].openPrefsManageTeam() }
   teamButton.setVisible(false)
   teamDivider.setVisible(false)
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
@@ -17,12 +17,12 @@
  */
 package com.waz.zclient.preferences.pages
 
-import android.content.{Context, Intent}
-import android.net.Uri
+import android.content.Context
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.preferences.views.TextButton
 import com.waz.zclient.{R, ViewHelper}
 import com.waz.zclient.utils.BackStackKey
@@ -36,13 +36,8 @@ class SupportView(context: Context, attrs: AttributeSet, style: Int) extends Lin
   val websiteButton = findById[TextButton](R.id.settings_support_website)
   val contactButton = findById[TextButton](R.id.settings_support_contact)
 
-  websiteButton.onClickEvent{ _ =>
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.pref_support_website_url))))
-  }
-
-  contactButton.onClickEvent{ _ =>
-    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.pref_support_contact_url))))
-  }
+  websiteButton.onClickEvent{ _ => inject[BrowserController].openSupportPage() }
+  contactButton.onClickEvent{ _ => inject[BrowserController].openContactSupport() }
 }
 
 case class SupportBackStackKey(args: Bundle = new Bundle()) extends BackStackKey(args) {

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -96,11 +96,15 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
         }
       case SELECT_STAGING_BE =>
         // Note, the app must be terminated for this to work.
-        BackendController()(context).setStoredBackendConfig(Backend.StagingBackend)
+        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
+        implicit val injector = wireApplication.module
+        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.StagingBackend)
         setResultCode(Activity.RESULT_OK)
       case SELECT_PROD_BE =>
         // Note, the app must be terminated for this to work.
-        BackendController()(context).setStoredBackendConfig(Backend.ProdBackend)
+        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
+        implicit val injector = wireApplication.module
+        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.ProdBackend)
         setResultCode(Activity.RESULT_OK)
       case _ =>
         setResultData("Unknown Intent!")

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -31,7 +31,7 @@ import com.waz.zclient.controllers.userpreferences.UserPreferencesController
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController._
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.tracking.GlobalTrackingController
-import com.waz.zclient.utils.BackendSelector
+import com.waz.zclient.utils.BackendController
 import com.waz.zclient.{Backend, BuildConfig, WireApplication}
 
 /**
@@ -96,11 +96,11 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
         }
       case SELECT_STAGING_BE =>
         // Note, the app must be terminated for this to work.
-        new BackendSelector()(context).setStoredBackendConfig(Backend.StagingBackend)
+        BackendController()(context).setStoredBackendConfig(Backend.StagingBackend)
         setResultCode(Activity.RESULT_OK)
       case SELECT_PROD_BE =>
         // Note, the app must be terminated for this to work.
-        new BackendSelector()(context).setStoredBackendConfig(Backend.ProdBackend)
+        BackendController()(context).setStoredBackendConfig(Backend.ProdBackend)
         setResultCode(Activity.RESULT_OK)
       case _ =>
         setResultData("Unknown Intent!")

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -39,7 +39,6 @@ import com.waz.service.tracking.{GroupConversationEvent, TrackingEvent, Tracking
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.{Signal, Subscription}
 import com.waz.utils.returning
-import com.waz.utils.wrappers.AndroidURIUtil
 import com.waz.zclient._
 import com.waz.zclient.common.controllers._
 import com.waz.zclient.common.controllers.global.{AccentColorController, KeyboardController}
@@ -222,7 +221,7 @@ class SearchUIFragment extends BaseFragment[SearchUIFragment.Container]
       btn.setGlyph(R.string.glyph__invite)
     }
 
-    emptyListButton.foreach(_.onClick(browser.openUrl(AndroidURIUtil.parse(getString(R.string.pick_user_manage_team_url)))))
+    emptyListButton.foreach(_.onClick(browser.openStartUIManageTeam()))
     errorMessageView
     toolbarTitle
     emptyServicesButton
@@ -355,8 +354,7 @@ class SearchUIFragment extends BaseFragment[SearchUIFragment.Container]
     conversationController.selectConv(Some(conversationData.id), ConversationChangeRequester.START_CONVERSATION)
   }
 
-  override def onManageServicesClicked(): Unit =
-    browser.openManageTeamsPage()
+  override def onManageServicesClicked(): Unit = browser.openManageServices()
 
   override def onCreateConvClicked(): Unit = {
     keyboard.hideKeyboardIfVisible()

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -48,8 +48,7 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
     val teamsUrl = getStringPreference(TEAMS_URL_PREF)
     val accountsUrl = getStringPreference(ACCOUNTS_URL_PREF)
     val websiteUrl = getStringPreference(WEBSITE_URL_PREF)
-
-    // TODO: Find  a way to clean this up.
+    
     (environment, baseUrl, websocketUrl, blackListHost, teamsUrl, accountsUrl, websiteUrl) match {
       case (Some(env), Some(base), Some(web), Some(black), Some(teams), Some(accounts), Some(website)) =>
         info(l"Retrieved stored backend config for environment: ${redactedString(env)}")

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -46,9 +46,13 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
     val baseUrl = getStringPreference(BASE_URL_PREF)
     val websocketUrl = getStringPreference(WEBSOCKET_URL_PREF)
     val blackListHost = getStringPreference(BLACKLIST_HOST_PREF)
+    val teamsUrl = getStringPreference(TEAMS_URL_PREF)
+    val accountsUrl = getStringPreference(ACCOUNTS_URL_PREF)
+    val websiteUrl = getStringPreference(WEBSITE_URL_PREF)
 
-    (environment, baseUrl, websocketUrl, blackListHost) match {
-      case (Some(env), Some(base), Some(web), Some(black)) =>
+    // TODO: Find  a way to clean this up.
+    (environment, baseUrl, websocketUrl, blackListHost, teamsUrl, accountsUrl, websiteUrl) match {
+      case (Some(env), Some(base), Some(web), Some(black), Some(teams), Some(accounts), Some(website)) =>
         info(l"Retrieved stored backend config for environment: ${redactedString(env)}")
 
         // Staging requires its own firebase options, but all other BEs (prod or custom)
@@ -58,7 +62,7 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
         else
           Backend.ProdFirebaseOptions
 
-        val config = BackendConfig(env, base, web, black, firebaseOptions, Backend.certPin)
+        val config = BackendConfig(env, base, web, black, teams, accounts, website, firebaseOptions, Backend.certPin)
         Some(config)
 
       case _ =>
@@ -74,6 +78,9 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
       .putString(BASE_URL_PREF, config.baseUrl.toString)
       .putString(WEBSOCKET_URL_PREF, config.websocketUrl.toString)
       .putString(BLACKLIST_HOST_PREF, config.blacklistHost.toString)
+      .putString(TEAMS_URL_PREF, config.teamsUrl.toString)
+      .putString(ACCOUNTS_URL_PREF, config.accountsUrl.toString)
+      .putString(WEBSITE_URL_PREF, config.websiteUrl.toString)
       .commit()
   }
 
@@ -144,6 +151,9 @@ object BackendController {
   val BASE_URL_PREF = "CUSTOM_BACKEND_BASE_URL"
   val WEBSOCKET_URL_PREF = "CUSTOM_BACKEND_WEBSOCKET_URL"
   val BLACKLIST_HOST_PREF = "CUSTOM_BACKEND_BLACKLIST_HOST"
+  val TEAMS_URL_PREF = "CUSTOM_BACKEND_TEAMS_URL"
+  val ACCOUNTS_URL_PREF = "CUSTOM_BACKEND_ACCOUNTS_URL"
+  val WEBSITE_URL_PREF = "CUSTOM_BACKEND_WEBSITE_URL"
   val CONFIG_URL_PREF = "CUSTOM_BACKEND_CONFIG_URL"
 
   def apply()(implicit context: Context): BackendController = new BackendController()

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -88,6 +88,7 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
   /// the global module is ready.
   def switchBackend(globalModule: GlobalModule, configResponse: BackendConfigResponse, configUrl: URL): Unit = {
     globalModule.backend.update(configResponse)
+    globalModule.blacklistClient.loadVersionBlacklist()
     setStoredBackendConfig(globalModule.backend)
 
     prefs.edit().putString(CONFIG_URL_PREF, configUrl.toString).commit()

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -34,8 +34,8 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
   private def prefs: SharedPreferences =
     PreferenceManager.getDefaultSharedPreferences(context)
 
-  /// A custom backend is one that is neither the Wire production nor staging backend.
-  def hasCustomBackend: Boolean = getStringPreference(CONFIG_URL_PREF).isDefined
+  /// A custom backend is one that is loaded by a config url via deep link.
+  def hasCustomBackend: Boolean = customBackendConfigUrl.isDefined
 
   /// The url string where the custom backend config was downloaded from.
   def customBackendConfigUrl: Option[String] = getStringPreference(CONFIG_URL_PREF)

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -25,8 +25,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{BackendConfig, GlobalModule}
 import com.waz.sync.client.CustomBackendClient.BackendConfigResponse
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.{Backend, BuildConfig, R}
-import com.waz.znet2.http.Request.UrlCreator
+import com.waz.zclient.{Backend, BuildConfig}
 
 
 class BackendController(implicit context: Context) extends DerivedLogTag {
@@ -118,10 +117,6 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
   private def getStringPreference(key: String): Option[String] =
     Option(prefs.getString(key, null))
 
-  def urls: BackendUrls = {
-    val config = getStoredBackendConfig.getOrElse(Backend.ProdBackend)
-    new BackendUrls(config, hasCustomBackend)
-  }
 }
 
 object BackendController {
@@ -134,134 +129,4 @@ object BackendController {
   val ACCOUNTS_URL_PREF = "CUSTOM_BACKEND_ACCOUNTS_URL"
   val WEBSITE_URL_PREF = "CUSTOM_BACKEND_WEBSITE_URL"
   val CONFIG_URL_PREF = "CUSTOM_BACKEND_CONFIG_URL"
-}
-
-class BackendUrls(config: BackendConfig, isCustom: Boolean = false)(implicit context: Context) {
-
-  import BackendUrls._
-  import ContextUtils.getString
-
-
-
-  // Used to generate various links to external support websites.
-  val teamsUrl: UrlCreator = UrlCreator.simpleAppender(() =>  config.teamsUrl.toString)
-  val accountsUrl: UrlCreator = UrlCreator.simpleAppender(() => config.accountsUrl.toString)
-  val websiteUrl: UrlCreator = UrlCreator.simpleAppender(() => config.websiteUrl.toString)
-
-  // Accounts
-
-  def forgotPassword: String = {
-    if (isCustom) accountsUrl.create(ForgotPath, List.empty).toString
-    else if (config == Backend.StagingBackend) getString(R.string.url_password_reset_staging)
-    else getString(R.string.url_password_reset)
-  }
-
-  // Teams
-
-  def prefsManageTeam: String = {
-    if (isCustom) teamsUrl.create(PrefsManageTeamPath, List.empty).toString
-    else getString(R.string.pref_manage_team_url)
-  }
-
-  def startUIManageTeam: String = {
-    if (isCustom) teamsUrl.create(StartUIManageTeamPath, List.empty).toString
-    else getString(R.string.pick_user_manage_team_url)
-  }
-
-  def manageServices: String = {
-    if (isCustom) config.teamsUrl.toString
-    else if (config == Backend.StagingBackend) getString(R.string.url_manage_services_staging)
-    else getString(R.string.url_manage_services)
-  }
-
-  // Website
-
-  def homePage: String = {
-    if (isCustom) config.websiteUrl.toString
-    else getString(R.string.url_home)
-  }
-
-  def aboutWebsite: String = {
-    if (isCustom) config.websiteUrl.toString
-    else getString(R.string.pref_about_website_url)
-  }
-
-  def aboutTeams: String = {
-    if (isCustom) websiteUrl.create(AboutTeamsPath, List.empty).toString
-    else getString(R.string.url_about_teams)
-  }
-
-  def usernamesLearnMore: String = {
-    if (isCustom) websiteUrl.create(UsernamesLearnMorePath, List.empty).toString
-    else getString(R.string.usernames__learn_more__link)
-  }
-
-  def privacyPolicy: String = {
-    if (isCustom) websiteUrl.create(PrivacyPolicyPath, List.empty).toString
-    else getString(R.string.url_privacy_policy)
-  }
-
-  def personalTermsOfService: String = {
-    if (isCustom) websiteUrl.create(PersonalTermsOfServicePath, List.empty).toString
-    else getString(R.string.url_terms_of_service_personal)
-  }
-
-  def teamsTermsOfService: String = {
-    if (isCustom) websiteUrl.create(TeamsTermsOfServicePath, List.empty).toString
-    else getString(R.string.url_terms_of_service_teams)
-  }
-
-  def thirdPartyLicenses: String = {
-    if (isCustom) websiteUrl.create(ThirdPartyLicensesPath, List.empty).toString
-    else getString(R.string.url_third_party_licences)
-  }
-
-  def otrLearnWhy: String = {
-    if (isCustom) websiteUrl.create(OtrLearnWhyPath, List.empty).toString
-    else getString(R.string.url_otr_learn_why)
-  }
-
-  def otrLearnHow: String = {
-    if (isCustom) websiteUrl.create(OtrLearnHowPath, List.empty).toString
-    else getString(R.string.url_otr_learn_how)
-  }
-
-  def decryptionError1: String = {
-    if (isCustom) websiteUrl.create(DecryptionError1Path, List.empty).toString
-    else getString(R.string.url_otr_decryption_error_1)
-  }
-
-  def decryptionError2: String = {
-    if (isCustom) websiteUrl.create(DecryptionError2Path, List.empty).toString
-    else getString(R.string.url_otr_decryption_error_2)
-  }
-
-  // Support
-
-  def help: String = getString(R.string.url__help)
-
-  def supportPage: String = getString(R.string.pref_support_website_url)
-
-  def contactSupport: String = getString(R.string.pref_support_contact_url)
-
-  def invalidEmailHelp: String = getString(R.string.invalid_email_help)
-
-  def aboutSetTeamEmail: String = getString(R.string.teams_set_email_about_url)
-
-}
-
-object BackendUrls {
-  val ForgotPath = "/forgot/"
-  val PrefsManageTeamPath = "/login/?utm_source=client_settings&amp;utm_term=android"
-  val StartUIManageTeamPath = "/login/?utm_source=client_landing&amp;utm_term=android"
-  val PersonalTermsOfServicePath = "/legal/terms/personal/"
-  val TeamsTermsOfServicePath = "/legal/terms/teams/"
-  val PrivacyPolicyPath = "/legal/privacy/embed/"
-  val ThirdPartyLicensesPath = "/legal/#licenses"
-  val OtrLearnWhyPath = "/privacy/why"
-  val OtrLearnHowPath = "/privacy/how"
-  val DecryptionError1Path = "/privacy/error-1"
-  val DecryptionError2Path = "/privacy/error-2"
-  val AboutTeamsPath = "/products/pro-secure-team-collaboration/"
-  val UsernamesLearnMorePath = "/support/username/"
 }

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -28,8 +28,8 @@ import com.waz.sync.client.CustomBackendClient.BackendConfigResponse
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{Backend, BuildConfig}
 
-class BackendSelector(implicit context: Context) extends DerivedLogTag {
-  import BackendSelector._
+class BackendController(implicit context: Context) extends DerivedLogTag {
+  import BackendController._
 
   private def prefs: SharedPreferences =
     PreferenceManager.getDefaultSharedPreferences(context)
@@ -138,11 +138,13 @@ class BackendSelector(implicit context: Context) extends DerivedLogTag {
     Option(prefs.getString(key, null))
 }
 
-object BackendSelector {
+object BackendController {
   // Preference Keys
   val ENVIRONMENT_PREF = "CUSTOM_BACKEND_ENVIRONMENT"
   val BASE_URL_PREF = "CUSTOM_BACKEND_BASE_URL"
   val WEBSOCKET_URL_PREF = "CUSTOM_BACKEND_WEBSOCKET_URL"
   val BLACKLIST_HOST_PREF = "CUSTOM_BACKEND_BLACKLIST_HOST"
   val CONFIG_URL_PREF = "CUSTOM_BACKEND_CONFIG_URL"
+
+  def apply()(implicit context: Context): BackendController = new BackendController()
 }


### PR DESCRIPTION
## What's new in this PR?

### Changes

- A single `BackendController` instance is now bound in `WireApplication`. There was no need to recreate it every time we needed it, now we can inject it.
- The backend selector dialog has been extracted out of `BackendController`. This is a consequence of binding the controller (the context it uses is not able to present dialogs), but I believe it makes for a cleaner controller.
- The external support urls (accounts, teams, website) are now persisted.
- `BrowserController` has been refactored to use these support urls.
- All places where we were opening urls manually is now delegated to `BrowserController`.
- The urls in `strings_no_translate.xml` have been tidied up and adjusted to support replacement of the host. These string resources are not intended to be used directly, but rather through the `BrowserController`.
#### APK
[Download build #12590](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12590/artifact/build/artifact/wire-dev-PR2113-12590.apk)
[Download build #12591](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12591/artifact/build/artifact/wire-dev-PR2113-12591.apk)
[Download build #12592](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12592/artifact/build/artifact/wire-dev-PR2113-12592.apk)