### PR TITLE
fix: The password prompts appears when the app is launched

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -491,10 +491,6 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
   }
 
   override def onTerminate(): Unit = {
-    verbose(l"onTerminate")
-    //  This ensures asking for password when the app is restarted in an emulator
-    inject[SecurityPolicyChecker].clearBackgroundEntryTimer()
-
     controllerFactory.tearDown()
     controllerFactory = null
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1){

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -491,6 +491,10 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
   }
 
   override def onTerminate(): Unit = {
+    verbose(l"onTerminate")
+    //  This ensures asking for password when the app is restarted in an emulator
+    inject[SecurityPolicyChecker].clearBackgroundEntryTimer()
+
     controllerFactory.tearDown()
     controllerFactory = null
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1){

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -45,7 +45,7 @@ class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) exten
   private lazy val passwordController = inject[PasswordController]
 
   private val alc = inject[ActivityLifecycleCallback]
-  private val appInBackground = alc.appInBackground.map(_._1)
+  private val appInBackground = alc.appInBackground.map(_._1).onChanged
   private val currentActivity = alc.appInBackground.map(_._2)
 
   appInBackground.onUi {
@@ -67,23 +67,28 @@ class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) exten
       allChecksPassed <- runSecurityChecklist(Some(passwordController), globalPreferences, Some(userPrefs), Some(accManager), isForeground = true, authNeeded = authNeeded)
     } yield {
       verbose(l"all checks passed: $allChecksPassed")
-      if (allChecksPassed && authNeeded) {
-        timeEnteredBackground = None
-        authenticationNeeded ! false
-      }
+      if (allChecksPassed && authNeeded) authenticationNeeded ! false
     }
 
-  // This ensures asking for password when the app is first opened.
-  private var timeEnteredBackground: Option[Instant] = Some(Instant.EPOCH)
+  //  This ensures asking for password when the app is first opened / restarted.
+  private var timeEnteredBackground: Option[Instant] = None
   val authenticationNeeded = Signal(false)
 
   private def timerExpired: Boolean = {
-    val secondsSinceEnteredBackground = timeEnteredBackground.fold(0L)(_.until(Instant.now(), ChronoUnit.SECONDS))
+    val secondsSinceEnteredBackground = timeEnteredBackground.fold(Long.MaxValue)(_.until(Instant.now(), ChronoUnit.SECONDS))
     verbose(l"timeEnteredBackground: $timeEnteredBackground, secondsSinceEnteredBackground: $secondsSinceEnteredBackground, timeout is: ${BuildConfig.APP_LOCK_TIMEOUT}")
     secondsSinceEnteredBackground >= BuildConfig.APP_LOCK_TIMEOUT
   }
 
-  def updateBackgroundEntryTimer(): Unit = timeEnteredBackground = Some(Instant.now())
+  private def updateBackgroundEntryTimer(): Unit = {
+    verbose(l"updateBackgroundEntryTimer")
+    timeEnteredBackground = Some(Instant.now())
+  }
+
+  def clearBackgroundEntryTimer(): Unit = {
+    verbose(l"clearBackgroundEntryTimer")
+    timeEnteredBackground = None
+  }
 
   private def isAuthenticationNeeded(): Future[Boolean] =
     (if (BuildConfig.FORCE_APP_LOCK) Future.successful(true) else globalPreferences.preference(AppLockEnabled).apply()).flatMap {

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -85,11 +85,6 @@ class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) exten
     timeEnteredBackground = Some(Instant.now())
   }
 
-  def clearBackgroundEntryTimer(): Unit = {
-    verbose(l"clearBackgroundEntryTimer")
-    timeEnteredBackground = None
-  }
-
   private def isAuthenticationNeeded(): Future[Boolean] =
     (if (BuildConfig.FORCE_APP_LOCK) Future.successful(true) else globalPreferences.preference(AppLockEnabled).apply()).flatMap {
       case false => Future.successful(false)


### PR DESCRIPTION
## What's new in this PR?

A fix to an EY regression.

### Issues

The password prompt should appear if the app is in the background longer than `APP_LOCK_TIMEOUT`. **But** it also should appear if the app was killed (e.g. by clearing the recents view, restarting the device, etc.), regardless of the time from that event. So, if `APP_LOCK_TIMEOUT` is 1800s (0.5h, as required by EY) and the app goes to the background and then back to the foreground, the prompt should appear only if more than 0.5h has passed. But if the device is restarted or the app is killed in any other way and then launched back, the prompt should appear right away, even if only a few seconds passed.

### Causes

The recent changes to how the password is handled (we use a prompt from inside the app now) broke the functionality.

### Solutions

The variable `timeEnteredBackground` is now set to `None` when `SecurityPolicyChecker` is created (i.e. when the app is launched). It is then updated when the app goes to the background, but if the app is killed and restarted, it is `None` again. When comparing with `APP_LOCK_TIMEOUT`, `None` means that the timer expired.

### Testing

1. Open the app. Type in the password.
2. Go to the background and quickly back - no password prompt should appear.
3. Go to the background, wait 10s (on the default build), and go back - the prompt should appear.
4. Kill the app and quickly restart it (<10s) - the prompt should appear.

#### APK
[Download build #372](http://10.10.124.11:8080/job/Pull%20Request%20Builder/372/artifact/build/artifact/wire-dev-PR2429-372.apk)
[Download build #373](http://10.10.124.11:8080/job/Pull%20Request%20Builder/373/artifact/build/artifact/wire-dev-PR2429-373.apk)