### PR TITLE
BugFix : Missing error case - onBoarding flow milestone 2

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -24,7 +24,7 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.{ConnectionErrorCode, TimeoutCode}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model2.transport.responses.DomainSuccessful
-import com.waz.service.{SSOService}
+import com.waz.service.SSOService
 import com.waz.zclient.InputDialog._
 import com.waz.zclient._
 import com.waz.zclient.appentry.DialogErrorMessage.GenericDialogErrorMessage
@@ -129,18 +129,17 @@ trait SSOFragment extends FragmentHelper with DerivedLogTag {
     }
 
 
-
   private def verifyEmail(email: String): Future[Unit] = {
     val domain = ssoService.extractDomain(email)
     ssoService.verifyDomain(domain).flatMap {
       case Right(DomainSuccessful(configFileUrl)) =>
         val isUserLoggedIn = userAccountsController.currentUser.map(_.isDefined).head.isCompleted
-          if (!backendController.hasCustomBackend && isUserLoggedIn)
-            showInlineSsoError(getString(R.string.enterprise_signin_email_multiple_servers_not_supported))
-          else {
-            dismissSsoDialog()
-            Future.successful(activity.showCustomBackendDialog(new URL(configFileUrl)))
-          }
+        if (!backendController.hasCustomBackend && isUserLoggedIn)
+          showInlineSsoError(getString(R.string.enterprise_signin_email_multiple_servers_not_supported))
+        else {
+          dismissSsoDialog()
+          Future.successful(activity.showCustomBackendDialog(new URL(configFileUrl)))
+        }
       case Right(_) => showInlineSsoError(getString(R.string.enterprise_signin_domain_not_found_error))
       case Left(err) => handleVerificationError(err)
     }

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -24,7 +24,7 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.{ConnectionErrorCode, TimeoutCode}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model2.transport.responses.DomainSuccessful
-import com.waz.service.SSOService
+import com.waz.service.{SSOService}
 import com.waz.zclient.InputDialog._
 import com.waz.zclient._
 import com.waz.zclient.appentry.DialogErrorMessage.GenericDialogErrorMessage
@@ -134,8 +134,13 @@ trait SSOFragment extends FragmentHelper with DerivedLogTag {
     val domain = ssoService.extractDomain(email)
     ssoService.verifyDomain(domain).flatMap {
       case Right(DomainSuccessful(configFileUrl)) =>
-        dismissSsoDialog()
-        Future.successful(activity.showCustomBackendDialog(new URL(configFileUrl)))
+        val isUserLoggedIn = userAccountsController.currentUser.map(_.isDefined).head.isCompleted
+          if (!backendController.hasCustomBackend && isUserLoggedIn)
+            showInlineSsoError(getString(R.string.enterprise_signin_email_multiple_servers_not_supported))
+          else {
+            dismissSsoDialog()
+            Future.successful(activity.showCustomBackendDialog(new URL(configFileUrl)))
+          }
       case Right(_) => showInlineSsoError(getString(R.string.enterprise_signin_domain_not_found_error))
       case Left(err) => handleVerificationError(err)
     }


### PR DESCRIPTION
What's new in this PR?

### Issues

There is a missing error case for milestone 2 :  **When the user is connected to Wire backend and tries to make an enterprise login via a registered domain, this error message should be displayed**: 

> This email is linked to a different server, but the app can only be connected to one server at a time. Please log out of all Wire accounts on this device and try to log in again.

https://wearezeta.atlassian.net/browse/AN-6631

### Testing

- Login to a staging account (Wire backend)
- Go to profile -> New Team or account - > Enterprise Login
- Try to login with an email having a registered domain. Example: test@qa-demo.com



#### APK
[Download build #1214](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1214/artifact/build/artifact/wire-dev-PR2595-1214.apk)