### PR TITLE
UserDatabase Migration: Remove duplicated client entity from user database schema 

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
@@ -7,7 +7,6 @@ import com.waz.zclient.clients.datasources.remote.ClientsApi
 import com.waz.zclient.clients.datasources.remote.ClientsRemoteDataSource
 import com.waz.zclient.clients.mapper.ClientMapper
 import com.waz.zclient.core.network.NetworkClient
-import com.waz.zclient.storage.db.UserDatabase
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -17,5 +16,4 @@ val clientsModule: Module = module {
     factory { get<NetworkClient>().create(ClientsApi::class.java) }
     factory { ClientsRemoteDataSource(get(), get()) }
     factory { ClientsLocalDataSource(get()) }
-    //factory { get<UserDatabase>().clientsDao() }
 }

--- a/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/clients/di/ClientsModule.kt
@@ -17,5 +17,5 @@ val clientsModule: Module = module {
     factory { get<NetworkClient>().create(ClientsApi::class.java) }
     factory { ClientsRemoteDataSource(get(), get()) }
     factory { ClientsLocalDataSource(get()) }
-    factory { get<UserDatabase>().clientsDao() }
+    //factory { get<UserDatabase>().clientsDao() }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -111,7 +111,6 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun readReceiptsDao(): ReadReceiptsDao
     abstract fun editHistoryDao(): EditHistoryDao
 
-
     companion object {
         const val VERSION = 127
 

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -10,8 +10,6 @@ import com.waz.zclient.storage.db.assets.DownloadAssetsDao
 import com.waz.zclient.storage.db.assets.DownloadAssetsEntity
 import com.waz.zclient.storage.db.assets.UploadAssetsDao
 import com.waz.zclient.storage.db.assets.UploadAssetsEntity
-import com.waz.zclient.storage.db.clients.model.ClientEntity
-import com.waz.zclient.storage.db.clients.service.ClientsDao
 import com.waz.zclient.storage.db.contacts.ContactHashesDao
 import com.waz.zclient.storage.db.contacts.ContactHashesEntity
 import com.waz.zclient.storage.db.contacts.ContactOnWireDao
@@ -70,7 +68,7 @@ import com.waz.zclient.storage.db.users.service.UserDao
         ConversationMembersEntity::class, MessagesEntity::class, KeyValuesEntity::class,
         SyncJobsEntity::class, ErrorsEntity::class, NotificationDataEntity::class,
         ContactHashesEntity::class, ContactsOnWireEntity::class, UserClientsEntity::class,
-        ClientEntity::class, LikesEntity::class, ContactsEntity::class, EmailAddressesEntity::class,
+        LikesEntity::class, ContactsEntity::class, EmailAddressesEntity::class,
         PhoneNumbersEntity::class, MessageDeletionEntity::class, ConversationRoleActionEntity::class,
         ConversationFoldersEntity::class, FoldersEntity::class, CloudNotificationStatsEntity::class,
         CloudNotificationsEntity::class, AssetsEntity::class, DownloadAssetsEntity::class,
@@ -112,7 +110,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun foldersDao(): FoldersDao
     abstract fun readReceiptsDao(): ReadReceiptsDao
     abstract fun editHistoryDao(): EditHistoryDao
-    abstract fun clientsDao(): ClientsDao
+
 
     companion object {
         const val VERSION = 127


### PR DESCRIPTION
## What's new in this PR?

### Issues

`ClientEntity` is blocking the user database migration

### Causes

`ClientEntity` used by the Kotlin code in settings devices screen **(dev mode only)** does not have the same fields of the current `Clients` table. 

### Solutions

Removed ClientEntity and clientsDao temporary from user database schema to unblock the migration. (already replaced by `UserClientDao` and `UserClientsEntity`)

#### APK
[Download build #1662](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1662/artifact/build/artifact/wire-dev-PR2725-1662.apk)