### PR TITLE
fix: Ensure that the app is initialized or otherwise don't use its modules

### DIFF
--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -58,10 +58,8 @@ class FCMHandlerService extends FirebaseMessagingService with ZMessagingService 
     * According to the docs, we have 10 seconds to process notifications upon receiving the `remoteMessage`.
     * it is sometimes not enough time to process everything - leading to missing messages!
     */
-  override def onMessageReceived(remoteMessage: RemoteMessage) = {
+  override def onMessageReceived(remoteMessage: RemoteMessage) = if (WireApplication.ensureInitialized()){
     import FCMHandlerService._
-
-    WireApplication.APP_INSTANCE.ensureInitialized()
 
     Option(remoteMessage.getData).map(_.asScala.toMap).foreach { data =>
       verbose(l"onMessageReceived with data: ${redactedString(data.toString())}")

--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -23,6 +23,7 @@ import android.content
 import android.content.{BroadcastReceiver, Context, Intent}
 import android.os.{Build, IBinder}
 import android.support.v4.app.NotificationCompat
+import android.util.Log
 import com.waz.content.GlobalPreferences.{PushEnabledKey, WsForegroundKey}
 import com.waz.jobs.PushTokenCheckJob
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -81,46 +82,47 @@ class WebSocketController(implicit inj: Injector) extends Injectable {
   */
 class OnBootAndUpdateBroadcastReceiver extends BroadcastReceiver with DerivedLogTag {
 
-  private var context: Context = _
+  private val TAG = this.getClass.getName
 
-  implicit lazy val injector: Injector =
-    context.getApplicationContext.asInstanceOf[WireApplication].module
+  private var context: Context = _
 
   override def onReceive(context: Context, intent: Intent): Unit = {
     this.context = context
-    verbose(l"onReceive ${RichIntent(intent)}")
+    Log.i(TAG, s"onReceive ${intent.getDataString}")
 
-    WireApplication.APP_INSTANCE.ensureInitialized()
+    if (WireApplication.ensureInitialized())
+      Option(context.getApplicationContext.asInstanceOf[WireApplication].module).foreach { injector =>
+        injector.binding[AccountsService] match {
+          case Some(accounts) =>
+            Log.i(TAG, "AccountsService loaded")
+            accounts().zmsInstances.head.foreach { zs =>
+              zs.map(_.selfUserId).foreach(PushTokenCheckJob(_))
+            }(Threading.Background)
 
-    injector.binding[AccountsService] match {
-      case Some(accounts) =>
-        verbose(l"AccountsService loaded")
-        accounts().zmsInstances.head.foreach { zs =>
-          zs.map(_.selfUserId).foreach(PushTokenCheckJob(_))
-        } (Threading.Background)
+          case _ =>
+            Log.e(TAG, "Failed to load AccountsService")
+        }
 
-      case _ =>
-        error(l"Failed to load AccountsService")
-    }
+        injector.binding[WebSocketController] match {
+          case Some(controller) =>
+            Log.i(TAG, s"WebSocketController loaded")
+            controller().serviceInForeground.head.foreach {
+              case true =>
+                Log.i(TAG, s"startForegroundService")
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                  context.startForegroundService(new Intent(context, classOf[WebSocketService]))
+                else
+                  WebSocketService(context)
+              case false =>
+                Log.i(TAG, s"foreground service not needed, will wait for application to start service if necessary")
+            }(Threading.Ui)
 
-    injector.binding[WebSocketController] match {
-      case Some(controller) =>
-        verbose(l"WebSocketController loaded")
-        controller().serviceInForeground.head.foreach {
-          case true =>
-            verbose(l"startForegroundService")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-              context.startForegroundService(new Intent(context, classOf[WebSocketService]))
-            else
-              WebSocketService(context)
-          case false =>
-            verbose(l"foreground service not needed, will wait for application to start service if necessary")
-        } (Threading.Ui)
-
-      case None =>
-        error(l"Failed to load WebSocketController")
-    }
+          case None =>
+            Log.e(TAG, s"Failed to load WebSocketController")
+        }
+      }
   }
+
 }
 
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -29,6 +29,7 @@ import android.renderscript.RenderScript
 import android.support.multidex.MultiDexApplication
 import android.support.v4.app.{FragmentActivity, FragmentManager}
 import android.telephony.TelephonyManager
+import android.util.Log
 import com.evernote.android.job.{JobCreator, JobManager}
 import com.google.android.gms.security.ProviderInstaller
 import com.waz.api.NetworkMode
@@ -96,6 +97,10 @@ import scala.util.control.NonFatal
 
 object WireApplication extends DerivedLogTag {
   var APP_INSTANCE: WireApplication = _
+
+  def ensureInitialized(): Boolean =
+    if (Option(APP_INSTANCE).isEmpty) false // too early
+    else APP_INSTANCE.ensureInitialized()
 
   type AccountToImageLoader = (UserId) => Future[Option[ImageLoader]]
   type AccountToAssetsStorage = (UserId) => Future[Option[AssetsStorage]]
@@ -370,11 +375,21 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     ensureInitialized()
   }
 
-  def ensureInitialized(): Unit =
-    if (Option(ZMessaging.currentGlobal).isEmpty)
-      inject[BackendController].getStoredBackendConfig.foreach(ensureInitialized)
+  private[waz] def ensureInitialized(): Boolean =
+    if (Option(ZMessaging.currentGlobal).isDefined) true // the app is initialized, nothing to do here
+    else
+      try {
+        inject[BackendController].getStoredBackendConfig.fold(false){ config =>
+          ensureInitialized(config)
+          true
+        }
+      } catch {
+        case t: Throwable =>
+          Log.e(WireApplication.getClass.getName, "Failed to initialize the app", t)
+          false
+      }
 
-  def ensureInitialized(backend: BackendConfig) = {
+  def ensureInitialized(backend: BackendConfig): Unit = {
     JobManager.create(this).addJobCreator(new JobCreator {
       override def create(tag: String) =
         if      (tag.contains(FetchJob.Tag))          new FetchJob


### PR DESCRIPTION
Apart form the main path, whne the user opens the app manually, the app can be initialized via intents,
handled by services and receivers, such as `FCMHandlerService` and `OnBootAndUpdateBroadcastReceiver`.
The app should be initialized form them before any action can be taken as the result of receiving
the intent. However, sometime the initialization is not possible and in such cases the receiver should
log a message and close gracefully, without crashing.

I want to merge this hotfix directly into `release` and only then to `develop` when the new release is ready.
