### PR TITLE
fix: Hide the obfuscation option instead of disabling it

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -111,7 +111,6 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     appLockSwitch.setVisibility(View.GONE)
   }
 
-
   incognitoKeyboardSwitch.setPreference(IncognitoKeyboardEnabled, global = true)
   if (BuildConfig.FORCE_PRIVATE_KEYBOARD) {
     incognitoKeyboardSwitch.setVisibility(View.GONE)
@@ -123,7 +122,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   }
 
   if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
-    hideScreenContentSwitch.setDisabled(true)
+    hideScreenContentSwitch.setVisible(false)
     hideScreenContentSwitch.pref.foreach(_ := true)
   }
 


### PR DESCRIPTION
Just as the app lock switch is hidden if it's set to true in the configuration file, the obfuscation switch will also be hidden.
#### APK
[Download build #363](http://10.10.124.11:8080/job/Pull%20Request%20Builder/363/artifact/build/artifact/wire-dev-PR2422-363.apk)
[Download build #368](http://10.10.124.11:8080/job/Pull%20Request%20Builder/368/artifact/build/artifact/wire-dev-PR2422-368.apk)