### PR TITLE
AN-6612: Fixed the issue for Android 10 < devices for when we're declaring imp…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- GCM from Localytics TODO still needed? -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -52,10 +52,10 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
 
   // Since Android 10 we can't start the calling activity from the background, so instead we
   // show a calling notification.
-  private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(true)
+  private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)
 
   private def shouldShowNotification(notification: CallNotification): Boolean = {
     val notificationHasAction = notification.action != NotificationAction.Nothing
-    notificationHasAction && !(isAndroid10OrAbove && isUiActive)
+    notificationHasAction && (isAndroid10OrAbove && !isUiActive)
   }
 }

--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -52,7 +52,7 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
 
   // Since Android 10 we can't start the calling activity from the background, so instead we
   // show a calling notification.
-  private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)
+  private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(true)
 
   private def shouldShowNotification(notification: CallNotification): Boolean = {
     val notificationHasAction = notification.action != NotificationAction.Nothing

--- a/app/src/main/scala/com/waz/zclient/Intents.scala
+++ b/app/src/main/scala/com/waz/zclient/Intents.scala
@@ -55,7 +55,7 @@ object Intents {
     Intent(context, userId)
 
   def OpenCallingScreen()(implicit context: Context) =
-    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_UPDATE_CURRENT)
+    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_CANCEL_CURRENT)
 
   def SharingIntent(implicit context: Context) =
     new Intent(context, classOf[MainActivity]).putExtra(FromSharingExtra, true)

--- a/app/src/main/scala/com/waz/zclient/Intents.scala
+++ b/app/src/main/scala/com/waz/zclient/Intents.scala
@@ -54,8 +54,9 @@ object Intents {
   def OpenAccountIntent(userId: UserId, requestCode: Int = System.currentTimeMillis().toInt)(implicit context: Context) =
     Intent(context, userId)
 
-  def OpenCallingScreen()(implicit context: Context) =
-    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_CANCEL_CURRENT)
+  def OpenCallingScreen()(implicit context: Context) = {
+    PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_UPDATE_CURRENT)
+  }
 
   def SharingIntent(implicit context: Context) =
     new Intent(context, classOf[MainActivity]).putExtra(FromSharingExtra, true)

--- a/app/src/main/scala/com/waz/zclient/Intents.scala
+++ b/app/src/main/scala/com/waz/zclient/Intents.scala
@@ -54,9 +54,8 @@ object Intents {
   def OpenAccountIntent(userId: UserId, requestCode: Int = System.currentTimeMillis().toInt)(implicit context: Context) =
     Intent(context, userId)
 
-  def OpenCallingScreen()(implicit context: Context) = {
+  def OpenCallingScreen()(implicit context: Context) =
     PendingIntent.getActivity(context, System.currentTimeMillis().toInt, new Intent(context, classOf[CallingActivity]), PendingIntent.FLAG_UPDATE_CURRENT)
-  }
 
   def SharingIntent(implicit context: Context) =
     new Intent(context, classOf[MainActivity]).putExtra(FromSharingExtra, true)

--- a/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
@@ -21,6 +21,7 @@ import android.content.{Context, Intent}
 import android.os.{Build, Bundle}
 import android.view.WindowManager
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.services.calling.CallingNotificationsService
 import com.waz.threading.Threading
 import com.waz.zclient._
 import com.waz.zclient.calling.controllers.CallController
@@ -71,6 +72,7 @@ class CallingActivity extends BaseActivity {
 
   override def onResume() = {
     super.onResume()
+    stopService(new Intent(this, classOf[CallingNotificationsService]))
     controller.setVideoPause(pause = false)
   }
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -228,14 +228,15 @@ object CallingNotificationsController {
       .setCategory(NotificationCompat.CATEGORY_CALL)
       .setPriority(priority)
       .setOnlyAlertOnce(true)
-      .setOngoing(true)
-
-
-    if (isAndroid10OrAbove) builder.setFullScreenIntent(OpenCallingScreen(), true)
+      .setAutoCancel(true)
 
     if (!not.isMainCall) {
       builder.setDefaults(NotificationCompat.DEFAULT_LIGHTS | NotificationCompat.DEFAULT_VIBRATE)
       builder.setSound(RingtoneUtils.getUriForRawId(cxt, R.raw.empty_sound))
+    } else {
+      if (isAndroid10OrAbove) {
+        builder.setFullScreenIntent(OpenCallingScreen(), true)
+      }
     }
 
     not.action match {

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -225,11 +225,13 @@ object CallingNotificationsController {
       .setContentText(message)
       .setContentIntent(OpenCallingScreen())
       .setStyle(style)
-      .setFullScreenIntent(OpenCallingScreen(), isAndroid10OrAbove)
       .setCategory(NotificationCompat.CATEGORY_CALL)
       .setPriority(priority)
       .setOnlyAlertOnce(true)
       .setOngoing(true)
+
+
+    if (isAndroid10OrAbove) builder.setFullScreenIntent(OpenCallingScreen(), true)
 
     if (!not.isMainCall) {
       builder.setDefaults(NotificationCompat.DEFAULT_LIGHTS | NotificationCompat.DEFAULT_VIBRATE)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -233,10 +233,8 @@ object CallingNotificationsController {
     if (!not.isMainCall) {
       builder.setDefaults(NotificationCompat.DEFAULT_LIGHTS | NotificationCompat.DEFAULT_VIBRATE)
       builder.setSound(RingtoneUtils.getUriForRawId(cxt, R.raw.empty_sound))
-    } else {
-      if (isAndroid10OrAbove) {
-        builder.setFullScreenIntent(OpenCallingScreen(), true)
-      }
+    } else if (isAndroid10OrAbove) {
+      builder.setFullScreenIntent(OpenCallingScreen(), true)
     }
 
     not.action match {


### PR DESCRIPTION
…ortant notifications

## What's new in this PR?

### Issues

1. Notification is displaying over the overlay for Android10 devices when we open the call from the action item on the notification
2. Notification is displaying as-well as the overlay for Android 10 or lower devices. 

### Causes

Set full screen intent is too high priority for Android10 or below devices to the point it sticks around when we don't want it to also with the foreground service was still running when we open the overlay 

### Solutions

De-prioritised setFullIntent for Android 10 or below, changed the showNotification logic + pending intent flags for the calling activity. 

### Testing

#### Scenario 1 
1. Call a device with Android 10 or less inside the app 
2. Overlay should display with no calling push notifications

#### Scenario 2
1. Call a device with Android 10 or less with the app not in the background/foreground
2. Overlay should display with no calling push notifications 

#### Scenario 3
1. Call a device with Android 10 or less with the app is in the background
2. Overlay should display with no calling push notifications 

#### Scenario 4
1. Call a device with Android 10 or higher with the app is in the background
2. Push notification should display
3. Click open call
4. Call overlay should display and push notification should disappear
