### PR TITLE
Removed mockito inline and added bytebuddy as mockito-core was throwi…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -439,7 +439,7 @@ dependencies {
     // Unit Tests
     testImplementation "junit:junit:$rootProject.ext.versions.junit"
     testImplementation "org.mockito:mockito-core:$versions.mockito"
-    testImplementation "org.mockito:mockito-inline:$versions.mockito"
+    testImplementation "net.bytebuddy:byte-buddy:1.10.6"
     testImplementation "org.amshove.kluent:kluent:$versions.kluent"
     testImplementation "androidx.paging:paging-common:2.0.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"


### PR DESCRIPTION
...ng exceptions through it's own dependency on bytebuddy. This is a known issue with running unit tests from the command line

## What's new in this PR?

### Issues

When running unit tests through the terminal it was failing passing tests

### Causes

Due to the mocks not being seen as inline through the ByteBuddy dependency that Mockito-core uses 

### Solutions

Updated ByteBuddy dependency and added it to project whilst removing the mockito-inline dependency. 

#### APK
[Download build #715](http://10.10.124.11:8080/job/Pull%20Request%20Builder/715/artifact/build/artifact/wire-dev-PR2509-715.apk)