### PR TITLE
[Feature] Collapsible folders

### DIFF
--- a/app/src/main/res/layout/conv_list_section_header.xml
+++ b/app/src/main/res/layout/conv_list_section_header.xml
@@ -30,6 +30,7 @@
     tools:parentTag="android.widget.LinearLayout">
 
     <ImageView
+        android:id="@+id/header_imageview_expand"
         android:layout_width="10dp"
         android:layout_height="10dp"
         android:layout_gravity="center_vertical|start"

--- a/app/src/main/res/layout/conv_list_section_header.xml
+++ b/app/src/main/res/layout/conv_list_section_header.xml
@@ -30,7 +30,7 @@
     tools:parentTag="android.widget.LinearLayout">
 
     <ImageView
-        android:id="@+id/header_imageview_expand"
+        android:id="@+id/conv_list_section_imageview_expand"
         android:layout_width="10dp"
         android:layout_height="10dp"
         android:layout_gravity="center_vertical|start"
@@ -38,7 +38,7 @@
         android:tint="?wireSecondaryTextColor" />
 
     <com.waz.zclient.ui.text.TypefaceTextView
-        android:id="@+id/header_textview_title"
+        android:id="@+id/conv_list_section_textview_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|start"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1394,5 +1394,5 @@
     <string name="invalid_cookie_dialog_message">The application did not communicate with the server for a long period of time, or your session has been remotely invalidated.</string>
 
     <string name="conversation_folder_name_group">Groups</string>
-    <string name="conversation_folder_name_one_to_one">Contacts</string>
+    <string name="conversation_folder_name_one_to_one">People</string>
 </resources>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -130,8 +130,7 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
   private def configureAdapter(adapter: ConversationListAdapter): Unit = {
     adapter.setMaxAlpha(getResourceFloat(R.dimen.list__swipe_max_alpha))
-
-    // TODO: Do we need to consider folders title? We might be able to push these down to subclasses.
+    
     userAccountsController.currentUser.onUi(user => topToolbar.get.setTitle(adapterMode, user))
 
     adapter.onConversationClick { conv =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -154,7 +154,7 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
           oneToOnes <- convListController.oneToOneConvsWithoutFolder
         } yield (incoming, groups, oneToOnes)
 
-        // TODO: Here we can prune the states, or we do it in the adapter
+        // TODO: Here we will need to prune deleted folders from the folder states map.
         dataSource.onUi { case (incoming, groups, oneToOnes) =>
           a.setData(incoming, groups, oneToOnes, foldersUiState)
         }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
@@ -23,7 +23,7 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 class ArchiveConversationListAdapter extends ConversationListAdapter {
 
   def setData(convs: Seq[ConversationData]): Unit = {
-    items = convs.map(data => Item.Conversation(data)).toList
-    notifyDataSetChanged()
+    val newItems = convs.map(data => Item.Conversation(data)).toList
+    updateList(newItems)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -76,21 +76,16 @@ class ConversationFolderListAdapter(implicit context: Context)
   private def collapseSection(header: Item.Header, headerPosition: Int): Unit = {
     folderConversations(header.id).fold() { conversations =>
       updateHeader(header, headerPosition, isExpanded = false)
-
-      val positionAfterHeader = headerPosition + 1
-      val numberOfConversations = conversations.size
-      items.remove(positionAfterHeader, numberOfConversations)
-      notifyItemRangeRemoved(positionAfterHeader, numberOfConversations)
+      items.remove(headerPosition + 1, conversations.size)
+      notifyItemRangeRemoved(headerPosition + 1, conversations.size)
     }
   }
 
   private def expandSection(header: Item.Header, headerPosition: Int): Unit = {
     folderConversations(header.id).fold() { conversations =>
       updateHeader(header, headerPosition, isExpanded = true)
-
-      val positionAfterHeader = headerPosition + 1
-      items.insertAll(positionAfterHeader, conversations)
-      notifyItemRangeInserted(positionAfterHeader, conversations.size)
+      items.insertAll(headerPosition + 1, conversations)
+      notifyItemRangeInserted(headerPosition + 1, conversations.size)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -60,12 +60,12 @@ class ConversationFolderListAdapter(implicit context: Context)
       createFolder(GroupId, R.string.conversation_folder_name_group, groups, isExpanded)
     }
 
-    val peopleFolder = {
+    val oneToOnesFolder = {
       val isExpanded = folderStates.getOrElse(OneToOnesId, true)
       createFolder(OneToOnesId, R.string.conversation_folder_name_one_to_one, oneToOnes, isExpanded)
     }
 
-    Seq(groupsFolder, peopleFolder).flatten
+    Seq(groupsFolder, oneToOnesFolder).flatten
   }
 
   private def createFolder(id: Uid, titleResId: Int, conversations: Seq[ConversationData], isExpanded: Boolean): Option[Folder] = {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -20,8 +20,9 @@ package com.waz.zclient.conversationlist.adapters
 import android.content.Context
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, Uid}
+import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.zclient.R
-import com.waz.zclient.conversationlist.ConversationListFragment.{FolderState, FoldersUiState}
+import com.waz.zclient.conversationlist.ConversationFolderListFragment.{FolderState, FoldersUiState}
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter.Folder._
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter._
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
@@ -33,6 +34,8 @@ import com.waz.zclient.utils.ContextUtils.getString
 class ConversationFolderListAdapter(implicit context: Context)
   extends ConversationListAdapter
     with DerivedLogTag {
+
+  val onFolderStateChanged: SourceStream[FolderState] = EventStream[FolderState]()
 
   private var folders = Seq.empty[Folder]
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -68,7 +68,7 @@ abstract class ConversationListAdapter
 
   override def getItemId(position: Int): Long = items(position) match {
     case Item.IncomingRequests(first, _) => first.str.hashCode
-    case Item.Header(id, _)              => id.str.hashCode
+    case Item.Header(id, _, _)           => id.str.hashCode
     case Item.Conversation(data)         => data.id.str.hashCode
   }
 
@@ -120,7 +120,7 @@ object ConversationListAdapter {
   sealed trait Item
 
   object Item {
-    case class Header(id: Uid, title: String) extends Item
+    case class Header(id: Uid, title: String, isExpanded: Boolean) extends Item
     case class Conversation(data: ConversationData) extends Item
     case class IncomingRequests(first: ConvId, numberOfRequests: Int) extends Item
   }
@@ -155,6 +155,7 @@ object ConversationListAdapter {
     def bind(header: Item.Header, isFirst: Boolean): Unit = {
       row.setTitle(header.title)
       row.setIsFirstHeader(isFirst)
+      row.setIsExpanded(header.isExpanded)
     }
   }
 
@@ -210,8 +211,8 @@ object ConversationListAdapter {
 
     override def areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
       (oldList(oldItemPosition), newList(newItemPosition)) match {
-        case (Header(_, title), Header(_, newTitle)) =>
-          title == newTitle
+        case (Header(_, title, isExpanded), Header(_, newTitle, newIsExpanded)) =>
+          title == newTitle && isExpanded && newIsExpanded
         case (Conversation(data), Conversation(newData)) =>
           data == newData
         case (IncomingRequests(_, requests), IncomingRequests(_, newRequests)) =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -24,6 +24,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, Uid}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
+import com.waz.zclient.conversationlist.ConversationListFragment.FolderState
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
 import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, ConversationListRow, IncomingConversationListRow, NormalConversationListRow}
 import com.waz.zclient.log.LogUI._
@@ -39,6 +40,7 @@ abstract class ConversationListAdapter
 
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()
+  val onFolderStateChanged: SourceStream[FolderState] = EventStream[FolderState]()
 
   protected var items: List[Item] = List.empty
   protected var maxAlpha = 1.0f

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -24,7 +24,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, Uid}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
-import com.waz.zclient.conversationlist.ConversationListFragment.FolderState
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
 import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, ConversationListRow, IncomingConversationListRow, NormalConversationListRow}
 import com.waz.zclient.log.LogUI._
@@ -40,7 +39,6 @@ abstract class ConversationListAdapter
 
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()
-  val onFolderStateChanged: SourceStream[FolderState] = EventStream[FolderState]()
 
   protected var items: List[Item] = List.empty
   protected var maxAlpha = 1.0f

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -30,6 +30,8 @@ import com.waz.zclient.log.LogUI._
 import com.waz.zclient.pages.main.conversationlist.views.ConversationCallback
 import com.waz.zclient.{R, ViewHelper}
 
+import scala.collection.mutable.ListBuffer
+
 abstract class ConversationListAdapter
   extends RecyclerView.Adapter[ConversationRowViewHolder]
     with RowClickListener
@@ -40,7 +42,7 @@ abstract class ConversationListAdapter
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()
 
-  protected var items: List[Item] = List.empty
+  protected val items = new ListBuffer[Item]
   protected var maxAlpha = 1.0f
 
   def setMaxAlpha(maxAlpha: Float): Unit = {
@@ -54,8 +56,9 @@ abstract class ConversationListAdapter
     * @param newItems the new data source.
     */
   protected def updateList(newItems: List[Item]): Unit = {
-    DiffUtil.calculateDiff(new DiffCallback(items, newItems), false).dispatchUpdatesTo(this)
-    items = newItems
+    DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
+    items.clear()
+    items.appendAll(newItems)
   }
 
   override def getItemCount: Int = items.size

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -21,7 +21,7 @@ import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
 import android.view.{View, ViewGroup}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{ConvId, ConversationData}
+import com.waz.model.{ConvId, ConversationData, Uid}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
@@ -68,7 +68,7 @@ abstract class ConversationListAdapter
 
   override def getItemId(position: Int): Long = items(position) match {
     case Item.IncomingRequests(first, _) => first.str.hashCode
-    case Item.Header(title)              => title.hashCode
+    case Item.Header(id, _)              => id.str.hashCode
     case Item.Conversation(data)         => data.id.str.hashCode
   }
 
@@ -120,7 +120,7 @@ object ConversationListAdapter {
   sealed trait Item
 
   object Item {
-    case class Header(title: String) extends Item
+    case class Header(id: Uid, title: String) extends Item
     case class Conversation(data: ConversationData) extends Item
     case class IncomingRequests(first: ConvId, numberOfRequests: Int) extends Item
   }
@@ -210,7 +210,7 @@ object ConversationListAdapter {
 
     override def areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
       (oldList(oldItemPosition), newList(newItemPosition)) match {
-        case (Header(title), Header(newTitle)) =>
+        case (Header(_, title), Header(_, newTitle)) =>
           title == newTitle
         case (Conversation(data), Conversation(newData)) =>
           data == newData

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -205,8 +205,8 @@ object ConversationListAdapter {
 
     override def areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = {
       (oldList(oldItemPosition), newList(newItemPosition)) match {
-        case (_: Header,           _: Header)           => true
-        case (_: Conversation,     _: Conversation)     => true
+        case (lhs: Header,       rhs: Header)           => lhs.id == rhs.id
+        case (lhs: Conversation, rhs: Conversation)     => lhs.data.id == rhs.data.id
         case (_: IncomingRequests, _: IncomingRequests) => true
         case _                                          => false
       }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -23,13 +23,13 @@ import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 class NormalConversationListAdapter extends ConversationListAdapter {
 
   def setData(convs: Seq[ConversationData], incoming: Seq[ConvId]): Unit = {
-    items = List.empty
+    var newItems = List.empty[Item]
     
     if (incoming.nonEmpty) {
-      items = List(Item.IncomingRequests(incoming.head, incoming.size))
+      newItems = List(Item.IncomingRequests(incoming.head, incoming.size))
     }
 
-    items ++= convs.map { data => Item.Conversation(data) }
-    notifyDataSetChanged()
+    newItems ++= convs.map { data => Item.Conversation(data) }
+    updateList(newItems)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -233,7 +233,6 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   private var moveToAnimator: ObjectAnimator = _
 
   def setConversation(conversationData: ConversationData): Unit = if (this.conversationData.forall(_.id != conversationData.id)) {
-    // TODO: We don't need to store all this data.
     this.conversationData = Some(conversationData)
     title.setText(if (conversationData.displayName.str.nonEmpty) conversationData.displayName.str else getString(R.string.default_deleted_username))
 
@@ -575,8 +574,8 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
   }
 
   def setIsExpanded(isExpanded: Boolean): Unit = {
-    if (isExpanded) expandIcon.setImageDrawable(getDrawable(R.drawable.icon_arrow_down_white))
-    else expandIcon.setImageDrawable(getDrawable(R.drawable.icon_arrow_up_white))
+    val resId = if (isExpanded) R.drawable.icon_arrow_down_white else R.drawable.icon_arrow_up_white
+    expandIcon.setImageDrawable(getDrawable(resId))
   }
 
   private def setLayoutParameters(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -562,8 +562,8 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
   inflate(R.layout.conv_list_section_header)
   setLayoutParameters()
 
-  private val title = ViewUtils.getView(this, R.id.header_textview_title).asInstanceOf[TypefaceTextView]
-  private val expandIcon = ViewUtils.getView(this, R.id.header_imageview_expand).asInstanceOf[ImageView]
+  private val expandIcon = ViewUtils.getView(this, R.id.conv_list_section_imageview_expand).asInstanceOf[ImageView]
+  private val title = ViewUtils.getView(this, R.id.conv_list_section_textview_title).asInstanceOf[TypefaceTextView]
 
   def setTitle(title: String): Unit = this.title.setText(title)
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -24,7 +24,7 @@ import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.{View, ViewGroup}
 import android.widget.LinearLayout.LayoutParams
-import android.widget.{FrameLayout, LinearLayout}
+import android.widget.{FrameLayout, ImageView, LinearLayout}
 import com.waz.api.Message
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
@@ -564,6 +564,7 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
   setLayoutParameters()
 
   private val title = ViewUtils.getView(this, R.id.header_textview_title).asInstanceOf[TypefaceTextView]
+  private val expandIcon = ViewUtils.getView(this, R.id.header_imageview_expand).asInstanceOf[ImageView]
 
   def setTitle(title: String): Unit = this.title.setText(title)
 
@@ -571,6 +572,11 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
     val params = getLayoutParams.asInstanceOf[RecyclerView.LayoutParams]
     params.topMargin = if (isFirstHeader) 0 else getDimenPx(R.dimen.wire__padding__20)
     setLayoutParams(params)
+  }
+
+  def setIsExpanded(isExpanded: Boolean): Unit = {
+    if (isExpanded) expandIcon.setImageDrawable(getDrawable(R.drawable.icon_arrow_down_white))
+    else expandIcon.setImageDrawable(getDrawable(R.drawable.icon_arrow_up_white))
   }
 
   private def setLayoutParameters(): Unit = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CirceJSONSupport.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CirceJSONSupport.scala
@@ -18,9 +18,9 @@
 package com.waz.utils
 import java.net.{URI, URL}
 
-import com.waz.model.{AssetId, AssetToken, Name, RAssetId, Sha256, TeamId, UserId}
+import com.waz.model._
 import io.circe.generic.AutoDerivation
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 import org.threeten.bp.{Duration, Instant}
 
 trait CirceJSONSupport extends AutoDerivation {
@@ -48,4 +48,6 @@ trait CirceJSONSupport extends AutoDerivation {
   implicit def AssetIdDecoder: Decoder[AssetId] = Decoder[String].map(AssetId.apply)
   implicit def AssetTokenDecoder: Decoder[AssetToken] = Decoder[String].map(AssetToken.apply)
 
+  implicit def UidKeyDecoder: KeyDecoder[Uid] = KeyDecoder[String].map(Uid.apply)
+  implicit def UidKeyEncoder: KeyEncoder[Uid] = KeyEncoder[String].contramap(_.str)
 }


### PR DESCRIPTION
## What's new in this PR?

This PR contains changes two changes. First, `DiffUtil` is now used to efficiently update the list when the data source changes. Previously, any update was triggering a complete reload. Secondly, folders can now be collapsed and expanded, and these states are also persisted.


#### APK
[Download build #158](http://10.10.124.11:8080/job/Pull%20Request%20Builder/158/artifact/build/artifact/wire-dev-PR2342-158.apk)
[Download build #159](http://10.10.124.11:8080/job/Pull%20Request%20Builder/159/artifact/build/artifact/wire-dev-PR2342-159.apk)
[Download build #169](http://10.10.124.11:8080/job/Pull%20Request%20Builder/169/artifact/build/artifact/wire-dev-PR2342-169.apk)
[Download build #170](http://10.10.124.11:8080/job/Pull%20Request%20Builder/170/artifact/build/artifact/wire-dev-PR2342-170.apk)