### PR TITLE
Enable 'remove from group' button if the admin is a guest

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -170,17 +170,14 @@ class SingleParticipantFragment extends FragmentHelper {
     // TODO: merge this logic with ConversationOptionsMenuController
     (for {
       conv           <- participantsController.conv
-      isGroup        <- participantsController.isGroup
       createPerm     <- userAccountsController.hasCreateConvPermission
       remPerm        <- participantsController.selfRole.map(_.canRemoveGroupMember)
-      selfIsGuest    <- participantsController.isCurrentUserGuest
-      selfIsExternal <- userAccountsController.isExternal
       selfIsProUser  <- userAccountsController.isTeam
       other          <- participantsController.otherParticipant
       otherIsGuest    = other.isGuest(conv.team)
     } yield {
       if (fromDeepLink) !selfIsProUser || otherIsGuest
-      else (createPerm || remPerm) && !selfIsGuest && (!isGroup || !selfIsExternal)
+      else createPerm || remPerm
     }).map {
       case true => R.string.glyph__more
       case _    => R.string.empty_string


### PR DESCRIPTION
Before conversation roles were implemented, a guest was not permitted to remove other participants from a group conversation. Now this is controlled by the user's role in the conversation. Even if the user is a guest, if they're an admin, they can remove other participants.

### Test
1. As a team account A, create a new conversation and invite a private account B.
2. Promote the guest B to the admin status.
3. As B, go to the participants screen, click on the participant A.

Expected result: On the right side of the footer you should see the "..." icon and when you click it, there should be the "Remove from group" button.
Actual result: The right side of the footer is empty.


#### APK
[Download build #736](http://10.10.124.11:8080/job/Pull%20Request%20Builder/736/artifact/build/artifact/wire-dev-PR2515-736.apk)
[Download build #737](http://10.10.124.11:8080/job/Pull%20Request%20Builder/737/artifact/build/artifact/wire-dev-PR2515-737.apk)