### PR TITLE
fix:image orientation

### DIFF
--- a/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
@@ -18,13 +18,16 @@
 
 package com.waz.zclient.camera.controllers
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.concurrent.{Executors, ThreadFactory}
 
 import android.content.Context
 import android.content.res.Configuration
-import android.graphics.{Rect, SurfaceTexture}
+import android.graphics._
 import android.hardware.Camera
+import android.support.media.ExifInterface
 import android.view.{OrientationEventListener, Surface, WindowManager}
+import com.waz.bitmap.BitmapUtils
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.images.ImageAssetGenerator
 import com.waz.threading.{CancellableFuture, Threading}
@@ -218,7 +221,7 @@ class AndroidCamera(info: CameraInfo, texture: SurfaceTexture, w: Int, h: Int, c
     c.startPreview()
   }
 
-  override def takePicture(shutter: => Unit) = {
+  override def takePicture(shutter: => Unit): Future[Array[Byte]] = {
     val promise = Promise[Array[Byte]]()
     camera match {
       case Some(c) => try {
@@ -229,8 +232,17 @@ class AndroidCamera(info: CameraInfo, texture: SurfaceTexture, w: Int, h: Int, c
           null,
           DeprecationUtils.pictureCallback(new PictureCallbackDeprecated {
             override def onPictureTaken(data: Array[Byte], camera: CameraWrapper): Unit = {
-              c.startPreview() //restarts the preview as it gets stopped by camera.takePicture()
-              promise.success(data)
+              // Restart the preview as it gets stopped by camera.takePicture()
+              c.startPreview()
+
+              // Correct the orientation
+              val exif = new ExifInterface(new ByteArrayInputStream(data))
+              val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+              val corrected = BitmapUtils.fixOrientation(BitmapFactory.decodeByteArray(data, 0, data.length), orientation)
+              val output = new ByteArrayOutputStream()
+              corrected.compress(Bitmap.CompressFormat.JPEG, 100, output)
+
+              promise.success(output.toByteArray)
             }
           }))
       } catch {

--- a/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
@@ -235,14 +235,21 @@ class AndroidCamera(info: CameraInfo, texture: SurfaceTexture, w: Int, h: Int, c
               // Restart the preview as it gets stopped by camera.takePicture()
               c.startPreview()
 
-              // Correct the orientation
+              // Correct the orientation, if needed.
               val exif = new ExifInterface(new ByteArrayInputStream(data))
               val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
-              val corrected = BitmapUtils.fixOrientation(BitmapFactory.decodeByteArray(data, 0, data.length), orientation)
-              val output = new ByteArrayOutputStream()
-              corrected.compress(Bitmap.CompressFormat.JPEG, 100, output)
 
-              promise.success(output.toByteArray)
+              val result = orientation match {
+                case ExifInterface.ORIENTATION_NORMAL | ExifInterface.ORIENTATION_UNDEFINED =>
+                  data
+                case _ =>
+                  val corrected = BitmapUtils.fixOrientation(BitmapFactory.decodeByteArray(data, 0, data.length), orientation)
+                  val output = new ByteArrayOutputStream()
+                  corrected.compress(Bitmap.CompressFormat.JPEG, 100, output)
+                  output.toByteArray
+              }
+
+              promise.success(result)
             }
           }))
       } catch {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Images captured by the device camera were always being sent in landscape orientation.

### Causes

Orientation correction must be implemented manually.

### Solutions

After getting the capture image data, check the EXIF metadata for orientation, then rotate the image manually.

### Testing

Manually tested.
#### APK
[Download build #12660](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12660/artifact/build/artifact/wire-dev-PR2163-12660.apk)
[Download build #12661](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12661/artifact/build/artifact/wire-dev-PR2163-12661.apk)