### PR TITLE
Bump major version to 3.45

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@
 
 object Versions {
     //wire android client
-    const val ANDROID_CLIENT_MAJOR_VERSION = "3.44."
+    const val ANDROID_CLIENT_MAJOR_VERSION = "3.45."
 
     //core
     const val KOTLIN = "1.3.60"


### PR DESCRIPTION
Bumped the app version to 3.45 for the new release.
#### APK
[Download build #1234](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1234/artifact/build/artifact/wire-dev-PR2606-1234.apk)