### PR TITLE
Kotlin Code Review : remove implementation details from function names

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/features/settings/about/SettingsAboutFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/about/SettingsAboutFragment.kt
@@ -22,12 +22,13 @@ class SettingsAboutFragment : Fragment(R.layout.fragment_settings_about) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initToolbar()
-        initViewModel()
         initAboutWebsiteButton()
         initTermsAndConditionsButton()
         initPrivacyButton()
         initLicensesButton()
         initAppVersionDetailsButton()
+        observeUrlData()
+        observeVersionDetailsData()
     }
 
     private fun initAppVersionDetailsButton() {
@@ -65,11 +66,13 @@ class SettingsAboutFragment : Fragment(R.layout.fragment_settings_about) {
         activity?.title = getString(R.string.pref_about_screen_title)
     }
 
-    private fun initViewModel() {
+    private fun observeUrlData() {
         settingsAboutViewModel.urlLiveData.observe(viewLifecycleOwner) {
             openUrl(it.url)
         }
+    }
 
+    private fun observeVersionDetailsData() {
         settingsAboutViewModel.versionDetailsLiveData.observe(viewLifecycleOwner) {
             val translationId = resources.getIdentifier(
                 it.translationsVersionId,

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
@@ -48,7 +48,6 @@ class EditHandleDialogFragment : DialogFragment() {
         initOkButton()
         observeHandleSuccessData()
         observeHandleErrorData()
-        observeOkEnabledData()
         observeDismissData()
     }
 
@@ -64,6 +63,9 @@ class EditHandleDialogFragment : DialogFragment() {
     }
 
     private fun initOkButton() {
+        editHandleViewModel.okEnabledLiveData.observe(viewLifecycleOwner) {
+            editHandleDialogOkButton.isEnabled = it
+        }
         editHandleDialogOkButton.setOnClickListener {
             editHandleViewModel.onOkButtonClicked(editHandleDialogHandleEditText.text.toString())
         }
@@ -81,10 +83,6 @@ class EditHandleDialogFragment : DialogFragment() {
 
     private fun observeHandleErrorData() {
         editHandleViewModel.errorLiveData.observe(viewLifecycleOwner) { updateErrorMessage(it) }
-    }
-
-    private fun observeOkEnabledData() {
-        editHandleViewModel.okEnabledLiveData.observe(viewLifecycleOwner) { editHandleDialogOkButton.isEnabled = it }
     }
 
     private fun observeDismissData() {

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/edithandle/EditHandleDialogFragment.kt
@@ -43,10 +43,13 @@ class EditHandleDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initViewModel()
         initHandleInput()
         initBackButton()
         initOkButton()
+        observeHandleSuccessData()
+        observeHandleErrorData()
+        observeOkEnabledData()
+        observeDismissData()
     }
 
     private fun initHandleInput() {
@@ -72,13 +75,20 @@ class EditHandleDialogFragment : DialogFragment() {
         }
     }
 
-    private fun initViewModel() {
-        with(editHandleViewModel) {
-            successLiveData.observe(viewLifecycleOwner) { updateSuccessMessage() }
-            errorLiveData.observe(viewLifecycleOwner) { updateErrorMessage(it) }
-            okEnabledLiveData.observe(viewLifecycleOwner) { editHandleDialogOkButton.isEnabled = it }
-            dismissLiveData.observe(viewLifecycleOwner) { dismiss() }
-        }
+    private fun observeHandleSuccessData() {
+        editHandleViewModel.successLiveData.observe(viewLifecycleOwner) { updateSuccessMessage() }
+    }
+
+    private fun observeHandleErrorData() {
+        editHandleViewModel.errorLiveData.observe(viewLifecycleOwner) { updateErrorMessage(it) }
+    }
+
+    private fun observeOkEnabledData() {
+        editHandleViewModel.okEnabledLiveData.observe(viewLifecycleOwner) { editHandleDialogOkButton.isEnabled = it }
+    }
+
+    private fun observeDismissData() {
+        editHandleViewModel.dismissLiveData.observe(viewLifecycleOwner) { dismiss() }
     }
 
     private fun updateSuccessMessage() {

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailFragment.kt
@@ -1,9 +1,7 @@
 package com.waz.zclient.features.settings.devices.detail
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
@@ -14,31 +12,39 @@ import com.waz.zclient.features.settings.devices.ClientItem
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE_ID
 import kotlinx.android.synthetic.main.fragment_device_detail.*
 
-class SettingsDeviceDetailFragment : Fragment() {
+class SettingsDeviceDetailFragment : Fragment(R.layout.fragment_device_detail) {
 
     private val deviceDetailsViewModel by viewModel<SettingsDeviceDetailViewModel>(SETTINGS_SCOPE_ID)
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val rootView = inflater.inflate(R.layout.fragment_device_detail, container, false)
-        initViewModel()
-        return rootView
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeCurrentDeviceData()
+        observeLoadingData()
+        observeErrorData()
+        loadData()
     }
 
-    private fun initViewModel() {
-        with(deviceDetailsViewModel) {
-            currentDevice.observe(viewLifecycleOwner) { clientItem ->
-                bindDataToView(clientItem)
-            }
-
-            loading.observe(viewLifecycleOwner) { isLoading ->
-                bindLoading(isLoading)
-            }
-
-            error.observe(viewLifecycleOwner) { errorMessage ->
-                bindError(errorMessage)
-            }
+    private fun loadData(){
+        lifecycleScope.launchWhenResumed {
+            val id = arguments?.getString(DEVICE_ID_BUNDLE_KEY)
+            id?.let { deviceDetailsViewModel.loadData(it) }
         }
     }
+
+    private fun observeCurrentDeviceData() =
+        deviceDetailsViewModel.currentDevice.observe(viewLifecycleOwner) { clientItem ->
+            bindDataToView(clientItem)
+        }
+
+    private fun observeLoadingData() =
+        deviceDetailsViewModel.loading.observe(viewLifecycleOwner) { isLoading ->
+            bindLoading(isLoading)
+        }
+
+    private fun observeErrorData() =
+        deviceDetailsViewModel.error.observe(viewLifecycleOwner) { errorMessage ->
+            bindError(errorMessage)
+        }
 
     private fun bindError(errorMessage: String?) {
         //Show error when we need to
@@ -52,14 +58,6 @@ class SettingsDeviceDetailFragment : Fragment() {
         device_detail_id.text = clientItem.client.id
         device_detail_name.text = clientItem.client.label
         device_detail_activated.text = clientItem.client.time
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        lifecycleScope.launchWhenResumed {
-            val id = arguments?.getString(DEVICE_ID_BUNDLE_KEY)
-            id?.let { deviceDetailsViewModel.loadData(it) }
-        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailFragment.kt
@@ -24,7 +24,7 @@ class SettingsDeviceDetailFragment : Fragment(R.layout.fragment_device_detail) {
         loadData()
     }
 
-    private fun loadData(){
+    private fun loadData() {
         lifecycleScope.launchWhenResumed {
             val id = arguments?.getString(DEVICE_ID_BUNDLE_KEY)
             id?.let { deviceDetailsViewModel.loadData(it) }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/devices/list/SettingsDeviceListFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/devices/list/SettingsDeviceListFragment.kt
@@ -13,10 +13,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.viewModel
 import com.waz.zclient.core.ui.list.RecyclerViewItemClickListener
+import com.waz.zclient.features.settings.devices.ClientItem
 import com.waz.zclient.features.settings.devices.detail.SettingsDeviceDetailActivity
 import com.waz.zclient.features.settings.devices.list.adapter.DevicesRecyclerViewAdapter
 import com.waz.zclient.features.settings.devices.list.adapter.DevicesViewHolder
-import com.waz.zclient.features.settings.devices.ClientItem
 import com.waz.zclient.features.settings.di.SETTINGS_SCOPE_ID
 
 class SettingsDeviceListFragment : Fragment() {
@@ -42,12 +42,19 @@ class SettingsDeviceListFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val rootView = inflater.inflate(R.layout.fragment_settings_devices, container, false)
         initRecyclerView(rootView)
-        initViewModel()
         return rootView
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        observeCurrentDeviceData()
+        observeOtherDevicesData()
+        observeLoadingData()
+        observeErrorData()
+        loadData()
+    }
+
+    private fun loadData() {
         lifecycleScope.launchWhenResumed {
             deviceListViewModel.loadData()
         }
@@ -63,20 +70,27 @@ class SettingsDeviceListFragment : Fragment() {
         singleDeviceViewHolder = DevicesViewHolder(rootView)
     }
 
-    private fun initViewModel() {
-        with(deviceListViewModel) {
-            loading.observe(viewLifecycleOwner) { isLoading ->
-                updateLoadingVisibility(isLoading)
-            }
-            error.observe(viewLifecycleOwner) { errorMessage ->
-                showErrorMessage(errorMessage)
-            }
-            currentDevice.observe(viewLifecycleOwner) { currentDevice ->
-                bindCurrentDevice(currentDevice)
-            }
-            otherDevices.observe(viewLifecycleOwner) { otherDevices ->
-                devicesAdapter.updateList(otherDevices)
-            }
+    private fun observeCurrentDeviceData() {
+        deviceListViewModel.currentDevice.observe(viewLifecycleOwner) { currentDevice ->
+            bindCurrentDevice(currentDevice)
+        }
+    }
+
+    private fun observeOtherDevicesData() {
+        deviceListViewModel.otherDevices.observe(viewLifecycleOwner) { otherDevices ->
+            devicesAdapter.updateList(otherDevices)
+        }
+    }
+
+    private fun observeLoadingData() {
+        deviceListViewModel.loading.observe(viewLifecycleOwner) { isLoading ->
+            updateLoadingVisibility(isLoading)
+        }
+    }
+
+    private fun observeErrorData() {
+        deviceListViewModel.error.observe(viewLifecycleOwner) { errorMessage ->
+            showErrorMessage(errorMessage)
         }
     }
 

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/support/SettingsSupportFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/support/SettingsSupportFragment.kt
@@ -17,9 +17,9 @@ class SettingsSupportFragment : Fragment(R.layout.fragment_settings_support) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initToolbar()
-        initViewModel()
         initSupportWebsiteButton()
         initSupportContactButton()
+        observeUrlData()
     }
 
     private fun initSupportContactButton() {
@@ -34,7 +34,7 @@ class SettingsSupportFragment : Fragment(R.layout.fragment_settings_support) {
         }
     }
 
-    private fun initViewModel() {
+    private fun observeUrlData() {
         settingsSupportViewModel.urlLiveData.observe(viewLifecycleOwner) {
             openUrl(it.url)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

In some Kotlin classes, we are telling about implementing details in function names e.i. `initViewModel()`

### Solutions

Rename to something around the functionality i.e. `observeData() `

https://wearezeta.atlassian.net/browse/AN-6735

#### APK
[Download build #1495](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1495/artifact/build/artifact/wire-dev-PR2668-1495.apk)