### PR TITLE
Bump internal avs version to 5.5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ local.properties
 app/api-keys.properties
 app/*.keystore
 app/signing.gradle
+*user.gradle
 *local.gradle.kts
 testing-gallery/*.keystore
 testing-gallery/signing.gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.4.24@aar'
+    customAvsVersion = '5.5.6@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/AN-6667

## What's new in this PR?

Updates AVS library to version 5.5.6



#### APK
[Download build #1273](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1273/artifact/build/artifact/wire-dev-PR2617-1273.apk)