### PR TITLE
feat: Delete buttons when deleting messages

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
@@ -13,6 +13,7 @@ import scala.concurrent.Future
 
 trait ButtonsStorage extends CachedStorage[(MessageId, ButtonId), ButtonData] {
   def findByMessage(messageId: MessageId): Future[Seq[ButtonData]]
+  def deleteAllForMessage(messageId: MessageId): Future[Unit]
 }
 
 class ButtonsStorageImpl(context: Context, storage: Database)
@@ -22,4 +23,9 @@ class ButtonsStorageImpl(context: Context, storage: Database)
 
   override def findByMessage(messageId: MessageId): Future[Seq[ButtonData]] =
     find(_.messageId == messageId, ButtonDataDao.findForMessage(messageId)(_), identity)
+
+  override def deleteAllForMessage(messageId: MessageId): Future[Unit] = for {
+    buttons <- findByMessage(messageId)
+    _       <- removeAll(buttons.map(_.id))
+  } yield ()
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -339,7 +339,7 @@ class MessageEventProcessor(selfUserId:           UserId,
   private def addButtons(richMessages: Seq[RichMessage]) = {
     val msgsWithButtons = richMessages.filter(_.buttons.nonEmpty)
     if (msgsWithButtons.nonEmpty)
-      Future.sequence(msgsWithButtons.map(m => msgsService.addButtons(m.buttons)))
+      Future.sequence(msgsWithButtons.map(m => contentUpdater.addButtons(m.buttons)))
     else Future.successful(())
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -36,15 +36,24 @@ import scala.concurrent.duration._
 class MessagesContentUpdater(messagesStorage: MessagesStorage,
                              convs:           ConversationStorage,
                              deletions:       MsgDeletionStorage,
+                             buttonsStorage:  ButtonsStorage,
                              prefs:           GlobalPreferences) extends DerivedLogTag {
 
   import Threading.Implicits.Background
 
   def getMessage(msgId: MessageId) = messagesStorage.getMessage(msgId)
 
-  def deleteMessage(msg: MessageData) = messagesStorage.delete(msg)
+  def deleteMessage(msg: MessageData) = for {
+    _ <- messagesStorage.delete(msg)
+   _  <- if (msg.msgType == Message.Type.COMPOSITE) buttonsStorage.deleteAllForMessage(msg.id)
+         else Future.successful(())
+  } yield ()
 
-  def deleteMessagesForConversation(convId: ConvId): Future[Unit] = messagesStorage.deleteAll(convId)
+  def deleteMessagesForConversation(convId: ConvId): Future[Unit] = for {
+    msgIds <- messagesStorage.findMessageIds(convId)
+    _      <- messagesStorage.deleteAll(convId)
+    _      <- Future.sequence(msgIds.map(buttonsStorage.deleteAllForMessage))
+  } yield ()
 
   def updateMessage(id: MessageId)(updater: MessageData => MessageData): Future[Option[MessageData]] = messagesStorage.update(id, updater) map {
     case Some((msg, updated)) if msg != updated =>
@@ -56,11 +65,16 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
 
   // removes messages and records deletion
   // this is used when user deletes a message manually (on local or remote device)
-  def deleteOnUserRequest(ids: Seq[MessageId]) =
-    deletions.insertAll(ids.map(id => MsgDeletion(id, now(clock)))) flatMap { _ =>
-      messagesStorage.removeAll(ids)
-    }
+  def deleteOnUserRequest(ids: Seq[MessageId]) = for {
+    _ <- deletions.insertAll(ids.map(id => MsgDeletion(id, now(clock))))
+    _ <- messagesStorage.removeAll(ids)
+    _ <- Future.sequence(ids.map(buttonsStorage.deleteAllForMessage))
+  } yield ()
 
+  def addButtons(buttons: Seq[ButtonData]): Future[Unit] = {
+    val newButtons = buttons.map(b => b.id -> b).toMap
+    buttonsStorage.updateOrCreateAll2(newButtons.keys, { (id, _) => newButtons(id) }).map(_ => ())
+  }
   /**
     * @param exp ConvExpiry takes precedence over one-time expiry (exp), which takes precedence over the MessageExpiry
     */

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -91,7 +91,6 @@ trait MessagesService {
 
   def getAssetIds(messageIds: Set[MessageId]): Future[Set[GeneralAssetId]]
 
-  def addButtons(buttons: Seq[ButtonData]): Future[Unit]
   def buttonsForMessage(msgId: MessageId): Signal[Seq[ButtonData]]
 }
 
@@ -499,11 +498,6 @@ class MessagesServiceImpl(selfUserId:      UserId,
   override def findMessageIds(convId: ConvId): Future[Set[MessageId]] = storage.findMessageIds(convId)
 
   override def getAssetIds(messageIds: Set[MessageId]): Future[Set[GeneralAssetId]] = storage.getAssetIds(messageIds)
-
-  override def addButtons(buttons: Seq[ButtonData]): Future[Unit] = {
-    val newButtons = buttons.map(b => b.id -> b).toMap
-    buttonsStorage.updateOrCreateAll2(newButtons.keys, { (id, _) => newButtons(id) }).map(_ => ())
-  }
 
   override def buttonsForMessage(msgId: MessageId): Signal[Seq[ButtonData]] = RefreshingSignal[Seq[ButtonData]](
     loader       = CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
@@ -54,7 +54,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
   lazy val prefs =         new TestGlobalPreferences()
 
   def getService = {
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
     new MessagesServiceImpl(selfUserId, None, replyHashing, storage, updater, edits, convs, network, members, users, buttons, sync)
   }
 
@@ -129,6 +129,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
     (storage.getMessage _).expects(messageId).returning(Future.successful(Some(msg)))
     (deletions.insertAll _).expects(Seq(deletion)).returning(Future.successful(Set(deletion)))
     (storage.removeAll _).expects(Seq(messageId)).returning(Future.successful(()))
+    (buttons.deleteAllForMessage _).expects(messageId).atLeastOnce().returning(Future.successful(()))
 
     val recalledMessage = Await.result(service.recallMessage(convId, messageId, selfUserId, time = now), 1.second)
 
@@ -165,6 +166,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
     (storage.getMessage _).expects(messageId).returning(Future.successful(Some(msg)))
     (deletions.insertAll _).expects(Seq(deletion)).returning(Future.successful(Set(deletion)))
     (storage.removeAll _).expects(Seq(messageId)).returning(Future.successful(()))
+    (buttons.deleteAllForMessage _).expects(messageId).returning(Future.successful(()))
 
     val recalledMessage = Await.result(service.recallMessage(convId, messageId, selfUserId, time = now), 1.second)
 
@@ -201,6 +203,7 @@ class MessagesServiceSpec extends AndroidFreeSpec {
     val editHistory = EditHistory(messageId, messageId2, now)
 
     (storage.getMessage _).expects(messageId).returning(Future.successful(Some(msg)))
+    (buttons.deleteAllForMessage _).expects(messageId).returning(Future.successful(Nil))
     (edits.insert _).expects(editHistory).returning(Future.successful(editHistory))
     (deletions.getAll _).expects(Seq(messageId2)).returning(Future.successful(Seq(None)))
     (storage.updateOrCreate _).expects(*, *, *).onCall { (_, updater, _) => Future.successful(updater(msg)) }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
@@ -63,16 +63,16 @@ class ConversationServiceSpec extends AndroidFreeSpec {
   private lazy val network        = mock[NetworkModeService]
   private lazy val properties     = mock[PropertiesService]
   private lazy val deletions      = mock[MsgDeletionStorage]
+  private lazy val buttons        = mock[ButtonsStorage]
   private lazy val rolesService   = mock[ConversationRolesService]
 
   private lazy val globalPrefs    = new TestGlobalPreferences()
   private lazy val userPrefs      = new TestUserPreferences()
-  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, globalPrefs)
+  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, buttons, globalPrefs)
 
   private val selfUserId = UserId("user1")
   private val convId = ConvId("conv_id1")
   private val rConvId = RConvId("r_conv_id1")
-  private val convsInStorage = Signal[Map[ConvId, ConversationData]]()
 
   private lazy val service = new ConversationsServiceImpl(
     None,
@@ -236,6 +236,7 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (messages.findMessageIds _).expects(convId).once().returning(Future.successful(Set.empty))
       (messages.getAssetIds _).expects(*).returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
+      (convsStorage.remove _).expects(convId).once().returning(Future.successful(()))
 
       val dummyUserId = UserId()
       val events = Seq(
@@ -262,6 +263,7 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
       (messages.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (msgStorage.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
       (messages.getAssetIds _).expects(*).returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
@@ -286,6 +288,7 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
       (messages.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (msgStorage.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
       (messages.getAssetIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[GeneralAssetId]()))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.remove _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
@@ -338,7 +341,6 @@ class ConversationServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(()))
 
       val messageId = MessageId()
-      (messages.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set(messageId)))
       (messages.getAssetIds _).expects(Set(messageId)).anyNumberOfTimes()
         .returning(Future.successful(Set[GeneralAssetId]()))
 
@@ -348,6 +350,9 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (msgStorage.deleteAll _).expects(convId).once().returning(Future.successful(()))
       (folders.removeConversationFromAll _).expects(convId, false).once().returning(Future.successful(()))
       (rolesService.removeByConvId _).expects(convId).once().returning(Future.successful(()))
+      (messages.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set(messageId)))
+      (msgStorage.findMessageIds _).expects(convId).atLeastOnce().returning(Future.successful(Set(messageId)))
+      (buttons.deleteAllForMessage _).expects(messageId).atLeastOnce().returning(Future.successful(()))
 
       //EXPECT
       (receiptStorage.removeAllForMessages _).expects(Set(messageId)).once().returning(Future.successful(()))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -49,11 +49,12 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   val assetService =    mock[AssetService]
   val network =         mock[NetworkModeService]
   val properties =      mock[PropertiesService]
+  val buttons =         mock[ButtonsStorage]
 
   val prefs = new TestGlobalPreferences()
 
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
-    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, prefs)
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
     new ConversationsUiServiceImpl(selfUserId, teamId, assetService, usersStorage, messages, messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, client,
       accounts, tracking, errors, properties)


### PR DESCRIPTION
In many cases we delete messages by its id, without checking its type. I decided that in such situations it can be actually faster to just call a method on the Buttons table which will do nothing than querying the Messages table for the message type and then calling the method on Buttons only if the type is Composite.

I moved `def addButtons` from `MessagesService` to `MessagesContentUpdater`. This makes it clearer that buttons belong to a message and fewer changes in the tests are needed to support that.

I also took this opportunity to add a few checks for "empty" in storages. SOmetimes it happens that we call a method on the database with an empty set of identifiers, so the method will do nothing, but anyway it will first call a bunch of other methods and run a query. It's better to avoid it.
#### APK
[Download build #1524](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1524/artifact/build/artifact/wire-dev-PR2681-1524.apk)