### PR TITLE
Add ability to deflake tests on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ testui
 custom
 local_variables.sh
 /local.properties*
+failedTests.list
+failedTests.list.previous

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@
 #org.gradle.jvmargs=-XX:MaxPermSize=4g -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
 org.gradle.jvmargs=-XX:MaxPermSize=4g -Xmx5g -Xmx6144M
 
-# Enable to debug the daemon via port 8000
-# org.gradle.jvmargs=-XX:MaxPermSize=4g -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
+# This flag is needed to deflake. If you remove it, gradle will fail. We overwrite it when needed.
+wireDeflakeTests=0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,3 @@
 #org.gradle.parallel=true
 #org.gradle.jvmargs=-XX:MaxPermSize=4g -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
 org.gradle.jvmargs=-XX:MaxPermSize=4g -Xmx5g -Xmx6144M
-
-# This flag is needed to deflake. If you remove it, gradle will fail. We overwrite it when needed.
-wireDeflakeTests=0

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -1,9 +1,30 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jp.leafytree.android-scala'
 
+// Deflake
+def previouslyFailedTests = [].toSet()
+def failedTestsFile = new File("${projectDir}/failedTests.list")
+def failedTestsLogs = new File("${projectDir}/failedTests.list.previous")
+
+// Android
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+
+    // Load previous failed unit tests. This needs to be loaded before Android configuration is generated
+    // or tests will not be filtered out (they are filtered at configuration time)
+    if (failedTestsFile.exists()) {
+        failedTestsFile.eachLine { line ->
+            println "Found previously failed test: ${line}"
+            previouslyFailedTests.add(line.trim())
+        }
+
+        // copy for further analysis
+        failedTestsLogs.withWriter { writer ->
+            writer.write(failedTestsFile.text)
+        }
+        failedTestsFile.delete()
+    }
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -22,13 +43,39 @@ android {
     }
 
     testOptions {
+
         unitTests.all {
-            forkEvery 1
+
             jvmArgs "-Xmx4096M", "-XX:+CMSClassUnloadingEnabled",
                 "-Djava.net.preferIPv4Stack=true", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n"
+
+            test {
+
+                // Filter tests if deflaking
+                if (project.wireDeflakeTests == "1") { // use `-PwireDeflakeTests=1` from command line to enable this
+                    previouslyFailedTests.forEach {
+                        // After much trial-and-error, this seems to be the only way
+                        // to filter tests - hack the test class name.
+                        // It would have been better to use `inclideMatching`
+                        // but it's not supported by this plugin
+                        def testName = it.split("\\.").last()
+                        def testToRun = "**/*$testName*"
+                        println "Applying filter: ${testName}"
+                        include testToRun
+                    }
+                }
+            }
+
+            // Update failure state
+            afterTest { desc, result ->
+                if (result.resultType == TestResult.ResultType.FAILURE) {
+                    failedTestsFile.withWriterAppend {
+                        it.write("${desc.className}\n")
+                    }
+                }
+            }
         }
     }
-
 }
 
 repositories {
@@ -118,4 +165,10 @@ dependencies {
 
 }
 
-
+afterEvaluate {
+    // In order for the recording of failed tests (for deflake) to run reliably, we need
+    // to `cleanTest` or the `afterTest` block will be skipped for tests that did
+    // not change since last run
+    def unitTests = tasks.getByName("testDebugUnitTest")
+    unitTests.dependsOn("cleanTest")
+}

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -1,30 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jp.leafytree.android-scala'
-
-// Deflake
-def previouslyFailedTests = [].toSet()
-def failedTestsFile = new File("${projectDir}/failedTests.list")
-def failedTestsLogs = new File("${projectDir}/failedTests.list.previous")
+apply from: 'deflake.gradle'
 
 // Android
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
-
-    // Load previous failed unit tests. This needs to be loaded before Android configuration is generated
-    // or tests will not be filtered out (they are filtered at configuration time)
-    if (failedTestsFile.exists()) {
-        failedTestsFile.eachLine { line ->
-            println "Found previously failed test: ${line}"
-            previouslyFailedTests.add(line.trim())
-        }
-
-        // copy for further analysis
-        failedTestsLogs.withWriter { writer ->
-            writer.write(failedTestsFile.text)
-        }
-        failedTestsFile.delete()
-    }
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -48,32 +29,6 @@ android {
 
             jvmArgs "-Xmx4096M", "-XX:+CMSClassUnloadingEnabled",
                 "-Djava.net.preferIPv4Stack=true", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n"
-
-            test {
-
-                // Filter tests if deflaking
-                if (project.wireDeflakeTests == "1") { // use `-PwireDeflakeTests=1` from command line to enable this
-                    previouslyFailedTests.forEach {
-                        // After much trial-and-error, this seems to be the only way
-                        // to filter tests - hack the test class name.
-                        // It would have been better to use `inclideMatching`
-                        // but it's not supported by this plugin
-                        def testName = it.split("\\.").last()
-                        def testToRun = "**/*$testName*"
-                        println "Applying filter: ${testName}"
-                        include testToRun
-                    }
-                }
-            }
-
-            // Update failure state
-            afterTest { desc, result ->
-                if (result.resultType == TestResult.ResultType.FAILURE) {
-                    failedTestsFile.withWriterAppend {
-                        it.write("${desc.className}\n")
-                    }
-                }
-            }
         }
     }
 }
@@ -165,10 +120,3 @@ dependencies {
 
 }
 
-afterEvaluate {
-    // In order for the recording of failed tests (for deflake) to run reliably, we need
-    // to `cleanTest` or the `afterTest` block will be skipped for tests that did
-    // not change since last run
-    def unitTests = tasks.getByName("testDebugUnitTest")
-    unitTests.dependsOn("cleanTest")
-}

--- a/wire-android-sync-engine/zmessaging/deflake.gradle
+++ b/wire-android-sync-engine/zmessaging/deflake.gradle
@@ -43,8 +43,6 @@ android {
                 // Filter tests if deflaking
                 if (project.hasProperty('wireDeflakeTests')) { // use `-PwireDeflakeTests=1` from command line to enable this
 
-                    println "------------- APPLY FILTERS ${previouslyFailedTests}"
-
                     previouslyFailedTests.forEach {
                         // After much trial-and-error, this seems to be the only way
                         // to filter tests - hack the test class name.
@@ -60,7 +58,6 @@ android {
 
             // Update failure state
             afterTest { desc, result ->
-                println "Running test ${desc}....."
                 if (result.resultType == TestResult.ResultType.FAILURE) {
                     failedTestsFile.withWriterAppend {
                         it.write("${desc.className}\n")

--- a/wire-android-sync-engine/zmessaging/deflake.gradle
+++ b/wire-android-sync-engine/zmessaging/deflake.gradle
@@ -21,21 +21,6 @@ if (failedTestsFile.exists()) {
 
 android {
 
-    // Load previous failed unit tests. This needs to be loaded before Android configuration is generated
-    // or tests will not be filtered out (they are filtered at configuration time)
-    if (failedTestsFile.exists()) {
-        failedTestsFile.eachLine { line ->
-            println "Found previously failed test: ${line}"
-            previouslyFailedTests.add(line.trim())
-        }
-
-        // copy for further analysis
-        failedTestsLogs.withWriter { writer ->
-            writer.write(failedTestsFile.text)
-        }
-        failedTestsFile.delete()
-    }
-
     testOptions {
         unitTests.all {
             test {
@@ -46,7 +31,7 @@ android {
                     previouslyFailedTests.forEach {
                         // After much trial-and-error, this seems to be the only way
                         // to filter tests - hack the test class name.
-                        // It would have been better to use `inclideMatching`
+                        // It would have been better to use `includeMatching`
                         // but it's not supported by this plugin
                         def testName = it.split("\\.").last()
                         def testToRun = "**/*$testName*"

--- a/wire-android-sync-engine/zmessaging/deflake.gradle
+++ b/wire-android-sync-engine/zmessaging/deflake.gradle
@@ -1,0 +1,72 @@
+// Deflake
+def previouslyFailedTests = [].toSet()
+def failedTestsFile = new File("${projectDir}/failedTests.list")
+def failedTestsLogs = new File("${projectDir}/failedTests.list.previous")
+
+// Load previous failed unit tests. This needs to be loaded before Android configuration is generated
+// or tests will not be filtered out (they are filtered at configuration time)
+if (failedTestsFile.exists()) {
+    failedTestsFile.eachLine { line ->
+        println "Found previously failed test: ${line}"
+        previouslyFailedTests.add(line.trim())
+    }
+
+    // copy for further analysis
+    failedTestsLogs.withWriter { writer ->
+        writer.write(failedTestsFile.text)
+    }
+    failedTestsFile.delete()
+}
+
+
+android {
+
+    // Load previous failed unit tests. This needs to be loaded before Android configuration is generated
+    // or tests will not be filtered out (they are filtered at configuration time)
+    if (failedTestsFile.exists()) {
+        failedTestsFile.eachLine { line ->
+            println "Found previously failed test: ${line}"
+            previouslyFailedTests.add(line.trim())
+        }
+
+        // copy for further analysis
+        failedTestsLogs.withWriter { writer ->
+            writer.write(failedTestsFile.text)
+        }
+        failedTestsFile.delete()
+    }
+
+    testOptions {
+        unitTests.all {
+            test {
+
+                // Filter tests if deflaking
+                if (project.hasProperty('wireDeflakeTests')) { // use `-PwireDeflakeTests=1` from command line to enable this
+
+                    println "------------- APPLY FILTERS ${previouslyFailedTests}"
+
+                    previouslyFailedTests.forEach {
+                        // After much trial-and-error, this seems to be the only way
+                        // to filter tests - hack the test class name.
+                        // It would have been better to use `inclideMatching`
+                        // but it's not supported by this plugin
+                        def testName = it.split("\\.").last()
+                        def testToRun = "**/*$testName*"
+                        println "Applying filter: ${testName}"
+                        include testToRun
+                    }
+                }
+            }
+
+            // Update failure state
+            afterTest { desc, result ->
+                println "Running test ${desc}....."
+                if (result.resultType == TestResult.ResultType.FAILURE) {
+                    failedTestsFile.withWriterAppend {
+                        it.write("${desc.className}\n")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Add recording of failed tests to a local file. Tests can then be repeated by passing a property to gradle that will make it re-run only the tests that are mentioned in that file.

### Issues

We see that out of 600+ tests, some 2-3 fail at every run on CI (less than 1%). Tests seems to be flaky on CI due to timeouts. 

Re-running the entire test suite twice on CI would cause a separate random set of tests to fail also because of timeout, therefore failing again.

### Solutions

By re-running only the tests that failed (e.g. 2-3), the likelihood of those 2-3 tests failing again because of timeouts is very low, therefore allowing the CI build to finish.

### Notes

This also runs all tests on the same JVM, instead of forking one JVM per test. Forking was an attempt to avoid timeout issues, which was not working and overall slowing down the test execution.

#### APK
[Download build #60](http://10.10.124.11:8080/job/Pull%20Request%20Builder/60/artifact/build/artifact/wire-dev-PR2306-60.apk)
[Download build #61](http://10.10.124.11:8080/job/Pull%20Request%20Builder/61/artifact/build/artifact/wire-dev-PR2306-61.apk)
[Download build #62](http://10.10.124.11:8080/job/Pull%20Request%20Builder/62/artifact/build/artifact/wire-dev-PR2306-62.apk)