### PR TITLE
Fixed the issue where no push notifications were getting shown when o…

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -141,3 +141,5 @@
 -keepclassmembers class android.support.design.internal.BottomNavigationMenuView {
     boolean mShiftingMode;
 }
+
+-keep class com.google.android.gms.** { *; }

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -142,4 +142,5 @@
     boolean mShiftingMode;
 }
 
--keep class com.google.android.gms.** { *; }
+#Push Notification dependency
+-keep class com.google.android.gms.tasks.** { *; }


### PR DESCRIPTION
### What's new in this PR?
Proguard rule to keep google-play services classes when optimisation of the code occurs. 

### Issues

Push notifications weren't getting pushed on released builds when you're outside of the application

### Causes

Since migrating to AndroidX the dependency graph isn't clear when it comes to optimisation so proguard is removing some vital classes for push notifications. We suspect it's somewhere in the code using reflection within the play-services classes and isn't holding a direct reference to an object hence why it's being removed. 

### Solutions

Tell the optimisation tool to keep the classes associated with the google.gms package 

### Testing

You can test this by removing the tool and sending yourself a message from an account when you're outside of the application i.e. it's in the background or not open on a release build. 

Compare when the rule is applied, it'll show you a successful push notification when you receive a message and the app isn't open. 
#### APK
[Download build #344](http://10.10.124.11:8080/job/Pull%20Request%20Builder/344/artifact/build/artifact/wire-dev-PR2415-344.apk)