### PR TITLE
Hide screen content within recents

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -1,33 +1,44 @@
 /**
- * Wire
- * Copyright (C) 2019 Wire Swiss GmbH
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+  * Wire
+  * Copyright (C) 2019 Wire Swiss GmbH
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 package com.waz.zclient.security
 
 import android.app.{Activity, Application}
 import android.os.Bundle
+import android.view.WindowManager
+import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.events._
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.{Injectable, Injector, LaunchActivity}
+import com.waz.zclient.{BuildConfig, Injectable, Injector, LaunchActivity}
 
 class ActivityLifecycleCallback(implicit injector: Injector)
   extends Application.ActivityLifecycleCallbacks with Injectable with DerivedLogTag {
 
+  import com.waz.utils.events.EventContext.Implicits.global
+
+  private lazy val shouldHideScreenContent = for {
+    prefs <- userPreferences
+    hideScreenContent <- prefs.preference(UserPreferences.HideScreenContent).signal
+  } yield hideScreenContent
+
   private val activitiesRunning = Signal[(Int, Option[Activity])]((0, None))
+
+  protected lazy val userPreferences = inject[Signal[UserPreferences]]
 
   val appInBackground: Signal[(Boolean, Option[Activity])] = activitiesRunning.map { case (running, lastAct) => (running == 0, lastAct) }
 
@@ -36,7 +47,7 @@ class ActivityLifecycleCallback(implicit injector: Injector)
       case _: LaunchActivity =>
       case _ =>
         verbose(l"onActivityStopped, activities still active: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
-        activitiesRunning.mutate { case (running, _) => (running - 1, Option(activity))}
+        activitiesRunning.mutate { case (running, _) => (running - 1, Option(activity)) }
     }
   }
 
@@ -45,14 +56,31 @@ class ActivityLifecycleCallback(implicit injector: Injector)
       case _: LaunchActivity =>
       case _ =>
         verbose(l"onActivityStarted, activities active now: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
-        activitiesRunning.mutate { case (running, _) => (running + 1, Option(activity))}
+        activitiesRunning.mutate { case (running, _) => (running + 1, Option(activity)) }
 
     }
   }
 
-  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}
+  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {
+    if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
+      addSecureFlags(activity)
+    } else {
+      shouldHideScreenContent.onUi {
+        case true  => addSecureFlags(activity)
+        case false => activity.getWindow.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+      }
+    }
+  }
+
+  private def addSecureFlags(activity: Activity) = {
+    activity.getWindow.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+  }
+
   override def onActivityResumed(activity: Activity): Unit = {}
+
   override def onActivityPaused(activity: Activity): Unit = {}
+
   override def onActivityDestroyed(activity: Activity): Unit = {}
+
   override def onActivitySaveInstanceState(activity: Activity, bundle: Bundle): Unit = {}
 }

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -61,7 +61,9 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     }
   }
 
-  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {
+  override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}
+
+  override def onActivityResumed(activity: Activity): Unit = {
     if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
       addSecureFlags(activity)
     } else {
@@ -76,7 +78,6 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     activity.getWindow.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
   }
 
-  override def onActivityResumed(activity: Activity): Unit = {}
 
   override def onActivityPaused(activity: Activity): Unit = {}
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Not all screens were being securely hidden within the recents section on devices 

### Causes

Only screens extending BaseActivity were having flags set to them 

### Solutions

All activities in the application now have a secure flag registered the application class retrieves a lifecycle callback 

### Testing

Go to Settings > Options > Hide screen contents switch on > Press recents button > Shouldn't be able to see any contents of previous screen 

Go to Settings > Options > Hide screen contents switch off > Press recents button > Should be able to see contents of previous screen 
#### APK
[Download build #522](http://10.10.124.11:8080/job/Pull%20Request%20Builder/522/artifact/build/artifact/wire-dev-PR2459-522.apk)
[Download build #528](http://10.10.124.11:8080/job/Pull%20Request%20Builder/528/artifact/build/artifact/wire-dev-PR2459-528.apk)