### PR TITLE
Fix: audio message crash

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -191,6 +191,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
     fun startRecording() {
         showAudioRecordingInProgress()
         recordFile.delete()
+        recordWithEffectFile.delete()
         normalizedRecordLevels.clear()
         wave_graph_view.keepScreenOn = true
         listener?.onAudioMessageRecordingStarted()
@@ -215,9 +216,10 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
     }
 
     private fun sendRecording() {
+        val pcm = if (recordWithEffectFile.exists()) recordWithEffectFile else recordFile
         compressedRecordFile.delete()
         compressedRecordFile.createNewFile()
-        audioService.recodePcmToMp4(recordWithEffectFile, compressedRecordFile)
+        audioService.recodePcmToMp4(pcm, compressedRecordFile)
         listener?.sendRecording("audio/mp4a-latm", compressedRecordFile)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sending an audio message without applying any filters crashes the app.

### Causes

When sending the audio message, we compress the recorded pcm file to mp4. However we have two pcm files in the cache, one for the recording, one for the recording with an applied effect. If we don't apply an affect, this second pcm file doesn't exist, which leads to a `FileNotFoundException`.

### Solutions

If no effect pcm file is found, fallback to the recorded pcm file.

### Testing

Manually tested.
#### APK
[Download build #12681](http://192.168.120.33:8080/job/Pull%20Request%20Builder/12681/artifact/build/artifact/wire-dev-PR2171-12681.apk)