### PR TITLE
A fix for backup restoration

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1298,6 +1298,7 @@
     <string name="backup_password_dialog_message">The backup will be compressed, and if you set a password, also encrypted. Make sure to store it in a secure place.</string>
     <string name="backup_password_dialog_ok">OK</string>
     <string name="backup_password_dialog_no_password">Cancel</string>
+    <string name="restore_password_dialog_title">This backup is password protected.</string>
 
     <string name="add_email_address">Add your email address</string>
     <string name="set_a_password">Set a password</string>

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -155,7 +155,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
   private def requestPassword(backup: Option[URI]): Future[Unit] = {
     backup match {
       case Some(_) =>
-        val fragment = returning(new BackupPasswordDialog(InputPasswordMode)) { _.onPasswordEntered(p => enter(backup, p))}
+        val fragment = returning(new BackupPasswordDialog(InputPasswordMode)) { _.onPasswordEntered(p => enter(backup, Some(p)))}
         getActivity.asInstanceOf[BaseActivity]
           .getSupportFragmentManager
           .beginTransaction

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -184,6 +184,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
         }
 
         val accountManager = await(accountsService.createAccountManager(userId.get, backupFile, isLogin = Some(true), backupPassword = backupPassword))
+        accountManager.foreach(_.addUnsplashPicture())
         backupFile.foreach(_.delete())
         await { accountsService.setAccount(userId) }
         val registrationState = await { accountManager.fold2(Future.successful(Left(ErrorResponse.internalError(""))), _.getOrRegisterClient()) }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -40,6 +40,7 @@ import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.appentry.fragments.FirstLaunchAfterLoginFragment._
 import com.waz.zclient.pages.main.conversation.AssetIntentsManager
 import com.waz.zclient.preferences.dialogs.BackupPasswordDialog
+import com.waz.zclient.preferences.dialogs.BackupPasswordDialog.InputPasswordMode
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.views.ZetaButton
 import com.waz.zclient.utils.ViewUtils
@@ -154,7 +155,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
   private def requestPassword(backup: Option[URI]): Future[Unit] = {
     backup match {
       case Some(_) =>
-        val fragment = returning(new BackupPasswordDialog) { _.onPasswordEntered(p => enter(backup, p))}
+        val fragment = returning(new BackupPasswordDialog(InputPasswordMode)) { _.onPasswordEntered(p => enter(backup, p))}
         getActivity.asInstanceOf[BaseActivity]
           .getSupportFragmentManager
           .beginTransaction

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -155,7 +155,9 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
   private def requestPassword(backup: Option[URI]): Future[Unit] = {
     backup match {
       case Some(_) =>
-        val fragment = returning(new BackupPasswordDialog(InputPasswordMode)) { _.onPasswordEntered(p => enter(backup, Some(p)))}
+        val fragment = returning(BackupPasswordDialog.newInstance(InputPasswordMode)) {
+          _.onPasswordEntered(p => enter(backup, Some(p)))
+        }
         getActivity.asInstanceOf[BaseActivity]
           .getSupportFragmentManager
           .beginTransaction

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
@@ -122,9 +122,13 @@ class PhoneSetNameFragment extends FragmentHelper with TextWatcher with View.OnC
           editTextName.foreach(_.requestFocus)
           nameConfirmationButton.foreach(_.setState(PhoneConfirmationButton.State.INVALID))
         }
-      case _ =>
+      case Right(accountManager) =>
         activity.enableProgress(false)
         activity.onEnterApplication(false)
+        accountManager.foreach { am =>
+          am.initZMessaging()
+          am.addUnsplashPicture()
+        }
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
@@ -92,11 +92,14 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
               accountsService.register(credentials, createTeamController.teamUserName, Some(createTeamController.teamName)).flatMap {
                 case Left(error) =>
                   Future.successful(Some(getString(EmailError(error).bodyResource)))
-                case Right(am) =>
-                  am.fold(Future.successful({}))(_.setMarketingConsent(createTeamController.receiveNewsAndOffers).map(_ => {})).map { _ =>
+                case Right(Some(am)) =>
+                  am.initZMessaging()
+                  am.addUnsplashPicture()
+                  am.setMarketingConsent(createTeamController.receiveNewsAndOffers).map { _ =>
                     showFragment(InviteToTeamFragment(), InviteToTeamFragment.Tag)
                     None
                   }
+                case _ => Future.successful(None)
               }
             case false =>
               Future.successful(None)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -179,6 +179,8 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
       color               <- inject[AccentColorController].accentColor.head
       _                   <- resp match {
         case Right(Some(am)) =>
+          am.initZMessaging()
+          am.addUnsplashPicture()
           (if (!askMarketingConsent) Future.successful(Some(false)) else
             showConfirmationDialog(
               getString(R.string.receive_news_and_offers_request_title),

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
@@ -189,8 +189,12 @@ class VerifyPhoneFragment extends FragmentHelper with View.OnClickListener with 
         case Right(userId) =>
           activity.enableProgress(false)
           for {
-            am <- accountService.createAccountManager(userId, None, isLogin = Some(true))
-            _ <- accountService.setAccount(Some(userId))
+            am       <- accountService.createAccountManager(userId, None, isLogin = Some(true))
+            _        =  am.foreach { accManager =>
+                          accManager.initZMessaging()
+                          accManager.addUnsplashPicture()
+                        }
+            _        <- accountService.setAccount(Some(userId))
             regState <- am.fold2(Future.successful(Left(ErrorResponse.internalError(""))), _.getOrRegisterClient())
           } yield activity.onEnterApplication(openSettings = false, regState.fold(_ => None, Some(_)))
       }

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/BackupPasswordDialog.scala
@@ -29,11 +29,12 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.utils.events.EventStream
 import com.waz.utils.PasswordValidator
+import com.waz.zclient.preferences.dialogs.BackupPasswordDialog.{DialogMode, InputPasswordMode, SetPasswordMode}
 import com.waz.zclient.{BuildConfig, FragmentHelper, R}
 
 import scala.util.Try
 
-class BackupPasswordDialog extends DialogFragment with FragmentHelper with DerivedLogTag {
+class BackupPasswordDialog(mode: DialogMode = SetPasswordMode) extends DialogFragment with FragmentHelper with DerivedLogTag {
 
   val onPasswordEntered = EventStream[Option[Password]]()
 
@@ -56,10 +57,15 @@ class BackupPasswordDialog extends DialogFragment with FragmentHelper with Deriv
   private lazy val textInputLayout = findById[TextInputLayout](root, R.id.backup_password_title)
 
   override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
+    val (title, message) = mode match {
+      case SetPasswordMode   => (R.string.backup_password_dialog_title, R.string.backup_password_dialog_message)
+      case InputPasswordMode => (R.string.restore_password_dialog_title, R.string.empty_string)
+    }
+
     new AlertDialog.Builder(getActivity)
       .setView(root)
-      .setTitle(getString(R.string.backup_password_dialog_title))
-      .setMessage(R.string.backup_password_dialog_message)
+      .setTitle(getString(title))
+      .setMessage(message)
       .setPositiveButton(android.R.string.ok, null)
       .setNegativeButton(android.R.string.cancel, null)
       .create
@@ -91,4 +97,8 @@ class BackupPasswordDialog extends DialogFragment with FragmentHelper with Deriv
 
 object BackupPasswordDialog {
   val FragmentTag = RemoveDeviceDialog.getClass.getSimpleName
+
+  sealed trait DialogMode
+  case object SetPasswordMode   extends DialogMode
+  case object InputPasswordMode extends DialogMode
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
@@ -74,7 +74,7 @@ class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
     Future.successful(())
   }
 
-  private def backupData(password: Option[Password]): Unit = {
+  private def backupData(password: Password): Unit = {
     spinnerController.showDimmedSpinner(show = true, ContextUtils.getString(R.string.back_up_progress))
     import Threading.Implicits.Ui
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -257,7 +257,7 @@ class AccountManager(val userId:   UserId,
     }
   }
 
-  def exportDatabase(password: Option[Password]): Future[File] = for {
+  def exportDatabase(password: Password): Future[File] = for {
     zms     <- zmessaging
     user    <- zms.users.selfUser.head
     _       <- db.flushWALToDatabase()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -134,6 +134,10 @@ class AccountManager(val userId:   UserId,
     hasClient = exists
   }
 
+  def initZMessaging(): Unit = {
+    zmessaging
+  }
+
   def addUnsplashPicture(): Future[Unit] = zmessaging.flatMap(_.users.updateSelfPicture(Content.Uri(URI.toJava(UnsplashUrl))))
 
   def fingerprintSignal(uId: UserId, cId: ClientId): Signal[Option[Array[Byte]]] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -290,7 +290,7 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
   private def restoreFromBackup(accountManager: AccountManager, userId: UserId, importDbFile: File, password: Password) = {
     verbose(l"restore from backup")
     val db = accountManager.storage.db2
-    db.beginTransactionNonExclusive()
+    db.beginTransaction()
     try {
       returning(backupManager.importDatabase(userId, importDbFile, context.getDatabasePath(userId.toString).getParentFile, backupPassword = password)) { restore =>
         if (restore.isFailure) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -278,52 +278,44 @@ class AccountsServiceImpl(val global: GlobalModule, val backupManager: BackupMan
                                     backupPassword: Option[Password] = None) = Serialized.future(AccountManagersKey) {
     for {
       managers <- accountManagers.orElse(Signal.const(Set.empty[AccountManager])).head
-      manager <- managers.find(_.userId == userId).fold(createManager(userId, initialUser, isLogin, importDbFile.nonEmpty))(m => Future.successful(Some(m)))
-      _ = manager.foreach { mgr =>
-        (importDbFile, backupPassword) match {
-          case (Some(file), Some(password)) => restoreFromBackup(mgr, userId, file, password)
-          case _ =>
-        }
-      }
+      manager  <- managers.find(_.userId == userId)
+                          .fold(createManager(userId, initialUser, isLogin, importDbFile.nonEmpty))(m => Future.successful(Some(m)))
+      _        = (manager, importDbFile, backupPassword) match {
+                   case (Some(mgr), Some(file), Some(password)) => restoreFromBackup(mgr, userId, file, password)
+                   case _ =>
+                 }
     } yield manager
   }
 
   private def restoreFromBackup(accountManager: AccountManager, userId: UserId, importDbFile: File, password: Password) = {
-    verbose(l"BKP restore from backup")
+    verbose(l"restore from backup")
     val db = accountManager.storage.db2
     db.beginTransactionNonExclusive()
     try {
       returning(backupManager.importDatabase(userId, importDbFile, context.getDatabasePath(userId.toString).getParentFile, backupPassword = password)) { restore =>
         if (restore.isFailure) {
-          verbose(l"restore failed")
+          error(l"restore failed")
           global.trackingService.historyRestored(false)
         } // HistoryRestoreSucceeded is sent from the new AccountManager
       }.get // if the import failed this will rethrow the exception
-      verbose(l"BKP restore successful")
+      verbose(l"restore successful")
       db.setTransactionSuccessful()
     } finally {
-      verbose(l"BKP end transaction...")
       db.endTransaction()
     }
   }
 
-  private def createManager(userId: UserId, initialUser: Option[UserInfo], isLogin: Option[Boolean], fromBackup: Boolean): Future[Option[AccountManager]] = async {
-    val account = await(storage.flatMap(_.get(userId)))
-    val user = await {
-      for {
-        user <- prefs(LoggingInUser).apply().map(_.orElse(initialUser))
-        _    <- prefs(LoggingInUser) := None
-      } yield user
-    }
-    if (account.isEmpty) warn(l"No logged in account for user: $userId, not creating account manager")
-    account.map { acc =>
+  private def createManager(userId: UserId, initialUser: Option[UserInfo], isLogin: Option[Boolean], fromBackup: Boolean): Future[Option[AccountManager]] =
+    for {
+      account <- storage.flatMap(_.get(userId))
+      _       =  if (account.isEmpty) warn(l"No logged in account for user: $userId, not creating account manager")
+      user    <- if (account.isDefined) prefs(LoggingInUser).apply().map(_.orElse(initialUser)) else Future.successful(None)
+      _       <- if (account.isDefined) prefs(LoggingInUser) := None else Future.successful(())
+    } yield account.map { acc =>
       val newManager = new AccountManager(userId, acc.teamId, global, this, backupManager, startedJustAfterBackup = fromBackup, user, isLogin)
-      if (isLogin.isDefined) {
-        accountManagers.mutateOrDefault(_ + newManager, Set(newManager))
-      }
+      if (isLogin.isDefined) accountManagers.mutateOrDefault(_ + newManager, Set(newManager))
       newManager
     }
-  }
 
   @volatile private var accountStateSignals = Map.empty[UserId, Signal[AccountState]]
   override def accountState(userId: UserId) = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
@@ -218,18 +218,14 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
                 IoUtils.writeBytesToFile(decryptedDbExport, decryptedDbBytes)
                 Success(decryptedDbExport)
               case None =>
-                error(l"backup decryption failed")
                 Failure(new Throwable("backup decryption failed"))
             }
           case Some(_) =>
-            error(l" Uuid hashes don't match")
             Failure(new Throwable("Uuid hashes don't match"))
           case None =>
-            error(l"Uuid hashing failed")
             Failure(new Throwable("Uuid hashing failed"))
         }
       case None =>
-        error(l"metadata could not be read")
         Failure(new Throwable("metadata could not be read"))
     }
   }
@@ -245,7 +241,6 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
   private def importUnencryptedDatabase(userId: UserId, exportFile: File, targetDir: File,
                                         currentDbVersion: Int = BackupMetadata.currentDbVersion): Try[File] =
     Try {
-      verbose(l"exportFile: ${exportFile.getAbsolutePath}, size: ${exportFile.length()}")
       withResource(new ZipFile(exportFile)) { zip =>
         val metadataEntry = Option(zip.getEntry(backupMetadataFileName)).getOrElse { throw MetadataEntryNotFound }
         val metadataStr   = withResource(zip.getInputStream(metadataEntry))(Source.fromInputStream(_).mkString)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
@@ -46,11 +46,7 @@ trait BackupManager {
                      databaseDir: File,
                      targetDir: File,
                      backupPassword: Password): Try[File]
-  def importDatabase(userId: UserId,
-                     exportFile: File,
-                     targetDir: File,
-                     currentDbVersion: Int = BackupMetadata.currentDbVersion,
-                     backupPassword: Password): Try[File]
+  def importDatabase(userId: UserId, exportFile: File, targetDir: File, backupPassword: Password, currentDbVersion: Int = BackupMetadata.currentDbVersion): Try[File]
 }
 
 object BackupManager {
@@ -200,9 +196,9 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
   override def importDatabase(userId:           UserId,
                               exportFile:       File,
                               targetDir:        File,
-                              currentDbVersion: Int = BackupMetadata.currentDbVersion,
-                              backupPassword:   Password): Try[File] = {
-    verbose(l"importDatabase($userId, ${exportFile.getAbsolutePath}, ${targetDir.getAbsolutePath}, $currentDbVersion, $backupPassword)")
+                              backupPassword:   Password,
+                              currentDbVersion: Int = BackupMetadata.currentDbVersion): Try[File] = {
+    verbose(l"importDatabase($userId, ${exportFile.getAbsolutePath}, ${targetDir.getAbsolutePath}, $backupPassword, $currentDbVersion)")
     if (backupPassword.str.isEmpty)
       importUnencryptedDatabase(userId, exportFile, targetDir, currentDbVersion)
     else

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
@@ -135,7 +135,7 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
                               databaseDir:    File,
                               targetDir:      File,
                               backupPassword: Password): Try[File] = {
-    verbose(l"BKP exportDatabase($userId, $userHandle, ${databaseDir.getAbsolutePath}, $backupPassword)")
+    verbose(l"exportDatabase($userId, $userHandle, ${databaseDir.getAbsolutePath}, $backupPassword)")
     val backup = Try {
       returning(new File(targetDir, backupZipFileName(userHandle))) { zipFile =>
         zipFile.deleteOnExit()
@@ -151,38 +151,33 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
           withResource(new BufferedInputStream(new FileInputStream(dbFile))) {
             IoUtils.writeZipEntry(_, zip, dbFileName)
           }
-          verbose(l"BKP file: $dbFile exists: ${dbFile.exists}, length: ${if (dbFile.exists) dbFile.length else 0}")
+          verbose(l"file: $dbFile exists: ${dbFile.exists}, length: ${if (dbFile.exists) dbFile.length else 0}")
 
           val walFileName = getDbWalFileName(userId)
           val walFile = new File(databaseDir, walFileName)
-          verbose(l"BKP WAL file: $walFile exists: ${walFile.exists}, length: ${if (walFile.exists) walFile.length else 0}")
+          verbose(l"WAL file: $walFile exists: ${walFile.exists}, length: ${if (walFile.exists) walFile.length else 0}")
 
           if (walFile.exists) withResource(new BufferedInputStream(new FileInputStream(walFile))) {
             IoUtils.writeZipEntry(_, zip, walFileName)
           }
         }
 
-        verbose(l"BKP database export finished: $zipFile. Data contains: ${zipFile.length} bytes")
+        verbose(l"database export finished: $zipFile. Data contains: ${zipFile.length} bytes")
       }
     }.mapFailureIfNot[BackupError](UnknownBackupError.apply)
 
     for {
       unencryptedFile <- backup
-      _ = verbose(l"BKP unencrypted file: $unencryptedFile, exists: ${unencryptedFile.exists}, length: ${if (unencryptedFile.exists) unencryptedFile.length else 0}")
-      encryptedFile <- encryptDatabase(unencryptedFile, backupPassword, userId)
-      _ = verbose(l"BKP encrypted file: $encryptedFile, exists: ${encryptedFile.exists}, length: ${if (encryptedFile.exists) encryptedFile.length else 0}")
+      encryptedFile   <- encryptDatabase(unencryptedFile, backupPassword, userId)
     } yield encryptedFile
-
   }
 
   private def encryptDatabase(backup: File, password: Password, userId: UserId): Try[File] = {
-    verbose(l"BKP encryptDatabase(${backup.getAbsolutePath}, $password, $userId)")
-    val salt = libSodiumUtils.generateSalt()
+    val salt        = libSodiumUtils.generateSalt()
     val backupBytes = IoUtils.readFileBytes(backup)
 
     (libSodiumUtils.encrypt(backupBytes, password, salt), getMetaDataBytes(password, salt, userId)) match {
       case (Some(encryptedBytes), Some(meta)) =>
-        verbose(l"BKP encrypted data: ${encryptedBytes.length} bytes, meta: ${meta.length} bytes")
         Try {
           val encryptedBackup = returning(new File(backup.getPath + "_encrypted")) { encryptedDbFile =>
             encryptedDbFile.deleteOnExit()
@@ -194,12 +189,11 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
           new File(backup.getPath)
         }.mapFailureIfNot[BackupError](UnknownBackupError.apply)
       case (_, None) =>
-        error(l"BKP Failed to create metadata")
+        error(l"Failed to create metadata")
         Failure(new Throwable("Failed to create metadata"))
       case (None, _) =>
-        val msg = "Failed to encrypt backup"
-        error(l"BKP $msg")
-        Failure(new Exception(msg))
+        error(l"Failed to encrypt backup")
+        Failure(new Exception("Failed to encrypt backup"))
     }
   }
 
@@ -208,7 +202,7 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
                               targetDir:        File,
                               currentDbVersion: Int = BackupMetadata.currentDbVersion,
                               backupPassword:   Password): Try[File] = {
-    verbose(l"BKP importDatabase($userId, ${exportFile.getAbsolutePath}, ${targetDir.getAbsolutePath}, $currentDbVersion, $backupPassword)")
+    verbose(l"importDatabase($userId, ${exportFile.getAbsolutePath}, ${targetDir.getAbsolutePath}, $currentDbVersion, $backupPassword)")
     if (backupPassword.str.isEmpty)
       importUnencryptedDatabase(userId, exportFile, targetDir, currentDbVersion)
     else
@@ -223,75 +217,55 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
             val encryptedBackupBytes = IoUtils.readFileBytes(file, EncryptedBackupHeader.totalHeaderLength)
             libSodiumUtils.decrypt(encryptedBackupBytes, password, metadata.salt) match {
               case Some(decryptedDbBytes) =>
-                verbose(l"BKP decrypted data: ${decryptedDbBytes.length}")
                 val decryptedDbExport = File.createTempFile("wire_backup", ".zip")
                 decryptedDbExport.deleteOnExit()
                 IoUtils.writeBytesToFile(decryptedDbExport, decryptedDbBytes)
                 Success(decryptedDbExport)
               case None =>
-                error(l"BKP backup decryption failed")
+                error(l"backup decryption failed")
                 Failure(new Throwable("backup decryption failed"))
             }
           case Some(_) =>
-            error(l"BKP Uuid hashes don't match")
+            error(l" Uuid hashes don't match")
             Failure(new Throwable("Uuid hashes don't match"))
           case None =>
-            error(l"BKP Uuid hashing failed")
+            error(l"Uuid hashing failed")
             Failure(new Throwable("Uuid hashing failed"))
         }
       case None =>
-        error(l"BKP metadata could not be read")
+        error(l"metadata could not be read")
         Failure(new Throwable("metadata could not be read"))
     }
   }
 
   private def importEncryptedDatabase(userId: UserId, exportFile: File, targetDir: File,
                                       currentDbVersion: Int = BackupMetadata.currentDbVersion,
-                                      password: Password): Try[File] = {
+                                      password: Password): Try[File] =
     for {
       decryptedFile <- decryptDatabase(exportFile, password, userId)
-      _ = verbose(l"BKP encrypted file: $exportFile, exists: ${exportFile.exists}, length: ${if (exportFile.exists) exportFile.length else 0}")
-      _ = verbose(l"BKP decrypted file: $decryptedFile, exists: ${decryptedFile.exists}, length: ${if (decryptedFile.exists) decryptedFile.length else 0}")
-      importedFile <- importUnencryptedDatabase(userId, decryptedFile, targetDir, currentDbVersion)
-      _ = verbose(l"BKP imported file: $decryptedFile, exists: ${decryptedFile.exists}, length: ${if (decryptedFile.exists) decryptedFile.length else 0}")
+      importedFile  <- importUnencryptedDatabase(userId, decryptedFile, targetDir, currentDbVersion)
     } yield importedFile
-  }
 
   private def importUnencryptedDatabase(userId: UserId, exportFile: File, targetDir: File,
                                         currentDbVersion: Int = BackupMetadata.currentDbVersion): Try[File] =
     Try {
-      verbose(l"BKP importUnencryptedDatabase($userId, ${exportFile.getAbsolutePath}, ${targetDir.getAbsolutePath}, $currentDbVersion)")
-      verbose(l"BKP exportFile: $exportFile, exists: ${exportFile.exists}, size: ${if (exportFile.exists()) exportFile.length() else 0}")
-      val zipFile = new ZipFile(exportFile)
-      verbose(l"BKP -1")
       withResource(new ZipFile(exportFile)) { zip =>
-        verbose(l"BKP 0")
         val metadataEntry = Option(zip.getEntry(backupMetadataFileName)).getOrElse { throw MetadataEntryNotFound }
-        verbose(l"BKP 1")
-        val metadataStr = withResource(zip.getInputStream(metadataEntry))(Source.fromInputStream(_).mkString)
-        val metadata = decode[BackupMetadata](metadataStr).recoverWith {
+        val metadataStr   = withResource(zip.getInputStream(metadataEntry))(Source.fromInputStream(_).mkString)
+        val metadata      = decode[BackupMetadata](metadataStr).recoverWith {
           case err => Failure(InvalidMetadata.WrongFormat(err))
         }.get
-        verbose(l"BKP 2")
         if (userId != metadata.userId) throw InvalidMetadata.UserId
-        verbose(l"BKP 3")
         if (BackupMetadata.currentPlatform != metadata.platform) throw InvalidMetadata.Platform
-        verbose(l"BKP 4")
         if (currentDbVersion < metadata.version) throw InvalidMetadata.DbVersion
-        verbose(l"BKP 5")
         val dbFileName = getDbFileName(userId)
         val dbEntry = Option(zip.getEntry(dbFileName)).getOrElse { throw DbEntryNotFound }
-        verbose(l"BKP 6")
         val walFileName = getDbWalFileName(userId)
-        verbose(l"BKP walFileName: $walFileName")
         Option(zip.getEntry(walFileName)).foreach { walEntry =>
           IoUtils.copy(zip.getInputStream(walEntry), new File(targetDir, walFileName))
         }
-        verbose(l"BKP 7")
         returning(new File(targetDir, dbFileName)) { dbFile =>
-          verbose(l"BKP 8")
           IoUtils.copy(zip.getInputStream(dbEntry), dbFile)
-          verbose(l"BKP 9")
         }
       }
     }.mapFailureIfNot[BackupError](UnknownBackupError.apply)
@@ -309,10 +283,10 @@ class BackupManagerImpl(libSodiumUtils: LibSodiumUtils) extends BackupManager wi
           libSodiumUtils.getOpsLimit, libSodiumUtils.getMemLimit)
         Some(serializeHeader(header))
       case Some(uuidHash) =>
-        error(l"BKP uuidHash length invalid, expected: $uuidHashLength, got: ${uuidHash.length}")(logTag)
+        error(l"uuidHash length invalid, expected: $uuidHashLength, got: ${uuidHash.length}")(logTag)
         None
       case None =>
-        error(l"BKP Failed to hash account id for backup")(logTag)
+        error(l"Failed to hash account id for backup")(logTag)
         None
     }
   }


### PR DESCRIPTION
Fixes https://wearezeta.atlassian.net/browse/AN-6604

Restoring backup means replacing the database files with the ones from the backup. Currently we don't take into account that the app might use the database in the same time for initialization of other components. This PR wraps the backup restore operation in a transaction, makes the account manager initialization lazy, and moves some method calls around in order to make sure that nothing stands in the way of replacing the files.

Also, I fixed the password dialog appearing on restoration. Previously it had the same title and message as the backup *creation* popup, which was very confusing. Now it uses the same title as iOS and the message is empty. 
And I made the password required. It was optional which was against the specs. I maintained the check of restoration if the password is empty, to still have backward compatibility if anyone made a non-encrypted backup in the past (plus some unit tests require it). But all new backups have to be encrypted with the password.

#### APK
[Download build #1087](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1087/artifact/build/artifact/wire-dev-PR2577-1087.apk)
[Download build #1152](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1152/artifact/build/artifact/wire-dev-PR2577-1152.apk)
[Download build #1178](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1178/artifact/build/artifact/wire-dev-PR2577-1178.apk)
[Download build #1185](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1185/artifact/build/artifact/wire-dev-PR2577-1185.apk)
[Download build #1251](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1251/artifact/build/artifact/wire-dev-PR2577-1251.apk)