### PR TITLE
Conversation folders list milestone 1

### DIFF
--- a/app/src/main/res/drawable/icon_arrow_down_white.xml
+++ b/app/src/main/res/drawable/icon_arrow_down_white.xml
@@ -1,0 +1,23 @@
+<!--
+
+    Wire
+    Copyright (C) 2019 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<vector android:height="162dp" android:viewportHeight="162"
+    android:viewportWidth="282.969" android:width="283dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#fff" android:fillType="evenOdd" android:pathData="M277.144,34.057L156.322,154.739C156.084,154.978 155.827,155.186 155.58,155.409C155.356,155.656 155.148,155.913 154.909,156.151C147.105,163.946 134.451,163.946 126.647,156.151L5.825,35.468C-1.98,27.673 -1.98,15.034 5.825,7.239C13.629,-0.557 26.283,-0.557 34.087,7.239L140.778,113.806L248.882,5.827C256.686,-1.968 269.34,-1.968 277.144,5.827C284.948,13.622 284.948,26.261 277.144,34.057Z"/>
+</vector>

--- a/app/src/main/res/drawable/icon_arrow_up_white.xml
+++ b/app/src/main/res/drawable/icon_arrow_up_white.xml
@@ -1,0 +1,23 @@
+<!--
+
+    Wire
+    Copyright (C) 2019 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<vector android:height="162dp" android:viewportHeight="161.969"
+    android:viewportWidth="282.969" android:width="283dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#fff" android:fillType="evenOdd" android:pathData="M277.144,154.73C269.34,162.526 256.686,162.526 248.882,154.73L142.191,48.163L34.087,156.142C26.283,163.937 13.629,163.937 5.825,156.142C-1.98,148.346 -1.98,135.707 5.825,127.912L126.647,7.229C126.885,6.991 127.142,6.783 127.389,6.559C127.613,6.312 127.821,6.056 128.06,5.818C135.864,-1.977 148.518,-1.977 156.322,5.818L277.144,126.5C284.948,134.296 284.948,146.935 277.144,154.73Z"/>
+</vector>

--- a/app/src/main/res/layout/conv_list_section_header.xml
+++ b/app/src/main/res/layout/conv_list_section_header.xml
@@ -23,32 +23,27 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/conversation_list__row__height"
-    tools:parentTag="android.widget.FrameLayout">
+    android:orientation="horizontal"
+    android:paddingTop="@dimen/wire__padding__20"
+    android:paddingBottom="@dimen/wire__padding__20"
+    android:layout_marginStart="@dimen/wire__padding__big"
+    tools:parentTag="android.widget.LinearLayout">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        android:paddingTop="@dimen/wire__padding__20"
-        android:paddingBottom="@dimen/wire__padding__20"
-        android:layout_marginStart="@dimen/wire__padding__big" >
+    <ImageView
+        android:layout_width="10dp"
+        android:layout_height="10dp"
+        android:layout_gravity="center_vertical|start"
+        android:src="@drawable/icon_arrow_down_white"
+        android:tint="?wireSecondaryTextColor" />
 
-        <ImageView
-            android:layout_width="10dp"
-            android:layout_height="10dp"
-            android:layout_gravity="center_vertical|start"
-            android:src="@drawable/icon_arrow_down_white"
-            android:tint="?wireSecondaryTextColor" />
-
-        <com.waz.zclient.ui.text.TypefaceTextView
-            android:id="@+id/header_textview_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical|start"
-            android:layout_marginStart="@dimen/wire__padding__8"
-            app:w_font="@string/wire__typeface__light"
-            style="?startUiHeaderRowLabel"
-            tools:text="Title" />
-    </LinearLayout>
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/header_textview_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|start"
+        android:layout_marginStart="@dimen/wire__padding__8"
+        app:w_font="@string/wire__typeface__light"
+        style="?startUiHeaderRowLabel"
+        tools:text="Title" />
 
 </merge>

--- a/app/src/main/res/layout/conv_list_section_header.xml
+++ b/app/src/main/res/layout/conv_list_section_header.xml
@@ -26,7 +26,6 @@
     tools:parentTag="android.widget.FrameLayout">
 
     <LinearLayout
-        android:id="@+id/header_linearlayout_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="horizontal"
@@ -46,7 +45,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|start"
-            android:layout_marginLeft="@dimen/wire__padding__8"
+            android:layout_marginStart="@dimen/wire__padding__8"
             app:w_font="@string/wire__typeface__light"
             style="?startUiHeaderRowLabel"
             tools:text="Title" />

--- a/app/src/main/res/layout/conv_list_section_header.xml
+++ b/app/src/main/res/layout/conv_list_section_header.xml
@@ -18,20 +18,38 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/conversation_list__row__height">
+    android:layout_height="@dimen/conversation_list__row__height"
+    tools:parentTag="android.widget.FrameLayout">
 
-    <com.waz.zclient.ui.text.TypefaceTextView
-        android:id="@+id/title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/wire__padding__big"
-        android:layout_marginTop="@dimen/people_picker__header__padding_top"
-        android:layout_marginBottom="@dimen/people_picker__header__padding_bottom"
-        android:layout_gravity="center_vertical|start"
-        app:w_font="@string/wire__typeface__light"
-        style="?startUiHeaderRowLabel"
-        />
-</FrameLayout>
+    <LinearLayout
+        android:id="@+id/header_linearlayout_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:paddingTop="@dimen/wire__padding__20"
+        android:paddingBottom="@dimen/wire__padding__20"
+        android:layout_marginStart="@dimen/wire__padding__big" >
+
+        <ImageView
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:layout_gravity="center_vertical|start"
+            android:src="@drawable/icon_arrow_down_white"
+            android:tint="?wireSecondaryTextColor" />
+
+        <com.waz.zclient.ui.text.TypefaceTextView
+            android:id="@+id/header_textview_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|start"
+            android:layout_marginLeft="@dimen/wire__padding__8"
+            app:w_font="@string/wire__typeface__light"
+            style="?startUiHeaderRowLabel"
+            tools:text="Title" />
+    </LinearLayout>
+
+</merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1392,4 +1392,7 @@
 
     <string name="invalid_cookie_dialog_title">Your session expired</string>
     <string name="invalid_cookie_dialog_message">The application did not communicate with the server for a long period of time, or your session has been remotely invalidated.</string>
+
+    <string name="conversation_folder_name_group">Groups</string>
+    <string name="conversation_folder_name_one_to_one">Contacts</string>
 </resources>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -132,12 +132,13 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
     case Folders =>
       returning(new ConversationFolderListAdapter) { a =>
         val dataSource = for {
-          groups <- convListController.groupConvsWithoutFolder
+          incoming  <- convListController.incomingConversationListData
+          groups    <- convListController.groupConvsWithoutFolder
           oneToOnes <- convListController.oneToOneConvsWithoutFolder
-        } yield (groups, oneToOnes)
+        } yield (incoming, groups, oneToOnes)
 
-        dataSource.onUi { case (groups, oneToOnes) =>
-          a.setData(groups, oneToOnes)
+        dataSource.onUi { case (incoming, groups, oneToOnes) =>
+          a.setData(incoming, groups, oneToOnes)
         }
       }
     case Archive =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -180,7 +180,7 @@ class ArchiveListFragment extends ConversationListFragment with OnBackPressedLis
   }
 }
 
-object ArchiveListFragment{
+object ArchiveListFragment {
   val TAG = ArchiveListFragment.getClass.getSimpleName
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
@@ -17,41 +17,15 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
-import android.view.ViewGroup
 import com.waz.model.ConversationData
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
-import com.waz.zclient.log.LogUI._
 
 class ArchiveConversationListAdapter extends ConversationListAdapter {
 
-  setHasStableIds(true)
-
-  private var conversations = Seq.empty[ConversationData]
+  override protected var items: List[Item] = List.empty
 
   def setData(convs: Seq[ConversationData]): Unit = {
-    conversations = convs
+    items = convs.map(data => Item.Conversation(data)).toList
     notifyDataSetChanged()
-  }
-
-  private def getConversation(position: Int): Option[ConversationData] = conversations.lift(position)
-
-  private def getItem(position: Int): Option[ConversationData] = getConversation(position)
-
-  override def getItemCount: Int = conversations.size
-
-  override def getItemId(position: Int): Long = getItem(position).fold(position)(_.id.str.hashCode)
-
-  override def getItemViewType(position: Int): Int = NormalViewType
-
-  // View management
-
-  override def onCreateViewHolder(parent: ViewGroup, viewType: Int): NormalConversationRowViewHolder = {
-    ViewHolderFactory.newNormalConversationRowViewHolder(this, parent)
-  }
-
-  override def onBindViewHolder(holder: ConversationRowViewHolder, position: Int): Unit = {
-    getItem(position).fold(error(l"Conversation not found at position: $position")) { item =>
-      holder.asInstanceOf[NormalConversationRowViewHolder].bind(item)
-    }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
@@ -22,8 +22,6 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 
 class ArchiveConversationListAdapter extends ConversationListAdapter {
 
-  override protected var items: List[Item] = List.empty
-
   def setData(convs: Seq[ConversationData]): Unit = {
     items = convs.map(data => Item.Conversation(data)).toList
     notifyDataSetChanged()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -29,8 +29,9 @@ import com.waz.zclient.log.LogUI._
   */
 class ConversationFolderListAdapter extends ConversationListAdapter with DerivedLogTag {
 
-  // TODO: pull data from service when ready.
-  private val folders = Seq.empty[Folder]
+  setHasStableIds(true)
+
+  private var folders = Seq.empty[Folder]
   private var items = Seq.empty[Item]
 
   private def updateItems(): Unit = {
@@ -46,6 +47,11 @@ class ConversationFolderListAdapter extends ConversationListAdapter with Derived
   override def getItemViewType(position: Int): Int = items(position) match {
     case _: HeaderItem => FolderViewType
     case _: ConversationItem => NormalViewType
+  }
+
+  override def getItemId(position: Int): Long = items(position) match {
+    case HeaderItem(title) => title.hashCode
+    case ConversationItem(data) => data.id.str.hashCode
   }
 
   override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ConversationRowViewHolder = viewType match {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -17,20 +17,25 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
+import android.content.Context
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData}
+import com.waz.zclient.R
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter._
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
+import com.waz.zclient.utils.ContextUtils.getString
 
 /**
   * A list adapter for displaying conversations grouped into folders.
   */
-class ConversationFolderListAdapter extends ConversationListAdapter with DerivedLogTag {
+class ConversationFolderListAdapter(implicit context: Context)
+  extends ConversationListAdapter
+    with DerivedLogTag {
 
   def setData(incoming: Seq[ConvId], groups: Seq[ConversationData], oneToOnes: Seq[ConversationData]): Unit = {
     val folders = Seq(
-      Folder("Groups", groups.map(data => Item.Conversation(data)).toList),
-      Folder("One to One", oneToOnes.map(data => Item.Conversation(data)).toList)
+      Folder(getString(R.string.conversation_folder_name_group), groups.map(data => Item.Conversation(data)).toList),
+      Folder(getString(R.string.conversation_folder_name_one_to_one), oneToOnes.map(data => Item.Conversation(data)).toList)
     )
 
     items = folders.foldLeft(List.empty[Item]) { (result, folder) =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -34,10 +34,21 @@ class ConversationFolderListAdapter extends ConversationListAdapter with Derived
   private var folders = Seq.empty[Folder]
   private var items = Seq.empty[Item]
 
+  def setData(groups: Seq[ConversationData], oneToOnes: Seq[ConversationData]): Unit = {
+    folders = Seq(
+      Folder("Groups", groups.map(data => ConversationItem(data)).toList),
+      Folder("One to One", oneToOnes.map(data => ConversationItem(data)).toList)
+    )
+
+    updateItems()
+  }
+
   private def updateItems(): Unit = {
     items = folders.foldLeft(Seq.empty[Item]) { (result, folder) =>
       result ++ (HeaderItem(folder.title) :: folder.conversations)
     }
+
+    notifyDataSetChanged()
   }
 
   // Getters

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -73,7 +73,7 @@ class ConversationFolderListAdapter extends ConversationListAdapter with Derived
   override def onBindViewHolder(holder: ConversationRowViewHolder, position: Int): Unit = {
     (holder, items(position)) match {
       case (viewHolder: ConversationFolderRowViewHolder, header: HeaderItem) =>
-        viewHolder.bind(header)
+        viewHolder.bind(header, isFirst = position == 0)
       case (viewHolder: NormalConversationRowViewHolder, conversation: ConversationItem) =>
         viewHolder.bind(conversation.data)
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -17,21 +17,17 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
-import android.view.ViewGroup
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData}
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter._
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
-import com.waz.zclient.log.LogUI._
 
 /**
   * A list adapter for displaying conversations grouped into folders.
   */
 class ConversationFolderListAdapter extends ConversationListAdapter with DerivedLogTag {
 
-  setHasStableIds(true)
-
-  private var items = List.empty[Item]
+  override protected var items: List[Item] = List.empty
 
   def setData(incoming: Seq[ConvId], groups: Seq[ConversationData], oneToOnes: Seq[ConversationData]): Unit = {
     val folders = Seq(
@@ -48,41 +44,6 @@ class ConversationFolderListAdapter extends ConversationListAdapter with Derived
     }
 
     notifyDataSetChanged()
-  }
-
-  // Getters
-
-  override def getItemCount: Int = items.size
-
-  override def getItemViewType(position: Int): Int = items(position) match {
-    case _: Item.IncomingRequests => IncomingViewType
-    case _: Item.Header           => FolderViewType
-    case _: Item.Conversation     => NormalViewType
-  }
-
-  override def getItemId(position: Int): Long = items(position) match {
-    case Item.IncomingRequests(first, _) => first.str.hashCode
-    case Item.Header(title)              => title.hashCode
-    case Item.Conversation(data)         => data.id.str.hashCode
-  }
-
-  override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ConversationRowViewHolder = viewType match {
-    case IncomingViewType => ViewHolderFactory.newIncomingConversationRowViewHolder(this, parent)
-    case FolderViewType   => ViewHolderFactory.newConversationFolderRowViewHolder(this, parent)
-    case NormalViewType   => ViewHolderFactory.newNormalConversationRowViewHolder(this, parent)
-  }
-
-  override def onBindViewHolder(holder: ConversationRowViewHolder, position: Int): Unit = {
-    (items(position), holder) match {
-      case (incomingRequests: Item.IncomingRequests, viewHolder: IncomingConversationRowViewHolder) =>
-        viewHolder.bind(incomingRequests.first, incomingRequests.numberOfRequests)
-      case (header: Item.Header, viewHolder: ConversationFolderRowViewHolder) =>
-        viewHolder.bind(header, isFirst = position == 0)
-      case (conversation: Item.Conversation, viewHolder: NormalConversationRowViewHolder) =>
-        viewHolder.bind(conversation.data)
-      case _ =>
-        error(l"Invalid view holder/data pair")
-    }
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -27,8 +27,6 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
   */
 class ConversationFolderListAdapter extends ConversationListAdapter with DerivedLogTag {
 
-  override protected var items: List[Item] = List.empty
-
   def setData(incoming: Seq[ConvId], groups: Seq[ConversationData], oneToOnes: Seq[ConversationData]): Unit = {
     val folders = Seq(
       Folder("Groups", groups.map(data => Item.Conversation(data)).toList),
@@ -44,6 +42,11 @@ class ConversationFolderListAdapter extends ConversationListAdapter with Derived
     }
 
     notifyDataSetChanged()
+  }
+
+  override def onClick(position: Int): Unit = items(position) match {
+    case Item.Header(_) => // TODO: collapse logic
+    case _              => super.onClick(position)
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -119,8 +119,8 @@ object ConversationListAdapter {
       with View.OnClickListener
       with View.OnLongClickListener {
 
-    row.setOnClickListener(this)
-    row.setOnLongClickListener(this)
+    itemView.setOnClickListener(this)
+    itemView.setOnLongClickListener(this)
 
     override def onClick(v: View): Unit = listener.onClick(getAdapterPosition)
     override def onLongClick(v: View): Boolean = listener.onLongClick(getAdapterPosition)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -24,7 +24,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
-import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter.HeaderItem
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.ConversationRowViewHolder
 import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, IncomingConversationListRow, NormalConversationListRow}
 import com.waz.zclient.pages.main.conversationlist.views.ConversationCallback
@@ -49,6 +48,16 @@ object ConversationListAdapter {
   val IncomingViewType = 1
   val FolderViewType = 2
 
+  sealed trait Item
+
+  object Item {
+    case class Header(title: String) extends Item
+    case class Conversation(data: ConversationData) extends Item
+    case class IncomingRequests(first: ConvId, numberOfRequests: Int) extends Item
+  }
+
+
+
   trait ConversationRowViewHolder extends RecyclerView.ViewHolder
 
   case class NormalConversationRowViewHolder(view: NormalConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
@@ -63,7 +72,7 @@ object ConversationListAdapter {
   }
 
   case class ConversationFolderRowViewHolder(view: ConversationFolderListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(header: HeaderItem, isFirst: Boolean): Unit = {
+    def bind(header: Item.Header, isFirst: Boolean): Unit = {
       view.setTitle(header.title)
       view.setIsFirstHeader(isFirst)
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -21,7 +21,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.View.OnLongClickListener
 import android.view.{View, ViewGroup}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{ConvId, ConversationData, UserId}
+import com.waz.model.{ConvId, ConversationData}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter.HeaderItem
@@ -57,9 +57,8 @@ object ConversationListAdapter {
   }
 
   case class IncomingConversationRowViewHolder(view: IncomingConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(convsAndUsers: (Seq[ConversationData], Seq[UserId])): Unit = {
-      view.conversationId = convsAndUsers._1.headOption.map(_.id)
-      view.setIncomingUsers(convsAndUsers._2)
+    def bind(users: Seq[ConvId]): Unit = {
+      view.setIncoming(users)
     }
   }
 
@@ -102,7 +101,7 @@ object ConversationListAdapter {
     def newIncomingConversationRowViewHolder(adapter: ConversationListAdapter, parent: ViewGroup): IncomingConversationRowViewHolder = {
       val row = returning(inflate[IncomingConversationListRow](R.layout.incoming_conv_list_item, parent, addToParent = false)) { r =>
         r.setOnClickListener(new View.OnClickListener {
-          override def onClick(view: View): Unit = r.conversationId.foreach(adapter.onConversationClick ! _)
+          override def onClick(view: View): Unit = r.firstIncomingConversation.foreach(adapter.onConversationClick ! _)
         })
       }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -64,8 +64,10 @@ object ConversationListAdapter {
   }
 
   case class ConversationFolderRowViewHolder(view: ConversationFolderListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(header: HeaderItem): Unit =
+    def bind(header: HeaderItem, isFirst: Boolean): Unit = {
       view.setTitle(header.title)
+      view.setIsFirstHeader(isFirst)
+    }
   }
 
   object ViewHolderFactory extends DerivedLogTag {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -18,26 +18,28 @@
 package com.waz.zclient.conversationlist.adapters
 
 import android.support.v7.widget.RecyclerView
-import android.view.View.OnLongClickListener
 import android.view.{View, ViewGroup}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
-import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
-import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, IncomingConversationListRow, NormalConversationListRow}
+import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
+import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, ConversationListRow, IncomingConversationListRow, NormalConversationListRow}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.pages.main.conversationlist.views.ConversationCallback
 import com.waz.zclient.{R, ViewHelper}
 
-abstract class ConversationListAdapter extends RecyclerView.Adapter[ConversationRowViewHolder] with DerivedLogTag {
+abstract class ConversationListAdapter
+  extends RecyclerView.Adapter[ConversationRowViewHolder]
+    with RowClickListener
+    with DerivedLogTag {
 
   setHasStableIds(true)
 
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()
 
-  protected var items: List[Item]
+  protected var items: List[Item] = List.empty
   protected var maxAlpha = 1.0f
 
   def setMaxAlpha(maxAlpha: Float): Unit = {
@@ -77,6 +79,20 @@ abstract class ConversationListAdapter extends RecyclerView.Adapter[Conversation
         error(l"Invalid view holder/data pair")
     }
   }
+
+  override def onClick(position: Int): Unit = items(position) match {
+    case Item.IncomingRequests(first, _) => onConversationClick ! first
+    case Item.Conversation(data)         => onConversationClick ! data.id
+    case _                               =>
+  }
+
+  override def onLongClick(position: Int): Boolean = items(position) match {
+    case Item.Conversation(data) =>
+      onConversationLongClick ! data
+      true
+    case _ =>
+      false
+  }
 }
 
 object ConversationListAdapter {
@@ -84,6 +100,11 @@ object ConversationListAdapter {
   val NormalViewType = 0
   val IncomingViewType = 1
   val FolderViewType = 2
+
+  trait RowClickListener {
+    def onClick(position: Int): Unit
+    def onLongClick(position: Int): Boolean
+  }
 
   sealed trait Item
 
@@ -93,23 +114,36 @@ object ConversationListAdapter {
     case class IncomingRequests(first: ConvId, numberOfRequests: Int) extends Item
   }
 
-  trait ConversationRowViewHolder extends RecyclerView.ViewHolder
+  abstract class ConversationRowViewHolder(row: ConversationListRow, listener: RowClickListener)
+    extends RecyclerView.ViewHolder(row)
+      with View.OnClickListener
+      with View.OnLongClickListener {
 
-  case class NormalConversationRowViewHolder(view: NormalConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(conversation: ConversationData): Unit =
-      view.setConversation(conversation)
+    row.setOnClickListener(this)
+    row.setOnLongClickListener(this)
+
+    override def onClick(v: View): Unit = listener.onClick(getAdapterPosition)
+    override def onLongClick(v: View): Boolean = listener.onLongClick(getAdapterPosition)
   }
 
-  case class IncomingConversationRowViewHolder(view: IncomingConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(first: ConvId, numberOfRequest: Int): Unit = {
-      view.setIncoming(first, numberOfRequest)
-    }
+  class NormalConversationRowViewHolder(row: NormalConversationListRow, listener: RowClickListener)
+    extends ConversationRowViewHolder(row, listener) {
+
+    def bind(conversation: ConversationData): Unit = row.setConversation(conversation)
   }
 
-  case class ConversationFolderRowViewHolder(view: ConversationFolderListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
+  class IncomingConversationRowViewHolder(row: IncomingConversationListRow, listener: RowClickListener)
+    extends ConversationRowViewHolder(row, listener) {
+
+    def bind(first: ConvId, numberOfRequest: Int): Unit = row.setIncoming(first, numberOfRequest)
+  }
+
+  class ConversationFolderRowViewHolder(row: ConversationFolderListRow, listener: RowClickListener)
+    extends ConversationRowViewHolder(row, listener) {
+
     def bind(header: Item.Header, isFirst: Boolean): Unit = {
-      view.setTitle(header.title)
-      view.setIsFirstHeader(isFirst)
+      row.setTitle(header.title)
+      row.setIsFirstHeader(isFirst)
     }
   }
 
@@ -121,40 +155,24 @@ object ConversationListAdapter {
         r.setAlpha(1f)
         r.setMaxAlpha(adapter.maxAlpha)
 
-        r.setOnClickListener(new View.OnClickListener {
-          override def onClick(view: View): Unit =
-            r.conversationData.map(_.id).foreach(adapter.onConversationClick ! _)
-        })
-
-        r.setOnLongClickListener(new OnLongClickListener {
-          override def onLongClick(view: View): Boolean = {
-            r.conversationData.foreach(adapter.onConversationLongClick ! _)
-            true
-          }
-        })
-
+        // TODO: can we move this to our listener?
         r.setConversationCallback(new ConversationCallback {
           override def onConversationListRowSwiped(convId: String, view: View): Unit =
             r.conversationData.foreach(adapter.onConversationLongClick ! _)
         })
       }
 
-      NormalConversationRowViewHolder(row)
+      new NormalConversationRowViewHolder(row, listener = adapter)
     }
 
     def newIncomingConversationRowViewHolder(adapter: ConversationListAdapter, parent: ViewGroup): IncomingConversationRowViewHolder = {
-      val row = returning(inflate[IncomingConversationListRow](R.layout.incoming_conv_list_item, parent, addToParent = false)) { r =>
-        r.setOnClickListener(new View.OnClickListener {
-          override def onClick(view: View): Unit = r.firstIncomingConversation.foreach(adapter.onConversationClick ! _)
-        })
-      }
-
-      IncomingConversationRowViewHolder(row)
+      val row = inflate[IncomingConversationListRow](R.layout.incoming_conv_list_item, parent, addToParent = false)
+      new IncomingConversationRowViewHolder(row, listener = adapter)
     }
 
     def newConversationFolderRowViewHolder(adapter: ConversationListAdapter, parent: ViewGroup): ConversationFolderRowViewHolder = {
       val row = inflate[ConversationFolderListRow](R.layout.conv_folder_list_item, parent, addToParent = false)
-      ConversationFolderRowViewHolder(row)
+      new ConversationFolderRowViewHolder(row, listener = adapter)
     }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -57,8 +57,8 @@ object ConversationListAdapter {
   }
 
   case class IncomingConversationRowViewHolder(view: IncomingConversationListRow) extends RecyclerView.ViewHolder(view) with ConversationRowViewHolder {
-    def bind(users: Seq[ConvId]): Unit = {
-      view.setIncoming(users)
+    def bind(first: ConvId, numberOfRequest: Int): Unit = {
+      view.setIncoming(first, numberOfRequest)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -22,8 +22,6 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 
 class NormalConversationListAdapter extends ConversationListAdapter {
 
-  override protected var items: List[Item] = List.empty
-
   def setData(convs: Seq[ConversationData], incoming: Seq[ConvId]): Unit = {
     if (incoming.nonEmpty) {
       items = List(Item.IncomingRequests(incoming.head, incoming.size))

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -17,59 +17,19 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
-import android.view.ViewGroup
 import com.waz.model.{ConvId, ConversationData}
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
-import com.waz.zclient.log.LogUI._
 
 class NormalConversationListAdapter extends ConversationListAdapter {
 
-  setHasStableIds(true)
-
-  private var conversations = Seq.empty[ConversationData]
-  private var incomingRequests = Seq.empty[ConvId]
+  override protected var items: List[Item] = List.empty
 
   def setData(convs: Seq[ConversationData], incoming: Seq[ConvId]): Unit = {
-    conversations = convs
-    incomingRequests = incoming
+    if (incoming.nonEmpty) {
+      items = List(Item.IncomingRequests(incoming.head, incoming.size))
+    }
+
+    items ++= convs.map { data => Item.Conversation(data) }
     notifyDataSetChanged()
-  }
-
-  // Getters
-
-  private def getConversation(position: Int): Option[ConversationData] = conversations.lift(position)
-
-  private def getItem(position: Int): Option[ConversationData] = incomingRequests match {
-    case Seq() => getConversation(position)
-    case _ => if (position == 0) None else getConversation(position - 1)
-  }
-
-  override def getItemCount: Int =
-    if (hasIncomingRequests) conversations.size + 1
-    else conversations.size
-
-  override def getItemId(position: Int): Long = getItem(position).fold(position)(_.id.str.hashCode)
-
-  override def getItemViewType(position: Int): Int =
-    if (position == 0 && hasIncomingRequests) IncomingViewType
-    else NormalViewType
-
-  private def hasIncomingRequests: Boolean = incomingRequests.nonEmpty
-
-  // View management
-
-  override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ConversationRowViewHolder = viewType match {
-    case NormalViewType => ViewHolderFactory.newNormalConversationRowViewHolder(this, parent)
-    case IncomingViewType => ViewHolderFactory.newIncomingConversationRowViewHolder(this, parent)
-  }
-
-  override def onBindViewHolder(holder: ConversationRowViewHolder, position: Int): Unit = holder match {
-    case normalViewHolder: NormalConversationRowViewHolder =>
-      getItem(position).fold(error(l"Conversation not found at position: $position")) { item =>
-        normalViewHolder.bind(item)
-      }
-    case incomingViewHolder: IncomingConversationRowViewHolder =>
-      // TODO: don't force unwrap
-      incomingViewHolder.bind(incomingRequests.head, incomingRequests.size)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -69,6 +69,7 @@ class NormalConversationListAdapter extends ConversationListAdapter {
         normalViewHolder.bind(item)
       }
     case incomingViewHolder: IncomingConversationRowViewHolder =>
-      incomingViewHolder.bind(incomingRequests)
+      // TODO: don't force unwrap
+      incomingViewHolder.bind(incomingRequests.head, incomingRequests.size)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -23,6 +23,8 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 class NormalConversationListAdapter extends ConversationListAdapter {
 
   def setData(convs: Seq[ConversationData], incoming: Seq[ConvId]): Unit = {
+    items = List.empty
+    
     if (incoming.nonEmpty) {
       items = List(Item.IncomingRequests(incoming.head, incoming.size))
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -23,8 +23,8 @@ import android.support.constraint.ConstraintLayout
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.{View, ViewGroup}
-import android.widget.FrameLayout
 import android.widget.LinearLayout.LayoutParams
+import android.widget.{FrameLayout, LinearLayout}
 import com.waz.api.Message
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
@@ -57,7 +57,7 @@ import com.waz.zclient.{R, ViewHelper}
 
 import scala.collection.Set
 
-trait ConversationListRow extends FrameLayout
+trait ConversationListRow extends View
 
 class NormalConversationListRow(context: Context, attrs: AttributeSet, style: Int)
   extends FrameLayout(context, attrs, style)
@@ -553,16 +553,15 @@ class IncomingConversationListRow(context: Context, attrs: AttributeSet, style: 
 }
 
 class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: Int)
-  extends FrameLayout(context, attrs, style)
+  extends LinearLayout(context, attrs, style)
   with ConversationListRow
   with ViewHelper {
 
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
-  setLayoutParams(new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimenPx(R.dimen.conversation_list__row__height)))
-
   inflate(R.layout.conv_list_section_header)
+  setLayoutParameters()
 
   private val title = ViewUtils.getView(this, R.id.header_textview_title).asInstanceOf[TypefaceTextView]
 
@@ -572,5 +571,12 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
     val params = getLayoutParams.asInstanceOf[RecyclerView.LayoutParams]
     params.topMargin = if (isFirstHeader) 0 else getDimenPx(R.dimen.wire__padding__20)
     setLayoutParams(params)
+  }
+
+  private def setLayoutParameters(): Unit = {
+    val params = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimenPx(R.dimen.conversation_list__row__height))
+    setLayoutParams(params)
+    setOrientation(LinearLayout.HORIZONTAL)
+    setPadding(getDimenPx(R.dimen.wire__padding__24), getDimenPx(R.dimen.wire__padding__20), 0, getDimenPx(R.dimen.wire__padding__20))
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -536,16 +536,16 @@ class IncomingConversationListRow(context: Context, attrs: AttributeSet, style: 
   setLayoutParams(new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimenPx(R.dimen.conversation_list__row__height)))
   inflate(R.layout.conv_list_item)
 
-  var conversationId = Option.empty[ConvId]
+  var firstIncomingConversation = Option.empty[ConvId]
 
   val title = ViewUtils.getView(this, R.id.conversation_title).asInstanceOf[TypefaceTextView]
   val avatar = ViewUtils.getView(this, R.id.conversation_icon).asInstanceOf[ConversationAvatarView]
   val badge = ViewUtils.getView(this, R.id.conversation_badge).asInstanceOf[ConversationBadge]
 
-  def setIncomingUsers(users: Seq[UserId]): Unit = {
+  def setIncoming(convs: Seq[ConvId]): Unit = {
+    firstIncomingConversation = convs.headOption
     avatar.setAlpha(getResourceFloat(R.dimen.conversation_avatar_alpha_inactive))
-    //avatar.setMembers(users, ConversationType.Group)
-    title.setText(getInboxName(users.size))
+    title.setText(getInboxName(convs.size))
     badge.setStatus(ConversationBadge.WaitingConnection)
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -20,6 +20,7 @@ package com.waz.zclient.conversationlist.views
 import android.animation.ObjectAnimator
 import android.content.Context
 import android.support.constraint.ConstraintLayout
+import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.{View, ViewGroup}
 import android.widget.FrameLayout
@@ -563,7 +564,13 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
 
   inflate(R.layout.conv_list_section_header)
 
-  private val title = ViewUtils.getView(this, R.id.title).asInstanceOf[TypefaceTextView]
+  private val title = ViewUtils.getView(this, R.id.header_textview_title).asInstanceOf[TypefaceTextView]
 
   def setTitle(title: String): Unit = this.title.setText(title)
+
+  def setIsFirstHeader(isFirstHeader: Boolean): Unit = {
+    val params = getLayoutParams.asInstanceOf[RecyclerView.LayoutParams]
+    params.topMargin = if (isFirstHeader) 0 else getDimenPx(R.dimen.wire__padding__20)
+    setLayoutParams(params)
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -542,10 +542,10 @@ class IncomingConversationListRow(context: Context, attrs: AttributeSet, style: 
   val avatar = ViewUtils.getView(this, R.id.conversation_icon).asInstanceOf[ConversationAvatarView]
   val badge = ViewUtils.getView(this, R.id.conversation_badge).asInstanceOf[ConversationBadge]
 
-  def setIncoming(convs: Seq[ConvId]): Unit = {
-    firstIncomingConversation = convs.headOption
+  def setIncoming(first: ConvId, numberOfRequests: Int): Unit = {
+    firstIncomingConversation = Some(first)
     avatar.setAlpha(getResourceFloat(R.dimen.conversation_avatar_alpha_inactive))
-    title.setText(getInboxName(convs.size))
+    title.setText(getInboxName(numberOfRequests))
     badge.setStatus(ConversationBadge.WaitingConnection)
   }
 


### PR DESCRIPTION
## What's new in this PR?

This PR allows the user to navigate to the folders conversation list and see all conversations organized into the two default folders, "groups" and "one to ones". Incoming connection requests are displayed at the top of the list as per usual. 

I've also cleaned up the adapters by moving common functionality to the base `ConversationListAdapter` class, so each concrete subclass needs only to define how it accepts and organizes its data.

This PR unfortunately **does not contain functionality to expand/collapse folders** (and neither this state preservation), however there is some preliminary work for supporting this. Namely, I've redirected all click events on the rows through methods on the `ConversationListAdapter`. The base implementation will publish these events to the streams as usual, but now subclasses have the opportunity to respond to the events themselves.

## Notes

There is likely some opportunities to optimize the list loading. The previous implementation would call `notifiyDataSetChanged()` whenever any of the data changed, and this is still the case. However I think we could perhaps be a little smarter about how we update the list. I'll address this in a subsequent PR when I complete the expand/collapse functionality.

#### APK
[Download build #139](http://10.10.124.11:8080/job/Pull%20Request%20Builder/139/artifact/build/artifact/wire-dev-PR2340-139.apk)
[Download build #140](http://10.10.124.11:8080/job/Pull%20Request%20Builder/140/artifact/build/artifact/wire-dev-PR2340-140.apk)
[Download build #143](http://10.10.124.11:8080/job/Pull%20Request%20Builder/143/artifact/build/artifact/wire-dev-PR2340-143.apk)