### PR TITLE
fix: Don't fail on retrieving asset details

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.977-PR"
+    zMessagingVersion = "142.0.2298"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2297"
+    zMessagingVersion = "142.0.977-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/src/androidTest/scala/com/waz/zclient/storage/RawAssetStorageTest.scala
+++ b/app/src/androidTest/scala/com/waz/zclient/storage/RawAssetStorageTest.scala
@@ -64,7 +64,7 @@ class RawAssetStorageTest extends GeneralStorageTest(UploadAssetDao)(
       details = ImageDetails(Dim2(1,2)),
       assetId = None,
       status = AssetStatus.Done,
-      preview = Preview.Empty
+      preview = Empty
     )
 //    RawAsset(
 //      id = RawAssetId(),

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -475,6 +475,7 @@ class MainActivity extends BaseActivity
       }
 
       case _ =>
+        verbose(l"unknown intent $intent")
         setIntent(intent)
         Future.successful(false)
     }

--- a/app/src/main/scala/com/waz/zclient/ShareActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/ShareActivity.scala
@@ -92,8 +92,7 @@ class ShareActivity extends BaseActivity with ActivityHelper {
   private def handleIncomingIntent() =
     inject[PermissionsService].requestAllPermissions(ListSet(READ_EXTERNAL_STORAGE)).map {
       case true =>
-        val intent = getIntent
-        verbose(l"${RichIntent(intent)}")
+        verbose(l"${RichIntent(getIntent)}")
         val ir = ShareCompat.IntentReader.from(this)
         if (!ir.isShareIntent) finish()
         else {
@@ -102,7 +101,6 @@ class ShareActivity extends BaseActivity with ActivityHelper {
             val uris =
               (if (ir.isMultipleShare) (0 until ir.getStreamCount).flatMap(i => Option(ir.getStream(i))) else Option(ir.getStream).toSeq)
                 .flatMap(uri => getPath(getApplicationContext, uri))
-
             if (uris.nonEmpty)
               sharing.sharableContent ! Some(if (ir.getType.startsWith("image/") && uris.size == 1) ImageContent(uris) else FileContent(uris))
             else finish()

--- a/app/src/main/scala/com/waz/zclient/assets2/AndroidUriHelper.scala
+++ b/app/src/main/scala/com/waz/zclient/assets2/AndroidUriHelper.scala
@@ -78,6 +78,8 @@ class AndroidUriHelper(context: Context) extends UriHelper with DerivedLogTag {
   }
 
   private def cursor(uri: URI): Managed[Cursor] =
-    Managed.create(context.getContentResolver.query(androidUri(uri), null, null, null, null))(_.close())
+    Managed.create(
+      context.getContentResolver.query(androidUri(uri), null, null, null, null)
+    )(_.close())
 
 }

--- a/app/src/main/scala/com/waz/zclient/assets2/MetadataExtractionUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/assets2/MetadataExtractionUtils.scala
@@ -66,10 +66,9 @@ object MetadataExtractionUtils {
     }
 
   def retrieve[A](key: Int, tag: String, convert: String => A)
-                 (implicit retriever: MediaMetadataRetriever): Either[String, A] =
-    for {
-      s <- Option(retriever.extractMetadata(key)).toRight(s"$tag ($key) is null")
-      result <- Try(convert(s)).toRight(t => s"unable to convert $tag ($key) of value '$s': ${t.getMessage}")
-    } yield result
-
+                 (implicit retriever: MediaMetadataRetriever): Option[A] =
+    Option(retriever.extractMetadata(key)) match {
+      case None    => None
+      case Some(s) => Try(convert(s)).toOption
+    }
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -53,8 +53,7 @@ class SharingController(implicit injector: Injector, wContext: WireContext, even
           conversationController.sendTextMessage(convs, t, Nil, None, Some(expiration))
         case uriContent =>
           Future.traverse(uriContent.uris) { uriWrapper =>
-            val uri = URIWrapper.toJava(uriWrapper)
-            conversationController.sendAssetMessage(uri, activity, Some(expiration), convs)
+            conversationController.sendAssetMessage(URIWrapper.toJava(uriWrapper), activity, Some(expiration), convs)
           }
       }
 
@@ -63,7 +62,7 @@ class SharingController(implicit injector: Injector, wContext: WireContext, even
       convs         <- targetConvs.head
       expiration    <- ephemeralExpiration.head
       _             <- send(content, convs, expiration)
-      _             = resetContent()
+      _             =  resetContent()
     } yield convs
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -204,10 +204,10 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
         ui.sendAssetMessage(id, content, (s: Long) => showWifiWarningDialog(s, color), exp))
     )
 
-  def sendAssetMessage(convs:    Seq[ConvId],
-                       content:  ContentForUpload,
-                       activity: Activity,
-                       exp:      Option[Option[FiniteDuration]]): Future[Seq[Option[MessageData]]] =
+  private def sendAssetMessage(convs:    Seq[ConvId],
+                               content:  ContentForUpload,
+                               activity: Activity,
+                               exp:      Option[Option[FiniteDuration]]): Future[Seq[Option[MessageData]]] =
     for {
       ui    <- convsUi.head
       color <- accentColorController.accentColor.head

--- a/app/src/test/java/com/waz/zclient/pages/extendedcursor/voicefilter2/LinearInterpolationTest.kt
+++ b/app/src/test/java/com/waz/zclient/pages/extendedcursor/voicefilter2/LinearInterpolationTest.kt
@@ -9,7 +9,10 @@ class LinearInterpolationTest {
 
     @Test
     fun testInterpolationSize() {
-        val basePoints = intArrayOf(-187, -130, 124, 156, 135, -1179, -218, -459, -436, -580, -193, -155)
+        val basePoints = floatArrayOf(
+                -187.0f, -130.0f, 124.0f, 156.0f, 135.0f, -1179.0f,
+                -218.0f, -459.0f, -436.0f, -580.0f, -193.0f, -155.0f
+        )
         val interpolationSize = 56
         val interpolation = LinearInterpolation(basePoints, interpolationSize)
 


### PR DESCRIPTION
This is the UI part of the fix.
SE: https://github.com/wireapp/wire-android-sync-engine/pull/572
fixes: https://wearezeta.atlassian.net/browse/AN-6298

When we send an asset message, first we try to get some details about it. The data in the `AssetDetails` entity depends on the asset's type: it's different for video, audio, image, or an unrecognized file. In the old version, we tried to get the data based on the Mime type which
was provided. When the mime was wrong, we were not able to get the data and the process failed.
Now, the process tries to find out what the mime is by itself. Initially we guess it based on the extension of the filename, but if we fail to retrieve the data for that mime type, we either assume the asset is an unrecognized file, or - in the case of video - we check first if the asset isn't an audio file (MP4 is an extension for both video or audio). Only if we fail to retrieve audio data, we assume it's an
unrecognized file. In all cases, we don't crash the process.

The reason of the original bug was that we use MP4 as a format for audio recordings. It works well when the recording is sent directly, but when sharing to another conversation, the information about the mime type is lost, and on the receiving end we guess (wrongly) that it is video MP4.
