### PR TITLE
Remove `MaxPermSize` JVM parameter in tests

### DIFF
--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -24,7 +24,7 @@ android {
     testOptions {
         unitTests.all {
             forkEvery 1
-            jvmArgs "-Xmx4096M", "-XX:MaxPermSize=4096M", "-XX:+CMSClassUnloadingEnabled",
+            jvmArgs "-Xmx4096M", "-XX:+CMSClassUnloadingEnabled",
                 "-Djava.net.preferIPv4Stack=true", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n"
         }
     }


### PR DESCRIPTION
# What's new in this pull request?

Remove `MaxPermSize` JVM parameter in tests. OpenJDK does not support it, and we use OpenJVM on the build machine.

See the error:
```
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=4096M; support was removed in 8.0
```
