### PR TITLE
fix: Ephemeral assets are not displayed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.2320"
+    zMessagingVersion = "142.0.1024-PR"
     paging_version = "1.0.0"
 
     avsVersion = '5.1.186@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ ext {
     playServicesVersion = '15.0.1'
     audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
     stethoVersion = '1.5.0'
-    zMessagingVersion = "142.0.1024-PR"
+    zMessagingVersion = "142.0.2321"
     paging_version = "1.0.0"
 
     avsVersion = '5.1.186@aar'

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -59,7 +59,6 @@ trait MessageViewPart extends View {
   def set(msg: MessageAndLikes, part: Option[MessageContent], opts: Option[MsgBindOptions] = None): Unit =
     messageAndLikes.publish(msg, Threading.Ui)
 
-
   //By default disable clicks for all view types. There are fewer that need click functionality than those that don't
   this.onClick {}
   this.onLongClick(false)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
@@ -75,6 +75,8 @@ class ImagePartView(context: Context, attrs: AttributeSet, style: Int)
     }
   }
 
+  hideContent.onUi { hide => imageView.setVisible(!hide) }
+
   override def onInflated(): Unit = {}
 }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
@@ -38,7 +38,10 @@ class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int)
   private val controls = findById[View](R.id.controls)
   private val image = findById[ImageView](R.id.image)
 
-  hideContent.map(!_).on(Threading.Ui)(controls.setVisible)
+  hideContent.map(!_).onUi { visible =>
+    controls.setVisible(visible)
+    image.setVisible(visible)
+  }
 
   previewAssetId.onUi {
     case Some(aId) => WireGlide(context).load(aId).into(image)


### PR DESCRIPTION
With new assets the message data was enlarged with a new field, `assetId: Option[AssetId]`.
So, instead of looking through assets for those having the given messageId, we use the fact
that we display at most one asset per message and we can simply store its id in the message.
`MessageEventProcessor` was modified, so that now it looks for assets and sets `assetId` when
creating `MessageData`. However, that part was broken for ephemeral messages: if a message
was ephemeral and having an asset, it was recognized first as having an asset, but then
the code failed to set the asset's id, because the type of the event was invalid.

The fix is in SE: https://github.com/wireapp/wire-android-sync-engine/pull/593
In UI there's just a small fix enabling back obfuscation of assets when the time passed.