### PR TITLE
Backup Loading Improvement for testing

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -81,7 +81,7 @@ public class AssetIntentsManager {
     }
 
     public void openBackupImport() {
-        openDocument("*/*", IntentType.BACKUP_IMPORT, false);
+        openDocument("wire/backup-file", IntentType.BACKUP_IMPORT, false);
     }
 
     public void captureVideo() {

--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -81,7 +81,7 @@ public class AssetIntentsManager {
     }
 
     public void openBackupImport() {
-        openDocument("wire/backup-file", IntentType.BACKUP_IMPORT, false);
+        openDocument("application/octet-stream", IntentType.BACKUP_IMPORT, false);
     }
 
     public void captureVideo() {

--- a/testing_gallery/src/main/java/com/wire/testinggallery/CaptureDocumentActivity.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/CaptureDocumentActivity.java
@@ -39,6 +39,8 @@ public class CaptureDocumentActivity extends AppCompatActivity {
             return resolver.getImageUri();
         } else if (mime.startsWith("video")) {
             return resolver.getVideoUri();
+        } else if (mime.equals("wire/backup-file")) {
+            return resolver.getBackupUri();
         } else {
             return resolver.getDocumentUri();
         }

--- a/testing_gallery/src/main/java/com/wire/testinggallery/CaptureDocumentActivity.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/CaptureDocumentActivity.java
@@ -39,7 +39,7 @@ public class CaptureDocumentActivity extends AppCompatActivity {
             return resolver.getImageUri();
         } else if (mime.startsWith("video")) {
             return resolver.getVideoUri();
-        } else if (mime.equals("wire/backup-file")) {
+        } else if (mime.equals("application/octet-stream")) {
             return resolver.getBackupUri();
         } else {
             return resolver.getDocumentUri();

--- a/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
@@ -63,6 +63,10 @@ public class DocumentResolver {
         add("png");
     }};
 
+    private final static List<String> BACKUP_EXTENSIONS = new ArrayList<String>() {{
+        add("android_wbu");
+    }};
+
     private final ContentResolver contentResolver;
 
     DocumentResolver(ContentResolver contentResolver) {
@@ -72,6 +76,11 @@ public class DocumentResolver {
     Uri getDocumentUri() {
         Log.i(TAG, "Received request for File");
         return fileQuery(WIRE_TESTING_FILES_DIRECTORY, FILE_EXTENSIONS);
+    }
+
+    Uri getBackupUri() {
+        Log.i(TAG, "Received request for Backup");
+        return fileQuery(WIRE_TESTING_FILES_DIRECTORY, BACKUP_EXTENSIONS);
     }
 
     Uri getVideoUri() {


### PR DESCRIPTION


## What's new in this PR?
- changed the mime-type for android backup files from */* to wire/backup-file
- implemented custom backup loading code into the testing gallery

### Issues
Under special circumstances, backups were not loaded correctly when tested trough the testing gallery

### Causes
when there is an image in the same folder as the android_wbu file, thhe testing gallery choose the image instead of the backup file because the mimetype was */*

### Solutions

implemented a special mime-type named wire/backup-file

## Notes
this change should not effect any public user, it is only for helping purpose to improve, fix and stabilise our testing lab.
