### PR TITLE
Warn Android 4 users of discontinued support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2307"
+    zMessagingVersion = "142.0.2308"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1351,5 +1351,11 @@
     <string name="read_receipts_remotely_enabled_title">You have enabled read receipts</string>
     <string name="read_receipts_remotely_disabled_title">You have disabled read receipts</string>
     <string name="read_receipts_remotely_changed_message">You can change this option in your account settings.</string>
+    
+    <!--These are temporary and should be removed after release 3.36-->
+    <string name="android_4_warning_title"> Wire 3.36 is the last Android 4 compatible release.</string>
+    <string name="android_4_warning_message">To be able to install later versions, please update to Android 5 or higher.</string>
+    <string name="android_4_warning_action_ok">OK</string>
+    <string name="android_4_warning_action_dont_show_again">Don\'t show again</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1353,7 +1353,7 @@
     <string name="read_receipts_remotely_changed_message">You can change this option in your account settings.</string>
     
     <!--These are temporary and should be removed after release 3.36-->
-    <string name="android_4_warning_title"> Wire 3.36 is the last Android 4 compatible release.</string>
+    <string name="android_4_warning_title">Wire 3.36 is the last Android 4 compatible release.</string>
     <string name="android_4_warning_message">To be able to install later versions, please update to Android 5 or higher.</string>
     <string name="android_4_warning_action_ok">OK</string>
     <string name="android_4_warning_action_dont_show_again">Don\'t show again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1352,8 +1352,8 @@
     <string name="read_receipts_remotely_disabled_title">You have disabled read receipts</string>
     <string name="read_receipts_remotely_changed_message">You can change this option in your account settings.</string>
     
-    <!--These are temporary and should be removed after release 3.36-->
-    <string name="android_4_warning_title">Wire 3.36 is the last Android 4 compatible release.</string>
+    <!--TODO: remove after release 3.36-->
+    <string name="android_4_warning_title">Wire 3.36 is the last version that can be installed on Android 4.</string>
     <string name="android_4_warning_message">To be able to install later versions, please update to Android 5 or higher.</string>
     <string name="android_4_warning_action_ok">OK</string>
     <string name="android_4_warning_action_dont_show_again">Don\'t show again</string>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -24,7 +24,7 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.{Color, Paint, PixelFormat}
 import android.os.{Build, Bundle}
 import android.support.v4.app.{Fragment, FragmentTransaction}
-import com.waz.content.{TeamsStorage, UserPreferences}
+import com.waz.content.{GlobalPreferences, TeamsStorage, UserPreferences}
 import com.waz.content.UserPreferences._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.UserData.ConnectionStatus.{apply => _}
@@ -141,6 +141,9 @@ class MainActivity extends BaseActivity
         startActivity(returning(new Intent(this, classOf[AppEntryActivity]))(_.setFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK)))
       case false =>
     }
+
+    // TODO: remove after release 3.36
+    warnAndroid4UsersIfNeeded()
 
     for {
       Some(self) <- userAccountsController.currentUser.head
@@ -529,6 +532,30 @@ class MainActivity extends BaseActivity
       .commit
 
   override def onUsernameSet(): Unit = replaceMainFragment(new MainPhoneFragment, MainPhoneFragment.Tag, addToBackStack = false)
+
+  // TODO: remove after release 3.36
+  def warnAndroid4UsersIfNeeded(): Unit = {
+    def showDialog(accentColor: AccentColor): Future[Boolean] = showConfirmationDialog(
+      getString(R.string.android_4_warning_title),
+      getString(R.string.android_4_warning_message),
+      R.string.android_4_warning_action_dont_show_again,
+      R.string.android_4_warning_action_ok,
+      accentColor)
+
+    val prefs = inject[GlobalPreferences]
+
+    for {
+      shouldWarn <- prefs(GlobalPreferences.ShouldWarnAndroid4Users).apply()
+      isAndroid4User = Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
+      color <- accentColorController.accentColor.head
+    } yield {
+      if (isAndroid4User && shouldWarn) {
+        showDialog(color).foreach { dontShowAgain =>
+          prefs(GlobalPreferences.ShouldWarnAndroid4Users) := !dontShowAgain
+        }
+      }
+    }
+  }
 }
 
 object MainActivity {


### PR DESCRIPTION
## What's new in this PR?

After 3.36 we will drop support for Android 4. This PR includes changes to display a dialog informing them of this change.

## Notes

Once 3.36 is released, we will delete this code.
