### PR TITLE
Fix: Don't use get on an optional

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
@@ -100,9 +100,9 @@ class WebLinkPartView(context: Context, attrs: AttributeSet, style: Int)
 
   private val dotsDrawable = new ProgressDotsDrawable
 
-  image.map (_.map{
-    case Left(asset) => WireGlide(context).load(AssetId(asset.remoteId.get.str))
-    case Right(uri) => WireGlide(context).load(uri.toString)
+  image.map (_.flatMap{
+    case Left(asset) => asset.remoteId.map(id => WireGlide(context).load(AssetId(id.str)))
+    case Right(uri) => Some(WireGlide(context).load(uri.toString))
   }).onUi {
     case Some(request) =>
       request.apply(new RequestOptions().centerCrop().placeholder(dotsDrawable))


### PR DESCRIPTION
## What's new in this PR?

### Issues

@mythsunwind in in a crash loop due to a `NoSuchElementException`. 

### Causes

The crash log indicates it is due to a call to `get` on `None` value. The stack trace is pointing to `WebLinkPartView`.

### Solutions

Remove the only call to `get`, which is when we're trying to get the remote identifier of an asset. If there is no identifier, then we shouldn't try to load the image.