### PR TITLE
fix: Check if the poll's author is in the conversation

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -255,7 +255,7 @@ object SyncRequest {
     override val mergeKey = (cmd, convId, liking.id)
   }
 
-  case class PostButtonAction(messageId: MessageId, buttonId: ButtonId) extends BaseRequest(Cmd.PostButtonAction) {
+  case class PostButtonAction(messageId: MessageId, buttonId: ButtonId, senderId: UserId) extends BaseRequest(Cmd.PostButtonAction) {
     override val mergeKey: Any = (cmd, messageId, buttonId)
   }
 
@@ -400,7 +400,7 @@ object SyncRequest {
           case Cmd.PostLiking                => PostLiking(convId, JsonDecoder[Liking]('liking))
           case Cmd.PostAddBot                => PostAddBot(decodeId[ConvId]('convId), decodeId[ProviderId]('providerId), decodeId[IntegrationId]('integrationId))
           case Cmd.PostRemoveBot             => PostRemoveBot(decodeId[ConvId]('convId), decodeId[UserId]('botId))
-          case Cmd.PostButtonAction          => PostButtonAction(messageId, decodeId[ButtonId]('buttonId))
+          case Cmd.PostButtonAction          => PostButtonAction(messageId, decodeId[ButtonId]('button), decodeId[UserId]('sender))
           case Cmd.PostSessionReset          => PostSessionReset(convId, userId, decodeId[ClientId]('client))
           case Cmd.PostOpenGraphMeta         => PostOpenGraphMeta(convId, messageId, 'time)
           case Cmd.PostReceipt               => PostReceipt(convId, decodeMessageIdSeq('messages), userId, ReceiptType.fromName('type))
@@ -445,9 +445,10 @@ object SyncRequest {
         case PostRemoveBot(cId, botId)        =>
           o.put("convId", cId.str)
           o.put("botId", botId.str)
-        case PostButtonAction(messageId, buttonId) =>
+        case PostButtonAction(messageId, buttonId, senderId) =>
           putId("message", messageId)
-          putId("buttonId", buttonId)
+          putId("button", buttonId)
+          putId("sender", senderId)
         case ExactMatchHandle(handle)         => o.put("handle", handle.string)
         case SyncTeamMember(userId)           => o.put("user", userId.str)
         case DeletePushToken(token)           => putId("token", token)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -92,7 +92,7 @@ trait SyncServiceHandle {
   def postProperty(key: PropertyKey, value: Int): Future[SyncId]
   def postProperty(key: PropertyKey, value: String): Future[SyncId]
   def postFolders(): Future[SyncId]
-  def postButtonAction(messageId: MessageId, buttonId: ButtonId): Future[SyncId]
+  def postButtonAction(messageId: MessageId, buttonId: ButtonId, senderId: UserId): Future[SyncId]
 
   def registerPush(token: PushToken): Future[SyncId]
   def deletePushToken(token: PushToken): Future[SyncId]
@@ -187,7 +187,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postReceipt(conv: ConvId, messages: Seq[MessageId], user: UserId, tpe: ReceiptType): Future[SyncId] = addRequest(PostReceipt(conv, messages, user, tpe), priority = Priority.Optional)
   def postAddBot(cId: ConvId, pId: ProviderId, iId: IntegrationId) = addRequest(PostAddBot(cId, pId, iId))
   def postRemoveBot(cId: ConvId, botId: UserId) = addRequest(PostRemoveBot(cId, botId))
-  def postButtonAction(messageId: MessageId, buttonId: ButtonId): Future[SyncId] = addRequest(PostButtonAction(messageId, buttonId), forceRetry = true)
+  def postButtonAction(messageId: MessageId, buttonId: ButtonId, senderId: UserId): Future[SyncId] = addRequest(PostButtonAction(messageId, buttonId, senderId), forceRetry = true)
   def postProperty(key: PropertyKey, value: Boolean): Future[SyncId] = addRequest(PostBoolProperty(key, value), forceRetry = true)
   def postProperty(key: PropertyKey, value: Int): Future[SyncId] = addRequest(PostIntProperty(key, value), forceRetry = true)
   def postProperty(key: PropertyKey, value: String): Future[SyncId] = addRequest(PostStringProperty(key, value), forceRetry = true)
@@ -284,7 +284,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostLiking(convId, liking)                      => zms.reactionsSync.postReaction(convId, liking)
           case PostAddBot(cId, pId, iId)                       => zms.integrationsSync.addBot(cId, pId, iId)
           case PostRemoveBot(cId, botId)                       => zms.integrationsSync.removeBot(cId, botId)
-          case PostButtonAction(messageId, buttonId)           => zms.messagesSync.postButtonAction(messageId, buttonId)
+          case PostButtonAction(messageId, buttonId, senderId) => zms.messagesSync.postButtonAction(messageId, buttonId, senderId)
           case PostDeleted(convId, msgId)                      => zms.messagesSync.postDeleted(convId, msgId)
           case PostLastRead(convId, time)                      => zms.lastReadSync.postLastRead(convId, time)
           case PostOpenGraphMeta(conv, msg, time)              => zms.openGraphSync.postMessageMeta(conv, msg, time)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
@@ -90,21 +90,23 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     val convId = ConvId()
     val messageId = MessageId()
     val buttonId = ButtonId()
+    val senderId = UserId()
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(Option(MessageData(messageId, convId = convId))))
     (otrSync.postOtrMessage _).expects(convId, *, * ,*, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
 
-    result(getHandler.postButtonAction(messageId, buttonId)) shouldEqual SyncResult.Success
+    result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Success
   }
 
   scenario("post button action fails if the message is missing") {
 
     val messageId = MessageId()
     val buttonId = ButtonId()
+    val senderId = UserId()
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(None))
 
-    result(getHandler.postButtonAction(messageId, buttonId)) shouldEqual SyncResult.Failure("message not found")
+    result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Failure("message not found")
   }
 
   scenario("when post button action fails, sets button error on db") {
@@ -112,13 +114,14 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     val convId = ConvId()
     val messageId = MessageId()
     val buttonId = ButtonId()
+    val senderId = UserId()
     val errorText = "Error"
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(Option(MessageData(messageId, convId = convId))))
     (otrSync.postOtrMessage _).expects(convId, *, * ,*, *).returning(Future.successful(Left(internalError(errorText))))
     (service.setButtonError _).expects(messageId, buttonId).once().returning(Future.successful({}))
 
-    result(getHandler.postButtonAction(messageId, buttonId)) shouldEqual SyncResult.Failure(errorText)
+    result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Failure(errorText)
   }
 
 }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6763

If the author's of the poll is no longer a member of the conversation, responding to the poll should result in the error message. But a button action (i.e. a button click) is sent to BE as a regular message, so the standard error handling procedure doesn't work for us here - we receive a successful response from BE that the message was received.
Instead, before sending the button click we have to check who is the author, check if that person/service is still an active member of the conversation, and send it only if it's true. Otherwise, the error message should be displayed.
#### APK
[Download build #1613](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1613/artifact/build/artifact/wire-dev-PR2715-1613.apk)