### PR TITLE
Reorder sync handler updates

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -82,7 +82,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       case Right(ConversationsResult(convs, hasMore)) =>
         debug(l"syncConversations received ${convs.size}")
         val future = convService.updateConversationsWithDeviceStartMessage(convs)
-        if (hasMore) syncConversations(convs.lastOption.map(_.id)).flatMap(res => future.map(_ => res))
+        if (hasMore) future.flatMap(_ => syncConversations(convs.lastOption.map(_.id)))
         else future.map(_ => Success)
       case Left(error) =>
         warn(l"ConversationsClient.loadConversations($start) failed with error: $error")


### PR DESCRIPTION
## What's new in this PR?

### Issues

In `syncConversations`, we fetch a page of results, and then fetch the next page of results before updating the conversations with the results we just got. This means we could potentially only update the conversations all at once at the end. This might not scale well with older phones and lots of conversations.

### Solutions

This PR reorders the operations, so we update the current batch of conversations before moving onto the next one. This helps keep the number of futures we have scheduled at one time down.
#### APK
[Download build #309](http://10.10.124.11:8080/job/Pull%20Request%20Builder/309/artifact/build/artifact/wire-dev-PR2398-309.apk)