### PR TITLE
[Feature] Call notification

### DIFF
--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -19,18 +19,20 @@ package com.waz.services.calling
 
 import android.app.Service
 import android.content.{Context, Intent}
-import android.os.IBinder
+import android.os.{Build, IBinder}
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.service.ZMessaging
 import com.waz.zclient.ServiceHelper
 import com.waz.zclient.notifications.controllers.CallingNotificationsController
 import com.waz.zclient.notifications.controllers.CallingNotificationsController.{NotificationAction, androidNotificationBuilder}
 
-class CallingNotificationsService extends ServiceHelper {
+class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
   private lazy val callNCtrl = inject[CallingNotificationsController]
 
   implicit lazy val cxt: Context = getApplicationContext
 
   private lazy val sub = callNCtrl.notifications.map(_.find(_.isMainCall)).onUi {
-    case Some(not) if not.action != NotificationAction.Nothing =>
+    case Some(not) if shouldShowNotification && not.action != NotificationAction.Nothing =>
       val builder = androidNotificationBuilder(not)
       startForeground(not.convId.str.hashCode, builder.build())
     case _ =>
@@ -44,5 +46,12 @@ class CallingNotificationsService extends ServiceHelper {
     super.onStartCommand(intent, flags, startId)
     sub
     Service.START_STICKY
+  }
+
+  // Since Android 10, we show notifications for incoming calls, but only if the ui is inactive.
+  private def shouldShowNotification: Boolean = {
+    val isAndroid10OrAbove = Build.VERSION.SDK_INT >= 29
+    val isUiActive = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)
+    !isAndroid10OrAbove || !isUiActive
   }
 }

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -213,7 +213,7 @@ object CallingNotificationsController {
 
   val CallImageSizeDp = 64
 
-  def androidNotificationBuilder(not: CallNotification)(implicit cxt: content.Context): NotificationCompat.Builder = {
+  def androidNotificationBuilder(not: CallNotification, treatAsIncomingCall: Boolean = false)(implicit cxt: content.Context): NotificationCompat.Builder = {
     val title = if (not.isGroup) not.convName else not.caller
 
     val message = (not.isGroup, not.videoCall) match {
@@ -227,9 +227,7 @@ object CallingNotificationsController {
       .setBigContentTitle(title)
       .bigText(message)
 
-    // On Android 10+ we can't start the calling activity from the background, so we treat the
-    // notification like other incoming call notifications.
-    val isIncomingCall = !not.isMainCall || Build.VERSION.SDK_INT >= 29
+    val isIncomingCall = !not.isMainCall || treatAsIncomingCall
     val channelId = if (isIncomingCall) IncomingCallNotificationsChannelId else OngoingNotificationsChannelId
     val priority = if (isIncomingCall) NotificationCompat.PRIORITY_HIGH else NotificationCompat.PRIORITY_MAX
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -215,6 +215,7 @@ object CallingNotificationsController {
 
   def androidNotificationBuilder(not: CallNotification)(implicit cxt: content.Context): NotificationCompat.Builder = {
     val title = if (not.isGroup) not.convName else not.caller
+
     val message = (not.isGroup, not.videoCall) match {
       case (true, true)   => getString(R.string.system_notification__video_calling_group, not.caller)
       case (true, false)  => getString(R.string.system_notification__calling_group, not.caller)
@@ -222,17 +223,25 @@ object CallingNotificationsController {
       case (false, false) => getString(R.string.system_notification__calling_one)
     }
 
-    val builder = new NotificationCompat.Builder(cxt, if (not.isMainCall) OngoingNotificationsChannelId else IncomingCallNotificationsChannelId)
+    val style = new NotificationCompat.BigTextStyle()
+      .setBigContentTitle(title)
+      .bigText(message)
+
+    // On Android 10+ we can't start the calling activity from the background, so we treat the
+    // notification like other incoming call notifications.
+    val isIncomingCall = !not.isMainCall || Build.VERSION.SDK_INT >= 29
+    val channelId = if (isIncomingCall) IncomingCallNotificationsChannelId else OngoingNotificationsChannelId
+    val priority = if (isIncomingCall) NotificationCompat.PRIORITY_HIGH else NotificationCompat.PRIORITY_MAX
+
+    val builder = new NotificationCompat.Builder(cxt, channelId)
       .setSmallIcon(R.drawable.call_notification_icon)
       .setLargeIcon(not.bitmap.orNull)
       .setContentTitle(title)
       .setContentText(message)
       .setContentIntent(OpenCallingScreen())
-      .setStyle(new NotificationCompat.BigTextStyle()
-        .setBigContentTitle(title)
-        .bigText(message))
+      .setStyle(style)
       .setCategory(NotificationCompat.CATEGORY_CALL)
-      .setPriority(if (not.isMainCall) NotificationCompat.PRIORITY_HIGH else NotificationCompat.PRIORITY_MAX) //incoming calls go higher up in the list)
+      .setPriority(priority)
       .setOnlyAlertOnce(true)
       .setOngoing(true)
 
@@ -244,19 +253,35 @@ object CallingNotificationsController {
     not.action match {
       case NotificationAction.DeclineOrJoin =>
         builder
-          .addAction(R.drawable.ic_menu_silence_call_w, getString(R.string.system_notification__silence_call), createEndIntent(not.accountId, not.convId))
-          .addAction(R.drawable.ic_menu_join_call_w, getString(R.string.system_notification__join_call), if (not.isMainCall) createJoinIntent(not.accountId, not.convId) else CallIntent(not.accountId, not.convId))
+          .addAction(
+            R.drawable.ic_menu_silence_call_w,
+            getString(R.string.system_notification__silence_call),
+            createEndIntent(not.accountId, not.convId)
+          )
+          .addAction(
+            R.drawable.ic_menu_join_call_w,
+            getString(R.string.system_notification__join_call),
+            if (not.isMainCall) createJoinIntent(not.accountId, not.convId) else CallIntent(not.accountId, not.convId)
+          )
 
       case NotificationAction.Leave =>
-        builder.addAction(R.drawable.ic_menu_end_call_w, getString(R.string.system_notification__leave_call), createEndIntent(not.accountId, not.convId))
+        builder.addAction(
+          R.drawable.ic_menu_end_call_w,
+          getString(R.string.system_notification__leave_call),
+          createEndIntent(not.accountId, not.convId)
+        )
 
       case _ => //no available action
     }
     builder
   }
 
-  def createJoinIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) = pendingIntent((account.str + convId.str).hashCode, joinIntent(Context.wrap(cxt), account, convId))
-  def createEndIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) = pendingIntent((account.str + convId.str).hashCode, endIntent(Context.wrap(cxt), account, convId))
+  private def createJoinIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) =
+    pendingIntent((account.str + convId.str).hashCode, joinIntent(Context.wrap(cxt), account, convId))
 
-  def pendingIntent(reqCode: Int, intent: Intent)(implicit cxt: content.Context) = PendingIntent.getService(cxt, reqCode, Intent.unwrap(intent), PendingIntent.FLAG_UPDATE_CURRENT)
+  private def createEndIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) =
+    pendingIntent((account.str + convId.str).hashCode, endIntent(Context.wrap(cxt), account, convId))
+
+  private def pendingIntent(reqCode: Int, intent: Intent)(implicit cxt: content.Context) =
+    PendingIntent.getService(cxt, reqCode, Intent.unwrap(intent), PendingIntent.FLAG_UPDATE_CURRENT)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Due to Android 10 restrictions, we can't display the calling activity when the app is in the background. Therefore, the user would not be aware of any incoming calls while the app is minimized or the screen is locked.

### Solutions

As suggested by Android, we instead show a user notification informing the user of the incoming call. There already exists logic to display calling notifications, however their primary use is to display user notifications for *other* incoming calls (i.e, other than the current active call). Notifications for the main active call are scheduled, but they have lower priority than incoming calls and are also not displayed as a banner (the user can only see them in the notification tray).

In the case the device is running Android 10 or above, and the app is in the background, then we will need to consider the main call notification as if it were any other incoming call notification. 


#### APK
[Download build #324](http://10.10.124.11:8080/job/Pull%20Request%20Builder/324/artifact/build/artifact/wire-dev-PR2406-324.apk)