### PR TITLE
fix: Show audio and video assets in the collection view

### DIFF
--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
@@ -94,32 +94,31 @@ object CollectionController {
 
   trait ContentType {
     val msgTypes: Seq[Message.Type]
-    val typeFilter: Seq[TypeFilter]
+    lazy val typeFilter: Seq[TypeFilter] = msgTypes.map(TypeFilter(_, None))
   }
 
   case object Links extends ContentType {
     override val msgTypes = Seq(Message.Type.RICH_MEDIA)
-    override val typeFilter: Seq[TypeFilter] = Seq(TypeFilter(Message.Type.RICH_MEDIA, None))
   }
 
   case object Images extends ContentType {
     override val msgTypes = Seq(Message.Type.ASSET)
-    override val typeFilter: Seq[TypeFilter] = Seq(TypeFilter(Message.Type.ASSET, None))
   }
 
   //Now we can add more types to this sequence for the "others" category
   case object Files extends ContentType {
-    override val msgTypes = Seq(Message.Type.ANY_ASSET)
-    override val typeFilter: Seq[TypeFilter] = Seq(TypeFilter(Message.Type.ANY_ASSET, None))
+    override val msgTypes = Seq(Message.Type.ANY_ASSET, Message.Type.AUDIO_ASSET, Message.Type.VIDEO_ASSET)
   }
 
   case object AllContent extends ContentType {
     //feels a little bit messy... maybe think of a neater way to represent the types
     override val msgTypes = Images.msgTypes ++ Files.msgTypes ++ Links.msgTypes
-    override val typeFilter: Seq[TypeFilter] = Seq(
+    override lazy val typeFilter: Seq[TypeFilter] = Seq(
       TypeFilter(Message.Type.ASSET, Some(8)),
       TypeFilter(Message.Type.RICH_MEDIA, Some(3)),
-      TypeFilter(Message.Type.ANY_ASSET, Some(3))
+      TypeFilter(Message.Type.ANY_ASSET, Some(3)),
+      TypeFilter(Message.Type.AUDIO_ASSET, Some(3)),
+      TypeFilter(Message.Type.VIDEO_ASSET, Some(3))
     )
   }
 }

--- a/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
@@ -152,7 +152,7 @@ object QuickReplyContentAdapter {
           StringUtils.capitalise(context.getString(R.string.notification__message__group__add))
         case CONNECT_ACCEPTED =>
           context.getString(R.string.notification__message__single__accept_request, userName)
-        case ANY_ASSET =>
+        case ANY_ASSET | AUDIO_ASSET | VIDEO_ASSET =>
           context.getString(R.string.notification__message__one_to_one__shared_file)
         case _ => ""
       }


### PR DESCRIPTION
## What's new in this PR?

Audio and video assets are now displayed in the collection view as files.
fixes: https://wearezeta.atlassian.net/browse/AN-6282

### Issues


Audio and video assets have their own types, but the collection view tried to treat them as if their type was the same as for all other files. In result, they were filtered out.

### Solutions

In every place the collection view queries for `ANY_ASSET` I extended it to "one of `ANY_ASSET`, `AUDIO_ASSET`, or `VIDEO_ASSET`".

### Testing

1. Make an audio or video recording in a conversation.
2. Go to the collection (the "magnifying lens" icon).
3. You should see the recording under "files".

## Notes

I made the fix with the least amount of changes to the collection code. Apart from a few minor things, the code was not touched since January 2017. I think it's a good candidate for rewriting in Kotlin.
