### PR TITLE
fix: Timer and a blinking dot for quick recording

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
@@ -92,7 +92,7 @@ class MediaRecorderControllerImpl(context: Context) extends MediaRecorderControl
 
   override def cancelRecording(): Unit = stopRecording()
 
-  override def isRecording: Boolean = false //TODO: ???
+  override def isRecording: Boolean = recorder.isDefined
 
   override def getFile: File = file
 }


### PR DESCRIPTION
## What's new in this PR?

A minor fix for the quick recording feature.

### Issues

The red dot was not blinking while quick recording a message (only on the first recording - it worked for subsequent ones).
The timer next to the red dot was missing.

### Solutions

The animator for the red dot was initialized only *after* the recording. The timer was there, but displayed an empty string if the message was not played (and it was not *played* when it as being recorded).

### Testing

Try to record an audio message using the quick recording feature and look at the left side of the recording panel.

