### PR TITLE
fix: Fixes an inconsistency in the Conversation Muted status (#547)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.2275"
+    zMessagingVersion = "141.0.2277"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'


### PR DESCRIPTION
Fixes an inconsistency in how the Conversation Muted status is reported between Android and other platforms 

The number sent from Android - which identifies the new conversation's muted state - was different from other platforms and couldn't be interpreted
properly on them. Also, the `muteTime` property was set to a time in the past, which on iOS was interpreted as that the event has already taken
place and was ignored.

fixes https://wearezeta.atlassian.net/browse/AN-6224
fixes https://wearezeta.atlassian.net/browse/AN-6210
#### APK
[Download build #12617](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12617/artifact/build/artifact/wire-dev-PR2135-12617.apk)