### PR TITLE
perf: Optimize sharing many assets to many conversations

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -292,6 +292,17 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
                  else sendAssetMessage(convs, content, activity, exp).map(_.head)
     } yield msg
 
+  def sendAssetMessages(uris:    Seq[URI],
+                       activity: Activity,
+                       exp:      Option[Option[FiniteDuration]],
+                       convs:    Seq[ConvId]): Future[Unit] =
+    for {
+      ui       <- convsUi.head
+      color    <- accentColorController.accentColor.head
+      contents <- Future.traverse(uris) { uri => Future.fromTry(uriHelper.extractFileName(uri).map(ContentForUpload(_,  Content.Uri(uri)))) }
+      _        <- Future.traverse(convs) { id => ui.sendAssetMessages(id, contents, (s: Long) => showWifiWarningDialog(s, color), exp) }
+    } yield ()
+
   def sendMessage(location: api.MessageContent.Location): Future[Option[MessageData]] =
     convsUiwithCurrentConv((ui, id) => ui.sendLocationMessage(id, location))
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -61,6 +61,10 @@ trait ConversationsUiService {
                        content: ContentForUpload,
                        confirmation: WifiWarningConfirmation = DefaultConfirmation,
                        exp: Option[Option[FiniteDuration]] = None): Future[Some[MessageData]]
+  def sendAssetMessages(convId: ConvId,
+                        contents: Seq[ContentForUpload],
+                        confirmation: WifiWarningConfirmation = DefaultConfirmation,
+                        exp: Option[Option[FiniteDuration]] = None): Future[Unit]
 
   def sendLocationMessage(convId: ConvId, l: api.MessageContent.Location): Future[Some[MessageData]] //TODO remove use of MessageContent.Location
 
@@ -173,6 +177,34 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
       shouldSend <- checkSize(convId, rawAsset, message, confirmation)
       _          <- if (shouldSend) sync.postMessage(message.id, convId, message.editTime) else Future.successful(())
     } yield Some(message)
+  }
+
+  override def sendAssetMessages(convId:       ConvId,
+                                 contents:     Seq[ContentForUpload],
+                                 confirmation: WifiWarningConfirmation = DefaultConfirmation,
+                                 exp:          Option[Option[FiniteDuration]] = None): Future[Unit] = {
+    val contentMap = contents.map { c => MessageId() -> c }.toMap
+    for {
+      retention <- messages.retentionPolicy2ById(convId)
+      rr        <- readReceiptSettings(convId)
+      rawAssets <- Future.traverse(contentMap) { case (messageId, content) =>
+                     assets.createAndSaveUploadAsset(content, AES_CBC_Encryption.random, public = false, retention, Some(messageId))
+                           .map(asset => messageId -> asset)
+                   }
+      assetMap  =  rawAssets.toMap
+      msgs      <- Future.traverse(assetMap) { case (messageId, rawAsset) =>
+                     messages.addAssetMessage(convId, messageId, rawAsset, rr, exp)
+                   }
+      _         <- updateLastRead(msgs.toList.maxBy(_.time))
+      msgMap    =  msgs.map(m => m.id -> m).toMap
+      _         <- Future.traverse(assetMap) { case (messageId, rawAsset) =>
+                     val message = msgMap(messageId)
+                     checkSize(convId, rawAsset, message, confirmation).flatMap {
+                       case true  => sync.postMessage(message.id, convId, message.editTime)
+                       case false => Future.successful(())
+                     }
+                   }
+    } yield ()
   }
 
   override def sendLocationMessage(convId: ConvId, l: api.MessageContent.Location): Future[Some[MessageData]] = {


### PR DESCRIPTION
If the user goes to, for example, the gallery, and chooses a few photos and then share it to Wire to a few conversations at once, we handle that request in `SharingController`. We go through the collection of uris we got and for each uri we go through the collection of conversations, and for each pair we call a method which sends that one asset to that one conversation.
This PR inverts the procedure - first we go through conversations, and then through uris - and provides functionality for sending many assets at once to one conversation. Thanks to that, some operations, like setting the conversation's "last read time" or setting it to be the current conversation, are performed only once per sending all assets to that conversation, not each time for each asset. That makes the whole process much quicker, and also helps us avoid possible race conditions due to quick switching of the current conversation (still to be investigated).

Connected to: https://wearezeta.atlassian.net/browse/AN-5917
#### APK
[Download build #1378](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1378/artifact/build/artifact/wire-dev-PR2641-1378.apk)