### PR TITLE
Use API safe method

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
@@ -47,7 +47,7 @@ class MediaRecorderControllerImpl(context: Context)
       r.setAudioSource(AudioSource.MIC)
       r.setOutputFormat(OutputFormat.MPEG_4)
       r.setAudioEncoder(AudioEncoder.HE_AAC)
-      r.setOutputFile(file)
+      r.setOutputFile(file.getAbsolutePath)
     }
 
   override def startRecording(): Unit = {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Long tap to record an audio message crashes on android versions < 8.

### Causes

Use of a method added in API 26.

### Solutions

Use an older method (API 1)

### Testing

Manually tested.
#### APK
[Download build #12652](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12652/artifact/build/artifact/wire-dev-PR2159-12652.apk)