### PR TITLE
Android10: Incoming call notifications fix 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,7 +682,7 @@
 
     <!-- System notifications -->
     <string name="system_notification__silence_call">Decline</string>
-    <string name="system_notification__join_call">Accept</string>
+    <string name="system_notification__join_call">Open Call</string>
     <string name="system_notification__leave_call">End call</string>
     <string name="system_notification__calling_one">Calling…</string>
     <string name="system_notification__calling_group">%1$s is calling…</string>

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -23,7 +23,7 @@ import com.waz.api.Verification
 import com.waz.avs.VideoPreview
 import com.waz.content.GlobalPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{Picture, _}
+import com.waz.model._
 import com.waz.service.ZMessaging.clock
 import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo.CallState.{SelfJoining, _}

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -17,14 +17,13 @@
  */
 package com.waz.zclient.calling.controllers
 
-import android.os.PowerManager
+import android.os.{Build, PowerManager}
 import android.telephony.{PhoneStateListener, TelephonyManager}
 import com.waz.api.Verification
 import com.waz.avs.VideoPreview
 import com.waz.content.GlobalPreferences
-import com.waz.model.Picture
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model._
+import com.waz.model.{Picture, _}
 import com.waz.service.ZMessaging.clock
 import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo.CallState.{SelfJoining, _}
@@ -283,12 +282,13 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
     active
   }
 
-  onCallStarted.on(Threading.Ui) { _ =>
+  onCallStarted.on(Threading.Ui) { activeUi =>
     (for {
       incoming <- isCallIncoming.head
       allowed  <- allowedByStatus.head
-    } yield !incoming || allowed).foreach {
-      case true  => CallingActivity.start(cxt)
+      shouldDisplayOverlay = activeUi || Build.VERSION.SDK_INT < 29
+    } yield (!incoming || allowed) && shouldDisplayOverlay).foreach {
+      case true => CallingActivity.start(cxt)
       case false =>
     }
   }(EventContext.Global)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -238,6 +238,7 @@ object CallingNotificationsController {
       .setContentText(message)
       .setContentIntent(OpenCallingScreen())
       .setStyle(style)
+      .setFullScreenIntent(OpenCallingScreen(), true)
       .setCategory(NotificationCompat.CATEGORY_CALL)
       .setPriority(priority)
       .setOnlyAlertOnce(true)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -259,7 +259,7 @@ object CallingNotificationsController {
           .addAction(
             R.drawable.ic_menu_join_call_w,
             getString(R.string.system_notification__join_call),
-            if (not.isMainCall) createJoinIntent(not.accountId, not.convId) else CallIntent(not.accountId, not.convId)
+            if (not.isMainCall) OpenCallingScreen() else CallIntent(not.accountId, not.convId)
           )
 
       case NotificationAction.Leave =>
@@ -273,9 +273,6 @@ object CallingNotificationsController {
     }
     builder
   }
-
-  private def createJoinIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) =
-    pendingIntent((account.str + convId.str).hashCode, joinIntent(Context.wrap(cxt), account, convId))
 
   private def createEndIntent(account: UserId, convId: ConvId)(implicit cxt: content.Context) =
     pendingIntent((account.str + convId.str).hashCode, endIntent(Context.wrap(cxt), account, convId))


### PR DESCRIPTION
## What's new in this PR?

### Issues

On Android10 we need consistent behaviour when the application isn't in the foreground instead of showing an overlay and notification. 

### Causes

New restrictions on Android10 means we can't automatically show an overlay when an incoming call comes in, so we have to show a notification to bring the app to the foreground. 

### Solutions

Show just a notification for when the app is in background and an overlay when the app is active for Android10 + devices. 

#### APK
[Download build #789](http://10.10.124.11:8080/job/Pull%20Request%20Builder/789/artifact/build/artifact/wire-dev-PR2527-789.apk)
[Download build #790](http://10.10.124.11:8080/job/Pull%20Request%20Builder/790/artifact/build/artifact/wire-dev-PR2527-790.apk)