### PR TITLE
fix: Notifications are ignored if the app was killed before.

### DIFF
--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -28,6 +28,7 @@ import com.waz.service.{AccountsService, FCMNotificationStatsService, NetworkMod
 import com.waz.services.ZMessagingService
 import com.waz.threading.Threading
 import com.waz.utils.{JsonDecoder, RichInstant, Serialized}
+import com.waz.zclient.WireApplication
 import com.waz.zclient.log.LogUI._
 import org.json
 import org.threeten.bp.Instant
@@ -58,8 +59,9 @@ class FCMHandlerService extends FirebaseMessagingService with ZMessagingService 
     * it is sometimes not enough time to process everything - leading to missing messages!
     */
   override def onMessageReceived(remoteMessage: RemoteMessage) = {
-
     import FCMHandlerService._
+
+    WireApplication.APP_INSTANCE.ensureInitialized()
 
     Option(remoteMessage.getData).map(_.asScala.toMap).foreach { data =>
       verbose(l"onMessageReceived with data: ${redactedString(data.toString())}")
@@ -67,31 +69,24 @@ class FCMHandlerService extends FirebaseMessagingService with ZMessagingService 
         case Some(glob) if glob.backend.pushSenderId == remoteMessage.getFrom =>
           data.get(UserKey).map(UserId) match {
             case Some(target) =>
-              accounts.accountsWithManagers.head.flatMap { accs =>
+              accounts.accountsWithManagers.head.foreach { accs =>
                 accs.find(_ == target) match {
                   case Some(acc) =>
-                    accounts.getZms(acc).flatMap {
+                    accounts.getZms(acc).foreach {
                       case Some(zms) => FCMHandler(zms, data, Instant.ofEpochMilli(remoteMessage.getSentTime))
-                      case _ =>
-                        warn(l"Couldn't instantiate zms instance")
-                        Future.successful({})
+                      case _         => warn(l"Couldn't instantiate zms instance")
                     }
-                  case _ =>
-                    warn(l"Could not find target account for notification")
-                    Future.successful({})
+                  case _ => warn(l"Could not find target account for notification")
                 }
               }
             case _ =>
               warn(l"User key missing msg: ${redactedString(UserKeyMissingMsg)}")
               tracking.exception(new Exception(UserKeyMissingMsg), UserKeyMissingMsg)
-              Future.successful({})
           }
         case Some(_) =>
           warn(l"Received FCM notification from unknown sender: ${redactedString(remoteMessage.getFrom)}. Ignoring...")
-          Future.successful({})
         case _ =>
           warn(l"No ZMessaging global available - calling too early")
-          Future.successful({})
       }
     }
   }
@@ -123,7 +118,6 @@ object FCMHandlerService {
       data match {
         case NoticeNotification(nId) =>
           addNotificationToProcess(Some(nId))
-
         case _ =>
           warn(l"Unexpected notification, sync anyway")
           addNotificationToProcess(None)
@@ -134,12 +128,12 @@ object FCMHandlerService {
       for {
         false <- accounts.accountState(userId).map(_ == InForeground).head
         drift <- push.beDrift.head
-        now = clock.instant + drift
-        idle = network.isDeviceIdleMode
-        _ <- nId match {
-          case Some(n) => fcmPushes.markNotificationsWithState(Set(n), Pushed)
-          case _ => Future.successful(())
-        }
+        now   =  clock.instant + drift
+        idle  =  network.isDeviceIdleMode
+        _     <- nId match {
+                   case Some(n) => fcmPushes.markNotificationsWithState(Set(n), Pushed)
+                   case _       => Future.successful(())
+                 }
 
         /**
           * Warning: Here we want to trigger a direct fetch if we are in doze mode - when we get an FCM in doze mode, it is
@@ -150,7 +144,8 @@ object FCMHandlerService {
           * online at once. For that reason, we start a job which can run for as long as we need to avoid the app from being
           * killed mid-processing messages.
           */
-        _ <- if (idle) push.syncHistory(FetchFromIdle(nId)) else Serialized.future("fetch")(Future(FetchJob(userId, nId)))
+        _ <-     if (idle)  push.syncHistory(FetchFromIdle(nId))
+                 else Serialized.future("fetch")(Future(FetchJob(userId, nId)))
       } yield {}
   }
 

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -45,7 +45,12 @@ class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedL
     }
 
     if (backendController.shouldShowBackendSelector) showDialog(callback)
-    else callback(backendController.getStoredBackendConfig.getOrElse(Backend.ProdBackend))
+    else backendController.getStoredBackendConfig match {
+      case Some(be) => callback(be)
+      case None =>
+        backendController.setStoredBackendConfig(Backend.ProdBackend)
+        callback(Backend.ProdBackend)
+    }
   }
 
   /// Presents a dialog to select backend.

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -367,13 +367,14 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     controllerFactory = new ControllerFactory(getApplicationContext)
 
-    inject[BackendController].getStoredBackendConfig.foreach { be =>
-      ensureInitialized(be)
-    }
+    ensureInitialized()
   }
 
-  def ensureInitialized(backend: BackendConfig) = {
+  def ensureInitialized(): Unit =
+    if (Option(ZMessaging.currentGlobal).isEmpty)
+      inject[BackendController].getStoredBackendConfig.foreach(ensureInitialized)
 
+  def ensureInitialized(backend: BackendConfig) = {
     JobManager.create(this).addJobCreator(new JobCreator {
       override def create(tag: String) =
         if      (tag.contains(FetchJob.Tag))          new FetchJob
@@ -419,3 +420,4 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     super.onTerminate()
   }
 }
+


### PR DESCRIPTION
If a message arrives when the app is killed or in the background, it is first handled by `FCMHandlerService`. The service needs to access `GlobalModule` and `AccountsService` before it can call `PushService` in order to sync the app. (We don't use the received message directly as it might be out of sync - we perform a sync instead). But if the app is killed there is no `GlobalModule` (nor `AccountService`) present and the service silently stops without calling `PushService`.

In this PR the service first ensures that the app is initialized properly. If the app simply works in the background, no initialization is needed and the code will work as before. If the app is killed, we will look for the stored global config and initialize the app according to it. Only if the config is missing, we will not initialize the app and the service won't work. To avoid this, the first launch of the app after installing it should be done through `LaunchActivity`: there we choose the backend and we save our decision in the stored backend config. After that, even if the app is killed, we will have the information about the chosen backend and the service will be able to initialize the app. (It didn't work before because if we had our Prod backend as default, it was not saved in the stored backend config, and the service didn't know that Prod was our backend).
#### APK
[Download build #12620](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12620/artifact/build/artifact/wire-dev-PR2136-12620.apk)