### PR TITLE
fix: flaky test in SignalSpec

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
@@ -26,7 +26,6 @@ import com.waz.specs.AndroidFreeSpec.DefaultTimeout
 import com.waz.testutils.Implicits._
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.prop.PropertyChecks
 
 import scala.collection.JavaConverters._
 import scala.concurrent._
@@ -202,6 +201,7 @@ class SignalSpec extends AndroidFreeSpec with DerivedLogTag with Eventually {
       } yield y * 2
       r(capture)
       eventually { r.currentValue.get shouldEqual 2 }
+      eventually { received shouldEqual Seq(2) }
 
       // when
       s ! 1


### PR DESCRIPTION
### Issues

SignalSpec was failing about 1/3 of the time. Ticket: [AN-6566](https://wearezeta.atlassian.net/browse/AN-6566)

### Causes

Since this is a recurring issue, I'll give some background for future maintainers. When I disabled all tests except the flaky one, I managed to reproduce the exception(an example of this is in the ticket) in the for comprehension test reliably. Then from printing out state inside the `eventually` block on line 204, it became clear that `received` wasn't actually being updated with the value 2 until several attempts had been made. So it seems that the value 2 wasn't being saved in `received` until a considerable delay, by which point the final `eventually` block on line 211 had failed.

### Solutions

Checking for the state required before proceeding using an `eventually` block seems to do the trick.
#### APK
[Download build #665](http://10.10.124.11:8080/job/Pull%20Request%20Builder/665/artifact/build/artifact/wire-dev-PR2491-665.apk)