### PR TITLE
fix: The sync after backup restoration shouldn't be treated as the first sync.

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -447,6 +447,7 @@ object UserPreferences {
 
   lazy val OtrLastPrekey = PrefKey[Int]("otr_last_prekey_id")
   lazy val LastStableNotification = PrefKey[Option[Uid]]("last_notification_id")
+  lazy val FirstSyncAfterBackupRestoration = PrefKey[Boolean]("first_sync_after_backup_restoration", customDefault = false)
 
   lazy val LastSelfClientsSyncRequestedTime = PrefKey[Long]("last_self_clients_sync_requested")
 


### PR DESCRIPTION
This is another fix to the backup restoration issue. The restoration itself should now be done successfully, but we still have problems with setting up the app properly afterwards. One of them is that the first sync with the backend after the backup restoration is performed as if this was a fresh install. In such case, the app doesn't ask for old notifications which should be done in case of the backup restoration.

Unfortunately, this is not the only issue we have. The current workaround is to restart the app just after the backup restoration.
#### APK
[Download build #1450](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1450/artifact/build/artifact/wire-dev-PR2661-1450.apk)