### PR TITLE
Remove prefilling of Giphy search box

### DIFF
--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -319,7 +319,7 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
     case Location =>
       showLocationIfAllowed()
     case Gif =>
-      enteredText.head.foreach { case (CursorText(text, _), _) => screenController.showGiphy ! Some(text) }
+      enteredText.head.foreach { _ => screenController.showGiphy ! Some(s"") }
     case Send =>
       enteredText.head.foreach { case (CursorText(text, mentions), _) => submit(text, mentions) }
     case _ =>


### PR DESCRIPTION
## What's new in this PR?

Clicking on the Giphy search button will not prefill the Giphy search with the message being typed. This has been raised as a security concern (accidental tapping on Giphy) and this is a simple attempt at addressing the issue. In future we could move this to a user preference to allow for both behaviours.

### Testing

This has been tested manually on a device
#### APK
[Download build #513](http://10.10.124.11:8080/job/Pull%20Request%20Builder/513/artifact/build/artifact/wire-dev-PR2457-513.apk)