### PR TITLE
fix: A crash after migration to AndroidX when opening a picture in Collections

### DIFF
--- a/app/src/main/res/layout/fragment_single_image_collections.xml
+++ b/app/src/main/res/layout/fragment_single_image_collections.xml
@@ -26,7 +26,7 @@
               android:clickable="true"
               android:focusable="true" >
 
-    <androidx.core.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/image_view_pager"
         android:layout_width="match_parent"


### PR DESCRIPTION
The path to the ViewPager class was wrong.

#### APK
[Download build #316](http://10.10.124.11:8080/job/Pull%20Request%20Builder/316/artifact/build/artifact/wire-dev-PR2404-316.apk)