### PR TITLE
[Chore] Add content descriptions for rows

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -117,8 +117,12 @@ object ConversationFolderListAdapter {
     val OneToOnesId = Uid("OneToOnes")
 
     def apply(id: Uid, titleResId: Int, conversations: Seq[ConversationData])(implicit context: Context): Option[Folder] = {
-      if (conversations.nonEmpty) Some(Folder(id, getString(titleResId), conversations.map(d => Item.Conversation(d))))
-      else None
+      if (conversations.isEmpty) None
+      else {
+        val title = getString(titleResId)
+        val conversationItems = conversations.map { d => Item.Conversation(d, sectionTitle = Some(title))}
+        Some(Folder(id, title, conversationItems))
+      }
     }
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA needs to be able to identify the different types of rows on the conversation folders list. Specifically, they need to be able to identify what kind of item a row represents (incoming conversation, normal conversation, section header) as well as some state information (is the header expanded or collapsed, or which section a row belongs to).

### Solutions

Add content descriptions for each item type and set the content description on the row views when binding the items.
#### APK
[Download build #193](http://10.10.124.11:8080/job/Pull%20Request%20Builder/193/artifact/build/artifact/wire-dev-PR2349-193.apk)