### PR TITLE
Fix: Convert remote conversation IDs in folders payload to lowercase

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -250,7 +250,7 @@ object FoldersService {
     def toRemote: Seq[RemoteFolderData] = labels.map(label =>
       RemoteFolderData(
         FolderData(id = FolderId(label.id), name = Name(label.name.getOrElse("")), folderType = label.`type`),
-        label.conversations.map(RConvId(_)).toSet
+        label.conversations.map(id => RConvId(id.toLowerCase())).toSet
       )
     )
   }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -934,5 +934,35 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
       seq(1).folderData.folderType shouldEqual FolderData.FavoritesFolderType
       seq(1).conversations shouldEqual Set(RConvId("c2"))
     }
+
+    scenario ("uppercase conv IDs (thanks, iOS!) are lowercased") {
+
+      // given
+      val payload = """{
+                      |  "labels": [
+                      |    {
+                      |      "name" : "F1",
+                      |      "type" : 0,
+                      |      "id" : "f1",
+                      |      "conversations" : [
+                      |        "UPPERCASE",
+                      |        "c2"
+                      |      ]
+                      |    }
+                      |  ]
+                      |}""".stripMargin
+
+      // when
+      val seq = decode[FoldersProperty](payload) match {
+        case Right(fp)   => fp.toRemote
+        case Left(error) => fail(error.getMessage)
+      }
+
+      // then
+      seq(0).folderData.name shouldEqual Name("F1")
+      seq(0).folderData.id shouldEqual FolderId("f1")
+      seq(0).folderData.folderType shouldEqual FolderData.CustomFolderType
+      seq(0).conversations shouldEqual Set(RConvId("uppercase"), RConvId("c2"))
+    }
   }
 }


### PR DESCRIPTION
## What's new in this PR?

Fixing cross-platform compatibility with iOS folders metadata

### Causes

iOS uses uppercase UUIDs, Android expects lowercase UUIDs.

iOS generated payload
```json
{
  "labels" : [
    {
      "id" : "C06641F4-62E6-48F8-8E09-A3EBEA09058B",
      "type" : 1,
      "conversations" : [
        "5AE4CA03-2FDD-4CD5-8F62-F96FF6DA4F22",
        "3653D8CF-85F7-4B95-9A14-F03EC2F44F7D"
      ]
    }
  ]
}
```


Android generated payload
```{
  "labels" : [
    {
      "id" : "C06641F4-62E6-48F8-8E09-A3EBEA09058B",
      "name" : "",
      "type" : 1,
      "conversations" : [
        "3653d8cf-85f7-4b95-9a14-f03ec2f44f7d"
      ]
    }
  ]
}
```

### Solutions

Lowercase all conversation IDs when parsing them from the payload

### Testing

Covered by unit tests, and tested on real device against an iOS device

#### APK
[Download build #206](http://10.10.124.11:8080/job/Pull%20Request%20Builder/206/artifact/build/artifact/wire-dev-PR2355-206.apk)