### PR TITLE
Fix: Add ContextProvider class which was mistakenly deleted during auto-merge

### DIFF
--- a/app/src/main/java/com/waz/zclient/ContextProvider.java
+++ b/app/src/main/java/com/waz/zclient/ContextProvider.java
@@ -1,0 +1,28 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient;
+
+import android.content.Context;
+
+//TODO: delete this when deleting com.waz.zclient.core.di.Injector.kt
+public class ContextProvider {
+
+    public static Context getApplicationContext() {
+        return WireApplication.APP_INSTANCE().getApplicationContext();
+    }
+}

--- a/app/src/main/kotlin/com/waz/zclient/core/di/Injector.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/di/Injector.kt
@@ -3,8 +3,11 @@ package com.waz.zclient.core.di
 import android.content.Context
 import com.waz.zclient.BuildConfig
 import com.waz.zclient.ContextProvider
-import com.waz.zclient.ZApplication
-import com.waz.zclient.core.network.*
+import com.waz.zclient.core.network.AccessTokenAuthenticator
+import com.waz.zclient.core.network.AccessTokenInterceptor
+import com.waz.zclient.core.network.AccessTokenRepository
+import com.waz.zclient.core.network.AuthToken
+import com.waz.zclient.core.network.NetworkHandler
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit


### PR DESCRIPTION
## What's new in this PR?

### Issues

The ContextProvider class was deleted during merge as it was deleted on d9d1bc85e, but should've stayed since it is present in 7d25e55c44, causing a compilation error.

### Solutions

Added it back.


#### APK
[Download build #686](http://10.10.124.11:8080/job/Pull%20Request%20Builder/686/artifact/build/artifact/wire-dev-PR2500-686.apk)