### PR TITLE
fix: Don't try to sync history in response to web socket disconnecting

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -196,9 +196,11 @@ class PushServiceImpl(selfUserId:           UserId,
     syncNotifications(StoreNotifications(nots))
   }
 
-  wsPushService.connected().onChanged.map(WebSocketChange).on(dispatcher){ source =>
-    verbose(l"SYNC sync history due to web socket change")
-    syncNotifications(SyncHistory(source))
+  wsPushService.connected().onChanged.map(WebSocketChange).on(dispatcher){
+    case source@WebSocketChange(true) =>
+      verbose(l"SYNC sync history due to web socket change")
+      syncNotifications(SyncHistory(source))
+    case _ =>
   }
 
   private var fetchInProgress: Future[Unit] = Future.successful(())


### PR DESCRIPTION
Right now we sync history after each change of web socket connection, even on disconnection,
which does nothing and ends in an exception being thrown. It's not a crash, but it's unnecessary,
and the fix is very simple.

#### APK
[Download build #250](http://10.10.124.11:8080/job/Pull%20Request%20Builder/250/artifact/build/artifact/wire-dev-PR2378-250.apk)