### PR TITLE
fix: Various bugs connected to quick audio recording

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -353,7 +353,7 @@ object AssetsController {
 
     def playOrPause() = rPAction { case (rP, key, content, playing) => if (playing) rP.pause(key) else rP.play(key, content) }
 
-    def setPlayHead(duration: Duration) = rPAction { case (rP, key, content, playing) => rP.setPlayhead(key, content, duration) }
+    def setPlayHead(duration: Duration) = rPAction { case (rP, key, content, _) => rP.setPlayhead(key, content, duration) }
   }
 
   def getOpenFileIntent(uri: Uri, mimeType: String): Intent = {


### PR DESCRIPTION
1. https://wearezeta.atlassian.net/browse/AN-6288
One version of this bug was already fixed in another PR. This one is ocnnected to that the user was able to swipe up to "Send recording", and then back to "Recording", and again up, and down, and so on. Doing this it was possible to enter an invalid state of the view. The fix simply stops recording on swipe up and prevents the user from further action.

2. https://wearezeta.atlassian.net/browse/AN-6289 - the recording dot disappears
I wasn't able to reproduce it, but I tested it only after other changes, so maybe making the view
more resilient to swiping fixed that too.

3. https://wearezeta.atlassian.net/browse/AN-6290
The problem was not with the file, but with the progress bar which was broken in the new assets PR.

4. The timer on the audio message shows now the duration of the message is the message is not played, and switched to showing the progress if the message is played (previously it showed 00:00 if not played).