### PR TITLE
fix: reset log flag to off

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.2267"
+    zMessagingVersion = "141.0.2269"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'
@@ -320,7 +320,7 @@ dependencies {
     // TODO   when there are different SE APIs in dev vs internal/prod)
     boolean internal = true
     for (String taskName : gradle.startParameter.taskNames) {
-        if (taskName.contains("Prod") || taskName.contains("Candidate")) {
+        if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
             internal = false
             break
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Reset logging to off. Also interpret "aPR" as a non-debug build, currently only builds with the spellt-out "Prod" word are interpreted as production builds.

#### APK
[Download build #12594](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12594/artifact/build/artifact/wire-dev-PR2116-12594.apk)
[Download build #12595](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12595/artifact/build/artifact/wire-dev-PR2116-12595.apk)