### PR TITLE
Kotlin Spike: Navigation structure - Part 1: SettingsMainActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -375,6 +375,8 @@ dependencies {
         exclude group: 'androidx.room', module: 'room-runtime'
     }
     implementation BuildDependencies.androidX.viewPager2
+    implementation BuildDependencies.androidX.navigationFragment
+    implementation BuildDependencies.androidX.navigationUi
 
     // Play services
     implementation BuildDependencies.playServices.base

--- a/app/src/main/kotlin/com/waz/zclient/core/extension/Fragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/Fragment.kt
@@ -16,7 +16,7 @@ inline fun <T : Fragment> T.withArgs(argsBuilder: Bundle.() -> Unit): T =
         arguments = Bundle().apply(argsBuilder)
     }
 
-@Deprecated("use Navigator#openUri", ReplaceWith("navigator().openUri(Uri)"))
+@Deprecated("use Navigator#navigateTo(Uri)", ReplaceWith("navigator().navigateTo(uri)"))
 fun Fragment.openUrl(url: String) =
     requireActivity().startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
 

--- a/app/src/main/kotlin/com/waz/zclient/core/extension/Fragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/Fragment.kt
@@ -16,6 +16,7 @@ inline fun <T : Fragment> T.withArgs(argsBuilder: Bundle.() -> Unit): T =
         arguments = Bundle().apply(argsBuilder)
     }
 
+@Deprecated("use Navigator#openUri", ReplaceWith("navigator().openUri(Uri)"))
 fun Fragment.openUrl(url: String) =
     requireActivity().startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
 

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
@@ -1,0 +1,13 @@
+package com.waz.zclient.core.navigation
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.fragment.findNavController
+
+internal class NavigationComponentsNavigator(private val navController: NavController) : Navigator {
+    override fun navigateTo(navigationId: Int) {
+        navController.navigate(navigationId)
+    }
+}
+
+fun Fragment.navigator(): Navigator = NavigationComponentsNavigator(findNavController())

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
@@ -10,18 +10,19 @@ import androidx.navigation.fragment.findNavController
 import java.lang.ref.WeakReference
 
 internal class NavigationComponentsNavigator(
-    private val navController: NavController,
+    navController: NavController,
     activity: Activity?
 ) : Navigator {
 
+    private val navController = WeakReference<NavController>(navController)
     private val activityWeakRef = WeakReference<Activity>(activity)
 
     override fun navigateTo(navigationId: Int) {
-        navController.navigate(navigationId)
+        navController.get()?.navigate(navigationId)
     }
 
     override fun navigateTo(navigationId: Int, bundle: Bundle) {
-        navController.navigate(navigationId, bundle)
+        navController.get()?.navigate(navigationId, bundle)
     }
 
     //TODO: do we need a custom navigator (for backstack, etc.)

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
@@ -1,11 +1,21 @@
 package com.waz.zclient.core.navigation
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
+import java.lang.ref.WeakReference
 
-internal class NavigationComponentsNavigator(private val navController: NavController) : Navigator {
+internal class NavigationComponentsNavigator(
+    private val navController: NavController,
+    activity: Activity?
+) : Navigator {
+
+    private val activityWeakRef = WeakReference<Activity>(activity)
+
     override fun navigateTo(navigationId: Int) {
         navController.navigate(navigationId)
     }
@@ -13,6 +23,11 @@ internal class NavigationComponentsNavigator(private val navController: NavContr
     override fun navigateTo(navigationId: Int, bundle: Bundle) {
         navController.navigate(navigationId, bundle)
     }
+
+    //TODO: do we need a custom navigator (for backstack, etc.)
+    override fun navigateTo(uri: Uri) {
+        activityWeakRef.get()?.startActivity(Intent(Intent.ACTION_VIEW, uri))
+    }
 }
 
-fun Fragment.navigator(): Navigator = NavigationComponentsNavigator(findNavController())
+fun Fragment.navigator(): Navigator = NavigationComponentsNavigator(findNavController(), activity)

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/NavigationComponentsNavigator.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.core.navigation
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
@@ -7,6 +8,10 @@ import androidx.navigation.fragment.findNavController
 internal class NavigationComponentsNavigator(private val navController: NavController) : Navigator {
     override fun navigateTo(navigationId: Int) {
         navController.navigate(navigationId)
+    }
+
+    override fun navigateTo(navigationId: Int, bundle: Bundle) {
+        navController.navigate(navigationId, bundle)
     }
 }
 

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
@@ -1,0 +1,7 @@
+package com.waz.zclient.core.navigation
+
+import androidx.annotation.IdRes
+
+interface Navigator {
+    fun navigateTo(@IdRes navigationId: Int)
+}

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.core.navigation
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.IdRes
 
@@ -7,4 +8,6 @@ interface Navigator {
     fun navigateTo(@IdRes navigationId: Int)
 
     fun navigateTo(@IdRes navigationId: Int, bundle: Bundle)
+
+    fun navigateTo(uri: Uri)
 }

--- a/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/navigation/Navigator.kt
@@ -1,7 +1,10 @@
 package com.waz.zclient.core.navigation
 
+import android.os.Bundle
 import androidx.annotation.IdRes
 
 interface Navigator {
     fun navigateTo(@IdRes navigationId: Int)
+
+    fun navigateTo(@IdRes navigationId: Int, bundle: Bundle)
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/SettingsAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/SettingsAccountFragment.kt
@@ -12,6 +12,7 @@ import com.waz.zclient.core.extension.invisible
 import com.waz.zclient.core.extension.openUrl
 import com.waz.zclient.core.extension.viewModel
 import com.waz.zclient.core.extension.visible
+import com.waz.zclient.core.navigation.navigator
 import com.waz.zclient.core.ui.dialog.EditTextDialogFragment
 import com.waz.zclient.features.settings.account.edithandle.EditHandleDialogFragment
 import com.waz.zclient.features.settings.account.editphonenumber.EditPhoneNumberActivity
@@ -159,17 +160,24 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
         Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
 
     private fun showEditHandleDialog() =
-        EditHandleDialogFragment.newInstance(settingsAccountHandleTitleTextView.text.toString())
-            .show(requireActivity().supportFragmentManager, String.empty())
+        navigator().navigateTo(
+            R.id.action_settingsAccountFragment_to_editHandleDialogFragment,
+            EditHandleDialogFragment.bundle(settingsAccountHandleTitleTextView.text.toString())
+        )
 
-    private fun showDeleteAccountDialog(email: String, phoneNumber: String) {
-        DeleteAccountDialogFragment.newInstance(email, phoneNumber)
-            .show(requireActivity().supportFragmentManager, String.empty())
-    }
+    private fun showDeleteAccountDialog(email: String, phoneNumber: String) =
+        navigator().navigateTo(
+            R.id.action_settingsAccountFragment_to_deleteAccountDialogFragment,
+            DeleteAccountDialogFragment.bundle(email, phoneNumber)
+        )
 
     private fun launchEditPhoneScreen(phoneNumber: String, hasEmail: Boolean) =
-        startActivity(EditPhoneNumberActivity.newIntent(requireContext(), phoneNumber, hasEmail))
+        navigator().navigateTo(
+            R.id.action_settingsAccountFragment_to_editPhoneNumberActivity,
+            EditPhoneNumberActivity.bundle(phoneNumber, hasEmail)
+        )
 
+    //TODO: migrate to Navigator
     private fun showGenericEditDialog(
         title: String,
         defaultValue: String,
@@ -182,8 +190,4 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
                 }
             }
         ).show(requireActivity().supportFragmentManager, String.empty())
-
-    companion object {
-        fun newInstance() = SettingsAccountFragment()
-    }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/SettingsAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/SettingsAccountFragment.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.features.settings.account
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -9,7 +10,6 @@ import androidx.lifecycle.observe
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.invisible
-import com.waz.zclient.core.extension.openUrl
 import com.waz.zclient.core.extension.viewModel
 import com.waz.zclient.core.extension.visible
 import com.waz.zclient.core.navigation.navigator
@@ -107,7 +107,7 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
             settingsAccountViewModel.onResetPasswordClicked()
         }
         settingsAccountViewModel.resetPasswordUrlLiveData.observe(viewLifecycleOwner) {
-            openUrl(it)
+            navigator().navigateTo(Uri.parse(it))
         }
     }
 

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.observe
 import com.waz.zclient.R
@@ -59,10 +60,9 @@ class DeleteAccountDialogFragment : DialogFragment() {
         private const val EMAIL_BUNDLE_KEY = "emailBundleKey"
         private const val PHONE_NUMBER_BUNDLE_KEY = "phoneNumberBundleKey"
 
-        fun bundle(email: String, phoneNumber: String) =
-            Bundle().apply {
-                putString(EMAIL_BUNDLE_KEY, email)
-                putString(PHONE_NUMBER_BUNDLE_KEY, phoneNumber)
-            }
+        fun bundle(email: String, phoneNumber: String) = bundleOf(
+            EMAIL_BUNDLE_KEY to email,
+            PHONE_NUMBER_BUNDLE_KEY to phoneNumber
+        )
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
@@ -11,7 +11,6 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.toSpanned
-import com.waz.zclient.core.extension.withArgs
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE_ID
 
 class DeleteAccountDialogFragment : DialogFragment() {
@@ -60,8 +59,8 @@ class DeleteAccountDialogFragment : DialogFragment() {
         private const val EMAIL_BUNDLE_KEY = "emailBundleKey"
         private const val PHONE_NUMBER_BUNDLE_KEY = "phoneNumberBundleKey"
 
-        fun newInstance(email: String, phoneNumber: String) =
-            DeleteAccountDialogFragment().withArgs {
+        fun bundle(email: String, phoneNumber: String) =
+            Bundle().apply {
                 putString(EMAIL_BUNDLE_KEY, email)
                 putString(PHONE_NUMBER_BUNDLE_KEY, phoneNumber)
             }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
+import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.observe
@@ -118,8 +119,8 @@ class EditHandleDialogFragment : DialogFragment() {
     companion object {
         private const val CURRENT_HANDLE_BUNDLE_KEY = "currentHandleBundleKey"
 
-        fun bundle(currentHandle: String) = Bundle().apply {
-            putString(CURRENT_HANDLE_BUNDLE_KEY, currentHandle)
-        }
+        fun bundle(currentHandle: String) = bundleOf(
+            CURRENT_HANDLE_BUNDLE_KEY to currentHandle
+        )
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.observe
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.viewModel
-import com.waz.zclient.core.extension.withArgs
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE_ID
 import com.waz.zclient.user.handle.HandleAlreadyExists
 import com.waz.zclient.user.handle.HandleInvalid
@@ -119,8 +118,8 @@ class EditHandleDialogFragment : DialogFragment() {
     companion object {
         private const val CURRENT_HANDLE_BUNDLE_KEY = "currentHandleBundleKey"
 
-        fun newInstance(currentHandle: String):
-            EditHandleDialogFragment = EditHandleDialogFragment()
-            .withArgs { putString(CURRENT_HANDLE_BUNDLE_KEY, currentHandle) }
+        fun bundle(currentHandle: String) = Bundle().apply {
+            putString(CURRENT_HANDLE_BUNDLE_KEY, currentHandle)
+        }
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
@@ -2,6 +2,7 @@ package com.waz.zclient.features.settings.account.editphonenumber
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.replaceFragment
 import kotlinx.android.synthetic.main.activity_edit_phone.*
@@ -36,9 +37,9 @@ class EditPhoneNumberActivity : AppCompatActivity(R.layout.activity_edit_phone) 
         private const val CURRENT_PHONE_NUMBER_KEY = "currentPhoneNumber"
         private const val HAS_EMAIL_BUNDLE_KEY = "hasEmailBundleKey"
 
-        fun bundle(phoneNumber: String, hasEmail: Boolean) = Bundle().apply {
-            putString(CURRENT_PHONE_NUMBER_KEY, phoneNumber)
-            putBoolean(HAS_EMAIL_BUNDLE_KEY, hasEmail)
-        }
+        fun bundle(phoneNumber: String, hasEmail: Boolean) = bundleOf(
+            CURRENT_PHONE_NUMBER_KEY to phoneNumber,
+            HAS_EMAIL_BUNDLE_KEY to hasEmail
+        )
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
@@ -1,7 +1,5 @@
 package com.waz.zclient.features.settings.account.editphonenumber
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.waz.zclient.R
@@ -38,11 +36,9 @@ class EditPhoneNumberActivity : AppCompatActivity(R.layout.activity_edit_phone) 
         private const val CURRENT_PHONE_NUMBER_KEY = "currentPhoneNumber"
         private const val HAS_EMAIL_BUNDLE_KEY = "hasEmailBundleKey"
 
-        @JvmStatic
-        fun newIntent(context: Context, phoneNumber: String, hasEmail: Boolean) =
-            Intent(context, EditPhoneNumberActivity::class.java).also {
-                it.putExtra(CURRENT_PHONE_NUMBER_KEY, phoneNumber)
-                it.putExtra(HAS_EMAIL_BUNDLE_KEY, hasEmail)
-            }
+        fun bundle(phoneNumber: String, hasEmail: Boolean) = Bundle().apply {
+            putString(CURRENT_PHONE_NUMBER_KEY, phoneNumber)
+            putBoolean(HAS_EMAIL_BUNDLE_KEY, hasEmail)
+        }
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.createScope
-import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE_ID
 import kotlinx.android.synthetic.main.activity_settings.*
@@ -27,7 +26,6 @@ class SettingsMainActivity : AppCompatActivity(R.layout.activity_settings) {
         super.onCreate(savedInstanceState)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        replaceFragment(R.id.activitySettingsMainLayoutContainer, SettingsMainFragment.newInstance())
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainFragment.kt
@@ -2,19 +2,12 @@ package com.waz.zclient.features.settings.main
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.waz.zclient.R
-import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.core.ui.list.OnItemClickListener
-import com.waz.zclient.features.settings.about.SettingsAboutFragment
-import com.waz.zclient.features.settings.account.SettingsAccountFragment
-import com.waz.zclient.features.settings.advanced.SettingsAdvancedFragment
-import com.waz.zclient.features.settings.devices.list.SettingsDeviceListFragment
 import com.waz.zclient.features.settings.main.list.SettingsMainListAdapter
 import com.waz.zclient.features.settings.main.list.SettingsMainListItemsFactory
-import com.waz.zclient.features.settings.options.SettingsOptionsFragment
-import com.waz.zclient.features.settings.support.SettingsSupportFragment
 import kotlinx.android.synthetic.main.fragment_settings_main.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -33,21 +26,17 @@ class SettingsMainFragment : Fragment(R.layout.fragment_settings_main), OnItemCl
 
     override fun onItemClicked(position: Int) {
         when (position) {
-            ACCOUNT -> replaceFragment(SettingsAccountFragment.newInstance())
-            DEVICES -> replaceFragment(SettingsDeviceListFragment.newInstance())
-            OPTIONS -> replaceFragment(SettingsOptionsFragment.newInstance())
-            ADVANCED -> replaceFragment(SettingsAdvancedFragment.newInstance())
-            SUPPORT -> replaceFragment(SettingsSupportFragment.newInstance())
-            ABOUT -> replaceFragment(SettingsAboutFragment.newInstance())
+            //TODO: hide implementation details!
+            ACCOUNT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAccountFragment)
+            DEVICES -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsDeviceListFragment)
+            OPTIONS -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsOptionsFragment)
+            ADVANCED -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAdvancedFragment)
+            SUPPORT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsSupportFragment)
+            ABOUT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAboutFragment)
         }
     }
 
-    private fun replaceFragment(fragment: Fragment) {
-        (activity as AppCompatActivity).replaceFragment(R.id.activitySettingsMainLayoutContainer, fragment)
-    }
-
     companion object {
-        fun newInstance() = SettingsMainFragment()
         private const val ACCOUNT = 0
         private const val DEVICES = 1
         private const val OPTIONS = 2

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainFragment.kt
@@ -3,8 +3,8 @@ package com.waz.zclient.features.settings.main
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
 import com.waz.zclient.R
+import com.waz.zclient.core.navigation.navigator
 import com.waz.zclient.core.ui.list.OnItemClickListener
 import com.waz.zclient.features.settings.main.list.SettingsMainListAdapter
 import com.waz.zclient.features.settings.main.list.SettingsMainListItemsFactory
@@ -24,15 +24,14 @@ class SettingsMainFragment : Fragment(R.layout.fragment_settings_main), OnItemCl
         )
     }
 
-    override fun onItemClicked(position: Int) {
+    override fun onItemClicked(position: Int) = with(navigator()) {
         when (position) {
-            //TODO: hide implementation details!
-            ACCOUNT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAccountFragment)
-            DEVICES -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsDeviceListFragment)
-            OPTIONS -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsOptionsFragment)
-            ADVANCED -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAdvancedFragment)
-            SUPPORT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsSupportFragment)
-            ABOUT -> findNavController().navigate(R.id.action_settingsMainFragment_to_settingsAboutFragment)
+            ACCOUNT -> navigateTo(R.id.action_settingsMainFragment_to_settingsAccountFragment)
+            DEVICES -> navigateTo(R.id.action_settingsMainFragment_to_settingsDeviceListFragment)
+            OPTIONS -> navigateTo(R.id.action_settingsMainFragment_to_settingsOptionsFragment)
+            ADVANCED -> navigateTo(R.id.action_settingsMainFragment_to_settingsAdvancedFragment)
+            SUPPORT -> navigateTo(R.id.action_settingsMainFragment_to_settingsSupportFragment)
+            ABOUT -> navigateTo(R.id.action_settingsMainFragment_to_settingsAboutFragment)
         }
     }
 

--- a/app/src/main/res-migration/layout/activity_settings.xml
+++ b/app/src/main/res-migration/layout/activity_settings.xml
@@ -39,14 +39,17 @@
         app:popupTheme="?actionBarPopupTheme"
         app:titleMarginStart="@dimen/wire__padding__regular" />
 
-    <FrameLayout
+    <fragment
         android:id="@+id/activitySettingsMainLayoutContainer"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:navGraph="@navigation/settings_nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res-migration/navigation/settings_nav_graph.xml
+++ b/app/src/main/res-migration/navigation/settings_nav_graph.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" android:id="@+id/settings_nav_graph"
+    app:startDestination="@id/settingsMainFragment">
+
+    <fragment
+        android:id="@+id/settingsMainFragment"
+        android:name="com.waz.zclient.settings.main.SettingsMainFragment"
+        android:label="SettingsMainFragment" >
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsAccountFragment"
+            app:destination="@id/settingsAccountFragment" />
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsDeviceListFragment"
+            app:destination="@id/settingsDeviceListFragment" />
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsOptionsFragment"
+            app:destination="@id/settingsOptionsFragment" />
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsAdvancedFragment"
+            app:destination="@id/settingsAdvancedFragment" />
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsSupportFragment"
+            app:destination="@id/settingsSupportFragment" />
+        <action
+            android:id="@+id/action_settingsMainFragment_to_settingsAboutFragment"
+            app:destination="@id/settingsAboutFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/settingsAccountFragment"
+        android:name="com.waz.zclient.settings.account.SettingsAccountFragment"
+        android:label="SettingsAccountFragment" />
+    <fragment
+        android:id="@+id/settingsDeviceListFragment"
+        android:name="com.waz.zclient.settings.devices.list.SettingsDeviceListFragment"
+        android:label="SettingsDeviceListFragment" />
+    <fragment
+        android:id="@+id/settingsOptionsFragment"
+        android:name="com.waz.zclient.settings.options.SettingsOptionsFragment"
+        android:label="SettingsOptionsFragment" />
+    <fragment
+        android:id="@+id/settingsAdvancedFragment"
+        android:name="com.waz.zclient.settings.advanced.SettingsAdvancedFragment"
+        android:label="SettingsAdvancedFragment" />
+    <fragment
+        android:id="@+id/settingsSupportFragment"
+        android:name="com.waz.zclient.settings.support.SettingsSupportFragment"
+        android:label="SettingsSupportFragment" />
+    <fragment
+        android:id="@+id/settingsAboutFragment"
+        android:name="com.waz.zclient.settings.about.SettingsAboutFragment"
+        android:label="SettingsAboutFragment" />
+</navigation>

--- a/app/src/main/res-migration/navigation/settings_nav_graph.xml
+++ b/app/src/main/res-migration/navigation/settings_nav_graph.xml
@@ -5,7 +5,7 @@
 
     <fragment
         android:id="@+id/settingsMainFragment"
-        android:name="com.waz.zclient.settings.main.SettingsMainFragment"
+        android:name="com.waz.zclient.features.settings.main.SettingsMainFragment"
         android:label="SettingsMainFragment" >
         <action
             android:id="@+id/action_settingsMainFragment_to_settingsAccountFragment"
@@ -28,7 +28,7 @@
     </fragment>
     <fragment
         android:id="@+id/settingsAccountFragment"
-        android:name="com.waz.zclient.settings.account.SettingsAccountFragment"
+        android:name="com.waz.zclient.features.settings.account.SettingsAccountFragment"
         android:label="SettingsAccountFragment" >
         <action
             android:id="@+id/action_settingsAccountFragment_to_editPhoneNumberActivity"
@@ -42,34 +42,34 @@
     </fragment>
     <fragment
         android:id="@+id/settingsDeviceListFragment"
-        android:name="com.waz.zclient.settings.devices.list.SettingsDeviceListFragment"
+        android:name="com.waz.zclient.features.settings.devices.list.SettingsDeviceListFragment"
         android:label="SettingsDeviceListFragment" />
     <fragment
         android:id="@+id/settingsOptionsFragment"
-        android:name="com.waz.zclient.settings.options.SettingsOptionsFragment"
+        android:name="com.waz.zclient.features.settings.options.SettingsOptionsFragment"
         android:label="SettingsOptionsFragment" />
     <fragment
         android:id="@+id/settingsAdvancedFragment"
-        android:name="com.waz.zclient.settings.advanced.SettingsAdvancedFragment"
+        android:name="com.waz.zclient.features.settings.advanced.SettingsAdvancedFragment"
         android:label="SettingsAdvancedFragment" />
     <fragment
         android:id="@+id/settingsSupportFragment"
-        android:name="com.waz.zclient.settings.support.SettingsSupportFragment"
+        android:name="com.waz.zclient.features.settings.support.SettingsSupportFragment"
         android:label="SettingsSupportFragment" />
     <fragment
         android:id="@+id/settingsAboutFragment"
-        android:name="com.waz.zclient.settings.about.SettingsAboutFragment"
+        android:name="com.waz.zclient.features.settings.about.SettingsAboutFragment"
         android:label="SettingsAboutFragment" />
     <activity
         android:id="@+id/editPhoneNumberActivity"
-        android:name="com.waz.zclient.settings.account.editphonenumber.EditPhoneNumberActivity"
+        android:name="com.waz.zclient.features.settings.account.editphonenumber.EditPhoneNumberActivity"
         android:label="EditPhoneNumberActivity" />
     <dialog
         android:id="@+id/editHandleDialogFragment"
-        android:name="com.waz.zclient.settings.account.edithandle.EditHandleDialogFragment"
+        android:name="com.waz.zclient.features.settings.account.edithandle.EditHandleDialogFragment"
         android:label="EditHandleDialogFragment" />
     <dialog
         android:id="@+id/deleteAccountDialogFragment"
-        android:name="com.waz.zclient.settings.account.deleteaccount.DeleteAccountDialogFragment"
+        android:name="com.waz.zclient.features.settings.account.deleteaccount.DeleteAccountDialogFragment"
         android:label="DeleteAccountDialogFragment" />
 </navigation>

--- a/app/src/main/res-migration/navigation/settings_nav_graph.xml
+++ b/app/src/main/res-migration/navigation/settings_nav_graph.xml
@@ -29,7 +29,17 @@
     <fragment
         android:id="@+id/settingsAccountFragment"
         android:name="com.waz.zclient.settings.account.SettingsAccountFragment"
-        android:label="SettingsAccountFragment" />
+        android:label="SettingsAccountFragment" >
+        <action
+            android:id="@+id/action_settingsAccountFragment_to_editPhoneNumberActivity"
+            app:destination="@id/editPhoneNumberActivity" />
+        <action
+            android:id="@+id/action_settingsAccountFragment_to_editHandleDialogFragment"
+            app:destination="@id/editHandleDialogFragment" />
+        <action
+            android:id="@+id/action_settingsAccountFragment_to_deleteAccountDialogFragment"
+            app:destination="@id/deleteAccountDialogFragment" />
+    </fragment>
     <fragment
         android:id="@+id/settingsDeviceListFragment"
         android:name="com.waz.zclient.settings.devices.list.SettingsDeviceListFragment"
@@ -50,4 +60,16 @@
         android:id="@+id/settingsAboutFragment"
         android:name="com.waz.zclient.settings.about.SettingsAboutFragment"
         android:label="SettingsAboutFragment" />
+    <activity
+        android:id="@+id/editPhoneNumberActivity"
+        android:name="com.waz.zclient.settings.account.editphonenumber.EditPhoneNumberActivity"
+        android:label="EditPhoneNumberActivity" />
+    <dialog
+        android:id="@+id/editHandleDialogFragment"
+        android:name="com.waz.zclient.settings.account.edithandle.EditHandleDialogFragment"
+        android:label="EditHandleDialogFragment" />
+    <dialog
+        android:id="@+id/deleteAccountDialogFragment"
+        android:name="com.waz.zclient.settings.account.deleteaccount.DeleteAccountDialogFragment"
+        android:label="DeleteAccountDialogFragment" />
 </navigation>

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -198,7 +198,7 @@ trait FragmentHelper
 
   @inline
   def findFragment[T <: Fragment](tag: String): Option[T] =
-    findFragment(tag, getFragmentManager)
+    findFragment(tag, getParentFragmentManager)
 
   @inline
   def findChildFragment[T <: Fragment](tag: String): Option[T] =
@@ -224,7 +224,7 @@ trait FragmentHelper
   }
 
   def slideFragmentInFromRight(f: Fragment, tag: String): Unit =
-    getFragmentManager.beginTransaction
+    getParentFragmentManager.beginTransaction
       .setCustomAnimations(
         R.anim.fragment_animation_second_page_slide_in_from_right,
         R.anim.fragment_animation_second_page_slide_out_to_left,

--- a/app/src/main/scala/com/waz/zclient/appentry/CreateAccountFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/CreateAccountFragment.scala
@@ -55,8 +55,8 @@ class CreateAccountFragment extends FragmentHelper {
   }
 
   override def onBackPressed(): Boolean =
-    if (getFragmentManager.getBackStackEntryCount > 1) {
-      getFragmentManager.popBackStack()
+    if (getParentFragmentManager.getBackStackEntryCount > 1) {
+      getParentFragmentManager.popBackStack()
       true
     } else false
 

--- a/app/src/main/scala/com/waz/zclient/appentry/CreateTeamFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/CreateTeamFragment.scala
@@ -78,8 +78,8 @@ trait CreateTeamFragment extends FragmentHelper {
   protected def showFragment(f: => Fragment, tag: String, animated: Boolean = true): Unit = appEntryActivity().showFragment(f, tag, animated)
 
   override def onBackPressed(): Boolean =
-    if (getFragmentManager.getBackStackEntryCount > 1) {
-      getFragmentManager.popBackStack()
+    if (getParentFragmentManager.getBackStackEntryCount > 1) {
+      getParentFragmentManager.popBackStack()
       true
     } else {
       false

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -155,7 +155,7 @@ trait SSOFragment extends FragmentHelper with DerivedLogTag {
   private def showInlineSsoError(errorText: String) = Future.successful(getSsoDialog.foreach(_.setError(errorText)))
 
   protected def showSsoWebView(token: String) = {
-    getFragmentManager.popBackStack(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    getParentFragmentManager.popBackStack(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     Future.successful(activity.showFragment(SSOWebViewFragment.newInstance(token.toString), SSOWebViewFragment.Tag))
   }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -86,7 +86,7 @@ class SSOWebViewFragment extends FragmentHelper {
   }
 
   override def onBackPressed(): Boolean = {
-    getFragmentManager.popBackStack(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    getParentFragmentManager.popBackStack(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     inject[UserAccountsController].ssoToken ! None
     true
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
@@ -157,7 +157,7 @@ class PhoneSetNameFragment extends FragmentHelper with TextWatcher with View.OnC
   private def isNameValid(name: String): Boolean = name != null && name.trim.length > 1
 
   override def onBackPressed(): Boolean = {
-    getFragmentManager.popBackStack()
+    getParentFragmentManager.popBackStack()
     true
   }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetNameFragment.scala
@@ -56,7 +56,7 @@ case class SetNameFragment() extends CreateTeamFragment {
 
   override def onBackPressed(): Boolean = {
     createTeamController.code = ""
-    getFragmentManager.popBackStack(VerifyTeamEmailFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    getParentFragmentManager.popBackStack(VerifyTeamEmailFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     true
   }
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -423,8 +423,8 @@ class SignInFragment extends FragmentHelper with View.OnClickListener with Count
     Set(email, password, name, phone).foreach(_ ! "")
 
   override def onBackPressed(): Boolean =
-    if (getFragmentManager.getBackStackEntryCount > 1) {
-      getFragmentManager.popBackStack()
+    if (getParentFragmentManager.getBackStackEntryCount > 1) {
+      getParentFragmentManager.popBackStack()
       true
     } else {
       false

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -167,7 +167,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
     }
   }
 
-  private def goBack(): Unit = getFragmentManager.popBackStack()
+  private def goBack(): Unit = getParentFragmentManager.popBackStack()
 
   private def confirmCode(): Unit = {
     activity.enableProgress(true)

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
@@ -162,7 +162,7 @@ class VerifyPhoneFragment extends FragmentHelper with View.OnClickListener with 
     }
   }
 
-  private def goBack(): Unit = getFragmentManager.popBackStack()
+  private def goBack(): Unit = getParentFragmentManager.popBackStack()
 
   private def confirmCode(): Unit = {
     activity.enableProgress(true)

--- a/app/src/main/scala/com/waz/zclient/calling/CallParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallParticipantsFragment.scala
@@ -62,7 +62,7 @@ class CallParticipantsFragment extends FragmentHelper {
     super.onResume()
     toolbar.foreach(_.setNavigationOnClickListener(new View.OnClickListener() {
       override def onClick(v: View): Unit =
-        getFragmentManager.popBackStack()
+        getParentFragmentManager.popBackStack()
     }))
   }
 

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -121,7 +121,7 @@ class ControlsFragment extends FragmentHelper {
 
     callingMiddle.foreach(vh => subs += vh.onShowAllClicked.onUi { _ =>
       controller.callControlsVisible ! false
-      getFragmentManager.beginTransaction
+      getParentFragmentManager.beginTransaction
         .setCustomAnimations(
           R.anim.fragment_animation_second_page_slide_in_from_right_no_alpha,
           R.anim.fragment_animation_second_page_slide_out_to_left_no_alpha,

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
@@ -122,7 +122,7 @@ class ImageFragment extends FragmentHelper {
     val headerToolbar   = findById[Toolbar](view, R.id.header_toolbar)
 
     headerToolbar.setNavigationOnClickListener(new OnClickListener {
-      override def onClick(v: View): Unit = getFragmentManager.popBackStack()
+      override def onClick(v: View): Unit = getParentFragmentManager.popBackStack()
     })
 
     topCursorItems.onUi(bottomToolbar.topToolbar.cursorItems ! _)
@@ -142,13 +142,13 @@ class ImageFragment extends FragmentHelper {
         }
 
         method.foreach { m =>
-          getFragmentManager.popBackStack()
+          getParentFragmentManager.popBackStack()
           imageInput.head.collect { case Some(id: AssetId) => id }.foreach {
             screenController.showSketch ! Sketch.asset(_, m)
           }
         }
       case item: MessageActionToolbarItem =>
-        if (item.action == MessageAction.Reveal) getFragmentManager.popBackStack()
+        if (item.action == MessageAction.Reveal) getParentFragmentManager.popBackStack()
         message.head foreach { msg => messageActionsController.onMessageAction ! (item.action, msg) }
       case _ =>
     }
@@ -185,7 +185,7 @@ class ImageFragment extends FragmentHelper {
 
   private def closeSingleImageView(id: MessageId): Unit =
     if (collectionController.focusedItem.map(_.map(_.id)).currentValue.flatten.contains(id)) {
-      getFragmentManager.popBackStack()
+      getParentFragmentManager.popBackStack()
       singleImageController.hideSingleImage()
     }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -213,7 +213,7 @@ class AddParticipantsFragment extends FragmentHelper {
 
   private def close() = {
     keyboard.hideKeyboardIfVisible()
-    getFragmentManager.popBackStack()
+    getParentFragmentManager.popBackStack()
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationManagerFragment.scala
@@ -91,7 +91,7 @@ class CreateConversationManagerFragment extends DefaultToolbarFragment[NoOpConta
     ctrl.onShowCreateConversation.onUi {
       case false =>
         ctrl.fromScreen.head.map {
-          case GroupConversationEvent.StartUi => getFragmentManager.popBackStack(Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+          case GroupConversationEvent.StartUi => getParentFragmentManager.popBackStack(Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
           case _ =>
         } (Threading.Background)
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/integrations/IntegrationDetailsFragment.scala
@@ -147,7 +147,7 @@ class IntegrationDetailsFragment extends FragmentHelper {
                   setLoading(false)
                   res match {
                     case Right(_) =>
-                      getParentFragment.getFragmentManager.popBackStack()
+                      getParentFragment.getParentFragmentManager.popBackStack()
                       tracking.integrationRemoved(sId)
                     case Left(e) => Future.successful(showToast(errorMessage(e)))
                   }
@@ -190,7 +190,7 @@ class IntegrationDetailsFragment extends FragmentHelper {
   }
 
   def goBack(): Boolean = {
-    getFragmentManager.popBackStack()
+    getParentFragmentManager.popBackStack()
     true
   }
 
@@ -200,7 +200,7 @@ class IntegrationDetailsFragment extends FragmentHelper {
     inject[ParticipantsController].onLeaveParticipants ! true
     true
   } else {
-    Option(getFragmentManager).foreach { fm =>
+    Option(getParentFragmentManager).foreach { fm =>
       fm.popBackStack(SearchUIFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
       inject[IPickUserController].hidePickUser()
       inject[INavigationController].setLeftPage(Page.CONVERSATION_LIST, IntegrationDetailsFragment.Tag)

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -236,7 +236,7 @@ class MainPhoneFragment extends FragmentHelper
 
   private def newGroupConversation() = {
     inject[CreateConversationController].setCreateConversation(from = GroupConversationEvent.StartUi)
-    getFragmentManager.beginTransaction
+    getParentFragmentManager.beginTransaction
       .setCustomAnimations(
         R.anim.fragment_animation_second_page_slide_in_from_right,
         R.anim.fragment_animation_second_page_slide_in_from_left,

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/EphemeralOptionsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/EphemeralOptionsFragment.scala
@@ -82,7 +82,7 @@ class EphemeralOptionsFragment extends FragmentHelper {
               }).onComplete { res =>
                 if (res.isFailure) showToast(getString(R.string.generic_error_message))
                 spinner.showSpinner(false)
-                this.getFragmentManager.popBackStack()
+                this.getParentFragmentManager.popBackStack()
               }
             }
           }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
@@ -140,7 +140,7 @@ class GroupParticipantsFragment extends FragmentHelper {
           case true =>
             participantsController.conv.head.foreach { conv =>
               inject[CreateConversationController].setAddToConversation(conv.id)
-              getFragmentManager.beginTransaction
+              getParentFragmentManager.beginTransaction
                 .setCustomAnimations(
                   R.anim.in_from_bottom_enter,
                   R.anim.out_to_bottom_exit,

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/NotificationsOptionsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/NotificationsOptionsFragment.scala
@@ -59,7 +59,7 @@ class NotificationsOptionsFragment extends FragmentHelper {
               } yield {}).onComplete { res =>
                 if (res.isFailure) showToast(getString(R.string.generic_error_message))
                 spinner.showSpinner(false)
-                this.getFragmentManager.popBackStack()
+                this.getParentFragmentManager.popBackStack()
               }
             }
           }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -172,7 +172,7 @@ class SingleOtrClientFragment extends FragmentHelper {
   }
 
   private def close() = {
-    getFragmentManager.popBackStackImmediate
+    getParentFragmentManager.popBackStackImmediate
   }
 
   private def resetSession(): Unit = (userId, clientId) match {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -73,7 +73,7 @@ abstract class UntabbedRequestFragment extends SingleParticipantFragment {
       false
     } else if (fromDeepLink) {
       CancellableFuture.delay(750.millis).map { _ =>
-        getFragmentManager.popBackStack(Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        getParentFragmentManager.popBackStack(Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
       }
       true
     } else {

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -389,7 +389,7 @@ class SearchUIFragment extends BaseFragment[Container]
   override def onCreateConversationClicked(): Unit = {
     keyboard.hideKeyboardIfVisible()
     inject[CreateConversationController].setCreateConversation(from = GroupConversationEvent.StartUi)
-    getFragmentManager.beginTransaction
+    getParentFragmentManager.beginTransaction
       .setCustomAnimations(
         R.anim.slide_in_from_bottom_pick_user,
         R.anim.open_new_conversation__thread_list_out,
@@ -471,7 +471,7 @@ class SearchUIFragment extends BaseFragment[Container]
     verbose(l"onIntegrationClicked(${data.id})")
 
     import IntegrationDetailsFragment._
-    getFragmentManager.beginTransaction
+    getParentFragmentManager.beginTransaction
       .setCustomAnimations(
         R.anim.slide_in_from_bottom_pick_user,
         R.anim.open_new_conversation__thread_list_out,

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -716,10 +716,10 @@ class ConversationFragment extends FragmentHelper {
         case false => Future.successful((false, false, false))
       }.foreach {
         case (hasGuest, hasBot, isGroup) =>
-          val backStackSize = getFragmentManager.getBackStackEntryCount
+          val backStackSize = getParentFragmentManager.getBackStackEntryCount
           if (backStackSize > 0) {
             // update the guests' banner only if the conversation's fragment is on top
-            if (getFragmentManager.getBackStackEntryAt(backStackSize - 1).getName == ConversationFragment.TAG)
+            if (getParentFragmentManager.getBackStackEntryAt(backStackSize - 1).getName == ConversationFragment.TAG)
               updateGuestsBanner(hasGuest, hasBot, isGroup)
           } else
             updateGuestsBanner(hasGuest, hasBot, isGroup)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -36,6 +36,7 @@ object Versions {
     const val ANDROIDX_BIOMETRIC = "1.0.1"
     const val ANDROIDX_ANNOTATION = "1.0.0"
     const val ANDROIDX_VIEW_PAGER_2 = "1.0.0"
+    const val ANDROIDX_NAVIGATION = "2.2.1"
     const val PLAY_SERVICES = "17.0.0"
     const val PLAY_SERVICES_BASE = "17.1.0"
     const val FIREBASE_MESSAGING = "20.1.0"
@@ -99,7 +100,9 @@ object BuildDependencies {
         "biometric" to "androidx.biometric:biometric:${Versions.ANDROIDX_BIOMETRIC}",
         "workManager" to "androidx.work:work-runtime:${Versions.WORK_MANAGER}",
         "annotation" to "androidx.annotation:annotation:${Versions.ANDROIDX_ANNOTATION}",
-        "viewPager2" to "androidx.viewpager2:viewpager2:${Versions.ANDROIDX_VIEW_PAGER_2}"
+        "viewPager2" to "androidx.viewpager2:viewpager2:${Versions.ANDROIDX_VIEW_PAGER_2}",
+        "navigationFragment" to "androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION}",
+        "navigationUi" to "androidx.navigation:navigation-ui-ktx:${Versions.ANDROIDX_NAVIGATION}"
     ))
     val playServices = PlayServicesDependencyMap(mapOf(
         "base" to "com.google.android.gms:play-services-base:${Versions.PLAY_SERVICES_BASE}",

--- a/buildSrc/src/main/kotlin/DependencyMap.kt
+++ b/buildSrc/src/main/kotlin/DependencyMap.kt
@@ -42,6 +42,8 @@ class AndroidXDependencyMap(map: Map<String, String>) {
     val workManager: String by map
     val annotation: String by map
     val viewPager2: String by map
+    val navigationFragment: String by map
+    val navigationUi: String by map
 }
 
 class PlayServicesDependencyMap(map: Map<String, String>) {


### PR DESCRIPTION
## What's new in this PR?

Jira ticket: https://wearezeta.atlassian.net/browse/AN-6658

### Issues

We need to find a way to abstract navigation implementation details (replaceFragment, startActivity, openUrl...) from the view. The current implementation highly couples activity & fragment via direct calls, id references etc., which is something we're trying to avoid in the new architecture.

### Solution

This PR introduces Android Navigation Components here for that purpose, but hides the implementation details behind an interface called Navigator. Hence, we can replace the implementation with some other library or our own code later, if we want to.

Also updated deprecated `Fragment#getFragmentManager` calls to `Fragment#getParentFragment`, since they caused build to fail after adding navigation library dependencies.

### Testing

Seems like there's a testing library for navigation components, but some research is need to be made since we've never tested ui before.

#### APK
[Download build #1447](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1447/artifact/build/artifact/wire-dev-PR2659-1447.apk)
[Download build #1467](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1467/artifact/build/artifact/wire-dev-PR2659-1467.apk)
[Download build #1471](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1471/artifact/build/artifact/wire-dev-PR2659-1471.apk)
[Download build #1537](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1537/artifact/build/artifact/wire-dev-PR2659-1537.apk)
[Download build #1539](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1539/artifact/build/artifact/wire-dev-PR2659-1539.apk)