### PR TITLE
Preare the terrain for the Network Re-Write

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'hugo'
 apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
 apply from: 'config/quality.gradle'
 
-
 ext {
     majorVersion = "3.43."
 
@@ -306,6 +305,7 @@ def versions = [
     workManager : "2.0.1",
     paging : "1.0.0",
     mockito : "3.1.0",
+    kluent : "1.14",
     lifecycle : "2.0.0"
 ]
 
@@ -417,6 +417,7 @@ dependencies {
     testImplementation "junit:junit:$rootProject.ext.versions.junit"
     testImplementation "org.mockito:mockito-core:$versions.mockito"
     testImplementation "org.mockito:mockito-inline:$versions.mockito"
+    testImplementation "org.amshove.kluent:kluent:$versions.kluent"
     testImplementation "androidx.paging:paging-common:2.0.0"
     testImplementation("$rootProject.deps.scalaTest") {
         exclude module: 'scala-library'

--- a/app/src/main/kotlin/com/waz/zclient/core/functional/Either.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/functional/Either.kt
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2019 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.waz.zclient.core.functional
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val a: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val b: R) : Either<Nothing, R>()
+
+    /**
+     * Returns true if this is a Right, false otherwise.
+     * @see Right
+     */
+    val isRight get() = this is Right<R>
+
+    /**
+     * Returns true if this is a Left, false otherwise.
+     * @see Left
+     */
+    val isLeft get() = this is Left<L>
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) = Either.Left(a)
+
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) = Either.Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun fold(fnL: (L) -> Any, fnR: (R) -> Any): Any =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}
+
+/**
+ * Right-biased flatMap() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.flatMap(fn: (R) -> Either<L, T>): Either<L, T> =
+    when (this) {
+        is Either.Left -> Either.Left(a)
+        is Either.Right -> fn(b)
+    }
+
+/**
+ * Right-biased map() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.map(fn: (R) -> (T)): Either<L, T> = this.flatMap(fn.c(::right))
+
+/** Returns the value from this `Right` or the given argument if this is a `Left`.
+ *  Right(12).getOrElse(17) RETURNS 12 and Left(12).getOrElse(17) RETURNS 17
+ */
+fun <L, R> Either<L, R>.getOrElse(value: R): R =
+    when (this) {
+        is Either.Left -> value
+        is Either.Right -> b
+    }

--- a/app/src/test/kotlin/com/waz/zclient/InjectMocksRule.kt
+++ b/app/src/test/kotlin/com/waz/zclient/InjectMocksRule.kt
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2019 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.waz.zclient
+
+import org.junit.rules.TestRule
+import org.mockito.MockitoAnnotations
+
+class InjectMocksRule {
+
+    companion object {
+        fun create(testClass: Any) = TestRule { statement, _ ->
+            MockitoAnnotations.initMocks(testClass)
+            statement
+        }
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/UnitTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/UnitTest.kt
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2018 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.waz.zclient
+
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Base class for Unit tests. Inherit from it to create test cases which DO NOT contain android
+ * framework dependencies or components.
+ */
+@RunWith(MockitoJUnitRunner::class)
+abstract class UnitTest {
+
+    @Suppress("LeakingThis")
+    @Rule @JvmField val injectMocks = InjectMocksRule.create(this@UnitTest)
+}

--- a/app/src/test/kotlin/com/waz/zclient/core/functional/EitherTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/functional/EitherTest.kt
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2019 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.waz.zclient.core.functional
+
+import com.waz.zclient.UnitTest
+import com.waz.zclient.core.functional.Either.Left
+import com.waz.zclient.core.functional.Either.Right
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldEqualTo
+import org.junit.Test
+
+class EitherTest : UnitTest() {
+
+    @Test fun `Either Right should return correct type`() {
+        val result = Right("ironman")
+
+        result shouldBeInstanceOf Either::class.java
+        result.isRight shouldBe true
+        result.isLeft shouldBe false
+        result.fold({},
+            { right ->
+                right shouldBeInstanceOf String::class.java
+                right shouldEqualTo "ironman"
+            })
+    }
+
+    @Test fun `Either Left should return correct type`() {
+        val result = Left("ironman")
+
+        result shouldBeInstanceOf Either::class.java
+        result.isLeft shouldBe true
+        result.isRight shouldBe false
+        result.fold(
+            { left ->
+                left shouldBeInstanceOf String::class.java
+                left shouldEqualTo "ironman"
+            }, {})
+    }
+
+    @Test fun `Either fold should ignore passed argument if it is Right type`() {
+        val result = Right("Right").getOrElse("Other")
+
+        result shouldEqualTo "Right"
+    }
+
+    @Test fun `Either fold should return argument if it is Left type`() {
+        val result = Left("Left").getOrElse("Other")
+
+        result shouldEqualTo "Other"
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

The idea Is to rewrite the networking of the Android Client. This PR aims to prepare the terrain in order to make it happen. 

- Kluent Fluent Assertion library for kotlin was added. 
- Either<L,R> class added.

#### APK
[Download build #552](http://10.10.124.11:8080/job/Pull%20Request%20Builder/552/artifact/build/artifact/wire-dev-PR2466-552.apk)