### PR TITLE
fix: Postpone processing notifications until after the sync

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -77,7 +77,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
 
   private val schedulePushNotificationsToUi = Signal(false)
 
-  Signal(schedulePushNotificationsToUi, pushService.processing) {
+  Signal(schedulePushNotificationsToUi, pushService.processing).onChanged {
     case (true, false) =>
       pushNotificationsToUi().map { _ => schedulePushNotificationsToUi ! false }
     case _ =>
@@ -217,9 +217,9 @@ class NotificationServiceImpl(selfUserId:      UserId,
                                        case (n, None) if n.isConvDeleted => true
                                        case (_, None)                    => false
                                       }
-        showNotifications         = show.map(_._1).toSet
-        ignoreNotifications       = ignore.map(_._1.id).toSet
-        _                         <- if (showNotifications.nonEmpty) uiController.onNotificationsChanged(self.id, showNotifications) else Future.successful(())
+        showNotifications         =  show.map(_._1).toSet
+        ignoreNotifications       =  ignore.map(_._1.id).toSet
+        _                         <- if (toShow.nonEmpty) uiController.onNotificationsChanged(self.id, showNotifications) else Future.successful(())
         _                         <- storage.insertAll(showNotifications.map(_.copy(hasBeenDisplayed = true)))
         _                         <- storage.removeAll(ignoreNotifications)
       } yield {}).recoverWith {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -205,7 +205,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
   }
 
   private def pushNotificationsToUi(): Future[Unit] = storage.list().map {
-    case Nil => Future.successful(())
+    case Nil    => Future.successful(())
     case toShow =>
       verbose(l"pushNotificationsToUi, toShow: ${toShow.size}")
       (for {
@@ -219,7 +219,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
                                       }
         showNotifications         =  show.map(_._1).toSet
         ignoreNotifications       =  ignore.map(_._1.id).toSet
-        _                         <- if (toShow.nonEmpty) uiController.onNotificationsChanged(self.id, showNotifications) else Future.successful(())
+        _                         <- uiController.onNotificationsChanged(self.id, showNotifications)
         _                         <- storage.insertAll(showNotifications.map(_.copy(hasBeenDisplayed = true)))
         _                         <- storage.removeAll(ignoreNotifications)
       } yield {}).recoverWith {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -64,16 +64,24 @@ trait NotificationService {
 }
 
 class NotificationServiceImpl(selfUserId:      UserId,
-                          messages:        MessagesStorage,
-                          storage:         NotificationStorage,
-                          convs:           ConversationStorage,
-                          pushService:     PushService,
-                          uiController:    NotificationUiController,
-                          userService:     UserService,
-                          clock:           Clock) extends NotificationService {
+                              messages:        MessagesStorage,
+                              storage:         NotificationStorage,
+                              convs:           ConversationStorage,
+                              pushService:     PushService,
+                              uiController:    NotificationUiController,
+                              userService:     UserService,
+                              clock:           Clock) extends NotificationService {
 
   import Threading.Implicits.Background
   implicit lazy val logTag: LogTag = accountTag[NotificationService](selfUserId)
+
+  private val schedulePushNotificationsToUi = Signal(false)
+
+  Signal(schedulePushNotificationsToUi, pushService.processing) {
+    case (true, false) =>
+      pushNotificationsToUi().map { _ => schedulePushNotificationsToUi ! false }
+    case _ =>
+  }(EventContext.Global)
 
   uiController.notificationsSourceVisible { sources =>
     sources.get(selfUserId).map(Some(_)).foreach(dismissNotifications)
@@ -94,7 +102,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
         case Some(convs) => nots.filter(n => convs.contains(n.conv))
       }
       _ <- storage.removeAll(toRemove.map(_.id))
-      _ <- pushNotificationsToUi()
+      _ =  if (toRemove.nonEmpty) schedulePushNotificationsToUi ! true
     } yield {}
   }
 
@@ -116,28 +124,26 @@ class NotificationServiceImpl(selfUserId:      UserId,
         toRemove = undoneLikes ++ beforeEditsApplied ++ deleted
         _ <- storage.removeAll(toRemove)
         _ <- storage.insertAll(toShow)
-        _ <- pushNotificationsToUi()
+        _ =  if (toShow.nonEmpty || toRemove.nonEmpty) schedulePushNotificationsToUi ! true
       } yield {}
     } else Future.successful({})
   })
 
   override val connectionNotificationEventStage = EventScheduler.Stage[Event]({ (_, events) =>
-    if (events.nonEmpty) {
-      val toShow = events.collect {
-        case UserConnectionEvent(_, _, userId, msg, ConnectionStatus.PendingFromOther, time, name) =>
-          NotificationData(NotId(CONNECT_REQUEST, userId), msg.getOrElse(""), ConvId(userId.str), userId, CONNECT_REQUEST, time)
-        case UserConnectionEvent(_, _, userId, _, ConnectionStatus.Accepted, time, name) =>
-          NotificationData(NotId(CONNECT_ACCEPTED, userId), "", ConvId(userId.str), userId, CONNECT_ACCEPTED, time)
-        case ContactJoinEvent(userId, _) =>
-          verbose(l"ContactJoinEvent")
-          NotificationData(NotId(CONTACT_JOIN, userId), "", ConvId(userId.str), userId, CONTACT_JOIN)
-      }
+    val toShow = events.collect {
+      case UserConnectionEvent(_, _, userId, msg, ConnectionStatus.PendingFromOther, time, _) =>
+        NotificationData(NotId(CONNECT_REQUEST, userId), msg.getOrElse(""), ConvId(userId.str), userId, CONNECT_REQUEST, time)
+      case UserConnectionEvent(_, _, userId, _, ConnectionStatus.Accepted, time, _) =>
+        NotificationData(NotId(CONNECT_ACCEPTED, userId), "", ConvId(userId.str), userId, CONNECT_ACCEPTED, time)
+      case ContactJoinEvent(userId, _) =>
+        verbose(l"ContactJoinEvent")
+        NotificationData(NotId(CONTACT_JOIN, userId), "", ConvId(userId.str), userId, CONTACT_JOIN)
+    }
 
-      for {
-        _ <- storage.insertAll(toShow)
-        _ <- pushNotificationsToUi()
-      } yield {}
-    } else Future.successful({})
+    if (toShow.nonEmpty)
+      storage.insertAll(toShow).map { _ => schedulePushNotificationsToUi ! true }
+    else
+      Future.successful(())
   })
 
   override def displayNotificationForDeletingConversation(from: UserId, remoteTime: RemoteInstant, convData: ConversationData): Future[Unit] = {
@@ -198,31 +204,29 @@ class NotificationServiceImpl(selfUserId:      UserId,
     }
   }
 
-  private def pushNotificationsToUi(): Future[Unit] = {
-    verbose(l"pushNotificationsToUi")
-    (for {
-      notificationSourceVisible <- uiController.notificationsSourceVisible.head
-      _                         = verbose(l"source: $notificationSourceVisible")
-      toShow                    <- storage.list()
-      _ = verbose(l"toShow: $toShow")
-      Some(self)                <- userService.getSelfUser
-      convsWithNots             <- Future.sequence(toShow.map(n => convs.get(n.conv).map(c => (n, c))))
-      (show, ignore)            =  convsWithNots.partition {
-                                     case (n, Some(c))                 => shouldShowNotification(self, n, c, notificationSourceVisible)
-                                     case (n, None) if n.isConvDeleted => true
-                                     case (_, None)                    => false
-                                    }
-      showNotifications         = show.map(_._1).toSet
-      ignoreNotifications       = ignore.map(_._1.id).toSet
-      _                         =  verbose(l"show: $showNotifications, ignore: $ignoreNotifications")
-      _                         <- uiController.onNotificationsChanged(self.id, showNotifications)
-      _                         <- storage.insertAll(showNotifications.map(_.copy(hasBeenDisplayed = true)))
-      _                         <- storage.removeAll(ignoreNotifications)
-    } yield {}).recoverWith {
-      case exception: Exception =>
-        error(l"error while displaying notifications to ui $exception")
-        Future.successful(())
-    }
+  private def pushNotificationsToUi(): Future[Unit] = storage.list().map {
+    case Nil => Future.successful(())
+    case toShow =>
+      verbose(l"pushNotificationsToUi, toShow: ${toShow.size}")
+      (for {
+        notificationSourceVisible <- uiController.notificationsSourceVisible.head
+        Some(self)                <- userService.getSelfUser
+        convsWithNots             <- Future.sequence(toShow.map(n => convs.get(n.conv).map(c => (n, c))))
+        (show, ignore)            =  convsWithNots.partition {
+                                       case (n, Some(c))                 => shouldShowNotification(self, n, c, notificationSourceVisible)
+                                       case (n, None) if n.isConvDeleted => true
+                                       case (_, None)                    => false
+                                      }
+        showNotifications         = show.map(_._1).toSet
+        ignoreNotifications       = ignore.map(_._1.id).toSet
+        _                         <- if (showNotifications.nonEmpty) uiController.onNotificationsChanged(self.id, showNotifications) else Future.successful(())
+        _                         <- storage.insertAll(showNotifications.map(_.copy(hasBeenDisplayed = true)))
+        _                         <- storage.removeAll(ignoreNotifications)
+      } yield {}).recoverWith {
+        case exception: Exception =>
+          error(l"error while displaying notifications to ui $exception")
+          Future.successful(())
+      }
   }
 
   private def getMessageNotifications(rConvId: RConvId, events: Vector[Event]) = {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -40,6 +40,9 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
+
+  import Threading.Implicits.Background
+
   import ConversationRole._
 
   val messages      = mock[MessagesStorage]
@@ -49,21 +52,85 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val uiController  = mock[NotificationUiController]
   val userService   = mock[UserService]
 
-  var self = UserData(account1Id, "")
-
-  val beDrift = Signal(Duration.ZERO)
-  val uiNotificationsSourceVisible = Signal(Map.empty[UserId, Set[ConvId]])
-
-  val notificationsDispatcher = new SerialDispatchQueue()
-  val storedNotifications = Signal(Set.empty[NotificationData])
+  private val storedNotifications = Signal(Set.empty[NotificationData])
+  private val processing = Signal(true)
 
   private def lastEventTime = RemoteInstant.apply(clock.instant())
-  val rConvId = RConvId("r-conv")
-  val convId = ConvId("conv")
-  val conv = ConversationData(remoteId = rConvId, id = convId)
-  val content = TextMessage("abc")
-  val from = UserId("User1")
-  lazy val event = GenericMessageEvent(rConvId, lastEventTime, from, content)
+
+  private val self       = UserData(account1Id, "")
+  private val beDrift    = Signal(Duration.ZERO)
+  private val rConvId    = RConvId("r-conv")
+  private val convId     = ConvId("conv")
+  private val conv       = ConversationData(remoteId = rConvId, id = convId)
+  private val content    = TextMessage("abc")
+  private val from       = UserId("User1")
+  private lazy val event = GenericMessageEvent(rConvId, lastEventTime, from, content)
+
+  private val msg = MessageData(
+    MessageId(content.messageId),
+    conv.id,
+    msgType = Message.Type.TEXT,
+    protos  = Seq(content),
+    userId  = from,
+    time    = lastEventTime
+  )
+
+  private val compositeMsg = MessageData(
+    MessageId(content.messageId),
+    conv.id,
+    msgType = Message.Type.COMPOSITE,
+    protos  = Seq(content),
+    userId  = from,
+    time    = lastEventTime
+  )
+
+  (pushService.processing _).expects().anyNumberOfTimes().onCall(_ => processing)
+
+  (storage.list _).expects().anyNumberOfTimes().onCall { _ => storedNotifications.head.map(_.toSeq) }
+  (storage.removeAll _).expects(*).anyNumberOfTimes().onCall { toRemove: Iterable[NotId] =>
+    Future.successful[Unit] { storedNotifications.mutate { _.filterNot(n => toRemove.toSet.contains(n.id)) }; }
+  }
+  (storage.insertAll _).expects(*).anyNumberOfTimes().onCall { toAdd: Traversable[NotificationData] =>
+    Future.successful {
+      storedNotifications.mutate { _ ++ toAdd }
+      Set.empty[NotificationData] //return not important
+    }
+  }
+
+  (pushService.beDrift _).expects().anyNumberOfTimes().returning(beDrift)
+
+  private val notificationsSourceVisible = Signal(Map.empty[UserId, Set[ConvId]])
+  (uiController.notificationsSourceVisible _).expects().anyNumberOfTimes().returning(notificationsSourceVisible)
+
+  private def getService =
+    new NotificationServiceImpl(account1Id, messages, storage, convs, pushService, uiController, userService, clock)
+
+  private def testCompositeMessageNotificationShown(availability: Availability) = {
+    processing ! true
+
+    (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+    (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+    (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(
+      Future.successful(IndexedSeq(compositeMsg))
+    )
+
+    // in pushNotificationToUI
+    (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ =>
+      Future.successful(Option(self.copy(availability = availability)))
+    )
+    (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+    (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
+      nots.size shouldEqual 1
+      nots.head.msgType shouldEqual NotificationType.COMPOSITE
+      Future.successful({})
+    }
+
+    result(getService.messageNotificationEventsStage(rConvId, Vector(event)))
+
+    processing ! false
+
+    awaitAllTasks
+  }
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -75,19 +142,15 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   feature("Message events") {
     scenario("Process basic text message notifications") {
-      setup()
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            MessageId(content.messageId),
-            conv.id,
-            msgType = Message.Type.TEXT,
-            protos = Seq(content),
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(msg)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 1
         nots.head.msg shouldEqual "abc"
@@ -95,78 +158,94 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      val service = getService
+
+      result(service.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
-    scenario("Don't push notifications to UI when the user is away") {
-      setup(userAvailability = Availability.Away)
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            MessageId(content.messageId),
-            conv.id,
-            msgType = Message.Type.TEXT,
-            protos = Seq(content),
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+    scenario("Don't push standard notifications to UI when the user is away") {
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(msg)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ =>
+        Future.successful(Option(self.copy(availability = Availability.Away)))
+      )
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 0
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
-    scenario("Don't push notifications to UI when the user is busy and the message is not a reply/mention") {
-      setup(userAvailability = Availability.Busy)
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            MessageId(content.messageId),
-            conv.id,
-            msgType = Message.Type.TEXT,
-            protos = Seq(content),
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+    scenario("Don't push standard notifications to UI when the user is busy and the message is not a reply/mention") {
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(msg)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ =>
+        Future.successful(Option(self.copy(availability = Availability.Busy)))
+      )
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 0
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Push notifications to UI when the user is busy and the message is a reply/mention") {
-      val origMsg =
-        MessageData(
-          MessageId("orig"),
-          conv.id,
-          msgType = Message.Type.TEXT,
-          protos = Seq(content),
-          userId = self.id,
-          time = lastEventTime
-        )
-      val reply =
-        MessageData(
-          MessageId(content.messageId),
-          conv.id,
-          msgType = Message.Type.TEXT,
-          protos = Seq(content),
-          userId = from,
-          time   = lastEventTime,
-          quote = Some(QuoteContent(origMsg.id, validity = true, hash = None))
-        )
+      processing ! true
 
-      setup(msg = Some(origMsg), userAvailability = Availability.Busy)
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(origMsg, reply)
-      ))
+      val origMsg = MessageData(
+        MessageId("orig"),
+        conv.id,
+        msgType = Message.Type.TEXT,
+        protos  = Seq(content),
+        userId  = self.id,
+        time    = lastEventTime
+      )
+      val reply = MessageData(
+        MessageId(content.messageId),
+        conv.id,
+        msgType = Message.Type.TEXT,
+        protos  = Seq(content),
+        userId  = from,
+        time    = lastEventTime,
+        quote   = Some(QuoteContent(origMsg.id, validity = true, hash = None))
+      )
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(origMsg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(origMsg, reply)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ =>
+        Future.successful(Option(self.copy(availability = Availability.Busy)))
+      )
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 1
         nots.head.msg shouldEqual "abc"
@@ -174,23 +253,27 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Push composite message notifications to UI even when the user is away") {
-      setup(userAvailability = Availability.Away)
-      testCompositeMessageNotificationShown()
+      testCompositeMessageNotificationShown(Availability.Away)
     }
 
     scenario("Push composite message notifications to UI even when the user is busy") {
-      setup(userAvailability = Availability.Busy)
-      testCompositeMessageNotificationShown()
+      testCompositeMessageNotificationShown(Availability.Busy)
     }
 
     scenario("Notifications are only pushed to UI for conversations with correct mute states") {
       val rConvId2 = RConvId("conv2")
       val conv = ConversationData(ConvId("conv"), rConvId, muted = MuteSet.AllMuted)
       val conv2 = ConversationData(ConvId("conv2"), rConvId2, muted = MuteSet.OnlyMentionsAllowed)
+      val convMap = Seq(conv, conv2).toIdMap
+      val rConvMap = Seq(conv, conv2).map(c => c.remoteId -> c).toMap
 
       //prefil notification storage
       val previousNots = Set(
@@ -201,27 +284,31 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       )
       storedNotifications ! previousNots
 
-      setup(Seq((conv, true), (conv2, false)))
+      processing ! true
 
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            MessageId(content.messageId),
-            conv.id,
-            msgType = Message.Type.TEXT,
-            protos = Seq(content),
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(*).anyNumberOfTimes().onCall { rConvId: RConvId =>
+        Future.successful(rConvMap.get(rConvId))
+      }
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(msg)))
 
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(*).anyNumberOfTimes().onCall { convId: ConvId =>
+        Future.successful(convMap.get(convId))
+      }
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 2
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      val service = getService
+
+      result(service.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Previous notifications that have not been dismissed are passed with notifications from new events") {
@@ -232,19 +319,15 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       )
       storedNotifications ! previousNots
 
-      setup()
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            MessageId(content.messageId),
-            conv.id,
-            msgType = Message.Type.TEXT,
-            protos = Seq(content),
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, lastEventTime).returning(Future.successful(IndexedSeq(msg)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 3
         nots.exists(_.msg == "abc") shouldEqual true
@@ -254,7 +337,13 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      val service = getService
+
+      result(service.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Apply multiple message edit events to previous notifications") {
@@ -273,19 +362,26 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val editEvent2 = GenericMessageEvent(rConvId, edit2EventTime, from, editContent2)
 
       val originalNotification = NotificationData(
-        id = NotId(originalContent.messageId),
-        msg = "abc",
-        conv = conv.id,
-        user = from,
-        msgType = NotificationType.TEXT,
-        time = origEventTime,
+        id               = NotId(originalContent.messageId),
+        msg              = "abc",
+        conv             = conv.id,
+        user             = from,
+        msgType          = NotificationType.TEXT,
+        time             = origEventTime,
         hasBeenDisplayed = true
       )
 
       storedNotifications ! Set(originalNotification)
 
-      setup(Seq((conv, true)))
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (messages.findMessagesFrom _).expects(conv.id, edit1EventTime).returning(Future.successful(IndexedSeq.empty))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         val not = nots.head
         not.id shouldEqual NotId(editContent2.messageId)
@@ -293,7 +389,11 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(editEvent1, editEvent2)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(editEvent1, editEvent2)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Apply delete and recall (hide and delete) events to previous notifications in storage and stream") {
@@ -308,6 +408,8 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       )
       storedNotifications ! previousNots
 
+      processing ! true
+
       val from = UserId("User1")
       val msgContent = GenericMessage(Uid("messageId"), Text("abc"))
       val msgEvent = GenericMessageEvent(rConvId, RemoteInstant(clock.instant()), from, msgContent)
@@ -318,8 +420,13 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val deleteContent2 = GenericMessage(Uid(), MsgRecall(MessageId(msgContent.messageId)))
       val deleteEvent2 = GenericMessageEvent(rConvId, RemoteInstant.apply(clock.instant()), from, deleteContent2)
 
-      setup()
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(msg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (messages.findMessagesFrom _).expects(conv.id, *).returning(Future.successful(IndexedSeq.empty))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
 
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         Future.successful {
@@ -328,7 +435,11 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         }
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(msgEvent, deleteEvent1, deleteEvent2)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(msgEvent, deleteEvent1, deleteEvent2)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
     scenario("Multiple alternative likes and unlikes only ever apply the last event") {
@@ -365,8 +476,15 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
           time   = messageTime
         )
 
-      setup(msg = Some(originalMessage))
-      (messages.findMessagesFrom _).expects(conv.id, like1EventTime).returning(Future.successful(IndexedSeq.empty))
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(originalMessage))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(conv.id, *).returning(Future.successful(IndexedSeq.empty))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
 
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 2
@@ -378,7 +496,11 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(like1Event, unlikeEvent, otherLikeEvent, like2Event)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(like1Event, unlikeEvent, otherLikeEvent, like2Event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
   }
 
@@ -392,19 +514,23 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Map(account1Id -> MemberRole, from -> AdminRole), None
       ))
 
-      setup()
+      val memberJoinMsg = MessageData(
+        generatedMessageId,
+        conv.id,
+        msgType = Message.Type.MEMBER_JOIN,
+        userId  = from,
+        time    = lastEventTime
+      )
 
-      (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-        IndexedSeq(
-          MessageData(
-            generatedMessageId,
-            conv.id,
-            msgType = Message.Type.MEMBER_JOIN,
-            userId = from,
-            time   = lastEventTime
-          )
-        )
-      ))
+      processing ! true
+
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq(Option(memberJoinMsg))))
+      (convs.getByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (messages.findMessagesFrom _).expects(convId, *).returning(Future.successful(IndexedSeq(memberJoinMsg)))
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         nots.size shouldEqual 1
         nots.head.msg shouldEqual ""
@@ -413,7 +539,11 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         Future.successful({})
       }
 
-      result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
+      result(getService.messageNotificationEventsStage(rConvId, Vector(event)))
+
+      processing ! false
+
+      awaitAllTasks
     }
 
   }
@@ -424,6 +554,8 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       val conv1 = ConversationData()
       val conv2 = ConversationData()
+      val convMap = Seq(conv1, conv2).toIdMap
+      val rConvMap = Seq(conv1, conv2).map(c => c.remoteId -> c).toMap
 
       //prefil notification storage
       val previousNots = Set(
@@ -433,110 +565,34 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       )
       storedNotifications ! previousNots
 
-      setup(Seq((conv1, true), (conv2, true)))
+      processing ! true
 
-      val uiNotified = Signal(false)
+      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (convs.getByRemoteId _).expects(*).anyNumberOfTimes().onCall { rConvId: RConvId =>
+        Future.successful(rConvMap.get(rConvId))
+      }
+
+      // in pushNotificationToUI
+      (userService.getSelfUser _).expects().anyNumberOfTimes().onCall(_ => Future.successful(Option(self)))
+      (convs.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conv)))
+      (convs.get _).expects(*).anyNumberOfTimes().onCall { convId: ConvId =>
+        Future.successful(convMap.get(convId))
+      }
+
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         Future {
           nots.size shouldEqual 1
           nots.head.conv shouldEqual conv2.id
-          uiNotified ! true
-        } (Threading.Background)
+        }
       }
 
-      getService()
+      getService
 
-      uiNotificationsSourceVisible ! Map(account1Id -> Set(conv1.id))
-      result(uiNotified.filter(identity(_)).head)
+      notificationsSourceVisible ! Map(account1Id -> Set(conv1.id))
+
+      processing ! false
+
+      awaitAllTasks
     }
-
-  }
-
-  def getService() = {
-
-    (pushService.beDrift _).expects().anyNumberOfTimes().returning(beDrift)
-    (uiController.notificationsSourceVisible _).expects().anyNumberOfTimes().returning(uiNotificationsSourceVisible)
-
-    implicit val ec = notificationsDispatcher
-    (storage.insertAll _).expects(*).anyNumberOfTimes().onCall { (toAdd: Traversable[NotificationData]) =>
-      notificationsDispatcher {
-        storedNotifications.mutate { nots =>
-          nots ++ toAdd
-        }
-        Set.empty[NotificationData] //return not important
-      }.future
-    }
-
-    (storage.removeAll _).expects(*).anyNumberOfTimes().onCall { (toRemove: Iterable[NotId]) =>
-      notificationsDispatcher {
-        storedNotifications.mutate { nots =>
-          nots.filterNot(n => toRemove.toSet.contains(n.id))
-        }
-      }.future.map(_ => {})
-    }
-
-    (storage.list _).expects().anyNumberOfTimes().onCall { _ =>
-      storedNotifications.head.map(_.toSeq)
-    }
-
-    (userService.getSelfUser _).expects().anyNumberOfTimes().returning(Future.successful(Option(self)))
-
-    new NotificationServiceImpl(account1Id, messages, storage, convs, pushService, uiController, userService, clock)
-  }
-
-  private def setup(cs: Seq[(ConversationData, Boolean)] = Seq((conv, true)),
-                    msg: Option[MessageData] = None,
-                    userAvailability: Availability = Availability.Available
-                   ) = {
-    self = self.copy(availability = userAvailability)
-    cs.collect { case (c, true) => c }
-      .foreach(conv =>
-        (convs.getByRemoteId _)
-          .expects(conv.remoteId)
-          .anyNumberOfTimes()
-          .returning(Future.successful(Some(conv)))
-      )
-
-    val conversations = cs.map { case (c, _) => c.id -> c }.toMap
-
-
-    import Threading.Implicits.Background
-
-    (convs.getAll _)
-      .expects(*)
-      .anyNumberOfTimes()
-      .onCall { ids: Traversable[ConvId] => Future { ids.toSeq.map(conversations.get) } }
-
-    (convs.get _).expects(*).anyNumberOfTimes().onCall { id: ConvId => Future { conversations.get(id) } }
-
-    if (msg.isEmpty) {
-      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
-    } else if (msg.isDefined) msg.foreach { msg =>
-      (messages.getAll _).expects(Set(msg.id)).anyNumberOfTimes().returning(Future.successful(Seq(Some(msg))))
-      (messages.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
-    }
-  }
-
-  private def testCompositeMessageNotificationShown() {
-    (messages.findMessagesFrom _).expects(conv.id, lastEventTime).returning(Future.successful(
-      IndexedSeq(
-        MessageData(
-          MessageId(content.messageId),
-          conv.id,
-          msgType = Message.Type.COMPOSITE,
-          protos = Seq(content),
-          userId = from,
-          time   = lastEventTime
-        )
-      )
-    ))
-
-    (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
-      nots.size shouldEqual 1
-      nots.head.msgType shouldEqual NotificationType.COMPOSITE
-      Future.successful({})
-    }
-
-    result(getService().messageNotificationEventsStage(rConvId, Vector(event)))
   }
 }


### PR DESCRIPTION
The processing and displaying of notifications seems to be a major part of very slow sync with BE.
This PR fixes a bug in `NotificationService` which causes the process to build and display the same notification many times by postponing this process until processing of incoming events is done.

Imagine the user goes offline, three messages are sent to them, and then they go online again.
The sync starts and all three messages are received. Three notifications should be created and
displayed. But without this PR this process goes like that:

Message #1 (M1) comes -> Notification #1 is created (N1) -> Notification #1 is displayed
M2 comes -> N1 is dismissed -> N1 and N2 are created -> N1 and N2 are displayed
M3 comes -> N1 and N2 are dismissed -> N1, N2 and N3 are created -> N1, N2, and N3 are displayed

The process is done n times for n new messages, and within it the notifications are dismissed
and created (n + (n-1) + (n-2) + ... + 1) times. The creation of a notification is also slow and
can be improved a bit - but in another PR.

With this PR, the process runs only once, after all messages come. All notifications are created once, and none of them need to be dismissed.
#### APK
[Download build #1640](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1640/artifact/build/artifact/wire-dev-PR2702-1640.apk)
[Download build #1681](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1681/artifact/build/artifact/wire-dev-PR2702-1681.apk)