### PR TITLE
fix: Ignore incoming Button Action event

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -22,7 +22,7 @@ import com.waz.api.Message.Type._
 import com.waz.content.MessagesStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.GenericContent.{Asset, ButtonActionConfirmation, Calling, Cleared, Composite, DeliveryReceipt, Ephemeral, Knock, LastRead, LinkPreview, Location, MsgDeleted, MsgEdit, MsgRecall, Reaction, Text}
+import com.waz.model.GenericContent.{Asset, ButtonAction, ButtonActionConfirmation, Calling, Cleared, Composite, DeliveryReceipt, Ephemeral, Knock, LastRead, LinkPreview, Location, MsgDeleted, MsgEdit, MsgRecall, Reaction, Text}
 import com.waz.model.{GenericContent, _}
 import com.waz.service.EventScheduler
 import com.waz.service.assets.{AssetService, AssetStatus, DownloadAsset, DownloadAssetStatus, DownloadAssetStorage, GeneralAsset, Asset => Asset2}
@@ -163,6 +163,7 @@ class MessageEventProcessor(selfUserId:           UserId,
     case DeliveryReceipt(_)            => RichMessage.Empty
     case GenericContent.ReadReceipt(_) => RichMessage.Empty
     case _: Calling                    => RichMessage.Empty
+    case _: ButtonAction               => RichMessage.Empty
     case _: ButtonActionConfirmation   => RichMessage.Empty
     case _ =>
       // TODO: this message should be processed again after app update, maybe future app version will understand it


### PR DESCRIPTION
If there is a poll in a group chat and the other user responds, the current user receives a Button Action event which should be ignored. By default, we don't ignore unknown message events, but treat them as "unknown" and store them. The side-effect of that is that an empty message appears in the conversation which indicates that the client don't know how to display a message, but anyway the message is there. This may happen for example when a new version of Wire introduces a new message type (like now, with Composite), but that new type of
message is received on a client with an older version.

#### APK
[Download build #1583](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1583/artifact/build/artifact/wire-dev-PR2698-1583.apk)