### PR TITLE
Gradle with Kotlin DSL: Dependencies Re-organization/Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ local.properties
 app/api-keys.properties
 app/*.keystore
 app/signing.gradle
-*user.gradle
+*local.gradle.kts
 testing-gallery/*.keystore
 testing-gallery/signing.gradle
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,31 +2,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jp.leafytree.android-scala'
-apply plugin: 'hugo'
 apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
+
 apply from: 'config/quality.gradle'
-
-ext {
-    majorVersion = "3.44."
-
-    audioVersion = System.getenv("AUDIO_VERSION") ?: '1.209.0@aar'
-
-    avsVersion = '5.3.191@aar'
-    avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
-    avsName = 'avs'
-    avsGroup = 'com.wire'
-
-    // proprietary avs artifact configuration
-    customAvsVersion = '5.4.9@aar'
-    customAvsInternalVersion = customAvsVersion
-    customAvsName = 'avs'
-    customAvsGroup = 'com.wearezeta.avs'
-
-}
-
-if (project.file('user.gradle').exists()) {
-    apply from: "user.gradle"
-}
 
 task copyCustomResources(type: Copy) {
     if (buildtimeConfiguration.customResourcesPath == null) {
@@ -83,7 +61,6 @@ android {
     //Trigger the licenseFormat task at least once in any compile phase
     applicationVariants.all { variant ->
         variant.javaCompiler.dependsOn(rootProject.licenseFormat)
-
     }
 
     preBuild.dependsOn(copyCustomResources)
@@ -95,7 +72,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
-        versionName majorVersion + android.defaultConfig.versionCode
+        versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 
@@ -208,7 +185,7 @@ android {
     productFlavors {
         dev {
             applicationId "com.waz.zclient.dev"
-            versionName majorVersion + android.defaultConfig.versionCode + "-dev"
+            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-dev"
             manifestPlaceholders = [applicationLabel       : "Wire Dev",
                                     applicationIcon        : "@drawable/ic_launcher_wire_dev",
                                     sharedUserId           : "",
@@ -220,7 +197,7 @@ android {
 
         candidate {
             applicationId "com.wire.candidate"
-            versionName majorVersion + android.defaultConfig.versionCode + "-candidate"
+            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-candidate"
             manifestPlaceholders = [applicationLabel       : "Wire Candidate",
                                     applicationIcon        : "@drawable/ic_launcher_wire_candidate",
                                     sharedUserId           : "",
@@ -245,7 +222,7 @@ android {
 
         internal {
             applicationId "com.wire.internal"
-            versionName majorVersion + android.defaultConfig.versionCode + "-internal"
+            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-internal"
             manifestPlaceholders = [applicationLabel : "Wire Internal",
                                     applicationIcon  : "@drawable/ic_launcher_wire_internal",
                                     sharedUserId     : "",
@@ -258,7 +235,7 @@ android {
 
         experimental {
             applicationId "com.wire.x"
-            versionName majorVersion + android.defaultConfig.versionCode + "-exp"
+            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-exp"
             manifestPlaceholders = [applicationLabel       : "Wire Exp",
                                     applicationIcon        : "@drawable/ic_launcher_wire_playground",
                                     sharedUserId           : "",
@@ -299,165 +276,132 @@ android {
         exclude 'LICENSE.txt'
         exclude 'META-INF/proguard/coroutines.pro'
     }
-
 }
 
 dexinfo {
     maxDepth 2
 }
 
-def versions = [
-    playServices : "17.0.0", //TODO can be independent now.
-    stetho: "1.5.0",
-    workManager : "2.0.1",
-    paging : "1.0.0",
-    mockito : "3.1.0",
-    lifecycle : "2.2.0-rc03",
-    okHttp : "3.12.0",
-    retrofit : "2.6.2",
-    kluent : "1.14",
-    coroutines : "1.3.2"
-]
-
 dependencies {
-    //    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.scala-lang:scala-library:$scalaVersion"
-    implementation "org.scala-lang:scala-reflect:$scalaVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation LegacyDependencies.scalaLibrary
+    implementation LegacyDependencies.scalaReflect
+    implementation LegacyDependencies.scalaShapeless
 
-    implementation "com.chuusai:shapeless_$rootProject.ext.scalaMajorVersion:2.3.3"
+    implementation BuildDependencies.kotlin.standardLibrary
+    implementation BuildDependencies.kotlin.coroutinesCore
+    implementation BuildDependencies.kotlin.coroutinesAndroid
 
-    //wire libraries:
-    implementation "com.wire:audio-notifications:$audioVersion"
+    implementation BuildDependencies.wire.avs
+    implementation BuildDependencies.wire.audioNotifications
     //don't include wire translations for custom builds
     if (buildtimeConfiguration.customResourcesPath == null) {
-        implementation 'com.wire:wiretranslations:1.+'
+        implementation BuildDependencies.wire.translations
     }
 
-    // TODO  Nasty hack to be able to build add only one wire-core flavor to the build
+    implementation BuildDependencies.libPhoneNumber
 
-    // TODO  (I know, it sucks, will think of a better way to do this, and we need this
-
-    // TODO   when there are different SE APIs in dev vs internal/prod)
-    boolean internal = true
-    for (String taskName : gradle.startParameter.taskNames) {
-        if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
-            internal = false
-            break
-        }
-    }
-
-    // For using local files in app/libs
-    //implementation (name:'avs', ext:'aar')
-    //implementation (name:'audio-notifications', ext:'aar')
-    //implementation (name:'zmessaging-android', ext:'aar')
-
-    implementation "$avsGroup:$avsName:${internal ? avsInternalVersion : avsVersion}"
-    api(project(':wire-android-sync-engine:zmessaging')) {
+    api project(ModuleDependencies.storage)
+    api(project(ModuleDependencies.syncEngine)) {
         exclude group: 'com.wire', module: 'avs'
     }
-    implementation "$rootProject.deps.libphonenumber"
 
-    //Android X
-    implementation 'androidx.multidex:multidex:2.0.0'
-    implementation "com.google.android.material:material:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.0.0"
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
-    implementation "androidx.preference:preference:1.1.0"
-    implementation "androidx.cardview:cardview:1.0.0"
-    implementation "androidx.gridlayout:gridlayout:1.0.0"
-    annotationProcessor "androidx.annotation:annotation:1.0.0"
-    implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "androidx.paging:paging-runtime:2.0.0"
-    implementation "androidx.exifinterface:exifinterface:1.0.0"
-    implementation "androidx.media:media:1.0.0"
+    //Android
+    implementation BuildDependencies.androidX.material
+    implementation BuildDependencies.androidX.multidex
+    implementation BuildDependencies.androidX.appCompat
+    implementation BuildDependencies.androidX.recyclerView
+    implementation BuildDependencies.androidX.preference
+    implementation BuildDependencies.androidX.cardView
+    implementation BuildDependencies.androidX.gridLayout
+    implementation BuildDependencies.androidX.constraintLayout
+    implementation BuildDependencies.androidX.paging
+    implementation BuildDependencies.androidX.exifInterface
+    implementation BuildDependencies.androidX.media
+    implementation BuildDependencies.androidX.lifecycleRuntime
+    implementation BuildDependencies.androidX.lifecycleLiveData
+    implementation BuildDependencies.androidX.lifecycleViewModel
+    implementation BuildDependencies.androidX.lifecycleExtensions
+    implementation BuildDependencies.androidX.roomRuntime
+    implementation BuildDependencies.androidX.roomKtx
+    implementation BuildDependencies.androidX.biometric
+    implementation(BuildDependencies.androidX.workManager) {
+        exclude group: 'androidx.room', module: 'room-runtime'
+    }
 
-    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$versions.lifecycle"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$versions.lifecycle"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$versions.lifecycle"
-    implementation "androidx.room:room-ktx:$rootProject.ext.versions.room"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.coroutines"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"
-
+    annotationProcessor BuildDependencies.androidX.annotation
 
     // Play services
-    implementation "com.google.android.gms:play-services-base:$versions.playServices"
-    implementation "com.google.android.gms:play-services-maps:$versions.playServices"
-    implementation "com.google.android.gms:play-services-location:$versions.playServices"
-    implementation "com.google.android.gms:play-services-gcm:$versions.playServices"
-    implementation ('com.google.firebase:firebase-messaging:19.0.0') {
+    implementation BuildDependencies.playServices.base
+    implementation BuildDependencies.playServices.maps
+    implementation BuildDependencies.playServices.location
+    implementation BuildDependencies.playServices.gcm
+
+    // Firebase
+    implementation (BuildDependencies.fireBaseMessaging) {
         exclude group: 'com.google.firebase', module: 'firebase-analytics'
         exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
     }
 
-    //WorkManager
-    implementation("androidx.work:work-runtime:$versions.workManager") {
-        exclude group: 'androidx.room', module: 'room-runtime'
-    }
-    implementation "androidx.room:room-runtime:$rootProject.ext.versions.room"
-
-    //third party libraries
-    implementation 'io.reactivex.rxjava2:rxkotlin:2.3.0'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'com.evernote:android-job:1.2.6'
-    implementation 'com.jakewharton.timber:timber:4.7.0'
-    implementation('com.jakewharton.threetenabp:threetenabp:1.1.0') {
-        exclude group: 'org.threeten', module: 'threetenbp'
-    }
-    implementation "org.threeten:threetenbp:$rootProject.ext.versions.threetenbp"
-    implementation 'com.facebook.rebound:rebound:0.3.8'
-    implementation 'com.atlassian.commonmark:commonmark:0.11.0'
-    implementation 'net.java.dev.jna:jna:4.4.0@aar'
-    devImplementation "com.facebook.stetho:stetho:$versions.stetho"
-    experimentalImplementation "com.facebook.stetho:stetho:$versions.stetho"
-    internalImplementation "com.facebook.stetho:stetho:$versions.stetho"
-    implementation("com.github.bumptech.glide:glide:4.10.0"){
+    //Glide
+    implementation(BuildDependencies.glide.core){
         exclude group: 'com.android.support'
         transitive = true
     }
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
-
-    // biometric prompt
-    implementation 'androidx.biometric:biometric:1.0.0-rc02'
+    annotationProcessor BuildDependencies.glide.compiler
 
     //Retrofit
-    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-protobuf:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$versions.okHttp"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$versions.okHttp"
+    implementation BuildDependencies.retrofit.core
+    implementation BuildDependencies.retrofit.protoBufConverter
+    implementation BuildDependencies.retrofit.gsonConverter
 
-    //Koin
-    implementation "org.koin:koin-android:$rootProject.ext.versions.koin"
-    implementation "org.koin:koin-android-scope:$rootProject.ext.versions.koin"
-    implementation "org.koin:koin-android-viewmodel:$rootProject.ext.versions.koin"
+    //OkHttp
+    implementation BuildDependencies.okHttpLoggingInterceptor
 
-    api project(":storage")
+    //DI - Koin
+    implementation BuildDependencies.koin.androidCore
+    implementation BuildDependencies.koin.androidScope
+    implementation BuildDependencies.koin.androidViewModel
+
+    // RxJava
+    implementation BuildDependencies.rxJava.rxKotlin
+    implementation BuildDependencies.rxJava.rxAndroid
+
+    //third party libraries
+    implementation BuildDependencies.androidJob
+    implementation BuildDependencies.timber
+    implementation(BuildDependencies.threetenbpAndroid) {
+        exclude group: 'org.threeten', module: 'threetenbp'
+    }
+    implementation BuildDependencies.threetenbpJava
+    implementation BuildDependencies.rebound
+    implementation BuildDependencies.commonMark
+    implementation BuildDependencies.jna
 
     // Unit Tests
-    testImplementation "junit:junit:$rootProject.ext.versions.junit"
-    testImplementation "org.mockito:mockito-core:$versions.mockito"
-    testImplementation "org.mockito:mockito-inline:$versions.mockito"
-    testImplementation "org.amshove.kluent:kluent:$versions.kluent"
-    testImplementation "androidx.paging:paging-common:2.0.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"
-    testImplementation("$rootProject.deps.scalaTest") {
-        exclude module: 'scala-library'
-    }
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines"
-    testImplementation "androidx.paging:paging-common:2.0.0"
+    testImplementation TestDependencies.jUnit
+    testImplementation TestDependencies.mockito.core
+    testImplementation TestDependencies.mockito.inline
+    testImplementation TestDependencies.kluent
+    testImplementation BuildDependencies.kotlin.coroutinesCore
+    testImplementation TestDependencies.kotlin.coroutinesTest
+    testImplementation TestDependencies.androidX.testCore
+    testImplementation TestDependencies.okHttpMockWebServer
+    testImplementation(LegacyDependencies.scalaTest) { exclude module: 'scala-library' }
 
-    // UI Tests
-    androidTestImplementation "junit:junit:$rootProject.ext.versions.junit"
-    androidTestImplementation "org.mockito:mockito-core:$versions.mockito"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.1.1'
+    // Functional Tests
+    androidTestImplementation TestDependencies.jUnit
+    androidTestImplementation TestDependencies.mockito.core
+    androidTestImplementation TestDependencies.kluent
+    androidTestImplementation TestDependencies.androidX.testJunit
+    androidTestImplementation TestDependencies.androidX.testRules
+    androidTestImplementation TestDependencies.androidX.testWorkManager
 
-    androidTestImplementation "androidx.work:work-testing:$versions.workManager"
+    // Development - Experimental
+    devImplementation DevDependencies.stetho
+    experimentalImplementation DevDependencies.stetho
+    internalImplementation DevDependencies.stetho
 
+    // Legacy Scala
     ScalaCompileOptions.metaClass.daemonServer = true
     ScalaCompileOptions.metaClass.fork = true
     ScalaCompileOptions.metaClass.useAnt = false
@@ -498,12 +442,10 @@ android.applicationVariants.all { variant ->
     variant.outputs.each { output ->
         def newApkName
         if(buildtimeConfiguration.isCustomBuild()) {
-            newApkName = "${appName}-${buildtimeConfiguration.configuration.applicationId}-${output.baseName}-${majorVersion}${android.defaultConfig.versionCode}.apk"
+            newApkName = "${appName}-${buildtimeConfiguration.configuration.applicationId}-${output.baseName}-${Versions.ANDROID_CLIENT_MAJOR_VERSION}${android.defaultConfig.versionCode}.apk"
         } else {
-            newApkName = "${appName}-${output.baseName}-${majorVersion}${android.defaultConfig.versionCode}.apk"
+            newApkName = "${appName}-${output.baseName}-${Versions.ANDROID_CLIENT_MAJOR_VERSION}${android.defaultConfig.versionCode}.apk"
         }
-
-
         output.outputFileName = new File("../..", newApkName)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,6 @@ import groovy.json.JsonOutput
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.60'
-    ext.retrofit_version = "2.6.2"
-
     repositories {
         maven {
             url "https://dl.bintray.com/wire-android/third-party"
@@ -20,12 +17,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
         classpath 'com.mutualmobile.gradle.plugins:dexinfo:0.1.2'
         classpath 'com.wire.gradle:gradle-android-scala-plugin:1.6'
         classpath 'com.google.gms:google-services:3.1.1'
         classpath 'org.ajoberstar.grgit:grgit-core:3.0.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
     }
 }
 
@@ -80,22 +76,6 @@ ext {
     buildToolsVersion = '28.0.3'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_8
     targetCompatibilityVersion = JavaVersion.VERSION_1_8
-
-    scalaMajorVersion = 2.11
-    scalaVersion = scalaMajorVersion + '.12'
-
-    versions = [
-        threetenbp: "1.3.8",
-        junit     : "4.12",
-        room      : "2.2.2",
-        koin      : "2.0.1"
-    ]
-
-    deps = [
-        scalaTest              : "org.scalatest:scalatest_$ext.scalaMajorVersion:3.0.5",
-        libphonenumber         : "com.googlecode.libphonenumber:libphonenumber:7.1.1", // 7.2.x breaks protobuf
-        robolectric_android_all: "org.robolectric:android-all:5.0.0_r2-robolectric-1"
-    ]
 
     // configuration and external config
     customCheckoutDir = "$rootDir/custom"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+    jcenter()
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@
 
 object Versions {
     //wire android client
-    const val ANDROID_CLIENT_MAJOR_VERSION = "3.43."
+    const val ANDROID_CLIENT_MAJOR_VERSION = "3.44."
 
     //core
     const val KOTLIN = "1.3.60"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,173 @@
+@file:Suppress("MemberVisibilityCanBePrivate", "SpellCheckingInspection")
+
+object Versions {
+    //wire android client
+    const val ANDROID_CLIENT_MAJOR_VERSION = "3.43."
+
+    //core
+    const val KOTLIN = "1.3.60"
+    const val WIRE_TRANSLATIONS = "1.+"
+    val AVS = System.getenv("AVS_VERSION") ?: "5.3.191@aar"
+    val WIRE_AUDIO = System.getenv("AUDIO_VERSION") ?: "1.209.0@aar"
+
+    //build
+    const val COROUTINES = "1.3.2"
+    const val WORK_MANAGER = "2.0.1"
+    const val ANDROIDX_MATERIAL = "1.0.0"
+    const val ANDROIDX_MULTIDEX = "2.0.0"
+    const val ANDROIDX_APP_COMPAT = "1.0.0"
+    const val ANDROIDX_RECYCLER_VIEW = "1.0.0"
+    const val ANDROIDX_PREFERENCE = "1.0.0"
+    const val ANDROIDX_CARD_VIEW = "1.0.0"
+    const val ANDROIDX_GRID_LAYOUT = "1.0.0"
+    const val ANDROIDX_CONSTRAINT_LAYOUT = "1.1.3"
+    const val ANDROIDX_PAGING_RUNTIME = "2.0.0"
+    const val ANDROIDX_EXIF_INTERFACE = "1.0.0"
+    const val ANDROIDX_MEDIA = "1.0.0"
+    const val ANDROIDX_LIFECYCLE = "2.2.0-rc03"
+    const val ANDROIDX_LIFECYCLE_EXTENSIONS = "2.1.0"
+    const val ANDROIDX_CORE_KTX = "1.0.2"
+    const val ANDROIDX_ROOM = "2.2.2"
+    const val ANDROIDX_BIOMETRIC = "1.0.0-rc02"
+    const val ANDROIDX_ANNOTATION = "1.0.0"
+    const val PLAY_SERVICES = "17.0.0"
+    const val FIREBASE_MESSAGING = "19.0.0"
+    const val GLIDE = "4.10.0"
+    const val RETROFIT = "2.6.2"
+    const val OKHTTP = "3.12.0"
+    const val KOIN = "2.0.1"
+    const val RX_KOTLIN = "2.3.0"
+    const val RX_ANDROID = "2.1.1"
+    const val ANDROID_JOB = "1.2.6"
+    const val TIMBER = "4.7.0"
+    const val THREE_TEN_BP_ANDROID = "1.1.0"
+    const val THREE_TEN_BP_JAVA = "1.3.8"
+    const val REBOUND = "0.3.8"
+    const val COMMON_MARK = "0.11.0"
+    const val JNA = "4.4.0@aar"
+    const val LIB_PHONE_NUMBER = "7.1.1" // 7.2.x breaks protobuf
+
+    //testing
+    const val JUNIT = "4.12"
+    const val MOCKITO = "3.1.0"
+    const val KLUENT = "1.14"
+    const val ANDROIDX_TEST_CORE = "2.1.0"
+    const val ANDROIDX_TEST_JUNIT = "1.1.1"
+    const val ROBOLECTRIC = "5.0.0_r2-robolectric-1"
+
+    //dev
+    const val STETHO = "1.5.0"
+}
+
+object BuildDependencies {
+    val kotlin = KotlinDependencyMap(mapOf(
+        "standardLibrary" to "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.KOTLIN}",
+        "coroutinesCore" to "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.COROUTINES}",
+        "coroutinesAndroid" to "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.COROUTINES}"
+    ))
+    val wire = WireDependencyMap(mapOf(
+        "audioNotifications" to "com.wire:audio-notifications:${Versions.WIRE_AUDIO}",
+        "translations" to "com.wire:wiretranslations:${Versions.WIRE_TRANSLATIONS}",
+        "avs" to "com.wire:${System.getenv("AVS_NAME") ?: "avs"}:${Versions.AVS}"
+    ))
+    val androidX = AndroidXDependencyMap(mapOf(
+        "material" to "com.google.android.material:material:${Versions.ANDROIDX_MATERIAL}",
+        "multidex" to "androidx.multidex:multidex:${Versions.ANDROIDX_MULTIDEX}",
+        "appCompat" to "androidx.appcompat:appcompat:${Versions.ANDROIDX_APP_COMPAT}",
+        "recyclerView" to "androidx.recyclerview:recyclerview:${Versions.ANDROIDX_RECYCLER_VIEW}",
+        "preference" to "androidx.preference:preference:${Versions.ANDROIDX_PREFERENCE}",
+        "cardView" to "androidx.cardview:cardview:${Versions.ANDROIDX_CARD_VIEW}",
+        "gridLayout" to "androidx.gridlayout:gridlayout:${Versions.ANDROIDX_GRID_LAYOUT}",
+        "constraintLayout" to "androidx.constraintlayout:constraintlayout:${Versions.ANDROIDX_CONSTRAINT_LAYOUT}",
+        "paging" to "androidx.paging:paging-runtime:${Versions.ANDROIDX_PAGING_RUNTIME}",
+        "exifInterface" to "androidx.exifinterface:exifinterface:${Versions.ANDROIDX_EXIF_INTERFACE}",
+        "media" to "androidx.media:media:${Versions.ANDROIDX_MEDIA}",
+        "lifecycleRuntime" to "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE}",
+        "lifecycleLiveData" to "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.ANDROIDX_LIFECYCLE}",
+        "lifecycleViewModel" to "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.ANDROIDX_LIFECYCLE}",
+        "lifecycleExtensions" to "androidx.lifecycle:lifecycle-extensions:${Versions.ANDROIDX_LIFECYCLE_EXTENSIONS}",
+        "coreKtx" to "androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX}",
+        "roomRuntime" to "androidx.room:room-runtime:${Versions.ANDROIDX_ROOM}",
+        "roomKtx" to "androidx.room:room-ktx:${Versions.ANDROIDX_ROOM}",
+        "roomCompiler" to "androidx.room:room-compiler:${Versions.ANDROIDX_ROOM}",
+        "biometric" to "androidx.biometric:biometric:${Versions.ANDROIDX_BIOMETRIC}",
+        "workManager" to "androidx.work:work-runtime:${Versions.WORK_MANAGER}",
+        "annotation" to "androidx.annotation:annotation:${Versions.ANDROIDX_ANNOTATION}"
+    ))
+    val playServices = PlayServicesDependencyMap(mapOf(
+        "base" to "com.google.android.gms:play-services-base:${Versions.PLAY_SERVICES}",
+        "maps" to "com.google.android.gms:play-services-maps:${Versions.PLAY_SERVICES}",
+        "location" to "com.google.android.gms:play-services-location:${Versions.PLAY_SERVICES}",
+        "gcm" to "com.google.android.gms:play-services-gcm:${Versions.PLAY_SERVICES}"
+    ))
+    val fireBaseMessaging = "com.google.firebase:firebase-messaging:${Versions.FIREBASE_MESSAGING}"
+    val glide = GlideDependencyMap(mapOf(
+        "core" to "com.github.bumptech.glide:glide:${Versions.GLIDE}",
+        "compiler" to "com.github.bumptech.glide:compiler:${Versions.GLIDE}"
+    ))
+    val retrofit = RetrofitDependencyMap(mapOf(
+        "core" to "com.squareup.retrofit2:retrofit:${Versions.RETROFIT}",
+        "protoBufConverter" to "com.squareup.retrofit2:converter-protobuf:${Versions.RETROFIT}",
+        "gsonConverter" to "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT}"
+    ))
+    val okHttpLoggingInterceptor = "com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP}"
+    val koin = KoinDependencyMap(mapOf(
+        "androidCore" to "org.koin:koin-android:${Versions.KOIN}",
+        "androidScope" to "org.koin:koin-android-scope:${Versions.KOIN}",
+        "androidViewModel" to "org.koin:koin-android-viewmodel:${Versions.KOIN}"
+    ))
+    val rxJava = RxJavaDependencyMap(mapOf(
+        "rxKotlin" to "io.reactivex.rxjava2:rxkotlin:${Versions.RX_KOTLIN}",
+        "rxAndroid" to "io.reactivex.rxjava2:rxandroid:${Versions.RX_ANDROID}"
+    ))
+    val androidJob = "com.evernote:android-job:${Versions.ANDROID_JOB}"
+    val timber = "com.jakewharton.timber:timber:${Versions.TIMBER}"
+    val threetenbpAndroid = "com.jakewharton.threetenabp:threetenabp:${Versions.THREE_TEN_BP_ANDROID}"
+    val threetenbpJava = "org.threeten:threetenbp:${Versions.THREE_TEN_BP_JAVA}"
+    val rebound = "com.facebook.rebound:rebound:${Versions.REBOUND}"
+    val commonMark = "com.atlassian.commonmark:commonmark:${Versions.COMMON_MARK}"
+    val jna= "net.java.dev.jna:jna:${Versions.JNA}"
+    val libPhoneNumber = "com.googlecode.libphonenumber:libphonenumber:${Versions.LIB_PHONE_NUMBER}"
+}
+
+object ModuleDependencies {
+    val storage = ":storage"
+    val syncEngine = ":wire-android-sync-engine:zmessaging"
+}
+
+object TestDependencies {
+    val jUnit = "junit:junit:${Versions.JUNIT}"
+    val kluent = "org.amshove.kluent:kluent:${Versions.KLUENT}"
+    val kotlin = KotlinTestDependencyMap(mapOf(
+        "coroutinesTest" to "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.COROUTINES}"
+    ))
+    val mockito = MockitoDependencyMap(mapOf(
+        "core" to "org.mockito:mockito-core:${Versions.MOCKITO}",
+        "inline" to "org.mockito:mockito-inline:${Versions.MOCKITO}"
+    ))
+    val androidX =  AndroidXTestDependencyMap(mapOf(
+        "testCore" to "androidx.arch.core:core-testing:${Versions.ANDROIDX_TEST_CORE}",
+        "testJunit" to "androidx.test.ext:junit:${Versions.ANDROIDX_TEST_JUNIT}",
+        "testRules" to "androidx.test:rules:${Versions.ANDROIDX_TEST_JUNIT}",
+        "testWorkManager" to "androidx.work:work-testing:${Versions.WORK_MANAGER}"
+    ))
+    val okHttpMockWebServer = "com.squareup.okhttp3:mockwebserver:${Versions.OKHTTP}"
+    val robolectric = "org.robolectric:android-all:${Versions.ROBOLECTRIC}"
+}
+
+object DevDependencies {
+    val stetho = "com.facebook.stetho:stetho:${Versions.STETHO}"
+}
+
+object LegacyDependencies {
+    const val SCALA_MAJOR_VERSION = "2.11"
+    const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
+
+    //build
+    val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"
+    val scalaReflect = "org.scala-lang:scala-reflect:$SCALA_VERSION"
+    val scalaShapeless = "com.chuusai:shapeless_$SCALA_MAJOR_VERSION:2.3.3"
+
+    //test
+    val scalaTest = "org.scalatest:scalatest_${SCALA_MAJOR_VERSION}:3.0.5"
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     const val ANDROIDX_MULTIDEX = "2.0.0"
     const val ANDROIDX_APP_COMPAT = "1.0.0"
     const val ANDROIDX_RECYCLER_VIEW = "1.0.0"
-    const val ANDROIDX_PREFERENCE = "1.0.0"
+    const val ANDROIDX_PREFERENCE = "1.1.0"
     const val ANDROIDX_CARD_VIEW = "1.0.0"
     const val ANDROIDX_GRID_LAYOUT = "1.0.0"
     const val ANDROIDX_CONSTRAINT_LAYOUT = "1.1.3"

--- a/buildSrc/src/main/kotlin/DependencyMap.kt
+++ b/buildSrc/src/main/kotlin/DependencyMap.kt
@@ -1,0 +1,91 @@
+
+//TODO: Remove and refactor when gradle version > 5
+//This is a solution to make more friendly managing dependencies
+//There is a bug with the version of Kotlin DSL we are using:
+//https://github.com/gradle/gradle/issues/9251
+//It is not possible at the moment to upgrade gradle due to breaking the Gradle Scala plugin
+//Once we are up to date, we can nest objects in the dependencies.kt file and remove all these maps.
+
+//Build Dependencies
+class KotlinDependencyMap(map: Map<String, String>) {
+    val standardLibrary: String by map
+    val coroutinesCore: String by map
+    val coroutinesAndroid: String by map
+}
+
+class WireDependencyMap(map: Map<String, String>) {
+    val audioNotifications: String by map
+    val translations: String by map
+    val avs: String by map
+}
+
+class AndroidXDependencyMap(map: Map<String, String>) {
+    val material: String by map
+    val multidex: String by map
+    val appCompat: String by map
+    val recyclerView: String by map
+    val preference: String by map
+    val cardView: String by map
+    val gridLayout: String by map
+    val constraintLayout: String by map
+    val paging: String by map
+    val exifInterface: String by map
+    val media: String by map
+    val lifecycleRuntime: String by map
+    val lifecycleLiveData: String by map
+    val lifecycleViewModel: String by map
+    val lifecycleExtensions: String by map
+    val coreKtx: String by map
+    val roomRuntime: String by map
+    val roomKtx: String by map
+    val roomCompiler: String by map
+    val biometric: String by map
+    val workManager: String by map
+    val annotation: String by map
+}
+
+class PlayServicesDependencyMap(map: Map<String, String>) {
+    val base: String by map
+    val maps: String by map
+    val location: String by map
+    val gcm: String by map
+}
+
+class GlideDependencyMap(map: Map<String, String>) {
+    val core: String by map
+    val compiler: String by map
+}
+
+class RetrofitDependencyMap(map: Map<String, String>) {
+    val core: String by map
+    val protoBufConverter: String by map
+    val gsonConverter: String by map
+}
+
+class KoinDependencyMap(map: Map<String, String>) {
+    val androidCore: String by map
+    val androidScope: String by map
+    val androidViewModel: String by map
+}
+
+//Test Dependencies
+class KotlinTestDependencyMap(map: Map<String, String>) {
+    val coroutinesTest: String by map
+}
+
+class MockitoDependencyMap(map: Map<String, String>) {
+    val core: String by map
+    val inline: String by map
+}
+
+class RxJavaDependencyMap(map: Map<String, String>) {
+    val rxKotlin: String by map
+    val rxAndroid: String by map
+}
+
+class AndroidXTestDependencyMap(map: Map<String, String>) {
+    val testCore: String by map
+    val testJunit: String by map
+    val testRules: String by map
+    val testWorkManager: String by map
+}

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -34,13 +34,17 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.0.2'
-    implementation "androidx.room:room-runtime:$rootProject.ext.versions.room"
-    implementation "androidx.room:room-ktx:$rootProject.ext.versions.room"
-    kapt "androidx.room:room-compiler:$rootProject.ext.versions.room"
-    implementation "org.koin:koin-android:$rootProject.ext.versions.koin"
-    implementation "org.koin:koin-android-scope:$rootProject.ext.versions.koin"
-    implementation "org.koin:koin-android-viewmodel:$rootProject.ext.versions.koin"
+    //Core Dependencies
+    implementation BuildDependencies.kotlin.standardLibrary
+
+    // Room Data Storage
+    implementation BuildDependencies.androidX.coreKtx
+    implementation BuildDependencies.androidX.roomRuntime
+    implementation BuildDependencies.androidX.roomKtx
+    kapt BuildDependencies.androidX.roomCompiler
+
+    // DI - Koin
+    implementation BuildDependencies.koin.androidCore
+    implementation BuildDependencies.koin.androidScope
+    implementation BuildDependencies.koin.androidViewModel
 }

--- a/wire-android-sync-engine/macrosupport/build.gradle
+++ b/wire-android-sync-engine/macrosupport/build.gradle
@@ -7,6 +7,6 @@ android {
 }
 
 dependencies {
-    compileOnly "org.scala-lang:scala-reflect:$rootProject.ext.scalaVersion"
-    compileOnly "$rootProject.deps.robolectric_android_all"
+    compileOnly LegacyDependencies.scalaReflect
+    compileOnly TestDependencies.robolectric
 }

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -74,54 +74,53 @@ dependencies {
 
     api project(':wire-android-sync-engine:macrosupport')
 
-    implementation project(':storage')
+    implementation project(ModuleDependencies.storage)
 
-    api "org.scala-lang.modules:scala-async_$rootProject.ext.scalaMajorVersion:0.9.7"
+    api "org.scala-lang.modules:scala-async_${LegacyDependencies.SCALA_MAJOR_VERSION}:0.9.7"
     implementation "com.squareup.okhttp3:okhttp:$versions.okHttp"
     // should match okhttp3's mockserver version (see test dependencies)
-    implementation "$rootProject.deps.libphonenumber"
+    implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
     api "com.wire:generic-message-proto:1.23.0"
     implementation "com.wire:backend-api-proto:1.1"
-    implementation "io.circe:circe-core_$rootProject.ext.scalaMajorVersion:$versions.circe"
-    implementation "io.circe:circe-generic_$rootProject.ext.scalaMajorVersion:$versions.circe"
-    implementation "io.circe:circe-parser_$rootProject.ext.scalaMajorVersion:$versions.circe"
+    implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
+    implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
+    implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "com.wire:icu4j-shrunk:57.1"
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
     implementation "com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:2.0.2"
 
     //Provided dependencies
-    compileOnly "com.softwaremill.macwire:macros_$rootProject.ext.scalaMajorVersion:2.3.3"
-    compileOnly "com.softwaremill.macwire:macrosakka_$rootProject.ext.scalaMajorVersion:2.3.3"
-    compileOnly "com.softwaremill.macwire:util_$rootProject.ext.scalaMajorVersion:2.3.3"
-    compileOnly "com.softwaremill.macwire:proxy_$rootProject.ext.scalaMajorVersion:2.3.3"
+    compileOnly "com.softwaremill.macwire:macros_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
+    compileOnly "com.softwaremill.macwire:macrosakka_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
+    compileOnly "com.softwaremill.macwire:util_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
+    compileOnly "com.softwaremill.macwire:proxy_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.wire:avs:3.4.100"
     compileOnly "androidx.legacy:legacy-support-v4:1.0.0"
-    compileOnly "org.threeten:threetenbp:$rootProject.ext.versions.threetenbp"
+    compileOnly BuildDependencies.threetenbpJava
     compileOnly "net.java.dev.jna:jna:4.4.0@aar"
-    compileOnly "$rootProject.deps.robolectric_android_all"
+    compileOnly TestDependencies.robolectric
 
     //Test dependencies
-    testImplementation("$rootProject.deps.scalaTest") {
+    testImplementation(LegacyDependencies.scalaTest) {
         exclude module: 'scala-library'
     }
-    testImplementation "org.scalamock:scalamock_$rootProject.ext.scalaMajorVersion:4.1.0"
-    testImplementation "org.scalacheck:scalacheck_$rootProject.ext.scalaMajorVersion:1.14.0"
-    testImplementation("com.wire:robotest_$rootProject.ext.scalaMajorVersion:0.7") {
+    testImplementation "org.scalamock:scalamock_${LegacyDependencies.SCALA_MAJOR_VERSION}:4.1.0"
+    testImplementation "org.scalacheck:scalacheck_${LegacyDependencies.SCALA_MAJOR_VERSION}:1.14.0"
+    testImplementation("com.wire:robotest_${LegacyDependencies.SCALA_MAJOR_VERSION}:0.7") {
         exclude(group: "org.scalatest", module: "scalatest")
     }
-    testImplementation "$rootProject.deps.robolectric_android_all"
-    testImplementation "junit:junit:$rootProject.ext.versions.junit"             //to override version included in robolectric
+    testImplementation TestDependencies.robolectric
+    testImplementation TestDependencies.jUnit   //to override version included in robolectric
     testImplementation "com.squareup.okhttp3:mockwebserver:$versions.okHttp"
     //should match okhttp version.
     testImplementation "org.apache.httpcomponents:httpclient:4.5.3"
-    testImplementation "com.typesafe.akka:akka-http_$rootProject.ext.scalaMajorVersion:10.1.8"
-    testImplementation "com.typesafe.akka:akka-actor_$rootProject.ext.scalaMajorVersion:2.5.22"
-    testImplementation "com.typesafe.akka:akka-stream_$rootProject.ext.scalaMajorVersion:2.5.22"
+    testImplementation "com.typesafe.akka:akka-http_${LegacyDependencies.SCALA_MAJOR_VERSION}:10.1.8"
+    testImplementation "com.typesafe.akka:akka-actor_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
+    testImplementation "com.typesafe.akka:akka-stream_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
     testImplementation "com.wire:avs:3.4.100"
     testImplementation "androidx.legacy:legacy-support-v4:1.0.0"
-    testImplementation "org.threeten:threetenbp:$rootProject.ext.versions.threetenbp"
+    testImplementation BuildDependencies.threetenbpJava
     testImplementation "net.java.dev.jna:jna:4.4.0@aar"
-
 }
 


### PR DESCRIPTION
## What's new in this PR?

Our current build system is unorganized and legacy. In order to build a mature and robust CI environment and a modularized architecture, we need to start from the very deep, in this case with the logic related to how we build our android client. 

This part aims to configure Kotlin DSL to work with Gradle. As a first step, all project dependencies are being refactor and re-organized. 
#### APK
[Download build #730](http://10.10.124.11:8080/job/Pull%20Request%20Builder/730/artifact/build/artifact/wire-dev-PR2514-730.apk)
[Download build #739](http://10.10.124.11:8080/job/Pull%20Request%20Builder/739/artifact/build/artifact/wire-dev-PR2514-739.apk)
[Download build #740](http://10.10.124.11:8080/job/Pull%20Request%20Builder/740/artifact/build/artifact/wire-dev-PR2514-740.apk)
[Download build #765](http://10.10.124.11:8080/job/Pull%20Request%20Builder/765/artifact/build/artifact/wire-dev-PR2514-765.apk)
[Download build #776](http://10.10.124.11:8080/job/Pull%20Request%20Builder/776/artifact/build/artifact/wire-dev-PR2514-776.apk)