### PR TITLE
Optimization: Don't call the convService if there's no unexpected members

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -308,7 +308,9 @@ class MessageEventProcessor(selfUserId:           UserId,
       case e: MemberLeaveEvent if e.userIds.contains(e.from) => false
       case _ => true
     }.map(_.from).toSet
-    convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
+    if (potentiallyUnexpectedMembers.nonEmpty)
+      convsService.addUnexpectedMembersToConv(convId, potentiallyUnexpectedMembers)
+    else Future.successful(())
   }
 
   private def applyRecalls(convId: ConvId, toProcess: Seq[MessageEvent]) = {


### PR DESCRIPTION
A quick optimization in `MessageEventProcessor`: 

Every time we process an event, one of the steps is to check the possibility of that the event is about members leaving the conversation. It's a very rare event in comparison to message events, but anyway, every time a new event comes, we access the service, and from there the storage to fetch the conversation, and only then we check if there is something to change. This optimization gets rid of this call to the storage if the event is not a `MemberLeaveEvent`.
#### APK
[Download build #243](http://10.10.124.11:8080/job/Pull%20Request%20Builder/243/artifact/build/artifact/wire-dev-PR2371-243.apk)