### PR TITLE
PoC to enforce device password policy

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,6 +211,17 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name="com.waz.services.SecurityPolicyService"
+            android:label="@string/security_policy_title"
+            android:description="@string/security_policy_desc"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data android:name="android.app.device_admin"
+                android:resource="@xml/device_admin" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
         <provider
             android:name="com.waz.content.WireContentProvider"
             android:authorities="${applicationId}"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1178,6 +1178,14 @@
     <string name="new_conv_no_results">No results</string>
     <string name="new_conv_no_contacts">No contacts</string>
 
+    <string name="security_policy_title">Wire Security Policy Service</string>
+    <string name="security_policy_desc">This Service is a test of security policies with Wire</string>
+    <string name="security_policy_enabled">Wire sec policy enabled</string>
+    <string name="security_policy_auth_dialog_title">Enable Security Policy</string>
+    <string name="security_policy_auth_dialog_message">Wire needs admin privileges to set security policies</string>
+    <string name="security_policy_pass_dialog_title">Password strength insufficient</string>
+    <string name="security_policy_pass_dialog_message">Your phone must have a password with minimum 12 characters to login</string>
+
     <string name="participants_divider_services">SERVICES (%1$s)</string>
     <string name="participants_divider_people">PEOPLE (%1$s)</string>
     <string name="group_name_hint">GROUP NAME</string>

--- a/app/src/main/res/xml/device_admin.xml
+++ b/app/src/main/res/xml/device_admin.xml
@@ -1,0 +1,24 @@
+<!--
+
+    Wire
+    Copyright (C) 2019 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+<uses-policies>
+    <limit-password />
+</uses-policies>
+</device-admin>

--- a/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
+++ b/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.services
+
+import android.app.admin.{DeviceAdminReceiver, DevicePolicyManager}
+import android.content.{ComponentName, Context, Intent}
+import com.waz.content.GlobalPreferences
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.zclient.Injectable
+
+/**
+  * This class performs two functions, firstly it serves as the required DeviceAdminReceived instance
+  * defined in the AndroidManifest. It sets our policy once we have been granted admin rights.
+  *
+  * Secondly, we use it to implement some static helper methods. This means we can use the
+  * `getManager` method to get the policy manager service, rather than pass it in as a parameter
+  * which we would have to do if we used a companion object.
+  */
+class SecurityPolicyService
+  extends DeviceAdminReceiver with DerivedLogTag with Injectable {
+
+  import com.waz.zclient.log.LogUI._
+
+  override def onEnabled(context: Context, intent: Intent): Unit = {
+    verbose(l"admin rights enabled, setting policy")
+    setPasswordPolicy(context)
+  }
+
+  def checkSecurityPolicyIsEnabled(context: Context, prefs: GlobalPreferences): Boolean = {
+    val secPolicy = new ComponentName(context, classOf[SecurityPolicyService])
+    getManager(context).isAdminActive(secPolicy)
+  }
+
+  def isPasswordCompliant(context: Context): Boolean = getManager(context).isActivePasswordSufficient
+
+  private def setPasswordPolicy(cxt: Context): Unit = {
+    val dpm = cxt.getSystemService(Context.DEVICE_POLICY_SERVICE).asInstanceOf[DevicePolicyManager]
+    val secPolicy = new ComponentName(cxt, classOf[SecurityPolicyService])
+    /**
+    We must set the password quality to some minimum quality, PASSWORD_QUALITY_SOMETHING and
+     PASSWORD_QUALITY_UNSPECIFIED both result in our minimum length requirement not being enforced.
+     PASSWORD_QUALITY_ALPHABETIC is used here as an example, as it's permissive.
+     From the Android Device Admin API docs:
+
+     "This constraint is only imposed if the administrator has also requested either
+     PASSWORD_QUALITY_NUMERIC , PASSWORD_QUALITY_NUMERIC_COMPLEX, PASSWORD_QUALITY_ALPHABETIC,
+     PASSWORD_QUALITY_ALPHANUMERIC, or PASSWORD_QUALITY_COMPLEX with setPasswordQuality(ComponentName, int)"
+      **/
+    dpm.setPasswordQuality(secPolicy, DevicePolicyManager.PASSWORD_QUALITY_ALPHABETIC)
+    dpm.setPasswordMinimumLength(secPolicy, 12)
+  }
+
+}

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -47,6 +47,7 @@ import com.waz.service.conversation.{ConversationsService, ConversationsUiServic
 import com.waz.service.images.ImageLoader
 import com.waz.service.messages.MessagesService
 import com.waz.service.tracking.TrackingService
+import com.waz.services.SecurityPolicyService
 import com.waz.services.fcm.FetchJob
 import com.waz.services.gps.GoogleApiImpl
 import com.waz.services.websocket.WebSocketController
@@ -309,6 +310,8 @@ object WireApplication extends DerivedLogTag {
     bind [UiTrackingController]    to new UiTrackingController()
 
     bind[MessagePagedListController] to new MessagePagedListController()
+
+    bind[SecurityPolicyService] to new SecurityPolicyService()
   }
 
   protected def clearOldVideoFiles(context: Context): Unit = {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -372,28 +372,9 @@ class SignInFragment
         }
 
         if(!secPolicyManager.checkSecurityPolicyIsEnabled(getContext, prefs)) {
-          ViewUtils.showAlertDialog(
-            getActivity,
-            getString(R.string.security_policy_auth_dialog_title),
-            getString(R.string.security_policy_auth_dialog_message),
-            getString(android.R.string.ok), getString(android.R.string.cancel),
-            new DialogInterface.OnClickListener() {
-              def onClick(dialog: DialogInterface, which: Int) = {
-                val secPolicy = new ComponentName(getContext, classOf[SecurityPolicyService])
-                val intent = new android.content.Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
-                  .putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, secPolicy)
-                  .putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION,
-                    ContextUtils.getString(R.string.security_policy_desc))
-                val REQUEST_CODE_ENABLE_ADMIN = 1
-                startActivityForResult(intent, REQUEST_CODE_ENABLE_ADMIN)
-              }
-            }, null)
+          displayDeviceAdminRequestDialog()
         } else if(!secPolicyManager.isPasswordCompliant(getContext)) {
-          ViewUtils.showAlertDialog(
-            getActivity,
-            getString(R.string.security_policy_pass_dialog_title),
-            getString(R.string.security_policy_pass_dialog_message),
-            getString(android.R.string.ok), null, null, null)
+          displayPasswordInadequateDialog()
         } else {
           uiSignInState.head.flatMap {
             case m@SignInMethod(Login, Email, _) =>
@@ -468,6 +449,33 @@ class SignInFragment
     } else {
       false
     }
+
+  def displayDeviceAdminRequestDialog(): Unit = {
+    ViewUtils.showAlertDialog(
+      getActivity,
+      getString(R.string.security_policy_auth_dialog_title),
+      getString(R.string.security_policy_auth_dialog_message),
+      getString(android.R.string.ok), getString(android.R.string.cancel),
+      new DialogInterface.OnClickListener() {
+        def onClick(dialog: DialogInterface, which: Int) = {
+          val secPolicy = new ComponentName(getContext, classOf[SecurityPolicyService])
+          val intent = new android.content.Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
+            .putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, secPolicy)
+            .putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+              ContextUtils.getString(R.string.security_policy_desc))
+          val REQUEST_CODE_ENABLE_ADMIN = 1
+          startActivityForResult(intent, REQUEST_CODE_ENABLE_ADMIN)
+        }
+      }, null)
+  }
+
+  def displayPasswordInadequateDialog(): Unit = {
+    ViewUtils.showAlertDialog(
+      getActivity,
+      getString(R.string.security_policy_pass_dialog_title),
+      getString(R.string.security_policy_pass_dialog_message),
+      getString(android.R.string.ok), null, null, null)
+  }
 
   override protected def activity: AppEntryActivity = getActivity.asInstanceOf[AppEntryActivity]
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -17,7 +17,8 @@
  */
 package com.waz.zclient.appentry.fragments
 
-import android.content.Context
+import android.app.admin.DevicePolicyManager
+import android.content.{ComponentName, Context, DialogInterface}
 import android.graphics.Color
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.KITKAT
@@ -27,8 +28,10 @@ import android.transition._
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{FrameLayout, LinearLayout}
 import com.waz.api.impl.ErrorResponse
+import com.waz.content.GlobalPreferences
 import com.waz.model.{EmailAddress, PhoneNumber}
 import com.waz.service.{AccountsService, ZMessaging}
+import com.waz.services.SecurityPolicyService
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.{returning, PasswordValidator => StrongValidator}
@@ -63,6 +66,8 @@ class SignInFragment
   private lazy val accountsService    = inject[AccountsService]
   private lazy val browserController  = inject[BrowserController]
   private lazy val tracking           = inject[GlobalTrackingController]
+  private lazy val secPolicyManager   = inject[SecurityPolicyService]
+  private lazy val prefs              = inject[GlobalPreferences]
 
   private lazy val isAddingAccount = accountsService.zmsInstances.map(_.nonEmpty)
 
@@ -366,52 +371,77 @@ class SignInFragment
           }
         }
 
-        uiSignInState.head.flatMap {
-          case m@SignInMethod(Login, Email, _) =>
-            activity.enableProgress(true)
-
-            for {
-              email     <- email.head
-              password  <- password.head
-              req       <- accountsService.loginEmail(email, password)
-            } yield onResponse(req, m).right.foreach { id =>
-              KeyboardUtils.closeKeyboardIfShown(getActivity)
-              activity.showFragment(FirstLaunchAfterLoginFragment(id), FirstLaunchAfterLoginFragment.Tag)
-            }
-          case m@SignInMethod(Register, Email, false) =>
-            for {
-              email     <- email.head
-              password  <- password.head
-              name      <- name.head
-            } yield {
-              if (strongPasswordValidator.isValidPassword(password)) {
-               accountsService.requestEmailCode(EmailAddress(email)).foreach { req =>
-                  onResponse(req, m).right.foreach { _ =>
-                    KeyboardUtils.closeKeyboardIfShown(getActivity)
-                    activity.showFragment(VerifyEmailWithCodeFragment(email, name, password), VerifyEmailWithCodeFragment.Tag)
-                  }
-                }
-              } else { // Invalid password
-                passwordPolicyHint.foreach(_.setTextColor(getColor(R.color.teams_error_red)))
+        if(!secPolicyManager.checkSecurityPolicyIsEnabled(getContext, prefs)) {
+          ViewUtils.showAlertDialog(
+            getActivity,
+            getString(R.string.security_policy_auth_dialog_title),
+            getString(R.string.security_policy_auth_dialog_message),
+            getString(android.R.string.ok), getString(android.R.string.cancel),
+            new DialogInterface.OnClickListener() {
+              def onClick(dialog: DialogInterface, which: Int) = {
+                val secPolicy = new ComponentName(getContext, classOf[SecurityPolicyService])
+                val intent = new android.content.Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
+                  .putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, secPolicy)
+                  .putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+                    ContextUtils.getString(R.string.security_policy_desc))
+                val REQUEST_CODE_ENABLE_ADMIN = 1
+                startActivityForResult(intent, REQUEST_CODE_ENABLE_ADMIN)
               }
-            }
+            }, null)
+        } else if(!secPolicyManager.isPasswordCompliant(getContext)) {
+          ViewUtils.showAlertDialog(
+            getActivity,
+            getString(R.string.security_policy_pass_dialog_title),
+            getString(R.string.security_policy_pass_dialog_message),
+            getString(android.R.string.ok), null, null, null)
+        } else {
+          uiSignInState.head.flatMap {
+            case m@SignInMethod(Login, Email, _) =>
+              activity.enableProgress(true)
 
-          case m@SignInMethod(method, Phone, false) =>
-            val isLogin = method == Login
-            activity.enableProgress(true)
-            for {
-              country <- phoneCountry.head
-              phoneStr <- phone.head
-              phone = PhoneNumber(s"+${country.getCountryCode}$phoneStr")
-              req <- accountsService.requestPhoneCode(phone, login = isLogin)
-            } yield onResponse(req, m).right.foreach { _ =>
-              KeyboardUtils.closeKeyboardIfShown(getActivity)
-              activity.showFragment(VerifyPhoneFragment(phone.str, login = isLogin), VerifyPhoneFragment.Tag)
-            }
-          case SignInMethod(_, _, true) =>
-            error(l"Invalid sign in state")
-            Future.successful({})
-          case _ => throw new NotImplementedError("Only login with email works right now") //TODO
+              for {
+                email <- email.head
+                password <- password.head
+                req <- accountsService.loginEmail(email, password)
+              } yield onResponse(req, m).right.foreach { id =>
+                KeyboardUtils.closeKeyboardIfShown(getActivity)
+                activity.showFragment(FirstLaunchAfterLoginFragment(id), FirstLaunchAfterLoginFragment.Tag)
+              }
+            case m@SignInMethod(Register, Email, false) =>
+              for {
+                email <- email.head
+                password <- password.head
+                name <- name.head
+              } yield {
+                if (strongPasswordValidator.isValidPassword(password)) {
+                  accountsService.requestEmailCode(EmailAddress(email)).foreach { req =>
+                    onResponse(req, m).right.foreach { _ =>
+                      KeyboardUtils.closeKeyboardIfShown(getActivity)
+                      activity.showFragment(VerifyEmailWithCodeFragment(email, name, password), VerifyEmailWithCodeFragment.Tag)
+                    }
+                  }
+                } else { // Invalid password
+                  passwordPolicyHint.foreach(_.setTextColor(getColor(R.color.teams_error_red)))
+                }
+              }
+
+            case m@SignInMethod(method, Phone, false) =>
+              val isLogin = method == Login
+              activity.enableProgress(true)
+              for {
+                country <- phoneCountry.head
+                phoneStr <- phone.head
+                phone = PhoneNumber(s"+${country.getCountryCode}$phoneStr")
+                req <- accountsService.requestPhoneCode(phone, login = isLogin)
+              } yield onResponse(req, m).right.foreach { _ =>
+                KeyboardUtils.closeKeyboardIfShown(getActivity)
+                activity.showFragment(VerifyPhoneFragment(phone.str, login = isLogin), VerifyPhoneFragment.Tag)
+              }
+            case SignInMethod(_, _, true) =>
+              error(l"Invalid sign in state")
+              Future.successful({})
+            case _ => throw new NotImplementedError("Only login with email works right now") //TODO
+          }
         }
 
       case R.id.ttv_signin_forgot_password =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR is a proof-of-concept to implement the requirements in [AN-6292](https://wearezeta.atlassian.net/browse/AN-6292). It uses the Android Device Administration API to require users to set a device/lock screen password of a given strength before they are allowed to login to the Wire app. 

`SecurityPolicyService` is used by the Android system to notify the App that we have been granted device admin privileges. Then we set the password policy, or any other admin policy.

The policy is set in `SecurityPolicyService` and is currently a minimum password length of 12 alphabetic characters.

### Steps to use

This PoC does not support enforcing password policies on Apps with accounts already logged in, although this would be a straightforward addition(probably to `startFirstFragment` in `MainActivity`).

1. Wipe any existing data or log out of Wire
2. Enter email+pass
3. Click login
4. The app will display a dialog and afterwards fire and Intent which will prompt the user to enable Admin privileges for the Wire application.
5. Once enabled, Wire will set and enforce a password policy of a minimum 12 character alphabetic password. Try logging in again, if the pre-existing password doesn't comply with the policy, the user will again be prompted by a dialog to set a compliant password, otherwise, login will continue as normal.

### Further work

 - Override the `onDisabled` method in `SecurityPolicyService` to detect when we lose privileges and log the user out when this happens. This is necessary as the user can remove our admin privileges at any time.
 - Check `isAdminActive` and if we don't have admin privileges then log the user out until they comply with the policy. This is necessary for users who are already logged in.