### PR TITLE
Fix: Downgrade material library to fix bottom navigation background issue

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/auth/registration/personal/CreatePersonalAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/auth/registration/personal/CreatePersonalAccountFragment.kt
@@ -3,7 +3,6 @@ package com.waz.zclient.auth.registration.personal
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import com.google.android.material.tabs.TabLayoutMediator
 import com.waz.zclient.R
 import kotlinx.android.synthetic.main.fragment_create_personal_account.*
 
@@ -23,9 +22,11 @@ class CreatePersonalAccountFragment : Fragment(R.layout.fragment_create_personal
     private fun initTabLayout() {
         val tabTitles = listOf(getString(R.string.authentication_tab_layout_title_email),
             getString(R.string.authentication_tab_layout_title_phone))
-        TabLayoutMediator(createPersonalAccountTabLayout, createPersonalAccountViewPager) { tab, position ->
-            tab.text = tabTitles[position]
-        }.attach()
+        //we cannot use this class until we upgrade material library to version 1.1.0
+        //please see the note at ANDROIDX_MATERIAL in Dependencies.kt
+//        TabLayoutMediator(createPersonalAccountTabLayout, createPersonalAccountViewPager) { tab, position ->
+//            tab.text = tabTitles[position]
+//        }.attach()
     }
 
     companion object {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,9 @@ object Versions {
     //build
     const val COROUTINES = "1.3.2"
     const val WORK_MANAGER = "2.0.1"
-    const val ANDROIDX_MATERIAL = "1.1.0"
+    //TODO: do not upgrade to 1.1.0 until google fixes this issue:
+    //https://github.com/material-components/material-components-android/issues/1077
+    const val ANDROIDX_MATERIAL = "1.0.0"
     const val ANDROIDX_MULTIDEX = "2.0.0"
     const val ANDROIDX_APP_COMPAT = "1.0.0"
     const val ANDROIDX_RECYCLER_VIEW = "1.0.0"


### PR DESCRIPTION
## What's new in this PR?

Jira Ticket: https://wearezeta.atlassian.net/browse/AN-6700

### Issues

The bottom navigation background went black, whereas it should be transparent.

### Causes

This is due to a bug introduced in Google's android-material library, which contains BottomNavigationView class. There's already and issue opened to Google [here](https://github.com/material-components/material-components-android/issues/1077).

### Solutions

Downgraded the library version. This means that we cannot use TabMediatorLayout, which is introduced in version 1.1.0. We commented out the code for now, since that code won't be in the production.

### Testing

Manually tested.


#### APK
[Download build #1437](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1437/artifact/build/artifact/wire-dev-PR2656-1437.apk)