### PR TITLE
fix: Record and send video files.

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -23,48 +23,38 @@ import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
-import android.os.Bundle;
 import android.provider.MediaStore;
+import android.support.annotation.Nullable;
 import android.support.v4.content.FileProvider;
+
+import com.waz.utils.IoUtils;
 import com.waz.utils.wrappers.AndroidURI;
 import com.waz.utils.wrappers.AndroidURIUtil;
 import com.waz.utils.wrappers.URI;
 import com.waz.zclient.BuildConfig;
-import timber.log.Timber;
+import com.waz.zclient.Intents;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-public class AssetIntentsManager {
-    public static final String SAVED_STATE_PENDING_URI = "SAVED_STATE_PENDING_URI";
+import timber.log.Timber;
 
+public class AssetIntentsManager {
     private static final String INTENT_GALLERY_TYPE = "image/*";
-    private final PackageManager pm;
+    private final Context context;
+    private final Callback callback;
 
     @TargetApi(19)
     private static String openDocumentAction() {
         return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT;
     }
 
-    private URI pendingFileUri;
-    private Callback callback;
-
-    public AssetIntentsManager(Activity activity, Callback callback, Bundle savedInstanceState) {
-        setCallback(callback);
-
-        if (savedInstanceState != null) {
-            Uri uri = savedInstanceState.getParcelable(SAVED_STATE_PENDING_URI);
-            if (uri != null) {
-                pendingFileUri = new AndroidURI(uri);
-            }
-        }
-        pm = activity.getPackageManager();
-    }
-
-    public void setCallback(Callback callback) {
+    public AssetIntentsManager(Context context, Callback callback) {
+        this.context = context;
         this.callback = callback;
     }
 
@@ -73,7 +63,7 @@ public class AssetIntentsManager {
             // trying to load file from testing gallery,
             // this is needed because we are not able to override DocumentsUI on some android versions.
             Intent intent = new Intent("com.wire.testing.GET_DOCUMENT").setType(mimeType);
-            if (!pm.queryIntentActivities(intent, PackageManager.MATCH_ALL).isEmpty()) {
+            if (!context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_ALL).isEmpty()) {
                 callback.openIntent(intent, tpe);
                 return;
             }
@@ -94,15 +84,17 @@ public class AssetIntentsManager {
         openDocument("*/*", IntentType.BACKUP_IMPORT, false);
     }
 
-    public void captureVideo(Context context) {
+    public void captureVideo() {
         Intent intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
-        pendingFileUri = getOutputMediaFileUri(context, IntentType.VIDEO);
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, AndroidURIUtil.unwrap(pendingFileUri));
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 0);
         }
-        callback.openIntent(intent, IntentType.VIDEO);
+
+        if (intent.resolveActivity(this.context.getPackageManager()) != null) {
+            callback.openIntent(intent, IntentType.VIDEO);
+        }
     }
 
     public void openGallery() {
@@ -114,13 +106,7 @@ public class AssetIntentsManager {
     }
 
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
-
-        if (callback == null) {
-            throw new IllegalStateException("A callback must be set!");
-        }
-
         IntentType type = IntentType.get(requestCode);
-
         if (type == IntentType.UNKNOWN) {
             return false;
         }
@@ -130,57 +116,45 @@ public class AssetIntentsManager {
             return true;
         }
 
-        if (resultCode != Activity.RESULT_OK) {
+        if (resultCode != Activity.RESULT_OK || data == null) {
             callback.onFailed(type);
             return true;
         }
 
-        File possibleFile = null;
-        if (pendingFileUri != null) {
-            possibleFile = new File(pendingFileUri.getPath());
-        }
-        if ((type == IntentType.CAMERA || type == IntentType.VIDEO) &&
-            possibleFile != null &&
-            possibleFile.exists() &&
-            possibleFile.length() > 0) {
-                callback.onDataReceived(type, pendingFileUri);
-            pendingFileUri = null;
-        } else if (data != null) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-                callback.onDataReceived(type, AndroidURIUtil.parse(data.getDataString()));
-            } else if(data.getClipData() != null) {
-                ClipData clipData = data.getClipData();
-                for (int i = 0; i < clipData.getItemCount(); i++) {
-                    callback.onDataReceived(type, new AndroidURI(clipData.getItemAt(i).getUri()));
-                }
-            } else if (data.getData() != null) {
-                callback.onDataReceived(type, new AndroidURI(data.getData()));
-            } else {
-                callback.onFailed(type);
-            }
-        } else {
-            callback.onFailed(type);
+        Timber.d("onActivityResult - data: %s", Intents.RichIntent(data).toString());
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+            callback.onDataReceived(type, AndroidURIUtil.parse(data.getDataString()));
+            return true;
         }
 
+        if(data.getClipData() != null) {
+            ClipData clipData = data.getClipData();
+            for (int i = 0; i < clipData.getItemCount(); i++) {
+                callback.onDataReceived(type, new AndroidURI(clipData.getItemAt(i).getUri()));
+            }
+            return true;
+        }
+
+        if (data.getData() == null) {
+            callback.onFailed(type);
+            return false;
+        }
+
+        URI uri = new AndroidURI(data.getData());
+        Timber.d("uri is %s", uri);
+        if (type == IntentType.VIDEO) {
+            uri = copyVideoToCache(uri);
+        }
+
+        if (uri != null) {
+            callback.onDataReceived(type, uri);
+        }
         return true;
     }
 
-    /**
-     * Create a file Uri for saving an image or video
-     *
-     * @param type
-     */
-    private static URI getOutputMediaFileUri(Context context, IntentType type) {
-        File file = getOutputMediaFile(context, type);
-        return file != null ? new AndroidURI(FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName() + ".fileprovider", file)) : null;
-    }
-
-    /**
-     * Create a File for saving an image or video
-     *
-     * @param type
-     */
-    private static File getOutputMediaFile(Context context, IntentType type) {
+    @Nullable
+    private URI copyVideoToCache(URI uri) {
         File mediaStorageDir = context.getExternalCacheDir();
         if (mediaStorageDir == null || !mediaStorageDir.exists()) {
             return null;
@@ -188,14 +162,29 @@ public class AssetIntentsManager {
 
         java.util.Date date = new java.util.Date();
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(date.getTime());
+        File targetFile = new File(mediaStorageDir.getPath() + File.separator + "VID_" + timeStamp + ".mp4");
+        Timber.d("target file is %s", targetFile.getAbsolutePath());
 
-        switch (type) {
-            case VIDEO:
-                return new File(mediaStorageDir.getPath() + File.separator + "VID_" + timeStamp + ".mp4");
-            case CAMERA:
-                return new File(mediaStorageDir.getPath() + File.separator + "IMG_" + timeStamp + ".jpg");
+        if (targetFile.exists()) {
+            targetFile.delete();
         }
-        return null;
+        try {
+            targetFile.createNewFile();
+            InputStream inputStream = context.getContentResolver().openInputStream(AndroidURIUtil.unwrap(uri));
+            if (inputStream != null) {
+                IoUtils.copy(inputStream, targetFile);
+            } else {
+                Timber.e("Input stream is null for %s", uri);
+            }
+        } catch (IOException e) {
+            Timber.e("Unable to save the file! %s", targetFile.getAbsolutePath());
+            Timber.e(e);
+            return null;
+        } finally {
+            context.getContentResolver().delete(AndroidURIUtil.unwrap(uri), null, null);
+        }
+
+        return new AndroidURI(FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", targetFile));
     }
 
     public enum IntentType {
@@ -214,7 +203,6 @@ public class AssetIntentsManager {
         }
 
         public static IntentType get(int requestCode) {
-
             if (requestCode == GALLERY.requestCode) {
                 return GALLERY;
             }
@@ -240,12 +228,6 @@ public class AssetIntentsManager {
             }
 
             return UNKNOWN;
-        }
-    }
-
-    public void onSaveInstanceState(Bundle outState) {
-        if (pendingFileUri != null) {
-            outState.putParcelable(SAVED_STATE_PENDING_URI, AndroidURIUtil.unwrap(pendingFileUri));
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -88,7 +88,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
 
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
-    assetIntentsManager = Option(new AssetIntentsManager(getActivity, assetIntentsManagerCallback, savedInstanceState))
+    assetIntentsManager = Option(new AssetIntentsManager(getActivity, assetIntentsManagerCallback))
   }
 
   override def onViewCreated(view: View, savedInstanceState: Bundle) = {

--- a/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
@@ -118,7 +118,7 @@ class CameraFragment extends FragmentHelper
       override def onFailed(t: AssetIntentsManager.IntentType): Unit = showCameraFeed()
       override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
         startActivityForResult(intent, intentType.requestCode)
-    }, savedInstanceState)
+    })
   }
 
   override def onCreateView(inflater: LayoutInflater, c: ViewGroup, savedInstanceState: Bundle): View = {
@@ -135,11 +135,6 @@ class CameraFragment extends FragmentHelper
     previewProgressBar
 
     view.setBackgroundResource(R.color.black)
-  }
-
-  override def onSaveInstanceState(outState: Bundle): Unit = {
-    intentsManager.onSaveInstanceState(outState)
-    super.onSaveInstanceState(outState)
   }
 
   override def onDestroyView(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -222,7 +222,7 @@ class DrawingFragment extends FragmentHelper
     super.onCreate(savedInstanceState)
     imageInput = getInputFromBundle(getArguments)
     drawingMethod = getStringArg(ArgDrawingMethod).map(DrawingMethod.valueOf)
-    assetIntentsManager = new AssetIntentsManager(getActivity, this, savedInstanceState)
+    assetIntentsManager = new AssetIntentsManager(getActivity, this)
   }
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View =

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -194,7 +194,7 @@ class ConversationFragment extends FragmentHelper {
 
   override def onCreate(@Nullable savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
-    assetIntentsManager = Option(new AssetIntentsManager(getActivity, assetIntentsManagerCallback, savedInstanceState))
+    assetIntentsManager = Option(new AssetIntentsManager(getActivity, assetIntentsManagerCallback))
 
     zms.flatMap(_.errors.getErrors).onUi { _.foreach(handleSyncError) }
 
@@ -444,7 +444,6 @@ class ConversationFragment extends FragmentHelper {
 
   override def onSaveInstanceState(outState: Bundle): Unit = {
     super.onSaveInstanceState(outState)
-    assetIntentsManager.foreach { _.onSaveInstanceState(outState) }
     previewShown.head.foreach { isShown => outState.putBoolean(SAVED_STATE_PREVIEW, isShown) }
   }
 
@@ -646,8 +645,8 @@ class ConversationFragment extends FragmentHelper {
   private def captureVideoAskPermissions() = for {
     _ <- inject[GlobalCameraController].releaseCamera() //release camera so the camera app can use it
     _ <- permissions.requestAllPermissions(ListSet(CAMERA, WRITE_EXTERNAL_STORAGE)).map {
-      case true => assetIntentsManager.foreach(_.captureVideo(getContext.getApplicationContext))
-      case false => //
+      case true  => assetIntentsManager.foreach(_.captureVideo())
+      case false =>
     }(Threading.Ui)
   } yield {}
 


### PR DESCRIPTION
## What's new in this PR?

A fix to recording and sending video assets. It changes the recording procedure, so it should be tested also on devices which do not have the bug.

### Issues

Until now the process of reconding and sending videos looked as following:
1. Create a path to the video file in our media cache directory.
2. Provide that path to the intent sent to the camera.
3. The camera records the video to the file with the path we specified.
4. We use the specified file to send the video.

On some devices the access to the provided location was not possible. The bug didn't appear to be connected to the Android version, and on affected devices it didn't matter what permissions were given to the app or the cache directory. But also, our way of recording videos was different than usual. The usual way is to let the camera create a file at its own location, and then use it. We chose another approach because of security reasons - we wanted to keep our videos in our
internal directories.

### Solutions

The fix lets the camera write to its own file, and then copies the file to our cache directory and deletes the original one.

### Testing
Get one of the devices which had the bug. Go to a conversation. Record a video. Send it. The bug results in no asset being sent.
