### PR TITLE
Chore: Update targetSdk version to 28

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,8 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false"
@@ -79,6 +81,12 @@
         android:vmSafeMode="${applicationVmSafeMode}"
         tools:replace="android:allowBackup"
         >
+
+<!--    TODO: not required when using play-services-maps:16.1.0 and above
+           https://developer.android.com/about/versions/pie/android-9.0-changes-28#apache-p
+           https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library
+-->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 
         <!-- main activity -->
         <activity

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
@@ -29,12 +29,12 @@ import android.text.style.QuoteSpan
  */
 class CustomQuoteSpan(
     color: Int,
-    val stripeWidth: Int,
-    val gapWidth: Int,
+    stripeWidth: Int,
+    gapWidth: Int,
     private val density: Float = 1f,
     val beforeSpacing: Int = 0,
     val afterSpacing: Int = 0
-) : QuoteSpan(color) {
+) : QuoteSpan(color, stripeWidth, gapWidth) {
 
     override fun getLeadingMargin(first: Boolean): Int {
         return ((stripeWidth + gapWidth) * density).toInt()

--- a/app/src/main/java/com/waz/zclient/pages/main/conversationpager/SlidingPaneLayout.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversationpager/SlidingPaneLayout.java
@@ -985,7 +985,7 @@ public class SlidingPaneLayout extends ViewGroup {
     protected boolean drawChild(Canvas canvas, View child, long drawingTime) {
         final LayoutParams lp = (LayoutParams) child.getLayoutParams();
         boolean result;
-        final int save = canvas.save(Canvas.CLIP_SAVE_FLAG);
+        final int save = canvas.save();
 
         if (canSlide && !lp.slideable && slideableView != null) {
             // Clip against the slider; no sense drawing what will immediately be covered.

--- a/app/src/main/java/com/waz/zclient/ui/sketch/DrawingCanvasView.java
+++ b/app/src/main/java/com/waz/zclient/ui/sketch/DrawingCanvasView.java
@@ -26,7 +26,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import android.os.Build;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -166,13 +166,7 @@ public class DrawingCanvasView extends View {
             invalidate();
             return true;
         }
-        int whiteColor;
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            //noinspection deprecation
-            whiteColor = getResources().getColor(R.color.draw_white);
-        } else {
-            whiteColor = getResources().getColor(R.color.draw_white, getContext().getTheme());
-        }
+        final int whiteColor = ContextCompat.getColor(getContext(), R.color.draw_white);
         if (backgroundBitmap == null &&
             canvasHistory.size() == 0 &&
             drawingPaint.getColor() == whiteColor) {

--- a/app/src/main/java/com/waz/zclient/ui/views/SketchEditText.java
+++ b/app/src/main/java/com/waz/zclient/ui/views/SketchEditText.java
@@ -18,11 +18,11 @@
 package com.waz.zclient.ui.views;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.TypedValue;
-import android.widget.EditText;
 
 import com.waz.zclient.R;
 import com.waz.zclient.ui.utils.TypefaceUtils;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
 
-public class SketchEditText extends EditText {
+public class SketchEditText extends AppCompatEditText {
 
     public Set<SketchEditTextListener> weakListenerSet;
     private String customHint;

--- a/app/src/main/java/com/waz/zclient/utils/extensions/BottomNavigationExtensions.kt
+++ b/app/src/main/java/com/waz/zclient/utils/extensions/BottomNavigationExtensions.kt
@@ -1,40 +1,27 @@
 @file:JvmName("BottomNavigationUtil")
-
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.waz.zclient.utils.extensions
 
-import android.annotation.SuppressLint
 import android.support.annotation.IdRes
 import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
-import android.support.design.internal.BottomNavigationItemView
 import android.view.View
-import timber.log.Timber
-
-@SuppressLint("RestrictedApi")
-//TODO: Use app:labelVisibilityMode="unlabeled" when support lib updated to 28.x
-// & delete relevant proguard rule
-fun BottomNavigationView.disableShiftMode() {
-    val menuView: BottomNavigationMenuView = getChildAt(0) as BottomNavigationMenuView
-    try {
-        menuView.javaClass.getDeclaredField("mShiftingMode").let {
-            it.isAccessible = true
-            it.setBoolean(menuView, false)
-            it.isAccessible = false
-        }
-
-        for (i in 0 until menuView.childCount) {
-            val item = menuView.getChildAt(i) as BottomNavigationItemView
-            item.setShiftingMode(false)
-            // set once again checked value, so view will be updated
-            item.setChecked(item.itemData.isChecked)
-        }
-    } catch (e: NoSuchFieldException) {
-        Timber.e(e, "Unable to get shift mode field")
-    } catch (e: IllegalAccessException) {
-        Timber.e(e, "Unable to change value of shift mode")
-    }
-
-}
 
 fun BottomNavigationView.setItemVisible(@IdRes id: Int, visible: Boolean) {
     val menuView: BottomNavigationMenuView = getChildAt(0) as BottomNavigationMenuView

--- a/app/src/main/java/com/waz/zclient/utils/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/waz/zclient/utils/extensions/ViewExtensions.kt
@@ -1,0 +1,32 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.utils.extensions
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.view.View
+
+//TODO: use View.drawToBitmap() after migration to androidx
+fun View.getViewBitmap(): Bitmap {
+    val returnedBitmap: Bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas (returnedBitmap)
+    background?.let { it.draw(canvas) } ?: canvas.drawColor(Color.WHITE)
+    draw(canvas)
+    return returnedBitmap
+}

--- a/app/src/main/res/layout/fragment_conversation_list_manager.xml
+++ b/app/src/main/res/layout/fragment_conversation_list_manager.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2019 Wire Swiss GmbH
@@ -18,8 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -58,15 +56,16 @@
         android:id="@+id/fragment_conversation_list_manager_view_bottom_border"
         android:layout_width="match_parent"
         android:layout_height="@dimen/people_picker__border_line__height"
-        app:layout_constraintBottom_toTopOf="@id/fragment_conversation_list_manager_bottom_navigation"
-        android:background="@color/separator_dark" />
+        android:background="@color/separator_dark"
+        app:layout_constraintBottom_toTopOf="@id/fragment_conversation_list_manager_bottom_navigation" />
 
     <android.support.design.widget.BottomNavigationView
         android:id="@+id/fragment_conversation_list_manager_bottom_navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:paddingTop="@dimen/wire__padding__4"
+        app:labelVisibilityMode="unlabeled"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:menu="@menu/main_bottom_navigation_items" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -17,12 +17,11 @@
  */
 package com.waz.zclient.appentry
 
-import android.app.FragmentManager
 import android.content.res.Configuration
 import android.content.{Context, Intent}
 import android.os.Bundle
 import android.support.v4.app.FragmentManager.OnBackStackChangedListener
-import android.support.v4.app.{Fragment, FragmentTransaction}
+import android.support.v4.app.{Fragment, FragmentManager, FragmentTransaction}
 import android.view.View
 import com.waz.content.Preferences.Preference.PrefCodec
 import com.waz.service.AccountManager.ClientRegistrationState
@@ -197,7 +196,7 @@ class AppEntryActivity extends BaseActivity {
               verbose(l"switched backend")
 
               // re-present fragment for updated ui.
-              getFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+              getSupportFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
               showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
           }
         }
@@ -235,7 +234,7 @@ class AppEntryActivity extends BaseActivity {
     // if the SSO token is present we use it to log in the user
     userAccountsController.ssoToken.head.foreach {
       case Some(_) =>
-        getFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        getSupportFragmentManager.popBackStackImmediate(AppLaunchFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         showFragment(AppLaunchFragment(), AppLaunchFragment.Tag, animated = false)
       case _ =>
     }(Threading.Ui)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -91,10 +91,7 @@ class ConversationListManagerFragment extends Fragment
   private var bottomNavigationBorder : View                 = _
 
   private lazy val bottomNavigationView = returning(view[BottomNavigationView](R.id.fragment_conversation_list_manager_bottom_navigation)) { vh =>
-    vh.foreach { view =>
-      BottomNavigationUtil.disableShiftMode(view)
-      view.setOnNavigationItemSelectedListener(ConversationListManagerFragment.this)
-    }
+    vh.foreach { _.setOnNavigationItemSelectedListener(ConversationListManagerFragment.this)}
 
     convListController.hasConversationsAndArchive.onUi { case (_, hasArchive) =>
       vh.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, hasArchive))

--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -50,6 +50,7 @@ import com.waz.zclient.ui.views.{CursorIconButton, SketchEditText}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.utils.debug.ShakeEventListener
+import com.waz.zclient.utils.extensions.ViewExtensionsKt
 import com.waz.zclient.{FragmentHelper, R}
 
 import scala.collection.immutable.ListSet
@@ -165,7 +166,6 @@ class DrawingFragment extends FragmentHelper
     vh.onClick { _ =>
       inject[PermissionsService].requestAllPermissions(ListSet(READ_EXTERNAL_STORAGE)).foreach {
         case true =>
-          sketchEditTextView.foreach(_.destroyDrawingCache())
           assetIntentsManager.openGalleryForSketch()
         case _ =>
       }
@@ -550,20 +550,16 @@ class DrawingFragment extends FragmentHelper
       //This has to be on a post otherwise the setAlpha and setCursor won't be noticeable in the drawing cache
       getView.post(new Runnable() {
         override def run(): Unit = {
-          sk.setDrawingCacheEnabled(true)
-          val bitmapDrawingCache = sk.getDrawingCache
-          if (bitmapDrawingCache != null) {
-            val params = sk.getLayoutParams.asInstanceOf[FrameLayout.LayoutParams]
-            canv.showText()
-            canv.drawTextBitmap(
-              bitmapDrawingCache.copy(bitmapDrawingCache.getConfig, true),
-              params.leftMargin,
-              params.topMargin,
-              sk.getText.toString,
-              sk.getSketchScale)
-          }
-          else canv.drawTextBitmap(null, 0, 0, "", 1.0f)
-          sk.setDrawingCacheEnabled(false)
+          val viewBitmap = ViewExtensionsKt.getViewBitmap(sk)
+          val params = sk.getLayoutParams.asInstanceOf[FrameLayout.LayoutParams]
+          canv.showText()
+          canv.drawTextBitmap(
+            viewBitmap,
+            params.leftMargin,
+            params.topMargin,
+            sk.getText.toString,
+            sk.getSketchScale
+          )
           sk.setAlpha(TextAlphaInvisible)
         }
       })

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,11 @@ task licenseFormatAndroid(type: nl.javadude.gradle.plugins.license.License) {
 licenseFormat.dependsOn licenseFormatAndroid
 
 ext {
-    compileSdkVersion = 27
+    compileSdkVersion = 28
     // When upgrading minimum sdk you might want to search for occurrences of Build.VERSION_CODES.
     // There are some classes with possibility of being simplified.
     minSdkVersion = 21
-    targetSdkVersion = 27
+    targetSdkVersion = 28
 
     buildToolsVersion = '28.0.3'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     scalaVersion = scalaMajorVersion + '.12'
 
     versions = [
-        supportLib: "27.1.1",
+        supportLib: "28.0.0",
         threetenbp: "1.3.8",
         junit     : "4.12",
     ]

--- a/testing_gallery/build.gradle
+++ b/testing_gallery/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:appcompat-v7:27.0.0"
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.versions.supportLib"
     implementation 'com.google.code.gson:gson:2.2.4'
     implementation 'com.google.guava:guava:19.0'
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Any updates to existing apps in Google Play Store should target at least API level 28.

### Causes

Link for the requirement: https://support.google.com/googleplay/android-developer/answer/113469#targetsdk

### Testing

Manually tested affected areas. A full automated test run is required.


#### APK
[Download build #254](http://10.10.124.11:8080/job/Pull%20Request%20Builder/254/artifact/build/artifact/wire-dev-PR2377-254.apk)
[Download build #255](http://10.10.124.11:8080/job/Pull%20Request%20Builder/255/artifact/build/artifact/wire-dev-PR2377-255.apk)