### PR TITLE
Feature: Switch to incognito keyboard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,7 @@ android {
         buildConfigField 'Integer', 'APP_LOCK_TIMEOUT',              "$buildtimeConfiguration.configuration.app_lock_timeout"
         buildConfigField 'boolean', 'BLOCK_ON_PASSWORD_POLICY',      "$buildtimeConfiguration.configuration.block_on_password_policy"
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
+        buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
     }
 
     packagingOptions {

--- a/app/src/main/java/com/waz/zclient/ui/utils/MathUtils.java
+++ b/app/src/main/java/com/waz/zclient/ui/utils/MathUtils.java
@@ -55,6 +55,6 @@ public class MathUtils {
         if((original & flag) != flag) { // the flag is not set
             return original;
         }
-        return original - flag;
+        return original & ~flag;
     }
 }

--- a/app/src/main/java/com/waz/zclient/ui/utils/MathUtils.java
+++ b/app/src/main/java/com/waz/zclient/ui/utils/MathUtils.java
@@ -39,4 +39,22 @@ public class MathUtils {
     public static boolean floatEqual(float val1, float val2) {
         return Float.compare(val2, val1) == 0;
     }
+
+    /**
+     * Removes the value of a binary flag from an original value if that flag was
+     * set, otherwise returns the original value
+     *
+     * E.g.
+     *      removeBinaryFlagIfSet(b'10101', b'100') -> b'10001'
+     *      removeBinaryFlagIfSet(b'10001', b'100') -> b'10001'
+     * @param original
+     * @param flag
+     * @return
+     */
+    public static int removeBinaryFlag(int original, int flag) {
+        if((original & flag) != flag) { // the flag is not set
+            return original;
+        }
+        return original - flag;
+    }
 }

--- a/app/src/main/res/layout/preferences_options_layout.xml
+++ b/app/src/main/res/layout/preferences_options_layout.xml
@@ -146,6 +146,14 @@
                 />
 
             <com.waz.zclient.preferences.views.SwitchPreference
+                android:id="@+id/preferences_incognito_keyboard"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_options_incognito_keyboard"
+                app:subtitle="@string/pref_options_incognito_keyboard_summary"
+                />
+
+            <com.waz.zclient.preferences.views.SwitchPreference
                 android:id="@+id/preferences_hide_screen"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,6 +475,8 @@
     <string name="pref_options_message_previews_summary">Display message content in notifications.</string>
     <string name="pref_options_app_lock_title">Lock with Passphrase</string>
     <string name="pref_options_app_lock_summary">Lock Wire after %1$s seconds in the background. Unlock with Pin, Pattern, Password or Biometrics.</string>
+    <string name="pref_options_incognito_keyboard">Incognito keyboard</string>
+    <string name="pref_options_incognito_keyboard_summary">The keyboard will not show suggestions when composing messages</string>
 
     <!-- Devices -->
     <string name="pref_devices_screen_title">Devices</string>

--- a/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
@@ -28,7 +28,6 @@ import android.widget.TextView.OnEditorActionListener
 import android.widget.{LinearLayout, ProgressBar, TextView}
 import com.waz.model.EmailAddress
 import com.waz.threading.Threading
-import com.waz.threading.Threading.Implicits.Ui
 import com.waz.utils.events.{Signal, SourceSignal}
 import com.waz.zclient.common.views.InputBox._
 import com.waz.zclient.common.views.TextViewHelpers.TextViewFlagsImprovement

--- a/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
@@ -28,8 +28,10 @@ import android.widget.TextView.OnEditorActionListener
 import android.widget.{LinearLayout, ProgressBar, TextView}
 import com.waz.model.EmailAddress
 import com.waz.threading.Threading
+import com.waz.threading.Threading.Implicits.Ui
 import com.waz.utils.events.{Signal, SourceSignal}
 import com.waz.zclient.common.views.InputBox._
+import com.waz.zclient.common.views.TextViewHelpers.TextViewFlagsImprovement
 import com.waz.zclient.ui.cursor.CursorEditText
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.utils.TextViewUtils
@@ -84,6 +86,8 @@ class InputBox(context: Context, attrs: AttributeSet, style: Int) extends Linear
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
     progressBar.setIndeterminateTintList(ColorStateList.valueOf(ContextUtils.getColor(R.color.teams_inactive_button)))
   editText.setImeOptions(EditorInfo.IME_ACTION_DONE)
+
+  editText.setPrivateModeFromPreferences()
 
   editText.setOnEditorActionListener(new OnEditorActionListener {
     override def onEditorAction(v: TextView, actionId: Int, event: KeyEvent): Boolean = {

--- a/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
@@ -26,7 +26,6 @@ import com.waz.utils.events.EventContext
 import com.waz.zclient.BuildConfig
 import com.waz.zclient.ui.utils.MathUtils
 
-import scala.concurrent.ExecutionContext
 
 /**
   * Utilities related to input fields
@@ -90,8 +89,8 @@ object TextViewHelpers {
     /**
       * Set incognito/suggestion mode on/off according to preferences
       */
-    def setPrivateModeFromPreferences()(implicit ec: EventContext, xc: ExecutionContext): Unit = {
-
+    def setPrivateModeFromPreferences(implicit eventContext: EventContext): Unit = {
+      import com.waz.threading.Threading.Implicits.Ui
       // If hardcoded by configuration, just turn it on
       if(BuildConfig.FORCE_PRIVATE_KEYBOARD) {
         textView.setPrivateMode(true)

--- a/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
@@ -74,11 +74,15 @@ object TextViewHelpers {
       */
     def setPrivateMode(on: Boolean): Unit = {
       if(on) {
-        textView.addImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
         textView.addInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+        // this disables autocomplete because it implies that you will provide your
+        // own autocomplete facility. We don't, so no autocomplete is shown
+        textView.addInputType(InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE)
+        textView.addImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
       } else {
-        textView.removeImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
         textView.removeInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+        textView.removeInputType(InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE)
+        textView.removeImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
       }
     }
 

--- a/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
@@ -1,0 +1,101 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.common.views
+
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
+import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
+import com.waz.service.ZMessaging
+import com.waz.utils.events.EventContext
+import com.waz.zclient.ui.utils.MathUtils
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Utilities related to input fields
+  */
+object TextViewHelpers {
+
+  implicit class TextViewFlagsImprovement(textView: TextView) {
+
+    /**
+      * Add an ime option to the existing options
+      * @param option
+      */
+    def addImeOption(option: Int): Unit = {
+      textView.setImeOptions(textView.getImeOptions() | option)
+    }
+
+    /**
+      * Remove an ime option from the existing options, if present
+      * @param option
+      */
+    def removeImeOption(option: Int): Unit = {
+      textView.setImeOptions(MathUtils.removeBinaryFlag(textView.getImeOptions(), option))
+    }
+
+    /**
+      * Add an input type to the existing input types
+      * @param inputType
+      */
+    def addInputType(inputType: Int): Unit = {
+      textView.setInputType(textView.getInputType() | inputType)
+    }
+
+    /**
+      * Remove an input type from the existing input types, if present
+      * @param inputType
+      */
+    def removeInputType(inputType: Int): Unit = {
+      textView.setInputType(MathUtils.removeBinaryFlag(textView.getInputType(), inputType))
+    }
+
+    /**
+      * Enable or disable private mode and suggestions on the field
+      * - If enabled, enables incognito mode and disables suggestions
+      * - If disabled, disables incognito mode and enables suggestions
+      * @param on true if private mode should be switched on, false if it should be switched off
+      */
+    def setPrivateMode(on: Boolean): Unit = {
+      if(on) {
+        textView.addImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
+        textView.addInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+      } else {
+        textView.removeImeOption(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
+        textView.removeInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+      }
+    }
+
+    /**
+      * Set incognito/suggestion mode on/off according to preferences
+      */
+    def setPrivateModeFromPreferences()(implicit ec: EventContext, xc: ExecutionContext): Unit = {
+      for {
+        globalModule <- ZMessaging.globalModule
+        prefs = globalModule.prefs
+        settingSignal = prefs(IncognitoKeyboardEnabled).signal
+      } yield {
+        settingSignal.onUi { v =>
+          textView.setPrivateMode(v)
+        }
+      }
+    }
+  }
+}
+

--- a/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
@@ -89,7 +89,7 @@ object TextViewHelpers {
     /**
       * Set incognito/suggestion mode on/off according to preferences
       */
-    def setPrivateModeFromPreferences(implicit eventContext: EventContext): Unit = {
+    def setPrivateModeFromPreferences()(implicit eventContext: EventContext): Unit = {
       import com.waz.threading.Threading.Implicits.Ui
       // If hardcoded by configuration, just turn it on
       if(BuildConfig.FORCE_PRIVATE_KEYBOARD) {

--- a/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TextViewHelpers.scala
@@ -23,6 +23,7 @@ import android.widget.TextView
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
 import com.waz.service.ZMessaging
 import com.waz.utils.events.EventContext
+import com.waz.zclient.BuildConfig
 import com.waz.zclient.ui.utils.MathUtils
 
 import scala.concurrent.ExecutionContext
@@ -90,6 +91,14 @@ object TextViewHelpers {
       * Set incognito/suggestion mode on/off according to preferences
       */
     def setPrivateModeFromPreferences()(implicit ec: EventContext, xc: ExecutionContext): Unit = {
+
+      // If hardcoded by configuration, just turn it on
+      if(BuildConfig.FORCE_PRIVATE_KEYBOARD) {
+        textView.setPrivateMode(true)
+        return
+      }
+
+      // else read from user preferences
       for {
         globalModule <- ZMessaging.globalModule
         prefs = globalModule.prefs

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -35,6 +35,7 @@ import com.waz.threading.Threading
 import com.waz.utils.events.{Signal, SourceSignal}
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController
+import com.waz.zclient.common.views.TextViewHelpers.TextViewFlagsImprovement
 import com.waz.zclient.controllers.globallayout.IGlobalLayoutController
 import com.waz.zclient.conversation.{ConversationController, ReplyController}
 import com.waz.zclient.cursor.CursorController.{EnteredTextSource, KeyboardState}
@@ -271,8 +272,14 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
 
   cursorEditText.setFocusableInTouchMode(true)
 
+  cursorEditText.setPrivateModeFromPreferences()
+
   controller.sendButtonEnabled.onUi { enabled =>
-    cursorEditText.setImeOptions(if (enabled) EditorInfo.IME_ACTION_NONE else EditorInfo.IME_ACTION_SEND)
+    if (enabled) {
+      cursorEditText.addImeOption(EditorInfo.IME_ACTION_SEND)
+    } else {
+      cursorEditText.removeImeOption(EditorInfo.IME_ACTION_SEND)
+    }
   }
 
   accentColor.map(_.color).onUi(cursorEditText.setAccentColor)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -110,6 +110,10 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     appLockSwitch.setVisibility(View.GONE)
   }
 
+  if (BuildConfig.FORCE_PRIVATE_KEYBOARD) {
+    appLockSwitch.setVisibility(View.GONE)
+  }
+
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
     soundsButton.setVisible(false)
     vibrationSwitch.setTitle(getString(R.string.pref_options_vibration_title_o))

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -42,7 +42,7 @@ import com.waz.model.UserId
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.AndroidNotificationsManager
 import com.waz.zclient.utils.ContextUtils.getString
-import com.waz.content.GlobalPreferences.AppLockEnabled
+import com.waz.content.GlobalPreferences.{AppLockEnabled, IncognitoKeyboardEnabled}
 
 trait OptionsView {
   def setSounds(level: IntensityLevel): Unit
@@ -79,6 +79,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   val downloadImagesSwitch    = findById[SwitchPreference](R.id.preferences_options_image_download)
   val hideScreenContentSwitch = findById[SwitchPreference](R.id.preferences_hide_screen)
   val messagePreviewSwitch = findById[SwitchPreference](R.id.preferences_message_previews)
+  val incognitoKeyboardSwitch = findById[SwitchPreference](R.id.preferences_incognito_keyboard)
 
   val ringToneButton         = findById[TextButton](R.id.preference_sounds_ringtone)
   val textToneButton         = findById[TextButton](R.id.preference_sounds_text)
@@ -110,8 +111,10 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     appLockSwitch.setVisibility(View.GONE)
   }
 
+
+  incognitoKeyboardSwitch.setPreference(IncognitoKeyboardEnabled, global = true)
   if (BuildConfig.FORCE_PRIVATE_KEYBOARD) {
-    appLockSwitch.setVisibility(View.GONE)
+    incognitoKeyboardSwitch.setVisibility(View.GONE)
   }
 
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
+++ b/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
@@ -1,0 +1,52 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.ui.utils
+
+import org.junit.Assert._
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+
+class MathUtilsTest extends JUnitSuite {
+
+  def bin(text: String): Int = {
+    return Integer.parseInt(text, 2)
+  }
+
+  @Test
+  def testRemoveBinaryFlag(): Unit = {
+    // flag is present
+    assertEquals(MathUtils.removeBinaryFlag(bin("10101"), bin("100")), bin("10001"))
+    assertEquals(MathUtils.removeBinaryFlag(bin("11111"), bin("101")), bin("11010"))
+    // flag is not present (flag is larger than number)
+    assertEquals(MathUtils.removeBinaryFlag(bin("00001"), bin("100")), bin("00001"))
+    assertEquals(MathUtils.removeBinaryFlag(bin("00011"), bin("101")), bin("00011"))
+    // flag is not present (flag is smaller than number)
+    assertEquals(MathUtils.removeBinaryFlag(bin("10001"), bin("100")), bin("10001"))
+    // flag is null
+    assertEquals(MathUtils.removeBinaryFlag(bin("10101"), bin("000")), bin("10101"))
+    // value is null
+    assertEquals(MathUtils.removeBinaryFlag(bin("00000"), bin("000")), bin("00000"))
+    assertEquals(MathUtils.removeBinaryFlag(bin("00000"), bin("111")), bin("00000"))
+  }
+
+
+}
+
+object MathUtilsTest {
+  type Block = () => Unit
+}

--- a/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
+++ b/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
@@ -20,12 +20,9 @@ package com.waz.zclient.ui.utils
 import org.junit.Assert._
 import org.junit.Test
 import org.scalatest.junit.JUnitSuite
+import MathUtilsTest.binary
 
 class MathUtilsTest extends JUnitSuite {
-
-  def binary(text: String): Int = {
-    return Integer.parseInt(text, 2)
-  }
 
   @Test
   def testRemoveBinaryFlag_flagIsPresent(): Unit = {
@@ -60,5 +57,8 @@ class MathUtilsTest extends JUnitSuite {
 }
 
 object MathUtilsTest {
+  def binary(text: String): Int = {
+    return Integer.parseInt(text, 2)
+  }
   type Block = () => Unit
 }

--- a/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
+++ b/app/src/test/scala/com/waz/zclient/ui/utils/MathUtilsTest.scala
@@ -23,26 +23,38 @@ import org.scalatest.junit.JUnitSuite
 
 class MathUtilsTest extends JUnitSuite {
 
-  def bin(text: String): Int = {
+  def binary(text: String): Int = {
     return Integer.parseInt(text, 2)
   }
 
   @Test
-  def testRemoveBinaryFlag(): Unit = {
-    // flag is present
-    assertEquals(MathUtils.removeBinaryFlag(bin("10101"), bin("100")), bin("10001"))
-    assertEquals(MathUtils.removeBinaryFlag(bin("11111"), bin("101")), bin("11010"))
-    // flag is not present (flag is larger than number)
-    assertEquals(MathUtils.removeBinaryFlag(bin("00001"), bin("100")), bin("00001"))
-    assertEquals(MathUtils.removeBinaryFlag(bin("00011"), bin("101")), bin("00011"))
-    // flag is not present (flag is smaller than number)
-    assertEquals(MathUtils.removeBinaryFlag(bin("10001"), bin("100")), bin("10001"))
-    // flag is null
-    assertEquals(MathUtils.removeBinaryFlag(bin("10101"), bin("000")), bin("10101"))
-    // value is null
-    assertEquals(MathUtils.removeBinaryFlag(bin("00000"), bin("000")), bin("00000"))
-    assertEquals(MathUtils.removeBinaryFlag(bin("00000"), bin("111")), bin("00000"))
+  def testRemoveBinaryFlag_flagIsPresent(): Unit = {
+    assertEquals(MathUtils.removeBinaryFlag(binary("10101"), binary("100")), binary("10001"))
+    assertEquals(MathUtils.removeBinaryFlag(binary("11111"), binary("101")), binary("11010"))
   }
+
+  @Test
+  def testRemoveBinaryFlag_flagIsNotPresent(): Unit = {
+    // flag is not present (flag is larger than number)
+    assertEquals(MathUtils.removeBinaryFlag(binary("00001"), binary("100")), binary("00001"))
+    assertEquals(MathUtils.removeBinaryFlag(binary("00011"), binary("101")), binary("00011"))
+    // flag is not present (flag is smaller than number)
+    assertEquals(MathUtils.removeBinaryFlag(binary("10001"), binary("100")), binary("10001"))
+  }
+
+  @Test
+  def testRemoveBinaryFlag_NullFlag(): Unit = {
+    // flag is null
+    assertEquals(MathUtils.removeBinaryFlag(binary("10101"), binary("000")), binary("10101"))
+  }
+
+  @Test
+  def testRemoveBinaryFlag_NullValue(): Unit = {
+    // value is null
+    assertEquals(MathUtils.removeBinaryFlag(binary("00000"), binary("000")), binary("00000"))
+    assertEquals(MathUtils.removeBinaryFlag(binary("00000"), binary("111")), binary("00000"))
+  }
+
 
 
 }

--- a/default.json
+++ b/default.json
@@ -35,5 +35,6 @@
   "force_app_lock": false,
   "app_lock_timeout": 10,
   "block_on_password_policy": false,
-  "wipe_on_cookie_invalid": false
+  "wipe_on_cookie_invalid": false,
+  "force_private_keyboard": false
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -388,6 +388,7 @@ object GlobalPreferences {
   lazy val ShouldWarnAndroid4Users = PrefKey[Boolean]( "should_warn_android_4_users", customDefault = true)
 
   lazy val AppLockEnabled: PrefKey[Boolean] = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
+  lazy val IncognitoKeyboardEnabled: PrefKey[Boolean] = PrefKey[Boolean]("incognito_keyboard_enabled", customDefault = false)
 
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts          = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")


### PR DESCRIPTION
## What's new in this PR?

Add setting to enable "private mode keyboard" to message composition and other input texts (like setting conversation name during conversation creation).

"Private mode" includes:
- Enable keyboard incognito mode
- Disable suggestions/autocompletion

### Testing

I added unit testing for flags math (add/remove), but I would have liked to add a test to verify that the right flags are set on the `TextView` too. However this requires instrumentation testing, and the instrumentation tests are currently broken (tests don't compile, and CI is not running them, only unit tests).

I manually tested the changes on the emulator. Incognito keyboard works fine, but disabling suggestions doesn't work on emulator. However according to [this](https://stackoverflow.com/questions/6281514/android-programmatically-disable-autocomplete-autosuggest-for-edittext-in-emulat/7313093), disabling suggestions never works on emulator. It should work on a range (but not all) devices.

### Notes

If later we have a strong requirement to disable suggestions on all devices, we can switch to use `TYPE_TEXT_VARIATION_VISIBLE_PASSWORD` which will though disable a set of essential features, such as the ability to switch language and to copy **from** the input field. Is it worth it?
#### APK
[Download build #64](http://10.10.124.11:8080/job/Pull%20Request%20Builder/64/artifact/build/artifact/wire-dev-PR2309-64.apk)
[Download build #65](http://10.10.124.11:8080/job/Pull%20Request%20Builder/65/artifact/build/artifact/wire-dev-PR2309-65.apk)
[Download build #68](http://10.10.124.11:8080/job/Pull%20Request%20Builder/68/artifact/build/artifact/wire-dev-PR2309-68.apk)
[Download build #73](http://10.10.124.11:8080/job/Pull%20Request%20Builder/73/artifact/build/artifact/wire-dev-PR2309-73.apk)
[Download build #74](http://10.10.124.11:8080/job/Pull%20Request%20Builder/74/artifact/build/artifact/wire-dev-PR2309-74.apk)