### PR TITLE
Allow custom config loading using local properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ class BuildtimeConfiguration {
 def prepareCustomizationEnvironment() {
     def properties = new Properties()
     def localProperties = project.rootProject.file("local.properties")
+
     if (localProperties.exists()) {
         properties.load(localProperties.newDataInputStream())
     }

--- a/build.gradle
+++ b/build.gradle
@@ -112,22 +112,25 @@ class BuildtimeConfiguration {
 // Will check out custom repo, if any, and load its configuration, merging it on top of the default configuration
 def prepareCustomizationEnvironment() {
 
+    def properties = new Properties()
+    properties.load(project.rootProject.file("local.properties").newDataInputStream())
+
     def jsonReader = new JsonSlurper()
     def wireConfigFile = new File("$rootDir/default.json")
     def defaultConfig = jsonReader.parseText(wireConfigFile.text)
 
-    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: ''
+    def customRepository = System.getenv("CUSTOM_REPOSITORY") ?: properties.getProperty("CUSTOM_REPOSITORY") ?: ''
     if (customRepository.isEmpty()) {
         project.logger.quiet("This is not a custom build (no custom repo)")
         return new BuildtimeConfiguration(defaultConfig, null)
     }
 
-    def customFolder = System.getenv("CUSTOM_FOLDER") ?: ''
+    def customFolder = System.getenv("CUSTOM_FOLDER") ?: properties.getProperty("CUSTOM_FOLDER") ?: ''
     if(customFolder.isEmpty()) {
         throw new GradleException('Custom repo specified, but not custom folder')
     }
 
-    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: ''
+    def gitHubToken = System.getenv("GITHUB_API_TOKEN") ?: properties.getProperty("GITHUB_API_TOKEN") ?: ''
     if (gitHubToken.isEmpty()) {
         throw new GradleException('Custom repo specified, but no GitHub API token provided')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -111,9 +111,11 @@ class BuildtimeConfiguration {
 
 // Will check out custom repo, if any, and load its configuration, merging it on top of the default configuration
 def prepareCustomizationEnvironment() {
-
     def properties = new Properties()
-    properties.load(project.rootProject.file("local.properties").newDataInputStream())
+    def localProperties = project.rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        properties.load(localProperties.newDataInputStream())
+    }
 
     def jsonReader = new JsonSlurper()
     def wireConfigFile = new File("$rootDir/default.json")


### PR DESCRIPTION
## What's new in this PR?

Custom build configurations can now be loaded by setting environment variables within the `local.properties` file in the root directory.