### PR TITLE
fix: Ephemeral videos and audios were never deleted

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -43,7 +43,7 @@ import com.waz.service.assets2.Asset.{Audio, Video}
 import com.waz.service.assets2.{AssetStatus, _}
 import com.waz.service.messages.MessagesService
 import com.waz.threading.Threading
-import com.waz.utils.events.{EventContext, EventStream, Signal}
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.wrappers.{URI => URIWrapper}
 import com.waz.utils.{IoUtils, returning, sha2}
 import com.waz.zclient.controllers.singleimage.ISingleImageController
@@ -83,11 +83,6 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
   //TODO make a preference controller for handling UI preferences in conjunction with SE preferences
   val downloadsAlwaysEnabled =
     zms.flatMap(_.userPrefs.preference(DownloadImagesAlways).signal).disableAutowiring()
-
-  val onFileOpened = EventStream[AssetData]()
-  val onFileSaved = EventStream[AssetData]()
-  val onVideoPlayed = EventStream[AssetData]()
-  val onAudioPlayed = EventStream[AssetData]()
 
   messageActionsController.onMessageAction
     .collect { case (MessageAction.OpenFile, msg) => msg.assetId } {


### PR DESCRIPTION
In theory, ephemeral video and audio recordings need to be treated a bit differently from other assets: on the receiver's side they should be treated as "read" (and so, the expiration clock should start on them) only when they are played.
The old solution to it was quite complex it broke down after we switched to new assets. The bug was that the videos and audios were never treated as "read", so the clock never started.

This fix makes videos and audios work like any other asset. The delayed expiration issue will be addressed in another PR.

I also removed some unused code.