### PR TITLE
fix: If obfuscation the "Recents" list is impossible, remove Wire from the list

### DIFF
--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -39,7 +39,7 @@ import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.security.ActivityLifecycle
+import com.waz.zclient.security.ActivityLifecycleCallback
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.ViewUtils
 
@@ -59,7 +59,7 @@ class BaseActivity extends AppCompatActivity
   protected lazy val themeController   = inject[ThemeController]
   protected lazy val permissions       = inject[PermissionsService]
   protected lazy val userPreferences   = inject[Signal[UserPreferences]]
-  protected lazy val activityLifecycle = inject[ActivityLifecycle]
+  protected lazy val activityLifecycle = inject[ActivityLifecycleCallback]
   protected lazy val activityManager   = inject[ActivityManager]
   protected lazy val uiLifeCycle       = inject[UiLifeCycle]
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -89,7 +89,7 @@ import com.waz.zclient.pages.main.conversationpager.controller.ISlidingPaneContr
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
-import com.waz.zclient.security.{SecurityLifecycleCallback, SecurityPolicyChecker}
+import com.waz.zclient.security.{ActivityLifecycle, SecurityPolicyChecker}
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
 import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendController, ExternalFileSharing, LocalThumbnailCache, UiStorage}
 import com.waz.zclient.views.DraftMap
@@ -273,6 +273,8 @@ object WireApplication extends DerivedLogTag {
 
     bind[MediaRecorderController] to new MediaRecorderControllerImpl(ctx)
 
+    bind[ActivityLifecycle] to new ActivityLifecycle()
+
     bind[SecurityPolicyService] to new SecurityPolicyService()
 
     bind[SecurityPolicyChecker] to new SecurityPolicyChecker()
@@ -445,6 +447,11 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
       inject[MessageNotificationsController],
       assets2Module)
 
+    val securityCallback = inject[ActivityLifecycle]
+    // we're unable to check if the callback is already registered - we have to re-register it to be sure
+    unregisterActivityLifecycleCallbacks(securityCallback)
+    registerActivityLifecycleCallbacks(securityCallback)
+
     inject[NotificationManagerWrapper]
     inject[ImageNotificationsController]
     inject[CallingNotificationsController]
@@ -457,12 +464,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     Future(clearOldVideoFiles(getApplicationContext))(Threading.Background)
     Future(checkForPlayServices(prefs, googleApi))(Threading.Background)
 
-    // we're unable to check if the callback is already registered - we have to re-register it to be sure
-    unregisterActivityLifecycleCallbacks(securityCallback)
-    registerActivityLifecycleCallbacks(securityCallback)
   }
-
-  private lazy val securityCallback = new SecurityLifecycleCallback()
 
   private def parseProxy(url: String, port: String): Option[Proxy] = {
     val proxyHost = if(!url.equalsIgnoreCase("none")) Some(url) else None

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -89,7 +89,7 @@ import com.waz.zclient.pages.main.conversationpager.controller.ISlidingPaneContr
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.preferences.PreferencesController
-import com.waz.zclient.security.{ActivityLifecycle, SecurityPolicyChecker}
+import com.waz.zclient.security.{ActivityLifecycleCallback, SecurityPolicyChecker}
 import com.waz.zclient.tracking.{CrashController, GlobalTrackingController, UiTrackingController}
 import com.waz.zclient.utils.{AndroidBase64Delegate, BackStackNavigator, BackendController, ExternalFileSharing, LocalThumbnailCache, UiStorage}
 import com.waz.zclient.views.DraftMap
@@ -273,7 +273,7 @@ object WireApplication extends DerivedLogTag {
 
     bind[MediaRecorderController] to new MediaRecorderControllerImpl(ctx)
 
-    bind[ActivityLifecycle] to new ActivityLifecycle()
+    bind[ActivityLifecycleCallback] to new ActivityLifecycleCallback()
 
     bind[SecurityPolicyService] to new SecurityPolicyService()
 
@@ -447,10 +447,10 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
       inject[MessageNotificationsController],
       assets2Module)
 
-    val securityCallback = inject[ActivityLifecycle]
+    val activityLifecycleCallback = inject[ActivityLifecycleCallback]
     // we're unable to check if the callback is already registered - we have to re-register it to be sure
-    unregisterActivityLifecycleCallbacks(securityCallback)
-    registerActivityLifecycleCallbacks(securityCallback)
+    unregisterActivityLifecycleCallbacks(activityLifecycleCallback)
+    registerActivityLifecycleCallbacks(activityLifecycleCallback)
 
     inject[NotificationManagerWrapper]
     inject[ImageNotificationsController]

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycle.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycle.scala
@@ -20,22 +20,24 @@ package com.waz.zclient.security
 import android.app.{Activity, Application}
 import android.os.Bundle
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.zclient.{Injectable, Injector, LaunchActivity}
+import com.waz.utils.events._
 import com.waz.zclient.log.LogUI._
+import com.waz.zclient.{Injectable, Injector, LaunchActivity}
 
-class SecurityLifecycleCallback(implicit injector: Injector)
+class ActivityLifecycle(implicit injector: Injector)
   extends Application.ActivityLifecycleCallbacks with Injectable with DerivedLogTag {
 
-  private var activitiesStarted = 0
+  private val activitiesRunning = Signal[(Int, Option[Activity])]((0, None))
+
+  val appInBackground: Signal[(Boolean, Option[Activity])] = activitiesRunning.map { case (running, lastAct) => (running == 0, lastAct) }
 
   override def onActivityPaused(activity: Activity): Unit = synchronized {
     activity match {
       case _: LaunchActivity =>
       case _: AppLockActivity =>
       case _ =>
-        activitiesStarted -= 1
-        verbose(l"onActivityPaused, activities still active: $activitiesStarted, ${activity.getClass.getName}")
-        if (activitiesStarted == 0) inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
+        verbose(l"onActivityPaused, activities still active: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
+        activitiesRunning.mutate { case (running, _) => (running - 1, Option(activity))}
     }
   }
 
@@ -44,9 +46,9 @@ class SecurityLifecycleCallback(implicit injector: Injector)
       case _: LaunchActivity =>
       case _: AppLockActivity =>
       case _ =>
-        activitiesStarted += 1
-        verbose(l"onActivityResumed, activities active now: $activitiesStarted, ${activity.getClass.getName}")
-        if (activitiesStarted == 1) inject[SecurityPolicyChecker].run(activity)
+        verbose(l"onActivityResumed, activities active now: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
+        activitiesRunning.mutate { case (running, _) => (running + 1, Option(activity))}
+
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -24,7 +24,7 @@ import com.waz.utils.events._
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{Injectable, Injector, LaunchActivity}
 
-class ActivityLifecycle(implicit injector: Injector)
+class ActivityLifecycleCallback(implicit injector: Injector)
   extends Application.ActivityLifecycleCallbacks with Injectable with DerivedLogTag {
 
   private val activitiesRunning = Signal[(Int, Option[Activity])]((0, None))

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -47,7 +47,7 @@ class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) exten
   private lazy val globalPreferences     = inject[GlobalPreferences]
   private lazy val accountManager        = inject[Signal[AccountManager]]
 
-  inject[ActivityLifecycle].appInBackground.onUi {
+  inject[ActivityLifecycleCallback].appInBackground.onUi {
     case (true, _)               => updateBackgroundEntryTimer()
     case (false, Some(activity)) => run(activity)
     case _ => warn(l"The app is coming to the foreground, but the information about the activity is missing")


### PR DESCRIPTION
**Please don't merge before we decide what Android versions should use what solution**

Implements an alternative solution to obfuscation of the "Recents" list for Android 5.1 where the obfuscation doesn't work:
Instead the app is completely removed from the list of "Recents" apps. It can be still accessed simply by clicking the icon on the main screen of the device.

I rewrote the old `SecurityLifecycleCallback` into `ActivityLifecycle`. Now it exposes a signal and classes which want to react to going to the background may subscribe to the signal (that's the process reversal - `SecurityLifecycleCallback` called `SecurityPolicyChecker` directly). In result, `ActivityLifecycle` serves now a similar role to `UiLifeCycle`, but it doesn't rely on `BaseActivity` calling `acquireUi` and `releaseUi`. I think in another PR we should replace `UiLifeCycle`
with it.

#### APK
[Download build #244](http://10.10.124.11:8080/job/Pull%20Request%20Builder/244/artifact/build/artifact/wire-dev-PR2375-244.apk)
[Download build #252](http://10.10.124.11:8080/job/Pull%20Request%20Builder/252/artifact/build/artifact/wire-dev-PR2375-252.apk)