### PR TITLE
fix: Handle task switcher obfuscation properly

### DIFF
--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -60,23 +60,19 @@ class BaseActivity extends AppCompatActivity
 
   def injectJava[T](cls: Class[T]) = inject[T](reflect.Manifest.classType(cls), injector)
 
-  private lazy val flagSecure = for {
-    prefs  <- userPreferences
-    secure <- prefs.preference(UserPreferences.HideScreenContent).signal
-  } yield secure
+  private lazy val shouldHideScreenContent = for {
+    prefs             <- userPreferences
+    hideScreenContent <- prefs.preference(UserPreferences.HideScreenContent).signal
+  } yield hideScreenContent
 
   override protected def onCreate(savedInstanceState: Bundle): Unit = {
     verbose(l"onCreate")
     super.onCreate(savedInstanceState)
     setTheme(getBaseTheme)
 
-    flagSecure.onUi {
-      case true =>
-        verbose(l"Adding secure flag")
-        getWindow.addFlags(FLAG_SECURE)
-      case false =>
-        verbose(l"Removing secure flag")
-        getWindow.clearFlags(FLAG_SECURE)
+    shouldHideScreenContent.onUi {
+      case true  => getWindow.addFlags(FLAG_SECURE)
+      case false => getWindow.clearFlags(FLAG_SECURE)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -40,6 +40,7 @@ import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.ViewUtils
+import WindowManager.LayoutParams.FLAG_SECURE
 
 import scala.collection.breakOut
 import scala.collection.immutable.ListSet
@@ -59,10 +60,24 @@ class BaseActivity extends AppCompatActivity
 
   def injectJava[T](cls: Class[T]) = inject[T](reflect.Manifest.classType(cls), injector)
 
+  private lazy val flagSecure = for {
+    prefs  <- userPreferences
+    secure <- prefs.preference(UserPreferences.HideScreenContent).signal
+  } yield secure
+
   override protected def onCreate(savedInstanceState: Bundle): Unit = {
     verbose(l"onCreate")
     super.onCreate(savedInstanceState)
     setTheme(getBaseTheme)
+
+    flagSecure.onUi {
+      case true =>
+        verbose(l"Adding secure flag")
+        getWindow.addFlags(FLAG_SECURE)
+      case false =>
+        verbose(l"Removing secure flag")
+        getWindow.clearFlags(FLAG_SECURE)
+    }
   }
 
   override def onStart(): Unit = {
@@ -82,20 +97,6 @@ class BaseActivity extends AppCompatActivity
   override protected def onResume(): Unit = {
     super.onResume()
     onBaseActivityResume()
-    setScreenContentHiding()
-  }
-
-  private def setScreenContentHiding(): Unit = {
-    //FLAG_SECURE prevents all kinds of screenshots, not just in task switcher
-    import WindowManager.LayoutParams.FLAG_SECURE
-    userPreferences.currentValue.foreach { p =>
-      p.preference(UserPreferences.HideScreenContent).apply().foreach {
-        case true => verbose(l"Adding secure flag")
-          getWindow.addFlags(FLAG_SECURE)
-        case false => verbose(l"Removing secure flag")
-          getWindow.clearFlags(FLAG_SECURE)
-      }(Threading.Ui)
-    }
   }
 
   def onBaseActivityResume(): Unit =


### PR DESCRIPTION
### What's new in this PR?

A better way to set and clear `FLAG_SECURE` on windows as a result of setting the associated user preference.

### Issues

The old implementation set or cleared `FLAG_SECURE` on the current window only when `onResume` was called, and then did it in a future. It meant that not all windows were updated, and if there were a few windows one on the top of another, the contents on the future might have been called for an invalid window.

### Solutions

In the new implementation, the activity listens to the preference's signal and sets/clears `FLAG_SECURE` on its window the moment the value changes.

### Testing

1. Go to Preferences -> Options and set "Hide Screen Content".
2. Show the task switcher - the Wire window should be blank.
3. Go back to the main screen and show the task switcher - the Wire window should be blank as well.
4. You can check a few other screens.

Also, do the same on the EY build where the preference should be set by default.
#### APK
[Download build #67](http://10.10.124.11:8080/job/Pull%20Request%20Builder/67/artifact/build/artifact/wire-dev-PR2310-67.apk)
[Download build #75](http://10.10.124.11:8080/job/Pull%20Request%20Builder/75/artifact/build/artifact/wire-dev-PR2310-75.apk)