### PR TITLE
Don't put new password dialogs one over another

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
@@ -34,13 +34,11 @@ import com.waz.model.AccountData.Password
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.{EventContext, EventStream}
 import com.waz.utils.returning
-import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.ExecutorWrapper
 import com.waz.zclient.ui.utils.KeyboardUtils
 import com.waz.zclient.{FragmentHelper, R}
 
 import scala.concurrent.duration._
-import scala.util.Try
 
 class RequestPasswordDialog extends DialogFragment with FragmentHelper with DerivedLogTag {
   import RequestPasswordDialog._
@@ -78,22 +76,42 @@ class RequestPasswordDialog extends DialogFragment with FragmentHelper with Deri
   private lazy val prompt: BiometricPrompt = new BiometricPrompt(getActivity, ExecutorWrapper(Threading.Ui), new BiometricPrompt.AuthenticationCallback {
     override def onAuthenticationError(errorCode: Int, errString: CharSequence): Unit = {
       super.onAuthenticationError(errorCode, errString)
-      verbose(l"onAuthenticationError, code: $errorCode, str: $errString")
       onAnswer ! (if (errorCode == BiometricConstants.ERROR_NEGATIVE_BUTTON) BiometricCancelled else BiometricError(errString.toString))
     }
 
     override def onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult): Unit = {
       super.onAuthenticationSucceeded(result)
-      verbose(l"onAuthenticationSucceeded: $result")
       onAnswer ! BiometricSuccess
     }
 
     override def onAuthenticationFailed(): Unit = {
       super.onAuthenticationFailed()
-      verbose(l"onAuthenticationFailed")
       onAnswer ! BiometricFailure
     }
   })
+
+  private lazy val dialog: AlertDialog = {
+    val builder = new AlertDialog.Builder(getActivity)
+      .setView(root)
+      .setTitle(title)
+      .setMessage(message)
+      .setPositiveButton(R.string.request_password_ok, null)
+
+    Option(getBooleanArg(IsCancellable)).foreach(
+      if (_) builder.setNegativeButton(R.string.request_password_cancel, new OnClickListener {
+        override def onClick(dialog: DialogInterface, which: Int): Unit = onAnswer ! PasswordCancelled
+      })
+    )
+
+    // FIXME: the delay is necessary because of a bug introduced in androidx.biometric:1.0.0-alpha04
+    // https://stackoverflow.com/questions/55934108/fragmentmanager-is-already-executing-transactions-when-executing-biometricprompt
+    // try to apply the proposed solution
+    if (useBiometric) CancellableFuture.delay(100.millis).map { _ =>
+      prompt.authenticate(promptInfo)
+    }(Threading.Ui)
+
+    builder.create
+  }
 
   def show(activity: FragmentActivity): Unit =
     activity.getSupportFragmentManager
@@ -124,38 +142,24 @@ class RequestPasswordDialog extends DialogFragment with FragmentHelper with Deri
     if (!useBiometric) passwordEditText.requestFocus()
     errorLayout
 
-    val builder = new AlertDialog.Builder(getActivity)
-      .setView(root)
-      .setTitle(title)
-      .setMessage(message)
-      .setPositiveButton(R.string.request_password_ok, null)
-
-    Option(getBooleanArg(IsCancellable)).foreach(
-      if (_) builder.setNegativeButton(R.string.request_password_cancel, new OnClickListener {
-        override def onClick(dialog: DialogInterface, which: Int): Unit = onAnswer ! PasswordCancelled
-      })
-    )
-
-    builder.create
+    dialog
   }
 
   override def onStart() = {
     super.onStart()
-    verbose(l"onStart")
-    Try(getDialog.asInstanceOf[AlertDialog]).toOption.foreach { d =>
-      d.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-        def onClick(v: View) = onAnswer ! PasswordAnswer(Password(passwordEditText.getText.toString))
-      })
-    }
+    dialog.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+      def onClick(v: View) = onAnswer ! PasswordAnswer(Password(passwordEditText.getText.toString))
+    })
+  }
 
-    // FIXME: the delay is necessary because of a bug introduced in androidx.biometric:1.0.0-alpha04
-    // https://stackoverflow.com/questions/55934108/fragmentmanager-is-already-executing-transactions-when-executing-biometricprompt
-    // try to apply the proposed solution
-    if (useBiometric) CancellableFuture.delay(100.millis).map { _ => prompt.authenticate(promptInfo) }(Threading.Ui)
+  override def onStop() = {
+    dialog.dismiss()
+    super.onStop()
   }
 
   override def onActivityCreated(savedInstanceState: Bundle) = {
     super.onActivityCreated(savedInstanceState)
+
     if (!useBiometric) getDialog.getWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
     //hide content of wire when it's locked
     getDialog.getWindow.setDimAmount(1.0f)

--- a/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
@@ -95,8 +95,7 @@ class RequestPasswordCheck(pwdCtrl: PasswordController, prefs: UserPreferences)(
                                      }(Threading.Ui)
     case PasswordCancelled =>
     case BiometricError(err) =>
-      dialog.showError(Some(err))
-      dialog.cancelBiometric()
+      verbose(l"biometric error $err")
     case BiometricSuccess =>
       dialog.close()
       passwordCheckSatisfied.success(true)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,7 +28,7 @@ object Versions {
     const val ANDROIDX_LIFECYCLE_EXTENSIONS = "2.1.0"
     const val ANDROIDX_CORE_KTX = "1.0.2"
     const val ANDROIDX_ROOM = "2.2.2"
-    const val ANDROIDX_BIOMETRIC = "1.0.0-rc02"
+    const val ANDROIDX_BIOMETRIC = "1.0.1"
     const val ANDROIDX_ANNOTATION = "1.0.0"
     const val PLAY_SERVICES = "17.0.0"
     const val FIREBASE_MESSAGING = "19.0.0"


### PR DESCRIPTION
Fix to https://github.com/wireapp/wire-android/issues/2485

When the password dialog appears and the user goes back to the main screen and back,
a new dialog prompt will appear on top of it. The fix ensures we keep only one dialog open, and a reference to it, and dismisses it when the user goes out of the app. After the user comes back, the dialog is recreated from scratch.

#### APK
[Download build #866](http://10.10.124.11:8080/job/Pull%20Request%20Builder/866/artifact/build/artifact/wire-dev-PR2543-866.apk)
[Download build #901](http://10.10.124.11:8080/job/Pull%20Request%20Builder/901/artifact/build/artifact/wire-dev-PR2543-901.apk)