### PR TITLE
Scala/Room integration - Part 2 - Select Room/legacy database in runtime

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,7 @@ android {
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
         buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
         buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
-        buildConfigField 'boolean', 'KOTLIN_SETTINGS_MIGRATION', "false"
+        buildConfigField 'boolean', 'KOTLIN_SETTINGS_MIGRATION',     rootProject.ext.kotlinSettingsMigration
     }
 
     packagingOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ ext {
     buildtimeConfiguration = prepareCustomizationEnvironment()
 
     project.logger.quiet("Build time configuration is: ${JsonOutput.prettyPrint(JsonOutput.toJson(buildtimeConfiguration.configuration))}")
+
+    kotlinSettingsMigration = "true"
 }
 
 class BuildtimeConfiguration {

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ ext {
 
     project.logger.quiet("Build time configuration is: ${JsonOutput.prettyPrint(JsonOutput.toJson(buildtimeConfiguration.configuration))}")
 
-    kotlinSettingsMigration = "true"
+    kotlinSettingsMigration = "false"
 }
 
 class BuildtimeConfiguration {

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -17,7 +17,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
 
-        buildConfigField 'boolean', 'KOTLIN_SETTINGS_MIGRATION', "false"
+        buildConfigField 'boolean', 'KOTLIN_SETTINGS_MIGRATION', rootProject.ext.kotlinSettingsMigration
     }
 
     buildTypes {

--- a/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
@@ -13,7 +13,7 @@ import org.koin.dsl.module
 
 val storageModule: Module = module {
     single { GlobalPreferences(androidContext()) }
-    single { StorageModule.getUserDatabase(androidContext(), get<GlobalPreferences>().activeUserId, UserDatabase.migrations) }
+    factory { StorageModule.getUserDatabase(androidContext(), get<GlobalPreferences>().activeUserId, UserDatabase.migrations) }
     single { StorageModule.getGlobalDatabase(androidContext(), GlobalDatabase.migrations) }
     single { UserPreferences(androidContext(), get()) }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
@@ -1,6 +1,8 @@
 package com.waz.zclient.storage.di
 
+import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
 import com.waz.zclient.storage.db.GlobalDatabase
 import com.waz.zclient.storage.db.UserDatabase
 import com.waz.zclient.storage.pref.GlobalPreferences
@@ -11,20 +13,27 @@ import org.koin.dsl.module
 
 val storageModule: Module = module {
     single { GlobalPreferences(androidContext()) }
-    single {
-        @Suppress("SpreadOperator")
-        Room.databaseBuilder(androidContext(),
+    single { StorageModule.createUserDatabase(androidContext(), get<GlobalPreferences>().activeUserId, UserDatabase.migrations) }
+    single { StorageModule.createGlobalDatabase(androidContext(), GlobalDatabase.migrations) }
+    single { UserPreferences(androidContext(), get()) }
+}
+
+object StorageModule {
+
+    @Suppress("SpreadOperator")
+    @JvmStatic
+    fun createUserDatabase(context: Context, dbName: String, migrations: Array<out Migration>) =
+        Room.databaseBuilder(context,
             UserDatabase::class.java,
-            get<GlobalPreferences>().activeUserId
-        ).addMigrations(*UserDatabase.migrations).build()
-    }
-    single {
-        @Suppress("SpreadOperator")
+            dbName
+        ).addMigrations(*migrations).build()
+
+    @Suppress("SpreadOperator")
+    @JvmStatic
+    fun createGlobalDatabase(context: Context, migrations: Array<out Migration>) =
         Room.databaseBuilder(
-            androidContext(),
+            context,
             GlobalDatabase::class.java,
             GlobalDatabase.DB_NAME
-        ).addMigrations(*GlobalDatabase.migrations).build()
-    }
-    single { UserPreferences(androidContext(), get()) }
+        ).addMigrations(*migrations).build()
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/di/StorageModule.kt
@@ -13,7 +13,9 @@ import org.koin.dsl.module
 
 val storageModule: Module = module {
     single { GlobalPreferences(androidContext()) }
-    factory { StorageModule.getUserDatabase(androidContext(), get<GlobalPreferences>().activeUserId, UserDatabase.migrations) }
+    factory {
+        StorageModule.getUserDatabase(androidContext(), get<GlobalPreferences>().activeUserId, UserDatabase.migrations)
+    }
     single { StorageModule.getGlobalDatabase(androidContext(), GlobalDatabase.migrations) }
     single { UserPreferences(androidContext(), get()) }
 }

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -15,6 +15,7 @@ android {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
 
+        buildConfigField 'boolean', 'KOTLIN_SETTINGS_MIGRATION', rootProject.ext.kotlinSettingsMigration
     }
 
     externalNativeBuild {

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     compileOnly BuildDependencies.threetenbpJava
     compileOnly "net.java.dev.jna:jna:4.4.0@aar"
     compileOnly TestDependencies.robolectric
+    compileOnly BuildDependencies.androidX.roomRuntime
 
     //Test dependencies
     testImplementation(LegacyDependencies.scalaTest) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Database.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Database.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.content
 
-import com.waz.db.{DaoDB, inReadTransaction, inTransaction}
+import com.waz.db.{BaseDaoDB, inReadTransaction, inTransaction}
 import com.waz.log.BasicLogging.LogTag
 import com.waz.threading._
 import com.waz.utils.wrappers.DB
@@ -27,7 +27,7 @@ import scala.concurrent.Future
 trait Database {
   implicit val dispatcher: SerialDispatchQueue
 
-  val dbHelper: DaoDB
+  val dbHelper: BaseDaoDB
 
   lazy val readExecutionContext: DispatchQueue = new UnlimitedDispatchQueue(Threading.IO, name = "Database_readQueue_" + hashCode().toHexString)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
@@ -30,7 +30,7 @@ class GlobalDatabase(context: Context, dbNameSuffix: String = "", tracking: Trac
   override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "GlobalDatabase")
   override val dbHelper: BaseDaoDB =
     if (BuildConfig.KOTLIN_SETTINGS_MIGRATION)
-      new RoomDaoDB(StorageModule.createGlobalDatabase(
+      new RoomDaoDB(StorageModule.getGlobalDatabase(
         context,
         ZGlobalDB.Migrations.migrations(context).map(_.toRoomMigration).toArray ++ RoomGlobalDatabase.getMigrations)
       )

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
@@ -18,12 +18,21 @@
 package com.waz.content
 
 import android.content.Context
-import com.waz.db.ZGlobalDB
+import com.waz.db.{BaseDaoDB, RoomDaoDB, ZGlobalDB}
 import com.waz.service.tracking.TrackingService
 import com.waz.threading.{SerialDispatchQueue, Threading}
+import com.waz.zclient.storage.di.StorageModule
+import com.waz.zms.BuildConfig
+import com.waz.zclient.storage.db.{GlobalDatabase => RoomGlobalDatabase}
 
 class GlobalDatabase(context: Context, dbNameSuffix: String = "", tracking: TrackingService) extends Database {
 
   override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "GlobalDatabase")
-  val dbHelper = new ZGlobalDB(context, dbNameSuffix, tracking)
+  override val dbHelper: BaseDaoDB =
+    if (BuildConfig.KOTLIN_SETTINGS_MIGRATION)
+      new RoomDaoDB(StorageModule.createGlobalDatabase(
+        context,
+        ZGlobalDB.Migrations.migrations(context).map(_.toRoomMigration).toArray ++ RoomGlobalDatabase.getMigrations)
+      )
+    else new ZGlobalDB(context, dbNameSuffix, tracking)
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
@@ -33,7 +33,7 @@ class ZmsDatabase(user: UserId, context: Context, tracking: TrackingService) ext
   override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "ZmsDatabase_" + user.str.substring(24))
   override val dbHelper: BaseDaoDB =
     if (BuildConfig.KOTLIN_SETTINGS_MIGRATION)
-      new RoomDaoDB(StorageModule.createUserDatabase(
+      new RoomDaoDB(StorageModule.getUserDatabase(
         context, user.str,
         ZMessagingDB.migrations.map(_.toRoomMigration).toArray ++ UserDatabase.getMigrations)
       )

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
@@ -18,15 +18,24 @@
 package com.waz.content
 
 import android.content.Context
-import com.waz.db.{DaoDB, ZMessagingDB}
+import com.waz.db.{BaseDaoDB, RoomDaoDB, ZMessagingDB}
 import com.waz.model.UserId
 import com.waz.service.tracking.TrackingService
 import com.waz.threading.{SerialDispatchQueue, Threading}
+import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zclient.storage.di.StorageModule
+import com.waz.zms.BuildConfig
 
 /**
  * Single user storage. Keeps data specific to used user account.
   */
 class ZmsDatabase(user: UserId, context: Context, tracking: TrackingService) extends Database {
   override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "ZmsDatabase_" + user.str.substring(24))
-  override          val dbHelper  : DaoDB = new ZMessagingDB(context, user.str, tracking)
+  override val dbHelper: BaseDaoDB =
+    if (BuildConfig.KOTLIN_SETTINGS_MIGRATION)
+      new RoomDaoDB(StorageModule.createUserDatabase(
+        context, user.str,
+        ZMessagingDB.migrations.map(_.toRoomMigration).toArray ++ UserDatabase.getMigrations)
+      )
+    else new ZMessagingDB(context, user.str, tracking)
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/Migration.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/Migration.scala
@@ -23,6 +23,7 @@ import com.waz.log.LogSE._
 import com.waz.log.LogShow
 import com.waz.service.tracking.TrackingService
 import com.waz.utils.wrappers.DB
+import androidx.room.migration.{Migration => RoomMigration}
 
 import scala.util.control.NonFatal
 
@@ -31,6 +32,10 @@ trait Migration { self =>
   val toVersion: Int
   
   def apply(db: DB): Unit
+
+  def toRoomMigration: RoomMigration = new RoomMigration(fromVersion, toVersion) {
+    override def migrate(database: SupportSQLiteDatabase): Unit = apply(DB(database))
+  }
 }
 
 object Migration {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -34,6 +34,8 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.utils.wrappers.DB
 import com.waz.utils.{JsonDecoder, JsonEncoder, Resource}
+import com.waz.zclient.storage.db.GlobalDatabase
+import com.waz.zms.BuildConfig
 
 class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingService)
   extends DaoDB(context.getApplicationContext, DbName + dbNameSuffix, DbVersion, daos, Migrations.migrations(context), tracking)
@@ -53,7 +55,7 @@ class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingS
 
 object ZGlobalDB {
   val DbName = "ZGlobal.db"
-  val DbVersion = 24
+  val DbVersion = if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) GlobalDatabase.VERSION else 24
 
   lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDao)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -34,8 +34,6 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.utils.wrappers.DB
 import com.waz.utils.{JsonDecoder, JsonEncoder, Resource}
-import com.waz.zclient.storage.db.GlobalDatabase
-import com.waz.zms.BuildConfig
 
 class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingService)
   extends DaoDB(context.getApplicationContext, DbName + dbNameSuffix, DbVersion, daos, Migrations.migrations(context), tracking)
@@ -55,7 +53,7 @@ class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingS
 
 object ZGlobalDB {
   val DbName = "ZGlobal.db"
-  val DbVersion = if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) GlobalDatabase.VERSION else 24
+  val DbVersion = 24
 
   lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDao)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -51,8 +51,6 @@ import com.waz.service.assets.AssetStorageImpl.AssetDao
 import com.waz.service.assets.DownloadAssetStorage.DownloadAssetDao
 import com.waz.service.assets.UploadAssetStorage.UploadAssetDao
 import com.waz.service.tracking.TrackingService
-import com.waz.zclient.storage.db.UserDatabase
-import com.waz.zms.BuildConfig
 
 import scala.util.{Success, Try}
 
@@ -67,7 +65,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) UserDatabase.VERSION else 126
+  val DbVersion = 126
 
   lazy val daos = Seq (
     UserDataDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -66,7 +66,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = UserDatabase.VERSION
+  val DbVersion = 126
 
   lazy val daos = Seq (
     UserDataDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -52,6 +52,7 @@ import com.waz.service.assets.DownloadAssetStorage.DownloadAssetDao
 import com.waz.service.assets.UploadAssetStorage.UploadAssetDao
 import com.waz.service.tracking.TrackingService
 import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zms.BuildConfig
 
 import scala.util.{Success, Try}
 
@@ -66,7 +67,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = 126
+  val DbVersion = if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) UserDatabase.VERSION else 126
 
   lazy val daos = Seq (
     UserDataDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -66,7 +66,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = 126
+  val DbVersion = UserDatabase.VERSION
 
   lazy val daos = Seq (
     UserDataDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/backup/BackupManager.scala
@@ -34,6 +34,8 @@ import com.waz.utils.IoUtils.withResource
 import com.waz.utils.Json.syntax._
 import com.waz.utils.crypto.LibSodiumUtils
 import com.waz.utils.{IoUtils, JsonDecoder, JsonEncoder, RichTry, returning}
+import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zms.BuildConfig
 import org.json.JSONObject
 import org.threeten.bp.Instant
 
@@ -71,7 +73,7 @@ object BackupManager {
   object BackupMetadata {
 
     def currentPlatform: String = "android"
-    def currentDbVersion: Int = ZMessagingDB.DbVersion
+    def currentDbVersion: Int = if (BuildConfig.KOTLIN_SETTINGS_MIGRATION) UserDatabase.VERSION else ZMessagingDB.DbVersion
 
 
     implicit def backupMetadataEncoder: JsonEncoder[BackupMetadata] = new JsonEncoder[BackupMetadata] {


### PR DESCRIPTION
## What's new in this PR?

**This solution requires the Room database to always be compatible with the Scala side.** 

### Issues

When we run the app with KOTLIN_SETTINGS_MIGRATION flag on, when we kill the app and reopen it, the app gets stuck in the launch screen.

### Causes

When the new Kotlin code runs and Room database is initialized, the database versions throughout the app increases (for user-specific database: 126 -> 127, for global database 24 -> 25). However, since Scala side uses the old databases (ZMessagingDB and ZGlobal) with old versions, the next time the app tries to make a database transaction with these legacy databases, an exception is thrown saying: "`android.database.sqlite.SQLiteException: Can't downgrade database from version 127 to 126`".

This exception is not thrown but also not propagated up to UI layer, since it is hidden inside a Signal call. In that case the app does not crash, but waits for a Signal that will never come because we got an exception while retrieving the signal, hence, the app gets stuck.

### Solutions

We now select the database in the runtime. If KOTLIN_SETTINGS_MIGRATION is on, the Scala side also operates on same SQLiteSupport database that Room wraps for us in Kotlin side. Otherwise, it continues to operate with the legacy database.

### Testing

Manual testing is done. A build with KOTLIN_SETTINGS_MIGRATION flag on should be given to QA to perform update and fresh installs with such a case.

![WhatsApp Image 2020-02-18 at 18 46 13](https://user-images.githubusercontent.com/2143283/74762911-10899e00-527f-11ea-88f0-722be34f91cd.jpeg)

#### APK
[Download build #1326](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1326/artifact/build/artifact/wire-dev-PR2623-1326.apk)
[Download build #1329](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1329/artifact/build/artifact/wire-dev-PR2623-1329.apk)