### PR TITLE
refactor: harden account wiping code

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -29,7 +29,6 @@ import com.waz.log.LogShow.SafeToLog
 import com.waz.model.AccountData.Password
 import com.waz.model._
 import com.waz.service.backup.BackupManager
-import com.waz.service.tracking.LoggedOutEvent
 import com.waz.sync.client.AuthenticationManager.{AccessToken, Cookie}
 import com.waz.sync.client.{ErrorOr, LoginClient}
 import com.waz.sync.client.LoginClient.LoginResult
@@ -512,11 +511,20 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
     def delete(file: File) =
       if (file.exists) Try(file.delete()).isSuccess else true
 
-    delete(cryptoBoxDir(userId))
-    databaseFiles(userId).foreach(delete)
-    if(!otrFilesDir(userId).deleteRecursively()) warn(l"Failed to delete otr files, skipping")
-    logout(userId, DataWiped)
+    val deleteCryptoDir = Try(delete(cryptoBoxDir(userId)))
+    if(deleteCryptoDir.isFailure) error(l"failed to wipe cryptobox dir", deleteCryptoDir.failed.get)
 
+    val deleteDbFiles = Try(databaseFiles(userId).foreach(delete))
+    if(deleteDbFiles.isFailure) error(l"failed to wipe db files", deleteCryptoDir.failed.get)
+
+    val deleteOtrFiles = Try(otrFilesDir(userId).deleteRecursively())
+    if(deleteOtrFiles.isFailure) {
+      error(l"Got exception when attempting to delete otr files", deleteOtrFiles.failed.get)
+    } else if(deleteOtrFiles.isSuccess && !deleteOtrFiles.get) {
+      error(l"Failed to delete otr files")
+    }
+
+    logout(userId, DataWiped)
   }
 
   override def isWipedForAllAccounts: Future[Boolean] = accountManagers.head.map { ams =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -511,6 +511,8 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
     def delete(file: File) =
       if (file.exists) Try(file.delete()).isSuccess else true
 
+    //wrap everything in Try blocks as otherwise exceptions might cause us to skip future wiping
+    //operations and the logout call
     val deleteCryptoDir = Try(delete(cryptoBoxDir(userId)))
     if(deleteCryptoDir.isFailure) error(l"failed to wipe cryptobox dir", deleteCryptoDir.failed.get)
 


### PR DESCRIPTION
### Issues

The `wipeData` method in the `AccountsService` would abort account wiping and logout, allowing a user to bypass the account lock and gain full access to Wire, if an exception was thrown during the execution of `wipeData`. [A ticket for the issue is here](https://wearezeta.atlassian.net/browse/AN-6541).

### Causes

Thrown exceptions, for example from file operations, would cause the whole method to abort, skipping the logout check and further wiping steps.

### Solutions

The method was rewritten to wrap all risky operations in `Try` constructs. This way, we can skip failing steps and always continue to at least logging the user out, if we are unable to wipe all the data. Unfortunately, this means the method is less easy to read now, but I think in this case it makes sense to harden this particular method given the security risk. I'm open to suggestions for making it all nicer. 

### Testing

Testing was done manually.
#### APK
[Download build #616](http://10.10.124.11:8080/job/Pull%20Request%20Builder/616/artifact/build/artifact/wire-dev-PR2479-616.apk)