### PR TITLE
Disable FlowManager on emulator

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -62,19 +62,17 @@ class DefaultFlowManagerService(context:      Context,
     doWithFlowManager(_.networkChanged())
   }
 
-  lazy val flowManager: Option[FlowManager] = Try {
-    FlowManagerService.isEmulator match {
-      case true =>
-        warn(l"Emulator detected, skipping FlowManager initialization")
-        null
-      case _ =>
-        verbose(l"FlowManager initialization, detected PRODUCT ${Build.PRODUCT} MODEL ${Build.MODEL}")
-        val fm = new FlowManager(context, null, if (globalPrefs.getFromPref(AutoAnswerCallPrefKey)) avsAudioTestFlag else 0)
-        fm.addListener(flowListener)
-        fm
-    }
-
-  } .toOption
+  lazy val flowManager: Option[FlowManager] = if (FlowManagerService.isEmulator) {
+    warn(l"Emulator detected, skipping FlowManager initialization")
+    None
+  } else {
+    Try {
+      verbose(l"FlowManager initialization, detected non-emulator build")
+      val fm = new FlowManager(context, null, if (globalPrefs.getFromPref(AutoAnswerCallPrefKey)) avsAudioTestFlag else 0)
+      fm.addListener(flowListener)
+      fm
+    }.toOption
+  }
 
   private val flowListener = new FlowManagerListener {
     override def cameraFailed(): Unit = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -63,8 +63,8 @@ class DefaultFlowManagerService(context:      Context,
   }
 
   lazy val flowManager: Option[FlowManager] = Try {
-    Build.PRODUCT match {
-      case "sdk_gphone_x86" =>
+    FlowManagerService.isEmulator match {
+      case true =>
         warn(l"Emulator detected, skipping FlowManager initialization")
         null
       case _ =>
@@ -144,4 +144,14 @@ class DefaultFlowManagerService(context:      Context,
 
 object FlowManagerService {
   case class VideoCaptureDevice(id: String, name: String)
+
+  def isEmulator =
+    Build.FINGERPRINT.startsWith("generic") ||
+      Build.FINGERPRINT.startsWith("unknown") ||
+      Build.MODEL.contains("google_sdk") ||
+      Build.MODEL.contains("Emulator") ||
+      Build.MODEL.contains ("Android SDK built for x86") ||
+      Build.MANUFACTURER.contains ("Genymotion") ||
+      (Build.BRAND.startsWith ("generic") && Build.DEVICE.startsWith ("generic") ) ||
+      "google_sdk" == Build.PRODUCT
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.call
 
 import android.content.Context
+import android.os.Build
 import android.view.View
 import com.waz.log.LogSE._
 import com.waz.call._
@@ -62,9 +63,17 @@ class DefaultFlowManagerService(context:      Context,
   }
 
   lazy val flowManager: Option[FlowManager] = Try {
-    val fm = new FlowManager(context, null, if (globalPrefs.getFromPref(AutoAnswerCallPrefKey)) avsAudioTestFlag else 0)
-    fm.addListener(flowListener)
-    fm
+    Build.PRODUCT match {
+      case "sdk_gphone_x86" =>
+        warn(l"Emulator detected, skipping FlowManager initialization")
+        null
+      case _ =>
+        verbose(l"FlowManager initialization, detected PRODUCT ${Build.PRODUCT} MODEL ${Build.MODEL}")
+        val fm = new FlowManager(context, null, if (globalPrefs.getFromPref(AutoAnswerCallPrefKey)) avsAudioTestFlag else 0)
+        fm.addListener(flowListener)
+        fm
+    }
+
   } .toOption
 
   private val flowListener = new FlowManagerListener {


### PR DESCRIPTION
This is a temporary measure to allow QA to use emulator. Needed because AVS does not implement a specific function for x86 architecture, therefore starting the app on the emulator results in an error.
