### PR TITLE
Fix: Prevent injection of Koin modules (and Room DB!) for production

### DIFF
--- a/app/src/main/java/com/waz/zclient/ZApplication.java
+++ b/app/src/main/java/com/waz/zclient/ZApplication.java
@@ -95,7 +95,9 @@ public class ZApplication extends WireApplication implements ServiceContainer {
     public void onCreate() {
         super.onCreate();
 
-        Injector.start(this);
+        if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) {
+            Injector.start(this);
+        }
 
         AndroidThreeTen.init(this);
         TypefaceFactory.getInstance().init(typefaceloader);


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6649

### Issues

The previous implementation was installing Koin modules regardless of the fact they're going to be used or not. The storage module in particular here is the most crucial since it creates Room Databases, which are not fully migrated from Scala databases yet. This would potentially have effects on stored user data in production.

### Solutions

Install Koin modules only when Kotlin code is intended to be run (via KOTLIN_SETTINGS_MIGRATION flag).

### Testing

An update test should be done and QA is going to be informed.

#### APK
[Download build #1232](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1232/artifact/build/artifact/wire-dev-PR2604-1232.apk)