### PR TITLE
Handle onBackPressed on connect request screens opened with deep links

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -284,9 +284,9 @@ class ConversationListManagerFragment extends Fragment
       }
 
       (for {
-        usersStorage <- inject[Signal[UsersStorage]].head
-        user <- usersStorage.get(userId)
-        userRequester = if (fromDeepLink) UserRequester.DEEP_LINK else UserRequester.SEARCH
+        usersStorage  <- inject[Signal[UsersStorage]].head
+        user          <- usersStorage.get(userId)
+        userRequester =  if (fromDeepLink) UserRequester.DEEP_LINK else UserRequester.SEARCH
       } yield (user, userRequester)).foreach { case (Some(userData), userRequester) =>
         import com.waz.api.ConnectionStatus._
         userData.connection match {

--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
@@ -20,6 +20,7 @@ package com.waz.zclient.deeplinks
 import android.content.Intent
 import com.waz.content.MembersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.model.UserId
 import com.waz.service.AccountManager.ClientRegistrationState.Registered
 import com.waz.service.{AccountManager, AccountsService, UserService}
 import com.waz.threading.Threading
@@ -71,79 +72,63 @@ class DeepLinkService(implicit injector: Injector) extends Injectable with Deriv
     }
   }
 
-  private def checkDeepLink(deepLink: DeepLink, token: DeepLink.Token): Future[CheckingResult] = {
+  private def checkDeepLink(deepLink: DeepLink, token: DeepLink.Token): Future[CheckingResult] =
     async {
       val accounts = await { accountsService.accountsWithManagers.head }
-      val acc      = await { account.head }
-      val client   = acc match {
+      val client   = await { account.head } match {
         case None             => None
         case Some(accManager) => await { accManager.getOrRegisterClient().map(_.right.toOption) }
       }
-      (accounts, client)
-    }.flatMap { case (accounts, client) =>
-      token match {
-        case DeepLink.SSOLoginToken(_) =>
-          val res: CheckingResult = if (accounts.size >= BuildConfig.MAX_ACCOUNTS)
-            DoNotOpenDeepLink(deepLink, SSOLoginTooManyAccounts)
+      (accounts, client, token)
+    }.flatMap {
+      case (accounts, _, DeepLink.SSOLoginToken(_)) if accounts.size >= BuildConfig.MAX_ACCOUNTS =>
+        Future.successful(DoNotOpenDeepLink(deepLink, SSOLoginTooManyAccounts))
+      case (_, None, DeepLink.SSOLoginToken(_)) =>
+        Future.successful(OpenDeepLink(token))
+      case (_, Some(Registered(_)), DeepLink.SSOLoginToken(_)) =>
+        Future.successful(OpenDeepLink(token))
+      case (_, _, DeepLink.SSOLoginToken(_)) =>
+        Future.successful(DoNotOpenDeepLink(deepLink, Unknown))
+      case (_, Some(Registered(_)), DeepLink.ConversationToken(convId)) =>
+        convController.getConversation(convId).map {
+          case Some(_) => OpenDeepLink(token)
+          case _       => DoNotOpenDeepLink(Conversation, NotFound)
+        }
+      case (_, _, DeepLink.ConversationToken(_)) =>
+        Future.successful(DoNotOpenDeepLink(deepLink, Unknown))
+      case (_, Some(Registered(_)), DeepLink.UserToken(userId)) =>
+        checkUserDeepLink(deepLink, token, userId)
+      case (_, _, DeepLink.UserToken(_)) =>
+        Future.successful(DoNotOpenDeepLink(deepLink, Unknown))
+      case (accounts, _, DeepLink.CustomBackendToken(_)) if accounts.nonEmpty =>
+        Future.successful(DoNotOpenDeepLink(deepLink, UserLoggedIn))
+      case (_, _, DeepLink.CustomBackendToken(_)) =>
+        Future.successful(OpenDeepLink(token))
+      case _ =>
+        Future.successful(OpenDeepLink(token))
+    }
+
+  private def checkUserDeepLink(deepLink: DeepLink, token: DeepLink.Token, userId: UserId) =
+    async {
+      val service = await { userService.head }
+      await { service.syncIfNeeded(Set(userId)) }
+      await { service.getSelfUser.zip(service.findUser(userId)) } match {
+        case (Some(self), Some(other)) if self.id == other.id =>
+          OpenDeepLink(token, UserTokenInfo(connected = false, currentTeamMember = true, self = true))
+        case (Some(self), Some(other)) if self.isExternal(self.teamId) || other.isExternal(self.teamId) =>
+          val hasConv = await { membersStorage.getActiveConvs(other.id).map(_.nonEmpty) }
+          if (hasConv || self.createdBy.contains(self.id) || other.createdBy.contains(self.id))
+            OpenDeepLink(token, UserTokenInfo(other.isConnected, self.isInTeam(other.teamId)))
           else
-            client match {
-              case None => OpenDeepLink(token)
-              case Some(Registered(_)) => OpenDeepLink(token)
-              case _ => DoNotOpenDeepLink(deepLink, Unknown)
-            }
-
-          Future.successful(res)
-
-        case DeepLink.ConversationToken(convId) =>
-          client match {
-            case Some(Registered(_)) =>
-              convController.getConversation(convId).map {
-                case Some(_) => OpenDeepLink(token)
-                case _       => DoNotOpenDeepLink(Conversation, NotFound)
-              }
-            case _ => Future.successful(DoNotOpenDeepLink(deepLink, Unknown))
-          }
-
-        case DeepLink.UserToken(userId) =>
-          client match {
-            case Some(Registered(_)) =>
-              async {
-                val service = await { userService.head }
-                await { service.syncIfNeeded(Set(userId)) }
-                await { service.getSelfUser.zip(service.findUser(userId)) } match {
-                  case (Some(self), Some(other)) if self.id == other.id =>
-                    OpenDeepLink(token, UserTokenInfo(connected = false, currentTeamMember = true, self = true))
-                  case (Some(self), Some(other)) if self.isExternal(self.teamId) || other.isExternal(self.teamId) =>
-                    val hasConv = await { membersStorage.getActiveConvs(other.id).map(_.nonEmpty) }
-                    if (hasConv || self.createdBy.contains(self.id) || other.createdBy.contains(self.id))
-                      OpenDeepLink(token, UserTokenInfo(other.isConnected, self.isInTeam(other.teamId)))
-                    else
-                      DoNotOpenDeepLink(deepLink, NotAllowed)
-
-                  case (Some(self), Some(other)) =>
-                    OpenDeepLink(token, UserTokenInfo(other.isConnected, self.isInTeam(other.teamId)))
-                  case (Some(_), _) =>
-                    OpenDeepLink(token, UserTokenInfo(connected = false, currentTeamMember = false))
-                  case _ =>
-                    DoNotOpenDeepLink(deepLink, Unknown)
-                }
-              }
-            case _ => Future.successful(DoNotOpenDeepLink(deepLink, Unknown))
-          }
-
-        case DeepLink.CustomBackendToken(url) =>
-          val res: CheckingResult = if (accounts.nonEmpty)
-            DoNotOpenDeepLink(deepLink, UserLoggedIn)
-          else
-            OpenDeepLink(token)
-
-          Future.successful(res)
-
+            DoNotOpenDeepLink(deepLink, NotAllowed)
+        case (Some(self), Some(other)) =>
+          OpenDeepLink(token, UserTokenInfo(other.isConnected, self.isInTeam(other.teamId)))
+        case (Some(_), _) =>
+          OpenDeepLink(token, UserTokenInfo(connected = false, currentTeamMember = false))
         case _ =>
-          Future.successful(OpenDeepLink(token))
+          DoNotOpenDeepLink(deepLink, Unknown)
       }
     }
-  }
 }
 
 object DeepLinkService {

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -159,7 +159,6 @@ class MainPhoneFragment extends FragmentHelper
 
     deepLinkService.deepLink.collect { case Some(result) => result } onUi {
       case OpenDeepLink(UserToken(userId), UserTokenInfo(connected, currentTeamMember, self)) =>
-        pickUserController.hideUserProfile()
         participantsController.onLeaveParticipants ! true
 
         if (self) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -235,7 +235,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
     users.updateUserData(userId, { user =>
       if (user.connection == ConnectionStatus.PendingFromUser) user.copy(connection = ConnectionStatus.Cancelled)
       else {
-        warn(l"can't cancel connection for user in wrong state: $user")
+        warn(l"can't cancel connection for user in wrong state: ${user.connection}")
         user
       }
     }).flatMap {


### PR DESCRIPTION
Opening a connect request screen from a deep link may result in a situation when getting to the conversation screen by clicking the back button is impossible. The reason for that is that we jump directly to the connect screen and if the back button relies on the order of initialized screens, one over another, it might fail. Especially the send request screen is at risk because from the app it's always either the Search UI or the Participants screen that is its parent. In the case of a deep link, the parent is the conversation list.

This PR tries to improve the behaviour by popping the stack directly from `UntabbedRequestFragment.onBackPressed` for deep links. That should take the user back to the conversation list.

I refactored a part of `DeepLinkService` to "flatten" the match-cases. I think it's more readable now. I didn't change the functionality.

#### APK
[Download build #1065](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1065/artifact/build/artifact/wire-dev-PR2573-1065.apk)
[Download build #1083](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1083/artifact/build/artifact/wire-dev-PR2573-1083.apk)