### PR TITLE
fix: Handle all exceptions when creating tones for Wire's notifications

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.notifications.controllers
 
-import java.io.{File, FileNotFoundException, FileOutputStream, IOException}
+import java.io.{File, FileNotFoundException, IOException}
 
 import android.app.{Notification, NotificationChannel, NotificationChannelGroup, NotificationManager}
 import android.content.{ContentValues, Context}
@@ -26,9 +26,9 @@ import android.graphics.{Color, Typeface}
 import android.net.Uri
 import android.os.{Build, Environment}
 import android.provider.MediaStore
-import androidx.core.app.NotificationCompat.Style
 import android.text.style.{ForegroundColorSpan, StyleSpan}
 import android.text.{SpannableString, Spanned}
+import androidx.core.app.NotificationCompat.Style
 import androidx.core.app.{NotificationCompat, RemoteInput}
 import com.waz.content.Preferences.PrefKey
 import com.waz.content.UserPreferences
@@ -38,8 +38,8 @@ import com.waz.service.AccountsService
 import com.waz.services.notifications.NotificationsHandlerService
 import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, Signal}
-import com.waz.utils.returning
 import com.waz.utils.wrappers.Bitmap
+import com.waz.utils.{IoUtils, returning}
 import com.waz.zclient.Intents.{CallIntent, QuickReplyIntent}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.{MessageNotificationsChannelId, PingNotificationsChannelId}
@@ -49,6 +49,7 @@ import com.waz.zclient.{Injectable, Injector, Intents, R}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 case class Span(style: Int, range: Int, offset: Int = 0)
 
@@ -314,7 +315,16 @@ object NotificationManagerWrapper {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 
       addToExternalNotificationFolder(R.raw.new_message_gcm, getString(R.string.wire_notification_name))
+        .recover {
+          case ex: Exception =>
+            error(l"Failed to add ${(R.raw.new_message_gcm, getString(R.string.wire_notification_name))} to the external notification folder", ex)
+        }
+
       addToExternalNotificationFolder(R.raw.ping_from_them, getString(R.string.wire_ping_name))
+        .recover {
+          case ex: Exception =>
+            error(l"Failed to add ${(R.raw.ping_from_them, getString(R.string.wire_ping_name))} to the external notification folder", ex)
+        }
 
       accountChannels { channels =>
 
@@ -377,62 +387,67 @@ object NotificationManagerWrapper {
 
     def getNotificationChannel(channelId: String) = notificationManager.getNotificationChannel(channelId)
 
-    private def addToExternalNotificationFolder(rawId: Int, name: String) =
-      Option(cxt.getExternalFilesDir(Environment.DIRECTORY_NOTIFICATIONS)).foreach { dir =>
-        val uri      = MediaStore.Audio.Media.INTERNAL_CONTENT_URI
-        val query    = s"${MediaStore.MediaColumns.DATA} LIKE '%$name%'"
-        val toneFile = new File(s"${dir.getAbsolutePath}/$name.ogg")
-        if (toneFile.exists()) {
-          val contentValues = returning(new ContentValues) { values =>
-            values.put(MediaStore.MediaColumns.DATA, toneFile.getAbsolutePath)
-            values.put(MediaStore.MediaColumns.TITLE, name)
-            values.put(MediaStore.MediaColumns.MIME_TYPE, "audio/ogg")
-            values.put(MediaStore.MediaColumns.SIZE, toneFile.length.toInt.asInstanceOf[Integer])
-            values.put(MediaStore.Audio.AudioColumns.IS_RINGTONE, true)
-            values.put(MediaStore.Audio.AudioColumns.IS_NOTIFICATION, true)
-            values.put(MediaStore.Audio.AudioColumns.IS_ALARM, true)
-            values.put(MediaStore.Audio.AudioColumns.IS_MUSIC, false)
-          }
-
-          try {
-            val fIn = cxt.getResources.openRawResource(rawId)
-            val buffer = new Array[Byte](fIn.available)
-            fIn.read(buffer)
-            fIn.close()
-
-            returning(new FileOutputStream(toneFile)) { fOut =>
-              fOut.write(buffer)
-              fOut.flush()
-              fOut.close()
-            }
-
-            // TODO: On some devices (Redmi 6A, Xperia X Compact) the query causes SQLiteException.
-            // test on one of these devices and find out why.
-            val cursor = try {
-              Option(cxt.getContentResolver.query(uri, null, query, null, null))
-            } catch {
-              case ex: SQLiteException =>
-                error(l"query to access the media store failed; uri: $uri, query: ${redactedString(query)}", ex)
-                None
-            }
-
-            if (cursor.forall(_.getCount == 0)) cxt.getContentResolver.insert(uri, contentValues)
-            cursor.foreach(_.close())
-          } catch {
-            case ex: FileNotFoundException =>
-              error(l"File not found: $toneFile")
-            case ex: IOException =>
-              error(l"query to access the media store failed; uri: $uri, query: ${redactedString(query)}", ex)
-          }
-        } else {
-          error(l"File not found: $toneFile")
-        }
-      }
-
     override def cancelNotifications(ids: Set[Int]): Unit = {
       verbose(l"cancel: $ids")
       ids.foreach(notificationManager.cancel)
     }
+
+    private def addToExternalNotificationFolder(rawId: Int, name: String) =
+      for {
+        dir      <- externalFilesDir
+        toneFile =  new File(s"${dir.getAbsolutePath}/$name.ogg")
+        _        <- if (toneFile.exists()) createTone(rawId, name, toneFile)
+                    else Failure(new IOException(s"File not found: $toneFile"))
+      } yield ()
+
+    private def externalFilesDir =
+      Try(cxt.getExternalFilesDir(Environment.DIRECTORY_NOTIFICATIONS))
+        .map(Option(_))
+        .flatMap {
+          case Some(dir) => Success(dir)
+          case None      => Failure(new IOException(s"No external files dir ${Environment.DIRECTORY_NOTIFICATIONS}"))
+        }
+
+    private def createTone(rawId: Int, name: String, toneFile: File) = {
+      val uri   = MediaStore.Audio.Media.INTERNAL_CONTENT_URI
+      val query = s"${MediaStore.MediaColumns.DATA} LIKE '%$name%'"
+      (for {
+        _      <- Try(IoUtils.copy(cxt.getResources.openRawResource(rawId), toneFile))
+        cursor <- getCursor(uri, query)
+        _      =  if (cursor.getCount == 0) cxt.getContentResolver.insert(uri, createContentValues(name, toneFile))
+        _      =  cursor.close()
+      } yield ()).recoverWith {
+        case ex: FileNotFoundException =>
+          error(l"File not found: $toneFile")
+          Failure(ex)
+        case ex: IOException =>
+          error(l"query to access the media store failed; uri: $uri, query: ${redactedString(query)}", ex)
+          Failure(ex)
+      }
+    }
+
+    private def createContentValues(name: String, toneFile: File) = returning(new ContentValues) { values =>
+      values.put(MediaStore.MediaColumns.DATA, toneFile.getAbsolutePath)
+      values.put(MediaStore.MediaColumns.TITLE, name)
+      values.put(MediaStore.MediaColumns.MIME_TYPE, "audio/ogg")
+      values.put(MediaStore.MediaColumns.SIZE, toneFile.length.toInt.asInstanceOf[Integer])
+      values.put(MediaStore.Audio.AudioColumns.IS_RINGTONE, true)
+      values.put(MediaStore.Audio.AudioColumns.IS_NOTIFICATION, true)
+      values.put(MediaStore.Audio.AudioColumns.IS_ALARM, true)
+      values.put(MediaStore.Audio.AudioColumns.IS_MUSIC, false)
+    }
+
+    private def getCursor(uri: Uri, query: String) =
+      Try(cxt.getContentResolver.query(uri, null, query, null, null))
+        .map(Option(_))
+        .flatMap {
+          case Some(dir) => Success(dir)
+          case None      => Failure(new SQLiteException(s"The cursor is null for uri: $uri, and query: ${redactedString(query)}"))
+        }.recoverWith {
+          case ex: SQLiteException =>
+            error(l"query to access the media store failed; uri: $uri, query: ${redactedString(query)}", ex)
+            Failure(ex)
+        }
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -317,13 +317,13 @@ object NotificationManagerWrapper {
       addToExternalNotificationFolder(R.raw.new_message_gcm, getString(R.string.wire_notification_name))
         .recover {
           case ex: Exception =>
-            error(l"Failed to add ${(R.raw.new_message_gcm, getString(R.string.wire_notification_name))} to the external notification folder", ex)
+            error(l"Failed to add `new message GCM` (${getString(R.string.wire_notification_name)}) to the external notification folder", ex)
         }
 
       addToExternalNotificationFolder(R.raw.ping_from_them, getString(R.string.wire_ping_name))
         .recover {
           case ex: Exception =>
-            error(l"Failed to add ${(R.raw.ping_from_them, getString(R.string.wire_ping_name))} to the external notification folder", ex)
+            error(l"Failed to add `ping from them` (${getString(R.string.wire_ping_name)}) to the external notification folder", ex)
         }
 
       accountChannels { channels =>


### PR DESCRIPTION
When we open Wire, we try to register our own custom sounds for notifications: one for new message, and one for a ping. (Right now we're doing it every time we open the app - maybe we don't have to do it so often).
In order to do that we have to find the external notifications folder, find a tone file within it, copy our sound to that file, and notice Android about it by inserting some data into the content resolver. At each step of this process something may go wrong and an exception will be thrown. We try to handle those exceptions, but it seems that at least on some phones with Android 10 one of the exceptions escapes. [You can look into Google Play Console for that](https://play.google.com/apps/publish/?account=7098984309886892484#AndroidMetricsErrorsPlace:p=com.wire&appid=4973241010395499500&appVersion=PRODUCTION&clusterName=apps/com.wire/clusters/501b2c9d&detailsAppVersion=PRODUCTION&detailsSpan=7).

This PR refactors the process, wrapping everything in functional "Tries" in Scala. This way we should be able to catch all exceptions and handle them gracefully.

#### APK
[Download build #1355](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1355/artifact/build/artifact/wire-dev-PR2633-1355.apk)
[Download build #1370](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1370/artifact/build/artifact/wire-dev-PR2633-1370.apk)