### PR TITLE
Apply changes due to macrosupport version update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1013-PR"
+    zMessagingVersion = "142.0.2317"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2316"
+    zMessagingVersion = "142.0.1013-PR"
     paging_version = "1.0.0"
 
     avsVersion = '4.9.170@aar'

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/BlurTransformation.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/BlurTransformation.scala
@@ -15,23 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
-  * Wire
-  * Copyright (C) 2018 Wire Swiss GmbH
-  *
-  * This program is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  */
 package com.waz.zclient.glide.transformations
 
 import java.nio.charset.Charset
@@ -40,14 +23,14 @@ import java.security.MessageDigest
 import android.graphics.Bitmap
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
 import com.waz.bitmap.BitmapUtils
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.zclient.glide.transformations.BlurTransformation._
 
-class BlurTransformation extends BitmapTransformation {
+class BlurTransformation extends BitmapTransformation with DerivedLogTag {
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
   override def transform(pool: BitmapPool, toTransform: Bitmap, outWidth: Int, outHeight: Int): Bitmap = {
     BitmapUtils.createBlurredBitmap(toTransform, outWidth, BlurPasses, BlurRadius)

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/DarkenTransformation.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/DarkenTransformation.scala
@@ -1,6 +1,6 @@
 /**
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2019 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,25 +23,26 @@ import java.security.MessageDigest
 import android.graphics._
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.returning
 
-class DarkenTransformation(alpha: Int, saturation: Float = 1f) extends BitmapTransformation {
+class DarkenTransformation(alpha: Int, saturation: Float = 1f) extends BitmapTransformation
+  with DerivedLogTag {
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
   override def transform(pool: BitmapPool, toTransform: Bitmap, outWidth: Int, outHeight: Int): Bitmap = {
 
     val bitmap = pool.get(outWidth, outHeight, Bitmap.Config.ARGB_8888)
 
     val colorMatrix = returning(new ColorMatrix) {
-     _.setSaturation(saturation)
+      _.setSaturation(saturation)
     }
-    val saturationPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)){
+    val saturationPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)) {
       _.setColorFilter(new ColorMatrixColorFilter(colorMatrix))
     }
-    val darkenPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)){ p =>
+    val darkenPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)) { p =>
       p.setColor(Color.BLACK)
       p.setAlpha(alpha)
     }

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/GlyphOverlayTransformation.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/GlyphOverlayTransformation.scala
@@ -23,16 +23,16 @@ import java.security.MessageDigest
 import android.graphics._
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.returning
 import com.waz.zclient.ui.utils.TypefaceUtils
 
-class GlyphOverlayTransformation(glyph: String) extends BitmapTransformation {
+class GlyphOverlayTransformation(glyph: String) extends BitmapTransformation with DerivedLogTag {
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag + s"-$glyph"
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value + s"-$glyph"
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
-  private val darkenPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)){ p =>
+  private val darkenPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)) { p =>
     p.setColor(Color.BLACK)
     p.setAlpha(65)
   }

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/GreyScaleTransformation.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/GreyScaleTransformation.scala
@@ -23,13 +23,13 @@ import java.security.MessageDigest
 import android.graphics._
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.returning
 
-class GreyScaleTransformation extends BitmapTransformation{
+class GreyScaleTransformation extends BitmapTransformation with DerivedLogTag {
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
   override def transform(pool: BitmapPool, toTransform: Bitmap, outWidth: Int, outHeight: Int): Bitmap = {
     val bitmap = pool.get(outWidth, outHeight, Bitmap.Config.ARGB_8888)

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/IntegrationBackgroundCrop.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/IntegrationBackgroundCrop.scala
@@ -24,13 +24,13 @@ import android.graphics.Paint.Join
 import android.graphics._
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.returning
 
-class IntegrationBackgroundCrop extends BitmapTransformation {
+class IntegrationBackgroundCrop extends BitmapTransformation with DerivedLogTag {
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
   private val circlePaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG))(_.setColor(Color.WHITE))
   private val borderPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)) { p =>
@@ -56,9 +56,9 @@ class IntegrationBackgroundCrop extends BitmapTransformation {
     val canvas = new Canvas(bitmap)
     val targetRect = new RectF(canvas.getClipBounds)
     targetRect.inset(strokeWidth, strokeWidth)
-    canvas.drawRoundRect(targetRect, radius,radius, circlePaint)
+    canvas.drawRoundRect(targetRect, radius, radius, circlePaint)
     canvas.drawBitmap(toTransform, dx, dy, bitmapPaint)
-    canvas.drawRoundRect(targetRect, radius,radius, borderPaint)
+    canvas.drawRoundRect(targetRect, radius, radius, borderPaint)
     canvas.setBitmap(null)
 
     bitmap

--- a/app/src/main/scala/com/waz/zclient/glide/transformations/ScaleTransformation.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/transformations/ScaleTransformation.scala
@@ -23,13 +23,13 @@ import java.security.MessageDigest
 import android.graphics.{Bitmap, Canvas, Matrix, Paint}
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.waz.ZLog
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 
-class ScaleTransformation(scaleX: Float, scaleY: Float) extends BitmapTransformation {
+class ScaleTransformation(scaleX: Float, scaleY: Float) extends BitmapTransformation with DerivedLogTag {
   def this(scale: Float) = this(scale, scale)
 
-  private implicit val Tag: String = ZLog.ImplicitTag.implicitLogTag + s"($scaleX, $scaleY)"
-  private implicit val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
+  private val Tag: String = logTag.value + s"($scaleX, $scaleY)"
+  private val TagBytes: Array[Byte] = Tag.getBytes(Charset.forName("UTF-8"))
 
   override def transform(pool: BitmapPool, toTransform: Bitmap, outWidth: Int, outHeight: Int): Bitmap = {
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Applied changes due to macrosupport version update to 3.3 in sync-engine: [https://github.com/wireapp/wire-android-sync-engine/pull/588/commits/b5234c2f2f07f54b15436deb69769cd874beb651](url)

### Solutions

Migrated ZLog logging system to DerivedLogTag as required per library update.

### Testing

Being able to run the app is sufficient.

## Notes

This commit changes the hashCode computation of the relevant classes. However, since none of them is stored inside a hash-based collection, there should be no side effects.
