### PR TITLE
Use content descriptions instead of ids to identify views for QA

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
@@ -33,12 +33,12 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils._
 import com.waz.zclient.{Injectable, R}
 
-class BaseSingleParticipantAdapter(userId: UserId,
-                                   isGuest: Boolean,
-                                   isExternal: Boolean,
+class BaseSingleParticipantAdapter(userId:      UserId,
+                                   isGuest:     Boolean,
+                                   isExternal:  Boolean,
                                    isDarkTheme: Boolean,
-                                   isGroup: Boolean,
-                                   isWireless: Boolean
+                                   isGroup:     Boolean,
+                                   isWireless:  Boolean
                                   )(implicit context: Context)
   extends RecyclerView.Adapter[ViewHolder] with Injectable with DerivedLogTag {
   import BaseSingleParticipantAdapter._
@@ -48,7 +48,7 @@ class BaseSingleParticipantAdapter(userId: UserId,
   protected var selfRole:        Option[ConversationRole] = None
 
   protected def isGroupAdminViewVisible: Boolean = isGroup && !isWireless && selfRole.exists(_.canModifyOtherMember)
-  protected def hasInformation: Boolean = false
+  protected def hasInformation: Boolean          = false
 
   val onParticipantRoleChange = EventStream[ConversationRole]
 
@@ -82,10 +82,11 @@ class BaseSingleParticipantAdapter(userId: UserId,
 }
 
 object BaseSingleParticipantAdapter {
-  val CustomField = 0
-  val Header = 1
-  val GroupAdmin = 2
+  val CustomField  = 0
+  val Header       = 1
+  val GroupAdmin   = 2
   val ReadReceipts = 3
+  val UserName     = 4
 
   case class ParticipantHeaderRowViewHolder(view: View) extends ViewHolder(view) {
     private lazy val imageView            = view.findViewById[ChatHeadView](R.id.chathead)
@@ -98,12 +99,12 @@ object BaseSingleParticipantAdapter {
 
     private var userId = Option.empty[UserId]
 
-    def bind(userId: UserId,
-             isGuest: Boolean,
-             isExternal: Boolean,
-             isGroupAdmin: Boolean,
-             timerText: Option[String],
-             isDarkTheme: Boolean,
+    def bind(userId:         UserId,
+             isGuest:        Boolean,
+             isExternal:     Boolean,
+             isGroupAdmin:   Boolean,
+             timerText:      Option[String],
+             isDarkTheme:    Boolean,
              hasInformation: Boolean
             )(implicit context: Context): Unit = {
       this.userId = Some(userId)
@@ -131,11 +132,9 @@ object BaseSingleParticipantAdapter {
   case class GroupAdminViewHolder(view: View) extends ViewHolder(view) with DerivedLogTag {
     private implicit val ctx = view.getContext
 
-    private val switch = view.findViewById[SwitchCompat](R.id.participant_group_admin_toggle)
-    private var groupAdmin = Option.empty[Boolean]
+    private val switch                   = view.findViewById[SwitchCompat](R.id.participant_group_admin_toggle)
+    private var groupAdmin               = Option.empty[Boolean]
     private var onParticipantRoleChanged = Option.empty[SourceStream[ConversationRole]]
-
-    view.setId(R.id.participant_group_admin_toggle)
 
     switch.setOnCheckedChangeListener(new OnCheckedChangeListener {
       override def onCheckedChanged(buttonView: CompoundButton, groupAdminEnabled: Boolean): Unit =
@@ -149,6 +148,7 @@ object BaseSingleParticipantAdapter {
       if (!this.onParticipantRoleChanged.contains(onParticipantRoleChanged))
         this.onParticipantRoleChanged = Some(onParticipantRoleChanged)
       if (!groupAdmin.contains(groupAdminEnabled)) switch.setChecked(groupAdminEnabled)
+      view.setContentDescription(s"Group Admin: $groupAdminEnabled")
     }
   }
 }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantAdapter.scala
@@ -34,7 +34,7 @@ final class SingleParticipantAdapter(userId:      UserId,
                                      isWireless:  Boolean
                                     )(implicit context: Context)
   extends BaseSingleParticipantAdapter(userId, isGuest, isExternal, isDarkTheme, isGroup, isWireless) {
-  import BaseSingleParticipantAdapter.{Header, GroupAdmin}
+  import BaseSingleParticipantAdapter._
   import SingleParticipantAdapter._
 
   private var fields:       Seq[UserField] = Seq.empty
@@ -96,9 +96,6 @@ final class SingleParticipantAdapter(userId:      UserId,
 
 
 object SingleParticipantAdapter {
-  val CustomField = 0
-  val ReadReceipts = 3
-
   case class CustomFieldRowViewHolder(view: View) extends ViewHolder(view) {
     private lazy val name  = view.findViewById[TextView](R.id.custom_field_name)
     private lazy val value = view.findViewById[TextView](R.id.custom_field_value)
@@ -113,6 +110,8 @@ object SingleParticipantAdapter {
     private lazy val readReceiptsInfoTitle = view.findViewById[TypefaceTextView](R.id.read_receipts_info_title)
     private lazy val readReceiptsInfo1     = view.findViewById[TypefaceTextView](R.id.read_receipts_info_1)
     private lazy val readReceiptsInfo2     = view.findViewById[TypefaceTextView](R.id.read_receipts_info_2)
+
+    view.setContentDescription("Read Receipts")
 
     def bind(title: Option[String]): Unit = {
       readReceiptsInfoTitle.setVisible(title.isDefined)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UnconnectedParticipantAdapter.scala
@@ -74,8 +74,6 @@ class UnconnectedParticipantAdapter(userId:      UserId,
 }
 
 object UnconnectedParticipantAdapter {
-  val UserName = 4
-
   case class UserNameViewHolder(view: View) extends ViewHolder(view) {
     private lazy val userName   = view.findViewById[TypefaceTextView](R.id.user_name)
     private lazy val userHandle = view.findViewById[TypefaceTextView](R.id.user_handle)
@@ -83,6 +81,7 @@ object UnconnectedParticipantAdapter {
     def bind(userName: String, userHandle: String): Unit = {
       this.userName.setText(userName)
       this.userHandle.setText(userHandle)
+      view.setContentDescription(s"User: $userName")
     }
   }
 }


### PR DESCRIPTION
Fixes https://wearezeta.atlassian.net/browse/AN-6608

The tests should rely on content descriptions instead of ids in order to identify layout elements. It's especially important for layouts generated in adapters where ids are not static.

This PR fixes this problem only in the "connect request" views I was working on recently. Other changes will be made on case-by-case basis. 
I also made changes to indentation and I moved view types to the common superclass.
#### APK
[Download build #1021](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1021/artifact/build/artifact/wire-dev-PR2564-1021.apk)