### PR TITLE
Feature: app lock

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,6 +142,8 @@ android {
         buildConfigField 'String',  'HTTP_PROXY_PORT',               "\"$config.http_proxy_port\""
         buildConfigField 'boolean', 'BLOCK_ON_JAILBREAK_OR_ROOT',    "$config.block_on_jailbreak_or_root"
         buildConfigField 'boolean', 'FORCE_HIDE_SCREEN_CONTENT',     "$config.force_hide_screen_content"
+        buildConfigField 'boolean', 'FORCE_APP_LOCK',                "$config.force_app_lock"
+        buildConfigField 'Integer', 'APP_LOCK_TIMEOUT',              "$config.app_lock_timeout"
     }
 
     packagingOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2319"
+    zMessagingVersion = "142.0.2320"
     paging_version = "1.0.0"
 
     avsVersion = '5.1.186@aar'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,11 @@
             android:name=".security.SecureActivity"
             android:launchMode="singleTask"
             />
+
+        <activity
+            android:name=".security.AppLockActivity"
+            android:launchMode="singleTask" />
+
         <activity
             android:name="com.waz.zclient.calling.CallingActivity"
             android:hardwareAccelerated="true"

--- a/app/src/main/res/layout/preferences_options_layout.xml
+++ b/app/src/main/res/layout/preferences_options_layout.xml
@@ -138,6 +138,14 @@
                 />
 
             <com.waz.zclient.preferences.views.SwitchPreference
+                android:id="@+id/preferences_app_lock"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_options_app_lock_title"
+                app:subtitle="@string/pref_options_app_lock_summary"
+                />
+
+            <com.waz.zclient.preferences.views.SwitchPreference
                 android:id="@+id/preferences_hide_screen"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1354,6 +1354,11 @@
     <string name="read_receipts_remotely_disabled_title">You have disabled read receipts</string>
     <string name="read_receipts_remotely_changed_message">You can change this option in your account settings.</string>
     
+    <string name="app_lock_locked_title">Wire is locked due to inactivity</string>
+    <string name="app_lock_locked_message">Please enter your device credentials.</string>
+    <string name="app_lock_setup_dialog_messsage">To unlock Wire, set up a passphrase in your device settings.</string>
+    <string name="app_lock_setup_dialog_button">Open settings</string>
+    
     <!--TODO: remove after release 3.36-->
     <string name="android_4_warning_title">Wire 3.36 is the last version that can be installed on Android 4.</string>
     <string name="android_4_warning_message">To be able to install later versions, please update to Android 5 or higher.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -471,6 +471,8 @@
     <string name="pref_options_requested_category_title">By popular demand</string>
     <string name="pref_options_cursor_send_button_title">Send button</string>
     <string name="pref_options_cursor_send_button_summary">Disable to send via the keyboard.</string>
+    <string name="pref_options_app_lock_title">Lock with Passphrase</string>
+    <string name="pref_options_app_lock_summary">Lock Wire after %1$s seconds in the background. Unlock with Pin, Pattern, Password or Biometrics.</string>
 
     <!-- Devices -->
     <string name="pref_devices_screen_title">Devices</string>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -42,6 +42,7 @@ import com.waz.model.UserId
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.AndroidNotificationsManager
 import com.waz.zclient.utils.ContextUtils.getString
+import com.waz.content.GlobalPreferences.AppLockEnabled
 
 trait OptionsView {
   def setSounds(level: IntensityLevel): Unit
@@ -73,6 +74,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   val vibrationSwitch         = findById[SwitchPreference](R.id.preferences_vibration)
   val darkThemeSwitch         = findById[SwitchPreference](R.id.preferences_dark_theme)
   val sendButtonSwitch        = findById[SwitchPreference](R.id.preferences_send_button)
+  val appLockSwitch           = findById[SwitchPreference](R.id.preferences_app_lock)
   val soundsButton            = findById[TextButton](R.id.preferences_sounds)
   val downloadImagesSwitch    = findById[SwitchPreference](R.id.preferences_options_image_download)
   val hideScreenContentSwitch = findById[SwitchPreference](R.id.preferences_hide_screen)
@@ -96,16 +98,20 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   downloadImagesSwitch.setPreference(DownloadImagesAlways)
   hideScreenContentSwitch.setPreference(HideScreenContent)
   vbrSwitch.setPreference(VBREnabled)
-
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)
+
+  appLockSwitch.setPreference(AppLockEnabled)
+  appLockSwitch.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
+  appLockSwitch.setDisabled(BuildConfig.FORCE_APP_LOCK)
+  appLockSwitch.pref.foreach(_ := BuildConfig.FORCE_APP_LOCK)
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
     soundsButton.setVisible(false)
     vibrationSwitch.setTitle(getString(R.string.pref_options_vibration_title_o))
   }
 
-  if(BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
+  if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
     hideScreenContentSwitch.setDisabled(true)
     hideScreenContentSwitch.pref.foreach(_ := true)
   }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -101,10 +101,12 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)
 
-  appLockSwitch.setPreference(AppLockEnabled)
+  appLockSwitch.setPreference(AppLockEnabled, global = true)
   appLockSwitch.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
-  appLockSwitch.setDisabled(BuildConfig.FORCE_APP_LOCK)
-  appLockSwitch.pref.foreach(_ := BuildConfig.FORCE_APP_LOCK)
+
+  if (BuildConfig.FORCE_APP_LOCK) {
+    appLockSwitch.setVisibility(View.GONE)
+  }
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
     soundsButton.setVisible(false)

--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -76,7 +76,7 @@ class AppLockActivity extends AppCompatActivity with DerivedLogTag {
 
 object AppLockActivity extends DerivedLogTag {
 
-  val ConfirmDeviceCredentialsRequestCode = 1
+  final val ConfirmDeviceCredentialsRequestCode = 1
 
   private var timeEnteredBackground: Option[Instant] = Some(Instant.EPOCH)
 

--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -1,0 +1,87 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.security
+
+import java.util.Date
+
+import android.app.{Activity, AlertDialog, KeyguardManager}
+import android.content.{Context, DialogInterface, Intent}
+import android.provider.Settings
+import android.support.v7.app.AppCompatActivity
+import com.waz.zclient.{BuildConfig, R}
+
+class AppLockActivity extends AppCompatActivity {
+  import AppLockActivity._
+
+  private lazy val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE).asInstanceOf[KeyguardManager]
+
+  override def onStart(): Unit = {
+    super.onStart()
+
+    if (isDeviceSecure) showAuthenticationScreen()
+    else showSetupDialog()
+  }
+
+  private def isDeviceSecure: Boolean = keyguardManager.isKeyguardSecure
+
+  private def showAuthenticationScreen(): Unit = {
+    val (title, message) = (getString(R.string.app_lock_locked_title), getString(R.string.app_lock_locked_message))
+    val intent = keyguardManager.createConfirmDeviceCredentialIntent(title, message)
+    startActivityForResult(intent, ConfirmDeviceCredentialsRequestCode)
+  }
+
+  private def showSetupDialog(): Unit = {
+    val openSettingsAction = new DialogInterface.OnClickListener {
+      override def onClick(dialog: DialogInterface, which: Int): Unit = {
+        startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS))
+        finish()
+      }
+    }
+
+    new AlertDialog.Builder(this)
+      .setMessage(R.string.app_lock_setup_dialog_messsage)
+      .setPositiveButton(R.string.app_lock_setup_dialog_button, openSettingsAction)
+      .setCancelable(false)
+      .create()
+      .show()
+  }
+
+  override def onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Unit = {
+    super.onActivityResult(requestCode, resultCode, data)
+
+    if (requestCode == ConfirmDeviceCredentialsRequestCode) {
+      if (resultCode == Activity.RESULT_OK) {
+        dateOfLastUnlock = new Date()
+        finish()
+      }
+    }
+  }
+}
+
+object AppLockActivity {
+
+  val ConfirmDeviceCredentialsRequestCode = 1
+
+  private var dateOfLastUnlock = new Date(0)
+
+  def isAppLockExpired: Boolean = {
+    val now = new Date()
+    val secondsSinceLastUnlock = (now.getTime - dateOfLastUnlock.getTime) / 1000
+    secondsSinceLastUnlock >= BuildConfig.APP_LOCK_TIMEOUT
+  }
+}

--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -17,8 +17,6 @@
  */
 package com.waz.zclient.security
 
-import java.util.Date
-
 import android.app.{Activity, AlertDialog, KeyguardManager}
 import android.content.{Context, DialogInterface, Intent}
 import android.provider.Settings
@@ -26,6 +24,8 @@ import android.support.v7.app.AppCompatActivity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{BuildConfig, R}
+import org.threeten.bp.Instant
+import org.threeten.bp.temporal.ChronoUnit
 
 class AppLockActivity extends AppCompatActivity with DerivedLogTag {
   import AppLockActivity._
@@ -78,15 +78,15 @@ object AppLockActivity extends DerivedLogTag {
 
   val ConfirmDeviceCredentialsRequestCode = 1
 
-  private var timeEnteredBackground: Option[Date] = Some(new Date(0))
+  private var timeEnteredBackground: Option[Instant] = Some(Instant.EPOCH)
 
   def updateBackgroundEntryTimer(): Unit = {
-    timeEnteredBackground = Some(new Date())
+    timeEnteredBackground = Some(Instant.now())
   }
 
   def isAppLockExpired: Boolean = {
-    val now = new Date()
-    val secondsSinceEnteredBackground = (now.getTime - timeEnteredBackground.getOrElse(now).getTime) / 1000
+    val now = Instant.now()
+    val secondsSinceEnteredBackground = timeEnteredBackground.getOrElse(now).until(now, ChronoUnit.SECONDS)
     secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
   }
 }

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -20,21 +20,28 @@ package com.waz.zclient.security
 import android.content.{Context, Intent}
 import android.support.v7.app.AppCompatActivity
 import com.waz.content.GlobalPreferences
+import com.waz.content.GlobalPreferences.AppLockEnabled
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.Threading.Implicits.Ui
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
 import com.waz.zclient.{ActivityHelper, BuildConfig, R}
 
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
 
 class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
 
   private implicit val context: Context = this
 
+  private lazy val globalPreferences = inject[GlobalPreferences]
+
   override def onStart(): Unit = {
     super.onStart()
 
-    securityChecklist.run().foreach { _ =>
+    for {
+      _ <- securityChecklist.run()
+      shouldShowAppLock <- shouldShowAppLock
+    } yield {
       if (shouldShowAppLock) showAppLock()
     }
   }
@@ -48,8 +55,7 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
     val checksAndActions = new ListBuffer[(Check, List[Action])]()
 
     if (BuildConfig.BLOCK_ON_JAILBREAK_OR_ROOT) {
-      val preferences = inject[GlobalPreferences]
-      checksAndActions += RootDetectionCheck(preferences) -> List(
+      checksAndActions += RootDetectionCheck(globalPreferences) -> List(
         new WipeDataAction(),
         BlockWithDialogAction(R.string.root_detected_dialog_title, R.string.root_detected_dialog_message)
       )
@@ -58,9 +64,11 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
     new SecurityChecklist(checksAndActions.toList)
   }
 
-  private def shouldShowAppLock: Boolean = {
-    // TODO: Also read this from preferences
-      BuildConfig.FORCE_APP_LOCK && AppLockActivity.isAppLockExpired
+  private def shouldShowAppLock: Future[Boolean] = {
+    globalPreferences(AppLockEnabled).apply().map { preferenceEnabled =>
+      val appLockEnabled = preferenceEnabled || BuildConfig.FORCE_APP_LOCK
+      appLockEnabled && AppLockActivity.isAppLockExpired
+    }
   }
 
   private def showAppLock(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -17,9 +17,10 @@
  */
 package com.waz.zclient.security
 
-import android.content.Context
+import android.content.{Context, Intent}
 import android.support.v7.app.AppCompatActivity
 import com.waz.content.GlobalPreferences
+import com.waz.threading.Threading.Implicits.Ui
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
 import com.waz.zclient.{ActivityHelper, BuildConfig, R}
 
@@ -31,7 +32,9 @@ class SecureActivity extends AppCompatActivity with ActivityHelper {
 
   override def onStart(): Unit = {
     super.onStart()
-    securityChecklist.run()
+    securityChecklist.run().foreach { _ =>
+      if (shouldShowAppLock) showAppLock()
+    }
   }
 
   private def securityChecklist: SecurityChecklist = {
@@ -46,5 +49,15 @@ class SecureActivity extends AppCompatActivity with ActivityHelper {
     }
 
     new SecurityChecklist(checksAndActions.toList)
+  }
+
+  private def shouldShowAppLock: Boolean = {
+    // TODO: Also read this from preferences
+      BuildConfig.FORCE_APP_LOCK && AppLockActivity.isAppLockExpired
+  }
+
+  private def showAppLock(): Unit = {
+    val intent = new Intent(this, classOf[AppLockActivity])
+    startActivity(intent)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -20,21 +20,28 @@ package com.waz.zclient.security
 import android.content.{Context, Intent}
 import android.support.v7.app.AppCompatActivity
 import com.waz.content.GlobalPreferences
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.Threading.Implicits.Ui
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
 import com.waz.zclient.{ActivityHelper, BuildConfig, R}
 
 import scala.collection.mutable.ListBuffer
 
-class SecureActivity extends AppCompatActivity with ActivityHelper {
+class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
 
   private implicit val context: Context = this
 
   override def onStart(): Unit = {
     super.onStart()
+
     securityChecklist.run().foreach { _ =>
       if (shouldShowAppLock) showAppLock()
     }
+  }
+
+  override protected def onPause(): Unit = {
+    super.onPause()
+    AppLockActivity.updateBackgroundEntryTimer()
   }
 
   private def securityChecklist: SecurityChecklist = {

--- a/default.json
+++ b/default.json
@@ -32,6 +32,6 @@
   "http_proxy_port": "8888",
   "block_on_jailbreak_or_root": false,
   "force_hide_screen_content": true,
-  "force_app_lock": true,
+  "force_app_lock": false,
   "app_lock_timeout": 10
 }

--- a/default.json
+++ b/default.json
@@ -31,5 +31,7 @@
   "http_proxy_url": "none",
   "http_proxy_port": "8888",
   "block_on_jailbreak_or_root": false,
-  "force_hide_screen_content": true
+  "force_hide_screen_content": true,
+  "force_app_lock": true,
+  "app_lock_timeout": 10
 }


### PR DESCRIPTION
## What's new in this PR?

This PR includes changes relating to the App Lock. This is a feature where, in order to open the app, the user must authenticate using the device screen lock mechanism (pin, pattern, password etc). The user will only be prompted to unlock the app again if the app has been in the background for more than 10 seconds. 

This feature can be enabled in the options screen in the app settings, and it applies to the whole app (not for specific accounts).

For custom white label versions, this feature can be forced, and the timeout duration can be specified.
