### PR TITLE
Refactor/signal spec races

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
@@ -26,13 +26,14 @@ import com.waz.specs.AndroidFreeSpec.DefaultTimeout
 import com.waz.testutils.Implicits._
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import org.scalacheck.Gen
+import org.scalatest.concurrent.Eventually
 import org.scalatest.prop.PropertyChecks
 
 import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 
-class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks {
+class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks with Eventually {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   var received = Seq[Int]()
@@ -55,17 +56,16 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
     scenario("Receive initial value") {
       val s = Signal(1)
       s(capture)
-      Thread.sleep(100)
-      received shouldEqual Seq(1)
+      eventually { received shouldEqual Seq(1) }
     }
 
     scenario("Basic subscriber lifecycle") {
       val s = Signal(1)
-      s.hasSubscribers shouldEqual false
+      eventually { s.hasSubscribers shouldEqual false }
       val sub = s { _ => () }
-      s.hasSubscribers shouldEqual true
+      eventually { s.hasSubscribers shouldEqual true }
       sub.destroy()
-      s.hasSubscribers shouldEqual false
+      eventually { s.hasSubscribers shouldEqual false }
     }
 
     val listGen: Gen[Seq[Int]] = Gen.containerOfN[Set, Int](3, Gen.choose(Integer.MIN_VALUE, Integer.MAX_VALUE)).map(_.toSeq)
@@ -82,11 +82,11 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
         val s = Signal(sentValues.head)
         val sub = s(cap)
         s ! sentValues.tail.head
-        recv shouldEqual sentValues
+        eventually { recv shouldEqual sentValues }
 
         sub.destroy()
         s ! l.last
-        recv shouldEqual sentValues
+        eventually { recv shouldEqual sentValues }
         eventContext.onContextStop()
       }
     }
@@ -102,11 +102,11 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
         val s = Signal(sentValues.head)
         s(cap)
         s ! sentValues.tail.head
-        recv shouldEqual sentValues
+        eventually { recv shouldEqual sentValues }
 
         s.unsubscribeAll()
         s ! l.last
-        recv shouldEqual sentValues
+        eventually { recv shouldEqual sentValues }
         eventContext.onContextStop()
       }
     }
@@ -114,11 +114,11 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
     scenario("Signal mutation") {
       val s = Signal(42)
       s(capture)
-      received shouldEqual Seq(42)
+      eventually { received shouldEqual Seq(42) }
       s.mutate(_ + 1)
-      received shouldEqual Seq(42, 43)
+      eventually { received shouldEqual Seq(42, 43) }
       s.mutate(_ - 1)
-      received shouldEqual Seq(42, 43, 42)
+      eventually { received shouldEqual Seq(42, 43, 42) }
     }
   }
 
@@ -127,15 +127,15 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
       val s = Signal(1)
       s(capture)
       Seq(1, 2, 2, 1) foreach (s ! _)
-      received shouldEqual Seq(1, 2, 1)
+      eventually { received shouldEqual Seq(1, 2, 1) }
     }
 
     scenario("Idempotent signal mutation") {
       val s = Signal(42)
       s(capture)
-      received shouldEqual Seq(42)
+      eventually { received shouldEqual Seq(42) }
       s.mutate(_ + 1 - 1)
-      received shouldEqual Seq(42)
+      eventually { received shouldEqual Seq(42) }
     }
   }
 
@@ -149,10 +149,10 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
         y <- Seq(s1, s2)(x)
       } yield y * 2
       r(capture)
-      r.currentValue.get shouldEqual 2
+      eventually { r.currentValue.get shouldEqual 2 }
       s ! 1
-      r.currentValue.get shouldEqual 4
-      received shouldEqual Seq(2, 4)
+      eventually { r.currentValue.get shouldEqual 4 }
+      eventually { received shouldEqual Seq(2, 4) }
     }
   }
 
@@ -168,11 +168,11 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
       })
 
       val subs = Await.result(Future.sequence(Seq.fill(50)(add(barrier))), 10.seconds)
-      s.hasSubscribers shouldEqual true
-      num.getAndSet(0) shouldEqual 50
+      eventually { s.hasSubscribers shouldEqual true }
+      eventually { num.getAndSet(0) shouldEqual 50 }
 
       s ! 42
-      num.getAndSet(0) shouldEqual 50
+      eventually { num.getAndSet(0) shouldEqual 50 }
 
       val chaosBarrier = new CyclicBarrier(75)
       val removals = Future.traverse(subs.take(25)) (sub => Future(blocking {
@@ -189,16 +189,16 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
       Await.result(removals, 10.seconds)
       Await.result(sending, 10.seconds)
 
-      num.get should be <= 75*25
-      num.get should be >= 25*25
-      s.hasSubscribers shouldEqual true
+      eventually { num.get should be <= 75*25 }
+      eventually { num.get should be >= 25*25 }
+      eventually { s.hasSubscribers shouldEqual true }
 
       barrier.reset()
       Await.result(Future.traverse(moreSubs ++ subs.drop(25)) (sub => Future(blocking {
         barrier.await()
         sub.destroy()
       })), 10.seconds)
-      s.hasSubscribers shouldEqual false
+      eventually { s.hasSubscribers shouldEqual false }
     }
 
     scenario("Concurrent updates with incremental values") {
@@ -238,10 +238,10 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
 
         done.await(DefaultTimeout.toMillis, TimeUnit.MILLISECONDS)
 
-        signal.currentValue.get shouldEqual send.get()
+        eventually { signal.currentValue.get shouldEqual send.get() }
 
         val arr = received.asScala.toVector
-        arr shouldEqual arr.sorted
+        eventually { arr shouldEqual arr.sorted }
       }
     }
 
@@ -320,7 +320,7 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
     concurrentUpdates(dispatches, several, (s, n) => s.set(Some(n), dispatchExecutionContext), actualExecutionContext, subscribe)
 
   def concurrentMutations(dispatches: Int, several: Int, eventContext: EventContext, actualExecutionContext: ExecutionContext)(subscribe: Signal[Int] => (Int => Unit) => Subscription = s => g => s(g)(eventContext)): Unit =
-    concurrentUpdates(dispatches, several, (s, n) => s.mutate(_ + n), actualExecutionContext, subscribe, _.currentValue.get shouldEqual 55)
+    concurrentUpdates(dispatches, several, (s, n) => s.mutate(_ + n), actualExecutionContext, subscribe, eventually { _.currentValue.get shouldEqual 55 })
 
   def concurrentUpdates(dispatches: Int, several: Int, f: (SourceSignal[Int], Int) => Unit, actualExecutionContext: ExecutionContext, subscribe: Signal[Int] => (Int => Unit) => Subscription, additionalAssert: Signal[Int] => Unit = _ => ()): Unit =
     several times {
@@ -330,7 +330,7 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
       val received = new AtomicInteger(0)
       val p = Promise[Unit]()
 
-      val subscriber = subscribe(signal) { i =>
+      val _ = subscribe(signal) { i =>
         lastSent = i
         if (received.incrementAndGet() == dispatches + 1) p.trySuccess({})
       }
@@ -340,6 +340,6 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with PropertyChecks 
       Await.result(p.future, 30.seconds)
 
       additionalAssert(signal)
-      signal.currentValue.get shouldEqual lastSent
+      eventually { signal.currentValue.get shouldEqual lastSent }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After experimenting a little with the `SignalSpecs` test more, it was noted that a `Thread.sleep` call is required for the first test to work. Furthermore, if the first and second test are swapped, the second test fails now. This seems to be related to the JVM loading the code and caching it perhaps. It also looks like creating subscribers is an asynchronous task, and thus we can't safely check a signal subscriber count immediately after creating a subscription. This all makes sense, since we are testing an asynchronous library after all!

### Solutions

The solution for testing our async library is to have our tests wait for the right value to eventually appear, up to a timeout. `Scalatest` provides the `eventually` construct for this purpose. This appears to resolve all of the issues(which can be reliably reproduced without it).

### Testing

Testing was done locally using some scripts to run the test ~100 times, and manual testing, but this suite should be monitored for a wee while to ensure the issues are resolved(If only we could prove the absence of bugs!). Yesterday the old flaky suite was run locally hundreds of times without failing, so the above doesn't fill me with confidence. It appears Jenkins is the most likely place for it to fail.

## Notes

 - The property-based tests that were written before now appear overly complicated and don't add much, so they were removed and the originals restored, but this time using the `eventually` construct.
 - I've used the default timeouts for `eventually`, but these might need tweaking in other future. The default timeout is 150ms, more than the `Thread.sleep` call, so it shouldn't be any less reliable, and the default interval to check is 15ms, which should provide good performance. [More detail here](http://doc.scalatest.org/1.8/org/scalatest/concurrent/Eventually.html)
#### APK
[Download build #270](http://10.10.124.11:8080/job/Pull%20Request%20Builder/270/artifact/build/artifact/wire-dev-PR2388-270.apk)