### PR TITLE
Refactor UserData.displayName

### DIFF
--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -72,7 +72,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
   private lazy val accentColor = inject[AccentColorController].accentColor
 
   private lazy val nameTextView = returning(view[TypefaceTextView](R.id.ttv__name)) { vh =>
-    self.map(_.getDisplayName).onUi(name => vh.foreach(_.setText(name)))
+    self.map(_.displayName).onUi(name => vh.foreach(_.setText(name)))
   }
   private lazy val usernameTextView = view[TypefaceTextView](R.id.ttv__username)
   private lazy val keepButton = returning(view[ZetaButton](R.id.zb__username_first_assign__keep)){ vh =>

--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -72,7 +72,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
   private lazy val accentColor = inject[AccentColorController].accentColor
 
   private lazy val nameTextView = returning(view[TypefaceTextView](R.id.ttv__name)) { vh =>
-    self.map(_.displayName).onUi(name => vh.foreach(_.setText(name)))
+    self.map(_.name).onUi(name => vh.foreach(_.setText(name)))
   }
   private lazy val usernameTextView = view[TypefaceTextView](R.id.ttv__username)
   private lazy val keepButton = returning(view[ZetaButton](R.id.zb__username_first_assign__keep)){ vh =>

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -138,7 +138,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       CallParticipantInfo(
         userId         = user.id,
         picture        = user.picture,
-        displayName    = user.getDisplayName,
+        displayName    = user.displayName,
         isGuest        = user.isGuest(cZms.teamId),
         isVerified     = user.isVerified,
         isExternal     = user.isExternal(cZms.teamId),
@@ -373,7 +373,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       users <- userStorage
       userId <- callerId
       data <- users.signal(userId)
-    } yield data.getDisplayName.toUpperCase(getLocale) + " "
+    } yield data.displayName.toUpperCase(getLocale) + " "
 
   val callBannerText: Signal[String] =
     (for {
@@ -384,7 +384,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       duration <- duration
       callee <- otherUser
     } yield (state, isGroupCall, userName, convName, duration, callee)).map {
-      case (SelfCalling, false, _, _, _, Some(callee))  => getString(R.string.call_banner_outgoing, callee.getDisplayName)
+      case (SelfCalling, false, _, _, _, Some(callee))  => getString(R.string.call_banner_outgoing, callee.displayName)
       case (SelfCalling, true, _, convName, _, _)       => getString(R.string.call_banner_outgoing, convName)
       case (OtherCalling, true, caller, convName, _, _) => getString(R.string.call_banner_incoming_group, convName, caller)
       case (OtherCalling, false, caller, _, _, _)       => getString(R.string.call_banner_incoming, caller)
@@ -400,7 +400,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       dur        <- duration
       group      <- isGroupCall
       callerId   <- callerId
-      callerName <- callingZms.flatMap(_.usersStorage.signal(callerId).map(_.getDisplayName).map(Option(_))).orElse(Signal.const(None))
+      callerName <- callingZms.flatMap(_.usersStorage.signal(callerId).map(_.displayName).map(Option(_))).orElse(Signal.const(None))
     } yield (video, state, dur, callerName.filter(_ => group))).map {
       case (true,  SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_video_subtitle)
       case (false, SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_subtitle)

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -138,7 +138,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       CallParticipantInfo(
         userId         = user.id,
         picture        = user.picture,
-        displayName    = user.displayName,
+        displayName    = user.name,
         isGuest        = user.isGuest(cZms.teamId),
         isVerified     = user.isVerified,
         isExternal     = user.isExternal(cZms.teamId),
@@ -373,7 +373,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       users <- userStorage
       userId <- callerId
       data <- users.signal(userId)
-    } yield data.displayName.toUpperCase(getLocale) + " "
+    } yield data.name.toUpperCase(getLocale) + " "
 
   val callBannerText: Signal[String] =
     (for {
@@ -384,7 +384,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       duration <- duration
       callee <- otherUser
     } yield (state, isGroupCall, userName, convName, duration, callee)).map {
-      case (SelfCalling, false, _, _, _, Some(callee))  => getString(R.string.call_banner_outgoing, callee.displayName)
+      case (SelfCalling, false, _, _, _, Some(callee))  => getString(R.string.call_banner_outgoing, callee.name)
       case (SelfCalling, true, _, convName, _, _)       => getString(R.string.call_banner_outgoing, convName)
       case (OtherCalling, true, caller, convName, _, _) => getString(R.string.call_banner_incoming_group, convName, caller)
       case (OtherCalling, false, caller, _, _, _)       => getString(R.string.call_banner_incoming, caller)
@@ -400,7 +400,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       dur        <- duration
       group      <- isGroupCall
       callerId   <- callerId
-      callerName <- callingZms.flatMap(_.usersStorage.signal(callerId).map(_.displayName).map(Option(_))).orElse(Signal.const(None))
+      callerName <- callingZms.flatMap(_.usersStorage.signal(callerId).map(_.name).map(Option(_))).orElse(Signal.const(None))
     } yield (video, state, dur, callerName.filter(_ => group))).map {
       case (true,  SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_video_subtitle)
       case (false, SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_subtitle)

--- a/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
@@ -109,7 +109,7 @@ class AccountTabButton(val context: Context, val attrs: AttributeSet, val defSty
   } yield (tOu, s)).onUi {
     case (Right(user), s) =>
       drawable.setInfo(NameParts.maybeInitial(user.displayName).getOrElse(""), TeamIconDrawable.UserShape, s)
-      name.setText(user.getDisplayName)
+      name.setText(user.displayName)
       drawable.setPicture(user.picture)
     case (Left(team), s) =>
       drawable.setInfo(NameParts.maybeInitial(team.name).getOrElse(""), TeamIconDrawable.TeamShape, s)

--- a/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
@@ -108,8 +108,8 @@ class AccountTabButton(val context: Context, val attrs: AttributeSet, val defSty
     tOu <- teamOrUser
   } yield (tOu, s)).onUi {
     case (Right(user), s) =>
-      drawable.setInfo(NameParts.maybeInitial(user.displayName).getOrElse(""), TeamIconDrawable.UserShape, s)
-      name.setText(user.displayName)
+      drawable.setInfo(NameParts.maybeInitial(user.name).getOrElse(""), TeamIconDrawable.UserShape, s)
+      name.setText(user.name)
       drawable.setPicture(user.picture)
     case (Left(team), s) =>
       drawable.setInfo(NameParts.maybeInitial(team.name).getOrElse(""), TeamIconDrawable.TeamShape, s)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -108,7 +108,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
                   hideStatus: Boolean,
                   createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)
-    setTitle(userData.getDisplayName, userData.isSelf)
+    setTitle(userData.displayName, userData.isSelf)
     setAvailability(if (teamId.isDefined && !hideStatus) userData.availability else Availability.None)
     setVerified(userData.isVerified)
     setSubtitle(createSubtitle(userData))

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -108,7 +108,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
                   hideStatus: Boolean,
                   createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
     chathead.loadUser(userData.id)
-    setTitle(userData.displayName, userData.isSelf)
+    setTitle(userData.name, userData.isSelf)
     setAvailability(if (teamId.isDefined && !hideStatus) userData.availability else Availability.None)
     setVerified(userData.isVerified)
     setSubtitle(createSubtitle(userData))

--- a/app/src/main/scala/com/waz/zclient/common/views/TopUserChathead.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TopUserChathead.scala
@@ -65,7 +65,7 @@ class TopUserChathead(val context: Context, val attrs: AttributeSet, val defStyl
 
   def setUser(user: UserData): Unit = {
     chathead.loadUser(user.id)
-    footer.setText(transformer.transform(user.getDisplayName))
+    footer.setText(transformer.transform(user.displayName))
     AvailabilityView.drawable(user.availability, footer.getCurrentTextColor).foreach(icon.setImageDrawable)
     icon.setVisibility(if (user.availability != Availability.None) View.VISIBLE else View.GONE)
   }

--- a/app/src/main/scala/com/waz/zclient/common/views/TopUserChathead.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/TopUserChathead.scala
@@ -65,7 +65,7 @@ class TopUserChathead(val context: Context, val attrs: AttributeSet, val defStyl
 
   def setUser(user: UserData): Unit = {
     chathead.loadUser(user.id)
-    footer.setText(transformer.transform(user.displayName))
+    footer.setText(transformer.transform(user.name))
     AvailabilityView.drawable(user.availability, footer.getCurrentTextColor).foreach(icon.setImageDrawable)
     icon.setVisibility(if (user.availability != Availability.None) View.VISIBLE else View.GONE)
   }

--- a/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
@@ -43,7 +43,7 @@ class UserDetailsView(val context: Context, val attrs: AttributeSet, val defStyl
     case None => ""
   }.onUi(userNameTextView.setText(_))
 
-  userId.flatMap(users.user).map(_.getDisplayName).onUi(userInfoTextView.setText(_))
+  userId.flatMap(users.user).map(_.displayName).onUi(userInfoTextView.setText(_))
 
   def setUserId(id: UserId): Unit =
     Option(id).fold(throw new IllegalArgumentException("UserId should not be null"))(userId ! _)

--- a/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
@@ -43,7 +43,7 @@ class UserDetailsView(val context: Context, val attrs: AttributeSet, val defStyl
     case None => ""
   }.onUi(userNameTextView.setText(_))
 
-  userId.flatMap(users.user).map(_.displayName).onUi(userInfoTextView.setText(_))
+  userId.flatMap(users.user).map(_.name).onUi(userInfoTextView.setText(_))
 
   def setUserId(id: UserId): Unit =
     Option(id).fold(throw new IllegalArgumentException("UserId should not be null"))(userId ! _)

--- a/app/src/main/scala/com/waz/zclient/connect/PendingConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/PendingConnectRequestFragment.scala
@@ -61,7 +61,7 @@ class PendingConnectRequestFragment extends BaseFragment[PendingConnectRequestFr
   private lazy val isIgnoredConnection = userConnection.map(_ == ConnectionStatus.IGNORED)
 
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.getDisplayName).onUi(t => vh.foreach(_.setText(t)))
+    user.map(_.displayName).onUi(t => vh.foreach(_.setText(t)))
   }
   private lazy val userHandleView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>
     user.map(user => StringUtils.formatHandle(user.handle.map(_.string).getOrElse("")))

--- a/app/src/main/scala/com/waz/zclient/connect/PendingConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/PendingConnectRequestFragment.scala
@@ -61,7 +61,7 @@ class PendingConnectRequestFragment extends BaseFragment[PendingConnectRequestFr
   private lazy val isIgnoredConnection = userConnection.map(_ == ConnectionStatus.IGNORED)
 
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.displayName).onUi(t => vh.foreach(_.setText(t)))
+    user.map(_.name).onUi(t => vh.foreach(_.setText(t)))
   }
   private lazy val userHandleView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>
     user.map(user => StringUtils.formatHandle(user.handle.map(_.string).getOrElse("")))

--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -111,7 +111,7 @@ class SendConnectRequestFragment
   }
   private lazy val imageViewProfile = view[ImageView](R.id.send_connect)
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.getDisplayName).onUi(t => vh.foreach(_.setText(t)))
+    user.map(_.displayName).onUi(t => vh.foreach(_.setText(t)))
   }
   private lazy val userHandleView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>
     user.map(user => StringUtils.formatHandle(user.handle.map(_.string).getOrElse("")))

--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -111,7 +111,7 @@ class SendConnectRequestFragment
   }
   private lazy val imageViewProfile = view[ImageView](R.id.send_connect)
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.displayName).onUi(t => vh.foreach(_.setText(t)))
+    user.map(_.name).onUi(t => vh.foreach(_.setText(t)))
   }
   private lazy val userHandleView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>
     user.map(user => StringUtils.formatHandle(user.handle.map(_.string).getOrElse("")))

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
@@ -50,7 +50,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     msg         <- messagesController.getMessage(msgId)
     sender      <- usersController.user(msg.userId)
     asset       <- assetsController.assetSignal(msg.assetId)
-  } yield Option(ReplyContent(msg, asset, sender.getDisplayName))).orElse(Signal.const(None))
+  } yield Option(ReplyContent(msg, asset, sender.displayName))).orElse(Signal.const(None))
 
   messagesService.flatMap(ms => Signal.wrap(ms.msgEdited)) { case (from, to) =>
     replyData.mutate { data =>

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
@@ -50,7 +50,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     msg         <- messagesController.getMessage(msgId)
     sender      <- usersController.user(msg.userId)
     asset       <- assetsController.assetSignal(msg.assetId)
-  } yield Option(ReplyContent(msg, asset, sender.displayName))).orElse(Signal.const(None))
+  } yield Option(ReplyContent(msg, asset, sender.name))).orElse(Signal.const(None))
 
   messagesService.flatMap(ms => Signal.wrap(ms.msgEdited)) { case (from, to) =>
     replyData.mutate { data =>

--- a/app/src/main/scala/com/waz/zclient/conversation/TypingIndicatorView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/TypingIndicatorView.scala
@@ -60,7 +60,7 @@ class TypingIndicatorView(val context: Context, val attrs: AttributeSet, val def
       setVisibility(View.GONE)
       endAnimation()
     } else {
-      nameTextView.setText(users.map(_.getDisplayName).mkString(", "))
+      nameTextView.setText(users.map(_.displayName).mkString(", "))
       setVisibility(View.VISIBLE)
       startAnimation()
     }

--- a/app/src/main/scala/com/waz/zclient/conversation/TypingIndicatorView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/TypingIndicatorView.scala
@@ -60,7 +60,7 @@ class TypingIndicatorView(val context: Context, val attrs: AttributeSet, val def
       setVisibility(View.GONE)
       endAnimation()
     } else {
-      nameTextView.setText(users.map(_.displayName).mkString(", "))
+      nameTextView.setText(users.map(_.name).mkString(", "))
       setVisibility(View.VISIBLE)
       startAnimation()
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -146,7 +146,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     otherUser <- userData(ms.headOption)
     isGroupConv <- z.conversations.groupConversation(conv.id)
     missedCallerId <- controller.lastMessage(conv.id).map(_.lastMissedCall.map(_.userId))
-    userName <- missedCallerId.fold2(Signal.const(Option.empty[Name]), u => z.usersStorage.signal(u).map(d => Some(d.getDisplayName)))
+    userName <- missedCallerId.fold2(Signal.const(Option.empty[Name]), u => z.usersStorage.signal(u).map(d => Some(d.displayName)))
   } yield (conv.id, subtitleStringForLastMessages(conv, otherUser, ms.toSet, lastMessage, lastUnreadMessage, lastUnreadMessageUser, lastUnreadMessageMembers, typingUser, z.selfUserId, isGroupConv, userName))
 
   private def userData(id: Option[UserId]) = id.fold2(Signal.const(Option.empty[UserData]), uid => UserSignal(uid).map(Option(_)))
@@ -401,8 +401,8 @@ object ConversationListRow {
                                   )
                                   (implicit context: Context): String = {
 
-    lazy val senderName = user.map(_.getDisplayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
-    lazy val memberName = members.headOption.map(_.getDisplayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
+    lazy val senderName = user.map(_.displayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
+    lazy val memberName = members.headOption.map(_.displayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
 
     if (messageData.isEphemeral) {
       if (messageData.hasMentionOf(selfId)) {
@@ -530,7 +530,7 @@ object ConversationListRow {
           subtitleStringForLastMessage(msg, lastUnreadMessageUser, lastUnreadMessageMembers, isGroupConv, selfId, conv.unreadCount.quotes > 0)
         }
       } { usr =>
-        formatSubtitle(getString(R.string.conversation_list__typing), usr.getDisplayName, isGroupConv)
+        formatSubtitle(getString(R.string.conversation_list__typing), usr.displayName, isGroupConv)
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -146,7 +146,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     otherUser <- userData(ms.headOption)
     isGroupConv <- z.conversations.groupConversation(conv.id)
     missedCallerId <- controller.lastMessage(conv.id).map(_.lastMissedCall.map(_.userId))
-    userName <- missedCallerId.fold2(Signal.const(Option.empty[Name]), u => z.usersStorage.signal(u).map(d => Some(d.displayName)))
+    userName <- missedCallerId.fold2(Signal.const(Option.empty[Name]), u => z.usersStorage.signal(u).map(d => Some(d.name)))
   } yield (conv.id, subtitleStringForLastMessages(conv, otherUser, ms.toSet, lastMessage, lastUnreadMessage, lastUnreadMessageUser, lastUnreadMessageMembers, typingUser, z.selfUserId, isGroupConv, userName))
 
   private def userData(id: Option[UserId]) = id.fold2(Signal.const(Option.empty[UserData]), uid => UserSignal(uid).map(Option(_)))
@@ -401,8 +401,8 @@ object ConversationListRow {
                                   )
                                   (implicit context: Context): String = {
 
-    lazy val senderName = user.map(_.displayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
-    lazy val memberName = members.headOption.map(_.displayName).getOrElse(Name(getString(R.string.conversation_list__someone)))
+    lazy val senderName = user.map(_.name).getOrElse(Name(getString(R.string.conversation_list__someone)))
+    lazy val memberName = members.headOption.map(_.name).getOrElse(Name(getString(R.string.conversation_list__someone)))
 
     if (messageData.isEphemeral) {
       if (messageData.hasMentionOf(selfId)) {
@@ -530,7 +530,7 @@ object ConversationListRow {
           subtitleStringForLastMessage(msg, lastUnreadMessageUser, lastUnreadMessageMembers, isGroupConv, selfId, conv.unreadCount.quotes > 0)
         }
       } { usr =>
-        formatSubtitle(getString(R.string.conversation_list__typing), usr.displayName, isGroupConv)
+        formatSubtitle(getString(R.string.conversation_list__typing), usr.name, isGroupConv)
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -81,11 +81,11 @@ abstract class ConversationListTopToolbar(val context: Context, val attrs: Attri
 
   def setTitle(mode: ListMode, currentUser: Option[UserData]): Unit = (mode, currentUser) match {
     case (Normal | Folders, Some(user)) if user.teamId.nonEmpty =>
-      title.setText(user.displayName)
+      title.setText(user.name)
       AvailabilityView.displayStartOfText(title, user.availability, title.getCurrentTextColor, pushDown = true)
       title.onClick { AvailabilityView.showAvailabilityMenu(AvailabilityChanged.ListHeader) }
     case (Normal | Folders, Some(user)) =>
-      title.setText(user.displayName)
+      title.setText(user.name)
       AvailabilityView.displayStartOfText(title, Availability.None, title.getCurrentTextColor)
       title.setOnClickListener(null)
     case (mode, userOpt) =>
@@ -122,7 +122,7 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
       drawable.setInfo(NameParts.maybeInitial(team.name).getOrElse(""), TeamIconDrawable.TeamShape, selected = false)
     case (user, _) =>
       drawable.setPicture(user.picture)
-      drawable.setInfo(NameParts.maybeInitial(user.displayName).getOrElse(""), TeamIconDrawable.UserShape, selected = false)
+      drawable.setInfo(NameParts.maybeInitial(user.name).getOrElse(""), TeamIconDrawable.UserShape, selected = false)
   }
   profileButton.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
   profileButton.setImageDrawable(drawable)

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -219,7 +219,7 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
 
   userId(chathead.loadUser)
 
-  user.map(u => if (u.isWireBot) u.name else if (u.deleted) Name(getString(R.string.default_deleted_username)) else u.getDisplayName).onUi(tvName.setTransformedText(_))
+  user.map(u => if (u.isWireBot) u.name else if (u.deleted) Name(getString(R.string.default_deleted_username)) else u.displayName).onUi(tvName.setTransformedText(_))
   user.map(_.isWireBot).on(Threading.Ui) { isBot.setVisible }
 
   user.map(_.accent).on(Threading.Ui) { a =>

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -219,7 +219,7 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
 
   userId(chathead.loadUser)
 
-  user.map(u => if (u.isWireBot) u.name else if (u.deleted) Name(getString(R.string.default_deleted_username)) else u.displayName).onUi(tvName.setTransformedText(_))
+  user.map(u => if (u.isWireBot) u.name else if (u.deleted) Name(getString(R.string.default_deleted_username)) else u.name).onUi(tvName.setTransformedText(_))
   user.map(_.isWireBot).on(Threading.Ui) { isBot.setVisible }
 
   user.map(_.accent).on(Threading.Ui) { a =>

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -61,7 +61,7 @@ class UsersController(implicit injector: Injector, context: Context)
 
   def displayName(id: UserId): Signal[DisplayName] = zMessaging.flatMap { zms =>
     if (zms.selfUserId == id) Signal const Me
-    else user(id).map(u => Other(if (u.deleted) getString(R.string.default_deleted_username) else u.getDisplayName))
+    else user(id).map(u => Other(if (u.deleted) getString(R.string.default_deleted_username) else u.displayName))
   }
 
   lazy val availabilityVisible: Signal[Boolean] = for {

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -61,7 +61,7 @@ class UsersController(implicit injector: Injector, context: Context)
 
   def displayName(id: UserId): Signal[DisplayName] = zMessaging.flatMap { zms =>
     if (zms.selfUserId == id) Signal const Me
-    else user(id).map(u => Other(if (u.deleted) getString(R.string.default_deleted_username) else u.displayName))
+    else user(id).map(u => Other(if (u.deleted) getString(R.string.default_deleted_username) else u.name))
   }
 
   lazy val availabilityVisible: Signal[Boolean] = for {
@@ -149,7 +149,7 @@ class UsersController(implicit injector: Injector, context: Context)
       uToConnect <- user(userId).head
       zms <- zMessaging.head
       message = getString(R.string.connect__message, uToConnect.name, uSelf.name)
-      conv <- zms.connection.connectToUser(userId, message, uToConnect.displayName)
+      conv <- zms.connection.connectToUser(userId, message, uToConnect.name)
     } yield conv
   }
 }

--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -125,7 +125,7 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   private def copyMessage(message: MessageData) =
     zms.head.flatMap(_.usersStorage.get(message.userId)) foreach {
       case Some(user) =>
-        val clip = ClipData.newPlainText(getString(R.string.conversation__action_mode__copy__description, user.getDisplayName), message.contentString)
+        val clip = ClipData.newPlainText(getString(R.string.conversation__action_mode__copy__description, user.displayName), message.contentString)
         clipboard.setPrimaryClip(clip)
         Toast.makeText(context, R.string.conversation__action_mode__copy__toast, Toast.LENGTH_SHORT).show()
       case None =>

--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -125,7 +125,7 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   private def copyMessage(message: MessageData) =
     zms.head.flatMap(_.usersStorage.get(message.userId)) foreach {
       case Some(user) =>
-        val clip = ClipData.newPlainText(getString(R.string.conversation__action_mode__copy__description, user.displayName), message.contentString)
+        val clip = ClipData.newPlainText(getString(R.string.conversation__action_mode__copy__description, user.name), message.contentString)
         clipboard.setPrimaryClip(clip)
         Toast.makeText(context, R.string.conversation__action_mode__copy__toast, Toast.LENGTH_SHORT).show()
       case None =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
@@ -55,9 +55,9 @@ class MissedCallPartView(context: Context, attrs: AttributeSet, style: Int) exte
   private val locale = getLocale
   private val msg = user map {
     case u if u.isSelf => getString(R.string.content__missed_call__you_called)
-    case u if u.getDisplayName.isEmpty => ""
+    case u if u.displayName.isEmpty => ""
     case u =>
-      getString(R.string.content__missed_call__xxx_called, u.getDisplayName.toUpperCase(locale))
+      getString(R.string.content__missed_call__xxx_called, u.displayName.toUpperCase(locale))
   }
 
   msg.on(Threading.Ui) { m =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
@@ -55,9 +55,9 @@ class MissedCallPartView(context: Context, attrs: AttributeSet, style: Int) exte
   private val locale = getLocale
   private val msg = user map {
     case u if u.isSelf => getString(R.string.content__missed_call__you_called)
-    case u if u.displayName.isEmpty => ""
+    case u if u.name.isEmpty => ""
     case u =>
-      getString(R.string.content__missed_call__xxx_called, u.displayName.toUpperCase(locale))
+      getString(R.string.content__missed_call__xxx_called, u.name.toUpperCase(locale))
   }
 
   msg.on(Threading.Ui) { m =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
@@ -101,7 +101,7 @@ abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int)
 
   quoteComposer
     .map { _
-      .map(u => if (u.isWireBot) u.name else u.getDisplayName)
+      .map(u => if (u.isWireBot) u.name else u.displayName)
       .getOrElse(Name.Empty)
     }
     .onUi(name.setText(_))

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
@@ -101,7 +101,7 @@ abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int)
 
   quoteComposer
     .map { _
-      .map(u => if (u.isWireBot) u.name else u.displayName)
+      .map(u => if (u.isWireBot) u.name else u.name)
       .getOrElse(Name.Empty)
     }
     .onUi(name.setText(_))

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
@@ -47,7 +47,7 @@ class LikeDetailsView(context: Context, attrs: AttributeSet, style: Int) extends
             likers           <- reactionsStorage.likes(msg.id).map(_.likers)
             usersStorage     <- inject[Signal[UsersStorage]]
             users            <- usersStorage.listSignal(likers.keys)
-          } yield users.sortBy(u => likers(u.id)).map(_.getDisplayName).mkString(", ")
+          } yield users.sortBy(u => likers(u.id)).map(_.displayName).mkString(", ")
     }.onUi(description.setText)
 }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/LikeDetailsView.scala
@@ -47,7 +47,7 @@ class LikeDetailsView(context: Context, attrs: AttributeSet, style: Int) extends
             likers           <- reactionsStorage.likes(msg.id).map(_.likers)
             usersStorage     <- inject[Signal[UsersStorage]]
             users            <- usersStorage.listSignal(likers.keys)
-          } yield users.sortBy(u => likers(u.id)).map(_.displayName).mkString(", ")
+          } yield users.sortBy(u => likers(u.id)).map(_.name).mkString(", ")
     }.onUi(description.setText)
 }
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -278,7 +278,7 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
 
   private def getUserName(account: UserId, n: NotificationData) =
     inject[AccountToUsersStorage].apply(account).flatMap {
-      case Some(storage) => storage.get(n.user).map(_.map(_.getDisplayName))
+      case Some(storage) => storage.get(n.user).map(_.map(_.displayName))
       case None          => Future.successful(Option.empty[Name])
     }
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -278,7 +278,7 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
 
   private def getUserName(account: UserId, n: NotificationData) =
     inject[AccountToUsersStorage].apply(account).flatMap {
-      case Some(storage) => storage.get(n.user).map(_.map(_.displayName))
+      case Some(storage) => storage.get(n.user).map(_.map(_.name))
       case None          => Future.successful(Option.empty[Name])
     }
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -304,7 +304,7 @@ object NotificationManagerWrapper {
         msgSound <- Signal.future(getSound(UserPreferences.TextTone, R.raw.new_message_gcm))
         pingSound <- Signal.future(getSound(UserPreferences.PingTone, R.raw.ping_from_them))
         vibration <- Signal.future(am.userPrefs.preference(UserPreferences.VibrateEnabled).apply())
-        channel <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.getDisplayName, Set(
+        channel <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.displayName, Set(
             ChannelInfo(MessageNotificationsChannelId(am.userId), R.string.message_notifications_channel_name, R.string.message_notifications_channel_description, msgSound, vibration),
             ChannelInfo(PingNotificationsChannelId(am.userId), R.string.ping_notifications_channel_name, R.string.ping_notifications_channel_description, pingSound, vibration)
           )))

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -304,7 +304,7 @@ object NotificationManagerWrapper {
         msgSound <- Signal.future(getSound(UserPreferences.TextTone, R.raw.new_message_gcm))
         pingSound <- Signal.future(getSound(UserPreferences.PingTone, R.raw.ping_from_them))
         vibration <- Signal.future(am.userPrefs.preference(UserPreferences.VibrateEnabled).apply())
-        channel <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.displayName, Set(
+        channel <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.name, Set(
             ChannelInfo(MessageNotificationsChannelId(am.userId), R.string.message_notifications_channel_name, R.string.message_notifications_channel_description, msgSound, vibration),
             ChannelInfo(PingNotificationsChannelId(am.userId), R.string.ping_notifications_channel_name, R.string.ping_notifications_channel_description, pingSound, vibration)
           )))

--- a/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
@@ -107,7 +107,7 @@ class BlockedUserProfileFragment extends BaseFragment[BlockedUserProfileFragment
   private lazy val profileImageView = view[ImageView](R.id.blocked_user_picture)
 
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.getDisplayName).onUi(name => vh.foreach(_.setText(name)))
+    user.map(_.displayName).onUi(name => vh.foreach(_.setText(name)))
   }
 
   private lazy val userUsernameView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/connect/BlockedUserProfileFragment.scala
@@ -107,7 +107,7 @@ class BlockedUserProfileFragment extends BaseFragment[BlockedUserProfileFragment
   private lazy val profileImageView = view[ImageView](R.id.blocked_user_picture)
 
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
-    user.map(_.displayName).onUi(name => vh.foreach(_.setText(name)))
+    user.map(_.name).onUi(name => vh.foreach(_.setText(name)))
   }
 
   private lazy val userUsernameView = returning(view[TypefaceTextView](R.id.user_handle)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -104,7 +104,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
         isAdmin = participants.get(user.id).contains(ConversationRole.AdminRole),
         isSelf = user.id == selfId
       ))
-      .sortBy(_.userData.getDisplayName.str)
+      .sortBy(_.userData.displayName.str)
 
   protected lazy val positions = for {
     tId               <- team
@@ -384,7 +384,7 @@ object ParticipantsAdapter {
         case None    => view.setUserData(participant.userData, teamId, hideStatus)
       }
       view.setSeparatorVisible(!lastRow)
-      view.setContentDescription(s"${if (participant.isAdmin) "Admin" else "Member"}: ${participant.userData.getDisplayName}")
+      view.setContentDescription(s"${if (participant.isAdmin) "Admin" else "Member"}: ${participant.userData.displayName}")
     }
   }
 
@@ -509,7 +509,7 @@ class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle:  Option
       isGuest = user.isGuest(tId) && !user.isWireBot,
       isAdmin = false, // unused
       isSelf  = user.id == selfId
-    )).sortBy(_.userData.getDisplayName.str)
+    )).sortBy(_.userData.displayName.str)
 
   override protected lazy val positions = users.map { us =>
     val people = us.toList.filterNot(_.userData.isWireBot)

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -104,7 +104,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
         isAdmin = participants.get(user.id).contains(ConversationRole.AdminRole),
         isSelf = user.id == selfId
       ))
-      .sortBy(_.userData.displayName.str)
+      .sortBy(_.userData.name.str)
 
   protected lazy val positions = for {
     tId               <- team
@@ -384,7 +384,7 @@ object ParticipantsAdapter {
         case None    => view.setUserData(participant.userData, teamId, hideStatus)
       }
       view.setSeparatorVisible(!lastRow)
-      view.setContentDescription(s"${if (participant.isAdmin) "Admin" else "Member"}: ${participant.userData.displayName}")
+      view.setContentDescription(s"${if (participant.isAdmin) "Admin" else "Member"}: ${participant.userData.name}")
     }
   }
 
@@ -509,7 +509,7 @@ class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle:  Option
       isGuest = user.isGuest(tId) && !user.isWireBot,
       isAdmin = false, // unused
       isSelf  = user.id == selfId
-    )).sortBy(_.userData.displayName.str)
+    )).sortBy(_.userData.name.str)
 
   override protected lazy val positions = users.map { us =>
     val people = us.toList.filterNot(_.userData.isWireBot)

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -124,7 +124,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
     case Some(userData) =>
       val request = new ConfirmationRequest.Builder()
         .withHeader(getString(R.string.confirmation_menu__header))
-        .withMessage(getString(R.string.confirmation_menu_text_with_name, userData.displayName))
+        .withMessage(getString(R.string.confirmation_menu_text_with_name, userData.name))
         .withPositiveButton(getString(R.string.confirmation_menu__confirm_remove))
         .withNegativeButton(getString(R.string.confirmation_menu__cancel))
         .withConfirmationCallback(new TwoButtonConfirmationCallback() {

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -124,7 +124,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
     case Some(userData) =>
       val request = new ConfirmationRequest.Builder()
         .withHeader(getString(R.string.confirmation_menu__header))
-        .withMessage(getString(R.string.confirmation_menu_text_with_name, userData.getDisplayName))
+        .withMessage(getString(R.string.confirmation_menu_text_with_name, userData.displayName))
         .withPositiveButton(getString(R.string.confirmation_menu__confirm_remove))
         .withNegativeButton(getString(R.string.confirmation_menu__cancel))
         .withConfirmationCallback(new TwoButtonConfirmationCallback() {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -166,7 +166,7 @@ class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentH
 
         participantsController.otherParticipant.onUi { user =>
           vh.foreach { view =>
-            view.setText(user.getDisplayName)
+            view.setText(user.displayName)
             val shield = if (user.isVerified) Option(getDrawable(R.drawable.shield_full)) else None
             view.displayEndOfText(shield)
             if (shield.isDefined) view.setCompoundDrawablePadding(getDimenPx(R.dimen.wire__padding__tiny))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -166,7 +166,7 @@ class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentH
 
         participantsController.otherParticipant.onUi { user =>
           vh.foreach { view =>
-            view.setText(user.displayName)
+            view.setText(user.name)
             val shield = if (user.isVerified) Option(getDrawable(R.drawable.shield_full)) else None
             view.displayEndOfText(shield)
             if (shield.isDefined) view.setCompoundDrawablePadding(getDimenPx(R.dimen.wire__padding__tiny))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -92,7 +92,7 @@ class SingleOtrClientFragment extends FragmentHelper {
   private lazy val descriptionText = returning(view[TextView] (R.id.client_description)) { vh =>
     (userId match {
       case Some(uId) =>
-        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.getDisplayName))
+        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.displayName))
       case _ =>
         Signal.const(getString(R.string.otr__participant__my_device__description))
     }).onUi(t => vh.foreach(_.setText(t)))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -92,7 +92,7 @@ class SingleOtrClientFragment extends FragmentHelper {
   private lazy val descriptionText = returning(view[TextView] (R.id.client_description)) { vh =>
     (userId match {
       case Some(uId) =>
-        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.displayName))
+        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.name))
       case _ =>
         Signal.const(getString(R.string.otr__participant__my_device__description))
     }).onUi(t => vh.foreach(_.setText(t)))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -306,6 +306,8 @@ object SingleParticipantFragment {
   }
 
   private val TabToOpen: String = "TAB_TO_OPEN"
+
+
   private val FromDeepLink: String = "FROM_DEEP_LINK"
 
   def newInstance(tabToOpen: Option[String] = None, fromDeepLink: Boolean = false): SingleParticipantFragment =

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -276,7 +276,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   self.on(Threading.Ui) { self =>
     view.setAccentColor(AccentColor(self.accent).color)
     self.handle.foreach(handle => view.setHandle(StringUtils.formatHandle(handle.string)))
-    view.setUserName(self.getDisplayName)
+    view.setUserName(self.displayName)
   }
 
   for {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -276,7 +276,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   self.on(Threading.Ui) { self =>
     view.setAccentColor(AccentColor(self.accent).color)
     self.handle.foreach(handle => view.setHandle(StringUtils.formatHandle(handle.string)))
-    view.setUserName(self.displayName)
+    view.setUserName(self.name)
   }
 
   for {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -114,7 +114,7 @@ class SettingsViewController(view: SettingsView)(implicit inj: Injector, ec: Eve
   val selfInfo = for {
     z <- zms
     self <- UserSignal(z.selfUserId)
-  } yield (self.getDisplayName, self.handle.fold("")(_.string))
+  } yield (self.displayName, self.handle.fold("")(_.string))
 
   val team = zms.flatMap(_.teams.selfTeam)
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -114,7 +114,7 @@ class SettingsViewController(view: SettingsView)(implicit inj: Injector, ec: Eve
   val selfInfo = for {
     z <- zms
     self <- UserSignal(z.selfUserId)
-  } yield (self.displayName, self.handle.fold("")(_.string))
+  } yield (self.name, self.handle.fold("")(_.string))
 
   val team = zms.flatMap(_.teams.selfTeam)
 

--- a/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
@@ -120,7 +120,7 @@ class ProfileAccountTab(val context: Context, val attrs: AttributeSet, val defSt
   setLayerType(View.LAYER_TYPE_SOFTWARE, null)
 
   teamAndUser.map {
-    case (userData, None) => userData.getDisplayName
+    case (userData, None) => userData.displayName
     case (userData, Some(team)) => team.name
   }.onUi { setContentDescription(_) }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
@@ -92,7 +92,7 @@ class ProfileAccountTab(val context: Context, val attrs: AttributeSet, val defSt
 
   private val initials = teamAndUser.map {
     case (_, Some(team)) => team.name
-    case (user, _) => user.displayName
+    case (user, _) => user.name
   }.map(NameParts.maybeInitial(_).getOrElse(""))
 
   private val drawableCorners = teamAndUser.map {
@@ -120,7 +120,7 @@ class ProfileAccountTab(val context: Context, val attrs: AttributeSet, val defSt
   setLayerType(View.LAYER_TYPE_SOFTWARE, null)
 
   teamAndUser.map {
-    case (userData, None) => userData.displayName
+    case (userData, None) => userData.name
     case (userData, Some(team)) => team.name
   }.onUi { setContentDescription(_) }
 

--- a/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
@@ -117,7 +117,7 @@ object QuickReplyContentAdapter {
       zms <- inject[Signal[ZMessaging]]
       msg <- message
       user <- zms.usersStorage.signal(msg.userId)
-    } yield user.displayName
+    } yield user.name
 
     val contentStr = message.zip(userName) map {
       case (msg, name) if isGroupConv =>

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -417,7 +417,7 @@ class SearchUIFragment extends BaseFragment[Container]
   private def sendGenericInvite(fromSearch: Boolean): Unit =
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
-        getString(R.string.people_picker__invite__share_text__header, self.getDisplayName),
+        getString(R.string.people_picker__invite__share_text__header, self.displayName),
         getString(R.string.people_picker__invite__share_text__body, StringUtils.formatHandle(self.handle.map(_.string).getOrElse(""))))
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -417,7 +417,7 @@ class SearchUIFragment extends BaseFragment[Container]
   private def sendGenericInvite(fromSearch: Boolean): Unit =
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
-        getString(R.string.people_picker__invite__share_text__header, self.displayName),
+        getString(R.string.people_picker__invite__share_text__header, self.name),
         getString(R.string.people_picker__invite__share_text__body, StringUtils.formatHandle(self.handle.map(_.string).getOrElse(""))))
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }

--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -134,7 +134,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
         var contactsSection = Seq[SearchViewItem]()
 
         contactsSection = contactsSection ++ localResults.indices.map { i =>
-          ConnectionViewItem(ConnectionViewModel(i, localResults(i).id.str.hashCode, isConnected = true, shouldHideUserStatus, localResults, localResults(i).displayName, team))
+          ConnectionViewItem(ConnectionViewModel(i, localResults(i).id.str.hashCode, isConnected = true, shouldHideUserStatus, localResults, localResults(i).name, team))
         }
 
         val shouldCollapse = searchController.filter.currentValue.exists(_.nonEmpty) && collapsedContacts && contactsSection.size > CollapsedContacts

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -802,7 +802,7 @@ class ConversationFragment extends FragmentHelper {
 
         val unverifiedNames = unverifiedUsers.map { u =>
           if (self.map(_.id).contains(u.id)) getString(R.string.conversation_degraded_confirmation__header__you)
-          else u.getDisplayName.str
+          else u.displayName.str
         }
 
         val header =

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -802,7 +802,7 @@ class ConversationFragment extends FragmentHelper {
 
         val unverifiedNames = unverifiedUsers.map { u =>
           if (self.map(_.id).contains(u.id)) getString(R.string.conversation_degraded_confirmation__header__you)
-          else u.displayName.str
+          else u.name.str
         }
 
         val header =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -117,27 +117,27 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
     cs.get(user.id) foreach { n =>
       if (n.first != name.first) {
         contactsByName.removeBinding(n.first, user.id)
-        displayNameUpdater ! n.first
+        nameUpdater ! n.first
       }
     }
 
     cs(user.id) = name
     contactsByName.addBinding(name.first, user.id)
-    displayNameUpdater ! name.first
+    nameUpdater ! name.first
     name
   }
 
-  val displayNameUpdater: SerialProcessingQueue[String] = new SerialProcessingQueue[String]({ firstNames =>
+  val nameUpdater: SerialProcessingQueue[String] = new SerialProcessingQueue[String]({ firstNames =>
     contactNameParts map { cs =>
       firstNames.toSet foreach { (first: String) =>
-        updateDisplayNamesWithSameFirst(contactsByName.getOrElse(first, Set()).toSeq, cs)
+        updateNamesWithSameFirst(contactsByName.getOrElse(first, Set()).toSeq, cs)
       }
     }
-  }, "UsersDisplayNameUpdater")
+  }, "UsersNameUpdater")
 
-  def updateDisplayNamesWithSameFirst(users: Seq[UserId], cs: mutable.HashMap[UserId, NameParts]): Unit = {
-    def setFullName(user: UserId) = update(user, { (u : UserData) => u.copy(dispName = u.name) })
-    def setDisplayName(user: UserId, name: String) = update(user, (_: UserData).copy(dispName = Name(name)))
+  def updateNamesWithSameFirst(users: Seq[UserId], cs: mutable.HashMap[UserId, NameParts]): Unit = {
+    def setFullName(user: UserId) = update(user, { (u : UserData) => u.copy(name = u.name) })
+    def setDisplayName(user: UserId, name: String) = update(user, (_: UserData).copy(name = Name(name)))
 
     if (users.isEmpty) CancellableFuture.successful(())
     else if (users.size == 1) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -106,7 +106,7 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
 
   def addOrOverwrite(user: UserData): Future[UserData] = updateOrCreate(user.id, _ => user, user)
 
-  def onContactUpdated(user: UserData, updated: UserData) = if (user.name != updated.name) updateContactName(updated)
+  private def onContactUpdated(user: UserData, updated: UserData): Unit = if (user.name != updated.name) updateContactName(updated)
 
   private def updateContactName(user: UserData): CancellableFuture[Unit] = contactNameParts map { cs => updateContactName(user, cs) }
 
@@ -136,8 +136,8 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
   }, "UsersDisplayNameUpdater")
 
   def updateDisplayNamesWithSameFirst(users: Seq[UserId], cs: mutable.HashMap[UserId, NameParts]): Unit = {
-    def setFullName(user: UserId) = update(user, { (u : UserData) => u.copy(displayName = u.name) })
-    def setDisplayName(user: UserId, name: String) = update(user, (_: UserData).copy(displayName = Name(name)))
+    def setFullName(user: UserId) = update(user, { (u : UserData) => u.copy(dispName = u.name) })
+    def setDisplayName(user: UserId, name: String) = update(user, (_: UserData).copy(dispName = Name(name)))
 
     if (users.isEmpty) CancellableFuture.successful(())
     else if (users.size == 1) {
@@ -147,9 +147,9 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
       def firstWithInitial(user: UserId) = cs.get(user).fold("")(_.firstWithInitial)
 
       users.groupBy(firstWithInitial) map {
-        case ("", us) => Future.sequence(us map setFullName)
+        case ("", us)       => Future.sequence(us.map(setFullName))
         case (name, Seq(u)) => setDisplayName(u, name)
-        case (name, us) => Future.sequence(us map setFullName)
+        case (_, us)        => Future.sequence(us.map(setFullName))
       }
     }
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -22,12 +22,12 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model._
 import com.waz.service.SearchKey
-import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
+import com.waz.threading.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils._
 import com.waz.utils.events._
 
-import scala.collection.{breakOut, mutable}
+import scala.collection.breakOut
 import scala.concurrent.Future
 
 trait UsersStorage extends CachedStorage[UserId, UserData] {
@@ -37,8 +37,6 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
   def listSignal(ids: Traversable[UserId]): Signal[Vector[UserData]]
   def listUsersByConnectionStatus(p: Set[ConnectionStatus]): Future[Map[UserId, UserData]]
   def listAcceptedOrPendingUsers: Future[Map[UserId, UserData]]
-  def getOrElseUpdate(id: UserId, default: => UserData): Future[UserData]
-  def addOrOverwrite(user: UserData): Future[UserData]
 
   def findUsersForService(id: IntegrationId): Future[Set[UserData]]
 }
@@ -46,44 +44,7 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
 class UsersStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[UserId, UserData](new TrimmingLruCache(context, Fixed(2000)), storage)(UserDataDao, LogTag("UsersStorage_Cached"))
     with UsersStorage {
-
-  import EventContext.Implicits.global
   private implicit val dispatcher = new SerialDispatchQueue(name = "UsersStorage")
-
-  val contactsByName = new mutable.HashMap[String, mutable.Set[UserId]] with mutable.MultiMap[String, UserId]
-
-  private lazy val contactNamesSource = Signal[Map[UserId, (NameParts, SearchKey)]]()
-
-  def contactNames: Signal[Map[UserId, (NameParts, SearchKey)]] = contactNamesSource
-
-  private lazy val contactNameParts: CancellableFuture[mutable.HashMap[UserId, NameParts]] = storage { UserDataDao.listContacts(_) } map { us =>
-    val cs = new mutable.HashMap[UserId, NameParts]
-    us foreach { user =>
-      if (getRawCached(user.id) == null) put(user.id, user)
-      updateContactName(user, cs)
-    }
-    cs
-  }
-
-  onAdded { users =>
-    users foreach { user =>
-      // TODO: batch
-      if (user.isConnected || user.connection == ConnectionStatus.Self) updateContactName(user)
-    }
-  }
-
-  onUpdated { updates =>
-    updates foreach { case (user, updated) =>
-      // TODO: batch
-      (user.isConnected || user.connection == ConnectionStatus.Self, updated.isConnected) match {
-        case (true, _) => onContactUpdated(user, updated)
-        case (_, true) => updateContactName(updated)
-        case _ => // not connected
-      }
-    }
-  }
-
-  override def getOrElseUpdate(id: UserId, default: => UserData): Future[UserData] = getOrCreate(id, default)
 
   override def listAll(ids: Traversable[UserId]) = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))
 
@@ -92,67 +53,17 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
     new RefreshingSignal(listAll(ids).lift, onChanged.map(_.filter(u => idSet(u.id))).filter(_.nonEmpty))
   }
 
-  def listUsersByConnectionStatus(p: Set[ConnectionStatus]): Future[Map[UserId, UserData]] =
+  override def listUsersByConnectionStatus(p: Set[ConnectionStatus]): Future[Map[UserId, UserData]] =
     find[(UserId, UserData), Map[UserId, UserData]](
       user => p(user.connection) && !user.deleted,
       db   => UserDataDao.findByConnectionStatus(p)(db),
       user => (user.id, user))
 
-  def listAcceptedOrPendingUsers: Future[Map[UserId, UserData]] =
+  override def listAcceptedOrPendingUsers: Future[Map[UserId, UserData]] =
     find[(UserId, UserData), Map[UserId, UserData]](
       user => user.isAcceptedOrPending && !user.deleted,
       db   => UserDataDao.findByConnectionStatus(Set(ConnectionStatus.Accepted, ConnectionStatus.PendingFromOther, ConnectionStatus.PendingFromUser))(db),
       user => (user.id, user))
-
-  def addOrOverwrite(user: UserData): Future[UserData] = updateOrCreate(user.id, _ => user, user)
-
-  private def onContactUpdated(user: UserData, updated: UserData): Unit = if (user.name != updated.name) updateContactName(updated)
-
-  private def updateContactName(user: UserData): CancellableFuture[Unit] = contactNameParts map { cs => updateContactName(user, cs) }
-
-  private def updateContactName(user: UserData, cs: mutable.HashMap[UserId, NameParts]): NameParts = {
-    val name = NameParts.parseFrom(user.name)
-
-    // remove previous if different first name
-    cs.get(user.id) foreach { n =>
-      if (n.first != name.first) {
-        contactsByName.removeBinding(n.first, user.id)
-        nameUpdater ! n.first
-      }
-    }
-
-    cs(user.id) = name
-    contactsByName.addBinding(name.first, user.id)
-    nameUpdater ! name.first
-    name
-  }
-
-  val nameUpdater: SerialProcessingQueue[String] = new SerialProcessingQueue[String]({ firstNames =>
-    contactNameParts map { cs =>
-      firstNames.toSet foreach { (first: String) =>
-        updateNamesWithSameFirst(contactsByName.getOrElse(first, Set()).toSeq, cs)
-      }
-    }
-  }, "UsersNameUpdater")
-
-  def updateNamesWithSameFirst(users: Seq[UserId], cs: mutable.HashMap[UserId, NameParts]): Unit = {
-    def setFullName(user: UserId) = update(user, { (u : UserData) => u.copy(name = u.name) })
-    def setDisplayName(user: UserId, name: String) = update(user, (_: UserData).copy(name = Name(name)))
-
-    if (users.isEmpty) CancellableFuture.successful(())
-    else if (users.size == 1) {
-      val user = users.head
-      cs.get(user).fold(setFullName(user))(name => setDisplayName(user, name.first))
-    } else {
-      def firstWithInitial(user: UserId) = cs.get(user).fold("")(_.firstWithInitial)
-
-      users.groupBy(firstWithInitial) map {
-        case ("", us)       => Future.sequence(us.map(setFullName))
-        case (name, Seq(u)) => setDisplayName(u, name)
-        case (_, us)        => Future.sequence(us.map(setFullName))
-      }
-    }
-  }
 
   override def getByTeam(teams: Set[TeamId]) =
     find(data => data.teamId.exists(id => teams.contains(id)), UserDataDao.findForTeams(teams)(_), identity)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
@@ -146,7 +146,7 @@ trait LogShowInstancesSE {
   implicit val UserDataLogShow: LogShow[UserData] =
     LogShow.createFrom { u =>
       import u._
-      l"UserData(id: $id | teamId: $teamId | name: $name | displayName: $displayName | email: $email | phone: $phone | handle: $handle | deleted: $deleted)"
+      l"UserData(id: $id | teamId: $teamId | name: $name | displayName: $name | email: $email | phone: $phone | handle: $handle | deleted: $deleted)"
     }
 
   implicit val UserInfoLogShow: LogShow[UserInfo] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
@@ -146,7 +146,7 @@ trait LogShowInstancesSE {
   implicit val UserDataLogShow: LogShow[UserData] =
     LogShow.createFrom { u =>
       import u._
-      l"UserData(id: $id | teamId: $teamId | name: $name | displayName: $name | email: $email | phone: $phone | handle: $handle | deleted: $deleted)"
+      l"UserData(id: $id | teamId: $teamId | name: $name | email: $email | phone: $phone | handle: $handle | deleted: $deleted)"
     }
 
   implicit val UserInfoLogShow: LogShow[UserInfo] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -48,7 +48,6 @@ case class UserData(override val id:       UserId,
                     conversation:          Option[RConvId]        = None, // remote conversation id with this contact (one-to-one)
                     relation:              Relation               = Relation.Other, //unused - remove in future migration
                     syncTimestamp:         Option[LocalInstant]   = None,
-                    private val dispName:  Name                   = Name.Empty,
                     verified:              Verification           = Verification.UNKNOWN, // user is verified if he has any otr client, and all his clients are verified
                     deleted:               Boolean                = false,
                     availability:          Availability           = Availability.None,
@@ -69,8 +68,6 @@ case class UserData(override val id:       UserId,
   lazy val isAutoConnect: Boolean       = isConnected && ! isSelf && connectionMessage.isEmpty
   lazy val isReadOnlyProfile: Boolean   = managedBy.exists(_ != ManagedBy.Wire) //if none or "Wire", then it's not read only.
   lazy val isWireBot: Boolean           = integrationId.nonEmpty
-
-  lazy val displayName: Name            = if (dispName.isEmpty) name else dispName
 
   def updated(user: UserInfo): UserData = updated(user, withSearchKey = true)
   def updated(user: UserInfo, withSearchKey: Boolean): UserData = copy(
@@ -202,7 +199,6 @@ object UserData {
     val Conversation = opt(id[RConvId]('conversation))(_.conversation)
     val Rel = text[Relation]('relation, _.name, Relation.valueOf)(_.relation)
     val Timestamp = opt(localTimestamp('timestamp))(_.syncTimestamp)
-    val DisplayName = text[model.Name]('display_name, _.str, model.Name(_))(_.dispName)
     val Verified = text[Verification]('verified, _.name, Verification.valueOf)(_.verified)
     val Deleted = bool('deleted)(_.deleted)
     val AvailabilityStatus = int[Availability]('availability, _.id, Availability.apply)(_.availability)
@@ -219,13 +215,13 @@ object UserData {
     override val idCol = Id
     override val table = Table(
       "Users", Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
-      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId,
+      Conversation, Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId,
       ExpiresAt, Managed, SelfPermissions, CopyPermissions, CreatedBy // Fields are now lazy-loaded from BE every time the user opens a profile
     )
 
     override def apply(implicit cursor: DBCursor): UserData = new UserData(
       Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
-      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed,
+      Conversation, Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed,
       Seq.empty, (SelfPermissions, CopyPermissions), CreatedBy
     )
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -63,7 +63,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
     RichFuture.traverseSequential(es) { e =>
       users.getOrCreateUser(e.user) flatMap { _ =>
         // update user name if it was just created (has empty name)
-        users.updateUserData(e.user, u => if (u.displayName.isEmpty) u.copy(name = e.name) else u)
+        users.updateUserData(e.user, u => if (u.name.isEmpty) u.copy(name = e.name) else u)
       }
     }
   }
@@ -129,7 +129,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
           case None if conv.convType == ConversationType.Incoming =>
             val userId = convToUser(conv.id)
             val user = eventMap(userId).user
-            messages.addConnectRequestMessage(conv.id, user.id, selfUserId, user.connectionMessage.getOrElse(""), user.displayName, fromSync = eventMap(userId).fromSync)
+            messages.addConnectRequestMessage(conv.id, user.id, selfUserId, user.connectionMessage.getOrElse(""), user.name, fromSync = eventMap(userId).fromSync)
           case None if conv.convType == ConversationType.OneToOne =>
             messages.addDeviceStartMessages(Seq(conv), selfUserId)
           case _ =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -63,7 +63,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
     RichFuture.traverseSequential(es) { e =>
       users.getOrCreateUser(e.user) flatMap { _ =>
         // update user name if it was just created (has empty name)
-        users.updateUserData(e.user, u => u.copy(name = if (u.name == Name.Empty) e.name else u.name))
+        users.updateUserData(e.user, u => if (u.displayName.isEmpty) u.copy(name = e.name) else u)
       }
     }
   }
@@ -129,7 +129,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
           case None if conv.convType == ConversationType.Incoming =>
             val userId = convToUser(conv.id)
             val user = eventMap(userId).user
-            messages.addConnectRequestMessage(conv.id, user.id, selfUserId, user.connectionMessage.getOrElse(""), user.getDisplayName, fromSync = eventMap(userId).fromSync)
+            messages.addConnectRequestMessage(conv.id, user.id, selfUserId, user.connectionMessage.getOrElse(""), user.displayName, fromSync = eventMap(userId).fromSync)
           case None if conv.convType == ConversationType.OneToOne =>
             messages.addDeviceStartMessages(Seq(conv), selfUserId)
           case _ =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
@@ -171,11 +171,11 @@ class ContactsServiceImpl(userId:         UserId,
         val onWireButUnconnected = onWire.aftersets.keysIterator.filterNot(uid => acceptedOrPending.contains(uid) || users.get(uid).forall(_.isConnected)).to[ArrayBuffer]
 
         val allIds = notOnWire.iterator.map(Right[UserId, ContactId](_)).++(acceptedOrPending.keysIterator.++(onWireButUnconnected.iterator).map(Left[UserId, ContactId](_))).to[ArrayBuffer]
-        def sortKey(id: Either[UserId, ContactId]): String = id.fold(u => users(u).getDisplayName, c => contacts(c).sortKey)
+        def sortKey(id: Either[UserId, ContactId]): String = id.fold(u => users(u).displayName, c => contacts(c).sortKey)
         val sortedIds = sortWithCurrentLocale(allIds, sortKey)
 
         val indexing = Locales.indexing()
-        def initial(idx: Int): String = indexing.labelFor(sortedIds(idx).fold(u => users(u).getDisplayName, c => contacts(c).sortKey))
+        def initial(idx: Int): String = indexing.labelFor(sortedIds(idx).fold(u => users(u).displayName, c => contacts(c).sortKey))
         val groupedByInitial: SeqMap[String, IndexedSeq[Int]] = {
           val grouped = sortedIds.indices.groupBy(initial)
           val other = grouped.get("#")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
@@ -171,11 +171,11 @@ class ContactsServiceImpl(userId:         UserId,
         val onWireButUnconnected = onWire.aftersets.keysIterator.filterNot(uid => acceptedOrPending.contains(uid) || users.get(uid).forall(_.isConnected)).to[ArrayBuffer]
 
         val allIds = notOnWire.iterator.map(Right[UserId, ContactId](_)).++(acceptedOrPending.keysIterator.++(onWireButUnconnected.iterator).map(Left[UserId, ContactId](_))).to[ArrayBuffer]
-        def sortKey(id: Either[UserId, ContactId]): String = id.fold(u => users(u).displayName, c => contacts(c).sortKey)
+        def sortKey(id: Either[UserId, ContactId]): String = id.fold(u => users(u).name, c => contacts(c).sortKey)
         val sortedIds = sortWithCurrentLocale(allIds, sortKey)
 
         val indexing = Locales.indexing()
-        def initial(idx: Int): String = indexing.labelFor(sortedIds(idx).fold(u => users(u).displayName, c => contacts(c).sortKey))
+        def initial(idx: Int): String = indexing.labelFor(sortedIds(idx).fold(u => users(u).name, c => contacts(c).sortKey))
         val groupedByInitial: SeqMap[String, IndexedSeq[Int]] = {
           val grouped = sortedIds.indices.groupBy(initial)
           val other = grouped.get("#")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -73,7 +73,7 @@ class UserSearchService(selfUserId:           UserId,
     lazy val knownUsers = membersStorage.getByUsers(searchResults.map(_.id).toSet).map(_.map(_.userId).toSet)
     isExternal.flatMap {
       case true if teamId.isDefined =>
-        verbose(l"filterForExternal1 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = true and teamId")
+        verbose(l"filterForExternal1 Q: $query, RES: ${searchResults.map(_.displayName)}) with partner = true and teamId")
         for {
           Some(self)    <- userService.getSelfUser
           filteredUsers <- knownUsers.map(knownUsersIds =>
@@ -81,7 +81,7 @@ class UserSearchService(selfUserId:           UserId,
                            )
         } yield filteredUsers
       case false if teamId.isDefined =>
-        verbose(l"filterForExternal2 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = false and teamId")
+        verbose(l"filterForExternal2 Q: $query, RES: ${searchResults.map(_.displayName)}) with partner = false and teamId")
         knownUsers.map { knownUsersIds =>
           searchResults.filter { u =>
             u.createdBy.contains(selfUserId) ||
@@ -130,15 +130,15 @@ class UserSearchService(selfUserId:           UserId,
       }
 
       val rules: Seq[UserData => Boolean] = Seq(
-        _.getDisplayName.toLowerCase.startsWith(filter),
+        _.displayName.toLowerCase.startsWith(filter),
         _.searchKey.asciiRepresentation.split(" ").exists(_.startsWith(filter)),
         cmpHandle(_, _.startsWith(filter)),
-        _.getDisplayName.toLowerCase.contains(filter),
+        _.displayName.toLowerCase.contains(filter),
         cmpHandle(_, _.contains(filter))
       )
 
       rules.foldLeft[(Set[UserId],IndexedSeq[UserData])]((Set.empty, IndexedSeq())){ case ((found, results), rule) =>
-        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.getDisplayName.toLowerCase)
+        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.displayName.toLowerCase)
         (found ++ matches.map(_.id).toSet, results ++: matches)
       }._2
     }
@@ -172,7 +172,7 @@ class UserSearchService(selfUserId:           UserId,
       else if (query.handleOnly) {
         if (u.handle.exists(_.exactMatchQuery(query.str))) 0 else 1
       } else {
-        val userName = toLower(u.getDisplayName)
+        val userName = toLower(u.displayName)
         if (userName == toLowerSymbolStripped) 0 else if (userName.startsWith(toLowerSymbolStripped)) 1 else 2
       }
 
@@ -180,7 +180,7 @@ class UserSearchService(selfUserId:           UserId,
         val b1 = bucket(u1)
         val b2 = bucket(u2)
         if (b1 == b2)
-          u1.getDisplayName.compareTo(u2.getDisplayName) < 0
+          u1.displayName.compareTo(u2.displayName) < 0
         else
           b1 < b2
     }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -73,7 +73,7 @@ class UserSearchService(selfUserId:           UserId,
     lazy val knownUsers = membersStorage.getByUsers(searchResults.map(_.id).toSet).map(_.map(_.userId).toSet)
     isExternal.flatMap {
       case true if teamId.isDefined =>
-        verbose(l"filterForExternal1 Q: $query, RES: ${searchResults.map(_.displayName)}) with partner = true and teamId")
+        verbose(l"filterForExternal1 Q: $query, RES: ${searchResults.map(_.name)}) with partner = true and teamId")
         for {
           Some(self)    <- userService.getSelfUser
           filteredUsers <- knownUsers.map(knownUsersIds =>
@@ -81,7 +81,7 @@ class UserSearchService(selfUserId:           UserId,
                            )
         } yield filteredUsers
       case false if teamId.isDefined =>
-        verbose(l"filterForExternal2 Q: $query, RES: ${searchResults.map(_.displayName)}) with partner = false and teamId")
+        verbose(l"filterForExternal2 Q: $query, RES: ${searchResults.map(_.name)}) with partner = false and teamId")
         knownUsers.map { knownUsersIds =>
           searchResults.filter { u =>
             u.createdBy.contains(selfUserId) ||
@@ -130,15 +130,15 @@ class UserSearchService(selfUserId:           UserId,
       }
 
       val rules: Seq[UserData => Boolean] = Seq(
-        _.displayName.toLowerCase.startsWith(filter),
+        _.name.toLowerCase.startsWith(filter),
         _.searchKey.asciiRepresentation.split(" ").exists(_.startsWith(filter)),
         cmpHandle(_, _.startsWith(filter)),
-        _.displayName.toLowerCase.contains(filter),
+        _.name.toLowerCase.contains(filter),
         cmpHandle(_, _.contains(filter))
       )
 
       rules.foldLeft[(Set[UserId],IndexedSeq[UserData])]((Set.empty, IndexedSeq())){ case ((found, results), rule) =>
-        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.displayName.toLowerCase)
+        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.name.toLowerCase)
         (found ++ matches.map(_.id).toSet, results ++: matches)
       }._2
     }
@@ -172,7 +172,7 @@ class UserSearchService(selfUserId:           UserId,
       else if (query.handleOnly) {
         if (u.handle.exists(_.exactMatchQuery(query.str))) 0 else 1
       } else {
-        val userName = toLower(u.displayName)
+        val userName = toLower(u.name)
         if (userName == toLowerSymbolStripped) 0 else if (userName.startsWith(toLowerSymbolStripped)) 1 else 2
       }
 
@@ -180,7 +180,7 @@ class UserSearchService(selfUserId:           UserId,
         val b1 = bucket(u1)
         val b2 = bucket(u2)
         if (b1 == b2)
-          u1.displayName.compareTo(u2.displayName) < 0
+          u1.name.compareTo(u2.name) < 0
         else
           b1 < b2
     }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -167,7 +167,7 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def findUser(id: UserId): Future[Option[UserData]] = usersStorage.get(id)
 
-  override def getOrCreateUser(id: UserId) = usersStorage.getOrElseUpdate(id, {
+  override def getOrCreateUser(id: UserId) = usersStorage.getOrCreate(id, {
     sync.syncUsers(Set(id))
     UserData(id, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None)
   })

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
@@ -125,7 +125,7 @@ class NameUpdater(selfUserId:     UserId,
         members <- membersStorage.getByConv(conv.id)
         users <- usersStorage.getAll(members.map(_.userId).filter(_ != selfUserId))
         name = generatedName(users.map {
-          case Some(u) if !u.deleted => Some(u.getDisplayName)
+          case Some(u) if !u.deleted => Some(u.displayName)
           case _                     => None
         })
         newName = if(name.isEmpty) Name(defaultName) else name
@@ -176,7 +176,7 @@ class NameUpdater(selfUserId:     UserId,
 
     usersStorage.getAll(users) flatMap { uds =>
       val names: Map[UserId, Option[Name]] = users.zip(uds.map(_.flatMap {
-        case u if !u.deleted => Some(u.getDisplayName)
+        case u if !u.deleted => Some(u.displayName)
         case _               => None
       }))(breakOut)
       val convNames = members.mapValues { us => generatedName(us.filter(_ != selfUserId) map { names.get(_).flatten }) }
@@ -197,7 +197,7 @@ class NameUpdater(selfUserId:     UserId,
 object NameUpdater {
   def generatedName(convType: ConversationType)(users: GenTraversable[UserData]): Name = {
     val us = users.filter(u => u.connection != ConnectionStatus.Self && !u.deleted)
-    if (convType == ConversationType.Group) Name(us.map(user => user.getDisplayName).filter(_.nonEmpty).mkString(", "))
+    if (convType == ConversationType.Group) Name(us.map(user => user.displayName).filter(_.nonEmpty).mkString(", "))
     else us.headOption.fold(Name.Empty)(_.name)
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/NameUpdater.scala
@@ -66,7 +66,7 @@ class NameUpdater(selfUserId:     UserId,
     usersStorage.onAdded { onUsersChanged(_) }
     usersStorage.onUpdated { updates =>
       onUsersChanged(updates.collect {
-        case (prev, current) if prev.name != current.name || prev.displayName != current.displayName => current
+        case (prev, current) if prev.name != current.name || prev.name != current.name => current
       })
     }
 
@@ -125,7 +125,7 @@ class NameUpdater(selfUserId:     UserId,
         members <- membersStorage.getByConv(conv.id)
         users <- usersStorage.getAll(members.map(_.userId).filter(_ != selfUserId))
         name = generatedName(users.map {
-          case Some(u) if !u.deleted => Some(u.displayName)
+          case Some(u) if !u.deleted => Some(u.name)
           case _                     => None
         })
         newName = if(name.isEmpty) Name(defaultName) else name
@@ -176,7 +176,7 @@ class NameUpdater(selfUserId:     UserId,
 
     usersStorage.getAll(users) flatMap { uds =>
       val names: Map[UserId, Option[Name]] = users.zip(uds.map(_.flatMap {
-        case u if !u.deleted => Some(u.displayName)
+        case u if !u.deleted => Some(u.name)
         case _               => None
       }))(breakOut)
       val convNames = members.mapValues { us => generatedName(us.filter(_ != selfUserId) map { names.get(_).flatten }) }
@@ -197,7 +197,7 @@ class NameUpdater(selfUserId:     UserId,
 object NameUpdater {
   def generatedName(convType: ConversationType)(users: GenTraversable[UserData]): Name = {
     val us = users.filter(u => u.connection != ConnectionStatus.Self && !u.deleted)
-    if (convType == ConversationType.Group) Name(us.map(user => user.displayName).filter(_.nonEmpty).mkString(", "))
+    if (convType == ConversationType.Group) Name(us.map(user => user.name).filter(_.nonEmpty).mkString(", "))
     else us.headOption.fold(Name.Empty)(_.name)
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
@@ -165,7 +165,7 @@ class VerificationStateUpdater(selfUserId:     UserId,
       users     <- convUsers
       usersMap  =  users.filter(_._2.nonEmpty).toMap
       updates   <- convs.updateAll2(usersMap.keys.toSeq, { conv => update(conv, usersMap(conv.id)) })
-      _ = verbose(l"updateConversations: ${users.flatMap(_._2).map(_.map(_.getDisplayName))}")
+      _ = verbose(l"updateConversations: ${users.flatMap(_._2).map(_.map(_.displayName))}")
       flattened = usersMap.map { case (conv, userList) => conv -> userList.flatten }
       _         <- updateProcessor(VerificationStateUpdate(updates, flattened, changes))
     } yield ()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
@@ -165,7 +165,7 @@ class VerificationStateUpdater(selfUserId:     UserId,
       users     <- convUsers
       usersMap  =  users.filter(_._2.nonEmpty).toMap
       updates   <- convs.updateAll2(usersMap.keys.toSeq, { conv => update(conv, usersMap(conv.id)) })
-      _ = verbose(l"updateConversations: ${users.flatMap(_._2).map(_.map(_.displayName))}")
+      _ = verbose(l"updateConversations: ${users.flatMap(_._2).map(_.map(_.name))}")
       flattened = usersMap.map { case (conv, userList) => conv -> userList.flatten }
       _         <- updateProcessor(VerificationStateUpdate(updates, flattened, changes))
     } yield ()

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/Generators.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/Generators.scala
@@ -100,9 +100,8 @@ object Generators {
     conversation          <- arbitrary[Option[RConvId]]
     relation              <- arbitrary[Relation]
     syncTimestamp         <- arbitrary[Option[LocalInstant]]
-    displayName           <- arbitrary[Name]
     handle                <- arbitrary[Option[Handle]]
-  } yield UserData(id, teamId, name, email, phone, trackingId, picture, accent, searchKey, connection, connectionLastUpdated, connectionMessage, conversation, relation, syncTimestamp, displayName, handle = handle))
+  } yield UserData(id, teamId, name, email, phone, trackingId, picture, accent, searchKey, connection, connectionLastUpdated, connectionMessage, conversation, relation, syncTimestamp, handle = handle))
 
   implicit lazy val arbOpenGraphDataImage: Arbitrary[OpenGraphImage] = Arbitrary(
     for {


### PR DESCRIPTION
From time to time a bug comes up in our UI, usually about that the user name does not appear correctly in one place or another. After investigation, we find out that we used `UserData.name` or
`UserData.displayName` instead of `UserData.getDisplayName`.
This PR removes both`UserData.displayName` and  `UserData.getDisplayName`, and adds a migration to remove the column from the Users table in DB as well. From now on we can safely use `name` in all cases.
#### APK
[Download build #786](http://10.10.124.11:8080/job/Pull%20Request%20Builder/786/artifact/build/artifact/wire-dev-PR2523-786.apk)
[Download build #794](http://10.10.124.11:8080/job/Pull%20Request%20Builder/794/artifact/build/artifact/wire-dev-PR2523-794.apk)