### PR TITLE
Internal and external images in the gallery grid

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/image/CursorImagesAdapter.java
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/image/CursorImagesAdapter.java
@@ -21,6 +21,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.database.ContentObserver;
 import android.database.Cursor;
+import android.database.MergeCursor;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.provider.MediaStore;
@@ -103,11 +104,16 @@ class CursorImagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
         @Override
         protected Cursor doInBackground(Void... params) {
-            Cursor c = adapter.resolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, null, null, null);
-            if (c != null) {
-                c.moveToLast(); // force cursor loading and move to last, as we are displaying images in reverse order
-            }
-            return c;
+            Cursor[] cursors = new Cursor[2];
+            String selection = MediaStore.Images.Media.DATA + " NOT LIKE ? "; // Exclude images from /system/ which would be included in INTERNAL_CONTENT_URI
+            String excludeFolder = "/system";
+            String[] selectionArgs = new String[]{excludeFolder + "%"};
+            final String orderBy = MediaStore.Images.Media.DATE_TAKEN + " ASC";
+
+            cursors[0] = adapter.resolver.query(MediaStore.Images.Media.INTERNAL_CONTENT_URI, null, selection, selectionArgs, orderBy);
+            cursors[1] = adapter.resolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, null, null, orderBy);
+
+            return new MergeCursor(cursors);
         }
 
         @Override

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/image/CursorImagesAdapter.java
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/image/CursorImagesAdapter.java
@@ -113,7 +113,9 @@ class CursorImagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             cursors[0] = adapter.resolver.query(MediaStore.Images.Media.INTERNAL_CONTENT_URI, null, selection, selectionArgs, orderBy);
             cursors[1] = adapter.resolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, null, null, orderBy);
 
-            return new MergeCursor(cursors);
+            Cursor c = new MergeCursor(cursors);
+            c.moveToLast();  // force cursor loading
+            return c;
         }
 
         @Override


### PR DESCRIPTION
## What's new in this PR?
The gallery grid shows images from both the internal and the external storage

### Issues
- If no SD-card is mounted the app shows internal images in the grid, but if an SD-card is mounted it shows only external images (on the SD-card), not from both

### Solutions
The solution uses two ContentResolver queries and merges them, one for the external and one for the internal storage

### Testing
Tested on API 26 and 24 with and without SD-card

## Notes
The /system/ directory is removed from the internal query to not show system images