### PR TITLE
fix: memberless conversation name updating

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2291"
+    zMessagingVersion = "142.0.947-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.12@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.947-PR"
+    zMessagingVersion = "142.0.2292"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.12@aar'

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -113,8 +113,7 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
   } yield members.filter(_ != selfUserId)
 
   currentConvId { convId =>
-    conversations(_.forceNameUpdate(convId))
-    conversations.head.foreach(_.forceNameUpdate(convId))
+    conversations.head.foreach(_.forceNameUpdate(convId, getString(R.string.default_deleted_username)))
     if (!lastConvId.contains(convId)) { // to only catch changes coming from SE (we assume it's an account switch)
       verbose(l"a conversation change bypassed selectConv: last = $lastConvId, current = $convId")
       convChanged ! ConversationChange(from = lastConvId, to = Option(convId), requester = ConversationChangeRequester.ACCOUNT_CHANGE)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -106,8 +106,9 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     if (conv.displayName.isEmpty) {
       // This hack was in the UiModule Conversation implementation
       // XXX: this is a hack for some random errors, sometimes conv has empty name which is never updated
-      zms.head.foreach {_.conversations.forceNameUpdate(conv.id) }
-      Name(getString(R.string.default_deleted_username))
+      val defaultName = getString(R.string.default_deleted_username)
+      zms.head.foreach {_.conversations.forceNameUpdate(conv.id, defaultName) }
+      Name(defaultName)
     } else
       conv.displayName
   }
@@ -127,8 +128,6 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     call           <- z.calling.currentCall
     callDuration   <- call.filter(_.convId == conv.id).fold(Signal.const(""))(_.durationFormatted)
     isGroupConv    <- z.conversations.groupConversation(conv.id)
-    lastMessage    <- controller.lastMessage(conv.id)
-    selfId         <- selfId
   } yield (conv.id, badgeStatusForConversation(conv, conv.unreadCount, typing, availableCalls, callDuration, isGroupConv))
 
   val subtitleText = for {
@@ -151,7 +150,6 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   val avatarInfo = for {
     z <- zms
     conv <- conversation
-    isGroup <- z.conversations.groupConversation(conv.id)
     memberIds <- members
     memberSeq <- Signal.sequence(memberIds.map(uid => UserSignal(uid)):_*)
     isGroup <- Signal.future(z.conversations.isGroupConversation(conv.id))
@@ -217,7 +215,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   badge.onClickEvent {
     case ConversationBadge.IncomingCall =>
       (zms.map(_.selfUserId).currentValue, conversationData.map(_.id)) match {
-        case (Some(acc), Some(cId)) => callStartController.startCall(acc, cId, withVideo = false, forceOption = true)
+        case (Some(acc), Some(cId)) => callStartController.startCall(acc, cId, forceOption = true)
         case _ => //
       }
     case OngoingCall(_) =>
@@ -225,15 +223,13 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     case _=>
   }
 
-  private var conversationCallback: ConversationCallback = null
+  private var conversationCallback: ConversationCallback = _
   private var maxAlpha: Float = .0f
   private var openState: Boolean = false
   private val menuOpenOffset: Int = getDimenPx(R.dimen.list__menu_indicator__max_swipe_offset)
   private var moveTo: Float = .0f
   private var maxOffset: Float = .0f
-  private var swipeable: Boolean = true
-  private var moveToAnimator: ObjectAnimator = null
-  private var shouldRedraw = false
+  private var moveToAnimator: ObjectAnimator = _
 
   def setConversation(conversationData: ConversationData): Unit = if (this.conversationData.forall(_.id != conversationData.id)) {
     this.conversationData = Some(conversationData)

--- a/app/src/main/scala/com/waz/zclient/sharing/ShareToMultipleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ShareToMultipleFragment.scala
@@ -52,7 +52,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.utils.{ColorUtils, KeyboardUtils}
 import com.waz.zclient.ui.views.CursorIconButton
 import com.waz.zclient.usersearch.views.{PickerSpannableEditText, SearchEditText}
-import com.waz.zclient.utils.ContextUtils.{getDimenPx, showToast}
+import com.waz.zclient.utils.ContextUtils.{getDimenPx, showToast, getString}
 import com.waz.zclient.utils.{RichView, ViewUtils}
 
 import scala.util.Success
@@ -339,7 +339,7 @@ case class SelectableConversationRowViewHolder(view: SelectableConversationRow)(
       val name = conversationData.displayName
       if (name.isEmpty) {
         import Threading.Implicits.Background
-        zms.head.flatMap(_.conversations.forceNameUpdate(conversationData.id))
+        zms.head.flatMap(_.conversations.forceNameUpdate(conversationData.id, getString(R.string.default_deleted_username)(view.getContext)))
       }
       view.nameView.setText(conversationData.displayName)
     case _ => view.nameView.setText("")


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR introduces a new default name when forcing conversation name updates. See the [SE PR](https://github.com/wireapp/wire-android-sync-engine/pull/562) for details.

This commit also removes a few redundant/unused operations in `ConversationListRow` and `ConversationController`.
