### PR TITLE
Kotlin Code Review : moving layout id's to the constructor of activities/fragments

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/features/auth/registration/CreateAccountActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/auth/registration/CreateAccountActivity.kt
@@ -10,7 +10,7 @@ import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.features.auth.registration.di.REGISTRATION_SCOPE
 import com.waz.zclient.features.auth.registration.di.REGISTRATION_SCOPE_ID
 
-class CreateAccountActivity : AppCompatActivity() {
+class CreateAccountActivity : AppCompatActivity(R.layout.activity_create_account) {
 
     private val scope = createScope(
         scopeId = REGISTRATION_SCOPE_ID,
@@ -19,7 +19,6 @@ class CreateAccountActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_create_account)
         replaceFragment(R.id.activityCreateAccountLayoutContainer, CreateAccountFragment.newInstance(), false)
     }
 

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/account/editphonenumber/EditPhoneNumberActivity.kt
@@ -8,7 +8,7 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.replaceFragment
 import kotlinx.android.synthetic.main.activity_edit_phone.*
 
-class EditPhoneNumberActivity : AppCompatActivity() {
+class EditPhoneNumberActivity : AppCompatActivity(R.layout.activity_edit_phone) {
 
     private val phoneNumber: String by lazy {
         intent.getStringExtra(CURRENT_PHONE_NUMBER_KEY)
@@ -20,7 +20,6 @@ class EditPhoneNumberActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_edit_phone)
         setSupportActionBar(editPhoneActivityToolbar)
 
         replaceFragment(

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/devices/detail/SettingsDeviceDetailActivity.kt
@@ -8,11 +8,10 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.replaceFragment
 import kotlinx.android.synthetic.main.activity_device_detail.*
 
-class SettingsDeviceDetailActivity : AppCompatActivity() {
+class SettingsDeviceDetailActivity : AppCompatActivity(R.layout.activity_device_detail) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_device_detail)
         initToolbar()
         startDeviceDetailsFragment()
     }

--- a/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/features/settings/main/SettingsMainActivity.kt
@@ -13,7 +13,7 @@ import kotlinx.android.synthetic.main.activity_settings.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
-class SettingsMainActivity : AppCompatActivity() {
+class SettingsMainActivity : AppCompatActivity(R.layout.activity_settings) {
 
     private val scope = createScope(
         scopeId = SETTINGS_SCOPE_ID,
@@ -25,7 +25,6 @@ class SettingsMainActivity : AppCompatActivity() {
     //TODO Method level annotations as this is the top of the chain
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_settings)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(R.id.activitySettingsMainLayoutContainer, SettingsMainFragment.newInstance())

--- a/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
@@ -14,7 +14,7 @@ import kotlinx.android.synthetic.main.activity_settings_about.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
-class SettingsAboutActivity : AppCompatActivity() {
+class SettingsAboutActivity : AppCompatActivity(R.layout.activity_settings_about) {
 
     private val scope = createScope(
         scopeId = SETTINGS_SCOPE_ID,
@@ -25,7 +25,6 @@ class SettingsAboutActivity : AppCompatActivity() {
     @InternalCoroutinesApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_settings_about)
         setSupportActionBar(activitySettingsAboutToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(R.id.activitySettingsAboutLayoutContainer, SettingsAboutFragment.newInstance(), false)

--- a/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
@@ -14,7 +14,7 @@ import kotlinx.android.synthetic.main.activity_settings_support.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
-class SettingsSupportActivity : AppCompatActivity() {
+class SettingsSupportActivity : AppCompatActivity(R.layout.activity_settings_support) {
 
     private val scope = createScope(
         scopeId = SETTINGS_SCOPE_ID,
@@ -25,7 +25,6 @@ class SettingsSupportActivity : AppCompatActivity() {
     @InternalCoroutinesApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_settings_support)
         setSupportActionBar(activitySettingsSupportToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(R.id.activitySettingsSupportLayoutContainer, SettingsSupportFragment.newInstance(), false)


### PR DESCRIPTION
## What's new in this PR?

### Issues

No need to set the layout ID in `setContentView` inside Activities and `onCreateView` inside Fragments

### Solutions

Pass layout ID’s the constructor of Activities/Fragments

https://wearezeta.atlassian.net/browse/AN-6736

