### PR TITLE
fix: Default config values

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,8 +100,7 @@ android {
             customURLScheme   : buildtimeConfiguration.configuration.custom_url_scheme,
             applicationLabel  : "Wire Dev",
             applicationIcon   : "@mipmap/ic_launcher_wire_dev",
-            sharedUserId      : "",
-            internal_features : "true"
+            sharedUserId      : ""
         ]
 
         buildConfigField 'Integer', 'MAX_ACCOUNTS',                  "$buildtimeConfiguration.configuration.maxAccounts"
@@ -222,8 +221,7 @@ android {
             versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-dev"
             manifestPlaceholders = [applicationLabel       : "Wire Dev",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_dev",
-                                    sharedUserId           : "",
-                                    internal_features      : "true"]
+                                    sharedUserId           : ""]
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
             buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
@@ -234,8 +232,7 @@ android {
             versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-candidate"
             manifestPlaceholders = [applicationLabel       : "Wire Candidate",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_candidate",
-                                    sharedUserId           : "",
-                                    internal_features      : "false"]
+                                    sharedUserId           : ""]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        "$buildtimeConfiguration.configuration.loggingEnabled"
@@ -246,8 +243,7 @@ android {
             applicationId buildtimeConfiguration.configuration.applicationId
             manifestPlaceholders = [applicationLabel       : buildtimeConfiguration.configuration.appName,
                                     applicationIcon        : "@mipmap/ic_launcher_wire",
-                                    sharedUserId           : buildtimeConfiguration.configuration.userId,
-                                    internal_features      : "false"]
+                                    sharedUserId           : buildtimeConfiguration.configuration.userId]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        "$buildtimeConfiguration.configuration.loggingEnabled"
@@ -259,8 +255,7 @@ android {
             versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-internal"
             manifestPlaceholders = [applicationLabel : "Wire Internal",
                                     applicationIcon  : "@mipmap/ic_launcher_wire_internal",
-                                    sharedUserId     : "",
-                                    internal_features: "true"]
+                                    sharedUserId     : ""]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
@@ -272,8 +267,7 @@ android {
             versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-exp"
             manifestPlaceholders = [applicationLabel       : "Wire Exp",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_playground",
-                                    sharedUserId           : "",
-                                    internal_features      : "true"]
+                                    sharedUserId           : ""]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,13 @@ android {
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 
-        manifestPlaceholders = [customURLScheme: buildtimeConfiguration.configuration.custom_url_scheme]
+        manifestPlaceholders = [
+            customURLScheme   : buildtimeConfiguration.configuration.custom_url_scheme,
+            applicationLabel  : "Wire Dev",
+            applicationIcon   : "@mipmap/ic_launcher_wire_dev",
+            sharedUserId      : "",
+            internal_features : "true"
+        ]
 
         buildConfigField 'Integer', 'MAX_ACCOUNTS',                  "$buildtimeConfiguration.configuration.maxAccounts"
         buildConfigField 'String',  'BACKEND_URL',                   "\"$buildtimeConfiguration.configuration.backendUrl\""
@@ -130,6 +136,9 @@ android {
         buildConfigField 'boolean', 'WIPE_ON_COOKIE_INVALID',        "$buildtimeConfiguration.configuration.wipe_on_cookie_invalid"
         buildConfigField 'boolean', 'FORCE_PRIVATE_KEYBOARD',        "$buildtimeConfiguration.configuration.force_private_keyboard"
         buildConfigField 'Integer', 'PASSWORD_MAX_ATTEMPTS',         "$buildtimeConfiguration.configuration.password_max_attempts"
+        buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    "$buildtimeConfiguration.configuration.developer_features_enabled"
+        buildConfigField 'boolean', 'LOGGING_ENABLED',               "$buildtimeConfiguration.configuration.logging_enabled"
+        buildConfigField 'boolean', 'SAFE_LOGGING',                  "$buildtimeConfiguration.configuration.safe_logging"
 
         //Kotlin Feature Flags
         buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -300,8 +300,6 @@
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
 
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
-        <!-- Internal features from SE -->
-        <meta-data android:name="INTERNAL" android:value="${internal_features}"/>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/default.json
+++ b/default.json
@@ -37,5 +37,8 @@
   "block_on_password_policy": false,
   "wipe_on_cookie_invalid": false,
   "force_private_keyboard": false,
-  "password_max_attempts": 0
+  "password_max_attempts": 0,
+  "developer_features_enabled": false,
+  "logging_enabled": false,
+  "safe_logging": false
 }


### PR DESCRIPTION
A few buildConfigFields and manifestPlaceholders  were missing from app/build.gradle. This usually is not a problem, but after removing Gradle's cache and doing `./gradlew clean`, I wasn't able to compile the app again without them.

#### APK
[Download build #1489](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1489/artifact/build/artifact/wire-dev-PR2665-1489.apk)
[Download build #1569](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1569/artifact/build/artifact/wire-dev-PR2665-1569.apk)