### PR TITLE
Chore: Removed println from tests

### DIFF
--- a/app/src/test/scala/com/waz/zclient/messages/part/MentionsInputTest.scala
+++ b/app/src/test/scala/com/waz/zclient/messages/part/MentionsInputTest.scala
@@ -254,8 +254,6 @@ class MentionsInputTest extends JUnitSuite {
     val handle = "@456"
     val mention = Mention(Some(UserId()), input.indexOf(handle), handle.length)
     val (replaceString, holders) = TextPartView.replaceMentions(input, Seq(mention))
-    println(s"input: $input")
-    println(s"replaceString: $replaceString")
 
     assert(holders.size == 1)
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
@@ -56,7 +56,6 @@ class LruFileCacheSpec extends ZIntegrationSpec {
       val cache    = createLruFileCache(cacheDir)
       for {
         _ <- cache.putBytes(key, content)
-        _ = println(s"Cache directory content: ${cacheDir.listFiles().map(_.getName).mkString(" ")}")
         fromCache <- cache.findBytes(key)
       } yield {
         fromCache.nonEmpty shouldBe true

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/MessageDataDaoSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/MessageDataDaoSpec.scala
@@ -98,7 +98,6 @@ class MessageDataDaoSpec extends AndroidFreeSpec {
 
     scenario("Decode mentions") {
       val encoded = JsonEncoder.encode(contentWithMention)
-      println(encoded.toString)
       val decoded = JsonDecoder.decode[MessageContent](encoded.toString)
       decoded shouldEqual contentWithMention
     }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/MessageDataSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/MessageDataSpec.scala
@@ -88,9 +88,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val start = text.indexOf(handle)
       val mention = Mention(Some(UserId()), start, handle.length)
       val mentions = Seq(mention)
-      println(s"mentions: $mentions")
       val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
-      println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }
 
@@ -101,9 +99,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val mention1 = Mention(Some(UserId()), text.indexOf(handle1), handle1.length)
       val mention2 = Mention(Some(UserId()), text.indexOf(handle2), handle2.length)
       val mentions = Seq(mention1, mention2)
-      println(s"mentions: $mentions")
       val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
-      println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }
 
@@ -113,9 +109,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val start = text.indexOf(handle)
       val mention = Mention(Some(UserId()), start, handle.length)
       val mentions = Seq(mention)
-      println(s"mentions: $mentions")
       val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
-      println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }
   }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/permissions/PermissionsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/permissions/PermissionsServiceSpec.scala
@@ -44,7 +44,6 @@ class PermissionsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   def newProvider = new PermissionProvider {
     def requestPermissions(ps: ListSet[PermissionsService.Permission]) = {
-      println(s"requestPermissions from Provider: $ps")
       requestInput ! ps
       requestCalls += 1
       systemState.head
@@ -167,7 +166,6 @@ class PermissionsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     result(req) shouldEqual expectedPerms
     result(signal.filter { p =>
-      println(s"Testing $p")
       p == expectedPerms
     }.head)
 
@@ -283,7 +281,6 @@ class PermissionsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     */
   def userAccepts(toGrant: ListSet[Permission]) = {
     await(requestInput.filter(_.map(_.key) == toGrant.map(_.key)).head)
-    println(s"User will accept: $toGrant")
     systemState.mutate(ps => ps.map(p => toGrant.find(_.key == p.key).getOrElse(p)))
     Threading.Ui(service.onPermissionsResult(toGrant))
     requestInput ! ListSet.empty

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -66,7 +66,6 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
 
     val finished = EventStream[Unit]()
     (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      println(s"us: $us")
       if (!us.contains(wirelessId)) fail("Called sync for wrong user")
       finished ! {}
       Future.successful(SyncId())

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -171,7 +171,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
     val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"rn")
-    result(res.filter{u => println(u.map(_.displayName));u.size == 1}.head)
+    result(res.filter{u => u.size == 1}.head)
   }
 
   scenario("search conversation with handle containing query") {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallInfoSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallInfoSpec.scala
@@ -29,8 +29,6 @@ class CallInfoSpec extends AndroidFreeSpec with DerivedLogTag {
   scenario("Test duration advances once every second") {
     val call = callInfo()
 
-    call.durationFormatted(println)
-
     clock + 1.seconds
     Thread.sleep(1050)
     result(call.durationFormatted.head) shouldEqual "00:01"

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -432,7 +432,6 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       //TODO which user from a group conversation gets passed down here?
       service.onEstablishedCall(groupConv.remoteId, otherUser)
-      println(result(service.currentCall.map(_.get.others).head))
       awaitCP(checkpoint3)
 
       service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
@@ -454,7 +453,6 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       awaitCP(checkpoint2)
 
       service.onEstablishedCall(teamGroupConv.remoteId, otherUser)
-      println(result(service.currentCall.map(_.get.others).head))
       awaitCP(checkpoint3)
 
       service.onGroupChanged(teamGroupConv.remoteId, Set(otherUser, otherUser2))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -143,7 +143,6 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
       val convId = ConvId(otherUser.id.str)
 
       var previousConv = ConversationData(convId, tempRemoteId, convType = WaitForConnection)
-      println(previousConv)
 
       (usersStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[UserId], updater: ((UserId, Option[UserData]) => UserData)) =>
         Future.successful(keys.map {
@@ -161,7 +160,6 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         Future.successful(keys.map {
           case id if id == convId =>
             returning(updater(id, Some(previousConv))) { updated =>
-              println(updated)
               previousConv = updated
             }
           case _ => fail("Unexpected user being updated")
@@ -172,7 +170,6 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         if (!keys.toSet.contains(convId)) fail ("didn't try to update other conversation")
         val prev = previousConv
         Future.successful(Seq((prev, returning(updater(previousConv)) { updated =>
-          println(updated)
           previousConv = updated
         })))
       }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
@@ -322,7 +322,6 @@ class PushTokenServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       (sync.deletePushToken _).expects(oldToken).once().returning(Future.successful(SyncId()))
 
       (sync.registerPush _).expects(newToken).once().onCall { _: PushToken =>
-        println("registerPush")
         Future {
           service.onTokenRegistered(newToken)
           SyncId()

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -183,7 +183,7 @@ abstract class AndroidFreeSpec extends ZMockSpec { this: Suite =>
 object AndroidFreeSpec {
   val clock = TestClock()
 
-  val DefaultTimeout = 15.seconds
+  val DefaultTimeout = 30.seconds
   @volatile private var swallowedFailure = Option.empty[exceptions.TestFailedException]
 }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.sync.client
 
-import com.waz.model.TeamData
+import com.waz.model.{TeamData, UserId}
 import com.waz.model.UserPermissions.Permission._
 import com.waz.model.UserPermissions._
 import com.waz.specs.AndroidFreeSpec
@@ -52,11 +52,53 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
     }
 
     scenario("Team members response decoding") {
+
+      // given
       import io.circe.parser._
-      val response = "{\"members\":[{\"invited\":{\"at\":\"2019-01-18T15:46:00.938Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"7bba67b9-e0c4-43ec-8648-93ee2a567610\"},{\"invited\":{\"at\":\"2019-01-16T13:37:02.222Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"98bc4812-e0a1-426d-9126-441399a1c010\",\"permissions\":{\"copy\":1025,\"self\":1025}},{\"invited\":null,\"user\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},{\"invited\":{\"at\":\"2019-01-18T15:17:45.127Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"f3f4f763-ccee-4b3d-b450-582e2c99f8be\"}]}"
+      val response =
+        """{
+          "members": [
+            {
+              "invited":{ "at":"2019-01-18T15:46:00.938Z", "by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
+              "user":"7bba67b9-e0c4-43ec-8648-93ee2a567610"
+            },
+            {
+              "invited":{"at":"2019-01-16T13:37:02.222Z","by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
+              "user":"98bc4812-e0a1-426d-9126-441399a1c010",
+              "permissions":{"copy":1025,"self":1025}
+            },
+            {
+              "invited":null,
+              "user":"a630278f-5b7e-453b-8e7b-0b4838597312"
+            },
+            {
+              "invited":{"at":"2019-01-18T15:17:45.127Z","by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
+              "user":"f3f4f763-ccee-4b3d-b450-582e2c99f8be"
+            }
+            ]}"""
+
+      // when
       val result = decode[TeamMembers](response)
 
-      assert(result.isRight)
+      // then
+      val parsed = result.right.get
+      parsed.members.length shouldBe 4
+      parsed.members(0).user shouldEqual UserId("7bba67b9-e0c4-43ec-8648-93ee2a567610")
+      parsed.members(0).permissions shouldEqual None
+      parsed.members(0).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+
+      parsed.members(1).user shouldEqual UserId("98bc4812-e0a1-426d-9126-441399a1c010")
+      parsed.members(1).permissions shouldEqual Some(TeamsClient.Permissions(1025, 1025))
+      parsed.members(1).created_by shouldEqual Some(UserId("98bc4812-e0a1-426d-9126-441399a1c010"))
+
+      parsed.members(2).user shouldEqual UserId("a630278f-5b7e-453b-8e7b-0b4838597312")
+      parsed.members(2).permissions shouldEqual None
+      parsed.members(2).created_by shouldEqual None
+
+      parsed.members(3).user shouldEqual UserId("f3f4f763-ccee-4b3d-b450-582e2c99f8be")
+      parsed.members(3).permissions shouldEqual None
+      parsed.members(3).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+
     }
 
     scenario("Team data response decoding") {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -56,7 +56,7 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       val response = "{\"members\":[{\"invited\":{\"at\":\"2019-01-18T15:46:00.938Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"7bba67b9-e0c4-43ec-8648-93ee2a567610\"},{\"invited\":{\"at\":\"2019-01-16T13:37:02.222Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"98bc4812-e0a1-426d-9126-441399a1c010\",\"permissions\":{\"copy\":1025,\"self\":1025}},{\"invited\":null,\"user\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},{\"invited\":{\"at\":\"2019-01-18T15:17:45.127Z\",\"by\":\"a630278f-5b7e-453b-8e7b-0b4838597312\"},\"user\":\"f3f4f763-ccee-4b3d-b450-582e2c99f8be\"}]}"
       val result = decode[TeamMembers](response)
 
-      println(result)
+      assert(result.isRight)
     }
 
     scenario("Team data response decoding") {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -59,20 +59,21 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
         """{
           "members": [
             {
-              "invited":{ "at":"2019-01-18T15:46:00.938Z", "by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
+              "created_by": "a630278f-5b7e-453b-8e7b-0b4838597312",
+              "created_at": "2019-01-18T15:46:00.938Z",
               "user":"7bba67b9-e0c4-43ec-8648-93ee2a567610"
             },
             {
-              "invited":{"at":"2019-01-16T13:37:02.222Z","by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
+              "created_by": "a630278f-5b7e-453b-8e7b-0b4838597312",
+              "created_at": "2019-01-16T13:37:02.222Z",
               "user":"98bc4812-e0a1-426d-9126-441399a1c010",
               "permissions":{"copy":1025,"self":1025}
             },
             {
-              "invited":null,
+              "created_by": null,
               "user":"a630278f-5b7e-453b-8e7b-0b4838597312"
             },
             {
-              "invited":{"at":"2019-01-18T15:17:45.127Z","by":"a630278f-5b7e-453b-8e7b-0b4838597312"},
               "user":"f3f4f763-ccee-4b3d-b450-582e2c99f8be"
             }
             ]}"""
@@ -85,11 +86,11 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       parsed.members.length shouldBe 4
       parsed.members(0).user shouldEqual UserId("7bba67b9-e0c4-43ec-8648-93ee2a567610")
       parsed.members(0).permissions shouldEqual None
-      // parsed.members(0).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+      parsed.members(0).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
 
       parsed.members(1).user shouldEqual UserId("98bc4812-e0a1-426d-9126-441399a1c010")
       parsed.members(1).permissions shouldEqual Some(TeamsClient.Permissions(1025, 1025))
-      // parsed.members(1).created_by shouldEqual Some(UserId("98bc4812-e0a1-426d-9126-441399a1c010"))
+      parsed.members(1).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
 
       parsed.members(2).user shouldEqual UserId("a630278f-5b7e-453b-8e7b-0b4838597312")
       parsed.members(2).permissions shouldEqual None
@@ -97,7 +98,7 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
 
       parsed.members(3).user shouldEqual UserId("f3f4f763-ccee-4b3d-b450-582e2c99f8be")
       parsed.members(3).permissions shouldEqual None
-      // parsed.members(3).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+      parsed.members(3).created_by shouldEqual None
 
     }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -85,11 +85,11 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       parsed.members.length shouldBe 4
       parsed.members(0).user shouldEqual UserId("7bba67b9-e0c4-43ec-8648-93ee2a567610")
       parsed.members(0).permissions shouldEqual None
-      parsed.members(0).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+      // parsed.members(0).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
 
       parsed.members(1).user shouldEqual UserId("98bc4812-e0a1-426d-9126-441399a1c010")
       parsed.members(1).permissions shouldEqual Some(TeamsClient.Permissions(1025, 1025))
-      parsed.members(1).created_by shouldEqual Some(UserId("98bc4812-e0a1-426d-9126-441399a1c010"))
+      // parsed.members(1).created_by shouldEqual Some(UserId("98bc4812-e0a1-426d-9126-441399a1c010"))
 
       parsed.members(2).user shouldEqual UserId("a630278f-5b7e-453b-8e7b-0b4838597312")
       parsed.members(2).permissions shouldEqual None
@@ -97,7 +97,7 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
 
       parsed.members(3).user shouldEqual UserId("f3f4f763-ccee-4b3d-b450-582e2c99f8be")
       parsed.members(3).permissions shouldEqual None
-      parsed.members(3).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
+      // parsed.members(3).created_by shouldEqual Some(UserId("a630278f-5b7e-453b-8e7b-0b4838597312"))
 
     }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
@@ -69,7 +69,6 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
       // binding to port 0 means the OS can choose a free port
       bindingFuture = Http().bindAndHandle(route, "localhost", 0)
       wsPort = Await.result(bindingFuture, 5.seconds).localAddress.getPort()
-      println(s"Akka-http websocket server started at ${testPath}")
     }
 
     def stop(): Unit = {


### PR DESCRIPTION
## What's new in this PR?

Removing a bunch of `println` from tests. This was generating unnecessary output while running all tests, making it hard to spot more relevant messages.

There was even a test that was relying on `println` to prove it's working. That test had no assert, just a `println` of the expected result. I assume this was something committed in the middle of a debug session. I replaced it with an `assert`.

#### APK
[Download build #106](http://10.10.124.11:8080/job/Pull%20Request%20Builder/106/artifact/build/artifact/wire-dev-PR2328-106.apk)
[Download build #109](http://10.10.124.11:8080/job/Pull%20Request%20Builder/109/artifact/build/artifact/wire-dev-PR2328-109.apk)
[Download build #110](http://10.10.124.11:8080/job/Pull%20Request%20Builder/110/artifact/build/artifact/wire-dev-PR2328-110.apk)
[Download build #111](http://10.10.124.11:8080/job/Pull%20Request%20Builder/111/artifact/build/artifact/wire-dev-PR2328-111.apk)
[Download build #112](http://10.10.124.11:8080/job/Pull%20Request%20Builder/112/artifact/build/artifact/wire-dev-PR2328-112.apk)