### PR TITLE
fix: Audio message playing progress

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -21,7 +21,6 @@ import android.view.View.OnLayoutChangeListener
 import android.view.{View, ViewGroup}
 import android.widget.{FrameLayout, TextView}
 import com.waz.model.{Dim2, MessageContent}
-import com.waz.service.assets2.Asset.{Audio, Video}
 import com.waz.service.assets2._
 import com.waz.service.messages.MessageAndLikes
 import com.waz.threading.Threading
@@ -33,7 +32,7 @@ import com.waz.zclient.messages.ClickableViewPart
 import com.waz.zclient.messages.MessageView.MsgBindOptions
 import com.waz.zclient.messages.parts.assets.DeliveryState.{Downloading, OtherUploading}
 import com.waz.zclient.messages.parts.{EphemeralIndicatorPartView, EphemeralPartView, ImagePartView}
-import com.waz.zclient.utils.{StringUtils, _}
+import com.waz.zclient.utils._
 import com.waz.zclient.{R, ViewHelper}
 
 trait AssetPart extends View with ClickableViewPart with ViewHelper with EphemeralPartView { self =>
@@ -104,16 +103,10 @@ trait ActionableAssetPart extends AssetPart {
 }
 
 trait PlayableAsset extends ActionableAssetPart {
-  val duration = asset.map(_.details).map {
-    case details: Video => Some(details.duration)
-    case details: Audio => Some(details.duration)
-    case _ => None
-  }
-  val formattedDuration = duration.map(_.fold("")(d => StringUtils.formatTimeSeconds(d.getSeconds)))
-
   protected val durationView: TextView = findById(R.id.duration)
 
-  formattedDuration.on(Threading.Ui)(durationView.setText)
+  protected lazy val playControls = controller.getPlaybackControls(asset)
+  playControls.flatMap(_.isPlaying) (isPlaying ! _)
 }
 
 trait FileLayoutAssetPart extends AssetPart with EphemeralIndicatorPartView {

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
@@ -45,8 +45,6 @@ class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int)
     case _         => WireGlide(context).clear(image)
   }
 
-
-
   assetActionButton.onClick {
     assetStatus.map(_._1).currentValue.foreach {
       case UploadAssetStatus.Failed => message.currentValue.foreach(retr => {println(retr);  controller.retry(retr)})


### PR DESCRIPTION
## What's new in this PR?

A fix to a bug in the new assets: When an audio message is played in the conversation, the timer next to the progress bar should be running. Instead, it displayed the length of the recording.

### Issues

The timer's signal was incorrectly set to the total duration of the audio message. To make it right I moved some other signals around so their functionality is not duplicated by the new one.

### Testing

Tested manually
