### PR TITLE
Make UserConnectionEvent agree with the backend API

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -80,10 +80,20 @@ class ConnectionServiceImpl(selfUserId:      UserId,
   override def handleUserConnectionEvents(events: Seq[UserConnectionEvent]) = {
     def updateOrCreate(event: UserConnectionEvent)(user: Option[UserData]): UserData =
       user.fold {
-        UserData(event.to, None, event.fromUserName.getOrElse(Name.Empty), None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey.Empty, connectionLastUpdated = event.lastUpdated,
+        UserData(
+          event.to, None,
+          event.fromUserName.getOrElse(Name.Empty),
+          None,
+          None,
+          connection = event.status,
+          conversation = event.convId,
+          connectionMessage = event.message,
+          searchKey = SearchKey.Empty,
+          connectionLastUpdated = event.lastUpdated,
           handle = None)
       } {
-        _.copy(conversation = Some(event.convId)).updateConnectionStatus(event.status, Some(event.lastUpdated), event.message)
+        _.copy(conversation = event.convId)
+         .updateConnectionStatus(event.status, Some(event.lastUpdated), event.message)
       }
 
     val lastEvents = events.groupBy(_.to).map { case (to, es) => to -> es.maxBy(_.lastUpdated) }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/EventScheduler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/EventScheduler.scala
@@ -36,8 +36,6 @@ class EventScheduler(layout: EventScheduler.Stage) extends DerivedLogTag {
 
   def enqueue(events: Traversable[Event]): Future[Unit] = queue.enqueue(events.to[Vector]).recoverWithLog()
 
-  def post[A](conv: RConvId)(task: => Future[A]) = queue.post(conv)(task) // TODO this is rather hacky; maybe it could be replaced with a kind of "internal" event, i.e. events caused by events
-
   def createSchedule(events: Traversable[Event]): Schedule = schedule(layout, events.toStream)
 
   private def schedule(stage: Stage, events: Stream[Event]): Schedule = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -32,7 +32,6 @@ import com.waz.sync.client.{AccessTokenProvider, PushNotificationEncoded}
 import com.waz.sync.client.PushNotificationsClient.NotificationsResponseEncoded
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils.events._
-import com.waz.utils.wrappers.URI
 import com.waz.utils.{Backoff, ExponentialBackoff}
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.sync.client

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -50,6 +50,19 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       event.asInstanceOf[UserConnectionEvent].message should be(Some("Hello Test"))
     }
 
+    scenario("parse UserConnectionEvent with no explicit conversation id") {
+
+      Given("some json data")
+      val js = new JSONObject(userConectionEventData)
+
+      When("parsing json")
+      val event = EventDecoder(js)
+
+      Then("we should have a UserConnectionEvent with convId == selfUser.id") // TODO: This should depend on the user connection event status
+      event.isInstanceOf[UserConnectionEvent] shouldEqual true
+      event.asInstanceOf[UserConnectionEvent].convId should be(RConvId(selfUser.id.str))
+    }
+
     scenario("Read receipt off messages are parsed correctly") {
       val readReceiptJson = new JSONObject(
       s"""{
@@ -247,6 +260,18 @@ object EventSpec {
        |  "connection": {
        |    "status": "sent",
        |    "conversation": "f660330f-f0e3-4511-8d15-71251f44ce32",
+       |    "to": "${otherUser.id}",
+       |    "from": "${selfUser.id}",
+       |    "last_update": "2014-06-12T10:04:02.047Z",
+       |    "message": "Hello Test"
+       |  },
+       |  "type": "user.connection"
+       |}""".stripMargin
+
+  val userConectionEventDataNoConv =
+    s"""{
+       |  "connection": {
+       |    "status": "sent",
        |    "to": "${otherUser.id}",
        |    "from": "${selfUser.id}",
        |    "last_update": "2014-06-12T10:04:02.047Z",

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -43,7 +43,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       Then("we should have a UserConnectionEvent")
       event.isInstanceOf[UserConnectionEvent] shouldEqual true
       event.asInstanceOf[UserConnectionEvent].status should be(UserData.ConnectionStatus.PendingFromUser)
-      event.asInstanceOf[UserConnectionEvent].convId should be(RConvId("f660330f-f0e3-4511-8d15-71251f44ce32"))
+      event.asInstanceOf[UserConnectionEvent].convId should be(Some(RConvId("f660330f-f0e3-4511-8d15-71251f44ce32")))
       event.asInstanceOf[UserConnectionEvent].to should be(otherUser.id)
       event.asInstanceOf[UserConnectionEvent].from should be(selfUser.id)
       event.asInstanceOf[UserConnectionEvent].lastUpdated should be(RemoteInstant.ofEpochMilli(JsonDecoder.parseDate("2014-06-12T10:04:02.047Z").getTime))
@@ -58,9 +58,9 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       When("parsing json")
       val event = EventDecoder(js)
 
-      Then("we should have a UserConnectionEvent with convId == selfUser.id") // TODO: This should depend on the user connection event status
+      Then("we should have a UserConnectionEvent with convId == selfUser.id")
       event.isInstanceOf[UserConnectionEvent] shouldEqual true
-      event.asInstanceOf[UserConnectionEvent].convId should be(RConvId(selfUser.id.str))
+      event.asInstanceOf[UserConnectionEvent].convId should be(None)
     }
 
     scenario("Read receipt off messages are parsed correctly") {


### PR DESCRIPTION
`UserConnectionEvent` has a field for conversation id. On the backend side this field is option -
if it's missing, we can deduce if it should be `from` or `to` UserId converted to RConvId. But the backend provides the value for this field anyway, so on the Android side this field was required.
The difference was found out only after connecting the Android client to a customized BE which
followed the API to the letter.

work in progress