### PR TITLE
Fix: location message preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2298"
+    zMessagingVersion = "142.0.0-SNAPSHOT"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.0-SNAPSHOT"
+    zMessagingVersion = "142.0.2301"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/src/main/java/com/waz/zclient/WireGlideModule.java
+++ b/app/src/main/java/com/waz/zclient/WireGlideModule.java
@@ -24,9 +24,11 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.module.AppGlideModule;
+import com.waz.api.MessageContent;
 import com.waz.model.GeneralAssetId;
 import com.waz.model.UserData;
 import com.waz.zclient.glide.loaders.AssetModelLoader;
+import com.waz.zclient.glide.loaders.GoogleMapModelLoader;
 import com.waz.zclient.glide.loaders.PictureModelLoader;
 
 import java.io.InputStream;
@@ -37,5 +39,6 @@ public class WireGlideModule extends AppGlideModule {
     public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
         registry.prepend(GeneralAssetId.class, InputStream.class, new AssetModelLoader.Factory(context));
         registry.prepend(UserData.Picture.class, InputStream.class, new PictureModelLoader.Factory(context));
+        registry.prepend(MessageContent.Location.class, InputStream.class, new GoogleMapModelLoader.Factory(context));
     }
 }

--- a/app/src/main/scala/com/waz/zclient/glide/AssetRequest.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/AssetRequest.scala
@@ -19,6 +19,7 @@ package com.waz.zclient.glide
 
 import com.waz.model.UserData.Picture
 import com.waz.model._
+import com.waz.api.MessageContent.Location
 import com.waz.service.assets2.Asset
 
 sealed trait AssetRequest {
@@ -50,6 +51,9 @@ case class ImageAssetRequest(asset: Asset) extends AssetRequest {
 }
 case class UploadAssetIdRequest(assetId: UploadAssetId) extends AssetRequest {
   override val key: String = assetId.str
+}
+case class GoogleMapRequest(location: Location) extends AssetRequest {
+  override val key: String = location.toString
 }
 case class EmptyRequest() extends AssetRequest {
   override val key: String = ""

--- a/app/src/main/scala/com/waz/zclient/glide/loaders/GoogleMapModelLoader.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/loaders/GoogleMapModelLoader.scala
@@ -1,0 +1,60 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.glide.loaders
+
+import java.io.InputStream
+
+import android.content.Context
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.model.{ModelLoader, ModelLoaderFactory, MultiModelLoaderFactory}
+import com.bumptech.glide.load.model.ModelLoader.LoadData
+import com.waz.api.MessageContent.Location
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.service.ZMessaging
+import com.waz.utils.events.Signal
+import com.waz.zclient.{Injectable, Injector, WireContext}
+import com.waz.zclient.glide.{AssetKey, GoogleMapRequest, ImageAssetFetcher}
+import com.waz.zclient.log.LogUI._
+
+class GoogleMapModelLoader(zms: Signal[ZMessaging]) extends ModelLoader[Location, InputStream]
+  with DerivedLogTag {
+
+  override def buildLoadData(model: Location, width: Int, height: Int, options: Options): ModelLoader.LoadData[InputStream] = {
+    val request = GoogleMapRequest(model)
+    val key = AssetKey(request.toString, width, height, options)
+    verbose(l"key: $key")
+    new LoadData[InputStream](key, new ImageAssetFetcher(request, zms))
+  }
+
+  override def handles(model: Location): Boolean = true
+}
+
+object GoogleMapModelLoader {
+
+  class Factory(context: Context) extends ModelLoaderFactory[Location, InputStream]
+    with Injectable {
+
+    private implicit val injector: Injector = context.asInstanceOf[WireContext].injector
+
+    override def build(multiFactory: MultiModelLoaderFactory): ModelLoader[Location, InputStream] = {
+      new GoogleMapModelLoader(inject[Signal[ZMessaging]])
+    }
+
+    override def teardown(): Unit = {}
+  }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Location messages do not display the map preview, just an empty box.

### Causes

This functionality was removed during the assets refactoring, but was never reimplemented.

### Solutions

Changes in https://github.com/wireapp/wire-android-sync-engine/pull/573 allow us to make a request to obtain the image data given a location. The result from this request is an `InputStream` containing `png` data. Given this data, we can load it directly into _Glide_ by defining a model loader that will accept an instance of `Location`, fetch the image data and load it into an image view.

### Testing

Manually tested by opening a conversation containing location messages.

## Depends on
- [x] https://github.com/wireapp/wire-android-sync-engine/pull/573