### PR TITLE
Do not propagate status update when team size threshold is reached.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,6 +134,7 @@ android {
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
         buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
         buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
+        buildConfigField 'Integer', 'TEAM_SIZE_THRESHOLD_HACK',      "$buildtimeConfiguration.configuration.team_size_threshold_hack"
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -31,7 +31,7 @@ import com.waz.zclient.messages.UsersController._
 import com.waz.zclient.messages.UsersController.DisplayName.{Me, Other}
 import com.waz.zclient.tracking.AvailabilityChanged
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.{Injectable, Injector, R}
+import com.waz.zclient.{Injectable, Injector, BuildConfig, R}
 
 import com.waz.zclient.log.LogUI._
 
@@ -96,7 +96,8 @@ class UsersController(implicit injector: Injector, context: Context)
         }
       }
 
-      zms.users.updateAvailability(availability)
+      val teamSizeThreshold = BuildConfig.TEAM_SIZE_THRESHOLD_HACK
+      zms.users.updateAvailability(availability, teamSizeThreshold)
     }
   }
 

--- a/default.json
+++ b/default.json
@@ -37,5 +37,6 @@
   "block_on_password_policy": false,
   "wipe_on_cookie_invalid": false,
   "force_private_keyboard": false,
-  "password_max_attempts": 0
+  "password_max_attempts": 0,
+  "team_size_threshold_hack": 400
 }


### PR DESCRIPTION
## What's new in this PR?

### Description

When user in big team (with lots of connections) changes status, it will send out a message to all connections, which could be too big and sending will fail (backend rejects etc.)

To avoid such issue, we decided in first phase not to send out status message for members in big teams, with more than 400 users.

When your team reaches the limit, you also stop displaying status of other users in your team.

## Jira Ticket
 - [AN-6512](https://wearezeta.atlassian.net/browse/AN-6512)

#### APK
[Download build #387](http://10.10.124.11:8080/job/Pull%20Request%20Builder/387/artifact/build/artifact/wire-dev-PR2436-387.apk)