### PR TITLE
[Fix] Folder header height

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -860,7 +860,7 @@
 
     <dimen name="conversation_list__row__avatar_size">28dp</dimen>
     <dimen name="conversation_list__row__title__top">8dp</dimen>
-    <dimen name="conversation_list__folder_row__height">32dp</dimen>
+    <dimen name="conversation_list__folder_row__height">48dp</dimen>
     <dimen name="conversation_list__row__height">64dp</dimen>
     <dimen name="conversation_list__badge__height">20dp</dimen>
     <dimen name="conversation_list__avatar__inner_margin">2dp</dimen>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -574,7 +574,7 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
 
   def setIsFirstHeader(isFirstHeader: Boolean): Unit = {
     val params = getLayoutParams.asInstanceOf[RecyclerView.LayoutParams]
-    params.topMargin = if (isFirstHeader) 0 else getDimenPx(R.dimen.wire__padding__20)
+    params.topMargin = if (isFirstHeader) 0 else getDimenPx(R.dimen.wire__padding__10)
     setLayoutParams(params)
   }
 
@@ -584,9 +584,9 @@ class ConversationFolderListRow(context: Context, attrs: AttributeSet, style: In
   }
 
   private def setLayoutParameters(): Unit = {
-    val params = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimenPx(R.dimen.conversation_list__row__height))
+    val params = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimenPx(R.dimen.conversation_list__folder_row__height))
     setLayoutParams(params)
     setOrientation(LinearLayout.HORIZONTAL)
-    setPadding(getDimenPx(R.dimen.wire__padding__24), getDimenPx(R.dimen.wire__padding__20), 0, getDimenPx(R.dimen.wire__padding__20))
+    setPadding(getDimenPx(R.dimen.wire__padding__24), getDimenPx(R.dimen.wire__padding__10), 0, getDimenPx(R.dimen.wire__padding__10))
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The changes in https://github.com/wireapp/wire-android/pull/2363 didn't work correctly because it was setting the header height on a `merge` layout, which has no effect. The actual header height is set programmatically.

### Solutions

Make the changes programmatically, and tweak the values.

### Attachments

![Screenshot_1570987927](https://user-images.githubusercontent.com/28632506/66719475-b3716d80-edf0-11e9-8a9a-bffa002f1692.png)

#### APK
[Download build #229](http://10.10.124.11:8080/job/Pull%20Request%20Builder/229/artifact/build/artifact/wire-dev-PR2366-229.apk)