### PR TITLE
fix: Count the number of call participants with ConversationsService.activeMembersData

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallParticipantsFragment.scala
@@ -24,12 +24,15 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.utils.returning
 import com.waz.zclient.calling.controllers.CallController
 import com.waz.zclient.calling.views.CallParticipantsView
+import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{FragmentHelper, R}
 
 class CallParticipantsFragment extends FragmentHelper {
+  private lazy val themeController = inject[ThemeController]
+
   private lazy val toolbar = returning(view[Toolbar](R.id.toolbar)) { vh =>
-    controller.theme.map(controller.themeController.getTheme).onUi { theme =>
+    controller.theme.map(themeController.getTheme).onUi { theme =>
       vh.foreach(v => getStyledDrawable(R.attr.backNavigationIcon, theme).foreach(v.setNavigationIcon))
     }
   }

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -40,7 +40,7 @@ import com.waz.zclient.calling.controllers.CallController
 import com.waz.zclient.common.controllers.SoundController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.{IncomingCallNotificationsChannelId, OngoingNotificationsChannelId}
-import com.waz.zclient.utils.ContextUtils.{getString, _}
+import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.zclient.utils.RingtoneUtils
 
 import scala.concurrent.Future
@@ -54,8 +54,6 @@ class CallingNotificationsController(implicit cxt: WireContext, eventContext: Ev
   private lazy val soundController = inject[SoundController]
   private lazy val notificationManager = inject[NotificationManager]
   private lazy val callCtrler = inject[CallController]
-
-  private val callImageSizePx = toPx(CallImageSizeDp)
 
   private val filteredGlobalProfile: Signal[(Option[ConvId], Seq[(ConvId, (UserId, UserId))])] =
     for {
@@ -192,13 +190,12 @@ object CallingNotificationsController {
   object NotificationAction extends Enumeration {
     val DeclineOrJoin, Leave, Nothing = Value
   }
+
   type NotificationAction = NotificationAction.Value
 
   val CallNotificationTag = "call_notification"
 
-  val CallImageSizeDp = 64
-
-  def isAndroid10OrAbove: Boolean = Build.VERSION.SDK_INT >= 29
+  val isAndroid10OrAbove: Boolean = Build.VERSION.SDK_INT >= 29
 
   def androidNotificationBuilder(not: CallNotification, treatAsIncomingCall: Boolean = false)(implicit cxt: content.Context): NotificationCompat.Builder = {
     val title = if (not.isGroup) not.convName else not.caller

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -795,7 +795,7 @@ class ConversationFragment extends FragmentHelper {
       (for {
         self <- inject[UserAccountsController].currentUser.head
         members <- convController.convMembers(convId).head
-        unverifiedUsers <- usersController.users(members.keys).map(_.filter(_.isVerified)).head
+        unverifiedUsers <- usersController.users(members.keys).map(_.filter(!_.isVerified)).head
         unverifiedDevices <-
           if (unverifiedUsers.size == 1) Future.sequence(unverifiedUsers.map(u => convController.loadClients(u.id).map(_.filter(!_.isVerified)))).map(_.flatten.size)
           else Future.successful(0) // in other cases we don't need this number

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -173,7 +173,7 @@ class CallingServiceImpl(val accountId:       UserId,
   private implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(name = "CallingService")
 
   //need to ensure that flow manager and media manager are initialised for v3 (they are lazy values)
-  private val fm = flowManagerService.flowManager
+  flowManagerService.flowManager
   private var closingPromise = Option.empty[Promise[Unit]]
 
   private[call] val callProfile = Signal(CallProfile.Empty)
@@ -387,9 +387,9 @@ class CallingServiceImpl(val accountId:       UserId,
         profile <- callProfile.head
         isGroup <- convsService.isGroupConversation(convId)
         vbr     <- userPrefs.preference(UserPreferences.VBREnabled).apply()
-        mems    <- members.getActiveUsers(conv.id)
+        convSize <- convsService.activeMembersData(conv.id).map(_.size).head
         callType =
-          if (mems.size > VideoCallMaxMembers) Avs.WCallType.ForcedAudio
+          if (convSize > VideoCallMaxMembers) Avs.WCallType.ForcedAudio
           else if (isVideo) Avs.WCallType.Video
           else Avs.WCallType.Normal
         convType = if (isGroup) Avs.WCallConvType.Group else Avs.WCallConvType.OneOnOne


### PR DESCRIPTION
The video call is available only in group chats with 4 or fewer participants. If the current user belongs to the team and the number of participants is ok, a video icon will appear in the header. However, the way it was implemented meant that it was possible that when a new participant was added and then removed (so the group size would grow to 5 and then get back to 4), the video icon would disappear and not appear again. Also, when the current user was called from another device, they could not join the video call.

The PR changes the way we count call participants and refactors the calling code a bit.
I also tried to investigate a bit the problem with delayed call notifications, but couldn't reproduce them. (I refactored some more code as a result).
#### APK
[Download build #1394](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1394/artifact/build/artifact/wire-dev-PR2646-1394.apk)
[Download build #1427](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1427/artifact/build/artifact/wire-dev-PR2646-1427.apk)