### PR TITLE
fix: Make sure the AppLockActivity is not created from LaunchActivity

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -451,9 +451,13 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     inject[PreferencesController]
     Future(clearOldVideoFiles(getApplicationContext))(Threading.Background)
     Future(checkForPlayServices(prefs, googleApi))(Threading.Background)
-    
-    registerActivityLifecycleCallbacks(new SecurityLifecycleCallback())
+
+    // we're unable to check if the callback is already registered - we have to re-register it to be sure
+    unregisterActivityLifecycleCallbacks(securityCallback)
+    registerActivityLifecycleCallbacks(securityCallback)
   }
+
+  private lazy val securityCallback = new SecurityLifecycleCallback()
 
   private def parseProxy(url: String, port: String): Option[Proxy] = {
     val proxyHost = if(!url.equalsIgnoreCase("none")) Some(url) else None

--- a/app/src/main/scala/com/waz/zclient/security/SecurityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityLifecycleCallback.scala
@@ -20,22 +20,30 @@ package com.waz.zclient.security
 import android.app.{Activity, Application}
 import android.os.Bundle
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.zclient.{Injectable, Injector}
+import com.waz.zclient.{Injectable, Injector, LaunchActivity}
 import com.waz.zclient.log.LogUI._
 
 class SecurityLifecycleCallback(implicit injector: Injector) extends Application.ActivityLifecycleCallbacks with Injectable with DerivedLogTag {
   private var activitiesStarted = 0
 
   override def onActivityStarted(activity: Activity): Unit = synchronized {
-    activitiesStarted += 1
-    verbose(l"onActivityStarted, activities started now: $activitiesStarted")
-    if (activitiesStarted == 1) inject[SecurityPolicyChecker].run(activity)
+    activity match {
+      case _: LaunchActivity =>
+      case _ =>
+        activitiesStarted += 1
+        verbose(l"onActivityStarted, activities active now: $activitiesStarted, ${activity.getClass.getName}")
+        if (activitiesStarted == 1) inject[SecurityPolicyChecker].run(activity)
+    }
   }
 
   override def onActivityStopped(activity: Activity): Unit = synchronized {
-    activitiesStarted -= 1
-    verbose(l"onActivityStopped, activities still started: $activitiesStarted")
-    if (activitiesStarted == 0) inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
+    activity match {
+      case _: LaunchActivity =>
+      case _ =>
+        activitiesStarted -= 1
+        verbose(l"onActivityStopped, activities still active: $activitiesStarted, ${activity.getClass.getName}")
+        if (activitiesStarted == 0) inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
+    }
   }
 
   override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}


### PR DESCRIPTION
In order to ask for the Android password/PIN we have to start `AppLockActivity`. To do that, we need to provide a reference to the parent activity. Right now we do this by choosing whichever activity triggered the request to ask for the password/PIN. At the start of the application, that's `LaunchActivity`. `LaunchActivity` triggers `AppLockActivity`, but it also chooses to start `MainActivity` or `AppEntryActivity`, and then closes itself.
Depending on the device, the order in which these activities are started may differ. It may lead to the situation when Main- or AppEntryActivity goes on top of `AppLockActivity` and then freezes, because it's waiting for user authentication, which never comes, because `AppEntryActivity` is not on top.

The fix simply ignores `LaunchActivity`. We know for sure that just after `LaunchActivity` another activity will be started, and we can start `AppLockActivity` from that one, ensuring that it will always be on top.