### PR TITLE
AN-6714 && AN-6716: Conversation Search feature and about screen is broken 

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
@@ -5,12 +5,20 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.waz.zclient.R
+import com.waz.zclient.core.extension.createScope
 import com.waz.zclient.core.extension.replaceFragment
+import com.waz.zclient.settings.di.SETTINGS_SCOPE
+import com.waz.zclient.settings.di.SETTINGS_SCOPE_ID
 import kotlinx.android.synthetic.main.activity_settings_about.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
 class SettingsAboutActivity : AppCompatActivity() {
+
+    private val scope = createScope(
+        scopeId = SETTINGS_SCOPE_ID,
+        scopeName = SETTINGS_SCOPE
+    )
 
     @ExperimentalCoroutinesApi
     @InternalCoroutinesApi
@@ -30,5 +38,10 @@ class SettingsAboutActivity : AppCompatActivity() {
     companion object {
         @JvmStatic
         fun newIntent(context: Context) = Intent(context, SettingsAboutActivity::class.java)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.close()
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
@@ -5,12 +5,20 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.waz.zclient.R
+import com.waz.zclient.core.extension.createScope
 import com.waz.zclient.core.extension.replaceFragment
+import com.waz.zclient.settings.di.SETTINGS_SCOPE
+import com.waz.zclient.settings.di.SETTINGS_SCOPE_ID
 import kotlinx.android.synthetic.main.activity_settings_support.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
 class SettingsSupportActivity : AppCompatActivity() {
+
+    private val scope = createScope(
+        scopeId = SETTINGS_SCOPE_ID,
+        scopeName = SETTINGS_SCOPE
+    )
 
     @ExperimentalCoroutinesApi
     @InternalCoroutinesApi
@@ -30,5 +38,10 @@ class SettingsSupportActivity : AppCompatActivity() {
     companion object {
         @JvmStatic
         fun newIntent(context: Context) = Intent(context, SettingsSupportActivity::class.java)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.close()
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/MessageContentIndexEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/MessageContentIndexEntity.kt
@@ -2,11 +2,16 @@ package com.waz.zclient.storage.db.conversations
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Fts3
 import androidx.room.PrimaryKey
 
+@Fts3
 @Entity(tableName = "MessageContentIndex")
 data class MessageContentIndexEntity(
     @PrimaryKey
+    @ColumnInfo(name = "rowid")
+    val rowId: Int,
+
     @ColumnInfo(name = "message_id")
     val messageId: String,
 

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
@@ -34,8 +34,10 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(START_VERSION, END_V
         if (BuildConfig.KOTLIN_CORE) {
             migrateClientTable(database)
             migrateKeyValuesTable(database)
-            migrateUserTable(database)
         }
+
+        //Needed in production
+        migrateUserTable(database)
     }
 
     //TODO still needs determining what to do with this one.


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation Search feature had broken after the migrated database code was implemented

### Causes

> E/SQLiteQuery: exception: unable to use function MATCH in the requested context (code 1 SQLITE_ERROR); query:

### Solutions

MessageContentIndex relies on [FTS3](https://www.sqlite.org/fts3.html) to perform faster searches. The new migrated room database created a normal table for this rather than a virtual one for the Scala code to query to. 

### Testing

Conversation searching feature should now behave as it did before

### Notes

This table is the only table that relies on FTS3/FTS4 so we shouldn't face the same problem again. 

#### APK
[Download build #1455](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1455/artifact/build/artifact/wire-dev-PR2663-1455.apk)