### PR TITLE
fix: A timer appears over a chathead of another participant

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
@@ -132,7 +132,7 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
     val icon =
       if (user.connection == ConnectionStatus.Blocked)
         Some(OverlayIcon.Blocked)
-      else if (!user.isConnected && attributes.showWaiting && !user.isWireBot)
+      else if (pendingConnectionStatuses.contains(user.connection) && attributes.showWaiting && !user.isWireBot)
         Some(OverlayIcon.Waiting)
       else
         None
@@ -149,6 +149,8 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
 }
 
 object ChatHeadView {
+  private val pendingConnectionStatuses = Set(ConnectionStatus.PendingFromUser, ConnectionStatus.PendingFromOther)
+
   case class Attributes(isRound: Boolean,
                         showWaiting: Boolean,
                         greyScaleOnConnected: Boolean,


### PR DESCRIPTION
A timer icon over the avatar of another user indicates that we sent a connect request to that person, or that they sent a connect request to us. Instead, the timer icon appeared also on avatars of all participants in the given conversation who were not connected to us. That was fixed.
