### PR TITLE
Avs update 5.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.2@aar'
+    customAvsVersion = '5.4.6@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.3.29@aar'
+    customAvsVersion = '5.4.1@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.1@aar'
+    customAvsVersion = '5.4.2@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?
Update to AVS 5.4.6. The new library allows to symbolize stack traces in case it makes the client crash again. Latest tests with AVS 5.4.2 or AVS 5.4.6 didn't show any more crashes but only the full automation can tell.
#### APK
[Download build #531](http://10.10.124.11:8080/job/Pull%20Request%20Builder/531/artifact/build/artifact/wire-dev-PR2460-531.apk)