### PR TITLE
[Refactor] MessagesContentUpdater optimisations

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -73,9 +73,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       clock.advance(5.seconds)
       val event = GenericMessageEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, GenericMessage(Uid("uid"), Text(text)))
 
-      (storage.updateOrCreateAll _).expects(*).onCall { updaters: Map[MessageId, Option[MessageData] => MessageData] =>
-        Future.successful(updaters.values.map(_.apply(None)).toSet)
-      }
+      (storage.updateOrCreate _).expects(*, *, *).onCall { (_, _, creator) => Future.successful(creator)}
       (storage.get _).expects(*).once().returns(Future.successful(None))
 
       val processor = getProcessor

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
@@ -199,9 +199,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
     (storage.getMessage _).expects(messageId).returning(Future.successful(Some(msg)))
     (edits.insert _).expects(editHistory).returning(Future.successful(editHistory))
     (deletions.getAll _).expects(Seq(messageId2)).returning(Future.successful(Seq(None)))
-    (storage.updateOrCreateAll _).expects(*).onCall{ updaters: Map[MessageId, Option[MessageData] => MessageData] =>
-      Future.successful(updaters.get(messageId2).map(f => f(Some(msg))).toSet)
-    }
+    (storage.updateOrCreate _).expects(*, *, *).onCall { (_, updater, _) => Future.successful(updater(msg)) }
     (storage.findQuotesOf _).expects(*).returning(Future.successful(Seq()))
     (storage.updateAll2 _).expects(*, *).onCall { (keys, updater) =>
       Future.successful(Seq((msg, updater(msg))))


### PR DESCRIPTION
## What's new in this PR?

This PR contains two minor improvements to the `MessagesContentUpdater`.

### Issues

1. The data merger function was being unnecessarily recreated. 
2. We invoke some unnecessary collection methods.

### Causes

1. The anonymous function was defined in the scope of a method that gets called frequently, even though the declaration didn't depend on any local values.
2. `addContentMessages` takes a sequence of methods, but is usually called with only a single message.

### Solutions

1. Move the definition to the scope of the `Merger` object.
2. Provide a case for a single element set.

#### APK
[Download build #82](http://10.10.124.11:8080/job/Pull%20Request%20Builder/82/artifact/build/artifact/wire-dev-PR2316-82.apk)
[Download build #83](http://10.10.124.11:8080/job/Pull%20Request%20Builder/83/artifact/build/artifact/wire-dev-PR2316-83.apk)
[Download build #84](http://10.10.124.11:8080/job/Pull%20Request%20Builder/84/artifact/build/artifact/wire-dev-PR2316-84.apk)