### PR TITLE
Fix/delete session keys on wipe

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -530,8 +530,8 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
   private def databaseFiles(ams: Set[AccountManager]): Set[File] = ams.flatMap(acc => databaseFiles(acc.userId))
 
   private def databaseFiles(userId: UserId): Set[File] = {
-    val database = context.getDatabasePath(userId.str)
-    DbFileExtensions.map(ext => new File(s"${database.getAbsolutePath}$ext")).toSet
+    val databaseDir = s"${context.getApplicationInfo.dataDir}/databases"
+    new File(databaseDir).listFiles().filter(_.isFile).toSet
   }
 
   private def otrFilesDir(userId: UserId): Directory =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -39,6 +39,7 @@ import com.waz.utils.{Serialized, returning, _}
 
 import scala.async.Async.{async, await}
 import scala.concurrent.Future
+import scala.reflect.io.Directory
 import scala.util.control.NonFatal
 import scala.util.{Right, Try}
 
@@ -513,6 +514,7 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
 
     delete(cryptoBoxDir(userId))
     databaseFiles(userId).foreach(delete)
+    if(!otrFilesDir(userId).deleteRecursively()) warn(l"Failed to delete otr files, skipping")
     logout(userId, DataWiped)
 
   }
@@ -531,6 +533,9 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
     val database = context.getDatabasePath(userId.str)
     DbFileExtensions.map(ext => new File(s"${database.getAbsolutePath}$ext")).toSet
   }
+
+  private def otrFilesDir(userId: UserId): Directory =
+    new Directory(new File(s"${context.getApplicationInfo.dataDir}/files/otr/$userId"))
 
 }
 


### PR DESCRIPTION
### Issues

Session files, prekeys and the global DB were not being deleted when the account info was wiped. [More info here](https://wearezeta.atlassian.net/browse/AN-6459)

### Causes

These files were overlooked as they need to be inspected manually to ensure they are gone.

### Testing

Manual testing was done to verify the session files folder is deleted. Testing was also done to ensure that logging in was possible again even after wiping all the databases.
#### APK
[Download build #583](http://10.10.124.11:8080/job/Pull%20Request%20Builder/583/artifact/build/artifact/wire-dev-PR2472-583.apk)