### PR TITLE
fix: add permission for ReferralBroadcastReceiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -214,6 +214,7 @@
         <receiver
             android:name=".broadcast.ReferralBroadcastReceiver"
             android:exported="true"
+            android:permission="android.permission.INSTALL_PACKAGES"
             tools:ignore="ExportedReceiver"
             >
             <intent-filter>


### PR DESCRIPTION
## What's new in this PR?

### Issues

 -  [AN-6316](https://wearezeta.atlassian.net/browse/AN-6316)
 - This commit adds a required permission for the sender of the `INSTALL_REFERRER` broadcast.
 - This was requested by an external security review.
 - The permission was found [here](https://developers.google.com/android/reference/com/google/android/gms/tagmanager/InstallReferrerReceiver) and the idea is that it helps ensure that only the Play Store can invoke `ReferralBroadcastReceiver`.
 - This feature can only be tested by downloading Wire from the Play Store after being invited, so it would have to be merged first, and then tested on an internal release.
 - This PR is a draft meant to start a discussion around potentially adding this permission.
#### APK
[Download build #66](http://10.10.124.11:8080/job/Pull%20Request%20Builder/66/artifact/build/artifact/wire-dev-PR2268-66.apk)