### PR TITLE
fix: image preview is blank

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/ImagePreviewLayout.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/ImagePreviewLayout.scala
@@ -148,7 +148,7 @@ class ImagePreviewLayout(context: Context, attrs: AttributeSet, style: Int)
   def setImage(uri: URIWrapper, source: ImagePreviewLayout.Source): Unit = {
     this.source = Option(source)
     this.imageInput = Some(Content.Uri(URI.create(uri.toString)))
-    WireGlide(context).load(uri)
+    WireGlide(context).load(URIWrapper.unwrap(uri))
       .apply(new RequestOptions().centerInside()).into(imageView)
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When selecting an image from the gallery in the keyboard, the image preview would be blank.

### Causes

We we're passing a wrapped uri to Glide, confusing it causing it to fail to load the image.

### Solutions

Unwrap the uri.
#### APK
[Download build #12657](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12657/artifact/build/artifact/wire-dev-PR2161-12657.apk)