### PR TITLE
Fix: Linear Onboarding - Add error message for custom backend server not found error case

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1408,6 +1408,10 @@
     <string name="custom_backend_dialog_network_error_title">The server is not responding</string>
     <string name="custom_backend_dialog_network_error_message">Please check your internet connection, verify the link and try again.</string>
 
+    <string name="custom_backend_not_found_error_title">This server can\'t be reached</string>
+    <string name="custom_backend_not_found_error_message">We can\'t connect to the server at %1$s.\nLet your server
+        administrator know about this issue.</string>
+
     <string name="custom_backend_dialog_logged_in_error_title">Can\'t switch servers</string>
     <string name="custom_backend_dialog_logged_in_error_message">You are already logged in.\nTo connect to this server, log out of all accounts and try again.</string>
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
@@ -43,6 +43,7 @@ case class ErrorResponse(code: Int, message: String, label: String) extends Thro
 object ErrorResponse {
 
   val Forbidden = 403
+  val NotFound = 404
   val InternalErrorCode = 499
   val CancelledCode = 498
   val UnverifiedCode = 497


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6648

### Issues

With the changes for Linear Onboarding Milestone 2, we should now distinguish custom backend loading error for "404 Not Found" case and show a specific error message as described in Step 4.a. in [custom backend use case](https://github.com/wearezeta/documentation/blob/master/topics/custom-versions/use-cases/005-custom-backend-by-domain.md).

We also trimmed the url for custom backend confirmation dialog for consistency.

### Testing

Manual testing done on qa-demo domain, by manipulating the response to return 404.


#### APK
[Download build #1230](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1230/artifact/build/artifact/wire-dev-PR2603-1230.apk)