### PR TITLE
Fix empty conversation list options menu when the current conversation id is not set

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -91,6 +91,13 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
   def getConversation(convId: ConvId): Future[Option[ConversationData]] =
     convsStorage.head.flatMap(_.get(convId))
 
+  def isCurrentUserCreator(convId: ConvId): Future[Boolean] = for {
+    convs   <- conversations.head
+    selfId  <- selfId.head
+    conv    <- getConversation(convId)
+    isGroup <- convs.groupConversation(convId).head
+  } yield isGroup && conv.exists(_.creator == selfId)
+
   val currentConvType: Signal[ConversationType] = currentConv.map(_.convType).disableAutowiring()
   val currentConvName: Signal[String] = currentConv.map(_.displayName).map {
     case Name.Empty => getString(R.string.default_deleted_username)

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -100,7 +100,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
     teamMember           <- otherUser.map(_.exists(u => u.teamId.nonEmpty && u.teamId == teamId))
     isBot                <- otherUser.map(_.exists(_.isWireBot))
     selfRole             <- convController.selfRoleInConv(convId)
-    isCurrentUserCreator <- participantsController.isCurrentUserCreator
+    isCurrentUserCreator <- Signal.future(convController.isCurrentUserCreator(convId))
     selectedParticipant  <- participantsController.selectedParticipant
     favoriteConvIds      <- convListController.favoriteConversations.map(convs => convs.map(_.id))
     customFolderId       <- Signal.future(convListController.getCustomFolderId(convId))

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -104,13 +104,6 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
     currentConv <- conv
   } yield currentConv.team.isDefined && currentConv.team != currentUser.teamId
 
-  lazy val isCurrentUserCreator: Signal[Boolean] = for {
-    z           <- zms
-    currentUser <- UserSignal(z.selfUserId)
-    currentConv <- conv
-    isGroup     <- isGroup
-  } yield isGroup && currentConv.creator == currentUser.id
-
   lazy val currentUserBelongsToConversationTeam: Signal[Boolean] = for {
     z           <- zms
     currentUser <- UserSignal(z.selfUserId)


### PR DESCRIPTION
With conversation roles, we now need to know if the user is the creator of the given conversation
to make sure we are allowed to show the "Delete conversation" button. The way it was done
involved asking for `currentConvId `which is not set at the fresh start.
(And which shouldn't be asked for anyway).

## Test

1. Install and open the app (or wipe the data and login)
2. On the conversation list, before going to any conversation, long tap or swipe a conversation.

## Expected result

The bottom menu should appear, with options.

## Actual result

The bottom menu does not appear or is empty.