### PR TITLE
Fix audio recording so it works on iOS

### DIFF
--- a/app/src/main/java/com/waz/zclient/audio/AudioService.kt
+++ b/app/src/main/java/com/waz/zclient/audio/AudioService.kt
@@ -40,6 +40,8 @@ interface AudioService {
     /**
      * Returns Observable which is responsible for audio recording. Audio recording starts when
      * somebody subscribes to it and stops on unsubscribe.
+     * We record PCM directly instead of using MediaRecorder, because our voice filter code only
+     * supports .pcm and .wav files
      */
     fun recordPcmAudio(pcmFile: File, onFinish: () -> Unit = {}): Observable<RecordingProgress>
 

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -42,7 +42,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
 
     private val audioService: AudioService = KotlinServices.audioService
     private val recordFile: File = File(context.cacheDir, "record_temp.pcm")
-    private val compressedRecordFile: File = File(context.cacheDir, "record_temp.mp4")
+    private val compressedRecordFile: File = File(context.cacheDir, "record_temp.m4a")
     private val recordWithEffectFile: File = File(context.cacheDir, "record_with_effect_temp.pcm")
     private val normalizedRecordLevels: MutableList<Float> = mutableListOf()
     private var audioTrack: AudioTrack? = null


### PR DESCRIPTION
 - 
 - It looks like storing our .m4a file using a .mp4 extension was
causing some issues.

## What's new in this PR?

### Issues

Previously, audio messages recorded on Android didn't work on iOS, this commit fixes that.

### Causes

It looks like storing our `.m4a` file using a `.mp4` extension was causing some issues.

### Solutions

The file extension was changed to `.m4a`.

### Testing

Manual testing was done to make sure messages could be played on wrapper and iOS.
#### APK
[Download build #284](http://10.10.124.11:8080/job/Pull%20Request%20Builder/284/artifact/build/artifact/wire-dev-PR2392-284.apk)
[Download build #288](http://10.10.124.11:8080/job/Pull%20Request%20Builder/288/artifact/build/artifact/wire-dev-PR2392-288.apk)