### PR TITLE
Refactor/remove await in tests

### DIFF
--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -29,6 +29,11 @@ android {
 
             jvmArgs "-Xmx4096M", "-XX:+CMSClassUnloadingEnabled",
                 "-Djava.net.preferIPv4Stack=true", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n"
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen { false }
+                showStandardStreams = true
+            }
         }
     }
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -50,9 +50,9 @@ object FutureAwaitSyntax {
 trait FutureAwaitSyntax {
   import FutureAwaitSyntax._
 
-  @deprecated("await does not fail tests if the provided future fails! Better to just always use result and discard the return value", "?")
-  def await(future: Future[_])(implicit duration: FiniteDuration = DefaultTimeout): Unit =
-    Await.ready(future, duration)
+  def await(future: Future[_])(implicit duration: FiniteDuration = DefaultTimeout): Unit = {
+    Await.result(future, duration)
+  }
 
   def result[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): A =
     Await.result(future, duration)


### PR DESCRIPTION
## What's new in this PR?

### Issues

This branch removes the deprecated `await` call in tests. Some small fixes are also included as this change uncovered other bugs in some tests.

## Notes

During testing the SE `build.gradle` was modified to show stdout and stderr output to facilitate debugging using print statements. This was left in since we have the same thing in the UI `build.gradle`, although it does result in more noise.
#### APK
[Download build #267](http://10.10.124.11:8080/job/Pull%20Request%20Builder/267/artifact/build/artifact/wire-dev-PR2385-267.apk)