### PR TITLE
fix: conv system messages not showing

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -81,7 +81,9 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
     msgId = msg.id
 
     import opts._
-    val isOneToOne = !isGroup
+    //if we have just added a user to a conversation with a bot, we shouldn't count this as oneToOne,
+    //so we check the members size also
+    val isOneToOne = !isGroup && mAndL.message.members.size <= 2
 
     val contentParts = {
       if (msg.msgType == Message.Type.MEMBER_JOIN && msg.firstMessage) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

- Fixes [AN-6048](https://wearezeta.atlassian.net/browse/AN-6048)
 - MembersStorage and the members in MessageData are not updated at
exactly the same time, which resulted in us interpreting a conv as
OneToOne when we added a user to a conv with a bot.
 - This PR introduces an additional check to account for this situation