### PR TITLE
Fix: Do not match search query to user's email

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -252,12 +252,11 @@ object UserData {
                 |    (
                 |      ${SKey.name} LIKE ? OR ${SKey.name} LIKE ?
                 |    ) AND (${Rel.name} = '${Rel(Relation.First)}' OR ${Rel.name} = '${Rel(Relation.Second)}' OR ${Rel.name} = '${Rel(Relation.Third)}')
-                |  ) OR ${Email.name} = ?
-                |    OR ${Handle.name} LIKE ?
+                |  ) OR ${Handle.name} LIKE ?
                 |) AND ${Deleted.name} = 0
                 |  AND ${Conn.name} != '${Conn(ConnectionStatus.Accepted)}' AND ${Conn.name} != '${Conn(ConnectionStatus.Blocked)}' AND ${Conn.name} != '${Conn(ConnectionStatus.Self)}'
               """.stripMargin,
-        Array(s"${query.asciiRepresentation}%", s"% ${query.asciiRepresentation}%", prefix, s"%${query.asciiRepresentation}%"))
+        Array(s"${query.asciiRepresentation}%", s"% ${query.asciiRepresentation}%", s"%${query.asciiRepresentation}%"))
     }
 
     def search(whereClause: String, args: Array[String])(implicit db: DB): Managed[Iterator[UserData]] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -309,7 +309,7 @@ class UserSearchService(selfUserId:           UserId,
 
   private def recommendedPredicate(prefix: String): UserData => Boolean = {
     val key = SearchKey(prefix)
-    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.email.exists(_.str == prefix) || u.handle.exists(_.startsWithQuery(prefix)))
+    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.handle.exists(_.startsWithQuery(prefix)))
   }
 
   private def recommendedHandlePredicate(prefix: String): UserData => Boolean = {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -124,6 +124,13 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       permissions = (adminPermissions, adminPermissions),
       teamId = teamId,
       handle = Some(Handle("aa2"))
+    ),
+    id('me1) -> UserData(id('me1), "Team Member With Email").copy(
+      email = Some(EmailAddress("a_member@wire.com")),
+      teamId = teamId
+    ),
+    id('pe1) -> UserData(id('pe1), "Person With Email").copy(
+      email = Some(EmailAddress("a_person@wire.com"))
     )
   )
 
@@ -245,6 +252,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     scenario("Return no search results for handle") {
       verifySearch("@relt", Set.empty[UserId])
+    }
+
+    scenario("Return no search results for team member when query matches only to email") {
+      verifySearch("a_member@wire.com", Set.empty[UserId])
+    }
+
+    scenario("Return no search results for personal account when query matches only to email") {
+      verifySearch("a_person@wire.com", Set.empty[UserId])
     }
 
   }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -461,7 +461,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val res = result(preparedSearch.perform())
 
       // THEN
-      res shouldBe ids('mm1, 'mm2)
+      res shouldBe ids('mm1, 'mm2, 'me1)
     }
 
     scenario("as a member, search connected guests whether they are in a conversation with me or not") {
@@ -639,7 +639,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       // THEN
       res shouldBe ids(
-        'aa2, 'mm1, 'mm2, 'mm3, // all non-External team members
+        'aa2, 'mm1, 'mm2, 'mm3, 'me1, // all non-External team members
         'pp1 // External that I invited
       )
 


### PR DESCRIPTION
## What's new in this PR?

Jira ticket: https://wearezeta.atlassian.net/browse/AN-6744

### Issues

In Search page, a user is displayed in the search result if his/her e-mail matches the search query. This is a possible information leak and should be removed.

### Solutions

Removed checks for user's email while filtering users for the query.

### Testing

Unit tests are added.

#### APK
[Download build #1620](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1620/artifact/build/artifact/wire-dev-PR2714-1620.apk)