### PR TITLE
Improve kotlin migration flag calculation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,9 +132,9 @@ android {
         buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
 
         //Kotlin Feature Flags
-        buildConfigField 'boolean', 'KOTLIN_SETTINGS', rootProject.ext.kotlinSettings
-        buildConfigField 'boolean', 'KOTLIN_REGISTRATION', rootProject.ext.kotlinRegistration
-        buildConfigField 'boolean', 'KOTLIN_CORE', rootProject.ext.kotlinCore
+        buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"
+        buildConfigField 'boolean', 'KOTLIN_REGISTRATION', "$rootProject.ext.kotlinRegistration"
+        buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
     }
 
     packagingOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -87,9 +87,9 @@ ext {
 
     project.logger.quiet("Build time configuration is: ${JsonOutput.prettyPrint(JsonOutput.toJson(buildtimeConfiguration.configuration))}")
 
-    kotlinSettings = "false"
-    kotlinRegistration = "false"
-    kotlinCore = "false"
+    kotlinSettings = false
+    kotlinRegistration = false
+    kotlinCore = kotlinSettings || kotlinRegistration
 }
 
 class BuildtimeConfiguration {

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ ext {
 
     project.logger.quiet("Build time configuration is: ${JsonOutput.prettyPrint(JsonOutput.toJson(buildtimeConfiguration.configuration))}")
 
+    //Update kotlinCore flag as well when adding new kotlin features
     kotlinSettings = false
     kotlinRegistration = false
     kotlinCore = kotlinSettings || kotlinRegistration

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -17,7 +17,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
 
-        buildConfigField 'boolean', 'KOTLIN_CORE', rootProject.ext.kotlinCore
+        buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
     }
 
     buildTypes {


### PR DESCRIPTION
## What's new in this PR?

Kotlin_core flag now gets enabled by default if at least one of the kotlin features are enabled.
#### APK
[Download build #1332](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1332/artifact/build/artifact/wire-dev-PR2628-1332.apk)
[Download build #1341](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1341/artifact/build/artifact/wire-dev-PR2628-1341.apk)