### PR TITLE
Big Teams hide user status: UI Part

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,6 @@ android {
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
         buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
         buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
-        buildConfigField 'Integer', 'TEAM_SIZE_THRESHOLD_HACK',      "$buildtimeConfiguration.configuration.team_size_threshold_hack"
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -179,7 +179,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[SelectedConversationService]]   to inject[Signal[ZMessaging]].map(_.selectedConv)
     bind [Signal[ConversationsUiService]]        to inject[Signal[ZMessaging]].map(_.convsUi)
     bind [Signal[UserService]]                   to inject[Signal[ZMessaging]].map(_.users)
-    bind [Signal[TeamSize]]                      to inject[Signal[ZMessaging]].map(_.teamSize)
+    bind [Signal[TeamSizeThreshold]]                      to inject[Signal[ZMessaging]].map(_.teamSize)
     bind [Signal[UserSearchService]]             to inject[Signal[ZMessaging]].map(_.userSearch)
     bind [Signal[ConversationStorage]]           to inject[Signal[ZMessaging]].map(_.convsStorage)
     bind [Signal[UsersStorage]]                  to inject[Signal[ZMessaging]].map(_.usersStorage)

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -179,6 +179,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[SelectedConversationService]]   to inject[Signal[ZMessaging]].map(_.selectedConv)
     bind [Signal[ConversationsUiService]]        to inject[Signal[ZMessaging]].map(_.convsUi)
     bind [Signal[UserService]]                   to inject[Signal[ZMessaging]].map(_.users)
+    bind [Signal[TeamSize]]                      to inject[Signal[ZMessaging]].map(_.teamSize)
     bind [Signal[UserSearchService]]             to inject[Signal[ZMessaging]].map(_.userSearch)
     bind [Signal[ConversationStorage]]           to inject[Signal[ZMessaging]].map(_.convsStorage)
     bind [Signal[UsersStorage]]                  to inject[Signal[ZMessaging]].map(_.usersStorage)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -100,7 +100,10 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
   def setUserData(userData: UserData, teamId: Option[TeamId], createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)
     setTitle(userData.getDisplayName)
+
+    //TODO: Only display if we do not reach the Threshold
     if (teamId.isDefined) setAvailability(userData.availability)
+
     setVerified(userData.isVerified)
     setSubtitle(createSubtitle(userData))
     setIsGuest(userData.isGuest(teamId) && !userData.isWireBot)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -98,7 +98,8 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
     videoIndicator.setVisibility(if (user.isVideoEnabled) View.VISIBLE else View.GONE)
   }
 
-  def setUserData(userData: UserData, teamId: Option[TeamId],
+  def setUserData(userData: UserData,
+                  teamId: Option[TeamId],
                   hideStatus: Boolean,
                   createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -24,6 +24,7 @@ import android.view.View.OnClickListener
 import android.view.{Gravity, View, ViewGroup}
 import android.widget.{CompoundButton, ImageView, LinearLayout, RelativeLayout}
 import androidx.appcompat.widget.AppCompatCheckBox
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Availability, IntegrationData, TeamId, UserData}
 import com.waz.utils.events.{EventStream, SourceStream}
 import com.waz.utils.returning
@@ -39,7 +40,7 @@ import com.waz.zclient.{R, ViewHelper}
 import org.threeten.bp.Instant
 
 class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
-  extends RelativeLayout(context, attrs, style) with ViewHelper with ThemedView {
+  extends RelativeLayout(context, attrs, style) with ViewHelper with ThemedView with DerivedLogTag {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
@@ -102,7 +103,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
                   createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)
     setTitle(userData.getDisplayName)
-    if (teamId.isDefined && !hideStatus) setAvailability(userData.availability)
+    setAvailability(if (teamId.isDefined && !hideStatus) userData.availability else Availability.None)
     setVerified(userData.isVerified)
     setSubtitle(createSubtitle(userData))
     setIsGuest(userData.isGuest(teamId) && !userData.isWireBot)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -97,13 +97,12 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
     videoIndicator.setVisibility(if (user.isVideoEnabled) View.VISIBLE else View.GONE)
   }
 
-  def setUserData(userData: UserData, teamId: Option[TeamId], createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
+  def setUserData(userData: UserData, teamId: Option[TeamId],
+                  hideStatus: Boolean,
+                  createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)
     setTitle(userData.getDisplayName)
-
-    //TODO: Only display if we do not reach the Threshold
-    if (teamId.isDefined) setAvailability(userData.availability)
-
+    if (teamId.isDefined && !hideStatus) setAvailability(userData.availability)
     setVerified(userData.isVerified)
     setSubtitle(createSubtitle(userData))
     setIsGuest(userData.isGuest(teamId) && !userData.isWireBot)

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -30,7 +30,7 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
-import com.waz.service.{TeamSize, ZMessaging}
+import com.waz.service.{TeamSizeThreshold, ZMessaging}
 import com.waz.service.tracking.{OpenSelectParticipants, TrackingService}
 import com.waz.threading.Threading
 import com.waz.utils.events._
@@ -260,7 +260,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
     usersSelected <- usersSelected
     _teamId        <- teamId
     servsSelected <- servicesSelected
-    hideStatus <- Signal.future(TeamSize.shouldHideStatus(teamId, usersStorage))
+    hideStatus <- Signal.future(TeamSizeThreshold.shouldHideStatus(teamId, usersStorage))
 
   } yield (_teamId, res, usersSelected, servsSelected, hideStatus)).onUi {
     case (teamId, res, usersSelected, servsSelected, hideStatus) =>

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -260,7 +260,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
     res           <- searchResults
     usersSelected <- usersSelected
     servsSelected <- servicesSelected
-    hideStatus <- TeamSize.hideStatus(Signal.const(teamId), usersStorage)
+    hideStatus <- Signal.future(TeamSize.shouldHideStatus(Signal.const(teamId), usersStorage))
 
   } yield (teamId, res, usersSelected, servsSelected, hideStatus)).onUi {
     case (teamId, res, usersSelected, servsSelected, hideStatus) =>

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -256,13 +256,13 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
   val onSelectionChanged = EventStream[(Either[UserId, (ProviderId, IntegrationId)], Boolean)]()
 
   (for {
-    teamId        <- teamId
     res           <- searchResults
     usersSelected <- usersSelected
+    _teamId        <- teamId
     servsSelected <- servicesSelected
-    hideStatus <- Signal.future(TeamSize.shouldHideStatus(Signal.const(teamId), usersStorage))
+    hideStatus <- Signal.future(TeamSize.shouldHideStatus(teamId, usersStorage))
 
-  } yield (teamId, res, usersSelected, servsSelected, hideStatus)).onUi {
+  } yield (_teamId, res, usersSelected, servsSelected, hideStatus)).onUi {
     case (teamId, res, usersSelected, servsSelected, hideStatus) =>
       team = teamId
       val prev = this.results

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -236,6 +236,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
 
   private implicit val ctx = context
   private lazy val themeController = inject[ThemeController]
+  private lazy val teamId = inject[Signal[Option[TeamId]]]
 
   private val searchController = new SearchController()
 
@@ -255,7 +256,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
   val onSelectionChanged = EventStream[(Either[UserId, (ProviderId, IntegrationId)], Boolean)]()
 
   (for {
-    teamId        <- inject[Signal[Option[TeamId]]]
+    teamId        <- teamId
     res           <- searchResults
     usersSelected <- usersSelected
     servsSelected <- servicesSelected

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ArchiveConversationListAdapter.scala
@@ -17,10 +17,13 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
+import android.content.Context
 import com.waz.model.ConversationData
+import com.waz.utils.events.EventContext
+import com.waz.zclient.Injector
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 
-class ArchiveConversationListAdapter extends ConversationListAdapter {
+class ArchiveConversationListAdapter(implicit context: Context, eventContext: EventContext, injector: Injector) extends ConversationListAdapter {
 
   def setData(convs: Seq[ConversationData]): Unit = {
     val newItems = convs.map(data => Item.Conversation(data)).toList

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -22,8 +22,8 @@ import java.util.Locale
 import android.content.Context
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
-import com.waz.utils.events.{EventStream, SourceStream}
-import com.waz.zclient.R
+import com.waz.utils.events.{EventContext, EventStream, SourceStream}
+import com.waz.zclient.{Injector, R}
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter.Folder._
 import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter._
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
@@ -32,7 +32,7 @@ import com.waz.zclient.utils.ContextUtils.getString
 /**
   * A list adapter for displaying conversations grouped into folders.
   */
-class ConversationFolderListAdapter(implicit context: Context)
+class ConversationFolderListAdapter(implicit context: Context, eventContext: EventContext, injector: Injector)
   extends ConversationListAdapter
     with DerivedLogTag {
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -19,30 +19,38 @@ package com.waz.zclient.conversationlist.adapters
 
 import androidx.recyclerview.widget.{DiffUtil, RecyclerView}
 import android.view.{View, ViewGroup}
+import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{ConvId, ConversationData, FolderId}
-import com.waz.utils.events.{EventStream, SourceStream}
+import com.waz.model.{ConvId, ConversationData, FolderId, TeamId}
+import com.waz.service.TeamSize
+import com.waz.utils.events.{EventContext, EventStream, Signal, SourceStream}
 import com.waz.utils.returning
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
 import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, ConversationListRow, IncomingConversationListRow, NormalConversationListRow}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.pages.main.conversationlist.views.ConversationCallback
-import com.waz.zclient.{R, ViewHelper}
+import com.waz.zclient.{Injectable, Injector, R, ViewHelper}
+import android.content.Context
 
 import scala.collection.mutable.ListBuffer
 
-abstract class ConversationListAdapter
+abstract class ConversationListAdapter (implicit context: Context, eventContext: EventContext, injector: Injector)
   extends RecyclerView.Adapter[ConversationRowViewHolder]
     with RowClickListener
-    with DerivedLogTag {
+    with DerivedLogTag
+    with Injectable {
 
   setHasStableIds(true)
+
+  private lazy val usersStorage = inject[Signal[UsersStorage]]
+  private lazy val teamId = inject[Signal[Option[TeamId]]]
 
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()
 
   protected val items = new ListBuffer[Item]
   protected var maxAlpha = 1.0f
+  private var hideStatus = false
 
   def setMaxAlpha(maxAlpha: Float): Unit = {
     this.maxAlpha = maxAlpha
@@ -55,9 +63,12 @@ abstract class ConversationListAdapter
     * @param newItems the new data source.
     */
   protected def updateList(newItems: List[Item]): Unit = {
-    DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
-    items.clear()
-    items.appendAll(newItems)
+    TeamSize.hideStatus(teamId, usersStorage).onUi { _hideStatus =>
+      hideStatus = _hideStatus
+      DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
+      items.clear()
+      items.appendAll(newItems)
+    }
   }
 
   override def getItemCount: Int = items.size
@@ -88,7 +99,7 @@ abstract class ConversationListAdapter
       case (header: Item.Header, viewHolder: ConversationFolderRowViewHolder) =>
         viewHolder.bind(header, isFirst = position == 0)
       case (conversation: Item.Conversation, viewHolder: NormalConversationRowViewHolder) =>
-        viewHolder.bind(conversation)
+        viewHolder.bind(conversation, hideStatus)
       case _ =>
         error(l"Invalid view holder/data pair")
     }
@@ -158,8 +169,8 @@ object ConversationListAdapter {
   class NormalConversationRowViewHolder(row: NormalConversationListRow, listener: RowClickListener)
     extends ConversationRowViewHolder(row, listener) {
 
-    def bind(item: Item.Conversation): Unit = {
-      row.setConversation(item.data)
+    def bind(item: Item.Conversation, hideStatus: Boolean): Unit = {
+      row.setConversation(item.data, hideStatus)
       row.setContentDescription(item.contentDescription)
     }
   }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -22,7 +22,7 @@ import android.view.{View, ViewGroup}
 import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, ConversationData, FolderId, TeamId}
-import com.waz.service.TeamSize
+import com.waz.service.TeamSizeThreshold
 import com.waz.utils.events.{EventContext, EventStream, Signal, SourceStream}
 import com.waz.utils.returning
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
@@ -64,7 +64,7 @@ abstract class ConversationListAdapter (implicit context: Context, eventContext:
     * @param newItems the new data source.
     */
   protected def updateList(newItems: List[Item]): Unit = {
-    TeamSize.shouldHideStatus(teamId, usersStorage).foreach { hide =>
+    TeamSizeThreshold.shouldHideStatus(teamId, usersStorage).foreach { hide =>
       hideStatus = hide
       DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
       items.clear()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -64,13 +64,11 @@ abstract class ConversationListAdapter (implicit context: Context, eventContext:
     * @param newItems the new data source.
     */
   protected def updateList(newItems: List[Item]): Unit = {
-    TeamSize.shouldHideStatus(teamId, usersStorage).onSuccess {
-      case hide => {
-        hideStatus = hide
-        DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
-        items.clear()
-        items.appendAll(newItems)
-      }
+    TeamSize.shouldHideStatus(teamId, usersStorage).foreach { hide =>
+      hideStatus = hide
+      DiffUtil.calculateDiff(new DiffCallback(items.toList, newItems), false).dispatchUpdatesTo(this)
+      items.clear()
+      items.appendAll(newItems)
     }(Threading.Ui)
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/NormalConversationListAdapter.scala
@@ -17,10 +17,13 @@
  */
 package com.waz.zclient.conversationlist.adapters
 
+import android.content.Context
 import com.waz.model.{ConvId, ConversationData}
+import com.waz.utils.events.EventContext
+import com.waz.zclient.Injector
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 
-class NormalConversationListAdapter extends ConversationListAdapter {
+class NormalConversationListAdapter(implicit context: Context, eventContext: EventContext, injector: Injector) extends ConversationListAdapter {
 
   def setData(convs: Seq[ConversationData], incoming: Seq[ConvId]): Unit = {
     var newItems = List.empty[Item]

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -241,9 +241,8 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     if (hideStatus) {
       AvailabilityView.hideAvailabilityIcon(title)
     } else {
-      controller.availability(conversationData.id).head.map({ s => Some(s) }).foreach {
-        case Some(status) => AvailabilityView.displayLeftOfText(title, status, title.getCurrentTextColor, pushDown = true)
-        case _ =>
+      controller.availability(conversationData.id).head.foreach { status =>
+        AvailabilityView.displayLeftOfText(title, status, title.getCurrentTextColor, pushDown = true)
       }
     }
     closeImmediate()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -56,6 +56,7 @@ import com.waz.zclient.views.AvailabilityView
 import com.waz.zclient.{R, ViewHelper}
 
 import scala.collection.Set
+import scala.concurrent.Future
 
 trait ConversationListRow extends View
 
@@ -243,6 +244,9 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     avatar.clearImages()
     avatar.setAlpha(getResourceFloat(R.dimen.conversation_avatar_alpha_active))
     conversationId.publish(Some(conversationData.id), Threading.Ui)
+    (if (hideStatus) Future.successful(Availability.None) else controller.availability(conversationData.id).head).onComplete { av =>
+      AvailabilityView.displayLeftOfText(title, av.getOrElse(Availability.None), title.getCurrentTextColor, pushDown = true)
+    }
     closeImmediate()
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -234,7 +234,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   private var maxOffset: Float = .0f
   private var moveToAnimator: ObjectAnimator = _
 
-  def setConversation(conversationData: ConversationData): Unit = if (this.conversationData.forall(_.id != conversationData.id)) {
+  def setConversation(conversationData: ConversationData, hideStatus: Boolean): Unit = if (this.conversationData.forall(_.id != conversationData.id)) {
     this.conversationData = Some(conversationData)
     title.setText(if (conversationData.displayName.str.nonEmpty) conversationData.displayName.str else getString(R.string.default_deleted_username))
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -180,6 +180,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     av <- controller.availability(convId)
   } yield (name, av)).onUi { case (name, av) =>
     title.setText(name)
+
     AvailabilityView.displayLeftOfText(title, av, title.getCurrentTextColor, pushDown = true)
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -181,6 +181,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   } yield (name, av)).onUi { case (name, av) =>
     title.setText(name)
 
+    //TODO: Only display if we do not reach the Threshold
     AvailabilityView.displayLeftOfText(title, av, title.getCurrentTextColor, pushDown = true)
   }
 

--- a/app/src/main/scala/com/waz/zclient/cursor/MentionCandidatesAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/MentionCandidatesAdapter.scala
@@ -22,7 +22,7 @@ import android.view.View.OnClickListener
 import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.model.{TeamId, UserData}
 import com.waz.utils.events.{EventStream, SourceStream}
-import com.waz.zclient.R
+import com.waz.zclient.{R}
 import com.waz.zclient.common.controllers.ThemeController.Theme
 import com.waz.zclient.common.views.SingleUserRowView
 
@@ -31,13 +31,16 @@ class MentionCandidatesAdapter extends RecyclerView.Adapter[MentionCandidateView
   private var _data = Seq[UserData]()
   private var _teamId = Option.empty[TeamId]
   private var _theme: Theme = Theme.Light
+  private var _hideUserStatus = false
 
   val onUserClicked: SourceStream[UserData] = EventStream()
 
-  def setData(data: Seq[UserData], teamId: Option[TeamId], theme: Theme): Unit = {
+  def setData(data: Seq[UserData], teamId: Option[TeamId], theme: Theme, hideStatus: Boolean): Unit = {
     _data = data
     _teamId = teamId
     _theme = theme
+    _hideUserStatus = hideStatus
+
     notifyDataSetChanged()
   }
 
@@ -54,7 +57,7 @@ class MentionCandidatesAdapter extends RecyclerView.Adapter[MentionCandidateView
   }
 
   override def onBindViewHolder(holder: MentionCandidateViewHolder, position: Int): Unit = {
-    holder.bind(getItem(position), _teamId)
+    holder.bind(getItem(position), _teamId, _hideUserStatus)
   }
 
   override def getItemId(position: Int): Long = getItem(position).id.str.hashCode
@@ -67,8 +70,8 @@ class MentionCandidateViewHolder(v: View, onUserClick: UserData => Unit) extends
     override def onClick(v: View): Unit = userData.foreach(onUserClick(_))
   })
 
-  def bind(userData: UserData, teamId: Option[TeamId]): Unit = {
+  def bind(userData: UserData, teamId: Option[TeamId], hideStatus: Boolean): Unit = {
     this.userData = Some(userData)
-    v.asInstanceOf[SingleUserRowView].setUserData(userData, teamId)
+    v.asInstanceOf[SingleUserRowView].setUserData(userData, teamId, hideStatus)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/cursor/MentionCandidatesAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/MentionCandidatesAdapter.scala
@@ -22,7 +22,7 @@ import android.view.View.OnClickListener
 import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.model.{TeamId, UserData}
 import com.waz.utils.events.{EventStream, SourceStream}
-import com.waz.zclient.{R}
+import com.waz.zclient.R
 import com.waz.zclient.common.controllers.ThemeController.Theme
 import com.waz.zclient.common.views.SingleUserRowView
 

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -31,7 +31,7 @@ import com.waz.zclient.messages.UsersController._
 import com.waz.zclient.messages.UsersController.DisplayName.{Me, Other}
 import com.waz.zclient.tracking.AvailabilityChanged
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.{Injectable, Injector, BuildConfig, R}
+import com.waz.zclient.{Injectable, Injector, R}
 
 import com.waz.zclient.log.LogUI._
 
@@ -95,9 +95,7 @@ class UsersController(implicit injector: Injector, context: Context)
           }
         }
       }
-
-      val teamSizeThreshold = BuildConfig.TEAM_SIZE_THRESHOLD_HACK
-      zms.users.updateAvailability(availability, teamSizeThreshold)
+      zms.users.updateAvailability(availability)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -48,6 +48,7 @@ import scala.concurrent.duration._
 import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{SearchQuery, TeamSize}
+import com.waz.threading.Threading
 
 //TODO Maybe it will be better to split this adapter in two? One for participants and another for options?
 class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
@@ -149,10 +150,11 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
   private val conv = convController.currentConv
 
   private var hideUserStatus = false
-  TeamSize.hideStatus(team, usersStorage).onUi { hide =>
-    hideUserStatus = hide
-    notifyDataSetChanged()
-  }
+  TeamSize.shouldHideStatus(team, usersStorage).onSuccess {
+    case (hide) => {}
+      hideUserStatus = hide
+      notifyDataSetChanged()
+  }(Threading.Ui)
 
   (for {
     name  <- conv.map(_.displayName)

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -47,7 +47,7 @@ import com.waz.zclient.{Injectable, Injector, R}
 import scala.concurrent.duration._
 import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.service.{SearchQuery, TeamSize}
+import com.waz.service.{SearchQuery, TeamSizeThreshold}
 import com.waz.threading.Threading
 
 //TODO Maybe it will be better to split this adapter in two? One for participants and another for options?
@@ -151,7 +151,7 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
   private val conv = convController.currentConv
   private var hideUserStatus = false
 
-  TeamSize.shouldHideStatus(team, usersStorage).foreach { hide =>
+  TeamSizeThreshold.shouldHideStatus(team, usersStorage).foreach { hide =>
     hideUserStatus = hide
     notifyDataSetChanged()
   }

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -59,6 +59,7 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
                          )(implicit context: Context, injector: Injector, eventContext: EventContext)
   extends RecyclerView.Adapter[ViewHolder] with Injectable with DerivedLogTag {
   import ParticipantsAdapter._
+  import Threading.Implicits.Ui
 
   private lazy val usersStorage = inject[Signal[UsersStorage]]
   private lazy val team         = inject[Signal[Option[TeamId]]]
@@ -148,13 +149,12 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
   }
 
   private val conv = convController.currentConv
-
   private var hideUserStatus = false
-  TeamSize.shouldHideStatus(team, usersStorage).onSuccess {
-    case (hide) => {}
-      hideUserStatus = hide
-      notifyDataSetChanged()
-  }(Threading.Ui)
+
+  TeamSize.shouldHideStatus(team, usersStorage).foreach { hide =>
+    hideUserStatus = hide
+    notifyDataSetChanged()
+  }
 
   (for {
     name  <- conv.map(_.displayName)

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -46,6 +46,7 @@ import com.waz.zclient.{Injectable, Injector, R}
 
 import scala.concurrent.duration._
 import com.waz.content.UsersStorage
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{SearchQuery, TeamSize}
 
 //TODO Maybe it will be better to split this adapter in two? One for participants and another for options?
@@ -55,7 +56,7 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
                           showArrow: Boolean = true,
                           createSubtitle: Option[(UserData) => String] = None
                          )(implicit context: Context, injector: Injector, eventContext: EventContext)
-  extends RecyclerView.Adapter[ViewHolder] with Injectable {
+  extends RecyclerView.Adapter[ViewHolder] with Injectable with DerivedLogTag {
   import ParticipantsAdapter._
 
   private lazy val usersStorage = inject[Signal[UsersStorage]]
@@ -148,8 +149,9 @@ class ParticipantsAdapter(userIds: Signal[Seq[UserId]],
   private val conv = convController.currentConv
 
   private var hideUserStatus = false
-  TeamSize.hideStatus(team, usersStorage).onUi {
-    hideUserStatus = _
+  TeamSize.hideStatus(team, usersStorage).onUi { hide =>
+    hideUserStatus = hide
+    notifyDataSetChanged()
   }
 
   (for {

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -26,6 +26,7 @@ import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.TeamSize
+import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.returning
 import com.waz.zclient._
@@ -113,9 +114,9 @@ class SearchUIAdapter(adapterCallback: SearchUIAdapter.Callback)(implicit inject
   }
 
   private var hideUserStatus = false
-  TeamSize.hideStatus(Signal.const(team.map(_.id)), usersStorage).onUi {
-    hideUserStatus = _
-  }
+  TeamSize.shouldHideStatus(Signal.const(team.map(_.id)), usersStorage).onSuccess {
+    case hide => hideUserStatus = hide
+  }(Threading.Ui)
 
   override def onDetachedFromRecyclerView(recyclerView: RecyclerView): Unit = {
     dataUpdateSub.destroy()

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -25,7 +25,7 @@ import android.widget.TextView
 import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
-import com.waz.service.TeamSize
+import com.waz.service.TeamSizeThreshold
 import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.returning
@@ -114,7 +114,7 @@ class SearchUIAdapter(adapterCallback: SearchUIAdapter.Callback)(implicit inject
   }
 
   private var hideUserStatus = false
-  TeamSize.shouldHideStatus(Signal.const(team.map(_.id)), usersStorage).foreach { hide =>
+  TeamSizeThreshold.shouldHideStatus(Signal.const(team.map(_.id)), usersStorage).foreach { hide =>
     hideUserStatus = hide
   }(Threading.Ui)
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -114,8 +114,8 @@ class SearchUIAdapter(adapterCallback: SearchUIAdapter.Callback)(implicit inject
   }
 
   private var hideUserStatus = false
-  TeamSize.shouldHideStatus(Signal.const(team.map(_.id)), usersStorage).onSuccess {
-    case hide => hideUserStatus = hide
+  TeamSize.shouldHideStatus(Signal.const(team.map(_.id)), usersStorage).foreach { hide =>
+    hideUserStatus = hide
   }(Threading.Ui)
 
   override def onDetachedFromRecyclerView(recyclerView: RecyclerView): Unit = {

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -205,8 +205,8 @@ class ConversationFragment extends FragmentHelper {
 
     convController.currentConvName.onUi { updateTitle }
 
-    TeamSize.shouldHideStatus(accountsController.teamId, usersStorage).onSuccess {
-      case hide => hideUserStatus = hide
+    TeamSize.shouldHideStatus(accountsController.teamId, usersStorage).foreach { hide =>
+      hideUserStatus = hide
     }(Threading.Ui)
 
     cancelPreviewOnChange.onUi {

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -205,9 +205,9 @@ class ConversationFragment extends FragmentHelper {
 
     convController.currentConvName.onUi { updateTitle }
 
-    Future({TeamSize.hideStatus(accountsController.teamId, usersStorage).onUi {
-      hideUserStatus = _
-    }})(Threading.Background)
+    TeamSize.shouldHideStatus(accountsController.teamId, usersStorage).onSuccess {
+      case hide => hideUserStatus = hide
+    }(Threading.Ui)
 
     cancelPreviewOnChange.onUi {
       case (change, Some(true)) if !change.noChange => imagePreviewCallback.onCancelPreview()

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -35,7 +35,7 @@ import com.waz.content.{GlobalPreferences, UsersStorage}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{AccentColor, MessageContent => _, _}
 import com.waz.permissions.PermissionsService
-import com.waz.service.{TeamSize, ZMessaging}
+import com.waz.service.{TeamSizeThreshold, ZMessaging}
 import com.waz.service.assets2.{Content, ContentForUpload}
 import com.waz.service.call.CallingService
 import com.waz.threading.{CancellableFuture, Threading}
@@ -205,7 +205,7 @@ class ConversationFragment extends FragmentHelper {
 
     convController.currentConvName.onUi { updateTitle }
 
-    TeamSize.shouldHideStatus(accountsController.teamId, usersStorage).foreach { hide =>
+    TeamSizeThreshold.shouldHideStatus(accountsController.teamId, usersStorage).foreach { hide =>
       hideUserStatus = hide
     }(Threading.Ui)
 

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -31,11 +31,11 @@ import android.widget.{AbsListView, FrameLayout, TextView}
 import androidx.appcompat.widget.{ActionMenuView, Toolbar}
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.waz.api.ErrorType
-import com.waz.content.GlobalPreferences
+import com.waz.content.{GlobalPreferences, UsersStorage}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{AccentColor, MessageContent => _, _}
 import com.waz.permissions.PermissionsService
-import com.waz.service.ZMessaging
+import com.waz.service.{TeamSize, ZMessaging}
 import com.waz.service.assets2.{Content, ContentForUpload}
 import com.waz.service.call.CallingService
 import com.waz.threading.{CancellableFuture, Threading}
@@ -115,6 +115,8 @@ class ConversationFragment extends FragmentHelper {
   private lazy val cameraController           = inject[ICameraController]
   private lazy val confirmationController     = inject[IConfirmationController]
 
+  private lazy val usersStorage               = inject[Signal[UsersStorage]]
+
   private var subs = Set.empty[com.waz.utils.events.Subscription]
 
   private val previewShown = Signal(false)
@@ -128,7 +130,6 @@ class ConversationFragment extends FragmentHelper {
   private lazy val loadingIndicatorView = returning(view[LoadingIndicatorView](R.id.lbv__conversation__loading_indicator)) { vh =>
     accentColor.map(_.color)(c => vh.foreach(_.setColor(c)))
   }
-
 
   private var containerPreview: ViewGroup = _
   private lazy val cursorView = returning(view[CursorView](R.id.cv__cursor)) { vh =>
@@ -159,6 +160,8 @@ class ConversationFragment extends FragmentHelper {
   private lazy val messagesOpacity = view[View](R.id.mentions_opacity)
   private lazy val mentionsList = view[RecyclerView](R.id.mentions_list)
   private lazy val replyView = view[ReplyView](R.id.reply_view)
+
+  private var hideUserStatus = false
 
   private def showMentionsList(visible: Boolean): Unit = {
     mentionsList.foreach(_.setVisible(visible))
@@ -201,6 +204,10 @@ class ConversationFragment extends FragmentHelper {
     zms.flatMap(_.errors.getErrors).onUi { _.foreach(handleSyncError) }
 
     convController.currentConvName.onUi { updateTitle }
+
+    Future({TeamSize.hideStatus(accountsController.teamId, usersStorage).onUi {
+      hideUserStatus = _
+    }})(Threading.Background)
 
     cancelPreviewOnChange.onUi {
       case (change, Some(true)) if !change.noChange => imagePreviewCallback.onCancelPreview()
@@ -413,7 +420,7 @@ class ConversationFragment extends FragmentHelper {
 
       subs += Signal(v.mentionSearchResults, accountsController.teamId, inject[ThemeController].currentTheme).onUi {
         case (data, teamId, theme) =>
-          mentionCandidatesAdapter.setData(data, teamId, theme)
+          mentionCandidatesAdapter.setData(data, teamId, theme, hideUserStatus)
           mentionsList.foreach(_.scrollToPosition(data.size - 1))
       }
 

--- a/default.json
+++ b/default.json
@@ -38,5 +38,4 @@
   "wipe_on_cookie_invalid": false,
   "force_private_keyboard": false,
   "password_max_attempts": 0,
-  "team_size_threshold_hack": 400
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSize.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSize.scala
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.service
+
+import com.waz.content._
+import com.waz.model._
+import com.waz.threading.Threading
+import com.waz.utils.events.EventContext
+
+import scala.concurrent.Future
+
+
+trait TeamSize {
+  def runIfNoThreshold(fnToRun: () => Future[_]): Future[Unit]
+}
+
+class TeamSizeImpl(teamId:       Option[TeamId],
+                   usersStorage: UsersStorage) extends TeamSize {
+
+  import Threading.Implicits.Background
+  private implicit val ec: EventContext.Global.type = EventContext.Global
+
+  private val teamSizeThreshold = 400
+
+  override def runIfNoThreshold(fnToRun: () => Future[_]): Future[Unit] =
+    selfTeamSize.flatMap {
+        case Some(teamSize) if teamSize < teamSizeThreshold => fnToRun().map(_ => ())
+        case _ => Future.successful({})
+    }
+
+  def selfTeamSize: Future[Option[Int]] = {
+    val empty: Future[Option[Int]] = Future.successful(None)
+    teamId.fold(empty)(id => usersStorage.getByTeam(Set(id)).map(users => Some(users.size)))
+  }
+}

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSize.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSize.scala
@@ -18,9 +18,11 @@
 package com.waz.service
 
 import com.waz.content._
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, Signal}
+import com.waz.log.LogSE._
 
 import scala.concurrent.Future
 
@@ -48,7 +50,7 @@ class TeamSizeImpl(teamId:       Option[TeamId],
   }
 }
 
-object TeamSize {
+object TeamSize extends DerivedLogTag {
 
   val teamSizeThreshold = 400
 
@@ -57,5 +59,7 @@ object TeamSize {
       teamId <- teamId
       usersStorage <- usersStorage
       teamSize <- teamId.fold(Signal.const(0))(tId => Signal.future(usersStorage.getByTeam(Set(tId)).map(_.size)(Threading.Background)))
-    } yield teamSize == 0 || teamSize > teamSizeThreshold
+      hiding = teamSize == 0 || teamSize > teamSizeThreshold
+      _ = verbose(l"Team size is ${teamSize} vs. threshold ${teamSizeThreshold}, hiding? ${hiding}")
+    } yield hiding
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSizeThreshold.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/TeamSizeThreshold.scala
@@ -26,24 +26,24 @@ import com.waz.utils.events.{EventContext, Signal}
 import scala.concurrent.Future
 
 
-trait TeamSize {
+trait TeamSizeThreshold {
   def runIfBelowStatusPropagationThreshold(fnToRun: () => Future[_]): Future[Unit]
 }
 
-class TeamSizeImpl(teamId:       Option[TeamId],
-                   usersStorage: UsersStorage) extends TeamSize {
+class TeamSizeThresholdImpl(teamId:       Option[TeamId],
+                            usersStorage: UsersStorage) extends TeamSizeThreshold {
 
   import Threading.Implicits.Background
   private implicit val ec: EventContext.Global.type = EventContext.Global
 
   override def runIfBelowStatusPropagationThreshold(fnToRun: () => Future[_]): Future[Unit] =
-    TeamSize.isAboveStatusPropagationThreshold(teamId, usersStorage).map {
+    TeamSizeThreshold.isAboveStatusPropagationThreshold(teamId, usersStorage).map {
       case true => fnToRun().map(_ => ())
       case _ => Future.successful({})
     }
 }
 
-object TeamSize extends DerivedLogTag {
+object TeamSizeThreshold extends DerivedLogTag {
 
   val statusPropagationThreshold = 400
   import Threading.Implicits.Background

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -98,7 +98,7 @@ class UserServiceImpl(selfUserId:        UserId,
                       sync:              SyncServiceHandle,
                       assetsStorage:     AssetStorage,
                       credentialsClient: CredentialsUpdateClient,
-                      teamSize:          TeamSize,
+                      teamSize:          TeamSizeThreshold,
                       selectedConv:      SelectedConversationService) extends UserService with DerivedLogTag {
 
   import Threading.Implicits.Background

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -79,7 +79,7 @@ trait UserService {
   //These self user properties should always succeed given no fatal errors, so we update locally and create sync jobs
   def updateName(name: Name): Future[Unit]
   def updateAccentColor(color: AccentColor): Future[Unit]
-  def updateAvailability(availability: Availability, teamSizeThreshold: Int): Future[Unit]
+  def updateAvailability(availability: Availability): Future[Unit]
 
   def storeAvailabilities(availabilities: Map[UserId, Availability]): Future[Seq[(UserData, UserData)]]
   def updateSelfPicture(content: Content): Future[Unit]
@@ -329,7 +329,7 @@ class UserServiceImpl(selfUserId:        UserId,
     updateAndSync(_.copy(accent = color.id), _ => sync.postSelfUser(UserInfo(selfUserId, accentId = Some(color.id))))
   }
 
-  override def updateAvailability(availability: Availability, teamSizeThreshold: Int) = {
+  override def updateAvailability(availability: Availability) = {
     updateAndSync(
       _.copy(availability = availability),
       _ => teamSize.runIfNoThreshold(() => sync.postAvailability(availability)))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -332,7 +332,7 @@ class UserServiceImpl(selfUserId:        UserId,
   override def updateAvailability(availability: Availability) = {
     updateAndSync(
       _.copy(availability = availability),
-      _ => teamSize.runIfNoThreshold(() => sync.postAvailability(availability)))
+      _ => teamSize.runIfBelowStatusPropagationThreshold(() => sync.postAvailability(availability)))
   }
 
   override def storeAvailabilities(availabilities: Map[UserId, Availability]) = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -232,7 +232,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val assetMetaData                              = wire[com.waz.service.assets.MetaDataService]
   lazy val oldAssets: AssetService                    = wire[AssetServiceImpl]
   lazy val users: UserService                         = wire[UserServiceImpl]
-  lazy val teamSize: TeamSize                         = wire[TeamSizeImpl]
+  lazy val teamSize: TeamSizeThreshold                         = wire[TeamSizeThresholdImpl]
   lazy val conversations: ConversationsService        = wire[ConversationsServiceImpl]
   lazy val convOrder: ConversationOrderEventsService  = wire[ConversationOrderEventsService]
   lazy val convsUi: ConversationsUiService            = wire[ConversationsUiServiceImpl]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -232,6 +232,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val assetMetaData                              = wire[com.waz.service.assets.MetaDataService]
   lazy val oldAssets: AssetService                    = wire[AssetServiceImpl]
   lazy val users: UserService                         = wire[UserServiceImpl]
+  lazy val teamSize: TeamSize                         = wire[TeamSizeImpl]
   lazy val conversations: ConversationsService        = wire[ConversationsServiceImpl]
   lazy val convOrder: ConversationOrderEventsService  = wire[ConversationOrderEventsService]
   lazy val convsUi: ConversationsUiService            = wire[ConversationsUiServiceImpl]

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -55,7 +55,7 @@ class UserServiceSpec extends AndroidFreeSpec {
   val assetsStorage   = mock[AssetStorage]
   val credentials     = mock[CredentialsUpdateClient]
   val selectedConv    = mock[SelectedConversationService]
-  val teamSize        = mock[TeamSize]
+  val teamSize        = mock[TeamSizeThreshold]
   val userPrefs       = new TestUserPreferences
 
   (usersStorage.optSignal _).expects(*).anyNumberOfTimes().onCall((id: UserId) => Signal.const(users.find(_.id == id)))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -76,7 +76,7 @@ class UserServiceSpec extends AndroidFreeSpec {
     )
   }
 
-  val completionHandlerThatExecutesFunction: (() => Future[_]) => Future[Unit] = { f => f().map(_ => {})(Threading.Ui)  }
+  val completionHandlerThatExecutesFunction: (() => Future[_]) => Future[Unit] = { f => f().map(_ => {})(Threading.Background) }
   val completionHandlerThatDoesNotExecuteFunction: (() => Future[_]) => Future[Unit] = { _ => Future.successful({}) }
 
 
@@ -106,8 +106,8 @@ class UserServiceSpec extends AndroidFreeSpec {
         Future.successful(Some((before, after)))
       }
 
+      (sync.postAvailability _).expects(after.availability).returning(Future.successful(SyncId()))
       (teamSize.runIfBelowStatusPropagationThreshold _).expects(*).onCall(completionHandlerThatExecutesFunction)
-      (sync.postAvailability _).expects(after.availability)
 
       //when
       result(userService.updateAvailability(Availability.Busy))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -75,37 +75,6 @@ class UserServiceSpec extends AndroidFreeSpec {
     )
   }
 
-//  feature("activity status") {
-//    scenario("change activity status") {
-//
-//      //given
-//      val id = me.id
-//      val teamId = TeamId("Wire")
-//      val someTeamId = Some(teamId)
-//      val availability = me.availability
-//      availability should not equal Availability.Busy
-//
-//      //expect
-//      val before = me.copy()
-//      val after = me.copy(availability = Availability.Busy)
-//      (usersStorage.update _).expects(id, *).once().onCall { (id, updater) =>
-//        updater(before) shouldEqual after
-//        Future.successful(Some((before, after)))
-//      }
-//      val userOne: UserData = UserData("1")
-//      val userTwo: UserData = UserData("2")
-//      val userSet = Set(userOne, userTwo)
-//      (usersStorage.getByTeam _).expects(Set(teamId)).returning(Future.successful(userSet))
-//      (sync.postAvailability _).expects(Availability.Busy).once().returning(Future.successful(SyncId()))
-//      (teamSize.runIfNoThreshold _).expects(*).once()
-//      (teamSize.membersCount _).expects().returning(Future.successful(Some(10)))
-//
-//      //when
-//      val service = getService
-//      result(service.updateAvailability(Availability.Busy))
-//    }
-//  }
-
   feature("load user") {
 
     scenario("update self user") {


### PR DESCRIPTION
## What's new in this PR?

### Disclaimer

This functionality will be rewritten at a later stage, therefore not too much thought has been put in the architecture.

### Notes

When user in big team (with lots of connections) changes status, it will send out a message to all connections, which could be too big and sending will fail (backend rejects etc.)

To avoid such issue, we decided in first phase not to send out status message for members in big teams, with more than 400 users.

When your team reaches the limit, you also stop displaying status of other users in your team.

### Description of this PR

As a continuation of #2436. This PR aims to cover the UI part, which is about hiding the status of every user if a team size is bigger than a threshold defined in the configuration. 

## Jira Ticket
 - [AN-6512](https://wearezeta.atlassian.net/browse/AN-6512)
#### APK
[Download build #401](http://10.10.124.11:8080/job/Pull%20Request%20Builder/401/artifact/build/artifact/wire-dev-PR2440-401.apk)