### PR TITLE
Chore/android 4 cleanup

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1360,12 +1360,6 @@
     <string name="app_lock_locked_message">Please enter your device credentials.</string>
     <string name="app_lock_setup_dialog_messsage">To unlock Wire, set up a passphrase in your device settings.</string>
     <string name="app_lock_setup_dialog_button">Open settings</string>
-    
-    <!--TODO: remove after release 3.36-->
-    <string name="android_4_warning_title">Wire 3.36 is the last version that can be installed on Android 4.</string>
-    <string name="android_4_warning_message">To be able to install later versions, please update to Android 5 or higher.</string>
-    <string name="android_4_warning_action_ok">OK</string>
-    <string name="android_4_warning_action_dont_show_again">Don\'t show again</string>
 
     <string name="security_policy_title">Wire Security Policy</string>
     <string name="security_policy_description">Allow Wire to make your device more secure.</string>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -24,7 +24,7 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.{Color, Paint, PixelFormat}
 import android.os.{Build, Bundle}
 import android.support.v4.app.{Fragment, FragmentTransaction}
-import com.waz.content.{GlobalPreferences, TeamsStorage, UserPreferences}
+import com.waz.content.{TeamsStorage, UserPreferences}
 import com.waz.content.UserPreferences._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.UserData.ConnectionStatus.{apply => _}
@@ -140,9 +140,6 @@ class MainActivity extends BaseActivity
         startActivity(returning(new Intent(this, classOf[AppEntryActivity]))(_.setFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK)))
       case false =>
     }
-
-    // TODO: remove after release 3.36
-    warnAndroid4UsersIfNeeded()
 
     for {
       Some(self) <- userAccountsController.currentUser.head
@@ -531,30 +528,6 @@ class MainActivity extends BaseActivity
       .commit
 
   override def onUsernameSet(): Unit = replaceMainFragment(new MainPhoneFragment, MainPhoneFragment.Tag, addToBackStack = false)
-
-  // TODO: remove after release 3.36
-  def warnAndroid4UsersIfNeeded(): Unit = {
-    def showDialog(accentColor: AccentColor): Future[Boolean] = showConfirmationDialog(
-      getString(R.string.android_4_warning_title),
-      getString(R.string.android_4_warning_message),
-      R.string.android_4_warning_action_dont_show_again,
-      R.string.android_4_warning_action_ok,
-      accentColor)
-
-    val prefs = inject[GlobalPreferences]
-
-    for {
-      shouldWarn <- prefs(GlobalPreferences.ShouldWarnAndroid4Users).apply()
-      isAndroid4User = Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
-      color <- accentColorController.accentColor.head
-    } yield {
-      if (isAndroid4User && shouldWarn) {
-        showDialog(color).foreach { dontShowAgain =>
-          prefs(GlobalPreferences.ShouldWarnAndroid4Users) := !dontShowAgain
-        }
-      }
-    }
-  }
 }
 
 object MainActivity {

--- a/app/src/test/AndroidManifest.xml
+++ b/app/src/test/AndroidManifest.xml
@@ -19,7 +19,7 @@
 
 -->
 <manifest package="com.waz.zclient" xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:minSdkVersion="17" />`
+    <uses-sdk android:minSdkVersion="21" />`
     <application
         android:theme="@style/Theme.Light"/>
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
     compileSdkVersion = 27
     // When upgrading minimum sdk you might want to search for occurrences of Build.VERSION_CODES.
     // There are some classes with possibility of being simplified.
-    minSdkVersion = 17
+    minSdkVersion = 21
     targetSdkVersion = 27
 
     buildToolsVersion = '28.0.3'

--- a/testing_gallery/build.gradle
+++ b/testing_gallery/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "com.wire.testinggallery"
-        minSdkVersion 17
+        minSdkVersion 21
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
         versionName "6.1." + versionCode


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to remove support for Android 4.x devices so that the minimum supported API level will be 21.

### Testing

The app shouldn't be able to be installed on Android 4.x devices. Those devices also expected to not to see the new version of the app in the Play Store.

