### PR TITLE
Fix random crash when accounts are switched while on folders view

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -124,7 +124,7 @@ class ConversationListController(implicit inj: Injector, ec: EventContext)
 
   def folderConversations(folderId: FolderId): Signal[Seq[ConversationData]] = for {
     fwc     <- foldersWithConvs
-    convIds =  fwc(folderId)
+    convIds =  fwc.getOrElse(folderId, Set.empty)
     convs   <- regularConversationListData
   } yield convs.filter(c => convIds.contains(c.id))
 


### PR DESCRIPTION
I'm not sure why this happens, but it happens if you switch accounts on a very slow device while you are on conversation view.
#### APK
[Download build #225](http://10.10.124.11:8080/job/Pull%20Request%20Builder/225/artifact/build/artifact/wire-dev-PR2362-225.apk)