### PR TITLE
Feature: Request permission before accessing location

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
 
     <string name="content__location__no_map_placeholder">THE LOCATION WILL APPEAR ON THE MAP WHEN YOU ARE BACK ONLINE.</string>
 
+
     <!-- Conversation actions -->
     <string name="conversation__action__delete">Delete content…</string>
     <string name="conversation__action__archive">Archive</string>
@@ -789,6 +790,11 @@
     <string name="location_sharing__enable_system_location__confirm">Settings</string>
     <string name="location_sharing__enable_system_location__cancel">Cancel</string>
     <string name="location_sharing__missing_play_services">Google Play Services is needed for location sharing</string>
+    <string name="location_sharing__permission__message">Do you want to allow Wire to access your location?</string>
+    <string name="location_sharing__permission__title">Location sharing</string>
+    <string name="location_sharing__permission__cancel">Cancel</string>
+    <string name="location_sharing__permission__continue">OK</string>
+
 
     <!-- From SyncEngine -->
     <string name="new_reg__phone_signup__create_account">Create an account</string>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -102,7 +102,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
 
   val members = conversationId.collect { case Some(convId) => convId } flatMap controller.members
 
-  val conversationName = conversation map { conv =>
+  val cconversationName = conversation map { conv =>
     if (conv.displayName.isEmpty) {
       // This hack was in the UiModule Conversation implementation
       // XXX: this is a hack for some random errors, sometimes conv has empty name which is never updated

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -102,7 +102,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
 
   val members = conversationId.collect { case Some(convId) => convId } flatMap controller.members
 
-  val cconversationName = conversation map { conv =>
+  val conversationName = conversation map { conv =>
     if (conv.displayName.isEmpty) {
       // This hack was in the UiModule Conversation implementation
       // XXX: this is a hack for some random errors, sometimes conv has empty name which is never updated

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -336,19 +336,18 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
         color
       ) else { Future.successful(true) } // skip dialog
     } yield {
-      if(!response) { // user canceled
-        return
-      }
-      // store that we asked and the user clicked "OK", so that we don't ask anymore
-      // this is not a synchronous operation, but we are not interested in waiting
-      askedForLocationPermissionPreference.update(true)
+      if(response) { // user canceled
+        // store that we asked and the user clicked "OK", so that we don't ask anymore
+        // this is not a synchronous operation, but we are not interested in waiting
+        askedForLocationPermissionPreference.update(true)
 
-      val googleAPI = GoogleApiAvailability.getInstance
-      if (ConnectionResult.SUCCESS == googleAPI.isGooglePlayServicesAvailable(ctx)) {
-        KeyboardUtils.hideKeyboard(activity)
-        locationController.showShareLocation()
+        val googleAPI = GoogleApiAvailability.getInstance
+        if (ConnectionResult.SUCCESS == googleAPI.isGooglePlayServicesAvailable(ctx)) {
+          KeyboardUtils.hideKeyboard(activity)
+          locationController.showShareLocation()
+        }
+        else showToast(R.string.location_sharing__missing_play_services)
       }
-      else showToast(R.string.location_sharing__missing_play_services)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -48,7 +48,6 @@ import com.waz.zclient.utils.ContextUtils
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.views.DraftMap
 import com.waz.zclient.{Injectable, Injector, R}
-import com.waz.zclient.log.LogUI._
 
 import scala.collection.immutable.ListSet
 import scala.concurrent.Future

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -468,4 +468,6 @@ object UserPreferences {
   lazy val StatusNotificationsBitmask       = PrefKey[Int]("status_notifications_bitmask", customDefault = 0)
   lazy val ShouldWarnStatusNotifications    = PrefKey[Boolean]( "should_warn_status_notifications", customDefault = true)
 
+  lazy val AskedForLocationPermission       = PrefKey[Boolean]("asked_for_location_permission", customDefault = false)
+
 }


### PR DESCRIPTION
## What's new in this PR?

The user is asked to confirm accessing the location, before the location sharing is displayed. This check might be redundant on some Android versions, where the operating system also asks before displaying location. However this is only asked once, any following time the user is not asked again.

### Testing

Lacking proper instrumentation tests, this was manually tested on emulator

#### APK
[Download build #78](http://10.10.124.11:8080/job/Pull%20Request%20Builder/78/artifact/build/artifact/wire-dev-PR2312-78.apk)