### PR TITLE
Refactor: Delete unused authentication related classes

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AccountsStorageOld.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AccountsStorageOld.scala
@@ -22,17 +22,7 @@ import com.waz.model.AccountData.AccountDataDao
 import com.waz.model.AccountDataOld.AccountDataOldDao
 import com.waz.model._
 import com.waz.utils.TrimmingLruCache.Fixed
-import com.waz.utils.wrappers.DB
-import com.waz.utils.{CachedStorage, CachedStorage2, CachedStorageImpl, DbStorage2, InMemoryStorage2, Storage2, TrimmingLruCache}
-
-import scala.concurrent.ExecutionContext
-
-trait AccountStorage2 extends Storage2[UserId, AccountData]
-class AccountStorageImpl2(context: Context, db: DB, ec: ExecutionContext)
-  extends CachedStorage2[UserId, AccountData](
-    new DbStorage2(AccountDataDao)(ec, db),
-    new InMemoryStorage2[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)))(ec)
-  )(ec) with AccountStorage2
+import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
 trait AccountStorage extends CachedStorage[UserId, AccountData]
 class AccountStorageImpl(context: Context, storage: Database) extends CachedStorageImpl[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)), storage)(AccountDataDao) with AccountStorage

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -42,7 +42,7 @@ import com.waz.utils._
 import com.waz.utils.events.Signal
 import com.waz.utils.wrappers.{Context, URI}
 import com.waz.znet2.http.ResponseCode
-import com.waz.znet2.{AuthRequestInterceptor, AuthRequestInterceptorOld}
+import com.waz.znet2.{AuthRequestInterceptor, AuthRequestInterceptorImpl}
 
 import scala.collection.immutable.ListMap
 import scala.concurrent.Future
@@ -89,7 +89,7 @@ class AccountManager(val userId:   UserId,
 
   val cryptoBox         = global.factory.cryptobox(userId, storage)
   val auth              = global.factory.auth(userId)
-  val authRequestInterceptor: AuthRequestInterceptor = new AuthRequestInterceptorOld(auth, global.httpClient)
+  val authRequestInterceptor: AuthRequestInterceptor = new AuthRequestInterceptorImpl(auth, global.httpClient)
   val otrClient         = new OtrClientImpl()(global.urlCreator, global.httpClient, authRequestInterceptor)
   val credentialsClient = global.factory.credentialsClient(global.urlCreator, global.httpClient, authRequestInterceptor)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
@@ -17,15 +17,15 @@
  */
 package com.waz.sync.client
 
-import com.waz.log.LogSE._
 import com.waz.api.EmailCredentials
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.Cancelled
-import com.waz.content.{AccountStorage, AccountStorage2}
+import com.waz.content.AccountStorage
 import com.waz.log.BasicLogging.LogTag
+import com.waz.log.LogSE._
 import com.waz.model.{AccountData, UserId}
 import com.waz.service.AccountsService
-import com.waz.service.AccountsService.{InvalidCookie, InvalidCredentials, LogoutReason, UserInitiated}
+import com.waz.service.AccountsService.{InvalidCookie, InvalidCredentials, LogoutReason}
 import com.waz.service.ZMessaging.{accountTag, clock}
 import com.waz.service.tracking.TrackingService
 import com.waz.sync.client.AuthenticationManager.AccessToken
@@ -197,104 +197,4 @@ object AuthenticationManager {
       override def apply(implicit js: JSONObject): AccessToken = AccessToken('token, 'type, 'expires)
     }
   }
-}
-
-class AuthenticationManager2(id: UserId, accStorage: AccountStorage2, client: LoginClient, tracking: TrackingService) extends AccessTokenProvider {
-
-  lazy implicit val logTag: LogTag = accountTag[AuthenticationManager](id)
-
-  import AuthenticationManager._
-
-  implicit val dispatcher = new SerialDispatchQueue(name = "AuthenticationManager")
-
-  private def token  = withAccount(_.accessToken)
-  private def cookie = withAccount(_.cookie)
-
-  private def withAccount[A](f: AccountData => A): Future[A] = {
-    accStorage.find(id).map {
-      case Some(acc) => f(acc)
-      case _         => throw LoggedOutException
-    }
-  }
-
-  //Only performs safe update - never wipes either the cookie or the token.
-  private def updateCredentials(token: Option[AccessToken] = None, cookie: Option[Cookie] = None) = {
-    verbose(l"updateCredentials: $token, $cookie")
-    accStorage.update(id, acc => acc.copy(accessToken = if (token.isDefined) token else acc.accessToken, cookie = cookie.getOrElse(acc.cookie)))
-  }
-
-  private def wipeCredentials(): Future[Unit] = {
-    verbose(l"wipe credentials")
-    accStorage.deleteByKey(id)
-  }
-
-  def invalidateToken(): Future[Unit] = token.map(_.foreach(t => updateCredentials(Some(t.copy(expiresAt = Instant.EPOCH)))))
-
-  def isExpired(token: AccessToken): Boolean = (token.expiresAt - ExpireThreshold) isBefore clock.instant()
-
-  /**
-    * Returns current token if not expired or performs access request. Failing that, the user gets logged out
-    */
-  override def currentToken() = returning(Serialized.future("login-client") {
-    verbose(l"currentToken")
-    token.flatMap {
-      case Some(token) if !isExpired(token) =>
-        verbose(l"Non expired token: $token")
-        Future.successful(Right(token))
-      case token => cookie.flatMap { cookie =>
-        debug(l"Non existent or potentially expired token: $token, will attempt to refresh with cookie: $cookie")
-        dispatchRequest(client.access(cookie, token)) {
-          case Left(resp @ ErrorResponse(ResponseCode.Forbidden | ResponseCode.Unauthorized, message, label)) =>
-            verbose(l"access request failed (label: ${showString(label)}, message: ${showString(message)}, will try login request. currToken: $token, cookie: $cookie, access resp: $resp")
-            tracking.exception(new RuntimeException(s"Access request failed: msg: $message, label: $label, cookie expired at: ${cookie.expiry} (is valid: ${cookie.isValid}), currToken expired at: ${token.map(_.expiresAt)} (is valid: ${token.exists(_.isValid)})"), null)
-            wipeCredentials().map(_ => Left(resp))
-        }
-      }
-    }
-  }.recover {
-    case LoggedOutException =>
-      warn(l"Request failed as we are logged out")
-      Left(ErrorResponse.Unauthorized)
-  })(_.failed.foreach(throw _))
-
-  override def onPasswordReset(emailCredentials: Option[EmailCredentials]): ErrorOr[Unit] =
-    Serialized.future("login-client") {
-      verbose(l"onPasswordReset: $emailCredentials")
-      cookie.flatMap { cookie =>
-        debug(l"Attempting access request to see if cookie is still valid: $cookie")
-        dispatchRequest(client.access(cookie, None)) {
-          case Left(resp @ ErrorResponse(ResponseCode.Forbidden | ResponseCode.Unauthorized, _, _)) =>
-            emailCredentials match {
-              case Some(credentials) =>
-                client.login(credentials).flatMap {
-                  case Right(LoginResult(token, c, _)) => updateCredentials(Some(token), c).map(_ => Right(token))
-                  case Left(resp @ ErrorResponse(ResponseCode.Forbidden | ResponseCode.Unauthorized, _, _)) => wipeCredentials().map(_ => Left(resp)) //credentials didn't match - log user out
-                  case Left(err) => Future.successful(Left(err))
-                }
-              case None =>
-                verbose(l"Cookie is now invalid, and no credentials were supplied. The user will now be logged out")
-                wipeCredentials().map(_ => Left(resp))
-            }
-        }.map(_.right.map(_ => ()))
-      }
-    }
-
-  private def dispatchRequest(request: => ErrorOr[LoginResult], retryCount: Int = 0)(handler: ResponseHandler): ErrorOr[AccessToken] =
-    request.flatMap(handler.orElse {
-      case Right(LoginResult(token, cookie, _)) =>
-        debug(l"receivedAccessToken: '$token'")
-        updateCredentials(Some(token), cookie).map(_ => Right(token))
-
-      case Left(err @ ErrorResponse(Cancelled.code, msg, label)) =>
-        debug(l"request has been cancelled")
-        Future.successful(Left(err))
-
-      case Left(err) if retryCount < MaxRetryCount =>
-        info(l"Received error from request: $err, will retry")
-        dispatchRequest(request, retryCount + 1)(handler)
-
-      case Left(err) =>
-        error(l"Login request failed after $retryCount retries, last status: $err")
-        Future.successful(Left(err))
-    })
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/AuthRequestInterceptor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/AuthRequestInterceptor.scala
@@ -18,11 +18,11 @@
 package com.waz.znet2
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.sync.client.{AuthenticationManager, AuthenticationManager2}
+import com.waz.log.LogSE._
+import com.waz.sync.client.AuthenticationManager
 import com.waz.threading.CancellableFuture
 import com.waz.znet2.http.HttpClient.ProgressCallback
 import com.waz.znet2.http._
-import com.waz.log.LogSE._
 
 trait AuthRequestInterceptor extends RequestInterceptor
 
@@ -51,40 +51,6 @@ class AuthRequestInterceptorOld(authManager: AuthenticationManager, httpClient: 
       CancellableFuture.lift(authManager.invalidateToken()).flatMap { _ =>
         httpClient.execute(
           request.copy(interceptor = new AuthRequestInterceptorOld(authManager, httpClient, attеmptsIfAuthFailed - 1)),
-          uploadCallback,
-          downloadCallback
-        )
-      }
-    } else CancellableFuture.successful(response)
-
-}
-
-class AuthRequestInterceptorImpl(authManager: AuthenticationManager2,
-                                 httpClient: HttpClient,
-                                 attеmptsIfAuthFailed: Int = 1)
-    extends AuthRequestInterceptor with DerivedLogTag {
-
-  import com.waz.threading.Threading.Implicits.Background
-
-  override def intercept(request: Request[Body]): CancellableFuture[Request[Body]] =
-    CancellableFuture.lift(authManager.currentToken()).map {
-      case Right(token) =>
-        request.copy(headers = Headers(request.headers.headers ++ token.headers))
-      case Left(err) =>
-        throw new IllegalArgumentException(err.toString)
-    }
-
-  override def intercept(
-      request: Request[Body],
-      uploadCallback: Option[ProgressCallback],
-      downloadCallback: Option[ProgressCallback],
-      response: Response[Body]
-  ): CancellableFuture[Response[Body]] =
-    if (response.code == ResponseCode.Unauthorized && attеmptsIfAuthFailed > 0) {
-      verbose(l"Got 'Unauthorized' error. Retrying... Attempts left: ${attеmptsIfAuthFailed - 1}")
-      CancellableFuture.lift(authManager.invalidateToken()).flatMap { _ =>
-        httpClient.execute(
-          request.copy(interceptor = new AuthRequestInterceptorImpl(authManager, httpClient, attеmptsIfAuthFailed - 1)),
           uploadCallback,
           downloadCallback
         )

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/AuthRequestInterceptor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/AuthRequestInterceptor.scala
@@ -26,8 +26,7 @@ import com.waz.znet2.http._
 
 trait AuthRequestInterceptor extends RequestInterceptor
 
-@deprecated("Use [com.waz.znet2.AuthRequestInterceptorImpl] instead.", "?")
-class AuthRequestInterceptorOld(authManager: AuthenticationManager, httpClient: HttpClient, attеmptsIfAuthFailed: Int = 1)
+class AuthRequestInterceptorImpl(authManager: AuthenticationManager, httpClient: HttpClient, attеmptsIfAuthFailed: Int = 1)
     extends AuthRequestInterceptor with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Background
@@ -50,7 +49,7 @@ class AuthRequestInterceptorOld(authManager: AuthenticationManager, httpClient: 
       verbose(l"Got 'Unauthorized' error. Retrying... Attempts left: ${attеmptsIfAuthFailed - 1}")
       CancellableFuture.lift(authManager.invalidateToken()).flatMap { _ =>
         httpClient.execute(
-          request.copy(interceptor = new AuthRequestInterceptorOld(authManager, httpClient, attеmptsIfAuthFailed - 1)),
+          request.copy(interceptor = new AuthRequestInterceptorImpl(authManager, httpClient, attеmptsIfAuthFailed - 1)),
           uploadCallback,
           downloadCallback
         )

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
@@ -28,7 +28,7 @@ import com.waz.sync.client.{AuthenticationManager, LoginClient, LoginClientImpl}
 import com.waz.utils.TestUriHelper
 import com.waz.znet2.http.HttpClient
 import com.waz.znet2.http.Request.UrlCreator
-import com.waz.znet2.{AuthRequestInterceptorOld, HttpClientOkHttpImpl}
+import com.waz.znet2.{AuthRequestInterceptorImpl, HttpClientOkHttpImpl}
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -72,7 +72,7 @@ trait AuthenticationConfig {
     new AuthenticationManager(userInfo.id, accountsService, accountStorage, LoginClient, DisabledTrackingService)
   }
 
-  implicit lazy val authRequestInterceptor: AuthRequestInterceptorOld = new AuthRequestInterceptorOld(AuthenticationManager, HttpClient)
+  implicit lazy val authRequestInterceptor: AuthRequestInterceptorImpl = new AuthRequestInterceptorImpl(AuthenticationManager, HttpClient)
 
   lazy val uriHelper: UriHelper = new TestUriHelper
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
@@ -16,21 +16,23 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package com.waz
+import java.util.concurrent.TimeUnit
+
 import com.waz.api.{Credentials, EmailCredentials}
-import com.waz.content.AccountStorage2
+import com.waz.content.AccountStorage
 import com.waz.model.AccountData.Password
-import com.waz.model.{AccountData, EmailAddress, UserId}
-import com.waz.service.MetaDataService
+import com.waz.model.{AccountData, EmailAddress}
+import com.waz.service.AccountsService
 import com.waz.service.assets2.UriHelper
-import com.waz.sync.client.{AuthenticationManager2, LoginClient, LoginClientImpl}
-import com.waz.utils.{TestUriHelper, UnlimitedInMemoryStorage}
+import com.waz.sync.client.{AuthenticationManager, LoginClient, LoginClientImpl}
+import com.waz.utils.TestUriHelper
 import com.waz.znet2.http.HttpClient
 import com.waz.znet2.http.Request.UrlCreator
-import com.waz.znet2.{AuthRequestInterceptorImpl, HttpClientOkHttpImpl, OkHttpUserAgentInterceptor}
+import com.waz.znet2.{AuthRequestInterceptorOld, HttpClientOkHttpImpl}
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
 
 trait AuthenticationConfig {
 
@@ -44,13 +46,16 @@ trait AuthenticationConfig {
 
   private val LoginClient: LoginClient = new LoginClientImpl(DisabledTrackingService)
 
-  lazy val AuthenticationManager: AuthenticationManager2 = {
-    val loginResult = Await.result(LoginClient.login(testCredentials), 1.minute) match {
+  val accountsService: AccountsService
+  val accountStorage: AccountStorage
+
+  lazy val AuthenticationManager: AuthenticationManager = {
+    val loginResult = Await.result(LoginClient.login(testCredentials), new FiniteDuration(1, TimeUnit.MINUTES)) match {
       case Right(result) => result
       case Left(errResponse) => throw errResponse
     }
 
-    val userInfo = Await.result(LoginClient.getSelfUserInfo(loginResult.accessToken), 1.minute) match {
+    val userInfo = Await.result(LoginClient.getSelfUserInfo(loginResult.accessToken), new FiniteDuration(1, TimeUnit.MINUTES)) match {
       case Right(result) => result
       case Left(errResponse) => throw errResponse
     }
@@ -62,14 +67,15 @@ trait AuthenticationConfig {
       accessToken = Some(loginResult.accessToken)
     )
 
-    val accountStorage = new UnlimitedInMemoryStorage[UserId, AccountData] with AccountStorage2
-    Await.ready(accountStorage.save(testAccountData), 1.minute)
+    setUpAccountData(testAccountData)
 
-    new AuthenticationManager2(userInfo.id, accountStorage, LoginClient, DisabledTrackingService)
+    new AuthenticationManager(userInfo.id, accountsService, accountStorage, LoginClient, DisabledTrackingService)
   }
 
-  implicit lazy val authRequestInterceptor: AuthRequestInterceptorImpl = new AuthRequestInterceptorImpl(AuthenticationManager, HttpClient)
+  implicit lazy val authRequestInterceptor: AuthRequestInterceptorOld = new AuthRequestInterceptorOld(AuthenticationManager, HttpClient)
 
   lazy val uriHelper: UriHelper = new TestUriHelper
+
+  def setUpAccountData(accountData: AccountData)
 
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
@@ -21,11 +21,13 @@ import java.io._
 import java.net.URI
 
 import com.waz.api.impl.ErrorResponse
+import com.waz.content.AccountStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.log.LogSE._
+import com.waz.log.LogSE.{debug, _}
 import com.waz.log.LogShow
 import com.waz.model.errors.NotFoundLocal
-import com.waz.model.{AssetId, Mime, Sha256, UploadAssetId}
+import com.waz.model.{AccountData, AssetId, Mime, Sha256, UploadAssetId}
+import com.waz.service.AccountsService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.AssetClient2.{FileWithSha, Retention}
 import com.waz.sync.client.{AssetClient2, AssetClient2Impl}
@@ -39,7 +41,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Random, Success}
 
 @RunWith(classOf[JUnitRunner])
-class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig with DerivedLogTag {
+class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with AuthenticationConfig {
 
   private val assetStorage        = mock[AssetStorage]
   private val inProgressAssetStorage   = mock[DownloadAssetStorage]
@@ -53,6 +55,9 @@ class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig wi
   private val client              = mock[AssetClient2]
   private val uriHelperMock       = mock[UriHelper]
   private val syncHandle          = mock[SyncServiceHandle]
+
+  override val accountsService: AccountsService = mock[AccountsService]
+  override val accountStorage: AccountStorage = mock[AccountStorage]
 
   private val testAssetContent = returning(Array.ofDim[Byte](128))(Random.nextBytes)
 
@@ -286,4 +291,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig wi
 
   }
 
+  override def setUpAccountData(accountData: AccountData): Unit = {
+    (accountStorage.get _).expects(*).anyNumberOfTimes().returning(Future.successful(Some(accountData)))
+  }
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/AssetClient2Spec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/AssetClient2Spec.scala
@@ -19,6 +19,7 @@ package com.waz.sync.client
 
 import java.io.ByteArrayInputStream
 
+import com.waz.ZIntegrationMockSpec
 import com.waz.api.impl.ErrorResponse
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
@@ -27,7 +28,9 @@ import com.waz.service.assets2.{Asset, BlobDetails, NoEncryption}
 import com.waz.sync.client.AssetClient.FileWithSha
 import com.waz.sync.client.AssetClient2.{AssetContent, Metadata, Retention, UploadResponse2}
 import com.waz.utils.{IoUtils, returning}
-import com.waz.{AuthenticationConfig, ZIntegrationSpec}
+import com.waz.znet2.AuthRequestInterceptor
+import com.waz.znet2.http.Request.UrlCreator
+import com.waz.znet2.http.{HttpClient, Request}
 import org.junit.runner.RunWith
 import org.scalatest.Ignore
 import org.scalatest.junit.JUnitRunner
@@ -38,7 +41,11 @@ import scala.util.Random
 //TODO Think about tests resources cleanup
 @Ignore
 @RunWith(classOf[JUnitRunner])
-class AssetClient2Spec extends ZIntegrationSpec with AuthenticationConfig with DerivedLogTag {
+class AssetClient2Spec extends ZIntegrationMockSpec with DerivedLogTag {
+
+  implicit lazy val urlCreator : Request.UrlCreator = mock[UrlCreator]
+  implicit lazy val httpClient = mock[HttpClient]
+  implicit lazy val authRequestInterceptor = mock[AuthRequestInterceptor]
 
   private lazy val assetClient = new AssetClient2Impl()
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/GiphyClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/GiphyClientSpec.scala
@@ -17,10 +17,13 @@
  */
 package com.waz.sync.client
 
+import com.waz.ZIntegrationMockSpec
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.{AuthenticationConfig, ZIntegrationSpec}
 import com.waz.log.LogSE._
 import com.waz.utils.RichSeq
+import com.waz.znet2.AuthRequestInterceptor
+import com.waz.znet2.http.Request.UrlCreator
+import com.waz.znet2.http.{HttpClient, Request}
 import org.junit.runner.RunWith
 import org.scalatest.Ignore
 import org.scalatest.junit.JUnitRunner
@@ -29,7 +32,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 @Ignore
 @RunWith(classOf[JUnitRunner])
-class GiphyClientSpec extends ZIntegrationSpec with AuthenticationConfig with DerivedLogTag {
+class GiphyClientSpec extends ZIntegrationMockSpec with DerivedLogTag {
+
+  implicit lazy val urlCreator : Request.UrlCreator = mock[UrlCreator]
+  implicit lazy val httpClient = mock[HttpClient]
+  implicit lazy val authRequestInterceptor = mock[AuthRequestInterceptor]
 
   private lazy val giphyClient = new GiphyClientImpl()
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

AccountStorage2 and "new" AuthRequestInterceptor classes were not used in production code and were only accessed by tests. Removed these redundant classes and modifies test code to use mocks and classes used in production code.

### Causes

These 2nd generation classes were created to replace the old ones but never made it that far. Since we're planning to write the network layer from scratch, there is no need to enforce a migration for them, they can be basically deleted and we can move on with the old implementations.

### Testing

There's no change in production code. The unit tests are fixed to use the original implementations.


#### APK
[Download build #572](http://10.10.124.11:8080/job/Pull%20Request%20Builder/572/artifact/build/artifact/wire-dev-PR2471-572.apk)