### PR TITLE
fix: Ignore markdown links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.2277"
+    zMessagingVersion = "141.0.2280"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.12@aar'


### PR DESCRIPTION
## What's new in this PR?

There should be no preview displayed for a markdown link. 
All changes are in the sync engine. This is only the SE number bump.

SE part: https://github.com/wireapp/wire-android-sync-engine/pull/548

### Issues

We have two types of links in the app: standard links, and markdown links. The app attempts to display a preview of the webpage for every link it recognizes. But for markdown links we shouldn't do it.

### Causes

To create a markdown link the user has to provide the url which is recognized by the app as a standard link.

### Solutions

Unfortunately, we parse the message data in SE and here we prepare links to be displayed with previews, but only much later in UI we apply markdown. When the parsed link part of the message is displayed in UI we no longer know that originally it was a markdown link, and it's difficult to find it out at that point.
Instead, I decided to ignore markdown links during the parsing in SE. It's a bit hacky (now even if there
was no markdown handling in UI we would still not display the preview), but it's much easier and faster.

### Testing

Manual tests. Send messages to an Android app containing standard links, markdown links, markdown references, and a mix of all of them. Previews should be displayed only for standard links (NOTE: not all webpages provide previews).

#### APK
[Download build #12669](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12669/artifact/build/artifact/wire-dev-PR2168-12669.apk)