### PR TITLE
fix: Sketch on existing photo is not showing the photo

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -183,6 +183,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[MembersStorage]]                to inject[Signal[ZMessaging]].map(_.membersStorage)
     bind [Signal[OtrClientsStorage]]             to inject[Signal[ZMessaging]].map(_.otrClientsStorage)
     bind [Signal[AssetStorage]]                  to inject[Signal[ZMessaging]].map(_.assetsStorage)
+    bind [Signal[AssetService]]                  to inject[Signal[ZMessaging]].map(_.assetService)
     bind [Signal[MessagesStorage]]               to inject[Signal[ZMessaging]].map(_.messagesStorage)
     bind [Signal[ImageLoader]]                   to inject[Signal[ZMessaging]].map(_.imageLoader)
     bind [Signal[MessagesService]]               to inject[Signal[ZMessaging]].map(_.messages)


### PR DESCRIPTION
## What's new in this PR?

A fix to a bug in the sketch functionality. Two bugs, in fact: displaying the background image, and pressing the back button.

### Issues
1. If the picture was taken from the conversation (i.e. sent by another user, not us) it was not displayed in the sketch.
2. If the sketch was open and we moved back to the conversation list and opened another conversation, the sketch did not go away.

### Causes
1. This is something we should be very catious about: The faulty code was trying to inject `AssetService`, but we didn't have it registered in our DI system (I think it was there, but it was removed after new assets were implemented). The problem wasn't caught in compilation. It manifested as an exception thrown at runtime, and the exception was ignored. **Always check in `WireApplication` if what you `inject` has an associated `bind`.

2. Pressing the back button instead of "X" in the header moved the user to the conversation list, instead of closing the drawing fragment. After opening another conversation, the old drawing fragment was displayed on top of the new conversation.
### Solutions

1. I registered `AssetService` in `WireApplication` and I also simplified the `setBackgroundBitmap` method, so now it's easier to see what we're doing there.
2. When the user presses the back button, now it calls the same method as the 'X' button - it closes the drawing fragment and the user goes back to the conversation. Only pressing the back button again takes them to the conversation list, but then the drawing fragment is already gone.

### Testing

1. Try to sketch over a picture received from another user.
2. Click the back button (instead of 'X') on the drawing fragment, go to the conversation list, and go to another conversation.