### PR TITLE
Fix: Store folder collapse state per user

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -88,23 +88,17 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
     }
   }
 
-  protected def beforeListCreation(): Future[Unit] = Future.successful(())
-
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) =
     inflater.inflate(layoutId, container, false)
 
   override def onViewCreated(view: View, savedInstanceState: Bundle) = {
     super.onViewCreated(view, savedInstanceState)
-    for {
-      _ <- beforeListCreation()
-    } yield {
-      conversationListView.foreach { lv =>
-        lv.setLayoutManager(new LinearLayoutManager(getContext))
-        lv.setAdapter(adapter)
-        lv.setAllowSwipeAway(true)
-        lv.setOverScrollMode(View.OVER_SCROLL_NEVER)
-        lv.addOnScrollListener(conversationsListScrollListener)
-      }
+    conversationListView.foreach { lv =>
+      lv.setLayoutManager(new LinearLayoutManager(getContext))
+      lv.setAdapter(adapter)
+      lv.setAllowSwipeAway(true)
+      lv.setOverScrollMode(View.OVER_SCROLL_NEVER)
+      lv.addOnScrollListener(conversationsListScrollListener)
     }
   }
 
@@ -336,8 +330,7 @@ class ConversationFolderListFragment extends NormalConversationFragment {
         groups    <- convListController.groupConvsWithoutFolder
         oneToOnes <- convListController.oneToOneConvsWithoutFolder
         custom    <- convListController.customFolderConversations
-        prefs     <- userPreferences
-        states    <- prefs(ConversationFoldersUiState).signal
+        states    <- foldersUiState
       } yield (incoming, favorites, groups, oneToOnes, custom, states)
 
       dataSource.onUi { case (incoming, favorites, groups, oneToOnes, custom, states) =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -323,30 +323,10 @@ class ConversationFolderListFragment extends NormalConversationFragment {
   import UserPreferences.ConversationFoldersUiState
 
   private lazy val userPreferences = inject[Signal[UserPreferences]]
-  private var foldersUiState: FoldersUiState = Map.empty
-
-  override protected def beforeListCreation(): Future[Unit] = loadFoldersUiState()
-
-  override def onStop(): Unit = {
-    storeFoldersUiState()
-    super.onStop()
-  }
-
-  private def loadFoldersUiState(): Future[Unit] = {
-    for {
-      prefs  <- userPreferences.head
-      states <- prefs(ConversationFoldersUiState).apply()
-    } yield {
-      foldersUiState = states
-    }
-  }
-
-  private def storeFoldersUiState(): Unit = {
-    for {
-      prefs <- userPreferences.head
-      _     <- prefs(ConversationFoldersUiState).update(foldersUiState)
-    } yield {}
-  }
+  private lazy val foldersUiState = for {
+    prefs     <- userPreferences
+    states    <- prefs(ConversationFoldersUiState).signal
+  } yield states
 
   override protected def createAdapter(): ConversationListAdapter = {
     returning(new ConversationFolderListAdapter) { a =>
@@ -356,10 +336,12 @@ class ConversationFolderListFragment extends NormalConversationFragment {
         groups    <- convListController.groupConvsWithoutFolder
         oneToOnes <- convListController.oneToOneConvsWithoutFolder
         custom    <- convListController.customFolderConversations
-      } yield (incoming, favorites, groups, oneToOnes, custom)
+        prefs     <- userPreferences
+        states    <- prefs(ConversationFoldersUiState).signal
+      } yield (incoming, favorites, groups, oneToOnes, custom, states)
 
-      dataSource.onUi { case (incoming, favorites, groups, oneToOnes, custom) =>
-        a.setData(incoming, favorites, groups, oneToOnes, custom, foldersUiState)
+      dataSource.onUi { case (incoming, favorites, groups, oneToOnes, custom, states) =>
+        a.setData(incoming, favorites, groups, oneToOnes, custom, states)
       }
 
       a.onFolderStateChanged(updateFolderState)
@@ -367,15 +349,23 @@ class ConversationFolderListFragment extends NormalConversationFragment {
     }
   }
 
-  private def pruneFolderStates(folderIds: Set[Uid]): Unit = {
-    val knownStates = foldersUiState.keySet
-    val unusedFolderStates = knownStates -- folderIds
-    foldersUiState --= unusedFolderStates
-  }
+  private def pruneFolderStates(folderIds: Set[Uid]): Future[Unit] = for {
+    state               <- foldersUiState.head
+    knownStates         = state.keySet
+    unusedFolderStates  = knownStates -- folderIds
+    _                   <- storeFoldersUiState(state -- unusedFolderStates)
+  } yield {}
 
-  private def updateFolderState(folderState: FolderState): Unit = {
-    foldersUiState += folderState.id -> folderState.isExpanded
-  }
+  private def updateFolderState(folderState: FolderState): Future[Unit] = for {
+    state           <- foldersUiState.head
+    _               <- storeFoldersUiState(state + (folderState.id -> folderState.isExpanded))
+  } yield {}
+
+  private def storeFoldersUiState(state: Map[Uid, Boolean]): Future[Unit] = for {
+    prefs <- userPreferences.head
+    _     <- prefs(ConversationFoldersUiState).update(state)
+  } yield {}
+
 }
 
 object ConversationFolderListFragment {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The folder collapse state was previously the same across all accounts

### Causes

The fragment survives the switching of accounts, and the preference was not reloaded. The preference was loaded once at creation of the fragment.

### Solutions

Instead of loading the property once, register for changes on a signal instead.

### Testing

Manually tested on emulator with two accounts.
#### APK
[Download build #223](http://10.10.124.11:8080/job/Pull%20Request%20Builder/223/artifact/build/artifact/wire-dev-PR2361-223.apk)
[Download build #224](http://10.10.124.11:8080/job/Pull%20Request%20Builder/224/artifact/build/artifact/wire-dev-PR2361-224.apk)