### PR TITLE
fix: Invalid system message about adding someone to the conversation

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
@@ -101,11 +101,11 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
 
       //Add
       case (MEMBER_JOIN, Me, Seq(`me`)) if userId == me                                    => getString(R.string.content__system__you_joined).toUpperCase
-      case (MEMBER_JOIN, Me, _) if shorten                                                 => getQuantityString(R.plurals.content__system__you_added_people_with_others, othersCount, namesListString, othersCount.toString)
-      case (MEMBER_JOIN, Me, _)                                                            => getString(R.string.content__system__you_added_people, namesListString)
+      case (MEMBER_JOIN, Me, others) if shorten && others.nonEmpty && !others.contains(me) => getQuantityString(R.plurals.content__system__you_added_people_with_others, othersCount, namesListString, othersCount.toString)
+      case (MEMBER_JOIN, Me, others) if others.nonEmpty && !others.contains(me)            => getString(R.string.content__system__you_added_people, namesListString)
       case (MEMBER_JOIN, Other(name), Seq(`me`))                                           => getString(R.string.content__system__someone_added_you, name)
       case (MEMBER_JOIN, Other(name), Seq(other)) if userId == other                       => getString(R.string.content__system__other_joined, name)
-      case (MEMBER_JOIN, Other(name), _) if shorten && msg.members.contains(me)            => getQuantityString(R.plurals.content__system__someone_added_people_and_you_with_others, othersCount, name, namesListString, othersCount.toString)
+      case (MEMBER_JOIN, Other(name), others) if shorten && others.contains(me)            => getQuantityString(R.plurals.content__system__someone_added_people_and_you_with_others, othersCount, name, namesListString, othersCount.toString)
       case (MEMBER_JOIN, Other(name), _) if shorten                                        => getQuantityString(R.plurals.content__system__someone_added_people_with_others, othersCount, name, namesListString, othersCount.toString)
       case (MEMBER_JOIN, Other(name), _)                                                   => getString(R.string.content__system__someone_added_people, name, namesListString)
 


### PR DESCRIPTION
fixes: https://wearezeta.atlassian.net/browse/AN-6299

Sometimes when the user creates a new conversation, a MEMBER_JOIN system message is received:
"You added X to the conversation" where X is the name of the same user.
I wasn't able to reproduce that situation, but I found a place in `MemberChangePartView`
which may lead to that invalid text being displayed. The creation of a conversation
may be treated as if the creator added him/herself to it, and then a system message may be
created which has the selfId both as the sender, and the other user id.

I believe this system message is redundant and can simply be ignored.
The right text should be displayed in `ConversationStartPartView` instead.