### PR TITLE
fix: A conversation badge tries to display a non-existent glyph

### DIFF
--- a/app/src/main/res/layout/conv_badge.xml
+++ b/app/src/main/res/layout/conv_badge.xml
@@ -34,7 +34,7 @@
         android:textColor="@color/white"
         android:textSize="@dimen/wire__text_size__small"
         app:w_font="@string/wire__typeface__bold"
-        android:visibility="invisible"
+        android:visibility="gone"
         />
 
     <com.waz.zclient.ui.text.GlyphTextView
@@ -47,7 +47,7 @@
         android:textSize="@dimen/wire__text_size__small"
         android:paddingStart="@dimen/conversation_list__badge__glyph_padding"
         android:paddingEnd="@dimen/conversation_list__badge__glyph_padding"
-        android:visibility="invisible"
+        android:visibility="gone"
         />
 
     <com.waz.zclient.conversationlist.views.ConversationBadgeStyleKitView
@@ -56,5 +56,6 @@
         android:layout_height="@dimen/conversation_list__badge__icon_size"
         android:gravity="center"
         android:layout_gravity="center"
+        android:visibility="gone"
     />
 </merge>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationBadge.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationBadge.scala
@@ -50,9 +50,9 @@ class ConversationBadge(context: Context, attrs: AttributeSet, style: Int) exten
 
   inflate(R.layout.conv_badge)
 
-  val textView = findById[TypefaceTextView](R.id.status_pill_text)
-  val glyphView = findById[GlyphTextView](R.id.status_pill_glyph)
-  val styleKitView = findById[ConversationBadgeStyleKitView](R.id.status_pill_style_kit)
+  private lazy val textView = findById[TypefaceTextView](R.id.status_pill_text)
+  private lazy val glyphView = findById[GlyphTextView](R.id.status_pill_glyph)
+  private lazy val styleKitView = findById[ConversationBadgeStyleKitView](R.id.status_pill_style_kit)
 
   val onClickEvent = EventStream[Status]()
 
@@ -65,8 +65,6 @@ class ConversationBadge(context: Context, attrs: AttributeSet, style: Int) exten
   def setGlyph(glyphId: Int, backgroundId: Int = R.drawable.conversation_badge, textColor: Int = R.color.white): Unit = {
     setVisibility(View.VISIBLE)
     glyphView.setVisibility(View.VISIBLE)
-    textView.setVisibility(View.GONE)
-    styleKitView.setVisibility(View.GONE)
     setBackground(getDrawable(backgroundId))
     glyphView.setText(glyphId)
     glyphView.setTextColor(getColor(textColor))
@@ -75,8 +73,6 @@ class ConversationBadge(context: Context, attrs: AttributeSet, style: Int) exten
   def setText(text: String, backgroundId: Int = R.drawable.conversation_badge, textColor: Int = R.color.white): Unit = {
     setVisibility(View.VISIBLE)
     textView.setVisibility(View.VISIBLE)
-    glyphView.setVisibility(View.INVISIBLE)
-    styleKitView.setVisibility(View.INVISIBLE)
     setBackground(getDrawable(backgroundId))
     textView.setText(text)
     textView.setTextColor(getColor(textColor))
@@ -85,8 +81,6 @@ class ConversationBadge(context: Context, attrs: AttributeSet, style: Int) exten
   //TODO: remove glyphs and use this only
   def setStyleKitView(status: Status, backgroundId: Int = R.drawable.conversation_badge, iconColor: Int = R.color.white): Unit = {
     setVisibility(View.VISIBLE)
-    textView.setVisibility(View.INVISIBLE)
-    glyphView.setVisibility(View.INVISIBLE)
     setBackground(getDrawable(backgroundId))
     styleKitView.setVisibility(View.VISIBLE)
     styleKitView.setColor(getColor(iconColor))


### PR DESCRIPTION
A conversation badge can be either a text, a glyph, or a style kit view. Only one of these should be displayed. But now, initially, we load all three, and only then hide two of them. In a manual test on the dev build it leads to a crash which I wasn't able to reproduce on Internal. But even if that's some sort of a glitch, we display a lot of conversation badges and it's an easy and useful optimization to just display the correct type and to never load the other ones.