### PR TITLE
Prepare target file immediately before sending

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -212,12 +212,11 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
         wave_graph_view.keepScreenOn = false
         showAudioFilters()
         recordingDisposable?.dispose()
-
-        compressedRecordFile.delete()
-        compressedRecordFile.createNewFile()
     }
 
     private fun sendRecording() {
+        compressedRecordFile.delete()
+        compressedRecordFile.createNewFile()
         audioService.recodePcmToMp4(recordWithEffectFile, compressedRecordFile)
         listener?.sendRecording("audio/mp4a-latm", compressedRecordFile)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-android/pull/2156, sending audio messages sometimes failed.

### Causes

With https://github.com/wireapp/wire-android/pull/2156, we were invoking `stopRecording()` when the audio message screen is closed. However, in addition to disposing of the recording, this method also deletes and recreates the `compressedRecordFile`. 

When attempting to send an audio message, we recoded the temp file into this compressed file, then pass that back to the listener for sending. At the same time, we also close the audio message screen, invoking `stopRecording()` and so also deleting file. Thus, a race condition occurs most of the time we're just sending an empty file.

### Solutions

This side effect can be avoided by preparing the compressed file within `sendRecording()`.

### Testing

Manually tested.
#### APK
[Download build #12650](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12650/artifact/build/artifact/wire-dev-PR2158-12650.apk)