### PR TITLE
fix: enforce password policy for backup passwords

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1280,7 +1280,6 @@
     <string name="backup_password_dialog_message">The backup will be compressed, and if you set a password, also encrypted. Make sure to store it in a secure place.</string>
     <string name="backup_password_dialog_ok">OK</string>
     <string name="backup_password_dialog_no_password">Cancel</string>
-    <string name="backup_password_dialog_invalid_pass">Password does not conform to password policy</string>
 
     <string name="add_email_address">Add your email address</string>
     <string name="set_a_password">Set a password</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1280,6 +1280,7 @@
     <string name="backup_password_dialog_message">The backup will be compressed, and if you set a password, also encrypted. Make sure to store it in a secure place.</string>
     <string name="backup_password_dialog_ok">OK</string>
     <string name="backup_password_dialog_no_password">Cancel</string>
+    <string name="backup_password_dialog_invalid_pass">Password does not conform to password policy</string>
 
     <string name="add_email_address">Add your email address</string>
     <string name="set_a_password">Set a password</string>

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
@@ -73,7 +73,7 @@ class BackupPasswordDialog extends DialogFragment with FragmentHelper with Deriv
           val pass = passwordEditText.getText.toString
           if (!BuildConfig.FORCE_APP_LOCK) {
             providePassword(if(pass.isEmpty) None else Some(Password(pass)))
-          } else if(BuildConfig.FORCE_APP_LOCK && isValidPassword(pass)) {
+          } else if(isValidPassword(pass)) {
             providePassword(Some(Password(pass)))
           } else {
             textInputLayout.setError(getString(R.string.password_policy_hint, minPasswordLength))

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
@@ -39,6 +39,7 @@ class BackupPasswordDialog extends DialogFragment with FragmentHelper with Deriv
 
   private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.backup_password_dialog, null)
 
+  val minPasswordLength = BuildConfig.NEW_PASSWORD_MINIMUM_LENGTH
   private lazy val strongPasswordValidator =
     PasswordValidator.createStrongPasswordValidator(BuildConfig.NEW_PASSWORD_MINIMUM_LENGTH, BuildConfig.NEW_PASSWORD_MAXIMUM_LENGTH)
 
@@ -75,7 +76,7 @@ class BackupPasswordDialog extends DialogFragment with FragmentHelper with Deriv
           } else if(BuildConfig.FORCE_APP_LOCK && isValidPassword(pass)) {
             providePassword(Some(Password(pass)))
           } else {
-            textInputLayout.setError(getString(R.string.backup_password_dialog_invalid_pass))
+            textInputLayout.setError(getString(R.string.password_policy_hint, minPasswordLength))
           }
         }
       })

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
@@ -62,7 +62,7 @@ class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
 
   def requestPassword(): Future[Unit] = {
     val fragment = returning(new BackupPasswordDialog)(
-      _.onPasswordEntered { p => verbose(l"Got password: $p"); backupData(p) }
+      _.onPasswordEntered(backupData)
     )
     context.asInstanceOf[BaseActivity]
       .getSupportFragmentManager


### PR DESCRIPTION
### Issues

This PR enforces the password policy for backup passwords on builds that have the `FORCE_APP_LOCK` flag set.

### Causes

Originally, no backup password was ever needed. However, on clients which enforce a password policy, this is undesirable.

### Solutions

We use the same machinery to check the password against the policy as we do for Wire account passwords.

### Testing

Manual testing was done.
#### APK
[Download build #586](http://10.10.124.11:8080/job/Pull%20Request%20Builder/586/artifact/build/artifact/wire-dev-PR2474-586.apk)
[Download build #594](http://10.10.124.11:8080/job/Pull%20Request%20Builder/594/artifact/build/artifact/wire-dev-PR2474-594.apk)
[Download build #633](http://10.10.124.11:8080/job/Pull%20Request%20Builder/633/artifact/build/artifact/wire-dev-PR2474-633.apk)