### PR TITLE
Feat: Buttons - Add migration for new Buttons table & change UserDatabase version

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/ButtonEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/ButtonEntity.kt
@@ -19,5 +19,5 @@ data class ButtonEntity(
     val state: Int,
 
     @ColumnInfo(name = "error")
-    val error: String
+    val error: String?
 )

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -33,7 +33,6 @@ import com.waz.zclient.storage.db.properties.PropertiesEntity
 import com.waz.zclient.storage.db.sync.SyncJobsEntity
 import com.waz.zclient.storage.db.userclients.UserClientsEntity
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.db.users.model.UserEntity
 import com.waz.zclient.storage.db.users.model.UserPreferenceEntity
 import com.waz.zclient.storage.db.users.service.UserDao
@@ -59,9 +58,9 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun clientsDbService(): ClientsDao
 
     companion object {
-        const val VERSION = 128
+        const val VERSION = 127
 
         @JvmStatic
-        val migrations = arrayOf(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        val migrations = arrayOf(USER_DATABASE_MIGRATION_126_TO_127)
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabaseMigration.kt
@@ -1,12 +1,10 @@
-@file:Suppress("MagicNumber", "NoBlankLineBeforeRbrace", "NoConsecutiveBlankLines", "FinalNewline")
+@file:Suppress("MagicNumber")
 package com.waz.zclient.storage.db.users.migration
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.waz.zclient.storage.BuildConfig
 
-private const val START_VERSION = 126
-private const val END_VERSION = 128
 private const val KEY_VALUES_TEMP_NAME = "KeyValuesTemp"
 private const val KEY_VALUES_TABLE_NAME = "KeyValues"
 
@@ -30,7 +28,7 @@ private const val NEW_CLIENT_LOCATION_NAME_KEY = "locationName"
 private const val NEW_CLIENT_TIME_KEY = "time"
 private const val NEW_CLIENT_TYPE_KEY = "type"
 
-val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(START_VERSION, 127) {
+val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(126, 127) {
     override fun migrate(database: SupportSQLiteDatabase) {
         if (BuildConfig.KOTLIN_CORE) {
             migrateClientTable(database)
@@ -39,6 +37,7 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(START_VERSION, 127) 
 
         //Needed in production
         migrateUserTable(database)
+        createButtonsTable(database)
     }
 
     //TODO still needs determining what to do with this one.
@@ -119,11 +118,14 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(START_VERSION, 127) 
             execSQL(renameTableBack)
         }
     }
-}
 
-val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, END_VERSION) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        // just a new table: ButtonEntity
+    private fun createButtonsTable(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS `Buttons` (
+                `message_id` TEXT NOT NULL, `button_id` TEXT NOT NULL, `title` TEXT NOT NULL, `state` INTEGER NOT NULL, 
+                `error` TEXT, 
+                PRIMARY KEY(`message_id`, `button_id`)
+            )""".trimIndent()
+        )
     }
-
 }


### PR DESCRIPTION
Bug: https://wearezeta.atlassian.net/browse/AN-6739
Feature: https://wearezeta.atlassian.net/browse/AN-6727

## What's new in this PR?

### Issues

We need to add a migration when a new table ("Buttons") is added to database.

I also changed the UserDatabase version number to 127, and moved all the migrations to Migration 126-127, since on production the current database number is 126 (ZMessagingDB version on commit tagged as 3.46), and it is more clear to increment it by 1 in every release, for future reference.


#### APK
[Download build #1490](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1490/artifact/build/artifact/wire-dev-PR2674-1490.apk)