### PR TITLE
[Fix] Folder design fixes

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,6 +1072,7 @@
     <string name="conversation_list__left_you">You left</string>
     <string name="conversation_list__removed_you">[[%1$s]] removed you</string>
     <string name="conversation_list__header__title">CONVERSATIONS</string>
+    <string name="conversation_list__header__folders_title">FOLDERS</string>
     <string name="conversation_list__header__archive_title">ARCHIVE</string>
     <string name="conversation_list__single_with_quote">Reply: %1$s</string>
     <string name="conversation_list__group_with_quote">Reply from %1$s: %2$s</string>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -190,8 +190,7 @@ object ConversationListController {
   }
 
   case object Folders extends ListMode {
-    // TODO: add real copy
-    override lazy val nameId: Int = R.string.conversation_list__header__title
+    override lazy val nameId: Int = R.string.conversation_list__header__folders_title
     override val filter: Filter = ConversationListController.RegularListFilter
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -84,7 +84,9 @@ abstract class ConversationListAdapter
   override def onBindViewHolder(holder: ConversationRowViewHolder, position: Int): Unit = {
     (items(position), holder) match {
       case (incomingRequests: Item.IncomingRequests, viewHolder: IncomingConversationRowViewHolder) =>
-        viewHolder.bind(incomingRequests.first, incomingRequests.numberOfRequests)
+        val Item.IncomingRequests(first, number) = incomingRequests
+        val showSeparator = !this.isInstanceOf[ConversationFolderListAdapter]
+        viewHolder.bind(first, number, showSeparator)
       case (header: Item.Header, viewHolder: ConversationFolderRowViewHolder) =>
         viewHolder.bind(header, isFirst = position == 0)
       case (conversation: Item.Conversation, viewHolder: NormalConversationRowViewHolder) =>
@@ -149,7 +151,10 @@ object ConversationListAdapter {
   class IncomingConversationRowViewHolder(row: IncomingConversationListRow, listener: RowClickListener)
     extends ConversationRowViewHolder(row, listener) {
 
-    def bind(first: ConvId, numberOfRequest: Int): Unit = row.setIncoming(first, numberOfRequest)
+    def bind(first: ConvId, numberOfRequest: Int, showSeparator: Boolean): Unit = {
+      row.setIncoming(first, numberOfRequest)
+      row.setSeparatorVisibility(showSeparator)
+    }
   }
 
   class ConversationFolderRowViewHolder(row: ConversationFolderListRow, listener: RowClickListener)
@@ -170,7 +175,6 @@ object ConversationListAdapter {
         r.setAlpha(1f)
         r.setMaxAlpha(adapter.maxAlpha)
 
-        // TODO: can we move this to our listener?
         r.setConversationCallback(new ConversationCallback {
           override def onConversationListRowSwiped(convId: String, view: View): Unit =
             r.conversationData.foreach(adapter.onConversationLongClick ! _)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -540,12 +540,17 @@ class IncomingConversationListRow(context: Context, attrs: AttributeSet, style: 
   val title = ViewUtils.getView(this, R.id.conversation_title).asInstanceOf[TypefaceTextView]
   val avatar = ViewUtils.getView(this, R.id.conversation_icon).asInstanceOf[ConversationAvatarView]
   val badge = ViewUtils.getView(this, R.id.conversation_badge).asInstanceOf[ConversationBadge]
+  val separator = ViewUtils.getView(this, R.id.conversation_separator).asInstanceOf[View]
 
   def setIncoming(first: ConvId, numberOfRequests: Int): Unit = {
     firstIncomingConversation = Some(first)
     avatar.setAlpha(getResourceFloat(R.dimen.conversation_avatar_alpha_inactive))
     title.setText(getInboxName(numberOfRequests))
     badge.setStatus(ConversationBadge.WaitingConnection)
+  }
+
+  def setSeparatorVisibility(isVisible: Boolean): Unit = {
+    separator.setVisibility(if (isVisible) View.VISIBLE else View.GONE)
   }
 
   private def getInboxName(convSize: Int): String = getResources.getQuantityString(R.plurals.connect_inbox__link__name, convSize, convSize.toString)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -30,7 +30,7 @@ import com.waz.utils.events.{EventStream, Signal}
 import com.waz.zclient.common.controllers.UserAccountsController
 import com.waz.zclient.common.drawables.TeamIconDrawable
 import com.waz.zclient.common.views.GlyphButton
-import com.waz.zclient.conversationlist.ConversationListController.{ListMode, Normal}
+import com.waz.zclient.conversationlist.ConversationListController.{Folders, ListMode, Normal}
 import com.waz.zclient.conversationlist.ListSeparatorDrawable
 import com.waz.zclient.tracking.AvailabilityChanged
 import com.waz.zclient.ui.text.TypefaceTextView
@@ -80,11 +80,11 @@ abstract class ConversationListTopToolbar(val context: Context, val attrs: Attri
     }
 
   def setTitle(mode: ListMode, currentUser: Option[UserData]): Unit = (mode, currentUser) match {
-    case (Normal, Some(user)) if user.teamId.nonEmpty =>
+    case (Normal | Folders, Some(user)) if user.teamId.nonEmpty =>
       title.setText(user.displayName)
       AvailabilityView.displayLeftOfText(title, user.availability, title.getCurrentTextColor, pushDown = true)
       title.onClick { AvailabilityView.showAvailabilityMenu(AvailabilityChanged.ListHeader) }
-    case (Normal, Some(user)) =>
+    case (Normal | Folders, Some(user)) =>
       title.setText(user.displayName)
       AvailabilityView.displayLeftOfText(title, Availability.None, title.getCurrentTextColor)
       title.setOnClickListener(null)


### PR DESCRIPTION
## What's new in this PR?

### Issues

- The row separator after "incoming request" should not be shown on the conversation folders screen.
- The title of the folder conversation screen was using temporary copy

#### APK
[Download build #187](http://10.10.124.11:8080/job/Pull%20Request%20Builder/187/artifact/build/artifact/wire-dev-PR2346-187.apk)