### PR TITLE
refactor: Decreasing the number of future calls in PushService

### DIFF
--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -24,7 +24,7 @@ import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InForeground
 import com.waz.service.ZMessaging.clock
 import com.waz.service._
-import com.waz.service.push.PushService.FetchFromIdle
+import com.waz.service.push.PushService.{FetchFromIdle, SyncHistory}
 import com.waz.service.push._
 import com.waz.services.ZMessagingService
 import com.waz.services.fcm.FCMHandlerService._
@@ -167,8 +167,8 @@ object FCMHandlerService {
           * online at once. For that reason, we start a job which can run for as long as we need to avoid the app from being
           * killed mid-processing messages.
           */
-        _ <-     if (idle)  push.syncHistory(FetchFromIdle(nId))
-                 else Serialized.future("fetch")(Future(FetchJob(userId, nId)))
+        _ <- if (idle) push.syncNotifications(SyncHistory(FetchFromIdle(nId)))
+              else Serialized.future("fetch")(Future(FetchJob(userId, nId)))
       } yield {}
   }
 

--- a/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FetchJob.scala
@@ -24,7 +24,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InBackground
 import com.waz.service.ZMessaging
-import com.waz.service.push.PushService.FetchFromJob
+import com.waz.service.push.PushService.{FetchFromJob, SyncHistory}
 import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.log.LogUI._
@@ -46,7 +46,7 @@ class FetchJob extends Job with DerivedLogTag {
     def syncAccount(userId: UserId, nId: Option[Uid]): Future[Unit] =
       for {
         Some(zms) <- ZMessaging.accountsService.flatMap(_.getZms(userId))
-        _ <- zms.push.syncHistory(FetchFromJob(nId), withRetries = false)
+        _         <- zms.push.syncNotifications(SyncHistory(FetchFromJob(nId), withRetries = false))
       } yield {}
 
     val result = account.fold(Future.successful({})) { id =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/FCMNotificationStatsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/FCMNotificationStatsService.scala
@@ -46,13 +46,12 @@ class FCMNotificationStatsServiceImpl(fcmTimestamps: FCMNotificationsRepository,
   override def markNotificationsWithState(ids: Set[Uid], stage: String): Future[Unit] =  async {
     stage match {
       case Pushed => await {
-        Future.traverse(ids.toSeq)(p => fcmTimestamps.storeNotificationState(p, stage, Instant.now))
+        Future.traverse(ids.toSeq)(fcmTimestamps.storeNotificationState(_, stage, Instant.now))
       }
       case _ =>
-          val fcmIds = await { filterFCMNotifications(ids) }
-          verbose(l"""marking ${showString(fcmIds.size.toString)} notifications
-               at stage ${showString(stage)} """)
-          await { calcAndStore(ids, stage) }
+        val fcmIds = await { filterFCMNotifications(ids) }
+        verbose(l"marking ${showString(fcmIds.size.toString)} notifications at stage ${showString(stage)}")
+        await { calcAndStore(ids, stage) }
     }
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PropertiesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PropertiesService.scala
@@ -25,7 +25,7 @@ import com.waz.model.{FoldersEvent, PropertyEvent, ReadReceiptEnabledPropertyEve
 import com.waz.service.EventScheduler.Stage
 import com.waz.service.assets2.Codec
 import com.waz.service.push.PushService
-import com.waz.service.push.PushService.ForceSync
+import com.waz.service.push.PushService.{ForceSync, SyncHistory}
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.utils.RichFuture
 import com.waz.utils.events.Signal
@@ -55,7 +55,7 @@ class PropertiesServiceImpl(prefs: UserPreferences, syncServiceHandle: SyncServi
     if readReceipts.isEmpty
     syncId <- syncServiceHandle.syncProperties()
     _ <- requestService.await(syncId)
-    _ <- pushService.syncHistory(ForceSync) // Force fetch to clear the sync event
+    _ <- pushService.syncNotifications(SyncHistory(ForceSync)) // Force fetch to clear the sync event
   } ()
 
   private def processEvent(event: PropertyEvent): Future[Unit] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -222,7 +222,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
       processConvWithRemoteId(remoteId, retryAsync = false, retryCount + 1)(processor)(tag, ec)
     } (ec)
 
-    convByRemoteId(remoteId) .flatMap {
+    convByRemoteId(remoteId).flatMap {
       case Some(conv) => processor(conv)
       case None if retryCount > 3 =>
         val ex = new NoSuchElementException("No conversation data found") with NoStackTrace

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -308,7 +308,9 @@ class MessageEventProcessor(selfUserId:           UserId,
       case e: MemberLeaveEvent if e.userIds.contains(e.from) => false
       case _ => true
     }.map(_.from).toSet
-    convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
+    if (potentiallyUnexpectedMembers.nonEmpty)
+      convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
+    else Future.successful(())
   }
 
   private def applyRecalls(convId: ConvId, toProcess: Seq[MessageEvent]) = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -308,9 +308,7 @@ class MessageEventProcessor(selfUserId:           UserId,
       case e: MemberLeaveEvent if e.userIds.contains(e.from) => false
       case _ => true
     }.map(_.from).toSet
-    if (potentiallyUnexpectedMembers.nonEmpty)
-      convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
-    else Future.successful(())
+    convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
   }
 
   private def applyRecalls(convId: ConvId, toProcess: Seq[MessageEvent]) = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -46,7 +46,7 @@ import scala.util.Left
 trait WSPushService {
   def activate(): Unit
   def deactivate(): Unit
-  def notifications(): EventStream[Seq[PushNotificationEncoded]]
+  val notifications: EventStream[Seq[PushNotificationEncoded]]
   def connected(): Signal[Boolean]
 }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -226,8 +226,8 @@ class TeamsServiceImpl(selfUser:           UserId,
     verbose(l"onConversationsCreated: convs: $convs")
     if (convs.nonEmpty)
       for {
-        convs <- Future.traverse(convs)(convsContent.convByRemoteId).map(_.collect { case Some(c) => c.id })
-        _     <- sync.syncConversations(convs)
+        convs <- convsContent.convsByRemoteId(convs)
+        _     <- sync.syncConversations(convs.values.map(_.id).toSet)
       } yield {}
     else Future.successful({})
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
@@ -95,11 +95,13 @@ class SyncRequestServiceImpl(accountId: UserId,
 
   override def syncState(account: UserId, commands: Seq[SyncCommand]) = {
     implicit val logTag: LogTag = LogTag("WorkManager#syncState")
-    returning {
-      content.syncJobs
-        .map(_.values.filter(job => commands.contains(job.request.cmd)))
-        .map(jobs => if (jobs.isEmpty) SyncState.COMPLETED else jobs.minBy(_.state.ordinal()).state)
-    }(s => verbose(l"commands: $commands => state: $s"))
+    for {
+      jobs     <- content.syncJobs
+      filtered =  jobs.filter { case (_, job) => commands.contains(job.request.cmd) }
+      _        =  verbose(l"jobs still not completed: ${filtered.toList.mkString(",")}")
+      state    =  if (filtered.isEmpty) SyncState.COMPLETED else filtered.minBy(_._2.state.ordinal())._2.state
+      _        =  verbose(l"commands: $commands => state: $state")
+    } yield state
   }
 
   //only used in tests currently

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -198,9 +198,9 @@ class AndroidSyncServiceHandle(account:         UserId,
       userIds <- usersStorage.list().map(_.map(_.id).toSet)
       id8     <- syncUsers(userIds)
       id9     <- syncFolders()
-      _ = verbose(l"SYNC waiting for full sync to finish...")
-      _ <- service.await(Set(id1, id2, id3, id4, id5, id6, id7, id8, id9))
-      _ = verbose(l"SYNC ... and done")
+      _       =  verbose(l"SYNC waiting for full sync to finish...")
+      _       <- service.await(Set(id1, id2, id3, id4, id5, id6, id7, id8, id9))
+      _       =  verbose(l"SYNC ... and done")
     } yield ()
   }
 }


### PR DESCRIPTION
This is an experimental PR.

The number of conversations and messages make the sync very slow, possibly even causing a variant of the stuck-on-sync bug (a race condition due to a lot of parallel syncs?). I decided to simplify PushService the best to my knowledge, limiting the number of created futures and async/awaits. It seems to work a bit faster, but:
1. more through performance testing is needed, both on dev and internal builds
2. the changes in code affect how the full sync is handled; this also needs to be tested.
#### APK
[Download build #76](http://10.10.124.11:8080/job/Pull%20Request%20Builder/76/artifact/build/artifact/wire-dev-PR2311-76.apk)
[Download build #77](http://10.10.124.11:8080/job/Pull%20Request%20Builder/77/artifact/build/artifact/wire-dev-PR2311-77.apk)
[Download build #135](http://10.10.124.11:8080/job/Pull%20Request%20Builder/135/artifact/build/artifact/wire-dev-PR2311-135.apk)
[Download build #136](http://10.10.124.11:8080/job/Pull%20Request%20Builder/136/artifact/build/artifact/wire-dev-PR2311-136.apk)
[Download build #237](http://10.10.124.11:8080/job/Pull%20Request%20Builder/237/artifact/build/artifact/wire-dev-PR2311-237.apk)
[Download build #238](http://10.10.124.11:8080/job/Pull%20Request%20Builder/238/artifact/build/artifact/wire-dev-PR2311-238.apk)
[Download build #239](http://10.10.124.11:8080/job/Pull%20Request%20Builder/239/artifact/build/artifact/wire-dev-PR2311-239.apk)
[Download build #240](http://10.10.124.11:8080/job/Pull%20Request%20Builder/240/artifact/build/artifact/wire-dev-PR2311-240.apk)
[Download build #241](http://10.10.124.11:8080/job/Pull%20Request%20Builder/241/artifact/build/artifact/wire-dev-PR2311-241.apk)
[Download build #242](http://10.10.124.11:8080/job/Pull%20Request%20Builder/242/artifact/build/artifact/wire-dev-PR2311-242.apk)