### PR TITLE
Bump custom AVS version to 5.4.24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.9@aar'
+    customAvsVersion = '5.4.24@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

Bumps AVS to version 5.4.24 which contains a few updates and bug fixes.

#### APK
[Download build #982](http://10.10.124.11:8080/job/Pull%20Request%20Builder/982/artifact/build/artifact/wire-dev-PR2556-982.apk)