### PR TITLE
Add Device Network Handler and Extension Functions

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/exception/Failure.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/exception/Failure.kt
@@ -1,0 +1,13 @@
+package com.waz.zclient.core.exception
+
+/**
+ * Base Class for handling errors/failures/exceptions.
+ * Every feature specific failure should extend [FeatureFailure] class.
+ */
+sealed class Failure {
+    object NetworkConnection : Failure()
+    object ServerError : Failure()
+
+    /** * Extend this class for feature specific failures.*/
+    abstract class FeatureFailure: Failure()
+}

--- a/app/src/main/kotlin/com/waz/zclient/core/extension/Context.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/Context.kt
@@ -1,0 +1,8 @@
+package com.waz.zclient.core.extension
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+
+val Context.networkInfo: NetworkInfo? get() =
+    (this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager).activeNetworkInfo

--- a/app/src/main/kotlin/com/waz/zclient/core/extension/String.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/String.kt
@@ -1,0 +1,3 @@
+package com.waz.zclient.core.extension
+
+fun String.Companion.empty() = ""

--- a/app/src/main/kotlin/com/waz/zclient/core/extension/View.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/View.kt
@@ -1,0 +1,15 @@
+package com.waz.zclient.core.extension
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+
+fun View.isVisible() = this.visibility == View.VISIBLE
+
+fun View.visible() { this.visibility = View.VISIBLE }
+
+fun View.invisible() { this.visibility = View.GONE }
+
+fun ViewGroup.inflate(@LayoutRes layoutRes: Int): View =
+        LayoutInflater.from(context).inflate(layoutRes, this, false)

--- a/app/src/main/kotlin/com/waz/zclient/core/network/NetworkHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/NetworkHandler.kt
@@ -1,0 +1,11 @@
+package com.waz.zclient.core.network
+
+import android.content.Context
+import com.waz.zclient.core.extension.networkInfo
+
+/**
+ * Class which returns information about the network connection state.
+ */
+class NetworkHandler(private val context: Context) {
+    val isConnected get() = context.networkInfo?.isConnected
+}


### PR DESCRIPTION
## What's new in this PR?

In continuation with #2466, in this part I'm just adding some useful extension functions and a Network Handler in order to start building the foundation for the networking. 

### Testing

No tests because the only theoretically testable thing is the NetworkHandler class which in essence is a wrapper around the framework that delegates the device active connection status. 

#### APK
[Download build #553](http://10.10.124.11:8080/job/Pull%20Request%20Builder/553/artifact/build/artifact/wire-dev-PR2467-553.apk)