### PR TITLE
fix: Changes to the password dialog handling

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -44,11 +44,19 @@ class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) exten
   private lazy val userPreferences    = inject[Signal[UserPreferences]]
   private lazy val passwordController = inject[PasswordController]
 
-  inject[ActivityLifecycleCallback].appInBackground.onUi {
-    case (true, _)               => updateBackgroundEntryTimer()
-    case (false, Some(activity)) => run()(activity)
-    case _                       =>
-      warn(l"The app is coming to the foreground, but the information about the activity is missing")
+  private val alc = inject[ActivityLifecycleCallback]
+  private val appInBackground = alc.appInBackground.map(_._1)
+  private val currentActivity = alc.appInBackground.map(_._2)
+
+  appInBackground.onUi {
+    case true =>
+      updateBackgroundEntryTimer()
+    case false =>
+      currentActivity.head.foreach {
+        case Some(activity) => run()(activity)
+        case None =>
+          warn(l"The app is coming to the foreground, but the information about the activity is missing")
+      }
   }
 
   def run()(implicit activity: Activity): Unit =
@@ -118,7 +126,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
                               accountManager: AccountManager,
                               authNeeded: Boolean)(implicit context: Context, eventContext: EventContext) =
     if (authNeeded) {
-      verbose(l"check request password")
+      verbose(l"check request password, force app lock: ${BuildConfig.FORCE_APP_LOCK}")
       val check = RequestPasswordCheck(passwordController, userPreferences)
       val actions = if (BuildConfig.FORCE_APP_LOCK) List(new WipeDataAction(Some(accountManager.userId))) else Nil
       Future.successful(Some(check, actions))

--- a/app/src/main/scala/com/waz/zclient/security/actions/WipeDataAction.scala
+++ b/app/src/main/scala/com/waz/zclient/security/actions/WipeDataAction.scala
@@ -38,10 +38,8 @@ class WipeDataAction(affectedAccount: Option[UserId])(implicit context: Context)
     case true  => Future.successful(())
     case false =>
       (affectedAccount match {
-        case Some(id) =>
-          ZMessaging.currentAccounts.wipeData(id)
-        case _ =>
-          ZMessaging.currentAccounts.wipeDataForAllAccounts()
+        case Some(id) => ZMessaging.currentAccounts.wipeData(id)
+        case _        => ZMessaging.currentAccounts.wipeDataForAllAccounts()
       }).map { _ =>
         WireApplication.clearOldVideoFiles(context)
         context.getCacheDir.delete()

--- a/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
@@ -57,7 +57,8 @@ class RequestPasswordCheck(pwdCtrl: PasswordController, prefs: UserPreferences)(
 
   private def checkPassword(password: Password): Future[PasswordCheck] = {
     import Threading.Implicits.Background
-    if (MaxAttempts == 0) { // don't count attempts
+
+    if (MaxAttempts == 0 || !BuildConfig.FORCE_APP_LOCK) { // don't count attempts
       pwdCtrl.checkPassword(password).map {
         case true  => PasswordCheckSuccessful
         case false => PasswordCheckFailed

--- a/default.json
+++ b/default.json
@@ -37,5 +37,5 @@
   "block_on_password_policy": false,
   "wipe_on_cookie_invalid": false,
   "force_private_keyboard": false,
-  "password_max_attempts": 0
+  "password_max_attempts": 10
 }

--- a/default.json
+++ b/default.json
@@ -37,5 +37,5 @@
   "block_on_password_policy": false,
   "wipe_on_cookie_invalid": false,
   "force_private_keyboard": false,
-  "password_max_attempts": 10
+  "password_max_attempts": 0
 }


### PR DESCRIPTION
1. The password_max_attempts is now set to 10 by default, instead of 0.
2. Regular users are still not going to get their data wiped, because that action is
   now guarded by the force_app_lock flag (before it was only password_max_attempts > 0)
3. There's a small change to checking if the app comes out from the background.
   The previous solution allowed for the checks to be run when switching from the
   main view to profile and back.

#### APK
[Download build #352](http://10.10.124.11:8080/job/Pull%20Request%20Builder/352/artifact/build/artifact/wire-dev-PR2419-352.apk)
[Download build #356](http://10.10.124.11:8080/job/Pull%20Request%20Builder/356/artifact/build/artifact/wire-dev-PR2419-356.apk)