### PR TITLE
Fix: Fix crash in Search page due to wrong import

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/NumberCodeInput.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/NumberCodeInput.scala
@@ -25,7 +25,7 @@ import android.text.{Editable, TextWatcher}
 import android.util.AttributeSet
 import android.view.View.OnTouchListener
 import android.view._
-import android.widget._
+import android.widget.{FrameLayout, LinearLayout, ProgressBar}
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.zclient.ui.cursor.CursorEditText

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
@@ -22,7 +22,7 @@ import android.graphics._
 import android.graphics.drawable.Drawable
 import android.util.{AttributeSet, TypedValue}
 import android.view.{View, ViewGroup}
-import android.widget._
+import android.widget.{FrameLayout, ImageButton, ImageView, TextView}
 import com.bumptech.glide.load.resource.bitmap.{CenterCrop, RoundedCorners}
 import com.bumptech.glide.request.RequestOptions
 import com.waz.api.Message.Type

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/FileAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/FileAssetPartView.scala
@@ -23,7 +23,7 @@ import android.content.Context
 import android.text.format.Formatter
 import android.util.AttributeSet
 import android.view.View
-import android.widget._
+import android.widget.{FrameLayout, TextView}
 import com.waz.service.assets2.{AssetStatus, UploadAssetStatus}
 import com.waz.threading.Threading
 import com.waz.zclient.R

--- a/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
@@ -28,7 +28,7 @@ import androidx.annotation.Nullable
 import androidx.fragment.app.Fragment
 import androidx.appcompat.widget.Toolbar
 import android.view.{MenuItem, View, ViewGroup}
-import android.widget._
+import android.widget.{FrameLayout, Toast}
 import com.waz.content.UserPreferences
 import com.waz.service.assets2.Content
 import com.waz.service.{AccountsService, ZMessaging}

--- a/app/src/main/scala/com/waz/zclient/sharing/ShareToMultipleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ShareToMultipleFragment.scala
@@ -28,8 +28,8 @@ import android.view.View.OnClickListener
 import android.view._
 import android.view.inputmethod.EditorInfo
 import android.widget.LinearLayout.LayoutParams
+import android.widget.{CheckBox, CompoundButton, ImageView, LinearLayout, RelativeLayout, TextView}
 import android.widget.TextView.OnEditorActionListener
-import android.widget._
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import com.waz.api.impl.ContentUriAssetForUpload
@@ -52,7 +52,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.utils.{ColorUtils, KeyboardUtils}
 import com.waz.zclient.ui.views.CursorIconButton
 import com.waz.zclient.usersearch.views.{PickerSpannableEditText, SearchEditText}
-import com.waz.zclient.utils.ContextUtils.{getDimenPx, showToast, getString}
+import com.waz.zclient.utils.ContextUtils.{getDimenPx, getString, showToast}
 import com.waz.zclient.utils.{RichView, ViewUtils}
 
 import scala.util.Success

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -27,8 +27,9 @@ import androidx.appcompat.app.AlertDialog
 import android.view._
 import android.view.animation.Animation
 import android.view.inputmethod.EditorInfo
+import android.widget.{CheckBox, CompoundButton, ImageView, RelativeLayout, TextView}
 import android.widget.TextView.OnEditorActionListener
-import android.widget._
+import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.waz.content.UserPreferences
 import com.waz.model.UserData.ConnectionStatus


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app crashes when clicked on "Search" icon in bottom navigation view.

### Causes

Whole package import of android.widget caused the Toolbar to be resolved in the wrong package.

### Solutions

Removed whole package import and used the androidx one for the Toolbar

#### APK
[Download build #299](http://10.10.124.11:8080/job/Pull%20Request%20Builder/299/artifact/build/artifact/wire-dev-PR2397-299.apk)
[Download build #300](http://10.10.124.11:8080/job/Pull%20Request%20Builder/300/artifact/build/artifact/wire-dev-PR2397-300.apk)
[Download build #302](http://10.10.124.11:8080/job/Pull%20Request%20Builder/302/artifact/build/artifact/wire-dev-PR2397-302.apk)