### PR TITLE
Create custom configuration for website links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,9 @@ android {
         buildConfigField 'String',  'CUSTOM_URL_SCHEME',          "\"$config.custom_url_scheme\""
         buildConfigField 'Integer', 'NEW_PASSWORD_MINIMUM_LENGTH', "$config.new_password_minimum_length"
         buildConfigField 'Integer', 'NEW_PASSWORD_MAXIMUM_LENGTH', "$config.new_password_maximum_length"
+        buildConfigField 'String',  'TEAMS_URL',                   "\"$config.teamsUrl\""
+        buildConfigField 'String',  'ACCOUNTS_URL',                "\"$config.accountsUrl\""
+        buildConfigField 'String',  'WEBSITE_URL',                 "\"$config.websiteUrl\""
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/Backend.scala
+++ b/app/src/main/scala/com/waz/zclient/Backend.scala
@@ -56,9 +56,9 @@ object Backend {
     BuildConfig.BACKEND_URL,
     BuildConfig.WEBSOCKET_URL,
     BuildConfig.BLACKLIST_HOST,
-    teamsUrl = "https://teams.wire.com",
-    accountsUrl = "https://account.wire.com",
-    websiteUrl = "https://wire.com",
+    teamsUrl = BuildConfig.TEAMS_URL,
+    accountsUrl = BuildConfig.ACCOUNTS_URL,
+    websiteUrl = BuildConfig.WEBSITE_URL,
     ProdFirebaseOptions,
     certPin)
 }

--- a/default.json
+++ b/default.json
@@ -21,6 +21,9 @@
       "domain": "*.wire.com",
       "certificate" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreYzBWuvnVKYfgNNX3dVjUnqIVtl4XqQnCcY6m/sWM15TTK0bo9FKnMxNAPtDzB6ViRvpZsKEefX8pi15Jcs4uZiuZ81ISV1bqxtpsjJ56Yjeme99Dca5ck35pThYuK6jZ8vG6pJiY9mRY9nGadid4qWL7uwAeoInx2mOM7HepCCh2NOXd+EjQ4sBsfgb+kWrcVQmBzvLHPUDoykm/m+BvL2eJ1njPNiM/GoeXbmIW1WM3ifucYJoD9g+V5NfHfANrVu2w4YcLDad0C85Nb8U1sgFNkrgOqzhd/1xHok1uOyjoeLTIHHYkryvbBEmdl6v+f2J1EM0+Fj9vseI2TYrQIDAQAB"
   },
+  "teamsUrl": "https://teams.wire.com",
+  "accountsUrl": "https://account.wire.com",
+  "websiteUrl": "https://wire.com",
   "loggingEnabled": false,
   "custom_url_scheme": "wire",
   "new_password_minimum_length": 8,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Custom builds could point to custom website / team settings only by modifying the string file (`strings_no_translate.xml`) and overwriting the host of the links. This is an error-prone process every time there is an update, as the `string_no_translate.xml` needs to be checked by hand for hosts.

### Solutions

Specify the hosts at the build configuration level. Custom builds will overwrite these.

### Testing

I manually tested a build with the default build configuration, and clicking on the links.
- Account pages: used the "Forget password" link
- Team settings: used the "Manage team" link
- Website: used the "About -> Website" link

The links are correct.
