### PR TITLE
fix: Small changes replacing many-line-spanning names with one line and ellipsize

### DIFF
--- a/app/src/main/res/layout/fragment_collection.xml
+++ b/app/src/main/res/layout/fragment_collection.xml
@@ -41,7 +41,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:orientation="vertical"
-            android:gravity="center">
+            android:gravity="center"
+            >
 
             <com.waz.zclient.ui.text.TypefaceTextView
                 android:id="@+id/tv__collection_toolbar__name"

--- a/app/src/main/res/layout/message_user_content.xml
+++ b/app/src/main/res/layout/message_user_content.xml
@@ -40,6 +40,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:maxLines="1"
+        android:ellipsize="end"
     />
 
     <View

--- a/app/src/main/res/layout/preference_text_button.xml
+++ b/app/src/main/res/layout/preference_text_button.xml
@@ -52,6 +52,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="@dimen/wire__text_size__regular"
+            android:lines="1"
             android:ellipsize="end"
             android:textColor="@color/white"
             app:w_font="@string/wire__typeface__light"

--- a/app/src/main/res/layout/preferences_account_layout.xml
+++ b/app/src/main/res/layout/preferences_account_layout.xml
@@ -48,6 +48,7 @@
                 android:id="@+id/preferences_account_name"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"
+                android:lines="1"
                 app:subtitle="@string/pref_account_name_title"
                 />
 

--- a/app/src/main/res/layout/preferences_profile_layout.xml
+++ b/app/src/main/res/layout/preferences_profile_layout.xml
@@ -31,6 +31,8 @@
         android:gravity="center"
         android:textSize="@dimen/wire__text_size__medium"
         app:w_font="@string/wire__typeface__light"
+        android:paddingStart="@dimen/wire__padding__small"
+        android:paddingEnd="@dimen/wire__padding__small"
         />
 
     <com.waz.zclient.ui.text.TypefaceTextView

--- a/app/src/main/res/layout/search_text_result_row.xml
+++ b/app/src/main/res/layout/search_text_result_row.xml
@@ -63,6 +63,7 @@
                 android:textSize="@dimen/wire__text_size__small"
                 android:textColor="?wireSecondaryTextColor"
                 android:maxLines="1"
+                android:ellipsize="end"
                 />
 
         </LinearLayout>

--- a/app/src/main/res/layout/view_conv_list_top.xml
+++ b/app/src/main/res/layout/view_conv_list_top.xml
@@ -79,6 +79,8 @@
             android:textColor="@color/white"
             android:drawablePadding="@dimen/wire__padding__8"
             android:paddingEnd="?attr/actionBarSize"
+            android:lines="1"
+            android:ellipsize="end"
             />
 
     </LinearLayout>


### PR DESCRIPTION
1. [AN-6694](https://wearezeta.atlassian.net/browse/AN-6694): User's self title on conversation list. Was multiline, changed to one line + ellipsize.
2. [AN-6693](https://wearezeta.atlassian.net/browse/AN-6693): User's own name on Self profile. Stays like this but padding is added.
3. [AN-6692](https://wearezeta.atlassian.net/browse/AN-6692): User's own name on Settings -> Account. Was multiline, changed to one line + ellipsize.
4. [AN-6689](https://wearezeta.atlassian.net/browse/AN-6689): No ellipsis on "search text messages" screen. Added ellipsize.
5. [AN-6690](https://wearezeta.atlassian.net/browse/AN-6690): Message author name. Was multiline, changed to one line + ellipsize.
6. [AN-6691](https://wearezeta.atlassian.net/browse/AN-6691): Username of message liker. There was no ellipsize. Added.
#### APK
[Download build #1410](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1410/artifact/build/artifact/wire-dev-PR2648-1410.apk)