### PR TITLE
fix: check to ensure build version is valid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,9 +37,8 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion + '-DEV'))
+    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + isPR(zMessagingVersion))
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
-
 }
 
 if (project.file('user.gradle').exists()) {
@@ -442,6 +441,10 @@ def getApiKey(String property) {
     } else {
         return UUID.randomUUID().toString().replaceAll("-", "")
     }
+}
+
+static def isPR(String versionString) {
+    if(versionString.endsWith("-PR")) "" else "-DEV"
 }
 
 //add pretty naming to apk filename

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ ext {
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 
-    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + isPR(zMessagingVersion))
+    zMessagingDevVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + buildSuffixForVersion(zMessagingVersion))
     zMessagingReleaseVersion = System.getenv("LOCAL_ZMESSAGING_VERSION") ?: ((System.getenv("ZMESSAGING_VERSION") ?: zMessagingVersion) + '@aar')
 }
 
@@ -443,7 +443,7 @@ def getApiKey(String property) {
     }
 }
 
-static def isPR(String versionString) {
+static def buildSuffixForVersion(String versionString) {
     if(versionString.endsWith("-PR")) "" else "-DEV"
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

On Jenkins, if we use PR builds, the build fails because we add '-DEV'.

### Causes

We blindly add '-DEV' to all build versions

### Solutions

Add a check to ensure we don't ever add a second suffix.

### Testing

Testing was done using this PR with a version string ending in '-PR', if it builds successfully then it works. Testing was also done with #2174 and it works. This PR also more closely follows the previous behaviour, appending `-DEV` to `ZMESSAGING_VERSION` if present. 
#### APK
[Download build #12680](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12680/artifact/build/artifact/wire-dev-PR2170-12680.apk)
[Download build #12686](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12686/artifact/build/artifact/wire-dev-PR2170-12686.apk)