### PR TITLE
fix: Image rotation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1018-PR"
+    zMessagingVersion = "142.0.2318"
     paging_version = "1.0.0"
 
     avsVersion = '5.1.186@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2317"
+    zMessagingVersion = "142.0.1018-PR"
     paging_version = "1.0.0"
 
     avsVersion = '5.1.186@aar'

--- a/app/src/main/scala/com/waz/zclient/assets2/AndroidImageRecoder.scala
+++ b/app/src/main/scala/com/waz/zclient/assets2/AndroidImageRecoder.scala
@@ -40,6 +40,7 @@ class AndroidImageRecoder extends ImageRecoder {
     val opts = new BitmapFactory.Options()
     opts.inJustDecodeBounds = false
     opts.inSampleSize = scaleFactor
+    opts.inPreferredConfig = com.waz.zclient.utils.BitmapOptions.inPreferredConfig
 
     if (scaleFactor <= 1) {
       val resizingSuccessful = IoUtils.withResource(source()) { in =>
@@ -48,17 +49,16 @@ class AndroidImageRecoder extends ImageRecoder {
         if (success) IoUtils.withResource(target())(resized.compress(compressFormat, 75, _))
         success
       }
-      //TODO What should we do in this case?
-//      if (!resizingSuccessful) {
-//        IoUtils.withResources(source(), target())(IoUtils.copy)
-//      }
+      // if resizing failed we just copy the source to the target
+      if (!resizingSuccessful) {
+        IoUtils.withResources(source(), target())(IoUtils.copy)
+      }
     } else {
       IoUtils.withResources(source(), target()) { (in, out) =>
         val resized = BitmapFactory.decodeStream(in, null, opts)
         resized.compress(compressFormat, 75, out)
       }
     }
-
   }
 
 }

--- a/app/src/main/scala/com/waz/zclient/assets2/AndroidImageRecoder.scala
+++ b/app/src/main/scala/com/waz/zclient/assets2/AndroidImageRecoder.scala
@@ -20,15 +20,17 @@ package com.waz.zclient.assets2
 import java.io.{InputStream, OutputStream}
 
 import android.graphics.{Bitmap, BitmapFactory}
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.errors.FailedExpectationsError
 import com.waz.model.{Dim2, Mime}
 import com.waz.service.assets2.ImageRecoder
 import com.waz.utils.IoUtils
+import com.waz.zclient.log.LogUI._
 
-class AndroidImageRecoder extends ImageRecoder {
+class AndroidImageRecoder extends ImageRecoder with DerivedLogTag {
 
   override def recode(dim: Dim2, targetMime: Mime, scaleTo: Int, source: () => InputStream, target: () => OutputStream): Unit = {
-    val compressFormat = targetMime match {
+    lazy val compressFormat = targetMime match {
       case Mime.Image.Jpg => Bitmap.CompressFormat.JPEG
       case Mime.Image.Png => Bitmap.CompressFormat.PNG
       case mime => throw FailedExpectationsError(s"We do not expect $mime as target mime.")
@@ -36,29 +38,16 @@ class AndroidImageRecoder extends ImageRecoder {
 
     // Determine how much to scale down the image
     val scaleFactor = Math.max(dim.width / scaleTo, dim.height / scaleTo)
+    verbose(l"scaleFactor is $scaleFactor")
+    if (scaleFactor > 1) {
+      val opts = new BitmapFactory.Options()
+      opts.inJustDecodeBounds = false
+      opts.inSampleSize = scaleFactor
+      opts.inPreferredConfig = com.waz.zclient.utils.BitmapOptions.inPreferredConfig
 
-    val opts = new BitmapFactory.Options()
-    opts.inJustDecodeBounds = false
-    opts.inSampleSize = scaleFactor
-    opts.inPreferredConfig = com.waz.zclient.utils.BitmapOptions.inPreferredConfig
-
-    if (scaleFactor <= 1) {
-      val resizingSuccessful = IoUtils.withResource(source()) { in =>
-        val resized = BitmapFactory.decodeStream(in, null, opts)
-        val success = resized != null
-        if (success) IoUtils.withResource(target())(resized.compress(compressFormat, 75, _))
-        success
-      }
-      // if resizing failed we just copy the source to the target
-      if (!resizingSuccessful) {
-        IoUtils.withResources(source(), target())(IoUtils.copy)
-      }
-    } else {
-      IoUtils.withResources(source(), target()) { (in, out) =>
-        val resized = BitmapFactory.decodeStream(in, null, opts)
-        resized.compress(compressFormat, 75, out)
-      }
-    }
+      val resized = IoUtils.withResource(source()) { in => BitmapFactory.decodeStream(in, null, opts) }
+      IoUtils.withResource(target()) { out => resized.compress(compressFormat, 75, out) }
+    } else
+      IoUtils.copy(source(), target())
   }
-
 }

--- a/app/src/main/scala/com/waz/zclient/assets2/ImageCompressUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/assets2/ImageCompressUtils.scala
@@ -21,18 +21,22 @@ import java.io.ByteArrayOutputStream
 
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
+import com.waz.model.Mime
+import com.waz.service.assets2.Content
 
 object ImageCompressUtils {
 
-  def defaultCompressionQuality(format: CompressFormat): Int = format match {
+  private def defaultCompressionQuality(format: CompressFormat): Int = format match {
     case CompressFormat.JPEG => 75
     case _ => 50
   }
 
-  def compress(in: Bitmap, toFormat: CompressFormat, quality: Option[Int] = None): Array[Byte] = {
+  private def compress(in: Bitmap, toFormat: CompressFormat, quality: Option[Int] = None): Array[Byte] = {
     val out = new ByteArrayOutputStream()
     in.compress(toFormat, quality.getOrElse(defaultCompressionQuality(toFormat)), out)
     out.toByteArray
   }
 
+  def toJpg(bitmap: Bitmap): Content.Bytes =
+    Content.Bytes(Mime.Image.Jpg, compress(bitmap, CompressFormat.JPEG))
 }

--- a/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
@@ -235,12 +235,11 @@ class CameraFragment extends FragmentHelper
     showCameraFeed()
   }
 
-  override def onSketchOnPreviewPicture(content: Content, source: ImagePreviewLayout.Source, method: IDrawingController.DrawingMethod): Unit =
-    screenController.showSketch ! Sketch.cameraPreview(content)
+  override def onSketchOnPreviewPicture(image: Content, method: IDrawingController.DrawingMethod): Unit =
+    screenController.showSketch ! Sketch.cameraPreview(image)
 
-  override def onSendPictureFromPreview(content: Content, source: ImagePreviewLayout.Source): Unit = {
-    cameraController.onBitmapSelected(content, cameraContext)
-  }
+  override def onSendPictureFromPreview(image: Content): Unit =
+    cameraController.onBitmapSelected(image, cameraContext)
 
   private def showPreview(setImage: (ImagePreviewLayout) => Unit) = {
     hideCameraFeed()
@@ -285,7 +284,7 @@ class CameraFragment extends FragmentHelper
   private def processGalleryImage(uri: URI): Unit = {
     hideCameraFeed()
     if (cameraContext != CameraContext.SIGN_UP) previewProgressBar.foreach(_.setVisible(true))
-    showPreview { _.setImage(uri, ImagePreviewLayout.Source.Camera) }
+    showPreview { _.setImage(uri) }
   }
 }
 
@@ -299,5 +298,4 @@ object CameraFragment {
       bundle.putInt(CAMERA_CONTEXT, cameraContext.ordinal)
     })
   }
-
 }

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -22,7 +22,6 @@ import java.net.URI
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.Bitmap.CompressFormat
 import com.waz.api
 import com.waz.api.{IConversation, Verification}
 import com.waz.content.{ConversationStorage, MembersStorage, OtrClientsStorage, UsersStorage}
@@ -43,13 +42,14 @@ import com.waz.zclient.conversation.ConversationController.ConversationChange
 import com.waz.zclient.conversationlist.ConversationListController
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.utils.Callback
+import com.waz.zclient.utils.{Callback, currentRotation, rotate}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{Injectable, Injector, R}
 import org.threeten.bp.Instant
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.{Success, Try}
 
 class ConversationController(implicit injector: Injector, context: Context, ec: EventContext)
   extends Injectable with DerivedLogTag {
@@ -204,6 +204,23 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
         ui.sendAssetMessage(id, content, (s: Long) => showWifiWarningDialog(s, color), exp))
     )
 
+  // NOTE: Rotating makes sense only for images, but at this point we accept any content. If it's
+  // not an image, `currentRotation` will return 0 and the method will return the original content.
+  def rotateImageIfNeeded(image: Content): Future[Content] = {
+    def rotateIfNeeded(image: Content, path: String): Future[Try[Content]] = {
+      val rotation = currentRotation(path)
+      if (rotation == 0) Future.successful(Success(image))
+      // rotation and compression is time-consuming - better not to do it on the Ui thread
+      else Future { rotate(path, rotation).map(ImageCompressUtils.toJpg) }(Threading.Background)
+    }
+
+    (image match {
+      case Content.Uri(uri)      => rotateIfNeeded(image, uri.getPath)
+      case Content.File(_, file) => rotateIfNeeded(image, file.getPath)
+      case _                     => Future.successful(Success(image))
+    }).map(_.getOrElse(image))
+  }
+
   private def sendAssetMessage(convs:    Seq[ConvId],
                                content:  ContentForUpload,
                                activity: Activity,
@@ -216,12 +233,10 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
                }
     } yield msgs
 
-  def sendAssetMessage(bitmap: Bitmap, assetName: String): Future[Option[MessageData]] =
-    for {
-      image   <- Future { ImageCompressUtils.compress(bitmap, CompressFormat.JPEG) }
-      content =  ContentForUpload(assetName, Content.Bytes(Mime.Image.Jpg, image))
-      msg     <- convsUiwithCurrentConv((ui, id) => ui.sendAssetMessage(id, content))
-    } yield msg
+  def sendAssetMessage(bitmap: Bitmap, assetName: String): Future[Option[MessageData]] = {
+    val content = ContentForUpload(assetName, ImageCompressUtils.toJpg(bitmap))
+    convsUiwithCurrentConv((ui, id) => ui.sendAssetMessage(id, content))
+  }
 
   def sendAssetMessage(uri:      URI,
                        activity: Activity,

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -233,10 +233,12 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
                }
     } yield msgs
 
-  def sendAssetMessage(bitmap: Bitmap, assetName: String): Future[Option[MessageData]] = {
-    val content = ContentForUpload(assetName, ImageCompressUtils.toJpg(bitmap))
-    convsUiwithCurrentConv((ui, id) => ui.sendAssetMessage(id, content))
-  }
+  def sendAssetMessage(bitmap: Bitmap, assetName: String): Future[Option[MessageData]] =
+    for {
+      img     <- Future { ImageCompressUtils.toJpg(bitmap) }(Threading.Background)
+      content =  ContentForUpload(assetName, img)
+      data    <- convsUiwithCurrentConv((ui, id) => ui.sendAssetMessage(id, content))
+    } yield data
 
   def sendAssetMessage(uri:      URI,
                        activity: Activity,

--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -225,8 +225,11 @@ class ConversationManagerFragment extends FragmentHelper
 
   override def onBitmapSelected(content: Content, cameraContext: CameraContext): Unit =
     if (cameraContext == CameraContext.MESSAGE) {
-      inject[ConversationController].sendAssetMessage(ContentForUpload(s"photo_${AESKey().str}", content))
-      cameraController.closeCamera(CameraContext.MESSAGE)
+      val convController = inject[ConversationController]
+      convController.rotateImageIfNeeded(content).foreach { photo =>
+        convController.sendAssetMessage(ContentForUpload(s"photo_${AESKey().str}", photo))
+        cameraController.closeCamera(CameraContext.MESSAGE)
+      }
   }
 
   override def onOpenCamera(cameraContext: CameraContext): Unit =

--- a/app/src/main/scala/com/waz/zclient/utils/LocalThumbnailCache.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/LocalThumbnailCache.scala
@@ -17,22 +17,18 @@
  */
 package com.waz.zclient.utils
 
-import android.graphics.{BitmapFactory, Matrix}
-import android.support.media.ExifInterface
+import android.graphics.BitmapFactory
 import android.media.ThumbnailUtils
 import com.waz.utils.TrimmingLruCache.CacheSize
 import com.waz.utils.wrappers.{Bitmap, Context}
-import android.graphics.{Bitmap => AndroidBitmap}
 import com.waz.utils.{Cache, TrimmingLruCache, returning}
 import com.waz.zclient.utils.LocalThumbnailCache._
-
-import scala.util.Try
 
 class LocalThumbnailCache(lru: Cache[Thumbnail, Bitmap]) {
 
   def getOrCreate(thumbnail: Thumbnail): Bitmap = Option(lru.get(thumbnail)).getOrElse {
     returning {
-      val decodedBitmap = BitmapFactory.decodeFile(thumbnail.path, opts)
+      val decodedBitmap = BitmapFactory.decodeFile(thumbnail.path, BitmapOptions)
       Bitmap.fromAndroid(
         ThumbnailUtils.extractThumbnail(
           rotateIfNeeded(decodedBitmap, thumbnail.path).getOrElse(decodedBitmap),
@@ -45,29 +41,6 @@ class LocalThumbnailCache(lru: Cache[Thumbnail, Bitmap]) {
 }
 
 object LocalThumbnailCache {
-  private val opts = returning(new BitmapFactory.Options) {
-    _.inPreferredConfig = android.graphics.Bitmap.Config.RGB_565
-  }
-
-  //TODO Maybe this is not good place for this logic? Find a better place while assets refactoring
-  def rotateIfNeeded(bitmap: Bitmap, path: String): Try[AndroidBitmap] = Try {
-    val exif = new ExifInterface(path)
-    val currentRotation =
-      exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL) match {
-        case ExifInterface.ORIENTATION_ROTATE_90  => 90
-        case ExifInterface.ORIENTATION_ROTATE_180 => 180
-        case ExifInterface.ORIENTATION_ROTATE_270 => 270
-        case _                                    => 0
-      }
-
-    if (currentRotation == 0) bitmap
-    else {
-      val matrix = new Matrix()
-      matrix.postRotate(currentRotation)
-      AndroidBitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth, bitmap.getHeight, matrix, true)
-    }
-  }
-
   case class Thumbnail(path: String, width: Int, height: Int)
 
   def apply(context: Context) = new LocalThumbnailCache(

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -506,9 +506,10 @@ class ConversationFragment extends FragmentHelper {
         })
     }
 
-    override def onSketchOnPreviewPicture(input: Content, method: IDrawingController.DrawingMethod): Unit = {
-      screenController.showSketch ! Sketch.cameraPreview(input, method)
-      extendedCursorContainer.foreach(_.close(true))
+    override def onSketchOnPreviewPicture(input: Content, method: IDrawingController.DrawingMethod): Unit =
+      convController.rotateImageIfNeeded(input).foreach { preparedInput =>
+        screenController.showSketch ! Sketch.cameraPreview(preparedInput, method)
+        extendedCursorContainer.foreach(_.close(true))
     }
 
     override def onSendPictureFromPreview(image: Content): Unit =


### PR DESCRIPTION
fixes: https://wearezeta.atlassian.net/browse/AN-6328
SE part: https://github.com/wireapp/wire-android-sync-engine/pull/589

Some images have their rotation written in the Exif information, e.g. they may appear landscape,
width longer than height, but they should be displayed as a portrait. While sending image
as an asset in a conversation we lose that information.
Trying to maintain the Exif info (and then use it on the receiver side) would affect too much
code, so we chose an alternative approach: Before sending, we first check the Exif info. If the
image needs rotation, we make a rotated copy of it - which no longer requires Exif - and send
the copy. It makes the sending process slower, but only in a corner case.
