### PR TITLE
fix: read receipts now match the spec

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -60,7 +60,7 @@ case class ConversationData(override val id:      ConvId                 = ConvI
                             access:               Set[Access]            = Set.empty,
                             accessRole:           Option[AccessRole]     = None, //option for migration purposes only - at some point we do a fetch and from that point it will always be defined
                             link:                 Option[Link]           = None,
-                            receiptMode:          Option[Int]            = None
+                            receiptMode:          Option[Int]            = None  //Some(1) if both users have RR enabled in a 1-to-1 convo
                            ) extends Identifiable[ConvId] {
 
   def displayName = if (convType == ConversationType.Group) name.getOrElse(generatedName) else generatedName

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -439,10 +439,8 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
 
   def shouldSendReadReceipts(convId: ConvId, readReceiptSettings: ReadReceiptSettings): Future[Boolean] =
     convs.isGroupConversation(convId).map {
-      case true =>
-        readReceiptSettings.convSetting.contains(1)
-      case false =>
-        readReceiptSettings.selfSettings && readReceiptSettings.convSetting.contains(1)
+      case true  => readReceiptSettings.convSetting.contains(1)
+      case false => readReceiptSettings.selfSettings
     }
 
   override def setLastRead(convId: ConvId, msg: MessageData): Future[Option[ConversationData]] = {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.service.conversation
+
+import com.waz.content._
+import com.waz.model._
+import com.waz.service.assets2.AssetService
+import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
+import com.waz.service.push.PushService
+import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService}
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.client.ConversationsClient
+import com.waz.sync.SyncServiceHandle
+import com.waz.testutils.TestGlobalPreferences
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class ConversationsUiServiceSpec extends AndroidFreeSpec {
+
+  val selfUserId = UserId()
+  val push =            mock[PushService]
+  val usersStorage =    mock[UsersStorage]
+  val convsStorage =    mock[ConversationStorage]
+  val content =         mock[ConversationsContentUpdater]
+  val convsService =    mock[ConversationsService]
+  val sync =            mock[SyncServiceHandle]
+  val errors =          mock[ErrorsService]
+  val messages =        mock[MessagesService]
+  val client =          mock[ConversationsClient]
+  val messagesStorage = mock[MessagesStorage]
+  val deletions =       mock[MsgDeletionStorage]
+  val members =         mock[MembersStorage]
+  val assetService =    mock[AssetService]
+  val network =         mock[NetworkModeService]
+  val properties =      mock[PropertiesService]
+
+  val prefs = new TestGlobalPreferences()
+
+  private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, prefs)
+    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, usersStorage, messages, messagesStorage,
+      msgContent, members, content, convsStorage, network, convsService, sync, client,
+      accounts, tracking, errors, properties)
+  }
+
+  feature("Read receipts should match the spec") {
+    scenario("Group conversation setting on means RR are always sent") {
+      val convId = ConvId("test")
+      val rrSettings = ReadReceiptSettings(selfSettings = false, Some(1))
+      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
+
+      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(true))
+
+      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual true
+    }
+
+    scenario("Group conversation setting off means RR are never sent ") {
+      val convId = ConvId("test")
+      val rrSettings = ReadReceiptSettings(selfSettings = true, Some(0))
+      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
+
+      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(true))
+
+      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
+    }
+
+    scenario("1-to-1 conversation setting empty means RR are never sent") {
+      val convId = ConvId("test")
+      val rrSettings = ReadReceiptSettings(selfSettings = false, None)
+      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
+
+      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))
+
+      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
+    }
+
+    scenario("1-to-1 conversation setting off means RR are not sent, despite user option") {
+      val convId = ConvId("test")
+      val rrSettings = ReadReceiptSettings(selfSettings = true, Some(0))
+      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
+
+      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))
+
+      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
+    }
+
+    scenario("RR are sent when convo and user option match") {
+      val convId = ConvId("test")
+      val rrSettings = ReadReceiptSettings(selfSettings = true, Some(1))
+      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
+
+      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))
+
+      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual true
+    }
+  }
+}

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -19,7 +19,7 @@ package com.waz.service.conversation
 
 import com.waz.content._
 import com.waz.model._
-import com.waz.service.assets2.AssetService
+import com.waz.service.assets.AssetService
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.PushService
 import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService}
@@ -83,16 +83,6 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
     scenario("1-to-1 conversation setting empty means RR are never sent") {
       val convId = ConvId("test")
       val rrSettings = ReadReceiptSettings(selfSettings = false, None)
-      val service = getService().asInstanceOf[ConversationsUiServiceImpl]
-
-      (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))
-
-      Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
-    }
-
-    scenario("1-to-1 conversation setting off means RR are not sent, despite user option") {
-      val convId = ConvId("test")
-      val rrSettings = ReadReceiptSettings(selfSettings = true, Some(0))
       val service = getService().asInstanceOf[ConversationsUiServiceImpl]
 
       (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -80,7 +80,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
       Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
     }
 
-    scenario("1-to-1 conversation setting empty means RR are never sent") {
+    scenario("1-to-1 self settings set to false means RR are never sent") {
       val convId = ConvId("test")
       val rrSettings = ReadReceiptSettings(selfSettings = false, None)
       val service = getService().asInstanceOf[ConversationsUiServiceImpl]
@@ -90,9 +90,9 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
       Await.result(service.shouldSendReadReceipts(convId, rrSettings), 1.second) shouldEqual false
     }
 
-    scenario("RR are sent when convo and user option match") {
+    scenario("1-to-1 self settings set to true means RR are sent") {
       val convId = ConvId("test")
-      val rrSettings = ReadReceiptSettings(selfSettings = true, Some(1))
+      val rrSettings = ReadReceiptSettings(selfSettings = true, None)
       val service = getService().asInstanceOf[ConversationsUiServiceImpl]
 
       (convsService.isGroupConversation _).expects(convId).once().returning(Future.successful(false))


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read receipts were getting sent when they weren't supposed to, as the group conversation setting was being ignored if it contained a value.

### Solutions

Some simple unit tests were added to help ensure the code remains compliant in future.

#### Notes

I've assumed that the conversation data has its read receipt setting updated by the backend when both clients have read receipts enabled, as this is my understanding of the spec.

#### APK
[Download build #1012](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1012/artifact/build/artifact/wire-dev-PR2396-1012.apk)
[Download build #1068](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1068/artifact/build/artifact/wire-dev-PR2396-1068.apk)