### PR TITLE
Fix: app lock

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -94,7 +94,7 @@ object AppLockActivity extends DerivedLogTag {
   }
 
   private def updateLockState(): Unit = {
-    if (isAppLockExpired) isAppLocked = true
+    isAppLocked |= isAppLockExpired
   }
 
  private def isAppLockExpired: Boolean = {

--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -92,14 +92,13 @@ object AppLockActivity extends DerivedLogTag {
   def updateBackgroundEntryTimer(): Unit = {
     timeEnteredBackground = Some(Instant.now())
   }
-  
+
   private def updateLockState(): Unit = {
     if (isAppLockExpired) isAppLocked = true
   }
 
  private def isAppLockExpired: Boolean = {
-    val now = Instant.now()
-    val secondsSinceEnteredBackground = timeEnteredBackground.getOrElse(now).until(now, ChronoUnit.SECONDS)
-    secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
+   val secondsSinceEnteredBackground = timeEnteredBackground.fold(0L)(_.until(Instant.now(), ChronoUnit.SECONDS))
+   secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
   }
 }

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -46,8 +46,8 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
     }
   }
 
-  override protected def onPause(): Unit = {
-    super.onPause()
+  override def onStop(): Unit = {
+    super.onStop()
     AppLockActivity.updateBackgroundEntryTimer()
   }
 
@@ -67,7 +67,7 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
   private def shouldShowAppLock: Future[Boolean] = {
     globalPreferences(AppLockEnabled).apply().map { preferenceEnabled =>
       val appLockEnabled = preferenceEnabled || BuildConfig.FORCE_APP_LOCK
-      appLockEnabled && AppLockActivity.isAppLockExpired
+      appLockEnabled && AppLockActivity.needsAuthentication
     }
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app lock could be bypassed by simply closing the app from the credentials screen and reopening it.

### Causes

We keep track of the instant in time whenever the app is closed. When we reopen the app, we check to see if the time spent in the background was above a certain threshold, and if so,  we present the credentials screen. In this case, if we closed and opened the app within this timeout period, we would not show the credentials screen again as expected.

### Solutions

Clearly the background time alone is not sufficient to determine whether we should show the credentials screen. It necessary to add another flag `isAppLocked` which is only set to false when the user authenticates. It is set to true whenever the background time exceeds the threshold.