### PR TITLE
updated AVS to 5.4.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.7@aar'
+    customAvsVersion = '5.4.8@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

### Issues

AVS crashing automation 

### Causes

Premature initialisation of the RTCLibrary with inAVS 

### Solutions

Update AVS to 5.4.8 with a potential fix 
