### PR TITLE
Fix: security policies

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -66,10 +66,15 @@ class AppLockActivity extends AppCompatActivity with ActivityHelper with Derived
   override def onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Unit = {
     super.onActivityResult(requestCode, resultCode, data)
 
-    if (requestCode == ConfirmDeviceCredentialsRequestCode && resultCode == Activity.RESULT_OK) {
-      info(l"authentication successful")
-      inject[SecurityPolicyChecker].clearBackgroundEntryTimer()
-      finish()
+    if (requestCode == ConfirmDeviceCredentialsRequestCode) {
+      if (resultCode == Activity.RESULT_OK) {
+        info(l"authentication successful")
+        inject[SecurityPolicyChecker].clearBackgroundEntryTimer()
+        finish()
+      } else {
+        info(l"authentication cancelled. Representing authentication screen.")
+        showAuthenticationScreen()
+      }
     }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -19,26 +19,26 @@ package com.waz.zclient.security
 
 import android.app.Activity
 import android.app.admin.DevicePolicyManager
-import android.content.{ComponentName, Context, Intent}
+import android.content.{ComponentName, Intent}
 import android.provider.Settings
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.AppLockEnabled
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.services.SecurityPolicyService
 import com.waz.utils.events.Signal
+import com.waz.zclient.log.LogUI._
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
 import com.waz.zclient.security.actions._
 import com.waz.zclient.security.checks._
 import com.waz.zclient.utils.ContextUtils
 import com.waz.zclient.{BuildConfig, Injectable, Injector, R}
-import com.waz.zclient.log.LogUI._
 import org.threeten.bp.Instant
 import org.threeten.bp.temporal.ChronoUnit
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 
-class SecurityPolicyChecker(implicit injector: Injector, context: Context) extends Injectable with DerivedLogTag {
+class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Ui
 
   private lazy val securityPolicyService = inject[SecurityPolicyService]
@@ -46,7 +46,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
 
   def run(activity: Activity): Unit = {
     for {
-      allChecksPassed  <- securityChecklist.run()
+      allChecksPassed  <- securityChecklist(activity).run()
       isAppLockEnabled <- if (allChecksPassed) appLockEnabled else Future.successful(false)
       _ = verbose(l"all checks passed: $allChecksPassed, is app lock enabled: $isAppLockEnabled")
     } yield {
@@ -54,7 +54,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
     }
   }
 
-  private def securityChecklist: SecurityChecklist = {
+  private def securityChecklist(implicit parentActivity: Activity): SecurityChecklist = {
     verbose(l"securityChecklist")
     val checksAndActions = new ListBuffer[(Check, List[Action])]()
 
@@ -77,7 +77,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
           R.string.security_policy_setup_dialog_title,
           R.string.security_policy_setup_dialog_message,
           R.string.security_policy_setup_dialog_button,
-          action = showDeviceAdminScreen
+          action = { () => showDeviceAdminScreen(parentActivity) }
         )
       )
 
@@ -89,7 +89,7 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
           ContextUtils.getString(R.string.security_policy_invalid_password_dialog_title),
           ContextUtils.getString(R.string.security_policy_invalid_password_dialog_message, SecurityPolicyService.PasswordMinimumLength.toString),
           ContextUtils.getString(R.string.security_policy_setup_dialog_button),
-          action = showSecuritySettings
+          action = { () => showSecuritySettings(parentActivity) }
         )
       )
 
@@ -99,17 +99,17 @@ class SecurityPolicyChecker(implicit injector: Injector, context: Context) exten
     new SecurityChecklist(checksAndActions.toList)
   }
 
-  private def showDeviceAdminScreen(): Unit = {
-    val secPolicy = new ComponentName(context, classOf[SecurityPolicyService])
+  private def showDeviceAdminScreen(implicit parentActivity: Activity): Unit = {
+    val secPolicy = new ComponentName(parentActivity, classOf[SecurityPolicyService])
     val intent = new android.content.Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
       .putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, secPolicy)
       .putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION, ContextUtils.getString(R.string.security_policy_description))
 
-    context.startActivity(intent)
+    parentActivity.startActivity(intent)
   }
 
-  private def showSecuritySettings(): Unit =
-    context.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS))
+  private def showSecuritySettings(implicit parentActivity: Activity): Unit =
+    parentActivity.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS))
 
   def appLockEnabled: Future[Boolean] =
     if (BuildConfig.FORCE_APP_LOCK) Future.successful(true) else globalPreferences(AppLockEnabled).apply()

--- a/build.gradle
+++ b/build.gradle
@@ -112,22 +112,25 @@ class BuildtimeConfiguration {
 // Will check out custom repo, if any, and load its configuration, merging it on top of the default configuration
 def prepareCustomizationEnvironment() {
 
+    def properties = new Properties()
+    properties.load(project.rootProject.file("local.properties").newDataInputStream())
+
     def jsonReader = new JsonSlurper()
     def wireConfigFile = new File("$rootDir/default.json")
     def defaultConfig = jsonReader.parseText(wireConfigFile.text)
 
-    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: ''
+    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: properties.getProperty("CUSTOM_REPOSITORY") ?: ''
     if (customRepository.isEmpty()) {
         project.logger.quiet("This is not a custom build (no custom repo)")
         return new BuildtimeConfiguration(defaultConfig, null)
     }
 
-    def customFolder = System.getenv("CUSTOM_FOLDER") ?: ''
+    def customFolder = System.getenv("CUSTOM_FOLDER") ?: properties.getProperty("CUSTOM_FOLDER") ?: ''
     if(customFolder.isEmpty()) {
         throw new GradleException('Custom repo specified, but not custom folder')
     }
 
-    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: ''
+    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: properties.getProperty("GITHUB_API_TOKEN") ?: ''
     if (gitHubToken.isEmpty()) {
         throw new GradleException('Custom repo specified, but no GitHub API token provided')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -112,25 +112,22 @@ class BuildtimeConfiguration {
 // Will check out custom repo, if any, and load its configuration, merging it on top of the default configuration
 def prepareCustomizationEnvironment() {
 
-    def properties = new Properties()
-    properties.load(project.rootProject.file("local.properties").newDataInputStream())
-
     def jsonReader = new JsonSlurper()
     def wireConfigFile = new File("$rootDir/default.json")
     def defaultConfig = jsonReader.parseText(wireConfigFile.text)
 
-    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: properties.getProperty("CUSTOM_REPOSITORY") ?: ''
+    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: ''
     if (customRepository.isEmpty()) {
         project.logger.quiet("This is not a custom build (no custom repo)")
         return new BuildtimeConfiguration(defaultConfig, null)
     }
 
-    def customFolder = System.getenv("CUSTOM_FOLDER") ?: properties.getProperty("CUSTOM_FOLDER") ?: ''
+    def customFolder = System.getenv("CUSTOM_FOLDER") ?: ''
     if(customFolder.isEmpty()) {
         throw new GradleException('Custom repo specified, but not custom folder')
     }
 
-    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: properties.getProperty("GITHUB_API_TOKEN") ?: ''
+    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: ''
     if (gitHubToken.isEmpty()) {
         throw new GradleException('Custom repo specified, but no GitHub API token provided')
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The security checklist was behaving erroneously. This includes the application lock from being easily bypassed, as well as informative dialogs not being presented.

### Causes

The `SecurityChecklist` was initially created on demand, receiving an implicit `Context` with which it used to start new activities, show dialogs, and perform other actions. This class was recently wrapped into `SecurityPolicyChecker` which in created in `WireApplication` and injected whenever needed. Despite passing in an `Activity` reference when running the security checks, the implicit `Context` was still being used to create dialogs. It appear that the application context was not able to present dialogs.

The `SecurityPolicyChecker` is now injected and run in response to activity lifecycle callbacks,  this somehow broke the functionality where the application lock would be represented if the user tapped the back arrow or the cancel button.

### Solutions

Remove the old implicit `Context`, instead use the `Activity` passed in when the security checklist is run. This solves the dialog issue.

The bypassing of the application lock is solved by handling the negative activity result return from the credentials screen. In this case, we just represent the credential screen.
