### PR TITLE
Fix: Guest icon is not visible in search results

### DIFF
--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -134,7 +134,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
         var contactsSection = Seq[SearchViewItem]()
 
         contactsSection = contactsSection ++ localResults.indices.map { i =>
-          ConnectionViewItem(ConnectionViewModel(i, localResults(i).id.str.hashCode, isConnected = true, shouldHideUserStatus, localResults, localResults(i).displayName))
+          ConnectionViewItem(ConnectionViewModel(i, localResults(i).id.str.hashCode, isConnected = true, shouldHideUserStatus, localResults, localResults(i).displayName, team))
         }
 
         val shouldCollapse = searchController.filter.currentValue.exists(_.nonEmpty) && collapsedContacts && contactsSection.size > CollapsedContacts
@@ -171,7 +171,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
         val directorySectionHeader = SectionViewItem(SectionViewModel(DirectorySection, 0))
         mergedResult = mergedResult ++ Seq(directorySectionHeader)
         mergedResult = mergedResult ++ directoryResults.indices.map { i =>
-          ConnectionViewItem(ConnectionViewModel(i, directoryResults(i).id.str.hashCode, isConnected = false, shouldHideUserStatus, directoryResults))
+          ConnectionViewItem(ConnectionViewModel(i, directoryResults(i).id.str.hashCode, isConnected = false, shouldHideUserStatus, directoryResults, team = team))
         }
       }
     }

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/ConnectionViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/ConnectionViewItem.scala
@@ -42,4 +42,4 @@ case class ConnectionViewModel(indexVal:              Int,
                                shouldHideUserStatus:  Boolean,
                                results:               Seq[UserData],
                                name:                  Name = Name.Empty,
-                               team:                  Option[TeamData] = None)
+                               team:                  Option[TeamData])


### PR DESCRIPTION
- This commit fixes issue AN-6577

## What's new in this PR?

### Issues

In contact search screen, we should be able to see whether a user returned in search results is a guest or not via an icon. This icon was missing even if the user is a guest.

### Causes

We check whether a contact is a guest if: 
- The current account (performing the search) is a team account, and
- The contact in the search results is in the same team as the current account

During a refactoring, the team information of the current account was passed as `None` via a default field in constructor, hence failing the first check.

### Solutions

Passed the correct team information.

### Testing

Manually tested.


#### APK
[Download build #724](http://10.10.124.11:8080/job/Pull%20Request%20Builder/724/artifact/build/artifact/wire-dev-PR2512-724.apk)