### PR TITLE
Fix Java "week year" date pattern

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -746,11 +746,11 @@
     <!-- Example: FRIDAY, MAR 9, 11:29 -->
     <string name="timestamp_pattern__date_and_time__no_year">EEE, MMM d, %1$s</string>
     <!-- Example: FRIDAY, MAR 9, 2015, 11:29 -->
-    <string name="timestamp_pattern__date_and_time__with_year">EEE, MMM d, YYYY, %1$s</string>
+    <string name="timestamp_pattern__date_and_time__with_year">EEE, MMM d, yyyy, %1$s</string>
     <!-- Example: MAR 9, 11:29 -->
     <string name="timestamp_pattern__date_and_time__no_year_no_weekday">MMM d, %1$s</string>
     <!-- Example: MAR 9, 2015, 11:29 -->
-    <string name="timestamp_pattern__date_and_time__with_year_no_weekday">MMM d, YYYY, %1$s</string>
+    <string name="timestamp_pattern__date_and_time__with_year_no_weekday">MMM d, yyyy, %1$s</string>
     <!-- Example: MONDAY, 9 MARCH 2015 \u30FB 12:08 -->
     <!-- MONDAY -->
      <!-- MARCH 2 -->


### PR DESCRIPTION
Usually when you have a time format "MMM d, YYYY" you suspect you'll get something like "DEC 30, 2019". But "YYYY", while accepted everywhere as denoting a year written with four digits, in Java means "the year rounded to the beginning of the week". The correct format for real years is "yyyy".

Here's why:
https://www.youtube.com/watch?v=D3jxx8Yyw1c

#### APK
[Download build #752](http://10.10.124.11:8080/job/Pull%20Request%20Builder/752/artifact/build/artifact/wire-dev-PR2519-752.apk)