### PR TITLE
Fix: root detection check

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/RootDetectionCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/RootDetectionCheck.scala
@@ -34,7 +34,7 @@ class RootDetectionCheck(preferences: GlobalPreferences)(implicit context: Conte
   extends SecurityChecklist.Check with Injectable with DerivedLogTag {
 
   override def isSatisfied: Future[Boolean] = wasPreviouslyRooted.map {
-    case true => true
+    case true => false
     case false =>
       lazy val releaseTagsExist = getSystemProperty("ro.build.tags").contains("release-keys")
       lazy val otacertsExist = new File("/etc/security/otacerts.zip").exists()

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -31,7 +31,6 @@ class SecureActivity extends AppCompatActivity with ActivityHelper {
 
   override def onStart(): Unit = {
     super.onStart()
-
     securityChecklist.run()
   }
 


### PR DESCRIPTION
## What's new in this PR?

The return value of `isSatisfied` was incorrect if the device was previously rooted, just needed to be flipped!