### PR TITLE
refactor: Automate turning collections of Identifiables into maps

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/AccentColor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/AccentColor.scala
@@ -21,8 +21,10 @@ import android.content.Context
 import android.graphics.Color
 import com.waz.log.LogShow.SafeToLog
 import com.waz.model.AccentColor._
+import com.waz.utils.Identifiable
 
-case class AccentColor(id: Int, r: Int, g: Int, b: Int, a: Int) extends SafeToLog {
+case class AccentColor(override val id: Int, r: Int, g: Int, b: Int, a: Int)
+  extends SafeToLog with Identifiable[Int] {
   def this(id: Int, r: Double, g: Double, b: Double, a: Double) = this(id, int(r), int(g), int(b), int(a))
 
   lazy val color = Color.argb(a, r, g, b)
@@ -46,7 +48,7 @@ object AccentColor {
 
   private val Default = new AccentColor(1, 0.141, 0.552, 0.827, 1)
 
-  private[AccentColor] var colors = Array(
+  private[AccentColor] var colors = Vector(
     new AccentColor(1, 0.141, 0.552, 0.827, 1),
     new AccentColor(2, 0, 0.784, 0, 1),
     new AccentColor(3, 1, 0.823, 0, 1),
@@ -56,19 +58,19 @@ object AccentColor {
     new AccentColor(7, 0.615, 0, 1, 1)
   )
 
-  private[AccentColor] var colorsMap = Map(0 -> Default) ++ colors.map(c => c.id -> c).toMap
+  private[AccentColor] var colorsMap = Map(0 -> Default) ++ colors.toIdMap
 
   def defaultColor = colorsMap.getOrElse(0, Default)
 
-  def getColors: Array[AccentColor] = colors
+  def getColors: Vector[AccentColor] = colors
 
-  def setColors(arr: Array[AccentColor]): Unit = {
-    colors = arr
+  def setColors(newColors: Vector[AccentColor]): Unit = {
+    colors = newColors
     colorsMap = Map(0 -> colors.headOption.getOrElse(Default)) ++ colors.map(c => c.id -> c).toMap
   }
 
-  def loadArray(context: Context, colorsArrayId: Int): Array[AccentColor] =
-    context.getResources.getIntArray(colorsArrayId).zipWithIndex map { case (color, id) => create(id + 1, color) }
+  def loadArray(context: Context, colorsArrayId: Int): Vector[AccentColor] =
+    context.getResources.getIntArray(colorsArrayId).zipWithIndex.map { case (color, id) => create(id + 1, color) }.toVector
 
   def create(id: Int, color: Int): AccentColor =
     new AccentColor(id, Color.red(color), Color.green(color), Color.blue(color), Color.alpha(color))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -80,15 +80,15 @@ object Location {
  * @param signalingKey - will only be set for current device
  * @param verified - client verification state, updated when user verifies client fingerprint
  */
-case class Client(id: ClientId,
-                  label: String,
-                  model: String = "",
-                  regTime: Option[Instant] = None,
-                  regLocation: Option[Location] = None,
-                  regIpAddress: Option[String] = None,
-                  signalingKey: Option[SignalingKey] = None,
-                  verified: Verification = Verification.UNKNOWN,
-                  devType: OtrClientType = OtrClientType.PHONE) {
+case class Client(override val id: ClientId,
+                  label:           String,
+                  model:           String = "",
+                  regTime:         Option[Instant] = None,
+                  regLocation:     Option[Location] = None,
+                  regIpAddress:    Option[String] = None,
+                  signalingKey:    Option[SignalingKey] = None,
+                  verified:        Verification = Verification.UNKNOWN,
+                  devType:         OtrClientType = OtrClientType.PHONE) extends Identifiable[ClientId] {
 
   def isVerified = verified == Verification.VERIFIED
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncJob.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncJob.scala
@@ -33,15 +33,16 @@ import scala.collection.breakOut
 import scala.util.Try
 
 case class SyncJob(override val id:        SyncId,
-                   request:   SyncRequest,
-                   dependsOn: Set[SyncId]           = Set(),
-                   priority:  Int                   = SyncJob.Priority.Normal,
-                   timestamp: Long                  = SyncJob.timestamp,
-                   startTime: Long                  = 0, // next scheduled execution time
-                   attempts:  Int                   = 0,
-                   offline:   Boolean               = false,
-                   state:     SyncState             = SyncState.WAITING,
-                   error:     Option[ErrorResponse] = None) extends Identifiable[SyncId] {
+                                request:   SyncRequest,
+                                dependsOn: Set[SyncId]           = Set(),
+                                priority:  Int                   = SyncJob.Priority.Normal,
+                                timestamp: Long                  = SyncJob.timestamp,
+                                startTime: Long                  = 0, // next scheduled execution time
+                                attempts:  Int                   = 0,
+                                offline:   Boolean               = false,
+                                state:     SyncState             = SyncState.WAITING,
+                                error:     Option[ErrorResponse] = None)
+  extends Identifiable[SyncId] {
 
   def mergeKey = request.mergeKey
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncJob.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncJob.scala
@@ -26,13 +26,13 @@ import com.waz.db.Dao
 import com.waz.model.SyncId
 import com.waz.sync.queue.SyncJobMerger.{MergeResult, Merged, Unchanged, Updated}
 import com.waz.utils.wrappers.DBCursor
-import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 
 import scala.collection.breakOut
 import scala.util.Try
 
-case class SyncJob(id:        SyncId,
+case class SyncJob(override val id:        SyncId,
                    request:   SyncRequest,
                    dependsOn: Set[SyncId]           = Set(),
                    priority:  Int                   = SyncJob.Priority.Normal,
@@ -41,7 +41,7 @@ case class SyncJob(id:        SyncId,
                    attempts:  Int                   = 0,
                    offline:   Boolean               = false,
                    state:     SyncState             = SyncState.WAITING,
-                   error:     Option[ErrorResponse] = None) {
+                   error:     Option[ErrorResponse] = None) extends Identifiable[SyncId] {
 
   def mergeKey = request.mergeKey
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -265,7 +265,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
 
       for {
         allUsers <- usersStorage.listAll(convsInfo.map(_.toUser))
-        userMap   = allUsers.map(u => u.id -> Vector(u)).toMap
+        userMap   = allUsers.toIdMap
         remoteIds = convsInfo.map(i => convIdForUser(i.toUser) -> i.remoteId).toMap
         newConvs  = convsInfo.map {
           case OneToOneConvData(toUser, remoteId, convType) =>
@@ -276,7 +276,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
               name          = None,
               creator       = selfUserId,
               convType      = convType,
-              generatedName = NameUpdater.generatedName(convType)(userMap(toUser)),
+              generatedName = NameUpdater.generatedName(convType)(Seq(userMap(toUser))),
               team          = teamId,
               access        = Set(Access.PRIVATE),
               accessRole    = Some(AccessRole.PRIVATE)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -196,7 +196,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
                      messages.addAssetMessage(convId, messageId, rawAsset, rr, exp)
                    }
       _         <- updateLastRead(msgs.toList.maxBy(_.time))
-      msgMap    =  msgs.map(m => m.id -> m).toMap
+      msgMap    =  msgs.toIdMap
       _         <- Future.traverse(assetMap) { case (messageId, rawAsset) =>
                      val message = msgMap(messageId)
                      checkSize(convId, rawAsset, message, confirmation).flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -83,7 +83,7 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
       newFolders      <- Future.sequence(folders.map { case RemoteFolderData(data, rConvIds) =>
         conversationStorage.getByRemoteIds(rConvIds).map(ids => data.id -> (data, ids.toSet))
       }).map(_.toMap)
-      currentFolders  <- foldersStorage.list().map(_.map(folder => folder.id -> folder).toMap)
+      currentFolders  <- foldersStorage.list().map(_.toIdMap)
       foldersToDelete =  currentFolders.keySet -- newFolders.keySet
       _               <- Future.sequence(foldersToDelete.map(removeFolder(_, false)))
       foldersToAdd    =  newFolders.filterKeys(id => !currentFolders.contains(id)).values

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
@@ -56,7 +56,7 @@ class VerificationStateUpdater(selfUserId:     UserId,
   }
 
   clientsStorage.getClients(selfUserId).map{ clients =>
-    onClientsChanged(Map(selfUserId -> (UserClients(selfUserId, clients.map(c => c.id -> c).toMap), ClientAdded)))
+    onClientsChanged(Map(selfUserId -> (UserClients(selfUserId, clients.toIdMap), ClientAdded)))
   }
 
   clientsStorage.onAdded { ucs =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -300,7 +300,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
 
     messages.getAll(reactions.map(_.message).toSet).map(_.flatten).map { msgs =>
 
-      val msgsById = msgs.map(m => m.id -> m).toMap
+      val msgsById = msgs.toIdMap
       val convsByMsg = msgs.iterator.by[MessageId, Map](_.id).mapValues(_.convId)
       val myMsgs = msgs.collect { case m if m.userId == selfUserId => m.id }.toSet
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -33,6 +33,7 @@ import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
+
 /**
  * Keeps actual SyncJobs in memory, and persists all changes to db.
  * Handles merging of new requests, only adds new jobs if actually needed.
@@ -102,7 +103,7 @@ class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater with Deriv
       syncStorage.onRemoved { job => onChange ! Del(job) }
     }
 
-    new AggregatingSignal[Cmd, Map[SyncId, SyncJob]](onChange, listSyncJobs.map(_.map(j => j.id -> j).toMap), { (jobs, cmd) =>
+    new AggregatingSignal[Cmd, Map[SyncId, SyncJob]](onChange, listSyncJobs.map(_.toIdMap), { (jobs, cmd) =>
       cmd match {
         case Add(job) => jobs + (job.id -> job)
         case Del(job) => jobs - job.id

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
@@ -34,10 +34,6 @@ import scala.collection.generic._
 import scala.collection.{GenTraversableOnce, Seq, breakOut, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Identifiable[K] {
-  def id: K
-}
-
 trait StorageDao[K, V <: Identifiable[K]] {
   def getById(key: K)(implicit db: DB): Option[V]
   def getAll(keys: Set[K])(implicit db: DB): Seq[V]
@@ -170,10 +166,10 @@ class ReactiveStorageImpl2[K, V <: Identifiable[K]](storage: Storage2[K,V]) exte
   override def loadAll(keys: Set[K]): Future[Seq[V]] = storage.loadAll(keys)
 
   override def saveAll(values: Iterable[V]): Future[Unit] = {
-    val valuesByKey = values.map(v => v.id -> v).toMap
+    val valuesByKey = values.toIdMap
     for {
       loadedValues <- loadAll(valuesByKey.keySet)
-      loadedValuesByKey = loadedValues.map(v => v.id -> v).toMap
+      loadedValuesByKey = loadedValues.toIdMap
       toSave = Vector.newBuilder[V]
       added = Vector.newBuilder[V]
       updated = Vector.newBuilder[(V, V)]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/package.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/package.scala
@@ -323,4 +323,14 @@ package object utils {
     def :&(k: String, v: String): URIBuilder = :?(k, v)
     def :&(k: String, v: Option[String]): URIBuilder = :?(k, v)
   }
+
+  trait Identifiable[K] {
+    def id: K
+  }
+
+  object Identifiable {
+    implicit class RichIdentifiable[V](val idfs: Iterable[V]) extends AnyVal {
+      def toIdMap[K](implicit ev: V <:< Identifiable[K]): Map[K, V] = idfs.map(idf => idf.id -> idf).toMap
+    }
+  }
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/ConversationRolesServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/ConversationRolesServiceSpec.scala
@@ -78,7 +78,7 @@ class ConversationRolesServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     insertAll(vs.toSeq).map(_ => vs.toSet)
   }
 
-  (storage.contents _).expects().anyNumberOfTimes().returning(roleActions.map(_.map(v => v.id -> v).toMap))
+  (storage.contents _).expects().anyNumberOfTimes().returning(roleActions.map(_.toIdMap))
 
   feature("Manage conversation roles") {
 


### PR DESCRIPTION
I made a small Scala exercise on the side and was able to hide one common operation under the hood.

In Scala code we have many classes which implement `Identifiable[K]`. It means that in the given class there is one or two (and in theory more) fields which serve as a unique identifier, and then `K` is the type of that field, or a tuple of them both. Usually those classes are the ones with corresponding db tables (`UserData`, `ConversationData`, ...) but it's not limited to them.

In many places in our code we retrieve a collection of instances of one of those classes and then turn it into a map where keys are identifiers and values are the instances themselves. It's a bit redundant, but it helps in performance and readability. With help from the Polish #scala slack channel I was ableto put that transformation in one implicit (i.e. extension) method, `toIdMap`.

It's just a small refactoring thanks to Scala type system magic. It's low priority. Feel free to just
look at the code and ask questions if you're interested, and we can either merge it or close it later on.

The new `toIdMap` method is like a Kotlin extension method added to the `Iterable` trait, which is a supertrait of almost all Scala collections, except `Array` and maybe a few others. (That's why I had to change `Array` to `Vector` in case of `AccentColor`s).
But `toIdMap` will be added only to collections of elements which are Identifiable. That was the tricky part. For elements which don't have the `Identifiable` trait this method won't work, so I don't even want it appear on the list of methods for such collections.

#### APK
[Download build #1503](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1503/artifact/build/artifact/wire-dev-PR2677-1503.apk)