### PR TITLE
Implements the Wire password policy

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1373,5 +1373,5 @@
     <string name="security_policy_setup_dialog_message">Wire needs admin privileges to set security policies.</string>
     <string name="security_policy_setup_dialog_button">Open settings</string>
     <string name="security_policy_invalid_password_dialog_title">Password strength insufficient</string>
-    <string name="security_policy_invalid_password_dialog_message">Your phone must have a password with minimum %1$s characters, at least one each of digit, uppercase, lowercase, and special symbol.</string>
+    <string name="security_policy_invalid_password_dialog_message">Your device must have a password with minimum %1$s characters, at least one each of digit, uppercase, lowercase, and special symbol.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1373,6 +1373,5 @@
     <string name="security_policy_setup_dialog_message">Wire needs admin privileges to set security policies.</string>
     <string name="security_policy_setup_dialog_button">Open settings</string>
     <string name="security_policy_invalid_password_dialog_title">Password strength insufficient</string>
-    <string name="security_policy_invalid_password_dialog_message">Your device must have a password with minimum 12 characters.</string>
-
+    <string name="security_policy_invalid_password_dialog_message">Your phone must have a password with minimum %1$s characters, at least one each of digit, uppercase, lowercase, and special symbol.</string>
 </resources>

--- a/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
+++ b/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
@@ -52,8 +52,8 @@ class SecurityPolicyService
      PASSWORD_QUALITY_NUMERIC , PASSWORD_QUALITY_NUMERIC_COMPLEX, PASSWORD_QUALITY_ALPHABETIC,
      PASSWORD_QUALITY_ALPHANUMERIC, or PASSWORD_QUALITY_COMPLEX with setPasswordQuality(ComponentName, int)"
       **/
-    dpm.setPasswordQuality(secPolicy, DevicePolicyManager.PASSWORD_QUALITY_ALPHABETIC)
-    dpm.setPasswordMinimumLength(secPolicy, 12)
+    dpm.setPasswordQuality(secPolicy, DevicePolicyManager.PASSWORD_QUALITY_COMPLEX)
+    dpm.setPasswordMinimumLength(secPolicy, SecurityPolicyService.PasswordMinimumLength)
   }
 
   def isSecurityPolicyEnabled(implicit context: Context): Boolean = {
@@ -62,4 +62,8 @@ class SecurityPolicyService
   }
 
   def isPasswordCompliant(implicit context: Context): Boolean = getManager(context).isActivePasswordSufficient
+}
+
+object SecurityPolicyService {
+  val PasswordMinimumLength: Int = 8
 }

--- a/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
+++ b/app/src/main/scala/com/waz/services/SecurityPolicyService.scala
@@ -54,12 +54,13 @@ class SecurityPolicyService
       **/
     dpm.setPasswordQuality(secPolicy, DevicePolicyManager.PASSWORD_QUALITY_COMPLEX)
     dpm.setPasswordMinimumLength(secPolicy, SecurityPolicyService.PasswordMinimumLength)
+    dpm.setPasswordMinimumLetters(secPolicy, 2)
+    dpm.setPasswordMinimumUpperCase(secPolicy, 1)
+    dpm.setPasswordMinimumLowerCase(secPolicy, 1)
   }
 
-  def isSecurityPolicyEnabled(implicit context: Context): Boolean = {
-    val secPolicy = new ComponentName(context, classOf[SecurityPolicyService])
-    getManager(context).isAdminActive(secPolicy)
-  }
+  def isSecurityPolicyEnabled(implicit context: Context): Boolean =
+    getManager(context).isAdminActive(new ComponentName(context, classOf[SecurityPolicyService]))
 
   def isPasswordCompliant(implicit context: Context): Boolean = getManager(context).isActivePasswordSufficient
 }

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
+import android.support.v7.app.AppCompatActivity
 import android.view.WindowManager
 import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -37,7 +38,6 @@ import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.security.SecureActivity
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.ViewUtils
 
@@ -45,7 +45,7 @@ import scala.collection.breakOut
 import scala.collection.immutable.ListSet
 import scala.concurrent.duration._
 
-class BaseActivity extends SecureActivity
+class BaseActivity extends AppCompatActivity
   with ServiceContainer
   with ActivityHelper
   with PermissionProvider
@@ -53,10 +53,9 @@ class BaseActivity extends SecureActivity
 
   import BaseActivity._
 
-  lazy val themeController          = inject[ThemeController]
-  lazy val globalTrackingController = inject[GlobalTrackingController]
-  lazy val permissions              = inject[PermissionsService]
-  lazy val userPreferences          = inject[Signal[UserPreferences]]
+  protected lazy val themeController = inject[ThemeController]
+  protected lazy val permissions     = inject[PermissionsService]
+  protected lazy val userPreferences = inject[Signal[UserPreferences]]
 
   def injectJava[T](cls: Class[T]) = inject[T](reflect.Manifest.classType(cls), injector)
 
@@ -81,7 +80,6 @@ class BaseActivity extends SecureActivity
   }
 
   override protected def onResume(): Unit = {
-    verbose(l"onResume")
     super.onResume()
     onBaseActivityResume()
     setScreenContentHiding()
@@ -142,7 +140,7 @@ class BaseActivity extends SecureActivity
 
   override def onDestroy() = {
     verbose(l"onDestroy")
-    globalTrackingController.flushEvents()
+    inject[GlobalTrackingController].flushEvents()
     permissions.unregisterProvider(this)
     super.onDestroy()
   }

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -143,15 +143,15 @@ class MainActivity extends BaseActivity
 
     for {
       Some(self) <- userAccountsController.currentUser.head
-      teamName   <- self.teamId.fold(
-                      Future.successful(Option.empty[Name])
-                    )(teamId =>
-                      inject[TeamsStorage].get(teamId).map(_.map(_.name))
-                    )
-      prefs      <- userPreferences.head
+      teamName <- self.teamId.fold(
+        Future.successful(Option.empty[Name])
+      )(teamId =>
+        inject[TeamsStorage].get(teamId).map(_.map(_.name))
+      )
+      prefs <- userPreferences.head
       shouldWarn <- prefs(UserPreferences.ShouldWarnStatusNotifications).apply()
-      avVisible  <- usersController.availabilityVisible.head
-      color      <- accentColorController.accentColor.head
+      avVisible <- usersController.availabilityVisible.head
+      color <- accentColorController.accentColor.head
     } yield {
       (shouldWarn && avVisible, self.availability, teamName) match {
         case (true, Availability.Away, Some(name)) =>
@@ -180,9 +180,9 @@ class MainActivity extends BaseActivity
     val loadingIndicator = findViewById[LoadingIndicatorView](R.id.progress_spinner)
 
     spinnerController.spinnerShowing.onUi {
-      case Show(animation, forcedIsDarkTheme)=>
+      case Show(animation, forcedIsDarkTheme) =>
         themeController.darkThemeSet.head.foreach(theme => loadingIndicator.show(animation, forcedIsDarkTheme.getOrElse(theme), 300))(Threading.Ui)
-      case Hide(Some(message))=> loadingIndicator.hideWithMessage(message, 750)
+      case Hide(Some(message)) => loadingIndicator.hideWithMessage(message, 750)
       case Hide(_) => loadingIndicator.hide()
     }
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -21,11 +21,11 @@ import java.io.File
 import java.net.{InetSocketAddress, Proxy}
 import java.util.Calendar
 
-import android.app.{Activity, ActivityManager, NotificationManager}
+import android.app.{Activity, ActivityManager, Application, NotificationManager}
 import android.content.{Context, ContextWrapper}
 import android.hardware.SensorManager
 import android.media.AudioManager
-import android.os.{Build, PowerManager, Vibrator}
+import android.os.{Build, Bundle, PowerManager, Vibrator}
 import android.renderscript.RenderScript
 import android.support.multidex.MultiDexApplication
 import android.support.v4.app.{FragmentActivity, FragmentManager}
@@ -89,6 +89,7 @@ import com.waz.zclient.pages.main.conversationpager.controller.ISlidingPaneContr
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
+import com.waz.zclient.security.SecurityPolicyChecker
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
 import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendController, ExternalFileSharing, LocalThumbnailCache, UiStorage}
 import com.waz.zclient.views.DraftMap
@@ -269,6 +270,8 @@ object WireApplication extends DerivedLogTag {
 
     bind[MediaRecorderController] to new MediaRecorderControllerImpl(ctx)
 
+    bind[SecurityPolicyChecker] to new SecurityPolicyChecker()
+
     KotlinServices.INSTANCE.init(ctx)
   }
 
@@ -334,7 +337,7 @@ object WireApplication extends DerivedLogTag {
   }
 }
 
-class WireApplication extends MultiDexApplication with WireContext with Injectable {
+class WireApplication extends MultiDexApplication with WireContext with Injectable with Application.ActivityLifecycleCallbacks {
   type NetworkSignal = Signal[NetworkMode]
   import WireApplication._
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -382,6 +385,8 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     enableTLS12OnOldDevices()
 
     controllerFactory = new ControllerFactory(getApplicationContext)
+
+    registerActivityLifecycleCallbacks(this)
 
     ensureInitialized()
   }
@@ -486,5 +491,25 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
     super.onTerminate()
   }
+
+  private var activitiesStarted = 0
+
+  override def onActivityStarted(activity: Activity): Unit = synchronized {
+    activitiesStarted += 1
+    verbose(l"onActivityStarted, activities started now: $activitiesStarted")
+    if (activitiesStarted == 1) inject[SecurityPolicyChecker].run(activity)
+  }
+
+  override def onActivityStopped(activity: Activity): Unit = synchronized {
+    activitiesStarted -= 1
+    verbose(l"onActivityStopped, activities still started: $activitiesStarted")
+    if (activitiesStarted == 0) inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
+  }
+
+  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}
+  override def onActivityDestroyed(activity: Activity): Unit = {}
+  override def onActivityPaused(activity: Activity): Unit = {}
+  override def onActivityResumed(activity: Activity): Unit = {}
+  override def onActivitySaveInstanceState(activity: Activity, bundle: Bundle): Unit = {}
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -274,9 +274,9 @@ class NormalConversationFragment extends ConversationListFragment {
     }
 
     topToolbar.foreach { toolbar =>
-      subs += toolbar.onRightButtonClick(_ =>
+      subs += toolbar.onRightButtonClick { _ =>
         getActivity.startActivityForResult(PreferencesActivity.getDefaultIntent(getContext), PreferencesActivity.SwitchAccountCode)
-      )
+      }
     }
 
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -183,7 +183,6 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     downloadImagesSwitch.setSubtitle(if (wifiOnly) names.head else names.last)
   }
 
-
   override def setShareEnabled(enabled: Boolean) = contactsSwitch.setVisible(enabled)
 
   private def showPrefDialog(f: Fragment, tag: String) = {

--- a/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecureActivity.scala
@@ -86,10 +86,10 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
 
       val devicePasswordComplianceCheck = new DevicePasswordComplianceCheck(securityPolicyService)
       val devicePasswordComplianceActions =  List(
-        ShowDialogAction(
-          R.string.security_policy_invalid_password_dialog_title,
-          R.string.security_policy_invalid_password_dialog_message,
-          R.string.security_policy_setup_dialog_button,
+        new ShowDialogAction(
+          ContextUtils.getString(R.string.security_policy_invalid_password_dialog_title),
+          ContextUtils.getString(R.string.security_policy_invalid_password_dialog_message, SecurityPolicyService.PasswordMinimumLength.toString),
+          ContextUtils.getString(R.string.security_policy_setup_dialog_button),
           action = showSecuritySettings
         )
       )

--- a/app/src/main/scala/com/waz/zclient/security/SecurityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityLifecycleCallback.scala
@@ -1,0 +1,46 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.security
+
+import android.app.{Activity, Application}
+import android.os.Bundle
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.zclient.{Injectable, Injector}
+import com.waz.zclient.log.LogUI._
+
+class SecurityLifecycleCallback(implicit injector: Injector) extends Application.ActivityLifecycleCallbacks with Injectable with DerivedLogTag {
+  private var activitiesStarted = 0
+
+  override def onActivityStarted(activity: Activity): Unit = synchronized {
+    activitiesStarted += 1
+    verbose(l"onActivityStarted, activities started now: $activitiesStarted")
+    if (activitiesStarted == 1) inject[SecurityPolicyChecker].run(activity)
+  }
+
+  override def onActivityStopped(activity: Activity): Unit = synchronized {
+    activitiesStarted -= 1
+    verbose(l"onActivityStopped, activities still started: $activitiesStarted")
+    if (activitiesStarted == 0) inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
+  }
+
+  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}
+  override def onActivityDestroyed(activity: Activity): Unit = {}
+  override def onActivityPaused(activity: Activity): Unit = {}
+  override def onActivityResumed(activity: Activity): Unit = {}
+  override def onActivitySaveInstanceState(activity: Activity, bundle: Bundle): Unit = {}
+}

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -17,51 +17,49 @@
  */
 package com.waz.zclient.security
 
+import android.app.Activity
 import android.app.admin.DevicePolicyManager
 import android.content.{ComponentName, Context, Intent}
 import android.provider.Settings
-import android.support.v7.app.AppCompatActivity
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.AppLockEnabled
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.services.SecurityPolicyService
-import com.waz.threading.Threading.Implicits.Ui
+import com.waz.utils.events.Signal
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
 import com.waz.zclient.security.actions._
 import com.waz.zclient.security.checks._
 import com.waz.zclient.utils.ContextUtils
-import com.waz.zclient.{ActivityHelper, BuildConfig, R}
+import com.waz.zclient.{BuildConfig, Injectable, Injector, R}
+import com.waz.zclient.log.LogUI._
+import org.threeten.bp.Instant
+import org.threeten.bp.temporal.ChronoUnit
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 
-class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
-
-  private implicit val context: Context = this
+class SecurityPolicyChecker(implicit injector: Injector, context: Context) extends Injectable with DerivedLogTag {
+  import com.waz.threading.Threading.Implicits.Ui
 
   private lazy val securityPolicyService = inject[SecurityPolicyService]
-  private lazy val globalPreferences = inject[GlobalPreferences]
+  private lazy val globalPreferences     = inject[GlobalPreferences]
 
-  override def onStart(): Unit = {
-    super.onStart()
-
+  def run(activity: Activity): Unit = {
     for {
-      allChecksPassed <- securityChecklist.run()
-      shouldShowAppLock <- shouldShowAppLock if allChecksPassed
+      allChecksPassed  <- securityChecklist.run()
+      isAppLockEnabled <- if (allChecksPassed) appLockEnabled else Future.successful(false)
+      _ = verbose(l"all checks passed: $allChecksPassed, is app lock enabled: $isAppLockEnabled")
     } yield {
-      if (shouldShowAppLock) showAppLock()
+      if (isAppLockEnabled) authenticateIfNeeded(activity)
     }
   }
 
-  override def onStop(): Unit = {
-    super.onStop()
-    AppLockActivity.updateBackgroundEntryTimer()
-  }
-
   private def securityChecklist: SecurityChecklist = {
+    verbose(l"securityChecklist")
     val checksAndActions = new ListBuffer[(Check, List[Action])]()
 
     if (BuildConfig.BLOCK_ON_JAILBREAK_OR_ROOT) {
+      verbose(l"check BLOCK_ON_JAILBREAK_OR_ROOT")
       val rootDetectionCheck = RootDetectionCheck(globalPreferences)
       val rootDetectionActions = List(
         new WipeDataAction(),
@@ -72,6 +70,7 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
     }
 
     if (BuildConfig.BLOCK_ON_PASSWORD_POLICY) {
+      verbose(l"check BLOCK_ON_PASSWORD_POLICY")
       val deviceAdminCheck = new DeviceAdminCheck(securityPolicyService)
       val deviceAdminActions = List(
         ShowDialogAction(
@@ -97,33 +96,49 @@ class SecureActivity extends AppCompatActivity with ActivityHelper with DerivedL
       checksAndActions += devicePasswordComplianceCheck -> devicePasswordComplianceActions
     }
 
-
     new SecurityChecklist(checksAndActions.toList)
   }
 
   private def showDeviceAdminScreen(): Unit = {
-    val secPolicy = new ComponentName(this, classOf[SecurityPolicyService])
+    val secPolicy = new ComponentName(context, classOf[SecurityPolicyService])
     val intent = new android.content.Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
       .putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, secPolicy)
       .putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION, ContextUtils.getString(R.string.security_policy_description))
 
-    startActivity(intent)
+    context.startActivity(intent)
   }
 
-  private def showSecuritySettings(): Unit = {
-    val intent = new Intent(Settings.ACTION_SECURITY_SETTINGS)
-    startActivity(intent)
+  private def showSecuritySettings(): Unit =
+    context.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS))
+
+  def appLockEnabled: Future[Boolean] =
+    if (BuildConfig.FORCE_APP_LOCK) Future.successful(true) else globalPreferences(AppLockEnabled).apply()
+
+  private var timeEnteredBackground: Option[Instant] = Some(Instant.EPOCH) // this ensures asking for password when the app is first opened
+  val authenticationNeeded = Signal(false)
+
+  private def needsAuthentication: Boolean = {
+    val secondsSinceEnteredBackground = timeEnteredBackground.fold(0L)(_.until(Instant.now(), ChronoUnit.SECONDS))
+    verbose(l"timeEnteredBackground: $timeEnteredBackground, secondsSinceEnteredBackground: $secondsSinceEnteredBackground")
+    secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
   }
 
-  private def shouldShowAppLock: Future[Boolean] = {
-    globalPreferences(AppLockEnabled).apply().map { preferenceEnabled =>
-      val appLockEnabled = preferenceEnabled || BuildConfig.FORCE_APP_LOCK
-      appLockEnabled && AppLockActivity.needsAuthentication
+  def updateBackgroundEntryTimer(): Unit = timeEnteredBackground = Some(Instant.now())
+
+  def clearBackgroundEntryTimer(): Unit = {
+    timeEnteredBackground = None
+    authenticationNeeded ! false
+  }
+
+  def authenticateIfNeeded(parentActivity: Activity): Unit = {
+    authenticationNeeded.mutate {
+      case false if needsAuthentication => true
+      case b => b
     }
-  }
 
-  private def showAppLock(): Unit = {
-    val intent = new Intent(this, classOf[AppLockActivity])
-    startActivity(intent)
+    authenticationNeeded.head.foreach {
+      case true => parentActivity.startActivity(new Intent(parentActivity, classOf[AppLockActivity]))
+      case _ =>
+    }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -117,7 +117,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
   private var timeEnteredBackground: Option[Instant] = Some(Instant.EPOCH) // this ensures asking for password when the app is first opened
   val authenticationNeeded = Signal(false)
 
-  private def needsAuthentication: Boolean = {
+  private def timerExpired: Boolean = {
     val secondsSinceEnteredBackground = timeEnteredBackground.fold(0L)(_.until(Instant.now(), ChronoUnit.SECONDS))
     verbose(l"timeEnteredBackground: $timeEnteredBackground, secondsSinceEnteredBackground: $secondsSinceEnteredBackground")
     secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
@@ -132,7 +132,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
 
   def authenticateIfNeeded(parentActivity: Activity): Unit = {
     authenticationNeeded.mutate {
-      case false if needsAuthentication => true
+      case false if timerExpired => true
       case b => b
     }
 


### PR DESCRIPTION
https://github.com/wearezeta/documentation/blob/master/topics/security-policies/meetings/2019-08-25_001-android-password-policy.md

This PR also includes a fix: 
"Prevent the password screen from being displayed when the password was already provided"

When the app asks for the password, the control is given to Android - the app's MainActivity
is stopped, and then started again when the control goes back to the app. On `onStart`
we perform the check if the password is correct. But due to the unsure order of methods
being called when leaving and entering the app, it was possible to check for the password
validity *before* the information about it was received from Android. In that case,
the app displayed the password screen again.

Because of the same issue when the user displayed their profile the app treated that as if
it went into background and asked for the password when the user went back to the conversations
list.