### PR TITLE
Fixed the issue around services name formatting inside the participan…

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1224,7 +1224,13 @@
     <string name="new_conv_no_results">No results</string>
     <string name="new_conv_no_contacts">No contacts</string>
 
-    <string name="participants_divider_services">SERVICES (%1$s)</string>
+
+    <plurals name="participants_divider_services">
+        <item quantity="zero">SERVICES</item>
+        <item quantity="one">SERVICES (%1$s)</item>
+        <item quantity="other">SERVICES (%1$s)</item>
+    </plurals>
+
     <string name="participants_divider_people">GROUP MEMBERS (%1$s)</string>
     <string name="participants_divider_admins">GROUP ADMINS (%1$s)</string>
     <string name="participants_divider_people_no_number">GROUP MEMBERS</string>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -245,7 +245,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
       h.setContentDescription("Options")
     case (Right(ServicesSeparator), h: SeparatorViewHolder) =>
       h.setId(R.id.services_section)
-      h.setTitle(getString(R.string.participants_divider_services))
+      h.setTitle(getQuantityString(R.plurals.participants_divider_services, botCount, botCount.toString))
       h.setEmptySection()
       h.setContentDescription(s"Services")
     case (Right(AdminsSeparator), h: SeparatorViewHolder) =>


### PR DESCRIPTION
…ts list for a group conversation

## What's new in this PR?

### Issues

Formatting syntax was being displayed on the screen without any formatted data 

### Causes

No amount of services was being passed to the formatted string

### Solutions

Made it a quantity string to avoid any issues around formatting for different number of bots 