### PR TITLE
Fix flaky tests in SignalSpec

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,6 +164,7 @@ android {
                 events "passed", "skipped", "failed", "standardOut", "standardError"
                 outputs.upToDateWhen { false }
                 showStandardStreams = true
+                exceptionFormat = 'full'
             }
         }
     }

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -33,6 +33,7 @@ android {
                 events "passed", "skipped", "failed", "standardOut", "standardError"
                 outputs.upToDateWhen { false }
                 showStandardStreams = true
+                exceptionFormat = 'full'
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The tests for signal subscriptions were flaky and occasionally failed. The errors were never involving failures of the unsubscribing itself, where a 3rd element would be sent after the subscription was destroyed, but rather were due to the reported number of sent elements being 0 or otherwise invalid. This points to issues in the test setup code in `beforeAll` and `afterAll`. Thus the test code itself appears to be at fault, rather than the `Signal` code.

### Solutions

This PR rewrites the signal subscription tests as property based tests which use local variables instead of shared variables. Property-based tests also provide better guarantees about the absence of race conditions since they run more than once.

### Causes

The exact cause of the previous failures is unclear, but these new tests have been run a few hundred million times without issues so it looks like an issue with the test suite code itself.

## Notes

The UI and SE `build.gradle` was changed so that the actual condition which failed is
now printed, instead of just the exception name.
#### APK
[Download build #268](http://10.10.124.11:8080/job/Pull%20Request%20Builder/268/artifact/build/artifact/wire-dev-PR2386-268.apk)