### PR TITLE
bugfix (M2 onboarding flow) : Flow should be restarted when I click on SSO link again 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -100,7 +100,7 @@ class SSOWebViewFragment extends FragmentHelper {
     true
   }
 
-  override def onPause(): Unit ={
+  override def onPause(): Unit = {
     super.onPause()
     onBackPressed()
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -17,14 +17,14 @@
  */
 package com.waz.zclient.appentry
 
-import android.app.FragmentManager
 import android.content.DialogInterface
 import android.os.Bundle
-import androidx.appcompat.widget.Toolbar
 import android.view.View.OnClickListener
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.webkit.WebView
 import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.FragmentManager
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.utils._
@@ -100,6 +100,11 @@ class SSOWebViewFragment extends FragmentHelper {
     true
   }
 
+  override def onPause(): Unit ={
+    super.onPause()
+    onBackPressed()
+  }
+  
   def activity = getActivity.asInstanceOf[AppEntryActivity]
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

There is a bug reported by QA : Flow should be restarted when I click on SSO link again https://wearezeta.atlassian.net/browse/AN-6645

### Solutions

Force sso webview to restart the flow when the app goes to the background

### Testing

- Open SSO deeplink. Example `wire://access/?config=https://aves.services.zinfra.io`
- Enter credentials on SSO page : email and password
- Minimise the application (Go to the background)
- Open same SSO deeplink
- Email and password fields in the webView should be empty

#### APK
[Download build #1229](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1229/artifact/build/artifact/wire-dev-PR2602-1229.apk)