### PR TITLE
Fix: Update room db version and fix migration versions

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/GlobalDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/GlobalDatabase.kt
@@ -3,12 +3,13 @@ package com.waz.zclient.storage.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.waz.zclient.storage.db.accountdata.ACTIVE_ACCOUNTS_MIGRATION
 import com.waz.zclient.storage.db.accountdata.AccessTokenConverter
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import com.waz.zclient.storage.db.accountdata.SsoIdConverter
 
-@Database(entities = [ActiveAccountsEntity::class], version = 25)
+@Database(entities = [ActiveAccountsEntity::class], version = GlobalDatabase.VERSION)
 @TypeConverters(value = [AccessTokenConverter::class, SsoIdConverter::class])
 abstract class GlobalDatabase : RoomDatabase() {
 
@@ -16,5 +17,9 @@ abstract class GlobalDatabase : RoomDatabase() {
 
     companion object {
         const val DB_NAME = "ZGlobal.db"
+        const val VERSION = 25
+
+        @JvmStatic
+        val migrations = arrayOf(ACTIVE_ACCOUNTS_MIGRATION)
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -11,7 +11,7 @@ import com.waz.zclient.storage.db.users.service.UserPreferenceDao
 
 @Database(
     entities = [UserPreferenceEntity::class, UserEntity::class, ClientEntity::class],
-    version = 126,
+    version = 127,
     exportSchema = false
 )
 abstract class UserDatabase : RoomDatabase() {

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -4,6 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.waz.zclient.storage.db.clients.model.ClientEntity
 import com.waz.zclient.storage.db.clients.service.ClientsDao
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.model.UserEntity
 import com.waz.zclient.storage.db.users.model.UserPreferenceEntity
 import com.waz.zclient.storage.db.users.service.UserDao
@@ -11,7 +12,7 @@ import com.waz.zclient.storage.db.users.service.UserPreferenceDao
 
 @Database(
     entities = [UserPreferenceEntity::class, UserEntity::class, ClientEntity::class],
-    version = 127,
+    version = UserDatabase.VERSION,
     exportSchema = false
 )
 abstract class UserDatabase : RoomDatabase() {
@@ -19,4 +20,11 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun userPreferencesDbService(): UserPreferenceDao
     abstract fun userDbService(): UserDao
     abstract fun clientsDbService(): ClientsDao
+
+    companion object {
+        const val VERSION = 127
+
+        @JvmStatic
+        val migrations = arrayOf(USER_DATABASE_MIGRATION_126_TO_127)
+    }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
@@ -4,8 +4,8 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.waz.zclient.storage.BuildConfig
 
-private const val START_VERSION = 125
-private const val END_VERSION = 126
+private const val START_VERSION = 126
+private const val END_VERSION = 127
 private const val USER_PREFERENCE_TABLE_NAME = "KeyValuesTemp"
 private const val KEY_VALUES_TABLE_NAME = "KeyValues"
 

--- a/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
@@ -3,8 +3,6 @@ package com.waz.zclient.storage.di
 import androidx.room.Room
 import com.waz.zclient.storage.db.GlobalDatabase
 import com.waz.zclient.storage.db.UserDatabase
-import com.waz.zclient.storage.db.accountdata.ACTIVE_ACCOUNTS_MIGRATION
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.pref.GlobalPreferences
 import com.waz.zclient.storage.pref.UserPreferences
 import org.koin.android.ext.koin.androidContext
@@ -17,14 +15,14 @@ val storageModule: Module = module {
         Room.databaseBuilder(androidContext(),
             UserDatabase::class.java,
             get<GlobalPreferences>().activeUserId
-        ).addMigrations(USER_DATABASE_MIGRATION_126_TO_127).build()
+        ).addMigrations(*UserDatabase.migrations).build()
     }
     single {
         Room.databaseBuilder(
             androidContext(),
             GlobalDatabase::class.java,
             GlobalDatabase.DB_NAME
-        ).addMigrations(ACTIVE_ACCOUNTS_MIGRATION).build()
+        ).addMigrations(*GlobalDatabase.migrations).build()
     }
     single { UserPreferences(androidContext(), get()) }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
@@ -12,12 +12,14 @@ import org.koin.dsl.module
 val storageModule: Module = module {
     single { GlobalPreferences(androidContext()) }
     single {
+        @Suppress("SpreadOperator")
         Room.databaseBuilder(androidContext(),
             UserDatabase::class.java,
             get<GlobalPreferences>().activeUserId
         ).addMigrations(*UserDatabase.migrations).build()
     }
     single {
+        @Suppress("SpreadOperator")
         Room.databaseBuilder(
             androidContext(),
             GlobalDatabase::class.java,

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -111,6 +111,7 @@ dependencies {
         exclude(group: "org.scalatest", module: "scalatest")
     }
     testImplementation TestDependencies.robolectric
+    testImplementation BuildDependencies.androidX.roomRuntime
     testImplementation TestDependencies.jUnit   //to override version included in robolectric
     testImplementation "com.squareup.okhttp3:mockwebserver:$versions.okHttp"
     //should match okhttp version.

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -43,7 +43,6 @@ repositories {
     mavenCentral()
     jcenter()
     google()
-    maven { url "http://repo1.maven.org/maven2" }
     maven {
         url "https://oss.sonatype.org/content/repositories/releases"
     }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/db/RoomDbCompatibilitySpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/db/RoomDbCompatibilitySpec.scala
@@ -1,0 +1,43 @@
+package com.waz.db
+
+import androidx.room.migration.{Migration => RoomMigration}
+import com.waz.specs.AndroidFreeSpec
+import com.waz.zclient.storage.db.{GlobalDatabase, UserDatabase}
+
+class RoomDbCompatibilitySpec extends AndroidFreeSpec {
+
+  scenario("Check UserDatabase Room database version") {
+    checkRoomDbVersion("UserDatabase", UserDatabase.VERSION, ZMessagingDB.DbVersion)
+  }
+
+  scenario("Check GlobalDatabase Room database version") {
+    checkRoomDbVersion("GlobalDatabase", GlobalDatabase.VERSION, ZGlobalDB.DbVersion)
+  }
+
+  scenario("Check UserDatabase Room db migration versions") {
+    checkMigrations(UserDatabase.getMigrations, ZMessagingDB.DbVersion, "UserDatabase", "ZMessagingDB")
+  }
+
+  scenario("Check GlobalDatabase Room db migration versions") {
+    checkMigrations(GlobalDatabase.getMigrations, ZGlobalDB.DbVersion, "GlobalDatabase", "ZGlobalDB")
+  }
+
+  private def checkRoomDbVersion(roomDbName: String, roomDbVersion: Int, legacyDbVersion: Int): Unit = {
+    assert(roomDbVersion > legacyDbVersion,
+    s"\nRoom database $roomDbName has an outdated version. " +
+      s"Room db version: $roomDbVersion, legacy db version: $legacyDbVersion")
+  }
+
+  private def checkMigrations(migrations: Array[RoomMigration],
+                              legacyDbVersion: Int,
+                              roomDbName: String,
+                              legacyDbName: String): Unit = {
+    val outdatedMigrations = migrations.filter(_.startVersion < legacyDbVersion)
+
+    val errorMessage: String = outdatedMigrations.map(m => s"(${m.startVersion}, ${m.endVersion})\n").mkString(",")
+
+    assert(outdatedMigrations.isEmpty,
+      s"\nSome Room migrations of $roomDbName try to operate on legacy $legacyDbName. " +
+        s"Consider updating the start/end versions for these migrations: $errorMessage")
+  }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app was getting stuck when KOTLIN_SETTINGS_MIGRATION was enabled.

### Causes

The Room db and Scala side SQL db had the same versions (126). Moreover, both of them had a migration from version 125 to 126. In such a case where there are more than two migrations with the same version numbers, whichever added last overrides the others.

### Solutions

Bumped Room db version to SQLite db version + 1, along with the migration numbers.

### Testing

Update scenario tested:
Open app when flag is disabled and let some db transactions happen,
Install app again with flag enabled, and let migration happen.

Introduced unit tests for version checks.

## Notes

As a future work, we could come up with a way that doesn't require this manual update every time.

#### APK
[Download build #1257](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1257/artifact/build/artifact/wire-dev-PR2614-1257.apk)
[Download build #1267](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1267/artifact/build/artifact/wire-dev-PR2614-1267.apk)