### PR TITLE
chore: OkHttp update to 3.14.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,6 +162,9 @@ android {
     compileOptions {
         compileSdkVersion rootProject.ext.compileSdkVersion
         buildToolsVersion rootProject.ext.buildToolsVersion
+
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 
     kotlinOptions {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,7 +37,7 @@ object Versions {
     const val FIREBASE_MESSAGING = "19.0.0"
     const val GLIDE = "4.11.0"
     const val RETROFIT = "2.6.2"
-    const val OKHTTP = "3.12.0"
+    const val OKHTTP = "3.14.6"
     const val KOIN = "2.0.1"
     const val RX_KOTLIN = "2.3.0"
     const val RX_ANDROID = "2.1.1"


### PR DESCRIPTION
The jump to 3.14 means that we need to add source and target compatibility with Java 8 in app.gradle.
We break the backward compatibility with Android 4.
In return, we get a lot of bugfixes and better cooperation with the websocket, i.e. more reliable
messages sending.

The whole list of changes:
https://square.github.io/okhttp/changelog_3x/

#### APK
[Download build #1274](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1274/artifact/build/artifact/wire-dev-PR2618-1274.apk)