### PR TITLE
Refactor: Enhancement related to the UX around loading a video when y…

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -72,6 +72,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
   val permissions: Signal[PermissionsService] = zms.map(_.permissions)
   val messages: Signal[MessagesService] = zms.map(_.messages)
   val messagesStorage: Signal[MessagesStorage] = zms.map(_.messagesStorage)
+  val openVideoProgress = Signal(false)
 
   lazy val messageActionsController: MessageActionsController = inject[MessageActionsController]
   lazy val singleImage: ISingleImageController = inject[ISingleImageController]
@@ -154,7 +155,6 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     def getPlaybackControls(asset: Signal[GeneralAsset]): Signal[PlaybackControls] = asset.flatMap { a =>
     (a.details, a) match {
       case (_: Audio, audioAsset: Asset) =>
-
         val file = new File(context.getCacheDir, s"${audioAsset.id.str}.m4a")
         Signal.future((if (!file.exists()) {
           file.createNewFile()
@@ -187,6 +187,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
           asset.details match {
             case _: Video =>
               context.startActivity(getOpenFileIntent(externalFileSharing.getUriForFile(file), asset.mime.orDefault.str))
+              openVideoProgress ! false
             case _ =>
               showOpenFileDialog(externalFileSharing.getUriForFile(file), asset)
           }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -135,11 +135,6 @@ trait ImageLayoutAssetPart extends AssetPart with EphemeralIndicatorPartView {
     case _ => Dim2(0, 0)
   }
 
-  val forceDownload = this match {
-    case _: ImagePartView => false
-    case _ => true
-  }
-
   private lazy val imageContainer = returning(findById[FrameLayout](R.id.image_container)) {
     _.addOnLayoutChangeListener(new OnLayoutChangeListener {
       override def onLayoutChange(v: View, left: Int, top: Int, right: Int, bottom: Int, oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int): Unit =

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/VideoAssetPartView.scala
@@ -24,10 +24,11 @@ import android.widget.{FrameLayout, ImageView}
 import com.waz.service.assets.{AssetStatus, DownloadAssetStatus, UploadAssetStatus}
 import com.waz.threading.Threading
 import com.waz.zclient.R
+import com.waz.zclient.common.controllers.AssetsController
 import com.waz.zclient.glide.WireGlide
+import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.{HighlightViewPart, MsgPart}
 import com.waz.zclient.utils.RichView
-import com.waz.zclient.log.LogUI._
 
 class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int)
   extends FrameLayout(context, attrs, style) with PlayableAsset with ImageLayoutAssetPart with HighlightViewPart {
@@ -38,6 +39,12 @@ class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int)
 
   private val controls = findById[View](R.id.controls)
   private val image = findById[ImageView](R.id.image)
+  private val assetController = inject[AssetsController]
+
+  assetController.openVideoProgress.onUi {
+    case true  => assetActionButton.startEndlessProgress()
+    case false => assetActionButton.clearProgress()
+  }
 
   hideContent.map(!_).onUi { visible =>
     controls.setVisible(visible)
@@ -54,7 +61,10 @@ class VideoAssetPartView(context: Context, attrs: AttributeSet, style: Int)
       case UploadAssetStatus.Failed       => message.currentValue.foreach(retr => { println(retr);  controller.retry(retr)})
       case UploadAssetStatus.InProgress   => message.currentValue.foreach(m => controller.cancelUpload(m.assetId.get, m))
       case DownloadAssetStatus.InProgress => message.currentValue.foreach(m => controller.cancelDownload(m.assetId.get))
-      case AssetStatus.Done               => asset.head.foreach(a => controller.openFile(a.id))(Threading.Ui)
+      case AssetStatus.Done               => {
+        assetController.openVideoProgress ! true
+        asset.head.foreach(a => controller.openFile(a.id))(Threading.Ui)
+      }
       case status                         => error(l"Unhandled asset status: $status")
     }
   }


### PR DESCRIPTION
…ou click to open it

## What's new in this PR?

### Issues

1: https://github.com/wireapp/wire-android/issues/2643

### Causes

There is no notifying the user when you click to a open a video once it has been downloaded, which can take a few seconds on slow devices. So, it's good to notify the user that something is happening. 

### Solutions

Shows a loading indicator around the play button when you would like to open the video asset. 