### PR TITLE
[Fix] Call participants list only shows 1 user at a time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.3.3@aar'
+    customAvsVersion = '5.3.10@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -146,12 +146,10 @@ class AvsImpl() extends Avs with DerivedLogTag {
     callingReady.future.map { _ =>
       val participantChangedHandler = new ParticipantChangedHandler {
         override def onParticipantChanged(convId: String, data: String, arg: Pointer): Unit = {
-          val members = ParticipantsChangeDecoder.decode(data) match {
-            case Some(participantsChange) => participantsChange.members.map(_.userid).toSet
-            case None                     => Set.empty[UserId]
+          ParticipantsChangeDecoder.decode(data).fold(()) { participantsChange =>
+            val members = participantsChange.members.map(_.userid).toSet
+            cs.onParticipantsChanged(RConvId(convId), members)
           }
-
-          cs.onParticipantsChanged(RConvId(convId), members)
         }
       }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -151,7 +151,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
             case None                     => Set.empty[UserId]
           }
 
-          cs.onGroupChanged(RConvId(convId), members)
+          cs.onParticipantsChanged(RConvId(convId), members)
         }
       }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -83,7 +83,7 @@ object Calling {
 
   @native def wcall_network_changed(inst: Handle): Unit
 
-  @native def wcall_set_group_changed_handler(inst: Handle, wcall_group_changed_h: GroupChangedHandler): Unit
+  @native def wcall_set_participant_changed_handler(inst: Handle, wcall_participant_changed_h: ParticipantChangedHandler, arg: Pointer): Unit
 
   @native def wcall_get_members(inst: Handle, convid: String): Members
 
@@ -150,7 +150,8 @@ object Calling {
     def onVideoReceiveStateChanged(convId: String, userId: String, clientId: String, state: Int, arg: Pointer): Unit
   }
 
-  trait GroupChangedHandler extends Callback {
+  trait ParticipantChangedHandler extends Callback {
+
     // Example of `data`
     //  {
     //      "convid": "df371578-65cf-4f07-9f49-c72a49877ae7",
@@ -163,7 +164,7 @@ object Calling {
     //          }
     //      ]
     //}
-    def onGroupChanged(convId: String, data: String, arg: Pointer): Unit
+    def onParticipantChanged(convId: String, data: String, arg: Pointer): Unit
   }
 
   trait MetricsHandler extends Callback {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -367,7 +367,7 @@ class CallingServiceImpl(val accountId:       UserId,
       }.toMap
 
       call.copy(others = updated, maxParticipants = math.max(call.maxParticipants, members.size + 1))
-    } ("onGroupChanged")
+    } ("onParticipantsChanged")
 
   network.networkMode.onChanged { _ =>
     currentCall.head.flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -359,7 +359,7 @@ class CallingServiceImpl(val accountId:       UserId,
       call.updateVideoState(Participant(UserId(userId), ClientId(clientId)), videoReceiveState)
     }("onVideoStateChanged")
 
-  def onGroupChanged(rConvId: RConvId, members: Set[UserId]): Future[Unit] =
+  def onParticipantsChanged(rConvId: RConvId, members: Set[UserId]): Future[Unit] =
     updateCallIfActive(rConvId) { (w, conv, call) =>
       verbose(l"group members changed, convId: ${conv.id}, other members: $members")
       val updated = members.map { userId =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
@@ -36,6 +36,12 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
         |      "clientid": "24cc758f602fb1f4",
         |      "aestab": 1,
         |      "vrecv": 0
+        |    },
+        |    {
+        |      "userid": "7cc36a2e-88d3-ac76-86ba-d02faca478ed",
+        |      "clientid": "64ca916f366fcc56",
+        |      "aestab": 0,
+        |      "vrecv": 1
         |    }
         |  ]
         |}
@@ -47,12 +53,18 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
     // Then
     result.isDefined shouldEqual true
     result.get.convid shouldEqual ConvId("df371578-65cf-4f07-9f49-c72a49877ae7")
-    result.get.members.size shouldEqual 1
+    result.get.members.size shouldEqual 2
 
-    val member = result.get.members.head
-    member.userid shouldEqual UserId("3f49da1d-0d52-4696-9ef3-0dd181383e8a")
-    member.clientid shouldEqual ClientId("24cc758f602fb1f4")
-    member.aestab shouldEqual 1
-    member.vrecv shouldEqual 0
+    val member1 = result.get.members.head
+    member1.userid shouldEqual UserId("3f49da1d-0d52-4696-9ef3-0dd181383e8a")
+    member1.clientid shouldEqual ClientId("24cc758f602fb1f4")
+    member1.aestab shouldEqual 1
+    member1.vrecv shouldEqual 0
+
+    val member2 = result.get.members.last
+    member2.userid shouldEqual UserId("7cc36a2e-88d3-ac76-86ba-d02faca478ed")
+    member2.clientid shouldEqual ClientId("64ca916f366fcc56")
+    member2.aestab shouldEqual 0
+    member2.vrecv shouldEqual 1
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -409,7 +409,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUser)
-        service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+        service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       }
 
       service.startCall(groupConv.id)
@@ -435,7 +435,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onEstablishedCall(groupConv.remoteId, otherUser)
       awaitCP(checkpoint3)
 
-      service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+      service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       awaitCP(checkpoint4)
     }
 
@@ -456,7 +456,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onEstablishedCall(teamGroupConv.remoteId, otherUser)
       awaitCP(checkpoint3)
 
-      service.onGroupChanged(teamGroupConv.remoteId, Set(otherUser, otherUser2))
+      service.onParticipantsChanged(teamGroupConv.remoteId, Set(otherUser, otherUser2))
       awaitCP(checkpoint4)
     }
 
@@ -472,7 +472,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUser)
-        service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+        service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       }
       service.startCall(groupConv.id)
       awaitCP(checkpoint1)
@@ -538,7 +538,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUser)
-        service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+        service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       }
 
       service.startCall(groupConv.id)
@@ -565,7 +565,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUser)
-        service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+        service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       }
 
       service.startCall(groupConv.id)
@@ -600,7 +600,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       awaitCP(checkpoint7)
 
-      service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+      service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
 
       awaitCP(checkpoint8)
 
@@ -830,7 +830,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (rId, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUser)
-        service.onGroupChanged(groupConv.remoteId, Set(otherUser, otherUser2))
+        service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
       }
       service.startCall(groupConv.id)
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

In a group call with 2 or more other participants, only the last connected participant is visible in the call participants list.

### Causes

When upgrading to AVS 5.3, I mistakenly changed the existing _group changed handler_ to receive a json argument, instead of implementing the new _participants changed handler_. As a result, the json parameter `data` wall always `null`, resulting in the failed json decoding.

### Solutions

Implement the new callback, and remove the old one (it's is deprecated and will be removed from AVS in the future).

Also, it doesn't make much sense to update the list even when the decoding fails (even though this should no longer happen). I've refactored the implementation to only pass on the members data after successfully decoding the json.

### Testing

- Manually tested
- Extended the decoding test to parse multiple participants

## Notes

This PR also bumps to the latest AVS 5.3.

There is another bug related to the participant list (where a user participating from multiple devices is only visible once in the list), but this will be addressed in a later PR.

#### APK
[Download build #275](http://10.10.124.11:8080/job/Pull%20Request%20Builder/275/artifact/build/artifact/wire-dev-PR2390-275.apk)