### PR TITLE
Chore: Bump app version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-    majorVersion = "3.33."
+    majorVersion = "3.35."
 
     scalaMajorVersion = '2.11'
     scalaVersion = scalaMajorVersion + '.12'


### PR DESCRIPTION
## What's new in this PR?

Just preemptively bumping the app version for the next release. The last release was actually 3.34, and it needed to be bumped at the last minute, causing the build process to run again. I think it's helpful that the app version reflects the _next_ release, not the last.