### PR TITLE
chore : add new config for qa demo

### DIFF
--- a/app/src/candidate/AndroidManifest.xml
+++ b/app/src/candidate/AndroidManifest.xml
@@ -39,6 +39,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_QA_BE" />
                 <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_QA_BE" />
                 <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>

--- a/app/src/experimental/AndroidManifest.xml
+++ b/app/src/experimental/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_QA_BE" />
                 <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>

--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <action android:name="${applicationId}.intent.action.HIDE_GDPR_POPUPS" />
                 <action android:name="${applicationId}.intent.action.FULL_CONVERSATION_INTENT" />
                 <action android:name="${applicationId}.intent.action.SELECT_STAGING_BE" />
+                <action android:name="${applicationId}.intent.action.SELECT_QA_BE" />
                 <action android:name="${applicationId}.intent.action.SELECT_PROD_BE" />
             </intent-filter>
         </receiver>

--- a/app/src/main/scala/com/waz/zclient/Backend.scala
+++ b/app/src/main/scala/com/waz/zclient/Backend.scala
@@ -51,6 +51,18 @@ object Backend {
     StagingFirebaseOptions,
     certPin)
 
+  //These are only here so that we can compile tests, the UI sets the backendConfig
+  val QaBackend = BackendConfig(
+    environment = "qa-demo",
+    baseUrl = "https://nginz-https.qa-demo.wire.link",
+    websocketUrl = "https://nginz-ssl.qa-demo.wire.link",
+    blacklistHost = "https://assets.qa-demo.wire.link/public/blacklist/android.json",
+    teamsUrl = "https://teams.qa-demo.wire.link",
+    accountsUrl = "https://account.qa-demo.wire.link",
+    websiteUrl = "https://webapp.qa-demo.wire.link",
+    StagingFirebaseOptions,
+    certPin)
+
   val ProdBackend = BackendConfig(
     environment = "prod",
     BuildConfig.BACKEND_URL,

--- a/app/src/main/scala/com/waz/zclient/Backend.scala
+++ b/app/src/main/scala/com/waz/zclient/Backend.scala
@@ -23,7 +23,7 @@ import com.waz.utils.SafeBase64
 object Backend {
 
   lazy val byName: Map[String, BackendConfig] =
-    Seq(StagingBackend, ProdBackend).map(b => b.environment -> b).toMap
+    Seq(StagingBackend,QaBackend,ProdBackend).map(b => b.environment -> b).toMap
 
   private val certBytes = SafeBase64.decode(BuildConfig.CERTIFICATE_PIN_BYTES).get
   val certPin = CertificatePin(BuildConfig.CERTIFICATE_PIN_DOMAIN, certBytes)

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -100,6 +100,12 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
         implicit val injector = wireApplication.module
         wireApplication.inject[BackendController].setStoredBackendConfig(Backend.StagingBackend)
         setResultCode(Activity.RESULT_OK)
+      case SELECT_QA_BE =>
+        // Note, the app must be terminated for this to work.
+        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
+        implicit val injector = wireApplication.module
+        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.QaBackend)
+        setResultCode(Activity.RESULT_OK)
       case SELECT_PROD_BE =>
         // Note, the app must be terminated for this to work.
         val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
@@ -130,6 +136,7 @@ object AbstractPreferenceReceiver {
   private val FULL_CONVERSATION_INTENT = packageName + ".intent.action.FULL_CONVERSATION_INTENT"
   private val HIDE_GDPR_POPUPS         = packageName + ".intent.action.HIDE_GDPR_POPUPS"
   private val SELECT_STAGING_BE        = packageName + ".intent.action.SELECT_STAGING_BE"
+  private val SELECT_QA_BE             = packageName + ".intent.action.SELECT_QA_BE"
   private val SELECT_PROD_BE           = packageName + ".intent.action.SELECT_PROD_BE"
 
   private lazy val DeveloperAnalyticsEnabled = PrefKey[Boolean]("DEVELOPER_TRACKING_ENABLED")

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -103,7 +103,7 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
     }
   }
 
-  private def updateStoredBackendConfig(context: Context, backendConfig: BackendConfig): Unit ={
+  private def updateStoredBackendConfig(context: Context, backendConfig: BackendConfig) = {
     // Note, the app must be terminated for this to work.
     val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
     implicit val injector = wireApplication.module

--- a/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
+++ b/app/src/main/scala/com/waz/zclient/qa/AbstractPreferenceReceiver.scala
@@ -25,7 +25,7 @@ import com.waz.content.Preferences.PrefKey
 import com.waz.content.Preferences.Preference.PrefCodec
 import com.waz.content.UserPreferences._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.service.ZMessaging
+import com.waz.service.{BackendConfig, ZMessaging}
 import com.waz.zclient.controllers.userpreferences.IUserPreferencesController._
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController
 import com.waz.zclient.controllers.userpreferences.UserPreferencesController._
@@ -94,28 +94,21 @@ trait AbstractPreferenceReceiver extends BroadcastReceiver with DerivedLogTag {
             setResultData("")
             setResultCode(Activity.RESULT_CANCELED)
         }
-      case SELECT_STAGING_BE =>
-        // Note, the app must be terminated for this to work.
-        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
-        implicit val injector = wireApplication.module
-        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.StagingBackend)
-        setResultCode(Activity.RESULT_OK)
-      case SELECT_QA_BE =>
-        // Note, the app must be terminated for this to work.
-        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
-        implicit val injector = wireApplication.module
-        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.QaBackend)
-        setResultCode(Activity.RESULT_OK)
-      case SELECT_PROD_BE =>
-        // Note, the app must be terminated for this to work.
-        val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
-        implicit val injector = wireApplication.module
-        wireApplication.inject[BackendController].setStoredBackendConfig(Backend.ProdBackend)
-        setResultCode(Activity.RESULT_OK)
+      case SELECT_STAGING_BE => updateStoredBackendConfig(context: Context, Backend.StagingBackend)
+      case SELECT_QA_BE => updateStoredBackendConfig(context: Context, Backend.QaBackend)
+      case SELECT_PROD_BE => updateStoredBackendConfig(context: Context, Backend.ProdBackend)
       case _ =>
         setResultData("Unknown Intent!")
         setResultCode(Activity.RESULT_CANCELED)
     }
+  }
+
+  private def updateStoredBackendConfig(context: Context, backendConfig: BackendConfig): Unit ={
+    // Note, the app must be terminated for this to work.
+    val wireApplication = context.getApplicationContext.asInstanceOf[WireApplication]
+    implicit val injector = wireApplication.module
+    wireApplication.inject[BackendController].setStoredBackendConfig(backendConfig)
+    setResultCode(Activity.RESULT_OK)
   }
 
 }


### PR DESCRIPTION
## What's new in this PR?

Added a new config in the project `QaBackend` and a new intent action `SELECT_QA_BE` to switch to `qa-demo` custom backend.

This action is requested by QA team to run automation directly to the new backend.

https://wearezeta.atlassian.net/browse/AN-6697
#### APK
[Download build #1403](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1403/artifact/build/artifact/wire-dev-PR2647-1403.apk)
[Download build #1405](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1405/artifact/build/artifact/wire-dev-PR2647-1405.apk)
[Download build #1406](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1406/artifact/build/artifact/wire-dev-PR2647-1406.apk)