### PR TITLE
fix: The sender's device fails to play the video the first time (SE bump)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2298"
+    zMessagingVersion = "142.0.2299"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'


### PR DESCRIPTION
SE changes: https://github.com/wireapp/wire-android-sync-engine/pull/575
fixes https://wearezeta.atlassian.net/browse/AN-6311

1. Send a video in a conversation.
2. Click on the video to play it.
3. The video fails to play the first time. It works the second time.

The reason of the bug was in that before playing the video we first check the sha (for security reasons).
We calculate the sha by loading the whole input stream. The stream should be reset if the sha is valid,
so it can be read again when we copy the video in order to play it afterwards.  And if the sha is invalid,
the stream should be closed. Instead, we tried to open it for the second time if the sha comparison was successful.