### PR TITLE
feat: hide content when prompting for password

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
@@ -157,6 +157,8 @@ class RequestPasswordDialog extends DialogFragment with FragmentHelper with Deri
   override def onActivityCreated(savedInstanceState: Bundle) = {
     super.onActivityCreated(savedInstanceState)
     if (!useBiometric) getDialog.getWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+    //hide content of wire when it's locked
+    getDialog.getWindow.setDimAmount(1.0f)
   }
 }
 


### PR DESCRIPTION
### Issues

When Wire is locked and prompts for the user's password, screen content is still visible in the background. This is a potential issue since the locking is supposed to prevent unauthorized access to the app, and sensitive data could be visible beneath the dialog. [Fixes AN-6568].(https://wearezeta.atlassian.net/browse/AN-6568)

### Solutions

Dialogs dim the background contents by default, so we simply turn up this dimming to the maximum, which makes it completely opaque, hiding all content all long as the dialog is open.

### Testing

Testing was done manually since this can't easily be automated.
#### APK
[Download build #704](http://10.10.124.11:8080/job/Pull%20Request%20Builder/704/artifact/build/artifact/wire-dev-PR2508-704.apk)