### PR TITLE
fix: A fix to IndexOutOfBoundsException in PagedStorageDiffHelper

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -98,10 +98,14 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
 
 object MessagePagedListController {
   case class PagedListConfig(pageSize: Int, initialLoadSizeHint: Int, prefetchDistance: Int) {
+    /**
+     * The reason why placeholders are disabled is taken from this Stackoverflow answer to a bug:
+     * https://stackoverflow.com/a/56873666/2975925
+     */
     lazy val config = new PagedList.Config.Builder()
       .setPageSize(pageSize)
       .setInitialLoadSizeHint(initialLoadSizeHint)
-      .setEnablePlaceholders(true)
+      .setEnablePlaceholders(false)
       .setPrefetchDistance(prefetchDistance)
       .build()
   }

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesPagedListAdapter.scala
@@ -18,7 +18,7 @@
 package com.waz.zclient.messages
 
 import android.view.ViewGroup
-import androidx.paging.{PagedList, PagedListAdapter}
+import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
@@ -78,10 +78,6 @@ class MessagesPagedListAdapter()(implicit ec: EventContext, inj: Injector)
     ds <- Option(list.getDataSource)
     pos <- if(convInfo.lastRead.isEpoch) None else ds.asInstanceOf[MessageDataSource].positionForMessage(convInfo.lastRead)
   } yield pos).getOrElse(-1)
-
-  override def onCurrentListChanged(currentList: PagedList[MessageAndLikes]): Unit = {
-    super.onCurrentListChanged(currentList)
-  }
 
   def positionForMessage(mId: MessageId): Option[Int] = for {
     list <- Option(getCurrentList)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,7 +26,7 @@ object Versions {
     const val ANDROIDX_CARD_VIEW = "1.0.0"
     const val ANDROIDX_GRID_LAYOUT = "1.0.0"
     const val ANDROIDX_CONSTRAINT_LAYOUT = "1.1.3"
-    const val ANDROIDX_PAGING_RUNTIME = "2.0.0"
+    const val ANDROIDX_PAGING_RUNTIME = "2.1.1"
     const val ANDROIDX_EXIF_INTERFACE = "1.0.0"
     const val ANDROIDX_MEDIA = "1.0.0"
     const val ANDROIDX_LIFECYCLE = "2.2.0-rc03"


### PR DESCRIPTION
This happens because of the AndroidX bug, described here:
https://stackoverflow.com/questions/55546116/room-livedata-with-paging-getting-indexoutofboundsexception-in-some-devices
The bug is currently the main source of crashes, according to Google Play Console.

The suggested fix is to update the androidx.paging library to 2.1.1 (from 2.0.0) and to disable null placeholders when building a paged list config (in MessagePagedListController).

Testing: As far as I understand, disabling null placeholders may mean slower performance of scrolling through the messages' list in the conversation or may result in some glitches during the scrolling (can someone confirm this?).
Please go to a long conversation and scroll fast up and down.
Take note than on a dev build the scrolling may display some performance problems anyway, so in case of glitches please compare with a dev build without this fix.

#### APK
[Download build #1488](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1488/artifact/build/artifact/wire-dev-PR2673-1488.apk)