### PR TITLE
Fix/folders property payload

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -27,6 +27,7 @@ import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.otr.{Client, ClientId}
 import com.waz.service.PropertyKey
 import com.waz.service.conversation.RemoteFolderData
+import com.waz.service.conversation.RemoteFolderData._
 import com.waz.sync.client.ConversationsClient.ConversationResponse
 import com.waz.sync.client.OtrClient
 import com.waz.utils.JsonDecoder._
@@ -422,7 +423,7 @@ object PropertyEvent {
           case e => UnknownPropertyEvent(ReadReceiptsEnabled, e)
         }
         case Folders => decodeString('type) match {
-          case "user.properties-set" => FoldersEvent(decodeSeq[RemoteFolderData]('value))
+          case "user.properties-set" => FoldersEvent(decode[FoldersPropertyRemotePayload]('value).labels.map(_.toRemoteFolderData))
           case "user.properties-delete" => FoldersEvent(Seq[RemoteFolderData]())
           case e => UnknownPropertyEvent(Folders, e)
         }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -825,24 +825,27 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val json = payload.asJson.noSpaces
 
       // then
-      json shouldEqual """[
-                         |  {
-                         |    "id" : "f1",
-                         |    "name" : "F1",
-                         |    "type" : 0,
-                         |    "conversations" : [
-                         |      "c1",
-                         |      "c2"
-                         |    ]
-                         |  },
-                         |  {
-                         |    "id" : "fav",
-                         |    "name" : "FAV",
-                         |    "type" : 1,
-                         |    "conversations" : [
-                         |      "c2"
-                         |    ]
+      json shouldEqual """{
+                         | "labels":
+                         |  [
+                         |    {
+                         |      "id" : "f1",
+                         |      "name" : "F1",
+                         |      "type" : 0,
+                         |      "conversations" : [
+                         |        "c1",
+                         |        "c2"
+                         |      ]
+                         |    },
+                         |    {
+                         |      "id" : "fav",
+                         |      "name" : "FAV",
+                         |      "type" : 1,
+                         |      "conversations" : [
+                         |        "c2"
+                         |      ]
                          |  }]
+                         |}
                        """.stripMargin.replaceAll("\\s","")
     }
   }
@@ -851,24 +854,26 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario ("with favorites") {
 
       // given
-      val payload = """[
-        {
-          "name" : "F1",
-          "type" : 0,
-          "id" : "f1",
-          "conversations" : [
-            "c1",
-            "c2"
-          ]
-        },
-        {
-          "name" : "FAV",
-          "type" : 1,
-          "id" : "fav",
-          "conversations" : [
-            "c2"
-          ]
-        }]"""
+      val payload = """{
+                 | "labels" : [
+                 |  {
+                 |    "name" : "F1",
+                 |    "type" : 0,
+                 |    "id" : "f1",
+                 |    "conversations" : [
+                 |      "c1",
+                 |      "c2"
+                 |    ]
+                 |  },
+                 |  {
+                 |    "name" : "FAV",
+                 |    "type" : 1,
+                 |    "id" : "fav",
+                 |    "conversations" : [
+                 |      "c2"
+                 |    ]
+                 |  }
+                 |]""".stripMargin
 
       // when
       val seq = decode[Seq[IntermediateFolderData]](payload) match {
@@ -891,23 +896,26 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     scenario ("favorites with no name") {
 
       // given
-      val payload = """[
-        {
-          "name" : "F1",
-          "type" : 0,
-          "id" : "f1",
-          "conversations" : [
-            "c1",
-            "c2"
-          ]
-        },
-        {
-          "type" : 1,
-          "id" : "fav",
-          "conversations" : [
-            "c2"
-          ]
-        }]"""
+      val payload = """{
+                       |  "labels": [
+                       |    {
+                       |      "name" : "F1",
+                       |      "type" : 0,
+                       |      "id" : "f1",
+                       |      "conversations" : [
+                       |        "c1",
+                       |        "c2"
+                       |      ]
+                       |    },
+                       |    {
+                       |      "type" : 1,
+                       |      "id" : "fav",
+                       |      "conversations" : [
+                       |        "c2"
+                       |      ]
+                       |    }
+                       |  ]
+                       |}""".stripMargin
 
       // when
       val seq = decode[Seq[IntermediateFolderData]](payload) match {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -20,7 +20,7 @@ package com.waz.service
 import com.waz.content.{ConversationFoldersStorage, ConversationStorage, FoldersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, ConversationFolderData, FolderData, FolderId, FoldersEvent, Name, RConvId, SyncId}
-import com.waz.service.conversation.RemoteFolderData.IntermediateFolderData
+import com.waz.service.conversation.RemoteFolderData.{FoldersPropertyRemotePayload, IntermediateFolderData}
 import com.waz.service.conversation.{FoldersService, FoldersServiceImpl, RemoteFolderData}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
@@ -816,10 +816,10 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val favoritesId = FolderId("fav")
       val folder1 = FolderData(folderId1, "F1", FolderData.CustomFolderType)
       val folderFavorites = FolderData(favoritesId, "FAV", FolderData.FavoritesFolderType)
-      val payload = List(
-        RemoteFolderData(folder1, Set(convId1, convId2)),
-        RemoteFolderData(folderFavorites, Set(convId2))
-      )
+      val payload = FoldersPropertyRemotePayload(List(
+        new IntermediateFolderData(RemoteFolderData(folder1, Set(convId1, convId2))),
+        new IntermediateFolderData(RemoteFolderData(folderFavorites, Set(convId2)))
+      ))
 
       // when
       val json = payload.asJson.noSpaces
@@ -873,11 +873,11 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
                  |      "c2"
                  |    ]
                  |  }
-                 |]""".stripMargin
+                 |]}""".stripMargin
 
       // when
-      val seq = decode[Seq[IntermediateFolderData]](payload) match {
-        case Right(fs)   => fs.map(_.toRemoteFolderData)
+      val seq = decode[FoldersPropertyRemotePayload](payload) match {
+        case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
         case Left(error) => fail(error.getMessage)
       }
 
@@ -918,8 +918,8 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
                        |}""".stripMargin
 
       // when
-      val seq = decode[Seq[IntermediateFolderData]](payload) match {
-        case Right(fs)   => fs.map(_.toRemoteFolderData)
+      val seq = decode[FoldersPropertyRemotePayload](payload) match {
+        case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
         case Left(error) => fail(error.getMessage)
       }
 


### PR DESCRIPTION
## What's new in this PR?

Fix cross-platform compatibility with webapp and iOS implementation for updates to the folders.

### Issues

There is a remote user property called `labels`. The Android application was assuming the **value** of that `label` property to be:
```
[
   {folder1},
   {folder2}
]
```

The iOS and webapp were assuming the **value** of that property to be:
```
{
   "labels": [
     {folder1},
     {folder2}
   ]
}
```

The webapp and iOS assumption comes from:

- Best practices of not having JSON array as top-level item (see [JSON Hijacking](https://haacked.com/archive/2009/06/25/json-hijacking.aspx/))
- Future-proofing for versioning (e.g. ability to introduce a "labels_v2" key later)

### Solutions

I updated the Android implementation to expect the same payload as iOS and webapp.

### Testing

Unit tests have been updated, and they cover the serialization extensively. Additionally, I tested the Android implementation on device against the web implementation on device, and they synchronize properly.
