### PR TITLE
[WIP] Re-add preference to force websocket to remain on in background

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.2280"
+    zMessagingVersion = "141.0.915-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.12@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '-DEV')
+    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion))
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "141.0.915-PR"
+    zMessagingVersion = "141.0.2281"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.12@aar'
@@ -36,7 +36,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion))
+    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion + '-DEV'))
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -504,7 +504,7 @@
     <string name="debug_report__title">Wire debug report - %1$s</string>
     <string name="debug_report__body">Please describe the steps required to reproduce the issue, provide screenshots if possible and send this email.\n\n</string>
     <string name="pref_advanced_ws_foreground_title">Maintain connection to server</string>
-    <string name="pref_advanced_ws_foreground_summary">We have detected that Google Play Services are not installed. Wire will try to keep a connection with the server open to receive notifications while the application is not in the foreground.
+    <string name="pref_advanced_ws_foreground_summary">Wire will try to keep a connection with the server open to receive notifications while the application is not in the foreground.
         Turning this setting off may improve battery performance, but you will no longer receive notifications when Wire is in the background. This applies to all accounts on this device.</string>
 
     <!-- Support -->

--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -36,7 +36,7 @@ import com.waz.zclient._
 import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.log.LogUI._
 
-class WebSocketController(implicit inj: Injector) extends Injectable {
+class WebSocketController(implicit inj: Injector) extends Injectable with DerivedLogTag {
   private lazy val global   = inject[GlobalModule]
   private lazy val accounts = inject[AccountsService]
 
@@ -49,12 +49,12 @@ class WebSocketController(implicit inj: Injector) extends Injectable {
   lazy val accountWebsocketStates: Signal[(Set[ZMessaging], Set[ZMessaging])] =
     for {
       cloudPushAvailable  <- cloudPushAvailable
-      uiActive            <- global.lifecycle.uiActive
       wsForegroundEnabled <- global.prefs(WsForegroundKey).signal
+      _ = verbose(l"wsForeground enabled: $wsForegroundEnabled")
       accs                <- accounts.zmsInstances
       accsInFG            <- Signal.sequence(accs.map(_.selfUserId).map(id => accounts.accountState(id).map(st => id -> st)).toSeq : _*).map(_.toMap)
       (zmsWithWSActive, zmsWithWSInactive) =
-        accs.partition(zms => accsInFG(zms.selfUserId) == InForeground || (!cloudPushAvailable && (uiActive || wsForegroundEnabled)))
+        accs.partition(zms => accsInFG(zms.selfUserId) == InForeground || wsForegroundEnabled || !cloudPushAvailable)
     } yield (zmsWithWSActive, zmsWithWSInactive)
 
   lazy val serviceInForeground: Signal[Boolean] =
@@ -65,15 +65,21 @@ class WebSocketController(implicit inj: Injector) extends Injectable {
 
   lazy val notificationTitleRes: Signal[Option[Int]] =
     serviceInForeground.flatMap {
-      case true => global.network.isOnline.flatMap {
+      case true =>
+        verbose(l"Service in foreground")
+        global.network.isOnline.flatMap {
         //checks to see if there are any accounts that haven't yet established a web socket
         case true => accounts.zmsInstances.flatMap(zs => Signal.sequence(zs.map(_.wsPushService.connected).toSeq: _ *).map(_.exists(!identity(_)))).map {
-          case true => Option(R.string.ws_foreground_notification_connecting_title)
-          case _    => Option(R.string.ws_foreground_notification_connected_title)
+          case true => verbose(l"connecting");Option(R.string.ws_foreground_notification_connecting_title)
+          case _    => verbose(l"connected");Option(R.string.ws_foreground_notification_connected_title)
         }
-        case _ => Signal.const(Option(R.string.ws_foreground_notification_no_internet_title))
+        case _ =>
+          verbose(l"Returning no notification titles despite service in foreground")
+          Signal.const(Option(R.string.ws_foreground_notification_no_internet_title))
       }
-      case _ => Signal.const(Option.empty[Int])
+      case _ =>
+        verbose(l"Returning no notification titles")
+        Signal.const(Option.empty[Int])
     }
 }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
@@ -26,11 +26,10 @@ import android.widget.{LinearLayout, TextView, Toast}
 import com.waz.content.GlobalPreferences.WsForegroundKey
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogsService
-import com.waz.service.{FCMNotificationStatsService, ZMessaging}
+import com.waz.service.{FCMNotificationStatsService, GlobalModule, ZMessaging}
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
-import com.waz.utils.wrappers.GoogleApi
 import com.waz.zclient.preferences.views.{SwitchPreference, TextButton}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{BackStackKey, DebugUtils}
@@ -93,7 +92,8 @@ class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int)
   statsDisplay.setVisible(BuildConfig.DEVELOPER_FEATURES_ENABLED)
 
   val webSocketForegroundServiceSwitch = returning(findById[SwitchPreference](R.id.preferences_websocket_service)) { v =>
-    inject[GoogleApi].isGooglePlayServicesAvailable.map(if (_) View.GONE else View.VISIBLE).onUi(v.setVisibility)
+    v.setVisible(true)
+    inject[GlobalModule].prefs(WsForegroundKey).signal.onUi(v.setChecked(_))
     v.setPreference(WsForegroundKey, global = true)
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR re-adds a flag in the advanced options to force the websocket to remain active when the app is not in the foreground. This is designed to enable devices without FCM to always receive notifications. For more information, see #2100

### Causes

The check we were using to determine if FCM was present wasn't accurate, since it only checks for Google Play Services, and not for FCM specifically. The code thus didn't work on devices with play services but with FCM disabled.

### Solutions

The decision was made to fall back to a preference again.

### Testing

Manual testing has been done on a device with and without Google Play Services(GPS),
#### APK
[Download build #12674](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12674/artifact/build/artifact/wire-dev-PR2169-12674.apk)
[Download build #12677](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12677/artifact/build/artifact/wire-dev-PR2169-12677.apk)
[Download build #12678](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12678/artifact/build/artifact/wire-dev-PR2169-12678.apk)
[Download build #12679](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12679/artifact/build/artifact/wire-dev-PR2169-12679.apk)