### PR TITLE
fix: Use new assets in DrawingFragment

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -46,9 +46,7 @@ import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, EventStream, Signal}
 import com.waz.utils.wrappers.{URI => URIWrapper}
 import com.waz.utils.{IoUtils, returning, sha2}
-import com.waz.zclient.controllers.drawing.IDrawingController.DrawingMethod
 import com.waz.zclient.controllers.singleimage.ISingleImageController
-import com.waz.zclient.drawing.DrawingFragment.Sketch
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.MessageBottomSheetDialog.MessageAction
 import com.waz.zclient.messages.controllers.MessageActionsController
@@ -192,13 +190,8 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
       singleImage.showSingleImage(msg.id.str)
     }
 
-  //FIXME: don't use java api
-  def openDrawingFragment(id: AssetId, drawingMethod: DrawingMethod): Unit =
-    screenController.showSketch ! Sketch.asset(id, drawingMethod)
-
   def openFile(idGeneral: GeneralAssetId): Unit = idGeneral match {
     case id: AssetId =>
-
       assetForSharing(id).foreach { case AssetForShare(asset, file) =>
         asset.details match {
           case _: Video =>

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
@@ -143,8 +143,8 @@ class ImageFragment extends FragmentHelper {
 
         method.foreach { m =>
           getFragmentManager.popBackStack()
-          imageInput.head.collect { case Some(id: AssetId) => id }.foreach { assetId =>
-            screenController.showSketch ! Sketch.asset(assetId, m)
+          imageInput.head.collect { case Some(id: AssetId) => id }.foreach {
+            screenController.showSketch ! Sketch.asset(_, m)
           }
         }
       case item: MessageActionToolbarItem =>

--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient.drawing
 
+import java.io.File
 import java.net.URI
 
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
@@ -59,17 +60,22 @@ import scala.concurrent.Future
 
 object DrawingFragment {
   val Tag: String = classOf[DrawingFragment].getName
-  private val SAVED_INSTANCE_BITMAP = "SAVED_INSTANCE_BITMAP"
+  private val SavedInstanceBitmap     = "SAVED_INSTANCE_BITMAP"
+  private val ArgDrawingDestination   = "ARGUMENT_DRAWING_DESTINATION"
+  private val ArgDrawingMethod        = "ARGUMENT_DRAWING_METHOD"
 
-  private val ArgDrawingDestination = "ARGUMENT_DRAWING_DESTINATION"
-  private val ArgDrawingMethod      = "ARGUMENT_DRAWING_METHOD"
+  private val ContentMimeArg          = "CONTENT_MIME"
+  private val BytesInputArg           = "BYTES_INPUT"
+  private val UriInputArg             = "URI_INPUT"
+  private val FileInputArg            = "FILE_INPUT"
+  private val AssetInputArg           = "ASSET_INPUT"
 
   private val TextAlphaInvisible      = 0F
   private val TextAlphaMove           = 0.2F
   private val TextAlphaVisible        = 1F
   private val SendButtonDisabledAlpha = 102
 
-  def newInstance(sketch: Sketch): DrawingFragment = {
+  def newInstance(sketch: Sketch): DrawingFragment =
     returning(new DrawingFragment) { f =>
       f.setArguments(returning(new Bundle) { b =>
         putInputToBundle(b, sketch.input)
@@ -77,7 +83,6 @@ object DrawingFragment {
         b.putString(ArgDrawingMethod, sketch.method.toString)
       })
     }
-  }
 
   case class Sketch(input: Option[Either[Content, AssetId]], dest: DrawingDestination, method: DrawingMethod)
 
@@ -86,42 +91,36 @@ object DrawingFragment {
     import DrawingMethod._
 
     val BlankSketch = Sketch(None, SKETCH_BUTTON, DRAW)
-    def cameraPreview(input: Content, method: DrawingMethod = DRAW) =
-      Sketch(Some(Left(input)), CAMERA_PREVIEW_VIEW, method)
-    def singleImage(input: Content, method: DrawingMethod = DRAW) =
-      Sketch(Some(Left(input)), SINGLE_IMAGE_VIEW, method)
-    def asset(assetId: AssetId, method: DrawingMethod = DRAW) =
-      Sketch(Some(Right(assetId)), SINGLE_IMAGE_VIEW, method)
+
+    def cameraPreview(input: Content, method: DrawingMethod = DRAW) = Sketch(Some(Left(input)), CAMERA_PREVIEW_VIEW, method)
+    def asset(assetId: AssetId, method: DrawingMethod = DRAW)       = Sketch(Some(Right(assetId)), SINGLE_IMAGE_VIEW, method)
   }
 
-  private val ContentMimeArg  = "CONTENT_MIME"
-  private val BytesInputArg   = "BYTES_INPUT"
-  private val UriInputArg     = "URI_INPUT"
-  private val FileInputArg    = "FILE_INPUT"
-  private val AssetInputArg   = "ASSET_INPUT"
-
-  def putInputToBundle(b: Bundle, input: Option[Either[Content, AssetId]]): Unit = {
-//    input match {
-//      case Some(Left(content)) => b.putString(ContentMimeArg, content.mime.str)
-//      case _ =>
-//    }
-//    input match {
-//      case Some(Left(Content.Bytes(_, bytes))) => b.putByteArray(BytesInputArg, bytes)
-//      case Some(Left(Content.Uri(_, uri))) => b.putString(UriInputArg, uri.toString)
-//      case Some(Left(Content.File(_, file))) => b.putString(FileInputArg, file.getAbsolutePath)
-//      case Some(Right(assetId)) => b.putString(AssetInputArg, assetId.str)
-//      case _ =>
-//    }
+  def putInputToBundle(b: Bundle, input: Option[Either[Content, AssetId]]): Unit = input match {
+    case Some(Left(Content.Bytes(mime, bytes))) =>
+      b.putByteArray(BytesInputArg, bytes)
+      b.putString(ContentMimeArg, mime.str)
+    case Some(Left(Content.Uri(uri))) =>
+      b.putString(UriInputArg, uri.toString)
+    case Some(Left(Content.File(mime, file))) =>
+      b.putString(FileInputArg, file.getAbsolutePath)
+      b.putString(ContentMimeArg, mime.str)
+    case Some(Right(assetId)) =>
+      b.putString(AssetInputArg, assetId.str)
+    case _ =>
   }
 
-  def getInputFromBundle(b: Bundle): Option[Either[Content, AssetId]] = {
-    None
-//    Option(b.getString(UriInputArg)).map(URI.create).map(Content.Uri).map(Left.apply)
-//      .orElse(Option(b.getByteArray(BytesInputArg)).map(Content.Bytes).map(Left.apply))
-//      .orElse(Option(b.getString(FileInputArg)).map(new File(_)).map(Content.File).map(Left.apply))
-//      .orElse(Option(b.getString(AssetInputArg)).map(AssetId.apply).map(Right.apply))
-  }
-
+  def getInputFromBundle(b: Bundle): Option[Either[Content, AssetId]] =
+    if (b.containsKey(UriInputArg)) Some(Left(Content.Uri(URI.create(b.getString(UriInputArg)))))
+    else if (b.containsKey(AssetInputArg)) Some(Right(AssetId(b.getString(AssetInputArg))))
+    else if (b.containsKey(ContentMimeArg)) {
+      val mime = if (b.containsKey(ContentMimeArg)) Mime.Image.supported.find { _.str == b.getString(ContentMimeArg) } else None
+      mime.flatMap { m =>
+        if (b.containsKey(BytesInputArg)) Some(Left(Content.Bytes(m, b.getByteArray(BytesInputArg))))
+        else if (b.containsKey(FileInputArg)) Some(Left(Content.File(m, new File(b.getString(FileInputArg)))))
+        else None
+      }
+    } else None
 }
 
 class DrawingFragment extends FragmentHelper
@@ -140,9 +139,7 @@ class DrawingFragment extends FragmentHelper
   private lazy val sensorManager      = inject[SensorManager]
   private lazy val uriHelper          = inject[UriHelper]
   private lazy val assetService       = inject[AssetService]
-
-  private lazy val accentColor = inject[Signal[AccentColor]].map(_.color)
-
+  private lazy val accentColor        = inject[Signal[AccentColor]].map(_.color)
   private lazy val drawingDestination = getStringArg(ArgDrawingDestination).map(DrawingDestination.valueOf)
 
   private var imageInput             = Option.empty[Either[Content, AssetId]]
@@ -220,8 +217,8 @@ class DrawingFragment extends FragmentHelper
 
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
-    imageInput = getInputFromBundle(getArguments)
-    drawingMethod = getStringArg(ArgDrawingMethod).map(DrawingMethod.valueOf)
+    imageInput          = getInputFromBundle(getArguments)
+    drawingMethod       = getStringArg(ArgDrawingMethod).map(DrawingMethod.valueOf)
     assetIntentsManager = new AssetIntentsManager(getActivity, this)
   }
 
@@ -313,7 +310,7 @@ class DrawingFragment extends FragmentHelper
     }
 
     // Use saved background image if exists
-    Option(savedInstanceState).flatMap(b => Option(b.getParcelable(SAVED_INSTANCE_BITMAP))) match {
+    Option(savedInstanceState).flatMap(b => Option(b.getParcelable(SavedInstanceBitmap))) match {
       case Some(bm) => drawingCanvasView.foreach(_.setBackgroundBitmap(bm))
       case _ => setBackgroundBitmap(true)
     }
@@ -608,7 +605,7 @@ class DrawingFragment extends FragmentHelper
       z      <- OptionT.liftF(inject[Signal[ZMessaging]].head)
       input  <- OptionT.fromOption(imageInput)
       is     <- input match {
-        case Left(content) => OptionT.liftF(Future.fromTry(content.openInputStream(uriHelper)))
+        case Left(content)  => OptionT.liftF(Future.fromTry(content.openInputStream(uriHelper)))
         case Right(assetId) => OptionT.liftF(assetService.loadContentById(assetId).future)
       }
       bitmap = BitmapFactory.decodeStream(is)
@@ -640,3 +637,4 @@ class DrawingFragment extends FragmentHelper
 
   override def onScrollChanged(): Unit = {}
 }
+

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
@@ -24,12 +24,11 @@ import android.widget.{FrameLayout, ImageView, LinearLayout}
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{AssetId, MessageContent}
+import com.waz.model.MessageContent
 import com.waz.service.messages.MessageAndLikes
 import com.waz.threading.Threading
 import com.waz.utils.events.{NoAutowiring, Signal, SourceSignal}
 import com.waz.zclient.common.controllers.AssetsController
-import com.waz.zclient.controllers.drawing.IDrawingController.DrawingMethod
 import com.waz.zclient.glide.WireGlide
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.MessageView.MsgBindOptions
@@ -61,12 +60,6 @@ class ImagePartView(context: Context, attrs: AttributeSet, style: Int)
     noW  <- noWifi
     hide <- hideContent
   } yield !hide && noW).on(Threading.Ui)(imageIcon.setVisible)
-
-  private def openDrawingFragment(drawingMethod: DrawingMethod) =
-    for {
-      msg <- message.currentValue
-      assetId <- msg.assetId.collect { case id: AssetId => id }
-    } { assets.openDrawingFragment(assetId, drawingMethod) }
 
   onClicked { _ => message.head.map(assets.showSingleImage(_, this))(Threading.Ui) }
 

--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -163,8 +163,8 @@ class ConversationManagerFragment extends FragmentHelper
     subs += screenController.hideGiphy.onUi(_ => hideFragment(GiphySharingPreviewFragment.Tag))
 
     subs += screenController.showSketch.onUi { sketch =>
-        import DrawingFragment._
-        showFragment(newInstance(sketch), Tag, Page.DRAWING)
+      import DrawingFragment._
+      showFragment(newInstance(sketch), Tag, Page.DRAWING)
     }
     subs += screenController.hideSketch.onUi { dest =>
       hideFragment(DrawingFragment.Tag)


### PR DESCRIPTION
### What's new in this PR?

The functionality of `DrawingFragment` had to be changed a little to use new assets.

### Issues
After introducing new assets, `DrawingFragment` was left unused - the parts of the code which didn't work were commented out.

### Solutions

I changed the way we recognize if the image used in sketching comes form the camera, an asset, etc.

### Testing

1. Take a photo and try to draw something on it and send it.
2. Use a photo from the gallery for the same purpose.