### PR TITLE
refactor: Disable tracking on the TrackingService level

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -58,7 +58,7 @@ import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.participants.ParticipantsController.ParticipantRequest
 import com.waz.zclient.shortcuts.Shortcuts
 import com.waz.zclient.tracking.GlobalTrackingController
-import com.waz.zclient.tracking.GlobalTrackingController.analyticsPrefKey
+import com.waz.service.tracking.TrackingService.analyticsPrefKey
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.views.menus.ConfirmationMenu
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
@@ -29,7 +29,7 @@ import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
 import com.waz.zclient.preferences.views.SwitchPreference
-import com.waz.zclient.tracking.GlobalTrackingController.analyticsPrefKey
+import com.waz.service.tracking.TrackingService.analyticsPrefKey
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.{BackStackKey, ContextUtils}
 import com.waz.zclient.{R, ViewHelper}

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -68,10 +68,8 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
   tracking.events.foreach {
     case (zms, event: OpenedTeamRegistration) =>
       ZMessaging.currentAccounts.accountManagers.head.map {
-        _.size match {
-          case 0 => sendEvent(event, zms)
-          case _ => sendEvent(OpenedTeamRegistrationFromProfile(), zms)
-        }
+        case managers if managers.isEmpty => sendEvent(event, zms)
+        case _                            => sendEvent(OpenedTeamRegistrationFromProfile(), zms)
       }
     case (_, event: LoggedOutEvent) if event.reason == LoggedOutEvent.InvalidCredentials =>
       //This event type is trigged a lot, so disable for now

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -21,17 +21,16 @@ package com.waz.zclient.tracking
 import android.content.Context
 import android.renderscript.RSRuntimeException
 import com.waz.api.impl.ErrorResponse
-import com.waz.content.Preferences.PrefKey
-import com.waz.content.{GlobalPreferences, UsersStorage}
+import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{UserId, _}
-import com.waz.service.{SearchQuery, ZMessaging}
+import com.waz.service.ZMessaging
 import com.waz.service.tracking.TrackingService.NoReporting
 import com.waz.service.tracking._
 import com.waz.threading.{SerialDispatchQueue, Threading}
-import com.waz.utils.events.{EventContext, Signal}
+import com.waz.utils.events.EventContext
 import com.waz.zclient._
 import com.waz.zclient.appentry.fragments.SignInFragment
 import com.waz.zclient.appentry.fragments.SignInFragment.{InputType, SignInMethod}
@@ -43,21 +42,14 @@ import scala.util.Try
 
 class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext)
   extends Injectable with DerivedLogTag {
-
   import GlobalTrackingController._
 
   private implicit val dispatcher = new SerialDispatchQueue(name = "Tracking")
 
-  private val isTrackingEnabled =
-    Signal.future(ZMessaging.globalModule).flatMap(_.prefs(analyticsPrefKey).signal)
-
   //For automation tests
   def getId: String = ""
 
-  val zmsOpt      = inject[Signal[Option[ZMessaging]]]
-  val zMessaging  = inject[Signal[ZMessaging]]
-  val currentConv = inject[Signal[ConversationData]]
-  val tracking    = inject[TrackingService]
+  val tracking  = inject[TrackingService]
 
   def optIn(): Future[Unit] = {
     verbose(l"optIn")
@@ -73,47 +65,37 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
     * Sets super properties and actually performs the tracking of an event. Super properties are user scoped, so for that
     * reason, we need to ensure they're correctly set based on whatever account (zms) they were fired within.
     */
-  ZMessaging.globalModule.map(_.trackingService.events).foreach {
-    _ { case (zms, event) =>
-      event match {
-        case _: OpenedTeamRegistration =>
-          ZMessaging.currentAccounts.accountManagers.head.map {
-            _.size match {
-              case 0 => sendEvent(event, zms)
-              case _ => sendEvent(OpenedTeamRegistrationFromProfile(), zms)
-            }
-          }
-        case e: LoggedOutEvent if e.reason == LoggedOutEvent.InvalidCredentials =>
-          //This event type is trigged a lot, so disable for now
-        case e@ExceptionEvent(_, _, description, Some(throwable)) =>
-          error(l"description: ${redactedString(description)}", throwable)(e.tag)
-          isTrackingEnabled.head.map {
-            case true =>
-              throwable match {
-                case _: NoReporting =>
-                case _ => saveException(throwable, description)(e.tag)
-              }
-            case _ => //no action
-          }
-        case _ => sendEvent(event, zms)
+  tracking.events.foreach {
+    case (zms, event: OpenedTeamRegistration) =>
+      ZMessaging.currentAccounts.accountManagers.head.map {
+        _.size match {
+          case 0 => sendEvent(event, zms)
+          case _ => sendEvent(OpenedTeamRegistrationFromProfile(), zms)
+        }
       }
-    }
+    case (_, event: LoggedOutEvent) if event.reason == LoggedOutEvent.InvalidCredentials =>
+      //This event type is trigged a lot, so disable for now
+    case (_, event@ExceptionEvent(_, _, description, Some(throwable))) =>
+      error(l"description: ${redactedString(description)}", throwable)(event.tag)
+      tracking.isTrackingEnabled.head.map {
+        case true =>
+          throwable match {
+            case _: NoReporting =>
+            case _              => saveException(throwable, description)(event.tag)
+          }
+        case _ => //no action
+      }
+    case (zms, event) => sendEvent(event, zms)
   }
 
   /**
     * @param eventArg the event to track
     * @param zmsArg a specific zms (account) to associate the event to. If none, we will try and use the current active one
+    *
+    * Right now it does nothing. The functionality stays here to be used when we implement a new tracking system
     */
   private def sendEvent(eventArg: TrackingEvent, zmsArg: Option[ZMessaging] = None) =
-    for {
-      zms          <- zmsArg.fold(zmsOpt.head)(z => Future.successful(Some(z)))
-      teamSize <- zms match {
-        case Some(z) => z.teamId.fold(Future.successful(0))(_ => z.teams.searchTeamMembers(SearchQuery.Empty).head.map(_.size))
-        case _ => Future.successful(0)
-      }
-    } yield {
-      verbose(l"send event: $eventArg")
-    }
+    Future.successful(verbose(l"send event: $eventArg"))
 
   def onEnteredCredentials(response: Either[ErrorResponse, _], method: SignInMethod): Unit =
     tracking.track(EnteredCredentialsEvent(method, responseToErrorPair(response)), None)
@@ -146,11 +128,6 @@ object GlobalTrackingController {
         val userId = Try(ZMessaging.context.getSharedPreferences("zprefs", Context.MODE_PRIVATE).getString("com.waz.device.id", "???")).getOrElse("????")
         error(l"userId: ${redactedString(userId)}", t)(tag)
     }
-  }
-
-  val analyticsPrefKey = BuildConfig.APPLICATION_ID match {
-    case "com.wire" | "com.wire.internal" => GlobalPreferences.AnalyticsEnabled
-    case _ => PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
   }
 
   def isBot(conv: ConversationData, users: UsersStorage): Future[Boolean] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -17,6 +17,8 @@
  */
 package com.waz.service.tracking
 
+import com.waz.content.GlobalPreferences
+import com.waz.content.Preferences.PrefKey
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
@@ -29,6 +31,7 @@ import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.SerialDispatchQueue
 import com.waz.utils.RichWireInstant
 import com.waz.utils.events.{EventContext, EventStream, Signal}
+import com.waz.zms.BuildConfig
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
@@ -57,6 +60,8 @@ trait TrackingService {
   def historyRestored(isSuccess: Boolean): Future[Unit]
 
   def trackCallState(userId: UserId, callInfo: CallInfo): Future[Unit]
+
+  def isTrackingEnabled: Signal[Boolean]
 }
 
 class DummyTrackingService extends TrackingService {
@@ -71,6 +76,7 @@ class DummyTrackingService extends TrackingService {
   override def historyBackedUp(isSuccess: Boolean): Future[Unit] = Future.successful(())
   override def historyRestored(isSuccess: Boolean): Future[Unit] = Future.successful(())
   override def trackCallState(userId: UserId, callInfo: CallInfo): Future[Unit] = Future.successful(())
+  override def isTrackingEnabled: Signal[Boolean] = Signal.const(true)
 }
 
 object TrackingService {
@@ -82,121 +88,156 @@ object TrackingService {
 
   trait NoReporting { self: Throwable => }
 
+  val analyticsPrefKey = BuildConfig.APPLICATION_ID match {
+    case "com.wire" | "com.wire.internal" => GlobalPreferences.AnalyticsEnabled
+    case _ => PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
+  }
+
 }
 
 class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: ZmsProvider)
   extends TrackingService with DerivedLogTag {
+
   import TrackingService._
+
+  override lazy val isTrackingEnabled: Signal[Boolean] =
+    Signal.future(ZMessaging.globalModule).flatMap(_.prefs(analyticsPrefKey).signal)
 
   val events = EventStream[(Option[ZMessaging], TrackingEvent)]()
 
-  override def track(event: TrackingEvent, userId: Option[UserId] = None): Future[Unit] =
-    zmsProvider(userId).map(events ! _ -> event)
+  override def track(event: TrackingEvent, userId: Option[UserId] = None): Future[Unit] = isTrackingEnabled.head.flatMap {
+    case true  => zmsProvider(userId).map(events ! _ -> event)
+    case false => Future.successful(())
+  }
 
   private def current = curAccount.head.flatMap(zmsProvider)
 
-  override def contribution(action: ContributionEvent.Action) = current.map {
-    case Some(z) =>
-      for {
-        Some(convId) <- z.selectedConv.selectedConversationId.head
-        Some(conv)   <- z.convsStorage.get(convId)
-        userIds      <- z.membersStorage.activeMembers(convId).head
-        users        <- z.usersStorage.listAll(userIds.toSeq)
-        isGroup      <- z.conversations.isGroupConversation(convId)
-      } {
-        events ! Option(z) -> ContributionEvent(action, isGroup, conv.ephemeralExpiration.map(_.duration), users.exists(_.isWireBot), !conv.isTeamOnly, conv.isMemberFromTeamGuest(z.teamId))
-      }
-    case _ => //
+  override def contribution(action: ContributionEvent.Action) = isTrackingEnabled.head.flatMap {
+    case true => current.map {
+      case Some(z) =>
+        for {
+          Some(convId) <- z.selectedConv.selectedConversationId.head
+          Some(conv)   <- z.convsStorage.get(convId)
+          userIds      <- z.membersStorage.activeMembers(convId).head
+          users        <- z.usersStorage.listAll(userIds.toSeq)
+          isGroup      <- z.conversations.isGroupConversation(convId)
+        } {
+          events ! Option(z) -> ContributionEvent(action, isGroup, conv.ephemeralExpiration.map(_.duration), users.exists(_.isWireBot), !conv.isTeamOnly, conv.isMemberFromTeamGuest(z.teamId))
+        }
+      case _ => //
+    }
+    case false => Future.successful(())
   }
 
-  override def exception(e: Throwable, description: String, userId: Option[UserId] = None)(implicit tag: LogTag) = {
-    val cause = rootCause(e)
-    track(ExceptionEvent(cause.getClass.getSimpleName, details(cause), description, throwable = Some(e))(tag), userId)
+  override def exception(e: Throwable, description: String, userId: Option[UserId] = None)(implicit tag: LogTag) = isTrackingEnabled.head(tag).flatMap {
+    case true =>
+      val cause = rootCause(e)
+      track(ExceptionEvent(cause.getClass.getSimpleName, details(cause), description, throwable = Some(e))(tag), userId)
+    case false => Future.successful(())
   }
 
-  override def crash(e: Throwable) = {
-    val cause = rootCause(e)
-    track(CrashEvent(cause.getClass.getSimpleName, details(cause), throwable = Some(e)))
+  override def crash(e: Throwable) = isTrackingEnabled.head.flatMap {
+    case true =>
+      val cause = rootCause(e)
+      track(CrashEvent(cause.getClass.getSimpleName, details(cause), throwable = Some(e)))
+    case false => Future.successful(())
   }
 
   @tailrec
   private def rootCause(e: Throwable): Throwable = Option(e.getCause) match {
     case Some(cause) => rootCause(cause)
-    case None => e
+    case None        => e
   }
 
   private def details(rootCause: Throwable) =
-    Try(rootCause.getStackTrace).toOption.filter(_.nonEmpty).map(_(0).toString).getOrElse("")
+    Try(rootCause.getStackTrace).toOption.filter(_.nonEmpty).map(_ (0).toString).getOrElse("")
 
-  override def assetContribution(assetId: AssetId, userId: UserId) = zmsProvider(Some(userId)).map {
-    case Some(z) =>
-      for {
-        Some(msg)   <- z.messagesStorage.get(MessageId(assetId.str))
-        Some(conv)  <- z.convsContent.convById(msg.convId)
-        asset       <- z.assetsStorage.get(assetId)
-        userIds     <- z.membersStorage.activeMembers(conv.id).head
-        users       <- z.usersStorage.listAll(userIds.toSeq)
-        isGroup     <- z.conversations.isGroupConversation(conv.id)
-      } yield track(ContributionEvent(fromMime(asset.mime), isGroup, msg.ephemeral, users.exists(_.isWireBot), !conv.isTeamOnly, conv.isMemberFromTeamGuest(z.teamId)), Some(userId))
-    case _ => //
-  }
-
-  override def integrationAdded(integrationId: IntegrationId, convId: ConvId, method: IntegrationAdded.Method) = current.map {
-    case Some(z) =>
-      for {
-        userIds <- z.membersStorage.activeMembers(convId).head
-        users   <- z.usersStorage.listAll(userIds.toSeq)
-        (bots, people) = users.partition(_.isWireBot)
-      } yield track(IntegrationAdded(integrationId, people.size, bots.filterNot(_.integrationId.contains(integrationId)).size + 1, method))
-    case None =>
-  }
-
-  def integrationRemoved(integrationId: IntegrationId) = track(IntegrationRemoved(integrationId))
-
-  override def historyBackedUp(isSuccess: Boolean) =
-    track(if (isSuccess) HistoryBackupSucceeded else HistoryBackupFailed)
-
-  override def historyRestored(isSuccess: Boolean) =
-    track(if (isSuccess) HistoryRestoreSucceeded else HistoryRestoreFailed)
-
-  override def trackCallState(userId: UserId, info: CallInfo) =
-    ((info.prevState, info.state) match {
-      case (None,    SelfCalling)      => Some("initiated")
-      case (None,    OtherCalling)     => Some("received")
-      case (Some(_), SelfJoining)      => Some("joined")
-      case (Some(_), SelfConnected)    => Some("established")
-      case (Some(_), Ended)            => Some("ended")
-      case _ =>
-        warn(l"Unexpected call state change: ${info.prevState} => ${info.state}, not tracking")
-        None
-    }).fold(Future.successful({})) { eventName =>
-
-      for {
-        Some(z)  <- zmsProvider(Some(userId))
-        isGroup  <- z.conversations.isGroupConversation(info.convId)
-        memCount <- z.membersStorage.activeMembers(info.convId).map(_.size).head
-        withService <- z.conversations.isWithService(info.convId)
-        withGuests  <-
-          if (isGroup)
-            z.convsStorage.get(info.convId).collect { case Some(conv) => !conv.isTeamOnly }.map(Some(_))
-          else Future.successful(None)
-        _ <-
-          track(new CallingEvent(
-            eventName,
-            info.startedAsVideoCall,
-            isGroup,
-            memCount,
-            withService,
-            info.caller != z.selfUserId,
-            withGuests,
-            Option(info.maxParticipants).filter(_ > 0),
-            info.estabTime.map(est => info.joinedTime.getOrElse(est).until(est)),
-            info.endTime.map(end => info.estabTime.getOrElse(end).until(end)),
-            info.endReason,
-            if (info.state == Ended) Some(info.wasVideoToggled) else None
-          ))
-      } yield {}
+  override def assetContribution(assetId: AssetId, userId: UserId) = isTrackingEnabled.head.flatMap {
+    case true => zmsProvider(Some(userId)).map {
+      case Some(z) =>
+        for {
+          Some(msg)  <- z.messagesStorage.get(MessageId(assetId.str))
+          Some(conv) <- z.convsContent.convById(msg.convId)
+          asset      <- z.assetsStorage.get(assetId)
+          userIds    <- z.membersStorage.activeMembers(conv.id).head
+          users      <- z.usersStorage.listAll(userIds.toSeq)
+          isGroup    <- z.conversations.isGroupConversation(conv.id)
+        } yield track(ContributionEvent(fromMime(asset.mime), isGroup, msg.ephemeral, users.exists(_.isWireBot), !conv.isTeamOnly, conv.isMemberFromTeamGuest(z.teamId)), Some(userId))
+      case _ => //
     }
+    case false => Future.successful(())
+  }
+
+  override def integrationAdded(integrationId: IntegrationId, convId: ConvId, method: IntegrationAdded.Method) = isTrackingEnabled.head.flatMap {
+    case true => current.map {
+      case Some(z) =>
+        for {
+          userIds        <- z.membersStorage.activeMembers(convId).head
+          users          <- z.usersStorage.listAll(userIds.toSeq)
+          (bots, people) =  users.partition(_.isWireBot)
+        } yield track(IntegrationAdded(integrationId, people.size, bots.filterNot(_.integrationId.contains(integrationId)).size + 1, method))
+      case None =>
+    }
+    case false => Future.successful(())
+  }
+
+  def integrationRemoved(integrationId: IntegrationId) = isTrackingEnabled.head.flatMap {
+    case true  => track(IntegrationRemoved(integrationId))
+    case false => Future.successful(())
+  }
+
+  override def historyBackedUp(isSuccess: Boolean) = isTrackingEnabled.head.flatMap {
+    case true if isSuccess => track(HistoryBackupSucceeded)
+    case true              => track(HistoryBackupFailed)
+    case false             => Future.successful(())
+  }
+
+  override def historyRestored(isSuccess: Boolean) = isTrackingEnabled.head.flatMap {
+    case true if isSuccess => track(HistoryRestoreSucceeded)
+    case true              => track(HistoryRestoreFailed)
+    case false             => Future.successful(())
+  }
+
+  override def trackCallState(userId: UserId, info: CallInfo) = isTrackingEnabled.head.flatMap {
+    case true =>
+      ((info.prevState, info.state) match {
+        case (None, SelfCalling)      => Some("initiated")
+        case (None, OtherCalling)     => Some("received")
+        case (Some(_), SelfJoining)   => Some("joined")
+        case (Some(_), SelfConnected) => Some("established")
+        case (Some(_), Ended)         => Some("ended")
+        case _ =>
+          warn(l"Unexpected call state change: ${info.prevState} => ${info.state}, not tracking")
+          None
+      }).fold(Future.successful(())) { eventName =>
+        for {
+          Some(z)     <- zmsProvider(Some(userId))
+          isGroup     <- z.conversations.isGroupConversation(info.convId)
+          memCount    <- z.membersStorage.activeMembers(info.convId).map(_.size).head
+          withService <- z.conversations.isWithService(info.convId)
+          withGuests  <-
+            if (isGroup)
+              z.convsStorage.get(info.convId).collect { case Some(conv) => !conv.isTeamOnly }.map(Some(_))
+            else Future.successful(None)
+            _ <-
+              track(new CallingEvent(
+                eventName,
+                info.startedAsVideoCall,
+                isGroup,
+                memCount,
+                withService,
+                info.caller != z.selfUserId,
+                withGuests,
+                Option(info.maxParticipants).filter(_ > 0),
+                info.estabTime.map(est => info.joinedTime.getOrElse(est).until(est)),
+                info.endTime.map(end => info.estabTime.getOrElse(end).until(end)),
+                info.endReason,
+                if (info.state == Ended) Some(info.wasVideoToggled) else None
+              ))
+        } yield {}
+      }
+    case false => Future.successful(())
+  }
 }
 
 object TrackingServiceImpl extends DerivedLogTag {
@@ -206,6 +247,7 @@ object TrackingServiceImpl extends DerivedLogTag {
   def apply(accountsService: => AccountsService): TrackingServiceImpl =
     new TrackingServiceImpl(
       accountsService.activeAccountId,
-      (userId: Option[UserId]) => userId.fold(Future.successful(Option.empty[ZMessaging]))(uId => accountsService.zmsInstances.head.map(_.find(_.selfUserId == uId))))
+      (userId: Option[UserId]) => userId.fold(Future.successful(Option.empty[ZMessaging]))(uId => accountsService.zmsInstances.head.map(_.find(_.selfUserId == uId)))
+    )
 }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -88,9 +88,9 @@ object TrackingService {
 
   trait NoReporting { self: Throwable => }
 
-  val analyticsPrefKey = BuildConfig.APPLICATION_ID match {
-    case "com.wire" | "com.wire.internal" => GlobalPreferences.AnalyticsEnabled
-    case _ => PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
+  val analyticsPrefKey = BuildConfig.FLAVOR match {
+    case "prod" | "internal" => GlobalPreferences.AnalyticsEnabled
+    case _                   => PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")
   }
 
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/DisabledTrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/DisabledTrackingService.scala
@@ -21,7 +21,7 @@ import com.waz.model.{AssetId, ConvId, IntegrationId, UserId}
 import com.waz.service.ZMessaging
 import com.waz.service.call.CallInfo
 import com.waz.service.tracking.{ContributionEvent, IntegrationAdded, TrackingEvent, TrackingService}
-import com.waz.utils.events.EventStream
+import com.waz.utils.events.{EventStream, Signal}
 
 import scala.concurrent.Future
 
@@ -37,4 +37,5 @@ object DisabledTrackingService extends TrackingService {
   override def historyBackedUp(isSuccess: Boolean): Future[Unit] = Future.successful(())
   override def historyRestored(isSuccess: Boolean): Future[Unit] = Future.successful(())
   override def trackCallState(userId: UserId, callInfo: CallInfo): Future[Unit] = Future.successful(())
+  override def isTrackingEnabled: Signal[Boolean] = Signal.const(false)
 }


### PR DESCRIPTION
We don't track events right now, but we have a scaffold functionality left which can be used again if we decide to use another tracking system in the future. Right now, calling a track method on an event results only in a log message.
However, before that happens, in some cases `TrackingService` and `GlobalTrackingController` can perform quite a lot of operations, esp. `TrackingService.contribution` and `TrackingService.assetContribution`. I decided to move the code around a bit to prevent that. With this PR if the preference  `GlobalPreferences.AnalyticsEnabled` is set to `false` (which it is in production) we will skip performing these operations.

#### APK
[Download build #1372](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1372/artifact/build/artifact/wire-dev-PR2640-1372.apk)
[Download build #1491](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1491/artifact/build/artifact/wire-dev-PR2640-1491.apk)