### PR TITLE
Fix: Crash due to QuoteSpan constructor

### DIFF
--- a/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/markdown/GroupSpanTest.kt
@@ -116,8 +116,8 @@ class GroupSpanTest {
             when (span) {
                 is CustomQuoteSpan -> {
                     assertEquals(Color.GREEN, span.color)
-                    assertEquals(4, span.stripeWidth)
-                    assertEquals(8, span.gapWidth)
+                    assertEquals(4, span.stripeWidthSize)
+                    assertEquals(8, span.gapWidthSize)
                 }
                 is ParagraphSpacingSpan -> {
                     assertEquals(16, span.before)

--- a/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
+++ b/app/src/main/java/com/waz/zclient/markdown/spans/custom/CustomQuoteSpan.kt
@@ -29,15 +29,15 @@ import android.text.style.QuoteSpan
  */
 class CustomQuoteSpan(
     color: Int,
-    stripeWidth: Int,
-    gapWidth: Int,
+    val stripeWidthSize: Int,
+    val gapWidthSize: Int,
     private val density: Float = 1f,
     val beforeSpacing: Int = 0,
     val afterSpacing: Int = 0
-) : QuoteSpan(color, stripeWidth, gapWidth) {
+) : QuoteSpan(color) {
 
     override fun getLeadingMargin(first: Boolean): Int {
-        return ((stripeWidth + gapWidth) * density).toInt()
+        return ((stripeWidthSize + gapWidthSize) * density).toInt()
     }
 
     override fun drawLeadingMargin(
@@ -66,7 +66,7 @@ class CustomQuoteSpan(
 
         p.style = Paint.Style.FILL
         p.color = this.color
-        c.drawRect(x.toFloat(), top.toFloat() + topOffset, (x + dir * stripeWidth * density), bottom.toFloat() + bottomOffset, p)
+        c.drawRect(x.toFloat(), top.toFloat() + topOffset, (x + dir * stripeWidthSize * density), bottom.toFloat() + bottomOffset, p)
 
         // reset paint
         p.style = style


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some devices crash while trying to display Quoted texts. #2431 

### Causes

Wrong QuoteSpan constructor is called.

### Solutions

Use the legacy constructor.

### Testing

Could not reproduce with Pixel 2 Android 8.0.0. Would be nice to reproduce the issue. Fixed based on the educated guess derived from the crash logs.

#### APK
[Download build #417](http://10.10.124.11:8080/job/Pull%20Request%20Builder/417/artifact/build/artifact/wire-dev-PR2444-417.apk)