### PR TITLE
Chore: Update scala gradle plugin to version 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
         classpath 'com.mutualmobile.gradle.plugins:dexinfo:0.1.2'
-        classpath 'com.wire:gradle-android-scala-plugin:1.5.0'
+        classpath 'com.wire.gradle:gradle-android-scala-plugin:1.6'
         classpath 'com.google.gms:google-services:3.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'org.ajoberstar.grgit:grgit-core:3.0.0'


### PR DESCRIPTION
## What's new in this PR?

Update scala gradle plugin to new version that supports android gradle plugin 3.2.1.

### Testing

App behaviour should not change.


#### APK
[Download build #258](http://10.10.124.11:8080/job/Pull%20Request%20Builder/258/artifact/build/artifact/wire-dev-PR2381-258.apk)