### PR TITLE
fix: Make WSPushService more responsive

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -28,7 +28,8 @@ import com.waz.content.GlobalPreferences.{PushEnabledKey, WsForegroundKey}
 import com.waz.jobs.PushTokenCheckJob
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.AccountsService.InForeground
-import com.waz.service.{AccountsService, GlobalModule, ZMessaging}
+import com.waz.service.push.WSPushService
+import com.waz.service.{AccountsService, GlobalModule, NetworkModeService}
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
@@ -36,25 +37,24 @@ import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient._
 import com.waz.zclient.log.LogUI._
 
-class WebSocketController(implicit inj: Injector) extends Injectable with DerivedLogTag {
+class WebSocketController(implicit inj: Injector) extends Injectable {
   private lazy val global = inject[GlobalModule]
   private lazy val accounts = inject[AccountsService]
 
   private lazy val cloudPushAvailable =
     for {
-      gpsAvailable <- global.googleApi.isGooglePlayServicesAvailable
+      gpsAvailable   <- global.googleApi.isGooglePlayServicesAvailable
       devPrefEnabled <- global.prefs(PushEnabledKey).signal
     } yield gpsAvailable && devPrefEnabled
 
-  lazy val accountWebsocketStates: Signal[(Set[ZMessaging], Set[ZMessaging])] =
+  lazy val accountWebsocketStates: Signal[(Set[WSPushService], Set[WSPushService])] =
     for {
-      cloudPushAvailable <- cloudPushAvailable
-      wsForegroundEnabled <- global.prefs(WsForegroundKey).signal
-      accs <- accounts.zmsInstances
-      accsInFG <- Signal.sequence(accs.map(_.selfUserId).map(id => accounts.accountState(id).map(st => id -> st)).toSeq: _*).map(_.toMap)
-      (zmsWithWSActive, zmsWithWSInactive) =
-      accs.partition(zms => accsInFG(zms.selfUserId) == InForeground || wsForegroundEnabled || !cloudPushAvailable)
-    } yield (zmsWithWSActive, zmsWithWSInactive)
+      cloudPushAvailable                   <- cloudPushAvailable
+      wsForegroundEnabled                  <- global.prefs(WsForegroundKey).signal
+      accs                                 <- accounts.zmsInstances
+      accsInFG                             <- Signal.sequence(accs.map(_.selfUserId).map(id => accounts.accountState(id).map(st => id -> st)).toSeq: _*).map(_.toMap)
+      (zmsWithWSActive, zmsWithWSInactive) =  accs.partition(zms => wsForegroundEnabled || !cloudPushAvailable || accsInFG(zms.selfUserId) == InForeground)
+    } yield (zmsWithWSActive.map(_.wsPushService), zmsWithWSInactive.map(_.wsPushService))
 
   lazy val serviceInForeground: Signal[Boolean] =
     for {
@@ -62,20 +62,17 @@ class WebSocketController(implicit inj: Injector) extends Injectable with Derive
       (zmsWithWS, _) <- accountWebsocketStates
     } yield !uiActive && zmsWithWS.nonEmpty
 
+  private lazy val anyPushServiceConnected =
+    accounts.zmsInstances.flatMap(zs =>
+      Signal.sequence(zs.map(_.wsPushService.connected).toSeq: _ *).map(_.exists(!identity(_)))
+    )
+
   lazy val notificationTitleRes: Signal[Option[Int]] =
-    serviceInForeground.flatMap {
-      case true =>
-        global.network.isOnline.flatMap {
-          //checks to see if there are any accounts that haven't yet established a web socket
-          case true => accounts.zmsInstances.flatMap(zs => Signal.sequence(zs.map(_.wsPushService.connected).toSeq: _ *).map(_.exists(!identity(_)))).map {
-            case true =>  Option(R.string.ws_foreground_notification_connecting_title)
-            case _ => Option(R.string.ws_foreground_notification_connected_title)
-          }
-          case _ =>
-            Signal.const(Option(R.string.ws_foreground_notification_no_internet_title))
-        }
-      case _ =>
-        Signal.const(Option.empty[Int])
+    Signal(serviceInForeground, global.network.isOnline, anyPushServiceConnected).map {
+      case (true, true, true)  => Option(R.string.ws_foreground_notification_connecting_title)
+      case (true, true, false) => Option(R.string.ws_foreground_notification_connected_title)
+      case (true, false, _)    => Option(R.string.ws_foreground_notification_no_internet_title)
+      case _                   => Option.empty[Int]
     }
 }
 
@@ -137,19 +134,27 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
 
   private implicit def context = getApplicationContext
 
-  private lazy val launchIntent = PendingIntent.getActivity(context, 1, Intents.ShowAdvancedSettingsIntent, 0)
+  private lazy val launchIntent        = PendingIntent.getActivity(context, 1, Intents.ShowAdvancedSettingsIntent, 0)
 
-  private lazy val controller = inject[WebSocketController]
+  private lazy val controller          = inject[WebSocketController]
+  private lazy val global              = inject[GlobalModule]
   private lazy val notificationManager = inject[NotificationManager]
 
   private lazy val webSocketActiveSubscription =
-    controller.accountWebsocketStates {
-      case (zmsWithWSActive, zmsWithWSInactive) =>
-        zmsWithWSActive.foreach(_.wsPushService.activate())
-        zmsWithWSInactive.foreach(_.wsPushService.deactivate())
-        if (zmsWithWSActive.isEmpty) stopSelf()
-
+    Signal(controller.accountWebsocketStates, global.network.networkMode) {
+      case ((zmsWithWSActive, zmsWithWSInactive), networkMode) if NetworkModeService.isOnlineMode(networkMode) =>
+        toggleWSPushServices(zmsWithWSActive, zmsWithWSInactive, stopIfNeeded = true)
+      case ((zmsWithWSActive, zmsWithWSInactive), _) =>
+        toggleWSPushServices(Set.empty, zmsWithWSActive ++ zmsWithWSInactive)
     }
+
+  private def toggleWSPushServices(activate:     Set[WSPushService],
+                                   deactivate:   Set[WSPushService],
+                                   stopIfNeeded: Boolean = false): Unit = {
+    activate.foreach(_.activate())
+    deactivate.foreach(_.deactivate())
+    if (stopIfNeeded && activate.isEmpty) stopSelf()
+  }
 
   private lazy val appInForegroundSubscription =
     controller.notificationTitleRes {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -218,7 +218,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val errors                                     = wire[ErrorsServiceImpl]
   lazy val reporting                                  = new ZmsReportingService(selfUserId, global.reporting)
   lazy val wsFactory                                  = new OkHttpWebSocketFactory(account.global.httpProxy)
-  lazy val wsPushService                              = wireWith(WSPushServiceImpl.apply _)
+  lazy val wsPushService: WSPushService               = wireWith(WSPushServiceImpl.apply _)
   lazy val userSearch                                 = wire[UserSearchService]
   lazy val users: UserService                         = wire[UserServiceImpl]
   lazy val teamSize: TeamSizeThreshold                = wire[TeamSizeThresholdImpl]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -194,7 +194,7 @@ class PushServiceImpl(selfUserId:           UserId,
     syncNotifications(StoreNotifications(nots))
   }
 
-  wsPushService.connected().onChanged.map(WebSocketChange).on(dispatcher){
+  wsPushService.connected.onChanged.map(WebSocketChange).on(dispatcher){
     case source@WebSocketChange(true) =>
       verbose(l"sync history due to web socket change")
       syncNotifications(SyncHistory(source))
@@ -265,7 +265,7 @@ class PushServiceImpl(selfUserId:           UserId,
           val retry = Promise[Unit]()
 
           network.networkMode.onChanged.filter(!NetworkOff.contains(_)).next.map(_ => retry.trySuccess({}))
-          wsPushService.connected().onChanged.next.map(_ => retry.trySuccess({}))
+          wsPushService.connected.onChanged.next.map(_ => retry.trySuccess({}))
 
           for {
             _ <- CancellableFuture.delay(syncHistoryBackoff.delay(attempts))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
@@ -143,9 +143,8 @@ class SyncSchedulerImpl(accountId:   UserId,
   }
 
   private def getStartTime(job: SyncJob): Long =
-    if (job.offline && network.isOnlineMode) 0  // start right away if request last failed due to possible network errors
+    if (job.offline && network.isOnline.currentValue.getOrElse(false)) 0  // start right away if request last failed due to possible network errors
     else job.startTime
-
 
   class WaitEntry(private var job: SyncJob) extends DerivedLogTag { self =>
     private val promise = Promise[Unit]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
@@ -59,9 +59,9 @@ class OkHttpWebSocketFactory(proxy: Option[Proxy]) extends WebSocketFactory with
 
   private lazy val okHttpClient =
     if(proxy.isDefined)
-      OkHttpWebSocketFactory.builder.proxy(proxy.get).build()
+      new OkHttpClient.Builder().pingInterval(30000, TimeUnit.MILLISECONDS).proxy(proxy.get).build()
     else
-      OkHttpWebSocketFactory.builder.build()
+      new OkHttpClient.Builder().pingInterval(30000, TimeUnit.MILLISECONDS).build()
 
   override def openWebSocket(request: Request[Body]): EventStream[SocketEvent] = {
     new EventStream[SocketEvent] {
@@ -116,6 +116,3 @@ class OkHttpWebSocketFactory(proxy: Option[Proxy]) extends WebSocketFactory with
 
 }
 
-object OkHttpWebSocketFactory {
-  private lazy val builder = new OkHttpClient.Builder().pingInterval(30000, TimeUnit.MILLISECONDS)
-}

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
@@ -29,6 +29,8 @@ import okio.ByteString
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
 
+import okhttp3.OkHttpClient
+
 import scala.util.Try
 
 object WebSocketFactory {
@@ -49,25 +51,17 @@ trait WebSocketFactory {
 
 class OkHttpWebSocketFactory(proxy: Option[Proxy]) extends WebSocketFactory with DerivedLogTag {
   import okhttp3.{
-    OkHttpClient,
     WebSocketListener,
-    Headers => OkHeaders,
-    Request => OkRequest,
     Response => OkResponse,
     WebSocket => OkWebSocket
   }
   import HttpClientOkHttpImpl.convertHttpRequest
 
-  //TODO Should be created somewhere outside
-  private lazy val builder = new OkHttpClient.Builder()
-    .pingInterval(30000, TimeUnit.MILLISECONDS)
-
   private lazy val okHttpClient =
     if(proxy.isDefined)
-      builder
-        .proxy(proxy.get)
-        .build()
-    else builder.build()
+      OkHttpWebSocketFactory.builder.proxy(proxy.get).build()
+    else
+      OkHttpWebSocketFactory.builder.build()
 
   override def openWebSocket(request: Request[Body]): EventStream[SocketEvent] = {
     new EventStream[SocketEvent] {
@@ -120,4 +114,8 @@ class OkHttpWebSocketFactory(proxy: Option[Proxy]) extends WebSocketFactory with
     }
   }
 
+}
+
+object OkHttpWebSocketFactory {
+  private lazy val builder = new OkHttpClient.Builder().pingInterval(30000, TimeUnit.MILLISECONDS)
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model2/transport/responses/DomainVerificationResponseSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/model2/transport/responses/DomainVerificationResponseSpec.scala
@@ -9,7 +9,7 @@ import org.robolectric.RobolectricTestRunner
 class DomainVerificationResponseSpec {
 
   @Test
-  def `given response has config_json_url responseDecoder returns DomainSuccessful with given url`() {
+  def `given response has config_json_url responseDecoder returns DomainSuccessful with given url`(): Unit = {
     val configUrl = "https://wire-rest.https.orange.com/config.json"
     val jsonString =
       s"""
@@ -26,7 +26,7 @@ class DomainVerificationResponseSpec {
   }
 
   @Test
-  def `given response has no config_json_url, responseDecoder returns DomainNotFound type`() {
+  def `given response has no config_json_url, responseDecoder returns DomainNotFound type`(): Unit = {
     val jsonObject = new JSONObject("{}")
 
     val response = DomainVerificationResponse.DomainVerificationResponseDecoder.apply(jsonObject)


### PR DESCRIPTION
`WSPushService` is a class controlling websockets. There's one websocket per account, and they should be open when the app is in foreground, but closed when it's in background - to save the battery and prevent Android from killing the app. `WSPushService` also takes care of retrying opening the web socket if there was an error.

Until now, being offline was also considered an error and `WSPushService` tried (and failed) to reconnect constantly, with an exponent backoff, i.e. the intervals between tries were getting longer the longer the device was offline. When eventually the device went online again, the app had to wait until the end of the given interval to try again. (Especially Android 10 responds to a retry with this error very quickly. Older Android versions seem to hold on which for longer offline times actually results in *shorter* intervals between retries).
Also, because of implementation details of how signals work, `WebSocketService` sometimes didn't notice that a reactivation is necessary. Together these two errors resulted in delays of receiving events from the backend, sometimes so long that for the customer it looked as if we missed some events.

The PR fixes the way WebSocketService handles activation and deactivation of `WSPushServices`, and it introduces the change in the network mode (going online/offline, but also a switch between different networks) as one more thing that can trigger activation and deactivation. `WSPushService` should be more responsive right now, and the app may also become a bit more battery-friendly, as it does not try anymore to reconnect when offline.

I also refactored a bit of code in other places where the information about being online/offline is
needed. In a few of them we tried to get that information by asking the signal for `.currentValue`,
which is less reliable than `.head`.
#### APK
[Download build #1270](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1270/artifact/build/artifact/wire-dev-PR2616-1270.apk)
[Download build #1278](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1278/artifact/build/artifact/wire-dev-PR2616-1278.apk)
[Download build #1300](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1300/artifact/build/artifact/wire-dev-PR2616-1300.apk)