### PR TITLE
Do not force hiding screen contents in task switcher for default build

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,7 +31,7 @@
   "http_proxy_url": "none",
   "http_proxy_port": "8888",
   "block_on_jailbreak_or_root": false,
-  "force_hide_screen_content": true,
+  "force_hide_screen_content": false,
   "force_app_lock": false,
   "app_lock_timeout": 10
 }


### PR DESCRIPTION
["Hide Content" feature](https://wearezeta.atlassian.net/browse/AN-6323) has a side effect of preventing taking screenshots,
and this blocks Appium tests. We removed forcing the feature to let Appium take
screenshots in test builds.

## What's new in this PR?

### Issues

Cannot take screenshots of the app on Appium.

### Causes

 "Window.FLAG_SECURE" (added to hide app contents on task switcher) prevents taking screenshots.

### Solutions

Do not force content hiding feature.

### Testing

The feature is now fully depends on the user preference in _Settings > Options >Hide screen content_ switch.

