### PR TITLE
Translations issue: removed long label for creating new group convers…

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/shortcuts/Shortcuts.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shortcuts/Shortcuts.kt
@@ -10,6 +10,13 @@ import com.waz.zclient.R
 @SuppressLint("NewApi")
 class Shortcuts {
 
+    companion object {
+        const val NEW_GROUP_CONVERSATION = "GROUP_CONVERSATION"
+        const val NEW_MESSAGE = "NEW_MESSAGE"
+        const val SHARE_PHOTO = "SHARE_PHOTO"
+        const val SHARE_PHOTO_REQUEST_CODE = 40
+    }
+
     fun newMessageShortcut(activity: Activity, intent: Intent): ShortcutInfo =
         ShortcutInfo.Builder(activity, "new_message")
             .setShortLabel(activity.getString(R.string.shortcut_new_message_label))
@@ -28,16 +35,9 @@ class Shortcuts {
 
     fun groupConversationShortcut(activity: Activity, intent: Intent): ShortcutInfo =
         ShortcutInfo.Builder(activity, "new_group")
-            .setShortLabel(activity.getString(R.string.shortcut_create_group_short_label))
-            .setLongLabel(activity.getString(R.string.shortcut_create_group_long_label))
+            .setShortLabel(activity.getString(R.string.shortcut_create_group_label))
+            .setLongLabel(activity.getString(R.string.shortcut_create_group_label))
             .setIcon(Icon.createWithResource(activity, R.drawable.ic_create_group))
             .setIntent(intent.setAction(NEW_GROUP_CONVERSATION))
             .build()
-
-    companion object {
-        const val NEW_GROUP_CONVERSATION = "GROUP_CONVERSATION"
-        const val NEW_MESSAGE = "NEW_MESSAGE"
-        const val SHARE_PHOTO = "SHARE_PHOTO"
-        const val SHARE_PHOTO_REQUEST_CODE = 40
-    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1451,8 +1451,7 @@
 
 
     <!-- Shortcuts -->
-    <string name="shortcut_create_group_short_label">Create Group</string>
-    <string name="shortcut_create_group_long_label">Create Group Conversation</string>
+    <string name="shortcut_create_group_label">Create Group</string>
     <string name="shortcut_share_a_photo_label">Share Photo</string>
     <string name="shortcut_new_message_label">New Message</string>
 


### PR DESCRIPTION
…ations

## What's new in this PR?

### Issues

Long label for create group conversations needs to be removed to be consistent with other platforms 

### Causes

Doesn't exist on other platforms for the translations 

### Solutions

Remove the long label for creating group conversations 