### PR TITLE
[Fix] Stabilize ids for conversation items

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -70,9 +70,9 @@ abstract class ConversationListAdapter
   }
 
   override def getItemId(position: Int): Long = items(position) match {
-    case Item.IncomingRequests(first, _) => first.str.hashCode
-    case Item.Header(id, _, _)           => id.str.hashCode
-    case Item.Conversation(data, _)      => data.id.str.hashCode
+    case Item.IncomingRequests(first, _)  => first.str.hashCode
+    case Item.Header(id, _, _)            => id.str.hashCode
+    case Item.Conversation(data, section) => (data.id.str + section.getOrElse("")).hashCode
   }
 
   override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ConversationRowViewHolder = viewType match {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would sometimes crash with the exception

```
IllegalStateException: Two different ViewHolders have the same stableID. Stable IDs in your adapter MUST BE unique and SHOULD NOT change.
```

### Causes

In `ConversationListAdapter`, we use stable ids. However, for `Item.Conversation`, we were only using the conversation id to uniquely identify the item. Since a single conversation can appear twice in the list (favorites and another folder), we could have two items with the same id.

### Solutions

Uniquely identify the conversation item using the conversation id **AND** the section title. If there is no section title, then the conversation id will be sufficient, since it would mean we're not in the folders view and there can only be one item per conversation.

#### APK
[Download build #207](http://10.10.124.11:8080/job/Pull%20Request%20Builder/207/artifact/build/artifact/wire-dev-PR2356-207.apk)
[Download build #208](http://10.10.124.11:8080/job/Pull%20Request%20Builder/208/artifact/build/artifact/wire-dev-PR2356-208.apk)