### PR TITLE
fix: Quick recorder exception

### DIFF
--- a/app/src/main/java/com/waz/zclient/KotlinServices.kt
+++ b/app/src/main/java/com/waz/zclient/KotlinServices.kt
@@ -1,0 +1,14 @@
+package com.waz.zclient
+
+import android.content.Context
+import com.waz.zclient.audio.AudioService
+import com.waz.zclient.audio.AudioServiceImpl
+
+object KotlinServices {
+
+    fun init(context: Context) {
+        audioService = AudioServiceImpl(context)
+    }
+
+    lateinit var audioService: AudioService
+}

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -9,9 +9,9 @@ import android.view.animation.Animation
 import android.widget.ViewAnimator
 import androidx.work.impl.Schedulers
 import com.waz.api.AudioEffect
+import com.waz.zclient.KotlinServices
 import com.waz.zclient.R
 import com.waz.zclient.audio.AudioService
-import com.waz.zclient.audio.AudioServiceImpl
 import com.waz.zclient.ui.animation.interpolators.penner.Expo
 import com.waz.zclient.utils.StringUtils
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -40,7 +40,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
     }
 
 
-    private val audioService: AudioService = AudioServiceImpl(context)
+    private val audioService: AudioService = KotlinServices.audioService
     private val recordFile: File = File(context.cacheDir, "record_temp.pcm")
     private val compressedRecordFile: File = File(context.cacheDir, "record_temp.mp4")
     private val recordWithEffectFile: File = File(context.cacheDir, "record_with_effect_temp.pcm")
@@ -188,7 +188,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
         }
     }
 
-    fun startRecording() {
+    private fun startRecording() {
         showAudioRecordingInProgress()
         recordFile.delete()
         recordWithEffectFile.delete()
@@ -209,7 +209,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
             })
     }
 
-    fun stopRecording() {
+    private fun stopRecording() {
         wave_graph_view.keepScreenOn = false
         showAudioFilters()
         recordingDisposable?.dispose()

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -264,6 +264,8 @@ object WireApplication extends DerivedLogTag {
     bind [UriHelper] to new AndroidUriHelper(ctx)
 
     bind[MediaRecorderController] to new MediaRecorderControllerImpl(ctx)
+
+    KotlinServices.INSTANCE.init(ctx)
   }
 
   def controllers(implicit ctx: WireContext) = new Module {

--- a/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
@@ -19,85 +19,92 @@ package com.waz.zclient.common.controllers
 
 import java.io.File
 
-import android.media.MediaRecorder
 import android.content.Context
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.utils.returning
-import com.waz.zclient.utils.media.{AudioEncoder, AudioSource, OutputFormat}
+import com.waz.zclient.{Injectable, Injector, KotlinServices}
 import com.waz.zclient.log.LogUI._
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.Disposable
+import io.reactivex.internal.functions.Functions
+import com.waz.zclient.utils.ScalaToKotlin._
 
+import scala.util.{Failure, Try}
 
 trait MediaRecorderController {
-  def startRecording(): Unit
-  def stopRecording(): Boolean
+  def startRecording(onFinish: File => Unit = _ => {}): Unit
+  def stopRecording(): Try[Unit]
   def cancelRecording(): Unit
   def isRecording: Boolean
 
-  def getFile: File
   def duration: Option[Long]
 }
 
-class MediaRecorderControllerImpl(context: Context) extends MediaRecorderController with DerivedLogTag {
+class MediaRecorderControllerImpl(context: Context)(implicit injector: Injector) extends MediaRecorderController with Injectable with DerivedLogTag {
 
-  private var recorder = Option.empty[MediaRecorder]
-  private lazy val file = new File(context.getCacheDir, "record_temp.mp4")
+  private lazy val mp4File = new File(context.getCacheDir, "record_temp.mp4")
 
+  private var recordingDisposable  = Option.empty[Disposable]
   private var startRecordingOffset = Option.empty[Long]
-  private var recordingDuration = Option.empty[Long]
+  private var recordingDuration    = Option.empty[Long]
+
+  private lazy val audioService = KotlinServices.INSTANCE.getAudioService
 
   override def duration: Option[Long] = recordingDuration
 
-  private def getRecorder(file: File): MediaRecorder = returning(new MediaRecorder()) { r =>
-      r.setAudioSource(AudioSource.MIC)
-      r.setOutputFormat(OutputFormat.MPEG_4)
-      r.setAudioEncoder(AudioEncoder.HE_AAC)
-      r.setOutputFile(file.getAbsolutePath)
-    }
-
-  override def startRecording(): Unit = {
-
+  override def startRecording(onFinish: File => Unit = _ => {}): Unit = {
+    verbose(l"startRecording")
     cancelRecording()
 
-    if (file.exists()) file.delete()
-    file.createNewFile()
+    if (mp4File.exists()) mp4File.delete()
+    mp4File.createNewFile()
 
-    val rec = getRecorder(file)
+    startRecordingOffset = Option(System.currentTimeMillis)
+    recordingDuration = None
 
-    try {
-      rec.prepare()
-      rec.start()
-    } catch {
-      case e: Throwable =>
-        verbose(l"Failed to prepare or start recorder: ${showString(e.getMessage)}")
-    } finally {
-      recorder = Some(rec)
-      startRecordingOffset = Option(System.currentTimeMillis())
-      recordingDuration = None
-    }
+    recordingDisposable = Option(
+      audioService.recordMp4Audio(mp4File, { file: File =>
+        recordingDuration = startRecordingOffset.map(System.currentTimeMillis - _)
+        onFinish(file)
+        recordingDisposable = None
+      })
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+          Functions.emptyConsumer(),
+          { t: Throwable =>
+            error(l"Recording failed", t)
+            reset()
+          }
+        )
+    )
   }
 
-  override def stopRecording(): Boolean =
-    recorder.fold(false){ r =>
-      try {
-        r.stop()
-        recordingDuration = startRecordingOffset.map(System.currentTimeMillis() - _)
-        true
-      } catch {
+  override def stopRecording(): Try[Unit] = recordingDisposable match {
+    case Some(r) =>
+      verbose(l"stopRecording")
+      Try(r.dispose()).recoverWith {
         case e: RuntimeException =>
-          verbose(l"Failed to stop recorder properly: ${showString(e.getMessage)}")
-          file.delete()
-          recordingDuration = None
-          false
-      } finally {
-        r.release()
-        recorder = None
-        startRecordingOffset = None
+          error(l"Failed to stop recorder properly: ${showString(e.getMessage)}", e)
+          reset()
+          Failure(e)
       }
-    }
+    case None =>
+      reset()
+      error(l"Recording failed")
+      Failure(new IllegalStateException("Recording failed"))
+  }
 
-  override def cancelRecording(): Unit = stopRecording()
+  override def cancelRecording(): Unit = {
+    verbose(l"cancelRecording")
+    recordingDisposable.foreach(_.dispose())
+    reset()
+  }
 
-  override def isRecording: Boolean = recorder.isDefined
+  override def isRecording: Boolean = recordingDisposable.isDefined
 
-  override def getFile: File = file
+  private def reset(): Unit = {
+    if (mp4File.exists()) mp4File.delete()
+    recordingDuration = None
+    recordingDisposable = None
+    startRecordingOffset = None
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AudioAssetPartView.scala
@@ -69,8 +69,10 @@ class AudioAssetPartView(context: Context, attrs: AttributeSet, style: Int)
 
   (for {
     ready         <- readyToPlay
+    duration      <- duration
     isPlaying     <- playControls.flatMap(_.isPlaying)
-    displayedTime <- if (isPlaying) progressInMillis else duration
+    progress      <- progressInMillis
+    displayedTime =  if (isPlaying || progress > 0) progress else duration
     formatted     =  if (ready) StringUtils.formatTimeMilliSeconds(displayedTime) else ""
   } yield formatted).onUi(durationView.setText)
 

--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -39,6 +39,10 @@ import com.waz.zclient.utils.ContextUtils._
 
 import scala.concurrent.duration._
 
+import scala.language.implicitConversions
+import io.reactivex.functions.Consumer
+import kotlin.jvm.functions.{Function0, Function1}
+
 package object utils {
 
   case class Offset(l: Int, t: Int, r: Int, b: Int)
@@ -288,5 +292,25 @@ package object utils {
     if (!oneLiner) sb.append("\n")
 
     sb.toString()
+  }
+
+  object ScalaToKotlin {
+    implicit def f0(f: () => Unit): Function0[kotlin.Unit] = new Function0[kotlin.Unit]() {
+      def invoke(): kotlin.Unit = {
+        f()
+        kotlin.Unit.INSTANCE
+      }
+    }
+
+    implicit def f1[T](f: T => Unit): Function1[T, kotlin.Unit] = new Function1[T, kotlin.Unit]() {
+      def invoke(t: T): kotlin.Unit = {
+        f(t)
+        kotlin.Unit.INSTANCE
+      }
+    }
+
+    implicit def toConsumer[T](f: T => Unit): Consumer[T] = new Consumer[T] {
+      def accept(t: T): Unit = f(t)
+    }
   }
 }


### PR DESCRIPTION
Standard recording was rewritten in Kotlin recently. Quick recording is in Scala, and it was failing on some of the devices. This fix makes the quick recording use the same Kotlin code as the standard recording.
It also provides the code which connects Scala and Kotlin for future use.
