### PR TITLE
feat: Wipe data after failed N attempts at typing in the password

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ android {
         buildConfigField 'boolean', 'BLOCK_ON_PASSWORD_POLICY',      "$buildtimeConfiguration.configuration.block_on_password_policy"
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
         buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
+        buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
     }
 
     packagingOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,8 +56,6 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-
-
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false"
@@ -231,6 +229,8 @@
                 android:resource="@xml/device_admin" />
             <intent-filter>
                 <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+                <action android:name="android.app.action.ACTION_PASSWORD_FAILED"/>
+                <action android:name="android.app.action.ACTION_PASSWORD_SUCCEEDED"/>
             </intent-filter>
         </receiver>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,8 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false"

--- a/app/src/main/res/xml/device_admin.xml
+++ b/app/src/main/res/xml/device_admin.xml
@@ -20,5 +20,6 @@
 <device-admin xmlns:android="http://schemas.android.com/apk/res/android">
 <uses-policies>
     <limit-password />
+    <watch-login />
 </uses-policies>
 </device-admin>

--- a/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/security/AppLockActivity.scala
@@ -23,6 +23,8 @@ import android.os.Bundle
 import android.provider.Settings
 import android.support.v7.app.AppCompatActivity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.services.SecurityPolicyService
+import com.waz.threading.Threading
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{ActivityHelper, R}
 
@@ -68,12 +70,13 @@ class AppLockActivity extends AppCompatActivity with ActivityHelper with Derived
 
     if (requestCode == ConfirmDeviceCredentialsRequestCode) {
       if (resultCode == Activity.RESULT_OK) {
-        info(l"authentication successful")
         inject[SecurityPolicyChecker].onAuthenticationSuccessful()
         finish()
       } else {
-        info(l"authentication cancelled. Representing authentication screen.")
-        showAuthenticationScreen()
+        inject[SecurityPolicyService].passwordFailed(this).foreach {
+          case true  => finish()
+          case false => showAuthenticationScreen()
+        }(Threading.Ui)
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -39,7 +39,7 @@ import org.threeten.bp.temporal.ChronoUnit
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 
-class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with DerivedLogTag {
+class SecurityPolicyChecker(implicit context: Context, injector: Injector) extends Injectable with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Ui
 
@@ -72,7 +72,7 @@ class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with
         BlockWithDialogAction(R.string.root_detected_dialog_title, R.string.root_detected_dialog_message)
       )
 
-      checksAndActions += rootDetectionCheck ->  rootDetectionActions
+      checksAndActions += rootDetectionCheck -> rootDetectionActions
     }
 
     if (BuildConfig.BLOCK_ON_PASSWORD_POLICY) {
@@ -100,7 +100,7 @@ class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with
       )
 
       checksAndActions += devicePasswordComplianceCheck -> devicePasswordComplianceActions
-    }
+   }
 
     if (BuildConfig.WIPE_ON_COOKIE_INVALID) {
       verbose(l"check WIPE_ON_COOKIE_INVALID")
@@ -145,6 +145,7 @@ class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with
   def onAuthenticationSuccessful(): Unit = {
     timeEnteredBackground = None
     authenticationNeeded ! false
+    securityPolicyService.passwordSucceeded()
   }
 
   def authenticateIfNeeded(parentActivity: Activity): Unit = {

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -100,7 +100,7 @@ class SecurityPolicyChecker(implicit context: Context, injector: Injector) exten
       )
 
       checksAndActions += devicePasswordComplianceCheck -> devicePasswordComplianceActions
-   }
+    }
 
     if (BuildConfig.WIPE_ON_COOKIE_INVALID) {
       verbose(l"check WIPE_ON_COOKIE_INVALID")

--- a/default.json
+++ b/default.json
@@ -36,5 +36,6 @@
   "app_lock_timeout": 10,
   "block_on_password_policy": false,
   "wipe_on_cookie_invalid": false,
-  "force_private_keyboard": false
+  "force_private_keyboard": false,
+  "password_max_attempts": 10
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -485,4 +485,6 @@ object UserPreferences {
 
   lazy val ConversationListType             = PrefKey[Int]("conversation_list_type", customDefault = -1)
   lazy val ConversationFoldersUiState       = PrefKey[Map[FolderId, Boolean]]("conversation_folders_ui_state", customDefault = Map.empty)
+
+  lazy val SecurityPolicyFailedPwdAttempts  = PrefKey[Int]("security_policy_failed_pwd_attempts", customDefault = 0)
 }


### PR DESCRIPTION
This code does not count failed attempts, because the app is not getting notified about them for some reason, but the number of times the user cancelled typing in the password. With this in use, the user has a choice:
either to stay on the Android's password page and typing in the right password (the policy uses the
exponential backoff, so with many failed attempts this may mean being locked out for a long time) or if they hit "Cancel" enough times, the Wire data will be wiped.

#### APK
[Download build #256](http://10.10.124.11:8080/job/Pull%20Request%20Builder/256/artifact/build/artifact/wire-dev-PR2380-256.apk)
[Download build #257](http://10.10.124.11:8080/job/Pull%20Request%20Builder/257/artifact/build/artifact/wire-dev-PR2380-257.apk)