### PR TITLE
[Fix] Remove favorites menu item for archived conversations

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -131,10 +131,12 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
           else
             Unmute
 
-        builder += (if (conv.archived) Unarchive else Archive)
-
         val isConvFavorite = favoriteConvIds.contains(convId)
-        builder += (if (isConvFavorite) RemoveFromFavorites else AddToFavorites)
+        
+        (conv.archived, isConvFavorite) match {
+          case (true, _)           => builder += Unarchive
+          case (false, isFavorite) => builder ++= List(Archive, if (isFavorite) RemoveFromFavorites else AddToFavorites)
+        }
 
         if (isGroup) {
           if (conv.isActive) builder += Leave


### PR DESCRIPTION
## What's new in this PR?

### Issues

Archived conversations should not have the option to be added or removed from favorites.

### Solutions

Adjust the logic to only add favorite menu options for unarchived conversations.

#### APK
[Download build #202](http://10.10.124.11:8080/job/Pull%20Request%20Builder/202/artifact/build/artifact/wire-dev-PR2352-202.apk)
[Download build #204](http://10.10.124.11:8080/job/Pull%20Request%20Builder/204/artifact/build/artifact/wire-dev-PR2352-204.apk)