### PR TITLE
Improvement: zmessaging version string suffix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -444,7 +444,7 @@ def getApiKey(String property) {
 }
 
 static def buildSuffixForVersion(String versionString) {
-    if(versionString.endsWith("-PR")) "" else "-DEV"
+    if (versionString.matches("\\d+\\.\\d+\\.\\d+(-[.0-9a-zA-Z]+)")) "" else "-DEV"
 }
 
 //add pretty naming to apk filename


### PR DESCRIPTION
## What's new in this PR?

A minor improvement to https://github.com/wireapp/wire-android/pull/2170. Instead of just checking for a `-PR` suffix, let's check if there is any suffix, and only append `-DEV` if none exists. This makes it simpler to not only specify PR builds, but also SNAPSHOT builds.
