### PR TITLE
[Fix] MoveToFolderActivity screen orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -206,7 +206,9 @@
             android:launchMode="singleTask">
         </activity>
 
-        <activity android:name=".conversation.folders.moveto.MoveToFolderActivity"/>
+        <activity
+            android:name=".conversation.folders.moveto.MoveToFolderActivity"
+            android:screenOrientation="portrait" />
 
         <receiver
             android:name=".broadcast.ReferralBroadcastReceiver"


### PR DESCRIPTION
## What's new in this PR?

### Issues

The "move to folder" screen can be rotated to horizontal orientation.

### Causes

This screen is part of a new activity, that didn't have the orientation property set.

### Solutions

Set the orientation mode to portrait only.

#### APK
[Download build #236](http://10.10.124.11:8080/job/Pull%20Request%20Builder/236/artifact/build/artifact/wire-dev-PR2370-236.apk)