### PR TITLE
Bugfix/crash conversation list

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/BaseFragment.java
+++ b/app/src/main/java/com/waz/zclient/pages/BaseFragment.java
@@ -21,14 +21,19 @@ import android.app.Activity;
 
 import androidx.fragment.app.Fragment;
 
+import com.waz.utils.events.Subscription;
 import com.waz.zclient.BaseActivity;
 import com.waz.zclient.ServiceContainer;
 import com.waz.zclient.controllers.IControllerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class BaseFragment<T> extends Fragment implements ServiceContainer {
 
     private T container;
     private IControllerFactory controllerFactory;
+    protected Set<Subscription> subs = new HashSet<>();
 
     @Override
     public final void onAttach(Activity activity) {
@@ -72,5 +77,13 @@ public class BaseFragment<T> extends Fragment implements ServiceContainer {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public void onDestroyView() {
+        for (Subscription s: subs) {
+            s.destroy();
+        }
+        super.onDestroyView();
     }
 }

--- a/app/src/main/java/com/waz/zclient/utils/extensions/FragmentExtensions.kt
+++ b/app/src/main/java/com/waz/zclient/utils/extensions/FragmentExtensions.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
  * @return the topmost fragment in the child fragment stack.
  */
 fun Fragment.getTopMostFragment() : Fragment? {
+    if (!isAdded) return null
     childFragmentManager.run {
         return when (backStackEntryCount) {
             0 -> null


### PR DESCRIPTION
## What's new in this PR?

### Issues

I got this crash while disabling the CrashController class and trying to login.

java.lang.IllegalStateException: Fragment ConversationListManagerFragment{2f98b00 (9dd6363e-40a9-495b-bc37-aedd75a86369)} has not been attached yet.
        at androidx.fragment.app.Fragment.getChildFragmentManager(Fragment.java:923)
        at com.waz.zclient.utils.extensions.FragmentUtils.getTopMostFragment(FragmentExtensions.kt:16)

### Causes

This happens when the fragment is no longer attached to its parent activity/fragment. 

### Solutions

Using the method isAdded() before calling getChildFragmentManager

### Testing

Disable the CrashController
Logout and login to your account
