### PR TITLE
[Fix] Invalid cookie

### DIFF
--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -30,9 +30,9 @@ import com.waz.services.ZMessagingService
 import com.waz.services.fcm.FCMHandlerService._
 import com.waz.threading.Threading
 import com.waz.utils.{JsonDecoder, RichInstant, Serialized}
+import com.waz.zclient.WireApplication
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.security._
-import com.waz.zclient.{Injectable, Injector, WireApplication}
 import org.json
 import org.threeten.bp.Instant
 
@@ -43,7 +43,7 @@ import scala.util.Try
 /**
   * For more information, see: https://firebase.google.com/docs/cloud-messaging/android/receive
   */
-class FCMHandlerService(implicit injector: Injector) extends FirebaseMessagingService with ZMessagingService with DerivedLogTag with Injectable {
+class FCMHandlerService extends FirebaseMessagingService with ZMessagingService with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
   lazy val pushSenderId = ZMessaging.currentGlobal.backend.pushSenderId
@@ -75,7 +75,7 @@ class FCMHandlerService(implicit injector: Injector) extends FirebaseMessagingSe
           warn(l"No ZMessaging global available - calling too early")
         case Some(globalModule) if !isSenderKnown(globalModule, remoteMessage.getFrom) =>
           warn(l"Received FCM notification from unknown sender: ${redactedString(remoteMessage.getFrom)}. Ignoring...")
-        case _ => inject[SecurityPolicyChecker].backgroundSecurityChecklist(context).run().foreach { allChecksPassed =>
+        case _ => SecurityPolicyChecker.backgroundSecurityChecklist(context).run().foreach { allChecksPassed =>
           if (allChecksPassed) {
             getTargetAccount(data) match {
               case None =>

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -31,7 +31,7 @@ import android.util.{AttributeSet, DisplayMetrics, TypedValue}
 import android.view.WindowManager
 import android.widget.Toast
 import com.waz.model.{AccentColor, Availability}
-import com.waz.service.AccountsService.{ClientDeleted, DataWiped, InvalidCookie, LogoutReason}
+import com.waz.service.AccountsService.{ClientDeleted, InvalidCookie, LogoutReason}
 import com.waz.utils.returning
 import com.waz.zclient.R
 import com.waz.zclient.appentry.DialogErrorMessage

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -318,7 +318,7 @@ object ContextUtils {
   }
 
   def showLogoutWarningIfNeeded(reason: LogoutReason)(implicit context: Context): Future[Unit] = {
-    if (reason == InvalidCookie || reason == ClientDeleted || reason == DataWiped) {
+    if (reason == InvalidCookie || reason == ClientDeleted) {
       showErrorDialog(R.string.invalid_cookie_dialog_title, R.string.invalid_cookie_dialog_message)
     } else {
       Future.successful(())


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. Fatal error when restarting the app.
2. The invalid cookie pop was sometimes being displayed when the user intentionally logged out.

### Causes

1. `FCMHanlderService` had a single argument constructor (an implicit `Injector`, used to inject the `SecurityPolicyChecker`). This class is initialized by the OS and therefore couldn't be constructed.
2. When the user logs out intentionally, we respond to this event with the reason `UserInitiated`. The cookie is now invalid, and if the build flag `wipe_on_cookie_invalid` is true, we will wipe the data for that account. This in turn will logout the user once more with the reason `DataWiped`, causing the alert to be shown.

### Solutions

1. Don't inject the `SecurityPolicyChecker`, instead use a static method.
2. Don't show the popup for the reason `DataWiped`, and additionally only logout if that user is not already.