### PR TITLE
Preparation for "connection screen" refactoring.

### DIFF
--- a/app/src/main/res/layout/participant_user_name_row.xml
+++ b/app/src/main/res/layout/participant_user_name_row.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Wire
+    Copyright (C) 2019 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/background_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    style="?wireBackground"
+    android:layout_weight="1"
+    >
+
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/user_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/wire__text_size__big"
+        android:textColor="?wirePrimaryTextColor"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        app:w_font="@string/wire__typeface__regular"
+        />
+
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/user_handle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/user_name"
+        android:layout_centerHorizontal="true"
+        android:layout_gravity="center_horizontal"
+        android:textColor="?wireSecondaryTextColor"
+        android:textSize="@dimen/wire__text_size__regular"
+        android:layout_marginTop="@dimen/wire__padding__small"
+        app:w_font="@string/wire__typeface__regular"
+        />
+</RelativeLayout>

--- a/app/src/main/res/layout/participant_user_name_row.xml
+++ b/app/src/main/res/layout/participant_user_name_row.xml
@@ -19,14 +19,15 @@
 
 -->
 
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/background_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:layout_gravity="center_horizontal"
     style="?wireBackground"
-    android:layout_weight="1"
     >
 
     <com.waz.zclient.ui.text.TypefaceTextView
@@ -35,8 +36,6 @@
         android:layout_height="wrap_content"
         android:textSize="@dimen/wire__text_size__big"
         android:textColor="?wirePrimaryTextColor"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
         app:w_font="@string/wire__typeface__regular"
         />
 
@@ -44,12 +43,9 @@
         android:id="@+id/user_handle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/user_name"
-        android:layout_centerHorizontal="true"
-        android:layout_gravity="center_horizontal"
         android:textColor="?wireSecondaryTextColor"
         android:textSize="@dimen/wire__text_size__regular"
         android:layout_marginTop="@dimen/wire__padding__small"
         app:w_font="@string/wire__typeface__regular"
         />
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/connect/SendConnectRequestFragment.scala
@@ -94,6 +94,7 @@ class SendConnectRequestFragment
       })
     }
   }
+
   private lazy val footerMenu = returning(view[FooterMenu](R.id.fm__footer)) { vh =>
     user.map(_.expiresAt.isDefined).map {
       case true => ("", "")
@@ -109,7 +110,9 @@ class SendConnectRequestFragment
       case _ => ""
     }.onUi(text => vh.foreach(_.setRightActionText(text)))
   }
+
   private lazy val imageViewProfile = view[ImageView](R.id.send_connect)
+
   private lazy val userNameView = returning(view[TypefaceTextView](R.id.user_name)) { vh =>
     user.map(_.name).onUi(t => vh.foreach(_.setText(t)))
   }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
@@ -1,0 +1,154 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.participants.fragments
+
+import android.content.Context
+import android.view.{LayoutInflater, View, ViewGroup}
+import android.widget.CompoundButton.OnCheckedChangeListener
+import android.widget.{CompoundButton, ImageView, LinearLayout}
+import androidx.appcompat.widget.SwitchCompat
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.model.{ConversationRole, UserId}
+import com.waz.utils.events.{EventStream, SourceStream}
+import com.waz.zclient.common.views.ChatHeadView
+import com.waz.zclient.paintcode.GuestIcon
+import com.waz.zclient.ui.text.TypefaceTextView
+import com.waz.zclient.utils._
+import com.waz.zclient.{Injectable, R}
+
+class BaseSingleParticipantAdapter(userId: UserId,
+                                   isGuest: Boolean,
+                                   isExternal: Boolean,
+                                   isDarkTheme: Boolean,
+                                   isGroup: Boolean,
+                                   isWireless: Boolean
+                                  )(implicit context: Context)
+  extends RecyclerView.Adapter[ViewHolder] with Injectable with DerivedLogTag {
+  import BaseSingleParticipantAdapter._
+
+  protected var timerText:       Option[String] = None
+  protected var participantRole: ConversationRole = ConversationRole.MemberRole
+  protected var selfRole:        ConversationRole = ConversationRole.MemberRole
+
+  protected def isGroupAdminViewVisible: Boolean = isGroup && !isWireless && selfRole.canModifyOtherMember
+  protected def hasInformation: Boolean = false
+
+  val onParticipantRoleChange = EventStream[ConversationRole]
+
+  override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder = viewType match {
+    case Header =>
+      val view = LayoutInflater.from(parent.getContext).inflate(R.layout.participant_header_row, parent, false)
+      ParticipantHeaderRowViewHolder(view)
+    case GroupAdmin =>
+      val view = LayoutInflater.from(parent.getContext).inflate(R.layout.group_admin_row, parent, false)
+      GroupAdminViewHolder(view)
+  }
+
+  override def onBindViewHolder(holder: ViewHolder, position: Int): Unit = holder match {
+    case h: ParticipantHeaderRowViewHolder =>
+      h.bind(userId, isGuest, isExternal, isGroup && participantRole == ConversationRole.AdminRole, timerText, isDarkTheme, hasInformation)
+    case h: GroupAdminViewHolder =>
+      h.bind(onParticipantRoleChange, participantRole == ConversationRole.AdminRole)
+  }
+
+  override def getItemCount: Int = if (isGroupAdminViewVisible) 2 else 1
+
+  override def getItemId(position: Int): Long = getItemViewType(position) match {
+    case Header     => 0L
+    case GroupAdmin => 1L
+  }
+
+  setHasStableIds(true)
+
+  override def getItemViewType(position: Int): Int =
+    if (position == 1 && isGroupAdminViewVisible) GroupAdmin else Header
+}
+
+object BaseSingleParticipantAdapter {
+  val CustomField = 0
+  val Header = 1
+  val GroupAdmin = 2
+  val ReadReceipts = 3
+
+  case class ParticipantHeaderRowViewHolder(view: View) extends ViewHolder(view) {
+    private lazy val imageView            = view.findViewById[ChatHeadView](R.id.chathead)
+    private lazy val guestIndication      = view.findViewById[LinearLayout](R.id.guest_indicator)
+    private lazy val guestIndicatorIcon   = view.findViewById[ImageView](R.id.guest_indicator_icon)
+    private lazy val externalIndication   = view.findViewById[LinearLayout](R.id.external_indicator)
+    private lazy val groupAdminIndication = view.findViewById[LinearLayout](R.id.group_admin_indicator)
+    private lazy val guestIndicatorTimer  = view.findViewById[TypefaceTextView](R.id.expiration_time)
+    private lazy val informationText      = view.findViewById[TypefaceTextView](R.id.information)
+
+    private var userId = Option.empty[UserId]
+
+    def bind(userId: UserId,
+             isGuest: Boolean,
+             isExternal: Boolean,
+             isGroupAdmin: Boolean,
+             timerText: Option[String],
+             isDarkTheme: Boolean,
+             hasInformation: Boolean
+            )(implicit context: Context): Unit = {
+      this.userId = Some(userId)
+
+      imageView.loadUser(userId)
+      guestIndication.setVisible(isGuest)
+      externalIndication.setVisible(isExternal)
+      groupAdminIndication.setVisible(isGroupAdmin)
+
+      val color = if (isDarkTheme) R.color.wire__text_color_primary_dark_selector else R.color.wire__text_color_primary_light_selector
+      guestIndicatorIcon.setImageDrawable(GuestIcon(color))
+
+      timerText match {
+        case Some(text) =>
+          guestIndicatorTimer.setVisible(true)
+          guestIndicatorTimer.setText(text)
+        case None =>
+          guestIndicatorTimer.setVisible(false)
+      }
+
+      informationText.setVisible(hasInformation)
+    }
+  }
+
+  case class GroupAdminViewHolder(view: View) extends ViewHolder(view) with DerivedLogTag {
+    private implicit val ctx = view.getContext
+
+    private val switch = view.findViewById[SwitchCompat](R.id.participant_group_admin_toggle)
+    private var groupAdmin = Option.empty[Boolean]
+    private var onParticipantRoleChanged = Option.empty[SourceStream[ConversationRole]]
+
+    view.setId(R.id.participant_group_admin_toggle)
+
+    switch.setOnCheckedChangeListener(new OnCheckedChangeListener {
+      override def onCheckedChanged(buttonView: CompoundButton, groupAdminEnabled: Boolean): Unit =
+        if (!groupAdmin.contains(groupAdminEnabled)) {
+          groupAdmin = Some(groupAdminEnabled)
+          onParticipantRoleChanged.foreach(_ ! (if (groupAdminEnabled) ConversationRole.AdminRole else ConversationRole.MemberRole))
+        }
+    })
+
+    def bind(onParticipantRoleChanged: SourceStream[ConversationRole], groupAdminEnabled: Boolean): Unit = {
+      if (!this.onParticipantRoleChanged.contains(onParticipantRoleChanged))
+        this.onParticipantRoleChanged = Some(onParticipantRoleChanged)
+      if (!groupAdmin.contains(groupAdminEnabled)) switch.setChecked(groupAdminEnabled)
+    }
+  }
+}

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -49,19 +49,18 @@ class SingleParticipantFragment extends FragmentHelper {
 
   import SingleParticipantFragment._
 
-  private lazy val participantsController = inject[ParticipantsController]
-  private lazy val userAccountsController = inject[UserAccountsController]
-  private lazy val navigationController   = inject[INavigationController]
+  protected lazy val participantsController = inject[ParticipantsController]
+  protected lazy val userAccountsController = inject[UserAccountsController]
+  protected lazy val navigationController   = inject[INavigationController]
 
-  private var subs = Set.empty[Subscription]
+  protected var subs = Set.empty[Subscription]
 
   private lazy val fromDeepLink: Boolean = getBooleanArg(FromDeepLink)
 
-  private val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
+  protected val visibleTab = Signal[SingleParticipantFragment.Tab](DetailsTab)
 
-  private lazy val tabs = returning(view[TabLayout](R.id.details_and_devices_tabs)) {
+  protected lazy val tabs = returning(view[TabLayout](R.id.details_and_devices_tabs)) {
     _.foreach { layout =>
-
       if (fromDeepLink)
         layout.setVisibility(View.GONE)
       else {
@@ -77,7 +76,7 @@ class SingleParticipantFragment extends FragmentHelper {
     }
   }
 
-  private lazy val timerText = for {
+  protected lazy val timerText = for {
     expires <- participantsController.otherParticipant.map(_.expiresAt)
     clock   <- if (expires.isDefined) ClockSignal(5.minutes) else Signal.const(Instant.EPOCH)
   } yield expires match {
@@ -85,31 +84,93 @@ class SingleParticipantFragment extends FragmentHelper {
     case _               => None
   }
 
-  private lazy val readReceipts = Signal(participantsController.isGroup, userAccountsController.isTeam, userAccountsController.readReceiptsEnabled).map {
-    case (false, true, true)  => Some(getString(R.string.read_receipts_info_title_enabled))
-    case (false, true, false) => Some(getString(R.string.read_receipts_info_title_disabled))
-    case _                    => None
+  protected lazy val readReceipts: Signal[Option[String]] =
+    Signal(participantsController.isGroup, userAccountsController.isTeam, userAccountsController.readReceiptsEnabled).map {
+      case (false, true, true)  => Some(getString(R.string.read_receipts_info_title_enabled))
+      case (false, true, false) => Some(getString(R.string.read_receipts_info_title_disabled))
+      case _                    => None
+    }
+
+  protected lazy val participantOtrDeviceAdapter = returning(new ParticipantOtrDeviceAdapter) { adapter =>
+    subs += adapter.onClientClick.onUi { client =>
+      participantsController.otherParticipantId.head.foreach {
+        case Some(userId) =>
+          Option(getParentFragment).foreach {
+            case f: ParticipantFragment => f.showOtrClient(userId, client.id)
+            case _ =>
+          }
+        case _ =>
+      }
+    }
+
+    subs += adapter.onHeaderClick { _ => inject[BrowserController].openOtrLearnWhy() }
   }
 
-  private lazy val devicesView = returning( view[RecyclerView](R.id.devices_recycler_view) ) { vh =>
+  protected lazy val devicesView = returning( view[RecyclerView](R.id.devices_recycler_view) ) { vh =>
     visibleTab.onUi {
       case DevicesTab => vh.foreach(_.setVisible(true))
       case _          => vh.foreach(_.setVisible(false))
     }
+
+    vh.foreach { view =>
+      view.setLayoutManager(new LinearLayoutManager(ctx))
+      view.setHasFixedSize(true)
+      view.setAdapter(participantOtrDeviceAdapter)
+      view.setPaddingBottomRes(R.dimen.participants__otr_device__padding_bottom)
+      view.setClipToPadding(false)
+    }
   }
 
-  private lazy val detailsView = returning( view[RecyclerView](R.id.details_recycler_view) ) { vh =>
-    visibleTab.onUi {
+  protected lazy val detailsView = returning( view[RecyclerView](R.id.details_recycler_view) ) { vh =>
+    subs += visibleTab.onUi {
       case DetailsTab => vh.foreach(_.setVisible(true))
       case _          => vh.foreach(_.setVisible(false))
     }
 
     if (fromDeepLink)
       vh.foreach(_.setMarginTop(ContextUtils.getDimenPx(R.dimen.wire__padding__50)))
+
+    vh.foreach(_.setLayoutManager(new LinearLayoutManager(ctx)))
+
+    (for {
+      zms                <- inject[Signal[ZMessaging]].head
+      user               <- participantsController.otherParticipant.head
+      isGroup            <- participantsController.isGroup.head
+      isGuest            =  !user.isWireBot && user.isGuest(zms.teamId)
+      isExternal         =  !user.isWireBot && user.isExternal(zms.teamId)
+      isTeamTheSame      =  !user.isWireBot && user.teamId == zms.teamId && zms.teamId.isDefined
+      // if the user is from our team we ask the backend for the rich profile (but we don't wait for it)
+      _                  =  if (isTeamTheSame) zms.users.syncRichInfoNowForUser(user.id) else Future.successful(())
+      isDarkTheme        <- inject[ThemeController].darkThemeSet.head
+      isWireless         =  user.expiresAt.isDefined
+    } yield (user.id, user.email, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame)).foreach {
+      case (userId, emailAddress, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame) =>
+        val adapter = new SingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless)
+        val emailUserField = emailAddress match {
+          case Some(email) => Seq(UserField(getString(R.string.user_profile_email_field_name), email.toString()))
+          case None        => Seq.empty
+        }
+
+        subs += Signal(
+          participantsController.otherParticipant.map(_.fields),
+          timerText,
+          readReceipts,
+          participantsController.participants.map(_(userId)),
+          participantsController.selfRole
+        ).onUi {
+          case (fields, tt, rr, pRole, sRole) if isTeamTheSame =>
+            adapter.set(emailUserField ++ fields, tt, rr, pRole, sRole)
+          case (_, tt, rr, pRole, sRole) =>
+            adapter.set(emailUserField, tt, rr, pRole, sRole)
+        }
+
+        subs += adapter.onParticipantRoleChange.on(Threading.Background)(participantsController.setRole(userId, _))
+        vh.foreach(_.setAdapter(adapter))
+    }
   }
 
-  private lazy val userHandle = returning(view[TextView](R.id.user_handle)) { vh =>
-    participantsController.otherParticipant.map(_.handle.map(_.string)).onUi {
+  protected lazy val userHandle = returning(view[TextView](R.id.user_handle)) { vh =>
+    subs += participantsController.otherParticipant.map(_.handle.map(_.string)).onUi {
       case Some(h) =>
         vh.foreach { view =>
           view.setText(StringUtils.formatHandle(h))
@@ -148,7 +209,7 @@ class SingleParticipantFragment extends FragmentHelper {
       }
   }
 
-  private lazy val leftActionStrings = for {
+  protected lazy val leftActionStrings = for {
     isWireless     <- participantsController.otherParticipant.map(_.expiresAt.isDefined)
     isGroupOrBot   <- participantsController.isGroupOrBot
     canCreateConv  <- userAccountsController.hasCreateConvPermission
@@ -165,24 +226,26 @@ class SingleParticipantFragment extends FragmentHelper {
     (R.string.glyph__conversation, R.string.conversation__action__open_conversation)
   }
 
-  private lazy val footerMenu = returning( view[FooterMenu](R.id.fm__footer) ) { vh =>
+  protected lazy val footerMenu = returning( view[FooterMenu](R.id.fm__footer) ) { vh =>
     // TODO: merge this logic with ConversationOptionsMenuController
-    (for {
-      conv            <- participantsController.conv
-      remPerm         <- participantsController.selfRole.map(_.canRemoveGroupMember)
-      selfIsProUser   <- userAccountsController.isTeam
-      other           <- participantsController.otherParticipant
-      otherIsGuest    =  other.isGuest(conv.team)
-      showRightAction =  if (fromDeepLink) !selfIsProUser || otherIsGuest else remPerm
-      rightActionStr  =  getString(if (showRightAction) R.string.glyph__more else R.string.empty_string)
-    } yield rightActionStr).onUi(text => vh.foreach(_.setRightActionText(text)))
+    subs += (for {
+        conv            <- participantsController.conv
+        remPerm         <- participantsController.selfRole.map(_.canRemoveGroupMember)
+        selfIsProUser   <- userAccountsController.isTeam
+        other           <- participantsController.otherParticipant
+        otherIsGuest    =  other.isGuest(conv.team)
+        showRightAction =  if (fromDeepLink) !selfIsProUser || otherIsGuest else remPerm
+        rightActionStr  =  getString(if (showRightAction) R.string.glyph__more else R.string.empty_string)
+      } yield rightActionStr).onUi(text => vh.foreach(_.setRightActionText(text)))
 
-    leftActionStrings.onUi { case (icon, text) =>
+    subs += leftActionStrings.onUi { case (icon, text) =>
       vh.foreach { menu =>
         menu.setLeftActionText(getString(icon))
         menu.setLeftActionLabelText(getString(text))
       }
     }
+
+    vh.foreach(_.setCallback(footerCallback))
   }
 
   override def onCreateView(inflater: LayoutInflater, viewGroup: ViewGroup, savedInstanceState: Bundle): View =
@@ -191,71 +254,17 @@ class SingleParticipantFragment extends FragmentHelper {
   override def onViewCreated(v: View, @Nullable savedInstanceState: Bundle): Unit = {
     super.onViewCreated(v, savedInstanceState)
 
+    initViews(savedInstanceState)
+  }
+
+  protected def initViews(savedInstanceState: Bundle): Unit = {
     userHandle
 
-    detailsView.foreach { view =>
-      view.setLayoutManager(new LinearLayoutManager(ctx))
+    detailsView
 
-      (for {
-        zms                <- inject[Signal[ZMessaging]].head
-        user               <- participantsController.otherParticipant.head
-        isGroup            <- participantsController.isGroup.head
-        isGuest            =  !user.isWireBot && user.isGuest(zms.teamId)
-        isExternal         =  !user.isWireBot && user.isExternal(zms.teamId)
-        isTeamTheSame      =  !user.isWireBot && user.teamId == zms.teamId && zms.teamId.isDefined
-                              // if the user is from our team we ask the backend for the rich profile (but we don't wait for it)
-        _                  =  if (isTeamTheSame) zms.users.syncRichInfoNowForUser(user.id) else Future.successful(())
-        isDarkTheme        <- inject[ThemeController].darkThemeSet.head
-        isWireless         =  user.expiresAt.isDefined
-      } yield (user.id, user.email, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame)).foreach {
-        case (userId, emailAddress, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame) =>
-          val adapter = new SingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless)
-          val emailUserField = emailAddress match {
-            case Some(email) => Seq(UserField(getString(R.string.user_profile_email_field_name), email.toString()))
-            case None        => Seq.empty
-          }
+    devicesView
 
-          Signal(
-            participantsController.otherParticipant.map(_.fields),
-            timerText,
-            readReceipts,
-            participantsController.participants.map(_(userId)),
-            participantsController.selfRole
-          ).onUi {
-            case (fields, tt, rr, pRole, sRole) if isTeamTheSame =>
-              adapter.set(emailUserField ++ fields, tt, rr, pRole, sRole)
-            case (_, tt, rr, pRole, sRole) =>
-              adapter.set(emailUserField, tt, rr, pRole, sRole)
-          }
-
-          subs += adapter.onParticipantRoleChange.on(Threading.Background)(participantsController.setRole(userId, _))
-          view.setAdapter(adapter)
-      }
-    }
-
-    devicesView.foreach { view =>
-      val participantOtrDeviceAdapter = returning(new ParticipantOtrDeviceAdapter) { adapter =>
-        adapter.onClientClick.onUi { client =>
-          participantsController.otherParticipantId.head.foreach {
-            case Some(userId) =>
-              Option(getParentFragment).foreach {
-                case f: ParticipantFragment => f.showOtrClient(userId, client.id)
-                case _ =>
-              }
-            case _ =>
-          }
-        }
-
-        adapter.onHeaderClick { _ => inject[BrowserController].openOtrLearnWhy() }
-      }
-      view.setLayoutManager(new LinearLayoutManager(ctx))
-      view.setHasFixedSize(true)
-      view.setAdapter(participantOtrDeviceAdapter)
-      view.setPaddingBottomRes(R.dimen.participants__otr_device__padding_bottom)
-      view.setClipToPadding(false)
-    }
-
-    footerMenu.foreach(_.setCallback(footerCallback))
+    footerMenu
 
     if (Option(savedInstanceState).isEmpty) {
       val tab = Tab(getStringArg(TabToOpen))
@@ -317,4 +326,65 @@ object SingleParticipantFragment {
       tabToOpen.foreach { t => args.putString(TabToOpen, t)}
       f.setArguments(args)
     }
+}
+
+class SendConnectRequestFragment2 extends SingleParticipantFragment {
+  import Threading.Implicits.Ui
+
+  override protected lazy val tabs = returning(view[TabLayout](R.id.details_and_devices_tabs)) {
+    _.foreach { _.setVisibility(View.GONE) }
+  }
+
+  override protected lazy val readReceipts = Signal.const(Option.empty[String])
+
+  override protected def initViews(savedInstanceState: Bundle): Unit = {
+    userHandle
+    detailsView
+    footerMenu
+  }
+
+  override protected lazy val detailsView = returning( view[RecyclerView](R.id.details_recycler_view) ) { vh =>
+    vh.foreach(_.setMarginTop(ContextUtils.getDimenPx(R.dimen.wire__padding__50)))
+    vh.foreach(_.setLayoutManager(new LinearLayoutManager(ctx)))
+
+    (for {
+      zms                <- inject[Signal[ZMessaging]].head
+      user               <- participantsController.otherParticipant.head
+      isGroup            <- participantsController.isGroup.head
+      isGuest            =  !user.isWireBot && user.isGuest(zms.teamId)
+      isExternal         =  !user.isWireBot && user.isExternal(zms.teamId)
+      isTeamTheSame      =  !user.isWireBot && user.teamId == zms.teamId && zms.teamId.isDefined
+      // if the user is from our team we ask the backend for the rich profile (but we don't wait for it)
+      _                  =  if (isTeamTheSame) zms.users.syncRichInfoNowForUser(user.id) else Future.successful(())
+      isDarkTheme        <- inject[ThemeController].darkThemeSet.head
+      isWireless         =  user.expiresAt.isDefined
+    } yield (user.id, user.email, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame)).foreach {
+      case (userId, emailAddress, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isTeamTheSame) =>
+        val adapter = new SingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless)
+        val emailUserField = emailAddress match {
+          case Some(email) => Seq(UserField(getString(R.string.user_profile_email_field_name), email.toString()))
+          case None        => Seq.empty
+        }
+
+        subs += Signal(
+          participantsController.otherParticipant.map(_.fields),
+          timerText,
+          readReceipts,
+          participantsController.participants.map(_(userId)),
+          participantsController.selfRole
+        ).onUi {
+          case (fields, tt, rr, pRole, sRole) if isTeamTheSame =>
+            adapter.set(emailUserField ++ fields, tt, rr, pRole, sRole)
+          case (_, tt, rr, pRole, sRole) =>
+            adapter.set(emailUserField, tt, rr, pRole, sRole)
+        }
+
+        subs += adapter.onParticipantRoleChange.on(Threading.Background)(participantsController.setRole(userId, _))
+        vh.foreach(_.setAdapter(adapter))
+    }
+  }
+}
+
+object SendConnectRequestFragment2 {
+  def newInstance(): SendConnectRequestFragment2 = new SendConnectRequestFragment2
 }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
@@ -1,0 +1,90 @@
+/**
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.participants.fragments
+
+import android.content.Context
+import android.view.{LayoutInflater, View, ViewGroup}
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.waz.model.{ConversationRole, UserId}
+import com.waz.zclient.R
+import com.waz.zclient.ui.text.TypefaceTextView
+
+class UnconnectedParticipantAdapter(userId:      UserId,
+                                    isGuest:     Boolean,
+                                    isExternal:  Boolean,
+                                    isDarkTheme: Boolean,
+                                    isGroup:     Boolean,
+                                    isWireless:  Boolean,
+                                    userName:    String,
+                                    userHandle:  String)(implicit context: Context)
+  extends BaseSingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless) {
+  import BaseSingleParticipantAdapter._
+
+
+  def set(timerText:       Option[String],
+          participantRole: ConversationRole,
+          selfRole:        ConversationRole
+         ): Unit = {
+    this.timerText       = timerText
+    this.participantRole = participantRole
+    this.selfRole        = selfRole
+    notifyDataSetChanged()
+  }
+
+  override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder = viewType match {
+    case UnconnectedParticipantAdapter.UserName =>
+      val view = LayoutInflater.from(parent.getContext).inflate(R.layout.participant_user_name_row, parent,false)
+      UnconnectedParticipantAdapter.UserNameViewHolder(view)
+    case _ =>
+      super.onCreateViewHolder(parent, viewType)
+  }
+
+  override def onBindViewHolder(holder: ViewHolder, position: Int): Unit = holder match {
+    case h: UnconnectedParticipantAdapter.UserNameViewHolder =>
+      h.bind(userName, userHandle)
+    case _ =>
+      super.onBindViewHolder(holder, position)
+  }
+
+  override def getItemCount: Int = super.getItemCount + 1
+
+  override def getItemId(position: Int): Long = getItemViewType(position) match {
+    case Header     => 0L
+    case GroupAdmin => 1L
+    case UnconnectedParticipantAdapter.UserName => 2L
+  }
+
+  override def getItemViewType(position: Int): Int =
+    if (position == 0) UnconnectedParticipantAdapter.UserName
+    else if (position == 2 && isGroupAdminViewVisible) GroupAdmin
+    else Header
+}
+
+object UnconnectedParticipantAdapter {
+  val UserName = 4
+
+  case class UserNameViewHolder(view: View) extends ViewHolder(view) {
+    private lazy val userName   = view.findViewById[TypefaceTextView](R.id.user_name)
+    private lazy val userHandle = view.findViewById[TypefaceTextView](R.id.user_handle)
+
+    def bind(userName: String, userHandle: String): Unit = {
+      this.userName.setText(userName)
+      this.userHandle.setText(userHandle)
+    }
+  }
+}

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
@@ -34,6 +34,7 @@ class UnconnectedParticipantAdapter(userId:      UserId,
                                     userHandle:  String)(implicit context: Context)
   extends BaseSingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless) {
   import BaseSingleParticipantAdapter._
+  import UnconnectedParticipantAdapter._
 
 
   def set(timerText:       Option[String],
@@ -47,18 +48,16 @@ class UnconnectedParticipantAdapter(userId:      UserId,
   }
 
   override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder = viewType match {
-    case UnconnectedParticipantAdapter.UserName =>
+    case UserName =>
       val view = LayoutInflater.from(parent.getContext).inflate(R.layout.participant_user_name_row, parent,false)
-      UnconnectedParticipantAdapter.UserNameViewHolder(view)
+      UserNameViewHolder(view)
     case _ =>
       super.onCreateViewHolder(parent, viewType)
   }
 
   override def onBindViewHolder(holder: ViewHolder, position: Int): Unit = holder match {
-    case h: UnconnectedParticipantAdapter.UserNameViewHolder =>
-      h.bind(userName, userHandle)
-    case _ =>
-      super.onBindViewHolder(holder, position)
+    case h: UserNameViewHolder => h.bind(userName, userHandle)
+    case _                     => super.onBindViewHolder(holder, position)
   }
 
   override def getItemCount: Int = super.getItemCount + 1
@@ -66,7 +65,7 @@ class UnconnectedParticipantAdapter(userId:      UserId,
   override def getItemId(position: Int): Long = getItemViewType(position) match {
     case Header     => 0L
     case GroupAdmin => 1L
-    case UnconnectedParticipantAdapter.UserName => 2L
+    case UserName   => 2L
   }
 
   override def getItemViewType(position: Int): Int =


### PR DESCRIPTION
The following screens are very similar to each other and to the SingleParticipantFragment screen,
but they are all written separately and duplicate a lot of their functionality, while some of the new functionality (e.g. conversation rules) is broken in all of them:
 - SendConnectRequestFragment (displayed for an unconnected user)
 - PendingConnectRequestFragment (after sending the connect request and waiting for the answer)
 - ConnectRequestFragment (when another user sent a connect request and we didn't answer yet)
 - BlockedUserProfileFragment (when the other user is blocked)

The idea is to rewrite them all based on SingleParticipantFragment.
The first step is to make SingleParticipantFragment more generic and extendable, together with
SingleParticipantAdapter.
This PR contains those changes plus a class called SendConnectRequestFragment2 which will in future take over from SendConnectRequestFragment, but is not used anywhere right now
(I needed it to better understand what I'm doing.)

#### APK
[Download build #781](http://10.10.124.11:8080/job/Pull%20Request%20Builder/781/artifact/build/artifact/wire-dev-PR2524-781.apk)
[Download build #817](http://10.10.124.11:8080/job/Pull%20Request%20Builder/817/artifact/build/artifact/wire-dev-PR2524-817.apk)
[Download build #824](http://10.10.124.11:8080/job/Pull%20Request%20Builder/824/artifact/build/artifact/wire-dev-PR2524-824.apk)
[Download build #833](http://10.10.124.11:8080/job/Pull%20Request%20Builder/833/artifact/build/artifact/wire-dev-PR2524-833.apk)