### PR TITLE
add permissions check for calling notification

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -393,6 +393,7 @@ class CallingServiceImpl(val accountId:       UserId,
           else if (isVideo) Avs.WCallType.Video
           else Avs.WCallType.Normal
         convType = if (isGroup) Avs.WCallConvType.Group else Avs.WCallConvType.OneOnOne
+        _ <- permissions.ensurePermissions(ListSet(android.Manifest.permission.RECORD_AUDIO) ++ (if(forceOption && isVideo) ListSet(android.Manifest.permission.CAMERA) else ListSet()))
         _ <-
           profile.activeCall match {
             case Some(call) if call.convId == convId =>


### PR DESCRIPTION
### Issues

When accepting an incoming call from the notification, there was no check made for the required permissions, resulting in a silent failure to accept the call, or a crash. This PR adds the required permissions check. [Fixes AN-6542](https://wearezeta.atlassian.net/browse/AN-6542)

### Testing

Testing was done manually, on Android 10 in emulator, and Android 9 on a real device.
#### APK
[Download build #628](http://10.10.124.11:8080/job/Pull%20Request%20Builder/628/artifact/build/artifact/wire-dev-PR2488-628.apk)