### PR TITLE
Fix: verification code is send if password is valid

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -383,12 +383,15 @@ class SignInFragment
               email     <- email.head
               password  <- password.head
               name      <- name.head
-              req       <- accountsService.requestEmailCode(EmailAddress(email))
             } yield {
               if (strongPasswordValidator.isValidPassword(password)) {
-                onResponse(req, m).right.foreach { _ =>
+                for {
+                  req       <- accountsService.requestEmailCode(EmailAddress(email))
+                } yield {
+                  onResponse(req, m).right.foreach { _ =>
                   KeyboardUtils.closeKeyboardIfShown(getActivity)
                   activity.showFragment(VerifyEmailWithCodeFragment(email, name, password), VerifyEmailWithCodeFragment.Tag)
+                  }
                 }
               } else { // Invalid password
                 passwordPolicyHint.foreach(_.setTextColor(getColor(R.color.teams_error_red)))

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -385,12 +385,10 @@ class SignInFragment
               name      <- name.head
             } yield {
               if (strongPasswordValidator.isValidPassword(password)) {
-                for {
-                  req       <- accountsService.requestEmailCode(EmailAddress(email))
-                } yield {
+               accountsService.requestEmailCode(EmailAddress(email)).foreach { req =>
                   onResponse(req, m).right.foreach { _ =>
-                  KeyboardUtils.closeKeyboardIfShown(getActivity)
-                  activity.showFragment(VerifyEmailWithCodeFragment(email, name, password), VerifyEmailWithCodeFragment.Tag)
+                    KeyboardUtils.closeKeyboardIfShown(getActivity)
+                    activity.showFragment(VerifyEmailWithCodeFragment(email, name, password), VerifyEmailWithCodeFragment.Tag)
                   }
                 }
               } else { // Invalid password


### PR DESCRIPTION
## What's new in this PR?

The verification code when creating a new personal account with email is only send if the typed password is valid according to the policy.

### Issues

When an user was trying to create a new account, if the typed password was invalid and the tapped the button to continue, an email with the verification code was sent although he was not able to enter the code due to the invalid password. And if the user still making the same mistake all over again, new emails were being sent with the same verification code. 

### Causes

The email with the verification code was beign sent before checking if the password was valid

### Solutions

For correcting the issue what I did was making the password verification before sending the email with the verification code

### Testing

1) Open the app
2) Select "Personal"
3) Select "EMAIL"
4) Fill in the form with an email that is not yet registered and use an invalid password, such as "abcefg"
5) Press the white button with the arrow to continue 
6) The password policy should be in red now
6.1) **App without the fix:** An email should have been sent with the verification code. You can type the button the times you want and a lot of emails will be received until you correct the password
6.2) **App with the fix:** No email is received yet
7) Correct the password to satisfy the policy, you can use something as "ABCDefg1_"
8) Receive an email with the verification code. In the "app with the fix", only one email should have been received

## Notes

Thanks to this fix, the new users don't receive a lot of emails with the same content
