### PR TITLE
Fix: Syntax error on deprecation warnings

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
@@ -185,7 +185,7 @@ object HttpClient {
 
   }
 
-  @deprecated("After circe integration we should use 'AutoDerivation'")
+  @deprecated("After circe integration we should use 'AutoDerivation'", "?")
   object AutoDerivationOld extends AutoDerivationRulesForSerializersOld with AutoDerivationRulesForDeserializersOld
 
   object AutoDerivation extends AutoDerivationRulesForSerializers with AutoDerivationRulesForDeserializers

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -49,7 +49,7 @@ object FutureAwaitSyntax {
 trait FutureAwaitSyntax {
   import FutureAwaitSyntax._
 
-  @deprecated("await does not fail tests if the provided future fails! Better to just always use result and discard the return value")
+  @deprecated("await does not fail tests if the provided future fails! Better to just always use result and discard the return value", "?")
   def await(future: Future[_])(implicit duration: FiniteDuration = DefaultTimeout): Unit =
     Await.ready(future, duration)
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

For some deprecation warnings, parsing the warning itself was generating a warning

### Causes

The current deprecation syntax requires a deprecation version, which was missing from the previous version

#### APK
[Download build #104](http://10.10.124.11:8080/job/Pull%20Request%20Builder/104/artifact/build/artifact/wire-dev-PR2326-104.apk)