### PR TITLE
reverted AVS version to unblock automation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.2@aar'
+    customAvsVersion = '5.3.29@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

### Issues

New AVS version was causing a crash

### Causes

A null pointer reference 

### Solutions

Reverted until further investigation takes place 

#### APK
[Download build #511](http://10.10.124.11:8080/job/Pull%20Request%20Builder/511/artifact/build/artifact/wire-dev-PR2456-511.apk)