### PR TITLE
fix: youtube preview image loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1000-PR"
+    zMessagingVersion = "142.0.1006-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1007-PR"
+    zMessagingVersion = "142.0.2315"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1006-PR"
+    zMessagingVersion = "142.0.1007-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.969-PR"
+    zMessagingVersion = "142.0.1000-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2313"
+    zMessagingVersion = "142.0.969-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -104,6 +104,8 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
             val contentWithOG = msg.content.filter(_.openGraph.isDefined)
             if (contentWithOG.size == 1 && msg.content.size == 1)
               msg.content.map(content => PartDesc(MsgPart(content.tpe), Some(content)))
+            else if (msg.content.headOption.nonEmpty && msg.content.head.tpe.equals(Message.Part.Type.YOUTUBE) && msg.content.size == 1)
+                Seq(PartDesc(MsgPart(msg.content.head.tpe), Some(msg.content.head)))
             else
               Seq(PartDesc(MsgPart(Message.Type.TEXT, isOneToOne))) ++ contentWithOG.map(content => PartDesc(MsgPart(content.tpe), Some(content))).filter(_.tpe == WebLink)
           }

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
@@ -108,6 +108,7 @@ object MessagesPagedListAdapter {
       updated.expired == prev.expired &&
       updated.imageDimensions == prev.imageDimensions &&
       updated.content.find(_.openGraph.nonEmpty) == prev.content.find(_.openGraph.nonEmpty) &&
+      updated.content.find(_.richMedia.nonEmpty) == prev.content.find(_.richMedia.nonEmpty) &&
       updated.assetId == prev.assetId
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/SoundMediaPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/SoundMediaPartView.scala
@@ -28,7 +28,7 @@ import com.bumptech.glide.request.target.CustomViewTarget
 import com.bumptech.glide.request.transition.Transition
 import com.waz.api.Message
 import com.waz.model.messages.media.{ArtistData, MediaAssetData}
-import com.waz.model.{AssetId, MessageContent}
+import com.waz.model.{GeneralAssetId, MessageContent}
 import com.waz.service.messages.MessageAndLikes
 import com.waz.utils._
 import com.waz.utils.events.Signal
@@ -65,8 +65,8 @@ class SoundMediaPartView(context: Context, attrs: AttributeSet, style: Int)
     case Some(richMedia) => richMedia
   }}
 
-  private val image = media.flatMap {
-    _.artwork.fold2(Signal.empty[AssetId], id => Signal.const(id))
+  private val image: Signal[GeneralAssetId] = media.flatMap {
+    _.artwork.fold2(Signal.empty[GeneralAssetId], id => Signal.const(id))
   }
 
   image.onUi { id =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

This commit is a SE bump to use the new youtube preview loading logic, along with some code quality fixes. There is some logic to recognize when we need to actually create YouTube view parts also. Fixes [AN-6028](https://wearezeta.atlassian.net/browse/AN-6028)

### Testing

Testing was done manually.

## Notes

When sending youtube links instead of the correct preview, a previous preview is sometimes displayed, especially if preview loading fails if there is not internet connection. This is a bug with our view part recycling or Glide usage, and should be solved in future, but it's minor and the correct preview is loaded once connectivity is restored.
