### PR TITLE
Fix the "..." button on the Single Participant screen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -40,7 +40,6 @@ import com.waz.zclient.utils.{ContextUtils, GuestUtils, RichView, StringUtils}
 import com.waz.zclient.views.menus.{FooterMenu, FooterMenuCallback}
 import com.waz.zclient.{FragmentHelper, R}
 import org.threeten.bp.Instant
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -169,19 +168,14 @@ class SingleParticipantFragment extends FragmentHelper {
   private lazy val footerMenu = returning( view[FooterMenu](R.id.fm__footer) ) { vh =>
     // TODO: merge this logic with ConversationOptionsMenuController
     (for {
-      conv           <- participantsController.conv
-      createPerm     <- userAccountsController.hasCreateConvPermission
-      remPerm        <- participantsController.selfRole.map(_.canRemoveGroupMember)
-      selfIsProUser  <- userAccountsController.isTeam
-      other          <- participantsController.otherParticipant
-      otherIsGuest    = other.isGuest(conv.team)
-    } yield {
-      if (fromDeepLink) !selfIsProUser || otherIsGuest
-      else createPerm || remPerm
-    }).map {
-      case true => R.string.glyph__more
-      case _    => R.string.empty_string
-    }.map(getString).onUi(text => vh.foreach(_.setRightActionText(text)))
+      conv            <- participantsController.conv
+      remPerm         <- participantsController.selfRole.map(_.canRemoveGroupMember)
+      selfIsProUser   <- userAccountsController.isTeam
+      other           <- participantsController.otherParticipant
+      otherIsGuest    =  other.isGuest(conv.team)
+      showRightAction =  if (fromDeepLink) !selfIsProUser || otherIsGuest else remPerm
+      rightActionStr  =  getString(if (showRightAction) R.string.glyph__more else R.string.empty_string)
+    } yield rightActionStr).onUi(text => vh.foreach(_.setRightActionText(text)))
 
     leftActionStrings.onUi { case (icon, text) =>
       vh.foreach { menu =>


### PR DESCRIPTION
When the current user is both a guest and and admin, they should be able to remove other users from the group, so the "..." button in the right-bottom corner of the Single Participant screen should be visible. When clicked, it should reveal a menu with the "Remove from group" button.
But if the current user is a guest but not an admin, no options are available and the "..." button should be hidden.

The previous fix to this problem was too liberal - the "..." button appeared even when it should not.
 now it should appear only when there is the "Remove from group" button in the menu behind the "..." button.
 the right way to do it would be to connect the two:
1. `ConversationOptionsMenuController` calculates what buttons are visible in the menu.
2. The footer shows the "..." button only if the number of buttons behind it is > 0.
 that's a bit more complicated though, so I don't want to do it as a quick fix.


#### APK
[Download build #744](http://10.10.124.11:8080/job/Pull%20Request%20Builder/744/artifact/build/artifact/wire-dev-PR2518-744.apk)