### PR TITLE
feat: Remove the background under the Buttons spinner

### DIFF
--- a/app/src/main/res/drawable/alarm_button_progressbar_background.xml
+++ b/app/src/main/res/drawable/alarm_button_progressbar_background.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?attr/alarmButtonProgressBarBackground" />
-    <corners android:topRightRadius="@dimen/rounded_button_radius"
-        android:bottomRightRadius="@dimen/rounded_button_radius"/>
-</shape>
-

--- a/app/src/main/res/layout/message_button.xml
+++ b/app/src/main/res/layout/message_button.xml
@@ -28,7 +28,6 @@
         android:id="@+id/message_button_item_progressbar"
         android:layout_width="@dimen/composite_message_button_progressbar_size"
         android:layout_height="0dp"
-        android:background="@drawable/alarm_button_progressbar_background"
         android:elevation="@dimen/composite_message_button_progressbar_elevation"
         android:indeterminateTint="@color/accent_red"
         android:padding="@dimen/composite_message_button_progressbar_padding"

--- a/app/src/main/res/values/theme_attrs.xml
+++ b/app/src/main/res/values/theme_attrs.xml
@@ -168,6 +168,5 @@
 
     <!-- Composite Message Alarm Buttons -->
     <attr name="alarmButtonTextColor" format="color"/>
-    <attr name="alarmButtonProgressBarBackground" format="color"/>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -190,7 +190,6 @@
 
         <!-- Composite Message Alarm Buttons -->
         <item name="alarmButtonTextColor">@color/white</item>
-        <item name="alarmButtonProgressBarBackground">@color/white_8</item>
     </style>
 
     <style name="Theme.Light" parent="@style/Theme.Design.Light.NoActionBar">
@@ -362,7 +361,6 @@
 
         <!-- Composite Message Alarm Buttons -->
         <item name="alarmButtonTextColor">@color/accent_red</item>
-        <item name="alarmButtonProgressBarBackground">@color/black_8</item>
     </style>
 
     <style name="Theme.Dark.Preferences" parent="@style/Theme.Design.NoActionBar">


### PR DESCRIPTION
As agreed with Design, in rare cases when the Button's text goes under the spinner, we just let it to happen without any semi-transparent background