### PR TITLE
Fix: SQLite exception "too many variables"

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -303,7 +303,7 @@ class MessagesStorageImpl(context:     Context,
 
   private def deleteUnsentMessages(convId: ConvId)(implicit storage: DB): Unit = {
     val unsentMessages = MessageDataDao.listUnsentMsgs(convId)
-    MessageDataDao.iterating(unsentMessages).foreach(_.foreach(delete))
+    MessageDataDao.iteratingMultiple(unsentMessages).foreach(_.foreach(delete))
   }
 }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -318,10 +318,10 @@ object ConversationData {
       list(db.rawQuery(select + " " + handleCondition + teamCondition.map(qu => s" $qu").getOrElse(""), null))
     }
 
-    def findByTeams(teams: Set[TeamId])(implicit db: DB) = iterating(findInSet(Team, teams.map(Option(_))))
+    def findByTeams(teams: Set[TeamId])(implicit db: DB) = iteratingMultiple(findInSet(Team, teams.map(Option(_))))
 
     def findByRemoteId(remoteId: RConvId)(implicit db: DB) = iterating(find(RemoteId, remoteId))
-    def findByRemoteIds(remoteIds: Set[RConvId])(implicit db: DB) = iterating(findInSet(RemoteId, remoteIds))
+    def findByRemoteIds(remoteIds: Set[RConvId])(implicit db: DB) = iteratingMultiple(findInSet(RemoteId, remoteIds))
   }
 }
 
@@ -342,8 +342,8 @@ object ConversationMemberData {
     }
 
     def findForConv(convId: ConvId)(implicit db: DB) = iterating(find(ConvId, convId))
-    def findForConvs(convs: Set[ConvId])(implicit db: DB) = iterating(findInSet(ConvId, convs))
+    def findForConvs(convs: Set[ConvId])(implicit db: DB) = iteratingMultiple(findInSet(ConvId, convs))
     def findForUser(userId: UserId)(implicit db: DB) = iterating(find(UserId, userId))
-    def findForUsers(users: Set[UserId])(implicit db: DB) = iterating(findInSet(UserId, users))
+    def findForUsers(users: Set[UserId])(implicit db: DB) = iteratingMultiple(findInSet(UserId, users))
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ReadReceipt.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ReadReceipt.scala
@@ -39,6 +39,6 @@ object ReadReceipt {
     override def apply(implicit c:  DBCursor): ReadReceipt = ReadReceipt(Message, User, Timestamp)
 
     def findForMessage(message: MessageId)(implicit db: DB): Managed[Iterator[ReadReceipt]] = iterating(find(Message, message))
-    def findForMessages(messages: Set[MessageId])(implicit db: DB): Managed[Iterator[ReadReceipt]] = iterating(findInSet(Message, messages))
+    def findForMessages(messages: Set[MessageId])(implicit db: DB): Managed[Iterator[ReadReceipt]] = iteratingMultiple(findInSet(Message, messages))
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -248,9 +248,9 @@ object UserData {
 
     override def delete(id: UserId)(implicit db: DB): Int = db.delete(table.name, Id.name + "=?", Array(id.toString))
 
-    def findByConnectionStatus(status: Set[ConnectionStatus])(implicit db: DB): Managed[Iterator[UserData]] = iterating(findInSet(Conn, status))
+    def findByConnectionStatus(status: Set[ConnectionStatus])(implicit db: DB): Managed[Iterator[UserData]] = iteratingMultiple(findInSet(Conn, status))
 
-    def findAll(users: Set[UserId])(implicit db: DB) = iterating(findInSet(Id, users))
+    def findAll(users: Set[UserId])(implicit db: DB) = iteratingMultiple(findInSet(Id, users))
 
     def listContacts(implicit db: DB) = list(db.query(table.name, null, s"(${Conn.name} = ? or ${Conn.name} = ?) and ${Deleted.name} = 0", Array(ConnectionStatus.Accepted.code, ConnectionStatus.Blocked.code), null, null, null))
 
@@ -292,7 +292,7 @@ object UserData {
       list(db.rawQuery(select + " " + handleCondition + teamCondition.map(qu => s" $qu").getOrElse(""), null)).toSet
     }
 
-    def findForTeams(teams: Set[TeamId])(implicit db: DB) = iterating(findInSet(TeamId, teams.map(Option(_))))
+    def findForTeams(teams: Set[TeamId])(implicit db: DB) = iteratingMultiple(findInSet(TeamId, teams.map(Option(_))))
 
     def findService(integrationId: IntegrationId)(implicit db: DB) = iterating(find(IntegrationId, Some(integrationId)))
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/repository/FCMNotificationsRepository.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/repository/FCMNotificationsRepository.scala
@@ -56,7 +56,7 @@ class FCMNotificationsRepositoryImpl(implicit db: Database) extends FCMNotificat
   override def deleteAllWithId(id: Uid): Future[Unit] = db.apply(deleteEvery(everyStage.map((id, _)))(_))
 
   def exists(ids: Set[Uid]): Future[Set[Uid]] = db.read { implicit db =>
-    iterating(FCMNotificationsDao.findInSet(Id, ids)).acquire(_.map(_.id).toSet)
+    iteratingMultiple(FCMNotificationsDao.findInSet(Id, ids)).acquire(_.map(_.id).toSet)
   }
 
   override def trimExcessRows(): Future[Unit] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/Managed.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/Managed.scala
@@ -57,4 +57,5 @@ object Cleanup {
   val empty: Cleanup[Any] = create(_ => ())
 
   implicit lazy val CloseableCleanup: Cleanup[Closeable] = create(_.close())
+  implicit lazy val SeqCloseableCleanup: Cleanup[Seq[Closeable]] = create(_.foreach(_.close()))
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/BaseDaoSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/BaseDaoSpec.scala
@@ -1,0 +1,65 @@
+package com.waz.model
+
+import java.util.UUID.randomUUID
+
+import com.waz.DisabledTrackingService
+import com.waz.db.{BaseDao, Dao, DaoDB, Table, ZMessagingDB}
+import com.waz.utils.wrappers.{DB, DBCursor}
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FeatureSpec, Matchers, RobolectricTests}
+
+@RunWith(classOf[JUnitRunner])
+class BaseDaoSpec extends FeatureSpec with Matchers with RobolectricTests {
+
+  case class TestModel(id: Uid)
+
+  object TestDao extends Dao[TestModel, Uid] {
+    import com.waz.db.Col._
+    val Id = id[Uid]('_id, "PRIMARY KEY").apply(_.id)
+    override val idCol = Id
+    override val table: Table[TestModel] = Table("TestTable", Id)
+    override def apply(implicit c: DBCursor): TestModel = TestModel(Id)
+  }
+
+  def dummyData(size: Int): Seq[TestModel] = (0 until size).map(_ => TestModel(Uid()))
+
+  def withDB(f: DB => Unit): Unit = {
+    val dbHelper = new DaoDB(Robolectric.application, s"testDB-$randomUUID", null, 1, List(TestDao), List.empty, DisabledTrackingService)
+    try f(dbHelper.getWritableDatabase) finally dbHelper.close()
+  }
+
+  scenario("findInSet queries in batches") (withDB { implicit db =>
+    // Given
+    val numberOfRows = 1000
+    val data = dummyData(numberOfRows)
+
+    TestDao insertOrReplace data
+    TestDao.list.size shouldEqual numberOfRows
+
+    // When
+    val cursors = TestDao.findInSet(TestDao.Id, data.map(_.id).toSet)
+
+    // Then
+    cursors.size shouldEqual 2
+    cursors.map(_.getCount) shouldEqual List.fill(2)(BaseDao.MaxQueryVariables)
+  })
+
+  scenario("iterating over several cursors") (withDB { implicit db =>
+    // Given
+    val numberOfRows = 1200
+    val data = dummyData(numberOfRows)
+    val ids = data.map(_.id).toSet
+
+    TestDao insertOrReplace data
+    TestDao.list.size shouldEqual numberOfRows
+    
+    // When
+    val cursors = TestDao.findInSet(TestDao.Id, ids)
+    val result = TestDao.iteratingMultiple(cursors).acquire(_.map(_.id).toSet)
+
+    // Then
+    result shouldEqual ids
+  })
+}


### PR DESCRIPTION
## What's new in this PR?

This PR addresses a potential issue causing the processing of backend events to get stuck, resulting in missing messages.

### Issues

If the `BaseDao` method `findInSet(col:values:)` is invoked with a set containing more than ~999 elements, an SQLite exception is thrown, indicating there are too many variables in the query. Apparently Android limits the number of variables.

### Causes

The `findInSet` method will generate a query, inserting each element of the `values` set.

### Solutions

Instead of executing a single (enormous) query, we execute a batch of queries each with a limited number of variables. `findInSet` now returns a sequence of `DBCursor`, one for each of the queries executed. New iterator methods have been added to allow sequential iteration over multiple cursors. I have arbitrarily limited the number of query variables to 500.

### Testing

- test that a query that should return 1000 rows now returns two cursors each containing 500 rows.
- test that iterating over a sequence of cursors works