### PR TITLE
fix: The avatar of the blocked person should be circular

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
@@ -18,10 +18,13 @@
 
 package com.waz.zclient.pages.main.connect
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.animation.Animation
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{ImageView, LinearLayout}
+import com.bumptech.glide.load.Transformation
+import com.bumptech.glide.load.resource.bitmap.{CenterCrop, CircleCrop}
 import com.bumptech.glide.request.RequestOptions
 import com.waz.model.UserData.Picture
 import com.waz.model.{ConvId, UserId}
@@ -63,6 +66,13 @@ object BlockedUserProfileFragment {
     def onUnblockedUser(restoredConversationWithUser: ConvId): Unit
   }
 
+  val requestOptions = returning(new RequestOptions()) { r =>
+    val transformations = returning(Seq.newBuilder[Transformation[Bitmap]]) { ts =>
+      ts += new CenterCrop()
+      ts += new CircleCrop()
+    }
+    r.transforms(transformations.result():_*)
+  }
 }
 
 class BlockedUserProfileFragment extends BaseFragment[BlockedUserProfileFragment.Container] with FragmentHelper {
@@ -136,9 +146,7 @@ class BlockedUserProfileFragment extends BaseFragment[BlockedUserProfileFragment
     userNameView
     userUsernameView
     pictureSignal.onUi { id =>
-      profileImageView.foreach(WireGlide(ctx).load(id)
-        .apply(new RequestOptions().centerCrop())
-        .into(_))
+      profileImageView.foreach(v => WireGlide(ctx).load(id).apply(requestOptions).into(v))
     }
     unblockButton.foreach(_.setIsFilled(true))
     cancelButton.foreach(_.setIsFilled(true))


### PR DESCRIPTION
## What's new in this PR?

A small change to `BlockedUserProfileFragment`. The initial issue was that the avatar of a blocked person should have the "blocked" icon on top. In the end we decided not to do it - iOS also displays the icon only on small chatheads, but not on the avatar in the profile. But in the meantime we found out the avatar appears as rectangular, not circular. That was changed. Also, now, if we want to display the "blocked" icon, it's just one additional line of code.