### PR TITLE
[Fix] Add new daos to ZMessagingDB

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -73,7 +73,7 @@ object ZMessagingDB {
     ContactHashesDao, ContactsOnWireDao, UserClientsDao, LikingDao, ContactsDao, EmailAddressesDao,
     PhoneNumbersDao, MsgDeletionDao, EditHistoryDao, MessageContentIndexDao,
     PushNotificationEventsDao, ReadReceiptDao, PropertiesDao, UploadAssetDao, DownloadAssetDao,
-    AssetDao, FCMNotificationsDao, FCMNotificationStatsDao
+    AssetDao, FCMNotificationsDao, FCMNotificationStatsDao, FolderDataDao, ConversationFolderDataDao
   )
 
   lazy val migrations = Seq(


### PR DESCRIPTION
## What's new in this PR?

### Issues

Database migration was failing at the last stage when we tried to create the new tables related to folders.

### Causes

The two new daos `FolderDataDao` and `ConversationFolderDataDao` were not added to the list of daos for the database.