### PR TITLE
fix: Bottom navigation bar highlights

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -96,8 +96,8 @@ class ConversationListManagerFragment extends Fragment
       view.setOnNavigationItemSelectedListener(ConversationListManagerFragment.this)
     }
 
-    convListController.hasConversationsAndArchive.onUi { case (_, enabled) =>
-      vh.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, enabled))
+    convListController.hasConversationsAndArchive.onUi { case (_, hasArchive) =>
+      vh.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, hasArchive))
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -20,13 +20,13 @@ package com.waz.zclient.conversationlist
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.support.annotation.Nullable
 import android.support.design.widget.BottomNavigationView
 import android.support.v4.app.{Fragment, FragmentManager}
 import android.view.{LayoutInflater, MenuItem, View, ViewGroup}
 import android.widget.FrameLayout
 import com.waz.api.SyncState._
 import com.waz.content.{UserPreferences, UsersStorage}
-import com.waz.model.ConversationData.ConversationType.{Self, Unknown}
 import com.waz.model._
 import com.waz.model.sync.SyncCommand._
 import com.waz.service.ZMessaging
@@ -74,7 +74,7 @@ class ConversationListManagerFragment extends Fragment
   with BottomNavigationView.OnNavigationItemSelectedListener {
 
   import ConversationListManagerFragment._
-  import Threading.Implicits.Background
+  import Threading.Implicits.Ui
 
   implicit lazy val context = getContext
 
@@ -82,22 +82,26 @@ class ConversationListManagerFragment extends Fragment
   private lazy val pickUserController   = inject[IPickUserController]
   private lazy val navController        = inject[INavigationController]
   private lazy val convScreenController = inject[IConversationScreenController]
+  private lazy val convListController   = inject[ConversationListController]
 
   private var startUiLoadingIndicator: LoadingIndicatorView = _
   private var listLoadingIndicator   : LoadingIndicatorView = _
   private var mainContainer          : FrameLayout          = _
   private var confirmationMenu       : ConfirmationMenu     = _
-  private var bottomNavigationView   : BottomNavigationView = _
   private var bottomNavigationBorder : View                 = _
 
-  lazy val zms = inject[Signal[ZMessaging]]
+  private lazy val bottomNavigationView = returning(view[BottomNavigationView](R.id.fragment_conversation_list_manager_bottom_navigation)) { vh =>
+    vh.foreach { view =>
+      BottomNavigationUtil.disableShiftMode(view)
+      view.setOnNavigationItemSelectedListener(ConversationListManagerFragment.this)
+    }
 
-  lazy val archiveEnabled = for {
-    z     <- zms
-    convs <- z.convsStorage.contents
-  } yield {
-      convs.values.exists(c => c.archived && !c.hidden && !Set(Self, Unknown).contains(c.convType))
+    convListController.hasConversationsAndArchive.onUi { case (_, enabled) =>
+      vh.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, enabled))
+    }
   }
+
+  lazy val zms = inject[Signal[ZMessaging]]
 
   private def stripToConversationList() = {
     pickUserController.hideUserProfile() // Hide possibly open self profile
@@ -120,7 +124,11 @@ class ConversationListManagerFragment extends Fragment
   }
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) =
-    returning(inflater.inflate(R.layout.fragment_conversation_list_manager, container, false)) { view =>
+    inflater.inflate(R.layout.fragment_conversation_list_manager, container, false)
+
+  override def onViewCreated(view: View, @Nullable savedInstanceState: Bundle): Unit = {
+    super.onViewCreated(view, savedInstanceState)
+
       mainContainer           = findById(view, R.id.fl__conversation_list_main)
       startUiLoadingIndicator = findById(view, R.id.liv__conversations__loading_indicator)
       listLoadingIndicator    = findById(view, R.id.lbv__conversation_list__loading_indicator)
@@ -128,16 +136,9 @@ class ConversationListManagerFragment extends Fragment
         v.setVisible(false)
         v.resetFullScreenPadding()
       }
-      bottomNavigationView = returning(
-        findById[BottomNavigationView](view, R.id.fragment_conversation_list_manager_bottom_navigation)
-      ) { v =>
-        BottomNavigationUtil.disableShiftMode(v)
-        v.setOnNavigationItemSelectedListener(ConversationListManagerFragment.this)
-      }
 
-      archiveEnabled.onUi { enabled =>
-        BottomNavigationUtil.setItemVisible(bottomNavigationView, R.id.navigation_archive, enabled)
-      }
+      bottomNavigationView
+
       bottomNavigationBorder = findById(view, R.id.fragment_conversation_list_manager_view_bottom_border)
 
       if (savedInstanceState == null) {
@@ -186,7 +187,7 @@ class ConversationListManagerFragment extends Fragment
       inject[AccentColorController].accentColor.map(_.color).onUi { c =>
         Option(startUiLoadingIndicator).foreach(_.setColor(c))
         Option(listLoadingIndicator).foreach(_.setColor(c))
-        Option(bottomNavigationView).foreach(_ => setUpBottomNavigationTintColors(c))
+        setUpBottomNavigationTintColors(c)
       }
     }
 
@@ -198,7 +199,7 @@ class ConversationListManagerFragment extends Fragment
     val colors = Array[Int](color, Color.WHITE)
 
     val colorStateList = new ColorStateList(states, colors)
-    bottomNavigationView.setItemIconTintList(colorStateList)
+    bottomNavigationView.foreach(_ .setItemIconTintList(colorStateList))
   }
 
   override def onShowPickUser() = {
@@ -302,7 +303,7 @@ class ConversationListManagerFragment extends Fragment
           case _ => //
         }
         case _ => //
-      } (Threading.Ui)
+      }
     }
 
   private def togglePeoplePicker(show: Boolean) = {
@@ -348,7 +349,7 @@ class ConversationListManagerFragment extends Fragment
     if (page != Page.ARCHIVE) closeArchive()
 
     val conversationsVisible = page == Page.START || page == Page.CONVERSATION_LIST
-    bottomNavigationView.setVisible(conversationsVisible)
+    bottomNavigationView.foreach(_.setVisible(conversationsVisible))
     bottomNavigationBorder.setVisible(conversationsVisible)
     if (conversationsVisible) {
       selectDefaultConversationType()
@@ -377,12 +378,11 @@ class ConversationListManagerFragment extends Fragment
     navController.setLeftPage(ARCHIVE, Tag)
   }
 
-  override def onConversationsLoadingStarted(): Unit = {
-    bottomNavigationView.setAlpha(0.5f)
-  }
+  override def onConversationsLoadingStarted(): Unit =
+    bottomNavigationView.foreach(_.setAlpha(0.5f))
 
   override def onConversationsLoadingFinished(): Unit = {
-    bottomNavigationView.animate().alpha(1f).setDuration(500)
+    bottomNavigationView.foreach(_.animate().alpha(1f).setDuration(500))
   }
 
   override def closeArchive() = {
@@ -495,27 +495,22 @@ class ConversationListManagerFragment extends Fragment
     }
   }
 
-  private def selectDefaultConversationType(): Unit = {
-    getConversationListType().map(t =>
-      bottomNavigationView.setSelectedItemId(
-        t match {
-          case ConversationListType.FOLDERS => R.id.navigation_folders
-          case _                            => R.id.navigation_conversations
-        }
-      )
-    )
+  private def selectDefaultConversationType(): Unit = bottomNavigationView.foreach { view =>
+    getConversationListType().map {
+      case ConversationListType.FOLDERS => R.id.navigation_folders
+      case _                            => R.id.navigation_conversations
+    }.foreach(view.setSelectedItemId)
   }
 
-  private def setConversationListType(@ConversationListType listType: Int): Unit = {
+  private def setConversationListType(@ConversationListType listType: Int): Unit =
     for {
-      userPrefs              <- zms.map(_.userPrefs).head
+      userPrefs               <- zms.map(_.userPrefs).head
       convListTypePreference  = userPrefs.preference(UserPreferences.ConversationListType)
     } yield {
       convListTypePreference.update(listType)
     }
-  }
 
-  private def getConversationListType(): Future[Int] = {
+  private def getConversationListType(): Future[Int] =
     for {
       userPrefs              <- zms.map(_.userPrefs).head
       convListTypePreference  = userPrefs.preference(UserPreferences.ConversationListType)
@@ -523,11 +518,12 @@ class ConversationListManagerFragment extends Fragment
     } yield {
       convListType
     }
-  }
 
   override def onMoveToFolder(convId: ConvId): Unit = {
-    startActivityForResult(MoveToFolderActivity.newIntent(requireContext(), convId),
-      MoveToFolderActivity.REQUEST_CODE_MOVE_CREATE)
+    startActivityForResult(
+      MoveToFolderActivity.newIntent(requireContext(), convId),
+      MoveToFolderActivity.REQUEST_CODE_MOVE_CREATE
+    )
   }
 }
 


### PR DESCRIPTION
The main problem was that the bottom navigation bar was updated in the background thread - it sohuld be done in UI. I changed that, but I also moved some code apart so that we to the background, because the other error showing in the logs was that we calculate in UI two heavy signals: one for checking if we should display the 'archive' icon, and the other to check if we have regular conversations to display. I merged them into one and moved to `ConversationListController` which works on the background thread.
#### APK
[Download build #211](http://10.10.124.11:8080/job/Pull%20Request%20Builder/211/artifact/build/artifact/wire-dev-PR2357-211.apk)
[Download build #212](http://10.10.124.11:8080/job/Pull%20Request%20Builder/212/artifact/build/artifact/wire-dev-PR2357-212.apk)
[Download build #214](http://10.10.124.11:8080/job/Pull%20Request%20Builder/214/artifact/build/artifact/wire-dev-PR2357-214.apk)
[Download build #215](http://10.10.124.11:8080/job/Pull%20Request%20Builder/215/artifact/build/artifact/wire-dev-PR2357-215.apk)
[Download build #216](http://10.10.124.11:8080/job/Pull%20Request%20Builder/216/artifact/build/artifact/wire-dev-PR2357-216.apk)