### PR TITLE
fix: Make audio recordings explicitly M4A

### DIFF
--- a/app/src/main/java/com/waz/zclient/audio/AudioService.kt
+++ b/app/src/main/java/com/waz/zclient/audio/AudioService.kt
@@ -47,9 +47,9 @@ interface AudioService {
 
     fun preparePcmAudioTrack(pcmFile: File): AudioTrack
 
-    fun recodePcmToMp4(pcmFile: File, mp4File: File)
+    fun recodePcmToM4A(pcmFile: File, m4aFile: File)
 
-    fun recordMp4Audio(mp4File: File, onFinish: (File) -> Unit = {}): Observable<RecordingProgress>
+    fun recordM4AAudio(m4aFile: File, onFinish: (File) -> Unit = {}): Observable<RecordingProgress>
 }
 
 class AudioServiceImpl(private val context: Context): AudioService {
@@ -152,7 +152,7 @@ class AudioServiceImpl(private val context: Context): AudioService {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     @Throws(IOException::class)
-    override fun recodePcmToMp4(pcmFile: File, mp4File: File) {
+    override fun recodePcmToM4A(pcmFile: File, m4aFile: File) {
         val codecTimeout = 5000
         val compressedAudioMime = "audio/mp4a-latm"
         val channelCount = 1
@@ -172,7 +172,7 @@ class AudioServiceImpl(private val context: Context): AudioService {
 
         val bufferInfo = MediaCodec.BufferInfo()
 
-        val mediaMuxer = MediaMuxer(mp4File.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        val mediaMuxer = MediaMuxer(m4aFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
         var totalBytesRead = 0
         var presentationTimeUs = 0.0
 
@@ -238,14 +238,14 @@ class AudioServiceImpl(private val context: Context): AudioService {
         mediaMuxer.release()
     }
 
-    override fun recordMp4Audio(mp4File: File, onFinish: (File) -> Unit): Observable<AudioService.Companion.RecordingProgress> {
-        val pcmFile = File(mp4File.parent, "${mp4File.nameWithoutExtension}_${System.currentTimeMillis()}.pcm")
+    override fun recordM4AAudio(m4aFile: File, onFinish: (File) -> Unit): Observable<AudioService.Companion.RecordingProgress> {
+        val pcmFile = File(m4aFile.parent, "${m4aFile.nameWithoutExtension}_${System.currentTimeMillis()}.pcm")
         if (pcmFile.exists()) pcmFile.delete()
         pcmFile.createNewFile()
         try {
             return recordPcmAudio(pcmFile) {
-                recodePcmToMp4(pcmFile, mp4File)
-                onFinish(mp4File)
+                recodePcmToM4A(pcmFile, m4aFile)
+                onFinish(m4aFile)
             }
         } finally {
             pcmFile.delete()

--- a/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
+++ b/app/src/main/java/com/waz/zclient/pages/extendedcursor/voicefilter2/AudioMessageRecordingScreen.kt
@@ -218,7 +218,7 @@ class AudioMessageRecordingScreen @JvmOverloads constructor(context: Context, at
         val pcm = if (recordWithEffectFile.exists()) recordWithEffectFile else recordFile
         compressedRecordFile.delete()
         compressedRecordFile.createNewFile()
-        audioService.recodePcmToMp4(pcm, compressedRecordFile)
+        audioService.recodePcmToM4A(pcm, compressedRecordFile)
         listener?.sendRecording("audio/mp4a-latm", compressedRecordFile)
     }
 

--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -159,7 +159,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     (a.details, a) match {
       case (_: Audio, audioAsset: Asset) =>
 
-        val file = new File(context.getCacheDir, s"${audioAsset.id.str}.mp4")
+        val file = new File(context.getCacheDir, s"${audioAsset.id.str}.m4a")
         Signal.future((if (!file.exists()) {
           file.createNewFile()
           assets.head.flatMap(_.loadContent(audioAsset)).map { is =>

--- a/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/MediaRecorderController.scala
@@ -41,7 +41,7 @@ trait MediaRecorderController {
 
 class MediaRecorderControllerImpl(context: Context)(implicit injector: Injector) extends MediaRecorderController with Injectable with DerivedLogTag {
 
-  private lazy val mp4File = new File(context.getCacheDir, "record_temp.mp4")
+  private lazy val m4aFile = new File(context.getCacheDir, "record_temp.m4a")
 
   private var recordingDisposable  = Option.empty[Disposable]
   private var startRecordingOffset = Option.empty[Long]
@@ -55,14 +55,14 @@ class MediaRecorderControllerImpl(context: Context)(implicit injector: Injector)
     verbose(l"startRecording")
     cancelRecording()
 
-    if (mp4File.exists()) mp4File.delete()
-    mp4File.createNewFile()
+    if (m4aFile.exists()) m4aFile.delete()
+    m4aFile.createNewFile()
 
     startRecordingOffset = Option(System.currentTimeMillis)
     recordingDuration = None
 
     recordingDisposable = Option(
-      audioService.recordMp4Audio(mp4File, { file: File =>
+      audioService.recordM4AAudio(m4aFile, { file: File =>
         recordingDuration = startRecordingOffset.map(System.currentTimeMillis - _)
         onFinish(file)
         recordingDisposable = None
@@ -102,7 +102,7 @@ class MediaRecorderControllerImpl(context: Context)(implicit injector: Injector)
   override def isRecording: Boolean = recordingDisposable.isDefined
 
   private def reset(): Unit = {
-    if (mp4File.exists()) mp4File.delete()
+    if (m4aFile.exists()) m4aFile.delete()
     recordingDuration = None
     recordingDisposable = None
     startRecordingOffset = None

--- a/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
@@ -234,11 +234,11 @@ class AudioMessageRecordingView (val context: Context, val attrs: AttributeSet, 
   }
 
   def show(): Unit = {
-    def onFinishRecording(mp4File: File): Unit = currentAssetKey.foreach { key =>
+    def onFinishRecording(m4aFile: File): Unit = currentAssetKey.foreach { key =>
       verbose(l"recording succeeded")
-      val content = ContentForUpload(s"recording-${System.currentTimeMillis}", Content.File(Mime.Audio.MP4, mp4File))
+      val content = ContentForUpload(s"recording-${System.currentTimeMillis}", Content.File(Mime.Audio.M4A, m4aFile))
       currentAudio = Some(content)
-      playbackControls ! new PlaybackControls(key.id, URI.fromFile(mp4File), recordAndPlay)
+      playbackControls ! new PlaybackControls(key.id, URI.fromFile(m4aFile), recordAndPlay)
       recordingController.duration.foreach(d => recordingSeekBar.setMax(d.toInt))
     }
 

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -614,7 +614,7 @@ class ConversationFragment extends FragmentHelper {
           }
 
           override def sendRecording(mime: String, audioFile: File): Unit = {
-            val content = ContentForUpload(s"audio_record_${System.currentTimeMillis()}.mp4", Content.File(Mime.Audio.MP4, audioFile))
+            val content = ContentForUpload(s"audio_record_${System.currentTimeMillis()}.m4a", Content.File(Mime.Audio.M4A, audioFile))
             convController.sendAssetMessage(content, getActivity, None)
             extendedCursorContainer.foreach(_.close(true))
           }

--- a/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
+++ b/testing_gallery/src/main/java/com/wire/testinggallery/DocumentResolver.java
@@ -54,6 +54,7 @@ public class DocumentResolver {
         add("wma");
         add("ac3");
         add("ogg");
+        add("m4a");
     }};
     private final static List<String> IMAGE_EXTENSIONS = new ArrayList<String>() {{
         add("gif");

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AudioTranscoder.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AudioTranscoder.scala
@@ -46,7 +46,7 @@ class AudioTranscoder(tempFiles: TempFileService, context: Context) {
   import AudioTranscoder._
   import Threading.Implicits.Background
 
-  def apply(uri: URI, mp4File: File, callback: ProgressIndicator.Callback): CancellableFuture[File] =
+  def apply(uri: URI, m4aFile: File, callback: ProgressIndicator.Callback): CancellableFuture[File] =
     ContentURIs.queryContentUriMetaData(context, uri).map(_.size.getOrElse(0L)).lift.flatMap { size =>
       val promisedFile = Promise[File]
 
@@ -64,11 +64,11 @@ class AudioTranscoder(tempFiles: TempFileService, context: Context) {
           val movie = returning(new Movie)(_.addTrack(aacTrack))
           val container = new DefaultMp4Builder().build(movie)
 
-          if (! promisedFile.isCompleted) Managed(new FileOutputStream(mp4File)).foreach(stream => container.writeContainer(stream.getChannel))
+          if (! promisedFile.isCompleted) Managed(new FileOutputStream(m4aFile)).foreach(stream => container.writeContainer(stream.getChannel))
           progress.fold2(callback.apply(ProgressData(0, -1, State.COMPLETED)), _.completed)
         }
 
-        mp4File
+        m4aFile
       })
 
       new CancellableFuture(promisedFile)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoader.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoader.scala
@@ -185,7 +185,7 @@ class AssetLoaderImpl(context:         Context,
 
     audioTranscoder(uri, entry.cacheFile, callback).flatMap { _ =>
 //      verbose(s"loaded audio from ${asset.cacheKey}, resulting file size: ${entry.length}")
-      CancellableFuture.lift(cache.move(asset.cacheKey, entry, Mime.Audio.MP4, asset.name, cacheLocation = Some(cache.cacheDir)))
+      CancellableFuture.lift(cache.move(asset.cacheKey, entry, Mime.Audio.M4A, asset.name, cacheLocation = Some(cache.cacheDir)))
     }.recoverWith {
       case ex: CancelException => CancellableFuture.failed(ex)
       case NonFatal(ex) =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/TestContentProvider.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/TestContentProvider.scala
@@ -54,7 +54,7 @@ class TestResourceContentProvider(val authority: String = "com.waz.testresources
   mimeMap.addExtensionMimeTypMapping("png", "image/png")
   mimeMap.addExtensionMimeTypMapping("jpg", "image/jpg")
   mimeMap.addExtensionMimeTypMapping("mp4", Mime.Video.MP4.str)
-  mimeMap.addExtensionMimeTypMapping("m4a", Mime.Audio.MP4.str)
+  mimeMap.addExtensionMimeTypMapping("m4a", Mime.Audio.M4A.str)
 
   case class Resource(uri: URI, mime: Mime, size: Long) {
     def inputStream = getClass.getResourceAsStream(uri.getPath)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6467

The encoding of our audio recordings does not change - it's the same for mp4 and for m4a files. But using the mp4 extension and MIME type for audio files may cause problems on the receiving side. This PR changes them explicitly to M4A in our code.

Most of the changes are in names of variables and methods. Only in a few places I changed a file extension or a mime type. And I added it to the lsit of audio extensions in `DocumentResolver` - a class involved in receiving shared files from other Android apps.

#### APK
[Download build #329](http://10.10.124.11:8080/job/Pull%20Request%20Builder/329/artifact/build/artifact/wire-dev-PR2408-329.apk)