### PR TITLE
Remove unnecessary prints from test suites

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
@@ -47,7 +47,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
   val members =       mock[MembersStorage]
   val users =         mock[UsersStorage]
   val replyHashing =  mock[ReplyHashing]
-  val prefs =         new TestGlobalPreferences()
+  lazy val prefs =         new TestGlobalPreferences()
 
   def getService = {
     val updater = new MessagesContentUpdater(storage, convsStorage, deletions, prefs)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/TeamSizeThresholdSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/TeamSizeThresholdSpec.scala
@@ -1,5 +1,0 @@
-package com.waz.service
-
-class TeamSizeThreshold {
-
-}

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/TeamSizeThresholdSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/TeamSizeThresholdSpec.scala
@@ -1,0 +1,5 @@
+package com.waz.service
+
+class TeamSizeThreshold {
+
+}

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
@@ -56,7 +56,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig wi
 
   private val testAssetContent = returning(Array.ofDim[Byte](128))(Random.nextBytes)
 
-  private val testAsset = Asset(
+  lazy private val testAsset = Asset(
     id = AssetId(),
     token = None,
     sha = Sha256.calculate(testAssetContent),
@@ -69,8 +69,6 @@ class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig wi
     details = BlobDetails,
     convId = None
   )
-
-  verbose(l"Test asset: $testAsset")
 
   private def service(rawAssetStorage: UploadAssetStorage = rawAssetStorage,
                       client: AssetClient2 = client): AssetService =

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -113,7 +113,7 @@ abstract class AndroidFreeSpec extends ZMockSpec { this: Suite =>
   def updateAccountState(id: UserId, state: AccountState) =
     accountStates.mutate(_ + (id -> state))
 
-  implicit val accountContext = new AccountContext(account1Id, accounts)
+  lazy implicit val accountContext = new AccountContext(account1Id, accounts)
 
   override protected def beforeEach() = {
     clock.reset()

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/SyncRequestServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/SyncRequestServiceSpec.scala
@@ -47,7 +47,7 @@ class SyncRequestServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val sync            = mock[SyncHandler]
   val reporting       = mock[ReportingService]
   val usersStorage    = mock[UsersStorage]
-  val prefs           = new TestUserPreferences {
+  lazy val prefs           = new TestUserPreferences {
     result(this.preference(UserPreferences.ShouldSyncInitial) := false)
     result(this.preference(UserPreferences.ShouldSyncConversations) := false)
   }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
@@ -58,72 +58,141 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with Eventually {
 
   feature("Basic Signals") {
     scenario("Receive initial value") {
+
+      // given
       val s = Signal(1)
+
+      // when
       s(capture)
+
+      // then
       eventually { received shouldEqual Seq(1) }
     }
 
     scenario("Basic subscriber lifecycle") {
+
+      // given
       val s = Signal(1)
       eventually { s.hasSubscribers shouldEqual false }
+
+      // when
       val sub = s { _ => () }
+
+      // then
       eventually { s.hasSubscribers shouldEqual true }
+
+      // and when
       sub.destroy()
+
+      // then
       eventually { s.hasSubscribers shouldEqual false }
     }
 
     scenario("Don't receive events after unregistering a single observer")  {
+
+      // given
       val s = Signal(1)
       val sub = s(capture)
+      eventually { s.hasSubscribers shouldEqual true }
+
+      // when
       s ! 2
+
+      // then
       eventually { received shouldEqual Seq(1, 2) }
 
+      // and given
       sub.destroy()
+      eventually { s.hasSubscribers shouldEqual false }
+
+      // when
       s ! 3
-      eventually { received shouldEqual Seq(1, 2) }
+
+      // then
+      Thread.sleep(200)
+      received shouldEqual Seq(1, 2)
     }
 
     scenario("Don't receive events after unregistering all observers")  {
+
+      // given
       val s = Signal(1)
       s(capture)
+      eventually { s.hasSubscribers shouldEqual true }
+
+      // when
       s ! 2
+
+      // then
       eventually { received shouldEqual Seq(1, 2) }
 
+      // and given
       s.unsubscribeAll()
+      eventually { s.hasSubscribers shouldEqual false }
+
+      // when
       s ! 3
-      eventually { received shouldEqual Seq(1, 2) }
+
+      // then
+      Thread.sleep(200)
+      received shouldEqual Seq(1, 2)
     }
 
     scenario("Signal mutation") {
+
+      // given
       val s = Signal(42)
       s(capture)
       eventually { received shouldEqual Seq(42) }
+
+      // when
       s.mutate(_ + 1)
+
+      // then
       eventually { received shouldEqual Seq(42, 43) }
+
+      // and when
       s.mutate(_ - 1)
+
+      // then
       eventually { received shouldEqual Seq(42, 43, 42) }
     }
   }
 
   feature("Caching") {
     scenario("Don't send the same value twice") {
+      // given
       val s = Signal(1)
       s(capture)
+      eventually { s.hasSubscribers shouldEqual true }
+
+      // when
       Seq(1, 2, 2, 1) foreach (s ! _)
+
+      // then
       eventually { received shouldEqual Seq(1, 2, 1) }
     }
 
     scenario("Idempotent signal mutation") {
+
+      // given
       val s = Signal(42)
       s(capture)
       eventually { received shouldEqual Seq(42) }
+
+      // when
       s.mutate(_ + 1 - 1)
-      eventually { received shouldEqual Seq(42) }
+
+      // then
+      Thread.sleep(200)
+      received shouldEqual Seq(42)
     }
   }
 
   feature("For comprehensions") {
     scenario("Simple for comprehension") {
+
+      // given
       val s = Signal(0)
       val s1 = Signal(1)
       val s2 = Signal(2)
@@ -133,7 +202,11 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with Eventually {
       } yield y * 2
       r(capture)
       eventually { r.currentValue.get shouldEqual 2 }
+
+      // when
       s ! 1
+
+      // then
       eventually { r.currentValue.get shouldEqual 4 }
       eventually { received shouldEqual Seq(2, 4) }
     }


### PR DESCRIPTION
## What's new in this PR?

Remove unnecessary log lines in tests

### Issues

Some text lines were being printed even when a test suite was not being executed, making it hard to read test logs


#### APK
[Download build #450](http://10.10.124.11:8080/job/Pull%20Request%20Builder/450/artifact/build/artifact/wire-dev-PR2447-450.apk)