### PR TITLE
Removed every window background image from all activities minus the f…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,7 +80,7 @@
         android:hardwareAccelerated="true"
         android:icon="${applicationIcon}"
         android:label="${applicationLabel}"
-        android:theme="@style/Theme.Light"
+        android:theme="@style/Theme.Splash"
         android:vmSafeMode="${applicationVmSafeMode}"
         tools:replace="android:allowBackup"
         >
@@ -166,7 +166,7 @@
             android:name=".LaunchActivity"
             android:label="@string/app_name"
             android:noHistory="true"
-            android:theme="@style/Theme.Light"
+            android:theme="@style/Theme.Splash"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -27,7 +27,6 @@
         <item name="colorPrimary">@color/dark_theme_primary</item>
         <item name="colorPrimaryDark">@color/black</item>
         <item name="colorAccent">@color/accent_default</item>
-        <item name="android:windowBackground">@drawable/window_background</item>
 
         <item name="alertDialogTheme">@style/Theme.Dark.Dialog.Alert</item>
         <item name="dialogTheme">@style/Theme.Dark.Dialog</item>
@@ -196,7 +195,6 @@
         <item name="colorPrimary">@color/light_theme_primary</item>
         <item name="colorPrimaryDark">@color/black</item>
         <item name="colorAccent">@color/accent_default</item>
-        <item name="android:windowBackground">@drawable/window_background</item>
 
         <item name="alertDialogTheme">@style/Theme.Light.Dialog.Alert</item>
         <item name="dialogTheme">@style/Theme.Light.Dialog</item>
@@ -377,6 +375,10 @@
         <item name="wireSecondaryTextColor">@color/text__secondary_dark</item>
         <item name="thinDividerColor">@color/white_16</item>
         <item name="replyBorderColor">@color/white_16</item>
+    </style>
+
+    <style name="Theme.Splash" parent="Theme.Light">
+        <item name="android:windowBackground">@drawable/window_background</item>
     </style>
 
     <style name="Theme.Popup" parent="@style/Theme.Design.NoActionBar">


### PR DESCRIPTION
…irst launch activity

## What's new in this PR?

### Issues

Every activity is loading an unnecessary image inside it's background to accomodate the splash screen 

### Causes

The theme which is set in the BaseActivity to select the dark or light theme is setting the background image, not just for those who start the app. 

### Solutions

Removed the window background from the light and dark themes and only added it into the LaunchActivity and Application load. 
