### PR TITLE
UserDatabase Migration Tests: Part 9

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
@@ -17,5 +17,5 @@ val clientsModule: Module = module {
     factory { get<NetworkClient>().create(ClientsApi::class.java) }
     factory { ClientsRemoteDataSource(get(), get()) }
     factory { ClientsLocalDataSource(get()) }
-    factory { get<UserDatabase>().clientDao() }
+    factory { get<UserDatabase>().clientsDao() }
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable126to127MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable126to127MigrationTest.kt
@@ -1,0 +1,60 @@
+package com.waz.zclient.storage.userdatabase.folders
+
+import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
+import com.waz.zclient.storage.di.StorageModule.getUserDatabase
+import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class FoldersTable126to127MigrationTest : UserDatabaseMigrationTest(TEST_DB_NAME, 126) {
+
+    @Test
+    fun givenFolderInsertedIntoFoldersTableVersion126_whenMigratedToVersion127_thenAssertDataIsStillIntact() {
+
+        val id = "testId"
+        val name = "testName"
+        val type = 2
+
+        FoldersTableTestHelper.insertFolder(
+            id = id,
+            name = name,
+            type = type,
+            openHelper = testOpenHelper
+        )
+
+        validateMigration()
+
+        runBlocking {
+            with(allFolders()[0]) {
+                assert(this.id == id)
+                assert(this.name == name)
+                assert(this.type == type)
+            }
+        }
+    }
+
+    private fun validateMigration() =
+        testHelper.validateMigration(
+            TEST_DB_NAME,
+            127,
+            true,
+            USER_DATABASE_MIGRATION_126_TO_127
+        )
+
+    private fun getUserDb() =
+        getUserDatabase(
+            getApplicationContext(),
+            TEST_DB_NAME,
+            UserDatabase.migrations
+        )
+
+    private suspend fun allFolders() =
+        getUserDb().foldersDao().allFolders()
+
+    companion object {
+        private const val TEST_DB_NAME = "userDatabase.db"
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTableTestHelper.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTableTestHelper.kt
@@ -1,0 +1,27 @@
+package com.waz.zclient.storage.userdatabase.folders
+
+import android.content.ContentValues
+import com.waz.zclient.storage.DbSQLiteOpenHelper
+
+class FoldersTableTestHelper private constructor() {
+
+    companion object {
+
+        private const val FOLDERS_TABLE_NAME = "Folders"
+        private const val FOLDERS_ID_COL = "_id"
+        private const val FOLDERS_NAME_COL = "name"
+        private const val FOLDERS_TYPE_COL = "type"
+
+        fun insertFolder(id: String, name: String, type: Int, openHelper: DbSQLiteOpenHelper) {
+            val contentValues = ContentValues().also {
+                it.put(FOLDERS_ID_COL, id)
+                it.put(FOLDERS_NAME_COL, name)
+                it.put(FOLDERS_TYPE_COL, type)
+            }
+            openHelper.insertWithOnConflict(
+                tableName = FOLDERS_TABLE_NAME,
+                contentValues = contentValues
+            )
+        }
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable126to127MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable126to127MigrationTest.kt
@@ -1,0 +1,60 @@
+package com.waz.zclient.storage.userdatabase.history
+
+import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
+import com.waz.zclient.storage.di.StorageModule.getUserDatabase
+import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class EditHistoryTable126to127MigrationTest : UserDatabaseMigrationTest(TEST_DB_NAME, 126) {
+
+    @Test
+    fun givenHistoryInsertedIntoEditHistoryTableVersion126_whenMigratedToVersion127_thenAssertDataIsStillIntact() {
+
+        val originalId = "testOriginalID"
+        val updatedId = "testUpdatedID"
+        val timestamp = 37227723
+
+        EditHistoryTableTestHelper.insertHistory(
+            originalId = originalId,
+            updatedId = updatedId,
+            timestamp = timestamp,
+            openHelper = testOpenHelper
+        )
+
+        validateMigration()
+
+        runBlocking {
+            with(allHistory()[0]) {
+                assert(this.originalId == originalId)
+                assert(this.updatedId == updatedId)
+                assert(this.timestamp == timestamp)
+            }
+        }
+    }
+
+    private fun validateMigration() =
+        testHelper.validateMigration(
+            TEST_DB_NAME,
+            127,
+            true,
+            USER_DATABASE_MIGRATION_126_TO_127
+        )
+
+    private fun getUserDb() =
+        getUserDatabase(
+            getApplicationContext(),
+            TEST_DB_NAME,
+            UserDatabase.migrations
+        )
+
+    private suspend fun allHistory() =
+        getUserDb().editHistoryDao().allHistory()
+
+    companion object {
+        private const val TEST_DB_NAME = "userDatabase.db"
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTableTestHelper.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTableTestHelper.kt
@@ -1,0 +1,28 @@
+package com.waz.zclient.storage.userdatabase.history
+
+import android.content.ContentValues
+import com.waz.zclient.storage.DbSQLiteOpenHelper
+
+class EditHistoryTableTestHelper private constructor() {
+
+    companion object {
+
+        private const val EDIT_HISTORY_TABLE_NAME = "EditHistory"
+        private const val EDIT_HISTORY_ORIGINAL_ID_COL = "original_id"
+        private const val EDIT_HISTORY_UPDATED_ID_COL = "updated_id"
+        private const val EDIT_HISTORY_TIMESTAMP_COL = "timestamp"
+
+        fun insertHistory(originalId: String, updatedId: String, timestamp: Int,
+                          openHelper: DbSQLiteOpenHelper) {
+            val contentValues = ContentValues().also {
+                it.put(EDIT_HISTORY_ORIGINAL_ID_COL, originalId)
+                it.put(EDIT_HISTORY_UPDATED_ID_COL, updatedId)
+                it.put(EDIT_HISTORY_TIMESTAMP_COL, timestamp)
+            }
+            openHelper.insertWithOnConflict(
+                tableName = EDIT_HISTORY_TABLE_NAME,
+                contentValues = contentValues
+            )
+        }
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable126to127MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable126to127MigrationTest.kt
@@ -1,0 +1,60 @@
+package com.waz.zclient.storage.userdatabase.receipts
+
+import com.waz.zclient.storage.db.UserDatabase
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
+import com.waz.zclient.storage.di.StorageModule.getUserDatabase
+import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ReadReceiptsTable126to127MigrationTest : UserDatabaseMigrationTest(TEST_DB_NAME, 126) {
+
+    @Test
+    fun givenReceiptsInsertedIntoReadReceiptsTableVersion126_whenMigratedToVersion127_thenAssertDataIsStillIntact() {
+
+        val messageId = "messageId"
+        val userId = "UserId"
+        val timestamp = 48484
+
+        ReadReceiptsTableTestHelper.insertReceipt(
+            messageId = messageId,
+            userId = userId,
+            timestamp = timestamp,
+            openHelper = testOpenHelper
+        )
+
+        validateMigration()
+
+        runBlocking {
+            with(allReceipts()[0]) {
+                assert(this.messageId == messageId)
+                assert(this.userId == userId)
+                assert(this.timestamp == timestamp)
+            }
+        }
+    }
+
+    private fun validateMigration() =
+        testHelper.validateMigration(
+            TEST_DB_NAME,
+            127,
+            true,
+            USER_DATABASE_MIGRATION_126_TO_127
+        )
+
+    private fun getUserDb() =
+        getUserDatabase(
+            getApplicationContext(),
+            TEST_DB_NAME,
+            UserDatabase.migrations
+        )
+
+    private suspend fun allReceipts() =
+        getUserDb().readReceiptsDao().allReceipts()
+
+    companion object {
+        private const val TEST_DB_NAME = "userDatabase.db"
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTableTestHelper.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTableTestHelper.kt
@@ -1,0 +1,28 @@
+package com.waz.zclient.storage.userdatabase.receipts
+
+import android.content.ContentValues
+import com.waz.zclient.storage.DbSQLiteOpenHelper
+
+class ReadReceiptsTableTestHelper private constructor() {
+
+    companion object {
+
+        private const val READ_RECEIPTS_TABLE_NAME = "ReadReceipts"
+        private const val READ_RECEIPTS_MESSAGE_ID_COL = "message_id"
+        private const val READ_RECEIPTS_USER_ID_COL = "user_id"
+        private const val READ_RECEIPTS_TIMESTAMP_COL = "timestamp"
+
+        fun insertReceipt(messageId: String, userId: String, timestamp: Int,
+                          openHelper: DbSQLiteOpenHelper) {
+            val contentValues = ContentValues().also {
+                it.put(READ_RECEIPTS_MESSAGE_ID_COL, messageId)
+                it.put(READ_RECEIPTS_USER_ID_COL, userId)
+                it.put(READ_RECEIPTS_TIMESTAMP_COL, timestamp)
+            }
+            openHelper.insertWithOnConflict(
+                tableName = READ_RECEIPTS_TABLE_NAME,
+                contentValues = contentValues
+            )
+        }
+    }
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -26,13 +26,14 @@ import com.waz.zclient.storage.db.conversations.ConversationRoleActionDao
 import com.waz.zclient.storage.db.conversations.ConversationRoleActionEntity
 import com.waz.zclient.storage.db.conversations.ConversationsDao
 import com.waz.zclient.storage.db.conversations.ConversationsEntity
-import com.waz.zclient.storage.db.conversations.EditHistoryEntity
-import com.waz.zclient.storage.db.conversations.ReadReceiptsEntity
 import com.waz.zclient.storage.db.email.EmailAddressesDao
 import com.waz.zclient.storage.db.email.EmailAddressesEntity
 import com.waz.zclient.storage.db.errors.ErrorsDao
 import com.waz.zclient.storage.db.errors.ErrorsEntity
+import com.waz.zclient.storage.db.folders.FoldersDao
 import com.waz.zclient.storage.db.folders.FoldersEntity
+import com.waz.zclient.storage.db.history.EditHistoryDao
+import com.waz.zclient.storage.db.history.EditHistoryEntity
 import com.waz.zclient.storage.db.messages.LikesDao
 import com.waz.zclient.storage.db.messages.LikesEntity
 import com.waz.zclient.storage.db.messages.MessageContentIndexEntity
@@ -50,6 +51,8 @@ import com.waz.zclient.storage.db.property.KeyValuesDao
 import com.waz.zclient.storage.db.property.KeyValuesEntity
 import com.waz.zclient.storage.db.property.PropertiesDao
 import com.waz.zclient.storage.db.property.PropertiesEntity
+import com.waz.zclient.storage.db.receipts.ReadReceiptsDao
+import com.waz.zclient.storage.db.receipts.ReadReceiptsEntity
 import com.waz.zclient.storage.db.sync.SyncJobsDao
 import com.waz.zclient.storage.db.sync.SyncJobsEntity
 import com.waz.zclient.storage.db.userclients.UserClientDao
@@ -96,7 +99,10 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun contactHashesDao(): ContactHashesDao
     abstract fun emailAddressesDao(): EmailAddressesDao
     abstract fun phoneNumbersDao(): PhoneNumbersDao
-    abstract fun clientDao(): ClientsDao
+    abstract fun foldersDao(): FoldersDao
+    abstract fun readReceiptsDao(): ReadReceiptsDao
+    abstract fun editHistoryDao(): EditHistoryDao
+    abstract fun clientsDao(): ClientsDao
 
     companion object {
         const val VERSION = 127

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/folders/FoldersDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/folders/FoldersDao.kt
@@ -1,0 +1,10 @@
+package com.waz.zclient.storage.db.folders
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface FoldersDao {
+    @Query("SELECT * FROM Folders")
+    suspend fun allFolders(): List<FoldersEntity>
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/history/EditHistoryDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/history/EditHistoryDao.kt
@@ -1,0 +1,10 @@
+package com.waz.zclient.storage.db.history
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface EditHistoryDao {
+    @Query("SELECT * FROM EditHistory")
+    suspend fun allHistory(): List<EditHistoryEntity>
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/history/EditHistoryEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/history/EditHistoryEntity.kt
@@ -1,4 +1,4 @@
-package com.waz.zclient.storage.db.conversations
+package com.waz.zclient.storage.db.history
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/receipts/ReadReceiptsDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/receipts/ReadReceiptsDao.kt
@@ -1,0 +1,10 @@
+package com.waz.zclient.storage.db.receipts
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface ReadReceiptsDao {
+    @Query("SELECT * FROM ReadReceipts")
+    suspend fun allReceipts(): List<ReadReceiptsEntity>
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/receipts/ReadReceiptsEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/receipts/ReadReceiptsEntity.kt
@@ -1,4 +1,4 @@
-package com.waz.zclient.storage.db.conversations
+package com.waz.zclient.storage.db.receipts
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity


### PR DESCRIPTION
## What's new in this PR?

Part 9 of #2699

Implemented integration tests for Folders, EditHistory and ReadReceipts tables for migration from version 126 to 127.

https://wearezeta.atlassian.net/browse/AN-6745