### PR TITLE
fix: A race condition when a push notification results in a new message 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -271,6 +271,15 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
+        <!--
+        We initialize Firebase dynamically.
+        https://firebase.googleblog.com/2017/03/take-control-of-your-firebase-init-on.html
+        -->
+        <provider
+            android:name="com.google.firebase.provider.FirebaseInitProvider"
+            android:authorities="${applicationId}.firebaseinitprovider"
+            tools:node="remove"/>
+
         <!--Disable tracking in the FCM core-->
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -129,12 +129,11 @@ object FCMHandlerService {
 
   val UserKeyMissingMsg = "Notification did not contain user key - discarding"
 
-  class FCMHandler(userId: UserId,
-                   accounts: AccountsService,
-                   push: PushService,
-                   network: NetworkModeService,
-                   fcmPushes: FCMNotificationStatsService,
-                   sentTime: Instant) extends DerivedLogTag {
+  class FCMHandler(userId:    UserId,
+                   accounts:  AccountsService,
+                   push:      PushService,
+                   network:   NetworkModeService,
+                   fcmPushes: FCMNotificationStatsService) extends DerivedLogTag {
 
     import com.waz.model.FCMNotification.Pushed
     import com.waz.threading.Threading.Implicits.Background
@@ -175,9 +174,14 @@ object FCMHandlerService {
   }
 
   object FCMHandler {
-    def apply(zms: ZMessaging, data: Map[String, String], sentTime: Instant): Future[Unit] =
-      new FCMHandler(zms.selfUserId, zms.accounts, zms.push, zms.network, zms.fcmNotStatsService, sentTime)
-        .handleMessage(data)
+
+    private val handlers = scala.collection.mutable.HashMap[UserId, FCMHandler]()
+
+    def apply(zms: ZMessaging, data: Map[String, String], sentTime: Instant): Unit =
+      handlers.getOrElseUpdate(
+        zms.selfUserId,
+        new FCMHandler(zms.selfUserId, zms.accounts, zms.push, zms.network, zms.fcmNotStatsService)
+      ).handleMessage(data)
   }
 
   val DataKey = "data"

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -498,5 +498,4 @@ object MessageNotificationsController {
 
   val ZETA_MESSAGE_NOTIFICATION_ID: Int = 1339272
   val ZETA_EPHEMERAL_NOTIFICATION_ID: Int = 1339279
-
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -34,7 +34,8 @@ object Versions {
     const val ANDROIDX_BIOMETRIC = "1.0.1"
     const val ANDROIDX_ANNOTATION = "1.0.0"
     const val PLAY_SERVICES = "17.0.0"
-    const val FIREBASE_MESSAGING = "19.0.0"
+    const val PLAY_SERVICES_BASE = "17.1.0"
+    const val FIREBASE_MESSAGING = "20.1.0"
     const val GLIDE = "4.11.0"
     const val RETROFIT = "2.6.2"
     const val OKHTTP = "3.14.6"
@@ -97,7 +98,7 @@ object BuildDependencies {
         "annotation" to "androidx.annotation:annotation:${Versions.ANDROIDX_ANNOTATION}"
     ))
     val playServices = PlayServicesDependencyMap(mapOf(
-        "base" to "com.google.android.gms:play-services-base:${Versions.PLAY_SERVICES}",
+        "base" to "com.google.android.gms:play-services-base:${Versions.PLAY_SERVICES_BASE}",
         "maps" to "com.google.android.gms:play-services-maps:${Versions.PLAY_SERVICES}",
         "location" to "com.google.android.gms:play-services-location:${Versions.PLAY_SERVICES}",
         "gcm" to "com.google.android.gms:play-services-gcm:${Versions.PLAY_SERVICES}"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -326,14 +326,16 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
         convOrder.conversationOrderEventsStage,
         conversations.convStateEventProcessingStage,
         msgEvents.messageEventProcessingStage,
+        notifications.messageNotificationEventsStage,
+        notifications.connectionNotificationEventStage,
         genericMsgs.eventProcessingStage,
         foldersService.eventProcessingStage,
-        propertiesService.eventProcessor,
-        notifications.messageNotificationEventsStage,
-        notifications.connectionNotificationEventStage
+        propertiesService.eventProcessor
       )
     )
   }
+
+  private lazy val blockStreamsWhenProcessing = push.processing(messagesStorage.blockStreams)
 
   // force loading of services which should run on start
   {
@@ -344,6 +346,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
     push // connect on start
     notifications
+    blockStreamsWhenProcessing
 
     // services listening on lifecycle verified login events
     contacts

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -51,10 +51,8 @@ class MessageEventProcessor(selfUserId:           UserId,
       verbose(l"processing events for conv: $conv, events: $events")
 
       convsService.isGroupConversation(conv.id).flatMap { isGroup =>
-        storage.blockStreams(true)
 
         returning(processEvents(conv, isGroup, events)){ result =>
-          storage.blockStreams(false)
           result.onFailure { case e: Exception => error(l"Message event processing failed.", e) }
         }
       }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -194,9 +194,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
   // updates server timestamp for local messages, this should make sure that local messages are ordered correctly after one of them is sent
   def updateLocalMessageTimes(conv: ConvId, prevTime: RemoteInstant, time: RemoteInstant) =
     messagesStorage.findLocalFrom(conv, prevTime) flatMap { local =>
-      verbose(l"local messages from $prevTime: $local")
       messagesStorage updateAll2(local.map(_.id), { m =>
-        verbose(l"try updating local message time, msg: $m, time: $time")
         if (m.isLocal) m.copy(time = time + (m.time.toEpochMilli - prevTime.toEpochMilli).millis) else m
       })
     }
@@ -220,8 +218,6 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
         msgs.head
       else {
         msgs.reduce { (prev, msg) =>
-          verbose(l"msgs reduce from $prev to $msg")
-
           if (prev.isLocal && prev.userId == msg.userId)
             mergeLocal(localMessage = prev, msg)
           else if (prev.userId == msg.userId)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
@@ -45,7 +45,7 @@ class ReceiptService(messages: MessagesStorage,
     Future.traverse(filteredMessages) { case ((convId, userId), groupMessages) =>
       for {
         false <- convsService.isGroupConversation(convId)
-        _ <- sync.postReceipt(convId, groupMessages.map(_.id), userId, ReceiptType.Delivery)
+        _     <- sync.postReceipt(convId, groupMessages.map(_.id), userId, ReceiptType.Delivery)
       } yield ()
     }
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -34,7 +34,7 @@ import com.waz.model.otr.ClientId
 import com.waz.service.ZMessaging.{accountTag, clock}
 import com.waz.service._
 import com.waz.service.otr.OtrService
-import com.waz.service.push.PushService.{Results, SyncMode, SyncSource}
+import com.waz.service.push.PushService.SyncMode
 import com.waz.service.tracking.TrackingService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.PushNotificationsClient.LoadNotificationsResult
@@ -116,14 +116,13 @@ class PushServiceImpl(selfUserId:           UserId,
 
   notificationStorage.registerEventHandler { () =>
     Serialized.future(PipelineKey) {
-      verbose(l"events processing started")
-      val t = System.currentTimeMillis()
       for {
         _ <- Future.successful(processing ! true)
+        t =  System.currentTimeMillis()
         _ <- processEncryptedRows()
         _ <- processDecryptedRows()
-        _ <- Future.successful(processing ! false)
         _ = verbose(l"events processing finished, time: ${System.currentTimeMillis() - t}ms")
+        _ <- Future.successful(processing ! false)
       } yield {}
     }.recover {
       case ex =>


### PR DESCRIPTION
A new message in the messages storage triggers sending back a read receipt and possibly some other updates, e.g. in the badge of unread messages. If one of those processes results in a sync job, it is possible that it will get in the way of processing the original push notification.
This PR fixes this by stopping the event streams of of `onAdded`, `onUpdated`, and `onDeleted` in `MessagesStorage`. The events which should be published to the streams are queued and released only after processing of the original push notification. It should help us with some cases of freezing at start and delayed/missing notifications.

Please note that one other big problem with push notifications is that Android does not wake our FCMHandlerService. That one can be fixed probably only by updating FCM, which right now is impossible. As part of this PR I updated our dependencies a bit, but it's not enough.

#### APK
[Download build #1275](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1275/artifact/build/artifact/wire-dev-PR2619-1275.apk)
[Download build #1279](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1279/artifact/build/artifact/wire-dev-PR2619-1279.apk)
[Download build #1285](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1285/artifact/build/artifact/wire-dev-PR2619-1285.apk)
[Download build #1286](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1286/artifact/build/artifact/wire-dev-PR2619-1286.apk)
[Download build #1287](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1287/artifact/build/artifact/wire-dev-PR2619-1287.apk)
[Download build #1293](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1293/artifact/build/artifact/wire-dev-PR2619-1293.apk)