### PR TITLE
fix: Password prompt eforced by the configuration should still respect the timeout

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -104,13 +104,13 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)
 
-  appLockSwitch.setPreference(AppLockEnabled, global = true)
-  appLockSwitch.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
-
   if (BuildConfig.FORCE_APP_LOCK) {
-    appLockSwitch.setVisibility(View.GONE)
+    appLockSwitch.setVisible(false)
+  } else {
+    appLockSwitch.setPreference(AppLockEnabled, global = true)
+    appLockSwitch.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
+    appLockSwitch.setVisible(true)
   }
-
 
   incognitoKeyboardSwitch.setPreference(IncognitoKeyboardEnabled, global = true)
   if (BuildConfig.FORCE_PRIVATE_KEYBOARD) {


### PR DESCRIPTION
The last changes o the password prompt  broke this.
If force_app_lock is set to true, the app should respect app_lock_timeout and show the prompt
only after the given time in background passed. Recently it worked this way only if the prompt
was switched on from the options, but if it was enforced, it appeared every time, regardless
of the timeout.

#### APK
[Download build #367](http://10.10.124.11:8080/job/Pull%20Request%20Builder/367/artifact/build/artifact/wire-dev-PR2423-367.apk)