### PR TITLE
Fix/audio recorder dispose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -362,6 +362,7 @@ dependencies {
 
     //third party libraries
     implementation 'io.reactivex.rxjava2:rxkotlin:2.3.0'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'com.jakewharton.timber:timber:4.7.0'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.0'

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/ExtendedCursorContainer.java
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/ExtendedCursorContainer.java
@@ -260,7 +260,7 @@ public class ExtendedCursorContainer extends FrameLayout implements KeyboardHeig
 
     private void closeVoiceFilter() {
         if (voiceFilterLayout != null) {
-//            voiceFilterLayout.onClose();
+            voiceFilterLayout.onClose();
             voiceFilterLayout = null;
         }
     }

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -82,6 +82,9 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
         showAudioRecordingHint()
     }
 
+    fun onClose() {
+        stopRecording()
+    }
 
     private fun showAudioRecordingHint() {
         audio_recording_container.visibility = View.VISIBLE

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -7,12 +7,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.Animation
 import android.widget.ViewAnimator
+import androidx.work.impl.Schedulers
 import com.waz.api.AudioEffect
 import com.waz.zclient.R
 import com.waz.zclient.audio.AudioService
 import com.waz.zclient.audio.AudioServiceImpl
 import com.waz.zclient.ui.animation.interpolators.penner.Expo
 import com.waz.zclient.utils.StringUtils
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.audio_message_recording_screen.view.*
 import java.io.File
@@ -187,6 +189,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
 
         recordingDisposable = audioService.withAudioFocus()
             .flatMap { audioService.recordPcmAudio(recordFile) }
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe({ progress ->
                 val normalizedAudioLevel = normalizeAudioLoudness(progress.maxAmplitude)
                 normalizedRecordLevels.add(normalizedAudioLevel)

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/WaveBinView.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/WaveBinView.kt
@@ -94,6 +94,6 @@ class WaveBinView @JvmOverloads constructor(context: Context, attrs: AttributeSe
     fun setAudioPlayingProgress(current: Long, total: Long) {
         this.currentHead = current
         this.duration = total
-        invalidate()
+        postInvalidate()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Navigating away from an ongoing recording doesn't dispose of the recording. Attempting to start a new recording will fail.

### Causes

The tear down logic for the audio recorder is triggered in `stopRecording()`, specifically in the cancellable of the `recordingDisposable`. Tear down is necessary for subsequent setups; if we don't tear down, then the next setup will fail. We simply weren't tearing down when the `AudioMessageRecordingScreen` is removed.

### Solutions

Stop the recording when we close the audio recoding screen.

### Testing

Manually tested.

#### APK
[Download build #12647](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12647/artifact/build/artifact/wire-dev-PR2156-12647.apk)