### PR TITLE
[Fix] Empty name when creating a folder

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/folders/moveto/MoveToFolderActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/folders/moveto/MoveToFolderActivity.scala
@@ -55,7 +55,7 @@ class MoveToFolderActivity extends BaseActivity
 
   override def onPrepareNewFolderClicked(): Unit = {
     conversationController.getConversation(convId).foreach {
-      case Some(conv) => openCreteNewFolderScreen(conv.name.getOrElse("").toString)
+      case Some(conv) => openCreteNewFolderScreen(conv.displayName.toString)
       case None => cancelOperation()
     }
   }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When moving a one to one conversation to a new folder, the string "Move the conversation "" to a new folder" contained an empty name for the conversation.

### Causes

The conversation name was being passed as an argument, which is only set for group conversations.

### Solutions

Use the `displayName` property, which will use the group conversation name, or a generated name from the participants (including one to one conversations).


#### APK
[Download build #228](http://10.10.124.11:8080/job/Pull%20Request%20Builder/228/artifact/build/artifact/wire-dev-PR2365-228.apk)