### PR TITLE
small typo in github readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to build Wire for Android locally, it is necessary to install the follo
 ## How to build locally
 
 1. Check out the `wire-android` repository.
-2. Switch to latest relase branch `release`
+2. Switch to latest release branch `release`
 3. From the checkout folder, run `./gradlew assembleProdRelease`. This will pull in all the necessary dependencies from Maven.
 
 These steps will build only the Wire client UI, pulling in all other Wire frameworks from Maven. If you want to modify the source/debug other Wire frameworks, you can check project dependencies and build other wire projects separately. The most interesting projects to check are:


### PR DESCRIPTION
## What's new in this PR?

### Issues

Small typo in github readme 

### Causes

Release is spelt wrong 

### Solutions

Fix typo 
#### APK
[Download build #656](http://10.10.124.11:8080/job/Pull%20Request%20Builder/656/artifact/build/artifact/wire-dev-PR2489-656.apk)