### PR TITLE
Fix for conversation roles in UserSearch and ConversationList

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
@@ -81,6 +81,8 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
         decodeBitmask(bitmask)
       }
 
+  lazy val isAdmin: Signal[Boolean] = selfPermissions.map(AdminPermissions.subsetOf)
+
   lazy val isExternal: Signal[Boolean] =
     selfPermissions
       .map(ps => ExternalPermissions.subsetOf(ps) && ExternalPermissions.size == ps.size)
@@ -92,6 +94,13 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
   }
 
   lazy val readReceiptsEnabled: Signal[Boolean] = zms.flatMap(_.propertiesService.readReceiptsEnabled)
+
+  def hasPermissionToAddService: Future[Boolean] = {
+    for {
+      tId <- teamId.head
+      ps  <- selfPermissions.head
+    } yield tId.isDefined && ps.contains(AddConversationMember)
+  }
 
   def isTeamMember(userId: UserId) =
     for {

--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -29,8 +29,8 @@ import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.waz.utils.events.{ClockSignal, Signal}
 import com.waz.utils.returning
+import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.common.controllers.global.{AccentColorController, KeyboardController}
-import com.waz.zclient.common.controllers.{ThemeController, UserAccountsController}
 import com.waz.zclient.connect.PendingConnectRequestFragment.ArgUserRequester
 import com.waz.zclient.controllers.navigation.{INavigationController, Page}
 import com.waz.zclient.conversation.ConversationController
@@ -64,14 +64,13 @@ class SendConnectRequestFragment
   private lazy val userToConnectId = UserId(getArguments.getString(ArgumentUserId))
   private lazy val userRequester = UserRequester.valueOf(getArguments.getString(ArgumentUserRequester))
 
-  private lazy val usersController = inject[UsersController]
-  private lazy val userAccountsController = inject[UserAccountsController]
+  private lazy val usersController        = inject[UsersController]
   private lazy val conversationController = inject[ConversationController]
-  private lazy val keyboardController = inject[KeyboardController]
-  private lazy val accentColorController = inject[AccentColorController]
-  private lazy val zms = inject[Signal[ZMessaging]]
-  private lazy val themeController = inject[ThemeController]
-  private lazy val navController = inject[INavigationController]
+  private lazy val keyboardController     = inject[KeyboardController]
+  private lazy val accentColorController  = inject[AccentColorController]
+  private lazy val zms                    = inject[Signal[ZMessaging]]
+  private lazy val themeController        = inject[ThemeController]
+  private lazy val navController          = inject[INavigationController]
 
   private lazy val user = usersController.user(userToConnectId)
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -31,7 +31,7 @@ import com.waz.model._
 import com.waz.model.otr.Client
 import com.waz.service.assets2.{Content, ContentForUpload, UriHelper}
 import com.waz.service.conversation.{ConversationsService, ConversationsUiService, SelectedConversationService}
-import com.waz.service.{AccountManager, ConversationRolesService}
+import com.waz.service.AccountManager
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue, Threading}
 import com.waz.utils.events.{EventContext, EventStream, Signal, SourceStream}
 import com.waz.utils.{Serialized, returning, _}
@@ -62,7 +62,6 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
   private lazy val conversations         = inject[Signal[ConversationsService]]
   private lazy val convsStorage          = inject[Signal[ConversationStorage]]
   private lazy val membersStorage        = inject[Signal[MembersStorage]]
-  private lazy val rolesService          = inject[Signal[ConversationRolesService]]
   private lazy val usersStorage          = inject[Signal[UsersStorage]]
   private lazy val otrClientsStorage     = inject[Signal[OtrClientsStorage]]
   private lazy val account               = inject[Signal[Option[AccountManager]]]
@@ -70,7 +69,7 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
   private lazy val convListController    = inject[ConversationListController]
   private lazy val uriHelper             = inject[UriHelper]
   private lazy val accentColorController = inject[AccentColorController]
-  private lazy val selfId                =  inject[Signal[UserId]]
+  private lazy val selfId                = inject[Signal[UserId]]
 
   private var lastConvId = Option.empty[ConvId]
 
@@ -108,36 +107,35 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
 
   val currentConvIsTeamOnly: Signal[Boolean] = currentConv.map(_.isTeamOnly)
 
-  lazy val currentConvOtherMembers: Signal[Map[UserId, ConversationRole]] =
-    selfId.flatMap(selfId => currentConvMembers.map(_.filter(_._1 != selfId)))
+  lazy val currentConvOtherMembers: Signal[Map[UserId, ConversationRole]] = for {
+    selfId  <- selfId
+    members <- currentConvMembers
+  } yield members.filter(_._1 != selfId)
 
-  lazy val currentConvMembers: Signal[Map[UserId, ConversationRole]] = currentConvId.flatMap(convMembers)
+  lazy val currentConvMembers: Signal[Map[UserId, ConversationRole]] =
+    for {
+      convId  <- currentConvIdOpt
+      _       =  if (convId.isEmpty) warn(l"Current conversation members queried in the context without the current conversation set")
+      members <- convId.fold(Signal.const(Map.empty[UserId, ConversationRole]))(convMembers)
+    } yield members
 
   def convMembers(convId: ConvId): Signal[Map[UserId, ConversationRole]] = for {
     convs          <- conversations
-    rolesStorage   <- rolesService
-    roles          <- rolesStorage.rolesByConvId(convId)
-    members        <- convs.getActiveMembersData(convId)
+    members        <- convs.activeMembersData(convId)
   } yield members.map(m => m.userId -> ConversationRole.getRole(m.role)).toMap
 
   lazy val selfRole: Signal[ConversationRole] =
-    selfId.flatMap(selfId => currentConvMembers.map(_.getOrElse(selfId, ConversationRole.MemberRole)))
+    for {
+      selfId  <- selfId
+      members <- currentConvMembers
+      _       =  if (!members.contains(selfId)) warn(l"No role specified for the self user")
+    } yield members.getOrElse(selfId, ConversationRole.MemberRole)
 
   def selfRoleInConv(convId: ConvId): Signal[ConversationRole] = for {
     selfId  <- selfId
     members <- convMembers(convId)
+    _       =  if (!members.contains(selfId)) warn(l"No role specified for the self user")
   } yield members.getOrElse(selfId, ConversationRole.MemberRole)
-
-  def setSelfRole(convId: ConvId, role: ConversationRole): Future[Unit] = for {
-    convs  <- conversations.head
-    selfId <- selfId.head
-  } yield convs.setConversationRole(convId, selfId, role)
-
-  def setSelfRole(role: ConversationRole): Future[Unit] = for {
-    convs  <- conversations.head
-    selfId <- selfId.head
-    convId <- currentConvId.head
-  } yield convs.setConversationRole(convId, selfId, role)
 
   def setRoleInCurrentConv(userId: UserId, role: ConversationRole): Future[Unit] = for {
     convs  <- conversations.head
@@ -155,7 +153,6 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
     case None =>
       convChanged ! ConversationChange(from = lastConvId, to = None, requester = ConversationChangeRequester.DELETE_CONVERSATION)
       lastConvId = None
-
   }
 
   // this should be the only UI entry point to change conv in SE

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -129,10 +129,10 @@ class AddParticipantsFragment extends FragmentHelper {
 
   private lazy val emptyServicesButton = returning(view[TypefaceTextView](R.id.empty_services_button)) { vh =>
     (for {
-      canAddServices <- newConvController.canAddServices
-      res            <- adapter.searchResults
+      isAdmin <- userAccounts.isAdmin
+      res     <- adapter.searchResults
     } yield res match {
-      case AddUserListState.NoServices if canAddServices => View.VISIBLE
+      case AddUserListState.NoServices if isAdmin => View.VISIBLE
       case _ => View.GONE
     }).onUi(vis => vh.foreach(_.setVisibility(vis)))
 
@@ -146,12 +146,12 @@ class AddParticipantsFragment extends FragmentHelper {
     }.onUi(vis => vh.foreach(_.setVisibility(vis)))
 
     (for {
-      canAddServices <- newConvController.canAddServices
-      res            <- adapter.searchResults
+      isAdmin <- userAccounts.isAdmin
+      res     <- adapter.searchResults
     } yield res match {
       case AddUserListState.NoUsers               => R.string.new_conv_no_contacts
       case AddUserListState.NoUsersFound          => R.string.new_conv_no_results
-      case AddUserListState.NoServices if canAddServices => R.string.empty_services_list_admin
+      case AddUserListState.NoServices if isAdmin => R.string.empty_services_list_admin
       case AddUserListState.NoServices            => R.string.empty_services_list
       case AddUserListState.NoServicesFound       => R.string.no_matches_found
       case AddUserListState.LoadingServices       => R.string.loading_services

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
@@ -53,8 +53,6 @@ class CreateConversationController(implicit inj: Injector, ev: EventContext)
   val readReceipts = Signal(true)
   val fromScreen = Signal[GroupConversationEvent.Method]()
 
-  val canAddServices: Signal[Boolean] = conversationController.selfRole.map(_.canAddGroupMember)
-
   teamOnly.onChanged {
     case true =>
       for {

--- a/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
@@ -113,11 +113,13 @@ class IntegrationDetailsFragment extends FragmentHelper {
     returning(findById[TypefaceTextView](R.id.integration_summary))(v => summary.foreach(v.setText(_)))
     returning(findById[TypefaceTextView](R.id.integration_description))(v => description.foreach(v.setText(_)))
 
-    fromConv.fold(
-      convController.selfRole.map(_.canAddGroupMember)
-    )(convId =>
-      convController.selfRoleInConv(convId).map(_.canRemoveGroupMember)
-    ).foreach {
+    // FIXME: we use the same button for adding and removing services...
+    val showAddRemoveButton = fromConv match {
+      case Some(id) => convController.selfRoleInConv(id).map(_.canRemoveGroupMember).head
+      case _        => userAccountsController.hasPermissionToAddService
+    }
+
+    showAddRemoveButton.foreach {
       case true =>
         addRemoveButtonText.foreach { v =>
           v.setText(if (isRemovingFromConv) R.string.remove_service_button_text else R.string.open_service_conversation_button_text)

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -54,7 +54,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   val onShowUser = EventStream[Option[UserId]]()
 
   lazy val otherParticipants: Signal[Map[UserId, ConversationRole]] = convController.currentConvOtherMembers
-  lazy val participants: Signal[Map[UserId, ConversationRole]] = convController.currentConvMembers
+  lazy val participants: Signal[Map[UserId, ConversationRole]]      = convController.currentConvMembers
   lazy val conv: Signal[ConversationData]                           = convController.currentConv
   lazy val isGroup: Signal[Boolean]                                 = convController.currentConvIsGroup
   lazy val selfRole: Signal[ConversationRole]                       = convController.selfRole

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -156,10 +156,10 @@ class SearchUIFragment extends BaseFragment[Container]
 
   private lazy val emptyServicesButton = returning(view[TypefaceTextView](R.id.empty_services_button)) { vh =>
     subs += (for {
-      canAddServices  <- conversationController.selfRole.map(_.canAddGroupMember)
-      res             <- searchController.searchUserOrServices
+      isAdmin <- userAccountsController.isAdmin
+      res     <- searchController.searchUserOrServices
     } yield res match {
-      case SearchUserListState.NoServices if canAddServices => View.VISIBLE
+      case SearchUserListState.NoServices if isAdmin => View.VISIBLE
       case _ => View.GONE
     }).onUi(vis => vh.foreach(_.setVisibility(vis)))
 
@@ -173,12 +173,12 @@ class SearchUIFragment extends BaseFragment[Container]
     }.onUi(vis => vh.foreach(_.setVisibility(vis)))
 
     subs += (for {
-      canAddServices  <- conversationController.selfRole.map(_.canAddGroupMember)
-      res             <- searchController.searchUserOrServices
+      isAdmin <- userAccountsController.isAdmin
+      res     <- searchController.searchUserOrServices
     } yield res match {
       case SearchUserListState.NoUsers               => R.string.new_conv_no_contacts
       case SearchUserListState.NoUsersFound          => R.string.new_conv_no_results
-      case SearchUserListState.NoServices if canAddServices => R.string.empty_services_list_admin
+      case SearchUserListState.NoServices if isAdmin => R.string.empty_services_list_admin
       case SearchUserListState.NoServices            => R.string.empty_services_list
       case SearchUserListState.NoServicesFound       => R.string.no_matches_found
       case SearchUserListState.LoadingServices       => R.string.loading_services
@@ -232,9 +232,7 @@ class SearchUIFragment extends BaseFragment[Container]
       rv.setAdapter(adapter)
     }
 
-    retrieveSearchResults.resultsData.onUi { results =>
-       adapter.updateResults(results)
-    }
+    retrieveSearchResults.resultsData.onUi(adapter.updateResults)
 
     searchBox
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -62,16 +62,15 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   val resultsData = Signal(mergedResult)
 
   (for {
-    curUser        <- userAccountsController.currentUser
-    teamData       <- userAccountsController.teamData
-    canAddServices <- convController.selfRole.map(_.canAddGroupMember)
-    results        <- searchController.searchUserOrServices
-  } yield (curUser, teamData, canAddServices, results)).onUi {
-    case (curUser, teamData, canAddServices, results) =>
-
+    curUser  <- userAccountsController.currentUser
+    teamData <- userAccountsController.teamData
+    isAdmin  <- userAccountsController.isAdmin
+    results  <- searchController.searchUserOrServices
+  } yield (curUser, teamData, isAdmin, results)).onUi {
+    case (curUser, teamData, isAdmin, results) =>
       verbose(l"Search user list state: $results")
       team = teamData
-      currentUserCanAddServices = canAddServices
+      currentUserCanAddServices = isAdmin
       currentUser = curUser
 
       results match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -119,7 +119,6 @@ class AccountManager(val userId:   UserId,
       cId     <- clientId.collect { case Some(id) => id }.head
       Some(_) <- checkCryptoBox()
     } yield {
-      verbose(l"Creating new ZMessaging instance for $userId, $cId, $teamId")
       global.factory.zmessaging(teamId, cId, this, storage, cryptoBox)
     }
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -48,7 +48,7 @@ trait ConversationsService {
   def content: ConversationsContentUpdater
   def convStateEventProcessingStage: EventScheduler.Stage
   def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0): Future[Any]
-  def getActiveMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]]
+  def activeMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]]
   def getSelfConversation: Future[Option[ConversationData]]
   def updateConversationsWithDeviceStartMessage(conversations: Seq[ConversationResponse], roles: Map[RConvId, Set[ConversationRole]]): Future[Unit]
   def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit]
@@ -247,7 +247,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     case _ => successful(())
   }
 
-  override def getActiveMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]] = {
+  override def activeMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]] = {
     val onConvMemberDataChanged =
       membersStorage
         .onChanged.map(_.filter(_.convId == conv).map(m => m.userId -> (Option(m), true)))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -135,8 +135,10 @@ class TeamsServiceImpl(selfUser:           UserId,
   }
 
   override lazy val selfTeam: Signal[Option[TeamData]] = teamId match {
-    case None => Signal.const[Option[TeamData]](None)
-    case Some(id) => new RefreshingSignal(CancellableFuture.lift(teamStorage.get(id)), teamStorage.onChanged.map(_.map(_.id)))
+    case None =>
+      Signal.const[Option[TeamData]](None)
+    case Some(id) =>
+      new RefreshingSignal(CancellableFuture.lift(teamStorage.get(id)), teamStorage.onChanged.map(_.map(_.id)))
   }
 
   override lazy val guests: Signal[Set[UserId]] = {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
@@ -293,6 +293,7 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
       (receiptStorage.removeAllForMessages _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (folders.removeConversationFromAll _).expects(convId, false).anyNumberOfTimes().returning(Future.successful(()))
+      (rolesService.rolesByConvId _).expects(convId).anyNumberOfTimes().returning(Signal.const(Set.empty))
 
       // WHEN
       result(service.convStateEventProcessingStage.apply(rConvId, events))


### PR DESCRIPTION
The bug was caused by using conversation roles when `currentConvId` was not yet set - after the first start of the app. On top of conversation roles we have the team roles. Sometimes the two overlap and that was the source of confusion.For example, in the User Search, we should use team roles to check if the user is able to add services to a conversation,not the conversation roles.

In the process of fixing I made some small changes to `IntegrationDetailsFragment`, but I decided not to rewrite it more than needed.It should be either refactored in another PR, or rewritten in Kotlin completely.

Test:
1. Log in as a team user to a freshly installed app.
2. Go to UserSearch

Expected result:
You see the "Create group" button, as well as some contacts if you have them.

Actual result:
No "Create group" button and the list is empty.
#### APK
[Download build #674](http://10.10.124.11:8080/job/Pull%20Request%20Builder/674/artifact/build/artifact/wire-dev-PR2496-674.apk)
[Download build #676](http://10.10.124.11:8080/job/Pull%20Request%20Builder/676/artifact/build/artifact/wire-dev-PR2496-676.apk)