### PR TITLE
Fix: Upload folders to backend on any change

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -182,7 +182,7 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
   }
 
   override def update(folderId: FolderId, folderName: Name, uploadAllChanges: Boolean): Future[Unit] = for {
-    _ <- foldersStorage.update(folderId, _.copy(name = folderName)).map(_ => ())
+    _ <- foldersStorage.update(folderId, _.copy(name = folderName))
     _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
   

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -36,19 +36,19 @@ trait FoldersService {
   def eventProcessingStage: EventScheduler.Stage
   def processFolders(folders: Seq[RemoteFolderData]): Future[Unit]
 
-  def addConversationTo(convId: ConvId, folderId: FolderId): Future[Unit]
-  def removeConversationFrom(convId: ConvId, folderId: FolderId): Future[Unit]
-  def removeConversationFromAll(convId: ConvId): Future[Unit]
+  def addConversationTo(convId: ConvId, folderId: FolderId, uploadAllChanges: Boolean): Future[Unit]
+  def removeConversationFrom(convId: ConvId, folderId: FolderId, uploadAllChanges: Boolean): Future[Unit]
+  def removeConversationFromAll(convId: ConvId, uploadAllChanges: Boolean): Future[Unit]
   def convsInFolder(folderId: FolderId): Future[Set[ConvId]]
   def isInFolder(convId: ConvId, folderId: FolderId): Future[Boolean]
 
   def favouritesFolderId: Signal[Option[FolderId]]
   def folders: Future[Seq[FolderData]]
-  def addFolder(folderName: Name, convIds: Set[ConvId]): Future[FolderId]
-  def removeFolder(folderId: FolderId): Future[Unit]
+  def addFolder(folderName: Name, uploadAllChanges: Boolean): Future[FolderId]
+  def removeFolder(folderId: FolderId, uploadAllChanges: Boolean): Future[Unit]
   def ensureFavouritesFolder(): Future[FolderId]
   def removeFavouritesFolder(): Future[Unit]
-  def update(folderId: FolderId, folderName: Name): Future[Unit]
+  def update(folderId: FolderId, folderName: Name, uploadAllChanges: Boolean): Future[Unit]
 
   def foldersForConv(convId: ConvId): Future[Set[FolderId]]
 
@@ -86,13 +86,13 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
                          }).map(_.toMap)
       currentFolders  <- foldersStorage.list().map(_.map(folder => folder.id -> folder).toMap)
       foldersToDelete =  currentFolders.keySet -- newFolders.keySet
-      _               <- Future.sequence(foldersToDelete.map(removeFolder))
+      _               <- Future.sequence(foldersToDelete.map(removeFolder(_, false)))
       foldersToAdd    =  newFolders.filterKeys(id => !currentFolders.contains(id)).values
       _               <- Future.sequence(foldersToAdd.map { case (data, convIds) =>
-                           foldersStorage.insert(data).flatMap(_ => addAllConversationsTo(convIds, data.id))
+                           foldersStorage.insert(data).flatMap(_ => addAllConversationsTo(convIds, data.id, false))
                          })
       foldersToUpdate =  newFolders.collect { case (id, (data, _)) if currentFolders.contains(id) && data.name != currentFolders(id).name => data }
-      _               <- Future.sequence(foldersToUpdate.map(folder => update(folder.id, folder.name)))
+      _               <- Future.sequence(foldersToUpdate.map(folder => update(folder.id, folder.name, false)))
       // at this point the list of folders in newFolders should be the same as in the storage, so we can use newFolders to get currentConvs
       currentConvs    <- Future.sequence(newFolders.keys.map(id =>
                            conversationFoldersStorage.findForFolder(id).map(convIds => id -> convIds)
@@ -102,14 +102,14 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
                            if (convsToDelete.nonEmpty) Some(folderId -> convsToDelete) else None
                          }
       _               <- Future.sequence(convsToDelete.flatMap { case (folderId, convIds) =>
-                           convIds.map(removeConversationFrom(_, folderId))
+                           convIds.map(removeConversationFrom(_, folderId, false))
                          })
       convsToAdd      =  currentConvs.flatMap { case (folderId, convIds) =>
                            val convsToAdd = newFolders(folderId)._2 -- convIds
                            if (convsToAdd.nonEmpty) Some(folderId -> convsToAdd) else None
                          }
       _               <- Future.sequence(convsToAdd.flatMap { case (folderId, convIds) =>
-                           convIds.map(addConversationTo(_, folderId))
+                           convIds.map(addConversationTo(_, folderId, false))
                          })
     } yield ()
 
@@ -122,26 +122,26 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
     } yield favoriteFolderId
 
 
-  override def addConversationTo(convId: ConvId, folderId: FolderId): Future[Unit] = for {
+  override def addConversationTo(convId: ConvId, folderId: FolderId, uploadAllChanges: Boolean): Future[Unit] = for {
     _ <- conversationFoldersStorage.put(convId, folderId)
-    _ <- sync.postFolders()
+    _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
 
 
-  private def addAllConversationsTo(convIds: Set[ConvId], folderId: FolderId): Future[Unit] = for {
-    _ <- conversationFoldersStorage.insertAll(convIds.map(id => ConversationFolderData(id, folderId))).map(_ => ())
-    _ <- sync.postFolders()
+  private def addAllConversationsTo(convIds: Set[ConvId], folderId: FolderId, uploadAllChanges: Boolean): Future[Unit] = for {
+    _ <- conversationFoldersStorage.insertAll(convIds.map(id => ConversationFolderData(id, folderId)))
+    _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
 
-  override def removeConversationFrom(convId: ConvId, folderId: FolderId): Future[Unit] = for {
+  override def removeConversationFrom(convId: ConvId, folderId: FolderId, uploadAllChanges: Boolean): Future[Unit] = for {
     _ <- conversationFoldersStorage.remove((convId, folderId))
-    _ <- sync.postFolders()
+    _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
 
-  override def removeConversationFromAll(convId: ConvId): Future[Unit] = for {
+  override def removeConversationFromAll(convId: ConvId, uploadAllChanges: Boolean): Future[Unit] = for {
     allFolders <- foldersForConv(convId)
     _ <- conversationFoldersStorage.removeAll(allFolders.map((convId, _)))
-    _ <- sync.postFolders()
+    _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
 
   override def foldersForConv(convId: ConvId): Future[Set[FolderId]] =
@@ -156,37 +156,38 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
   override def folder(folderId: FolderId): Signal[Option[FolderData]] =
     foldersStorage.optSignal(folderId)
 
-  override def addFolder(folderName: Name, convIds: Set[ConvId]): Future[FolderId] = for {
-    folderId <- addFolder(folderName, FolderData.CustomFolderType)
-    _        <- addAllConversationsTo(convIds, folderId) // this will sync too
-  } yield folderId
+  override def addFolder(folderName: Name, uploadAllChanges: Boolean): Future[FolderId] = addFolder(folderName, FolderData.CustomFolderType, uploadAllChanges)
 
-  private def addFolder(folderName: Name, folderType: Int): Future[FolderId] = for {
+  private def addFolder(folderName: Name, folderType: Int, uploadAllChanges: Boolean): Future[FolderId] = for {
     folder    <- Future.successful(FolderData(name = folderName, folderType = folderType))
     folderId  <- foldersStorage.put(folder.id, folder).map(_.id)
+    _         <- postFoldersIfNeeded(uploadAllChanges)
   } yield folderId
 
-  override def removeFolder(folderId: FolderId): Future[Unit] = for {
+  override def removeFolder(folderId: FolderId, uploadAllChanges: Boolean): Future[Unit] = for {
     convIds <- convsInFolder(folderId)
     _       <- conversationFoldersStorage.removeAll(convIds.map((_, folderId)))
     _       <- foldersStorage.remove(folderId)
-    _       <- sync.postFolders()
+    _       <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
 
   override def ensureFavouritesFolder(): Future[FolderId] = favouritesFolderId.head.flatMap {
     case Some(x) => Future.successful(x)
-    case None => addFolder("", FolderData.FavouritesFolderType)
+    case None => addFolder("", FolderData.FavouritesFolderType, true)
   }
 
   override def removeFavouritesFolder(): Future[Unit] = favouritesFolderId.head.flatMap {
-    case Some(id) => removeFolder(id)
+    case Some(id) => removeFolder(id, true)
     case None => Future.successful(())
   }
 
-  override def update(folderId: FolderId, folderName: Name): Future[Unit] = for {
+  override def update(folderId: FolderId, folderName: Name, uploadAllChanges: Boolean): Future[Unit] = for {
     _ <- foldersStorage.update(folderId, _.copy(name = folderName)).map(_ => ())
-    _ <- sync.postFolders()
+    _ <- postFoldersIfNeeded(uploadAllChanges)
   } yield ()
+  
+  private def postFoldersIfNeeded(shouldUpload: Boolean) =
+    if (shouldUpload) sync.postFolders() else Future.successful(())
 
   override def folders: Future[Seq[FolderData]] = foldersStorage.list()
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -159,12 +159,6 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
   (conversationFoldersStorage.onAdded _).expects().anyNumberOfTimes().returning(onConvsAdded)
   (conversationFoldersStorage.onDeleted _).expects().anyNumberOfTimes().returning(onConvsDeleted)
 
-  (sync.postFolders _).expects().anyNumberOfTimes().onCall { _ =>
-    callsToPostFolders += 1
-    Future.successful(SyncId())
-  }
-
-  var callsToPostFolders = 0
 
   private var _service = Option.empty[FoldersService]
 
@@ -181,6 +175,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -198,6 +193,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -214,6 +210,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Keep in favourites after adding to folder") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -231,6 +228,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Conversations stays in favourites after removing from another folder") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -250,6 +248,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // given
       val folderId = FolderId("folder_id1")
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -266,6 +265,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Multiple conversations in Favourites") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -283,6 +283,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Adding and removing multiple conversations in Favourites") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val favConvs = for {
@@ -301,6 +302,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Adding and removing conversations from custom folders does not change favourites") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       val favConvs = for {
         favId     <- service.ensureFavouritesFolder()
@@ -426,6 +428,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Get list of folders for conversation includes favourites") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val fs = for {
@@ -445,6 +448,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
     scenario("remove a conversation from a folder") {
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       val convInFavsAfterAdding = for {
         favFolder <- service.ensureFavouritesFolder()
@@ -464,6 +468,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Retrieve changes to the Favourites through a signal") {
       // given
       val service = getService
+      (sync.postFolders _).expects().repeat(2).returning{ Future.successful(SyncId()) }
 
       val states = mutable.ListBuffer[Map[FolderId, Set[ConvId]]]()
       service.foldersWithConvs { state =>
@@ -543,6 +548,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Get mapping from folders to conversations") {
       // given
       val service = getService
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val foldersFuture = for {
@@ -703,14 +709,13 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Add a folder will upload to backend") {
       // given
       val service = getService
-      callsToPostFolders = 0
+
+      // expect
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       val fid = Await.result(service.addFolder("custom folder", false), 500.millis)
       Await.result(service.addConversationTo(convId1, fid, true), 500.millis)
-
-      // then
-      callsToPostFolders shouldBe 1
     }
 
     scenario("Add to an existing folder will upload to backend") {
@@ -718,11 +723,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val service = getService
       val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
 
+      // expect
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
+
       // when
       Await.result(service.addConversationTo(ConvId("foo"), folderId, true), 500.millis)
-
-      // then
-      callsToPostFolders shouldBe 1
     }
 
     scenario("Remove from folder will upload to backend") {
@@ -732,11 +737,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
       Await.result(service.addConversationTo(convId, folderId, false), 500.millis)
 
+      // expect
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
+
       // when
       Await.result(service.removeConversationFrom(convId, folderId, true), 500.millis)
-
-      // then
-      callsToPostFolders shouldBe 1
     }
 
     scenario("Remove from all folders will upload to backend") {
@@ -745,26 +750,24 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val convId = ConvId("cid1")
       val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
       Await.result(service.addConversationTo(convId, folderId, false), 500.millis)
-      callsToPostFolders = 0
+
+      // expect
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       Await.result(service.removeConversationFromAll(convId, true), 500.millis)
-
-      // then
-      callsToPostFolders shouldBe 1
     }
 
     scenario("Renaming folder will upload to backend") {
       // given
       val service = getService
       val folderId = Await.result(service.addFolder("Foo", false), 500.millis)
-      callsToPostFolders = 0
+
+      // expect
+      (sync.postFolders _).expects().once().returning{ Future.successful(SyncId()) }
 
       // when
       Await.result(service.update(folderId, "Bam!", true), 500.millis)
-
-      // then
-      callsToPostFolders shouldBe 1
     }
   }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -185,7 +185,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId <- service.ensureFavouritesFolder()
-        _     <- service.addConversationTo(convId1, favId)
+        _     <- service.addConversationTo(convId1, favId, false)
         favs  <- service.convsInFolder(favId)
       } yield favs
 
@@ -202,8 +202,8 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId <- service.ensureFavouritesFolder()
-        _     <- service.addConversationTo(convId1, favId)
-        _     <- service.removeConversationFrom(convId1, favId)
+        _     <- service.addConversationTo(convId1, favId, false)
+        _     <- service.removeConversationFrom(convId1, favId, false)
         favs  <- service.convsInFolder(favId)
       } yield favs
 
@@ -218,9 +218,9 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId     <- service.ensureFavouritesFolder()
-        folderId  <- service.addFolder("custom folder", Set())
-        _         <- service.addConversationTo(convId1, favId)
-        _         <- service.addConversationTo(convId1, folderId)
+        folderId  <- service.addFolder("custom folder", false)
+        _         <- service.addConversationTo(convId1, favId, false)
+        _         <- service.addConversationTo(convId1, folderId, false)
         favs      <- service.convsInFolder(favId)
       } yield favs
 
@@ -235,10 +235,10 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId     <- service.ensureFavouritesFolder()
-        folderId  <- service.addFolder("custom folder", Set())
-        _         <- service.addConversationTo(convId1, favId)
-        _         <- service.addConversationTo(convId1, folderId)
-        _         <- service.removeConversationFrom(convId1, folderId)
+        folderId  <- service.addFolder("custom folder", false)
+        _         <- service.addConversationTo(convId1, favId, false)
+        _         <- service.addConversationTo(convId1, folderId, false)
+        _         <- service.removeConversationFrom(convId1, folderId, false)
         favs      <- service.convsInFolder(favId)
       } yield favs
 
@@ -254,8 +254,8 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId     <- service.ensureFavouritesFolder()
-        folderId  <- service.addFolder("custom folder", Set())
-        _         <- service.addConversationTo(convId1, folderId)
+        folderId  <- service.addFolder("custom folder", false)
+        _         <- service.addConversationTo(convId1, folderId, false)
         favs      <- service.convsInFolder(favId)
       } yield favs
 
@@ -270,9 +270,9 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId <- service.ensureFavouritesFolder()
-        _     <- service.addConversationTo(convId1, favId)
-        _     <- service.addConversationTo(convId2, favId)
-        _     <- service.addConversationTo(convId3, favId)
+        _     <- service.addConversationTo(convId1, favId, false)
+        _     <- service.addConversationTo(convId2, favId, false)
+        _     <- service.addConversationTo(convId3, favId, false)
         favs  <- service.convsInFolder(favId)
       } yield favs
 
@@ -287,10 +287,10 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val favConvs = for {
         favId <- service.ensureFavouritesFolder()
-        _     <- service.addConversationTo(convId1, favId)
-        _     <- service.addConversationTo(convId2, favId)
-        _     <- service.removeConversationFrom(convId1, favId)
-        _     <- service.addConversationTo(convId3, favId)
+        _     <- service.addConversationTo(convId1, favId, false)
+        _     <- service.addConversationTo(convId2, favId, false)
+        _     <- service.removeConversationFrom(convId1, favId, false)
+        _     <- service.addConversationTo(convId3, favId, false)
         favs  <- service.convsInFolder(favId)
       } yield favs
 
@@ -304,14 +304,14 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       val favConvs = for {
         favId     <- service.ensureFavouritesFolder()
-        _         <- service.addConversationTo(convId1, favId)
-        _         <- service.addConversationTo(convId2, favId)
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        _         <- service.addConversationTo(convId2, folderId2)
-        _         <- service.addConversationTo(convId3, folderId1)
-        _         <- service.removeConversationFrom(convId1, folderId1)
+        _         <- service.addConversationTo(convId1, favId, false)
+        _         <- service.addConversationTo(convId2, favId, false)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        _         <- service.addConversationTo(convId2, folderId2, false)
+        _         <- service.addConversationTo(convId3, folderId1, false)
+        _         <- service.removeConversationFrom(convId1, folderId1, false)
         favs      <- service.convsInFolder(favId)
       } yield favs
 
@@ -329,8 +329,8 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val res = for {
-        folderId1  <- service.addFolder("custom folder", Set())
-        _          <- service.addConversationTo(convId1, folderId1)
+        folderId1  <- service.addFolder("custom folder", false)
+        _          <- service.addConversationTo(convId1, folderId1, false)
         convs      <- service.convsInFolder(folderId1)
         isInFolder <- service.isInFolder(convId1, folderId1)
       } yield (convs, isInFolder)
@@ -345,11 +345,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val res = for {
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        _         <- service.addConversationTo(convId2, folderId2)
-        _         <- service.addConversationTo(convId3, folderId1)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        _         <- service.addConversationTo(convId2, folderId2, false)
+        _         <- service.addConversationTo(convId3, folderId1, false)
       } yield (folderId1, folderId2)
      val (folderId1, folderId2) = Await.result(res, 500.millis)
 
@@ -366,12 +366,12 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // given
       val service = getService
       val res = for {
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        _         <- service.addConversationTo(convId2, folderId2)
-        _         <- service.addConversationTo(convId3, folderId1)
-        _         <- service.removeConversationFrom(convId1, folderId1)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        _         <- service.addConversationTo(convId2, folderId2, false)
+        _         <- service.addConversationTo(convId3, folderId1, false)
+        _         <- service.removeConversationFrom(convId1, folderId1, false)
       } yield (folderId1, folderId2)
       val (folderId1, folderId2) = Await.result(res, 500.millis)
 
@@ -392,9 +392,9 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val convs = for {
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        _         <- service.removeConversationFrom(convId1, folderId1)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        _         <- service.removeConversationFrom(convId1, folderId1, false)
         convs     <- service.convsInFolder(folderId1)
       } yield convs
 
@@ -408,11 +408,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val convs = for {
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.addConversationTo(convId2, folderId1)
-        _         <- service.addConversationTo(convId1, folderId2)
-        _         <- service.removeConversationFromAll(convId1)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.addConversationTo(convId2, folderId1, false)
+        _         <- service.addConversationTo(convId1, folderId2, false)
+        _         <- service.removeConversationFromAll(convId1, false)
         convs1    <- service.convsInFolder(folderId1)
         convs2    <- service.convsInFolder(folderId2)
       } yield (convs1, convs2)
@@ -430,11 +430,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val fs = for {
         favId     <- service.ensureFavouritesFolder()
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        _         <- service.addConversationTo(convId1, folderId2)
-        _         <- service.addConversationTo(convId1, favId)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        _         <- service.addConversationTo(convId1, folderId2, false)
+        _         <- service.addConversationTo(convId1, favId, false)
         folders   <- service.foldersForConv(convId1)
       } yield ((favId, folderId1, folderId2), folders)
       val ((favId, folderId1, folderId2), folders) = Await.result(fs, 500.millis)
@@ -448,14 +448,14 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       val convInFavsAfterAdding = for {
         favFolder <- service.ensureFavouritesFolder()
-        _         <- service.addConversationTo(convId1, favFolder)
+        _         <- service.addConversationTo(convId1, favFolder, false)
         res       <- service.isInFolder(convId1, favFolder)
       } yield res
       assert(Await.result(convInFavsAfterAdding, 500.millis) == true)
 
       val convInFavsAfterRemoval = for {
         favFolder <- service.ensureFavouritesFolder()
-        _         <- service.removeConversationFrom(convId1, favFolder)
+        _         <- service.removeConversationFrom(convId1, favFolder, false)
         res       <- service.isInFolder(convId1, favFolder)
       } yield res
       assert(Await.result(convInFavsAfterRemoval, 500.millis) == false)
@@ -475,13 +475,13 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val res = for {
         favId     <- service.ensureFavouritesFolder()
-        _         <- service.addConversationTo(convId1, favId)
-        folderId1 <- service.addFolder("custom folder 1", Set())
-        _         <- service.addConversationTo(convId1, folderId1)
-        folderId2 <- service.addFolder("custom folder 2", Set())
-        _         <- service.removeConversationFrom(convId1, folderId1)
-        _         <- service.addConversationTo(convId1, folderId2)
-        _         <- service.removeFolder(folderId1)
+        _         <- service.addConversationTo(convId1, favId, false)
+        folderId1 <- service.addFolder("custom folder 1", false)
+        _         <- service.addConversationTo(convId1, folderId1, false)
+        folderId2 <- service.addFolder("custom folder 2", false)
+        _         <- service.removeConversationFrom(convId1, folderId1, false)
+        _         <- service.addConversationTo(convId1, folderId2, false)
+        _         <- service.removeFolder(folderId1, false)
         _         <- service.removeFavouritesFolder()
       } yield (favId, folderId1, folderId2)
 
@@ -547,9 +547,12 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // when
       val foldersFuture = for {
         favouriteId <- service.ensureFavouritesFolder()
-        folderId1   <- service.addFolder("F1", Set(convId1, convId2))
-        folderId2   <- service.addFolder("F2", Set(convId1))
-        _           <- service.addConversationTo(convId1, favouriteId)
+        folderId1   <- service.addFolder("F1", false)
+        _           <- service.addConversationTo(convId1, folderId1, false)
+        _           <- service.addConversationTo(convId2, folderId1, false)
+        folderId2   <- service.addFolder("F2", false)
+        _           <- service.addConversationTo(convId1, folderId2, false)
+        _           <- service.addConversationTo(convId1, favouriteId, false)
         folders     <- service.foldersToSynchronize()
       } yield (favouriteId, folderId1, folderId2, folders)
       val (favouriteId, folderId1, folderId2, folders) = Await.result(foldersFuture, 500.millis)
@@ -703,7 +706,8 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       callsToPostFolders = 0
 
       // when
-      Await.result(service.addFolder("custom folder", Set(convId1)), 500.millis)
+      val fid = Await.result(service.addFolder("custom folder", false), 500.millis)
+      Await.result(service.addConversationTo(convId1, fid, true), 500.millis)
 
       // then
       callsToPostFolders shouldBe 1
@@ -712,11 +716,10 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Add to an existing folder will upload to backend") {
       // given
       val service = getService
-      val folderId = Await.result(service.addFolder("custom folder", Set()), 500.millis)
-      callsToPostFolders = 0
+      val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
 
       // when
-      Await.result(service.addConversationTo(ConvId("foo"), folderId), 500.millis)
+      Await.result(service.addConversationTo(ConvId("foo"), folderId, true), 500.millis)
 
       // then
       callsToPostFolders shouldBe 1
@@ -726,12 +729,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // given
       val service = getService
       val convId = ConvId("cid1")
-      val folderId = Await.result(service.addFolder("custom folder", Set()), 500.millis)
-      Await.result(service.addConversationTo(convId, folderId), 500.millis)
-      callsToPostFolders = 0
+      val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
+      Await.result(service.addConversationTo(convId, folderId, false), 500.millis)
 
       // when
-      Await.result(service.removeConversationFrom(convId, folderId), 500.millis)
+      Await.result(service.removeConversationFrom(convId, folderId, true), 500.millis)
 
       // then
       callsToPostFolders shouldBe 1
@@ -741,12 +743,12 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       // given
       val service = getService
       val convId = ConvId("cid1")
-      val folderId = Await.result(service.addFolder("custom folder", Set()), 500.millis)
-      Await.result(service.addConversationTo(convId, folderId), 500.millis)
+      val folderId = Await.result(service.addFolder("custom folder", false), 500.millis)
+      Await.result(service.addConversationTo(convId, folderId, false), 500.millis)
       callsToPostFolders = 0
 
       // when
-      Await.result(service.removeConversationFromAll(convId), 500.millis)
+      Await.result(service.removeConversationFromAll(convId, true), 500.millis)
 
       // then
       callsToPostFolders shouldBe 1
@@ -755,11 +757,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario("Renaming folder will upload to backend") {
       // given
       val service = getService
-      val folderId = Await.result(service.addFolder("Foo", Set()), 500.millis)
+      val folderId = Await.result(service.addFolder("Foo", false), 500.millis)
       callsToPostFolders = 0
 
       // when
-      Await.result(service.update(folderId, "Bam!"), 500.millis)
+      Await.result(service.update(folderId, "Bam!", true), 500.millis)
 
       // then
       callsToPostFolders shouldBe 1


### PR DESCRIPTION
## What's new in this PR?

Folder changes were not uploaded to the backend. 

### Causes

The `postFolder()` method was never used.

### Solutions

Whenever a change is made in the `FolderService`, `postFolder()` is invoked. 

Note that we are not checking if the change is irrelevant, e.g. if I add a conversation to a folder and the folder was already there, there is no need to synchronize. We could optimize that in future if it becomes a problem.

### Testing

Covered by unit tests by monitoring calls to `postFolder()`
#### APK
[Download build #165](http://10.10.124.11:8080/job/Pull%20Request%20Builder/165/artifact/build/artifact/wire-dev-PR2343-165.apk)