### PR TITLE
Disable license header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,21 +52,23 @@ allprojects {
     }
 }
 
-task licenseFormatAndroid(type: nl.javadude.gradle.plugins.license.License) {
-    source = fileTree(dir: getRootDir()).include([
-        "**/*.java",
-        "**/*.scala",
-        "**/*.gradle",
-        "**/*.xml",
-    ]).exclude([
-        "**/*build*",
-        "**/*target*",
-        "**/*gen*",
-        "**/*generated*",
-        ".idea/**"
-    ])
-}
-licenseFormat.dependsOn licenseFormatAndroid
+// FIXME: License header is disabled because it breaks compilation
+//task licenseFormatAndroid(type: nl.javadude.gradle.plugins.license.License) {
+//    source = fileTree(dir: getRootDir()).include([
+//        "**/*.java",
+//        "**/*.scala",
+//        "**/*.gradle",
+//        "**/*.xml",
+//    ]).exclude([
+//        "**/*build*",
+//        "**/*target*",
+//        "**/*gen*",
+//        "**/*generated*",
+//        ".idea/**"
+//    ])
+//}
+//licenseFormat.dependsOn licenseFormatAndroid
+
 
 ext {
     compileSdkVersion = 28


### PR DESCRIPTION
Each new year our Gradle tries to rewrite the license headers, updating the year, and it breaks compilation.
The decision right now is to move the procedure to the CI level, and not add headers locally during the compilation. Since this needs additional work, right now I just disable the old procedure.
#### APK
[Download build #743](http://10.10.124.11:8080/job/Pull%20Request%20Builder/743/artifact/build/artifact/wire-dev-PR2517-743.apk)