### PR TITLE
Fixed the issue around the message line length being too short 

### DIFF
--- a/app/src/main/res/layout/cursor_view_content.xml
+++ b/app/src/main/res/layout/cursor_view_content.xml
@@ -81,8 +81,6 @@
                     android:maxLines="@integer/cursor__max_lines"
                     android:scrollHorizontally="false"
                     app:w_font="@string/wire__typeface__light">
-
-                    <requestFocus />
                 </com.waz.zclient.ui.cursor.CursorEditText>
 
                 <com.waz.zclient.ui.text.TypefaceTextView

--- a/app/src/main/res/layout/cursor_view_content.xml
+++ b/app/src/main/res/layout/cursor_view_content.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
-    Copyright (C) 2018 Wire Swiss GmbH
+    Copyright (C) 2019 Wire Swiss GmbH
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,74 +18,71 @@
 
 -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <View
         android:id="@+id/v__top_bar__cursor"
         style="?wireDivider"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/wire__divider__height__thin"
-        />
+        android:layout_height="@dimen/wire__divider__height__thin" />
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="@dimen/new_cursor_height"
-    >
+        android:layout_height="wrap_content">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal"
-            android:paddingEnd="@dimen/cursor_button_horizontal_margin"
-        >
+            android:paddingEnd="@dimen/cursor_button_horizontal_margin">
 
             <FrameLayout
                 android:id="@+id/fl__cursor__emoji_container"
                 android:layout_width="@dimen/cursor_anchor2"
                 android:layout_height="match_parent"
-                android:layout_gravity="start|center_vertical"
-            >
-                <com.waz.zclient.cursor.CursorIconButton android:id="@+id/cib__emoji"
-                                                         android:layout_width="@dimen/cursor__menu_button__diameter"
-                                                         android:layout_height="@dimen/cursor__menu_button__diameter"
-                                                         android:layout_gravity="end|center_vertical"
-                                                         android:layout_marginEnd="@dimen/chathead__margin"
-                                                         android:padding="@dimen/cursor__menu_button__padding"
-                                                         style="?cursorIconButton"/>
+                android:layout_gravity="start|center_vertical">
 
-                <com.waz.zclient.cursor.CursorIconButton android:id="@+id/cib__keyboard"
-                                                         android:layout_width="@dimen/cursor__menu_button__diameter"
-                                                         android:layout_height="@dimen/cursor__menu_button__diameter"
-                                                         android:layout_gravity="end|center_vertical"
-                                                         android:layout_marginEnd="@dimen/chathead__margin"
-                                                         android:padding="@dimen/cursor__menu_button__padding"
-                                                         style="?cursorIconButton"/>
+                <com.waz.zclient.cursor.CursorIconButton
+                    android:id="@+id/cib__emoji"
+                    style="?cursorIconButton"
+                    android:layout_width="@dimen/cursor__menu_button__diameter"
+                    android:layout_height="@dimen/cursor__menu_button__diameter"
+                    android:layout_gravity="end|center_vertical"
+                    android:layout_marginEnd="@dimen/chathead__margin"
+                    android:padding="@dimen/cursor__menu_button__padding" />
+
+                <com.waz.zclient.cursor.CursorIconButton
+                    android:id="@+id/cib__keyboard"
+                    style="?cursorIconButton"
+                    android:layout_width="@dimen/cursor__menu_button__diameter"
+                    android:layout_height="@dimen/cursor__menu_button__diameter"
+                    android:layout_gravity="end|center_vertical"
+                    android:layout_marginEnd="@dimen/chathead__margin"
+                    android:padding="@dimen/cursor__menu_button__padding" />
             </FrameLayout>
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_gravity="center_vertical"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="1"
                 android:paddingEnd="@dimen/wire__padding__small">
 
-                <!-- Edit Text -->
                 <com.waz.zclient.ui.cursor.CursorEditText
                     android:id="@+id/cet__cursor"
                     style="?cursorEditText"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:background="@null"
                     android:gravity="center_vertical"
                     android:imeOptions="actionNone"
                     android:inputType="textCapSentences|textMultiLine"
+                    android:lineSpacingExtra="@dimen/content__line_spacing_extra"
                     android:maxLines="@integer/cursor__max_lines"
                     android:scrollHorizontally="false"
-                    android:lineSpacingExtra="@dimen/content__line_spacing_extra"
-                    app:w_font="@string/wire__typeface__light"
-                >
+                    app:w_font="@string/wire__typeface__light">
 
-                    <requestFocus/>
+                    <requestFocus />
                 </com.waz.zclient.ui.cursor.CursorEditText>
 
                 <com.waz.zclient.ui.text.TypefaceTextView
@@ -95,34 +91,35 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:background="@null"
+                    android:drawablePadding="@dimen/wire__padding__8"
                     android:gravity="start"
+                    android:paddingStart="@dimen/wire__padding__small"
                     android:text="@string/cursor__type_a_message"
                     android:textColor="@color/light_graphite"
                     android:textSize="@dimen/wire__text_size__small"
-                    app:w_font="@string/wire__typeface__medium"
-                    android:paddingStart="@dimen/wire__padding__small"
-                    android:drawablePadding="@dimen/wire__padding__8"
-                />
+                    app:w_font="@string/wire__typeface__medium" />
 
             </FrameLayout>
 
-            <com.waz.zclient.cursor.EphemeralTimerButton android:id="@+id/cib__ephemeral"
-                                                         android:layout_width="@dimen/wire__margin__24"
-                                                         android:layout_height="@dimen/wire__margin__24"
-                                                         android:layout_gravity="center"
-                                                         android:letterSpacing="-0.1"
-                                                         android:includeFontPadding="false"
-                                                         android:gravity="center_vertical"/>
+            <com.waz.zclient.cursor.EphemeralTimerButton
+                android:id="@+id/cib__ephemeral"
+                android:layout_width="@dimen/wire__margin__24"
+                android:layout_height="@dimen/wire__margin__24"
+                android:layout_gravity="center"
+                android:gravity="center_vertical"
+                android:includeFontPadding="false"
+                android:letterSpacing="-0.1" />
 
-            <com.waz.zclient.cursor.SendButton android:id="@+id/cib__send"
-                                               android:visibility="gone"
-                                               android:layout_marginStart="@dimen/cursor_anchor1"
-                                               android:layout_width="@dimen/cursor__send_button__width"
-                                               android:layout_height="@dimen/cursor__send_button__width"
-                                               android:layout_gravity="center"
-                                               android:padding="@dimen/cursor__send_button__padding"
-                                               android:textColor="@color/text__primary_dark"
-                                               style="?cursorIconButton"/>
+            <com.waz.zclient.cursor.SendButton
+                android:id="@+id/cib__send"
+                style="?cursorIconButton"
+                android:layout_width="@dimen/cursor__send_button__width"
+                android:layout_height="@dimen/cursor__send_button__width"
+                android:layout_gravity="center"
+                android:layout_marginStart="@dimen/cursor_anchor1"
+                android:padding="@dimen/cursor__send_button__padding"
+                android:textColor="@color/text__primary_dark"
+                android:visibility="gone" />
 
 
         </LinearLayout>
@@ -134,47 +131,41 @@
             android:background="@android:drawable/toast_frame"
             android:gravity="center"
             android:textColor="@color/text__primary_dark"
-            app:w_font="@string/wire__typeface__light"
-        />
+            app:w_font="@string/wire__typeface__light" />
 
     </FrameLayout>
 
 
     <View
         android:id="@+id/v__cursor__divider"
+        style="?wireDivider"
         android:layout_width="match_parent"
         android:layout_height="@dimen/wire__divider__height__thin"
         android:layout_marginLeft="@dimen/wire__padding__regular"
-        android:layout_marginRight="@dimen/wire__padding__regular"
-        style="?wireDivider"
-    />
+        android:layout_marginRight="@dimen/wire__padding__regular" />
 
     <!-- Cursor Action -->
     <com.waz.zclient.cursor.CursorToolbarContainer
         android:id="@+id/cal__cursor"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/new_cursor_height"
-    >
+        android:layout_height="@dimen/new_cursor_height">
 
         <com.waz.zclient.cursor.CursorToolbar
             android:id="@+id/c__cursor__main"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-        />
+            android:layout_height="match_parent" />
 
         <com.waz.zclient.cursor.CursorToolbar
             android:id="@+id/c__cursor__secondary"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-        />
+            android:layout_height="match_parent" />
 
         <com.waz.zclient.cursor.EditCursorToolbar
             android:id="@+id/emct__edit_message__toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginLeft="@dimen/wire__padding__regular"
-            android:layout_marginRight="@dimen/wire__padding__regular"
-        />
+            android:layout_marginRight="@dimen/wire__padding__regular" />
 
 
     </com.waz.zclient.cursor.CursorToolbarContainer>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -35,6 +35,7 @@
     <integer name="calling_animation_duration_long">550</integer>
 
     <!-- Cursor-->
+    <integer name="cursor_starting_lines">2</integer>
     <integer name="cursor__max_lines">6</integer>
 
     <!-- Wire Values-->

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -110,7 +110,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     case false => getStyledColor(R.attr.wireBackgroundColor)
   }
 
-  val lineCount = Signal(1)
+  val lineCount = Signal(getInt(R.integer.cursor_starting_lines))
 
   Signal(controller.typingIndicatorVisible, replyController.currentReplyContent)
     .map { case (typing, currentReply) => !typing && currentReply.isEmpty  }
@@ -157,7 +157,11 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     }
   }
 
-  lineCount.onUi(cursorEditText.setLines(_))
+  lineCount.onUi { lineCount =>
+    if (lineCount.<(getInt(R.integer.cursor__max_lines))) {
+      cursorEditText.setLines(lineCount)
+    }
+  }
 
   dividerColor.onUi(dividerView.setBackgroundColor)
   bgColor.onUi(setBackgroundColor)
@@ -199,8 +203,10 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     override def onTextChanged(charSequence: CharSequence, start: Int, before: Int, count: Int): Unit = {
       val text = charSequence.toString
       controller.enteredText ! (getText, EnteredTextSource.FromView)
-      if (text.trim.nonEmpty) lineCount ! Math.max(cursorEditText.getLineCount, 1)
-      cursorText ! charSequence.toString
+      if (text.trim.nonEmpty && cursorEditText.getLineCount >= getInt(R.integer.cursor_starting_lines)) lineCount ! cursorEditText.getLineCount else {
+        lineCount ! getInt(R.integer.cursor_starting_lines)
+      }
+      cursorText ! text
     }
 
     override def afterTextChanged(editable: Editable): Unit = {}


### PR DESCRIPTION
made it so it's a maximum of 6 lines that wrap the content of the message to the user can see more of their message when they type

## What's new in this PR?

### Issues

https://github.com/wireapp/wire-android/issues/2289

### Causes

The current maximum is 2 lines for the text to be wrapped at as the edit text is a fixed height. 

### Solutions

Made it so the content is wrapped until it hits 6 lines to match iOS

### Testing

Type text into the conversation message box up until 6 lines and it should then allow you more space to type a message (the same applies with editing a message too) 

### Notes

This has been approved by design 

#### APK
[Download build #409](http://10.10.124.11:8080/job/Pull%20Request%20Builder/409/artifact/build/artifact/wire-dev-PR2442-409.apk)
[Download build #412](http://10.10.124.11:8080/job/Pull%20Request%20Builder/412/artifact/build/artifact/wire-dev-PR2442-412.apk)