### PR TITLE
Fixed the issues around ViewModels inside dialogs affecting the delet…

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/DeletePhoneDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/DeletePhoneDialogFragment.kt
@@ -8,13 +8,13 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
-import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.withArgs
 import com.waz.zclient.settings.di.SETTINGS_SCOPE_ID
 
 class DeletePhoneDialogFragment : DialogFragment() {
 
-    private val phoneViewModel by viewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
+    private val phoneViewModel by sharedViewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
 
     private val phoneNumber: String by lazy {
         arguments?.getString(CURRENT_PHONE_NUMBER_KEY, String.empty()) ?: String.empty()

--- a/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/EditPhoneNumberFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/EditPhoneNumberFragment.kt
@@ -12,7 +12,7 @@ import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.getDeviceLocale
 import com.waz.zclient.core.extension.removeFragment
 import com.waz.zclient.core.extension.replaceFragment
-import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.withArgs
 import com.waz.zclient.settings.di.SETTINGS_SCOPE_ID
 import com.waz.zclient.user.domain.usecase.phonenumber.Country
@@ -21,7 +21,7 @@ import kotlinx.android.synthetic.main.fragment_edit_phone.*
 @SuppressWarnings("TooManyFunctions")
 class EditPhoneNumberFragment : Fragment(R.layout.fragment_edit_phone) {
 
-    private val phoneViewModel by viewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
+    private val phoneViewModel by sharedViewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
 
     private val phoneNumber: String by lazy {
         arguments?.getString(CURRENT_PHONE_NUMBER_KEY, String.empty()) ?: String.empty()

--- a/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/UpdatePhoneDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/account/editphonenumber/UpdatePhoneDialogFragment.kt
@@ -8,13 +8,13 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
-import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.withArgs
 import com.waz.zclient.settings.di.SETTINGS_SCOPE_ID
 
 class UpdatePhoneDialogFragment : DialogFragment() {
 
-    private val viewModel by viewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
+    private val viewModel by sharedViewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
 
     private val phoneNumber: String by lazy {
         arguments?.getString(CURRENT_PHONE_NUMBER_KEY, String.empty()) ?: String.empty()


### PR DESCRIPTION
…e and edit phone functionality

## What's new in this PR?

### Issues

API requests for deleting/updating phone number wasn't getting executed 
 
### Causes

Dialog was destroying the viewModelScope too early and cancelling the jobs associated with deleting the account requests

### Solutions

Use sharedViewModel and created the viewModelScope attached to the parent EditPhoneActivity so the action can be performed when the dialog has been clicked and destroyed. 
