### PR TITLE
feat: add button content description for tests

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1146,6 +1146,12 @@
     <string name="app_entry_sso_dialog_message">Enter the company SSO access code.</string>
     <string name="app_entry_sso_input_hint"></string>
 
+    <string name="action_button_state_play">play</string>
+    <string name="action_button_state_pause">pause</string>
+    <string name="action_button_state_close">close</string>
+    <string name="action_button_state_redo">redo</string>
+    <string name="action_button_state_none">redo</string>
+
     <string name="pick_user_teams_invite">Invite people to join the team</string>
     <string name="teams_invitations_skip">SKIP</string>
     <string name="teams_invitations_done">DONE</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1150,7 +1150,7 @@
     <string name="action_button_state_pause">pause</string>
     <string name="action_button_state_close">close</string>
     <string name="action_button_state_redo">redo</string>
-    <string name="action_button_state_none">redo</string>
+    <string name="action_button_state_none">none</string>
 
     <string name="pick_user_teams_invite">Invite people to join the team</string>
     <string name="teams_invitations_skip">SKIP</string>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetActionButton.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetActionButton.scala
@@ -46,15 +46,16 @@ class AssetActionButton(context: Context, attrs: AttributeSet, style: Int) exten
   private def onCompletedDrawable(ext: String) = if (isFileType) new FileDrawable(Signal.const(ext)) else normalButtonDrawable
 
   def setStatus(status: AssetStatus, extension: String, playing: Boolean): Unit = {
-    val (icon, drawable) = status match {
-      case DownloadAssetStatus.InProgress | UploadAssetStatus.InProgress => (R.string.glyph__close, normalButtonDrawable)
-      case DownloadAssetStatus.Failed | DownloadAssetStatus.Cancelled =>    (R.string.glyph__redo, errorButtonDrawable)
-      case UploadAssetStatus.Failed | UploadAssetStatus.Cancelled =>        (R.string.glyph__redo, errorButtonDrawable)
-      case AssetStatus.Done if playing =>                                   (R.string.glyph__pause, onCompletedDrawable(extension))
-      case AssetStatus.Done if !playing =>                                  (R.string.glyph__play, onCompletedDrawable(extension))
-      case _ =>                                                             (0, null)
+    val (icon, drawable, stateText) = status match {
+      case DownloadAssetStatus.InProgress | UploadAssetStatus.InProgress => (R.string.glyph__close, normalButtonDrawable, R.string.action_button_state_close)
+      case DownloadAssetStatus.Failed | DownloadAssetStatus.Cancelled =>    (R.string.glyph__redo, errorButtonDrawable, R.string.action_button_state_redo)
+      case UploadAssetStatus.Failed | UploadAssetStatus.Cancelled =>        (R.string.glyph__redo, errorButtonDrawable, R.string.action_button_state_redo)
+      case AssetStatus.Done if playing =>                                   (R.string.glyph__pause, onCompletedDrawable(extension), R.string.action_button_state_pause)
+      case AssetStatus.Done if !playing =>                                  (R.string.glyph__play, onCompletedDrawable(extension), R.string.action_button_state_play)
+      case _ =>                                                             (0, null, R.string.action_button_state_none)
     }
 
+    setContentDescription(getString(stateText)) //Set content description for tests
     setBackground(drawable)
     setText(icon match {
       case 0 => ""


### PR DESCRIPTION
## What's new in this PR?

### Issues

Addresses [AN-6313](https://wearezeta.atlassian.net/browse/AN-6313). This PR adds a text description that can be read by automated tools. Determining the action button's state was otherwise unreliable, and was hampering testing.
