### PR TITLE
fix: Sharing messages and assets to many conversations

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -458,13 +458,11 @@ class MainActivity extends BaseActivity
         res.map(_ => true)
 
       case SharingIntent() =>
-        (for {
-          convs <- sharingController.targetConvs.head
-          exp   <- sharingController.ephemeralExpiration.head
-          _     <- sharingController.sendContent(this)
+        for {
+          convs <- sharingController.sendContent(this)
           _     <- if (convs.size == 1) conversationController.switchConversation(convs.head) else Future.successful({})
-        } yield clearIntent())
-          .map(_ => true)
+          _     =  clearIntent()
+        } yield true
 
       case OpenPageIntent(page) => page match {
         case Intents.Page.Settings =>

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -47,17 +47,16 @@ class SharingController(implicit injector: Injector, wContext: WireContext, even
   }
 
   def sendContent(activity: Activity): Future[Seq[ConvId]] = {
-    def send(content: SharableContent, convs: Seq[ConvId], expiration: Option[FiniteDuration]) = {
+    def send(content: SharableContent, convs: Seq[ConvId], expiration: Option[FiniteDuration]) =
       content match {
         case TextContent(t) =>
-          conversationController.sendMessage(t, List.empty, None, Some(expiration))
+          conversationController.sendTextMessage(convs, t, Nil, None, Some(expiration))
         case uriContent =>
           Future.traverse(uriContent.uris) { uriWrapper =>
             val uri = URIWrapper.toJava(uriWrapper)
             conversationController.sendAssetMessage(uri, activity, Some(expiration), convs)
           }
       }
-    }
 
     for {
       Some(content) <- sharableContent.head


### PR DESCRIPTION
###  What's new in this PR?

fixes: https://wearezeta.atlassian.net/browse/AN-6147
fixes: https://wearezeta.atlassian.net/browse/AN-6284

Also fixes a bug which led to losing information about the mime type of the shared asset.

### Issues

Sharing text messages was (wrongly) taking the current conversation as the receiver instead of the one specified in the intent. Sending assets was broken.

### Solutions

I made the methods involved in sharing more robust: they accept a sequence of conversations. I decided not to make the "send with current conv" methods a special case of the more robust ones, because they're used in different contexts, but I made them look more similar.
There was an additional problem with assets: The name of the shared file must have the correct extension. The code which created the shared filename sometime didn't add it.

### Testing

Follow steps from the bugs AN-6147 and AN-6284.
