### PR TITLE
Applied fixes from PR review

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -423,8 +423,8 @@ object PropertyEvent {
           case e => UnknownPropertyEvent(ReadReceiptsEnabled, e)
         }
         case Folders => decodeString('type) match {
-          case "user.properties-set" => FoldersEvent(decode[FoldersPropertyRemotePayload]('value).labels.map(_.toRemoteFolderData))
-          case "user.properties-delete" => FoldersEvent(Seq[RemoteFolderData]())
+          case "user.properties-set" => FoldersEvent(decode[FoldersProperty]('value).labels.map(_.toRemoteFolderData))
+          case "user.properties-delete" => FoldersEvent(Seq.empty[RemoteFolderData])
           case e => UnknownPropertyEvent(Folders, e)
         }
         case key => UnknownPropertyEvent(key, 'value)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -26,8 +26,8 @@ import com.waz.model.Event.EventDecoder
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.otr.{Client, ClientId}
 import com.waz.service.PropertyKey
+import com.waz.service.conversation.FoldersService.FoldersProperty
 import com.waz.service.conversation.RemoteFolderData
-import com.waz.service.conversation.RemoteFolderData._
 import com.waz.sync.client.ConversationsClient.ConversationResponse
 import com.waz.sync.client.OtrClient
 import com.waz.utils.JsonDecoder._
@@ -418,12 +418,12 @@ object PropertyEvent {
       import PropertyKey._
       decodePropertyKey('key) match {
         case ReadReceiptsEnabled => decodeString('type) match {
-          case "user.properties-set" => ReadReceiptEnabledPropertyEvent('value)
+          case "user.properties-set"    => ReadReceiptEnabledPropertyEvent('value)
           case "user.properties-delete" => ReadReceiptEnabledPropertyEvent(0)
           case e => UnknownPropertyEvent(ReadReceiptsEnabled, e)
         }
         case Folders => decodeString('type) match {
-          case "user.properties-set" => FoldersEvent(decode[FoldersProperty]('value).labels.map(_.toRemoteFolderData))
+          case "user.properties-set"    => FoldersEvent(decode[FoldersProperty]('value).toRemote)
           case "user.properties-delete" => FoldersEvent(Seq.empty[RemoteFolderData])
           case e => UnknownPropertyEvent(Folders, e)
         }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -27,7 +27,6 @@ import com.waz.sync.SyncServiceHandle
 import com.waz.threading.Threading
 import com.waz.utils.events.{AggregatingSignal, EventContext, EventStream, Signal}
 import com.waz.utils.{JsonDecoder, RichFuture}
-import io.circe.{Decoder, Encoder}
 import org.json.JSONObject
 
 import scala.concurrent.Future
@@ -243,26 +242,24 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
 
 }
 
-case class RemoteFolderData(folderData: FolderData, conversations: Set[RConvId])
-
-object RemoteFolderData {
+object FoldersService {
 
   // This type is matching the JSON payload on the backend
   // e. g. Do NOT rename "labels" or it will not serialize/deserialize properly
-  case class FoldersProperty(labels: Seq[IntermediateFolderData])
-
-  case class IntermediateFolderData(id: String, name: Option[String], `type`: Int, conversations: Vector[String]) {
-    def toRemoteFolderData: RemoteFolderData =
+  case class FoldersProperty(labels: Seq[IntermediateFolderData]) {
+    def toRemote: Seq[RemoteFolderData] = labels.map(label =>
       RemoteFolderData(
-        FolderData(id = FolderId(id), name = Name(name.getOrElse("")), folderType = `type`),
-        conversations.map(RConvId(_)).toSet
+        FolderData(id = FolderId(label.id), name = Name(label.name.getOrElse("")), folderType = label.`type`),
+        label.conversations.map(RConvId(_)).toSet
       )
+    )
   }
 
-  object IntermediateFolderData {
-    def apply(remoteFolderData: RemoteFolderData): IntermediateFolderData =
-      apply(remoteFolderData.folderData.id.str, Some(remoteFolderData.folderData.name.str), remoteFolderData.folderData.folderType, remoteFolderData.conversations.map(_.str).toVector)
+  object FoldersProperty {
+    def fromRemote(folders: Seq[RemoteFolderData]): FoldersProperty = FoldersProperty(folders.map(_.toIntermediate))
   }
+
+  case class IntermediateFolderData(id: String, name: Option[String], `type`: Int, conversations: Vector[String])
 
   // TODO: the old JSON decoder is still needed for FoldersEvent. Remove after migrating to circe.
   implicit val remoteFolderPropertyDecoder: JsonDecoder[FoldersProperty] = new JsonDecoder[FoldersProperty] {
@@ -287,4 +284,15 @@ object RemoteFolderData {
       )
     }
   }
+}
+
+case class RemoteFolderData(folderData: FolderData, conversations: Set[RConvId]) {
+  import FoldersService.IntermediateFolderData
+
+  def toIntermediate: IntermediateFolderData = IntermediateFolderData(
+    folderData.id.str,
+    Some(folderData.name.str),
+    folderData.folderType,
+    conversations.map(_.str).toVector
+  )
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/FoldersSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/FoldersSyncHandler.scala
@@ -37,11 +37,11 @@ class FoldersSyncHandler(prefsClient: PropertiesClient, foldersService: FoldersS
 
   def postFolders(): Future[SyncResult] =
     foldersService.foldersToSynchronize().flatMap(folders => prefsClient.putProperty(
-      PropertyKey.Folders, FoldersPropertyRemotePayload(labels = folders.map(new IntermediateFolderData(_))))
+      PropertyKey.Folders, FoldersProperty(labels = folders.map(IntermediateFolderData.apply)))
     ).map(SyncResult(_))
 
   def syncFolders(): Future[SyncResult] = {
-    prefsClient.getProperty[FoldersPropertyRemotePayload](PropertyKey.Folders).future.flatMap {
+    prefsClient.getProperty[FoldersProperty](PropertyKey.Folders).future.flatMap {
       case Right(Some(foldersProperty)) =>
         foldersService.processFolders(foldersProperty.labels.map(_.toRemoteFolderData)).map(_ => SyncResult.Success)
       case Right(None) => Future.successful(SyncResult.Success)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -877,7 +877,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val seq = decode[FoldersProperty](payload) match {
-        case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
+        case Right(fp)   => fp.labels.map(_.toRemote)
         case Left(error) => fail(error.getMessage)
       }
 
@@ -919,7 +919,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val seq = decode[FoldersProperty](payload) match {
-        case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
+        case Right(fp)   => fp.labels.map(_.toRemote)
         case Left(error) => fail(error.getMessage)
       }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -20,7 +20,7 @@ package com.waz.service
 import com.waz.content.{ConversationFoldersStorage, ConversationStorage, FoldersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, ConversationFolderData, FolderData, FolderId, FoldersEvent, Name, RConvId, SyncId}
-import com.waz.service.conversation.RemoteFolderData.{FoldersProperty, IntermediateFolderData}
+import com.waz.service.conversation.FoldersService.{FoldersProperty, IntermediateFolderData}
 import com.waz.service.conversation.{FoldersService, FoldersServiceImpl, RemoteFolderData}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
@@ -816,9 +816,9 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val favoritesId = FolderId("fav")
       val folder1 = FolderData(folderId1, "F1", FolderData.CustomFolderType)
       val folderFavorites = FolderData(favoritesId, "FAV", FolderData.FavoritesFolderType)
-      val payload = FoldersProperty(List(
-        IntermediateFolderData(RemoteFolderData(folder1, Set(convId1, convId2))),
-        IntermediateFolderData(RemoteFolderData(folderFavorites, Set(convId2)))
+      val payload = FoldersProperty.fromRemote(Seq(
+        RemoteFolderData(folder1, Set(convId1, convId2)),
+        RemoteFolderData(folderFavorites, Set(convId2))
       ))
 
       // when
@@ -877,7 +877,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val seq = decode[FoldersProperty](payload) match {
-        case Right(fp)   => fp.labels.map(_.toRemote)
+        case Right(fp)   => fp.toRemote
         case Left(error) => fail(error.getMessage)
       }
 
@@ -919,7 +919,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
 
       // when
       val seq = decode[FoldersProperty](payload) match {
-        case Right(fp)   => fp.labels.map(_.toRemote)
+        case Right(fp)   => fp.toRemote
         case Left(error) => fail(error.getMessage)
       }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -20,7 +20,7 @@ package com.waz.service
 import com.waz.content.{ConversationFoldersStorage, ConversationStorage, FoldersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, ConversationFolderData, FolderData, FolderId, FoldersEvent, Name, RConvId, SyncId}
-import com.waz.service.conversation.RemoteFolderData.{FoldersPropertyRemotePayload, IntermediateFolderData}
+import com.waz.service.conversation.RemoteFolderData.{FoldersProperty, IntermediateFolderData}
 import com.waz.service.conversation.{FoldersService, FoldersServiceImpl, RemoteFolderData}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
@@ -816,9 +816,9 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       val favoritesId = FolderId("fav")
       val folder1 = FolderData(folderId1, "F1", FolderData.CustomFolderType)
       val folderFavorites = FolderData(favoritesId, "FAV", FolderData.FavoritesFolderType)
-      val payload = FoldersPropertyRemotePayload(List(
-        new IntermediateFolderData(RemoteFolderData(folder1, Set(convId1, convId2))),
-        new IntermediateFolderData(RemoteFolderData(folderFavorites, Set(convId2)))
+      val payload = FoldersProperty(List(
+        IntermediateFolderData(RemoteFolderData(folder1, Set(convId1, convId2))),
+        IntermediateFolderData(RemoteFolderData(folderFavorites, Set(convId2)))
       ))
 
       // when
@@ -876,7 +876,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
                  |]}""".stripMargin
 
       // when
-      val seq = decode[FoldersPropertyRemotePayload](payload) match {
+      val seq = decode[FoldersProperty](payload) match {
         case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
         case Left(error) => fail(error.getMessage)
       }
@@ -918,7 +918,7 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
                        |}""".stripMargin
 
       // when
-      val seq = decode[FoldersPropertyRemotePayload](payload) match {
+      val seq = decode[FoldersProperty](payload) match {
         case Right(fp)   => fp.labels.map(_.toRemoteFolderData)
         case Left(error) => fail(error.getMessage)
       }


### PR DESCRIPTION
From here: https://github.com/wireapp/wire-android/pull/2347

> 1. We have now many layers of case classes describing folders: `FolderData`, `RemoteFolderData`, `IntermediateFolderData`, `FoldersPropertyRemotePayload`, and `FoldersEvent`. I think we can at least make `IntermediateFolderData` a private case class used only in `FoldersPropertyRemotePayload` (also, can we rename `FoldersPropertyRemotePayload` to e.g. `FoldersProperty`?) and never expose it to other parts of the code. `FoldersProperty` should be able to map the json to `Seq[RemoteFolderData]` by itself.

- I can't make `IntermediateFolderData` private or change `FoldersProperty` to use `Seq[RemoteFolderData]` instead. If I do that, then we have to write Encoder/Decoder for Circe by hand. With the current code, they are syntesized automatically.

- I renamed`FoldersPropertyRemotePayload` to `FoldersProperty`

> 2. There's no need to use `new` when creating case classes, and overloading constructors is usually done with the `apply` method in the companion object (although, I don't think we need to do that).

Fixed

> 3. Cosmetic: a case class without any methods or internal fields doesn't need empty curly brackets `{}` after the declaration, and by convention we declare an empty sequence with `Seq.empty[T]`, not `Seq[T]()` - the latter suggests that every empty sequence is a separate object while it only returns a reference to the same empty sequence (welcome to the Scala's functional programming world :) ).

Fixed
#### APK
[Download build #195](http://10.10.124.11:8080/job/Pull%20Request%20Builder/195/artifact/build/artifact/wire-dev-PR2350-195.apk)
[Download build #199](http://10.10.124.11:8080/job/Pull%20Request%20Builder/199/artifact/build/artifact/wire-dev-PR2350-199.apk)
[Download build #200](http://10.10.124.11:8080/job/Pull%20Request%20Builder/200/artifact/build/artifact/wire-dev-PR2350-200.apk)