### PR TITLE
fix: The contents go to a wrong conversation

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -84,7 +84,6 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
 
   lazy val pagedListData: Signal[(MessageAdapterData, PagedListWrapper[MessageAndLikes], Option[MessageId])] = for {
     z                       <- zms
-    false                   <- z.push.processing
     (cId, cTeam, teamOnly)  <- convController.currentConv.map(c => (c.id, c.team, c.isTeamOnly))
     isGroup                 <- Signal.future(z.conversations.isGroupConversation(cId))
     canHaveLink             = isGroup && cTeam.exists(z.teamId.contains(_)) && !teamOnly


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-5917

If the sync with BE takes a long time it is possible that in the meantime the user will open a conversation, read something, and the go to another one. In such case the contents of the conversation will not be refreshed (so, in fact, the contents does not "go" to a wrong conversation - it just does not go away at all). The reason was one line of code which I introduced in September 2019 during one of attempts to find out why there are delays in syncing. The line stops the contents from refreshing until the sync is finished.
Since then we figured out some other ways to prevent delays, and this one introduced the bug, so I just removed it.

Anyway, the delays still happen. More work is needed.
#### APK
[Download build #1579](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1579/artifact/build/artifact/wire-dev-PR2696-1579.apk)