### PR TITLE
Fix: Update "Delete group" button visibility rules

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -128,7 +128,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
       case Mode.Normal(false) if isGroup && selectedParticipant.isDefined =>
         if (removePerm && !isGuest) builder += RemoveMember
 
-      case Mode.Normal(_) =>
+      case Mode.Normal(inConversationList) =>
 
         def notifications: MenuItem =
           if (teamId.isDefined)
@@ -149,7 +149,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
           if (conv.isActive) builder += Leave
           if (mode.inConversationList || teamId.isEmpty) builder += notifications
           builder += Clear
-          if (admin) builder += DeleteGroupConv
+          if (!inConversationList && admin) builder += DeleteGroupConv
         } else {
           if (teamMember || connectStatus.contains(ACCEPTED) || isBot) {
             builder ++= Set(notifications, Clear)


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR changes the visibility rules of the "Delete Group" option menu.
- Should not be visible in the conversation list options menu. It should only be accessed via Conversation Details options menu.
- Should be visible only if it's a team conversation
- Should be visible only for conversation's creator

#### APK
[Download build #286](http://10.10.124.11:8080/job/Pull%20Request%20Builder/286/artifact/build/artifact/wire-dev-PR2393-286.apk)
[Download build #287](http://10.10.124.11:8080/job/Pull%20Request%20Builder/287/artifact/build/artifact/wire-dev-PR2393-287.apk)