### PR TITLE
Updated the notification intent to dismiss when the action has been c…

### DIFF
--- a/app/src/main/scala/com/waz/zclient/Intents.scala
+++ b/app/src/main/scala/com/waz/zclient/Intents.scala
@@ -55,7 +55,7 @@ object Intents {
     Intent(context, userId)
 
   def OpenCallingScreen()(implicit context: Context) =
-    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), 0)
+    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_UPDATE_CURRENT)
 
   def SharingIntent(implicit context: Context) =
     new Intent(context, classOf[MainActivity]).putExtra(FromSharingExtra, true)


### PR DESCRIPTION
…licked

## What's new in this PR?

### Issues

Call overlay notification won't dismiss when call has been opened 

### Causes

The PendingIntent being created as the action intent for the notification manager didn't have any flags set to it to notify it to update when it has been initialised 

### Solutions

Update the PendingIntent flag to update itself when an action has been taken 

### Testing

1. User A closes the app so it's in the background 
2. User B calls User A 
3. User A should see push notification
4. Click "Open Call" 
5. Notification should disappear when the overlay is displayed 
