### PR TITLE
fix: Delay loading the current conversation for after the sync

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
@@ -77,7 +77,6 @@ class ConnectivityFragment extends Fragment with FragmentHelper with Connectivit
     (for {
       mode       <- network
       processing <- longProcess
-//      err        <- websocketError
     } yield (mode, processing)).onUi {
       case (NetworkMode.OFFLINE | NetworkMode.UNKNOWN, _) =>
         loadingIndicatorView.hide()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -65,7 +65,7 @@ class ConversationListController(implicit inj: Injector, ec: EventContext)
 
   lazy val establishedConversations = for {
     z          <- zms
-    convs      <- z.convsStorage.contents.throttle(ConvListUpdateThrottling )
+    convs      <- z.convsStorage.contents.throttle(ConvListUpdateThrottling)
   } yield convs.values.filter(EstablishedListFilter)
 
   lazy val regularConversationListData = conversationData(ConversationListAdapter.Normal)


### PR DESCRIPTION
When Wire is stopped and opened again, the initialization of the UI interferes with syncing of new events, e.g. the fist conversation contents are loaded, even though it's not immediately displayed to the user.
Making the initialization lighter is a big issue, but one thing that can be done easy is to delay that
loading of the first conversation to after the syncing is done.

Also, I removed some unused code.