### PR TITLE
[Fix] Stuck app

### DIFF
--- a/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
@@ -29,9 +29,8 @@ import com.waz.threading.CancellableFuture
 import com.waz.utils.events.Signal
 import com.waz.zclient.log.LogUI._
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
   extends DataFetcher[InputStream] with DerivedLogTag {

--- a/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
@@ -30,7 +30,7 @@ import com.waz.utils.events.Signal
 import com.waz.zclient.log.LogUI._
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
@@ -54,12 +54,12 @@ class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
         case _ =>
           CancellableFuture.failed(NotSupportedError("Unsupported image request"))
       }
-    }
+    }.withTimeout(30.seconds)
 
     currentData.foreach(_.cancel())
     currentData = Some(data)
 
-    Try { Await.result(data, Duration.Inf) } match {
+    data.onComplete {
       case Failure(err) =>
         verbose(l"Asset loading failed $request, $err")
         callback.onLoadFailed(new RuntimeException(s"Fetcher. Asset loading failed: $err"))

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -380,10 +380,10 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
   private def getPictureForNotifications(userId: UserId, nots: Seq[NotificationData]): Future[Option[Bitmap]] =
     if (nots.size == 1 && !nots.exists(_.ephemeral)) {
       val result = for {
-        Some(userStorage) <- inject[AccountToUsersStorage].apply(userId)
-        user <- userStorage.get(nots.head.user)
-        Some(picture) = user.flatMap(_.picture)
-        bitmap <- loadPicture(picture)
+        Some(storage) <- inject[AccountToUsersStorage].apply(userId)
+        user          <- storage.get(nots.head.user)
+        picture        = user.flatMap(_.picture)
+        bitmap        <- picture.fold(Future.successful(Option.empty[Bitmap]))(loadPicture)
       } yield bitmap
 
       result.recoverWith {


### PR DESCRIPTION
## What's new in this PR?

### Issues

It could happen that after coming back online and opening the app, Wire would get stuck in the loading process. The result was typically visible in three ways:

1. The shield splash screen was shown indefinitely,
2. a black screen was shown indefinitely, or
3. the conversation list was shown, but some avatars were missing and tapping on a conversation did nothing (and the app was generally unusable).

Terminating the app and restarting would not resolve the problem.

### Causes

The exact cause is not known, but I have been able to reproduce this bug reliably and have located it to a very specific part of the app. The situation is as follows:

1. After logging in and being able to receive and send messages, terminate the app.
2. Enter airplane mode (so that we can accumulate notifications)
3. Send several messages to this device from another user with a profile picture.
4. Exit airplane mode
5. Launch the app.

When the app launches we'll process events from the notification stream to sync the app with the backend. Eventually, we will attempt to display user notifications in the UI. Since the sender has a profile picture, we will also attempt to display their avatar in the user notification.

We will ask `Glide` to fetch the image data for us, using a blocking request on a background thread:

```scala
Threading.Background {
  Option(WireGlide(cxt)
    .asBitmap()
    .load(picture)
    .apply(new RequestOptions().circleCrop())
    .submit(128, 128)
    .get()). // This method blocks!
}.future
```

`Glide` then will make the request to our backend via `ImageAssetFetcher`. The result is returned as a `CancellableFuture[InputStream]`, containing the image data. We then wait **_indefinitely_** for this future to complete, before passing the input stream into a callback. This also happens on a background thread:

```scala
Try { Await.result(data, Duration.Inf) } match {
  case Failure(err) =>
    verbose(l"Asset loading failed $request, $err")
    callback.onLoadFailed(new RuntimeException(s"Fetcher. Asset loading failed: $err"))
  case Success(is) =>
    verbose(l"Asset loaded $request")
    callback.onDataReady(is)
}
```

I'm not entirely sure how these two blocking calls affect each other, as I'm not certain that they're causing a deadlock. I'm also confused about why this issue seems to only occur after a cold start after accumulating notifications. It could be that these blocking calls are also interfering, or being interfered by other activity related to backend syncing.

### Solutions

I came across a few solutions to this problem. First, replacing an infinite `Await` when fetching the image data with a timeout resulted in the app being stuck as long as the timeout, then proceeded to load as normal.

Second, removing the avatar from the user notification altogether resulted in the app not being stuck at all.

Both of these solutions (also combined) aren't optimal, sync they only assist in reducing the symptoms. They therefore are not the solutions I ended up with.

After refactoring the code related to the user notification, I found that the bug was fixed, even if we had an infinite `Await`. The refactoring was only structural, I simplified a messy nested `for` comprehension to make the code readable, resulting in a single `for` comprehension. I'm not sure why, but for some reason it fixes the bug, and we still get to keep the avatar in the user notification.

As a precaution, I replaced the infinite `Await` for the image data with non blocking callbacks which timeout after 30 seconds. While this has no effect on the user notifications, it will prevent blocking situations if the download gets stuck for some reason.

### Testing

Manually tested multiple times.

## Notes

The issue described above may also be a cause of the "stuck in sync" bug, and I expect to see this bug much less, (hopefully not at all).

Also, the logic for determine which picture to fetch (from a group of notifications) has been simplified. It was inefficiently searching all users in the notifications and only displaying an image if there was only one image found. This expense contributes to the slowness of the app launch if there are many accumulated notifications. The simplification is to merely show the avatar, if there is only a single notification.

#### APK
[Download build #245](http://10.10.124.11:8080/job/Pull%20Request%20Builder/245/artifact/build/artifact/wire-dev-PR2376-245.apk)
[Download build #246](http://10.10.124.11:8080/job/Pull%20Request%20Builder/246/artifact/build/artifact/wire-dev-PR2376-246.apk)
[Download build #248](http://10.10.124.11:8080/job/Pull%20Request%20Builder/248/artifact/build/artifact/wire-dev-PR2376-248.apk)
[Download build #249](http://10.10.124.11:8080/job/Pull%20Request%20Builder/249/artifact/build/artifact/wire-dev-PR2376-249.apk)
[Download build #251](http://10.10.124.11:8080/job/Pull%20Request%20Builder/251/artifact/build/artifact/wire-dev-PR2376-251.apk)