### PR TITLE
Fixed the issue around displaying the notification for devices...

### DIFF
--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -1,32 +1,34 @@
 /**
- * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+  * Wire
+  * Copyright (C) 2018 Wire Swiss GmbH
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
 package com.waz.services.calling
 
 import android.app.Service
 import android.content.{Context, Intent}
-import android.os.{Build, IBinder}
+import android.os.IBinder
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
 import com.waz.zclient.ServiceHelper
 import com.waz.zclient.notifications.controllers.CallingNotificationsController
-import com.waz.zclient.notifications.controllers.CallingNotificationsController.{CallNotification, NotificationAction, androidNotificationBuilder}
 
 class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
+
+  import CallingNotificationsController._
+
   private lazy val callNCtrl = inject[CallingNotificationsController]
 
   implicit lazy val cxt: Context = getApplicationContext
@@ -50,7 +52,6 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
 
   // Since Android 10 we can't start the calling activity from the background, so instead we
   // show a calling notification.
-  private val isAndroid10OrAbove: Boolean = Build.VERSION.SDK_INT >= 29
   private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)
 
   private def shouldShowNotification(notification: CallNotification): Boolean = {

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -213,6 +213,8 @@ object CallingNotificationsController {
 
   val CallImageSizeDp = 64
 
+  def isAndroid10OrAbove: Boolean = Build.VERSION.SDK_INT >= 29
+
   def androidNotificationBuilder(not: CallNotification, treatAsIncomingCall: Boolean = false)(implicit cxt: content.Context): NotificationCompat.Builder = {
     val title = if (not.isGroup) not.convName else not.caller
 
@@ -238,7 +240,7 @@ object CallingNotificationsController {
       .setContentText(message)
       .setContentIntent(OpenCallingScreen())
       .setStyle(style)
-      .setFullScreenIntent(OpenCallingScreen(), true)
+      .setFullScreenIntent(OpenCallingScreen(), isAndroid10OrAbove)
       .setCategory(NotificationCompat.CATEGORY_CALL)
       .setPriority(priority)
       .setOnlyAlertOnce(true)


### PR DESCRIPTION
…below Android 10

## What's new in this PR?

### Issues

High alert push notifications were being sent to devices below Android10 

### Causes

All notifications were set to high priority and wasn't being suppressed for devices below Android 10.  

### Solutions

Check the build version and set the priority based on that. 