### PR TITLE
Fixed the issue around the app crashing when you use special unicode …

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
@@ -17,6 +17,8 @@
  */
 package com.waz.service.conversation
 
+import android.text.Html
+import androidx.core.text.HtmlCompat
 import com.waz.content._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
@@ -183,7 +185,12 @@ class NameUpdater(selfUserId:     UserId,
   }
 
   private def generatedName(userNames: GenTraversable[Option[Name]]): Name = {
-    Name(userNames.flatten.filter(_.nonEmpty).mkString(", "))
+    Name(getName(userNames).toString)
+  }
+
+  private def getName(userNames: GenTraversable[Option[Name]]): String = {
+    val name = userNames.flatten.filter(_.nonEmpty).mkString(", ")
+    HtmlCompat.fromHtml(name, HtmlCompat.FROM_HTML_MODE_LEGACY).toString
   }
 }
 


### PR DESCRIPTION
…characters in group names

## What's new in this PR?

### Issues

https://github.com/wireapp/wire-android/issues/2432

### Causes

Android leverages the http://cldr.unicode.org/ library for API 24 or above and one of the following characters (ᚠᚢᚦᚨᚱᚲᚷᚹᚺᚾᛁᛃᛈᛇᛉᛊᛏᛒᛖᛗᛚᛜᛞᛟ) isn't accepted by the CLDR library (for your standard setText). You can find more information on what they don't accept here: http://www.unicode.org/reports/tr35/#Unknown_or_Invalid_Identifiers. 

### Solutions

You can format the display name of the group by using HtmlCompat.fromHtml() with the legacy flag to behave as before but format the text through HTML rather than Android directly. 

### Testing

#### Scenario 1 
1. Create a new group with the name "ᚠᚢᚦᚨᚱᚲᚷᚹᚺᚾᛁᛃᛈᛇᛉᛊᛏᛒᛖᛗᛚᛜᛞᛟ" 
2. Invite other people 
3. Logout and logout back in (no crash) 

#### Scenario 2
1. Create a new group with the name "<a="www.google.co.uk"</a>"  
2. Invite other people 
3. Logout and logout back in (group message should be the tag in plain text) 

#### Scenario 3
1. Create a new group with the name "<a href="www.google.co.uk"</a>"  
2. Invite other people 
3. Logout and logout back in (group message should be the tag in plain text and doesn't direct to a url) 

#### Scenario 4
1. Create a new group with the name '<'b>group name'</'b>
2. Invite other people 
3. Logout and logout back in (group message should be the tag in plain text and doesn't make the name bold) 