### PR TITLE
fix: Resend messages edited when offline

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -29,7 +29,6 @@ import android.util.TypedValue
 import android.view.{Gravity, View}
 import android.widget.{TextView, Toast}
 import androidx.appcompat.app.AppCompatDialog
-import com.waz.api.Message
 import com.waz.content.MessagesStorage
 import com.waz.content.UserPreferences.DownloadImagesAlways
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -149,8 +148,8 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     case _ => ()
   }
 
-  def retry(m: MessageData) =
-    if (m.state == Message.Status.FAILED || m.state == Message.Status.FAILED_READ) messages.currentValue.foreach(_.retryMessageSending(m.convId, m.id))
+  def retry(m: MessageData): Unit =
+    if (m.isFailed) messages.currentValue.foreach(_.retryMessageSending(m.convId, m.id))
 
     def getPlaybackControls(asset: Signal[GeneralAsset]): Signal[PlaybackControls] = asset.flatMap { a =>
     (a.details, a) match {

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
@@ -61,7 +61,7 @@ class ReplyView(context: Context, attrs: AttributeSet, defStyle: Int) extends Fr
   def setOnClose(onClose: => Unit): Unit = this.onClose = () => onClose
 
   def setMessage(messageData: MessageData, asset: Option[GeneralAsset], senderName: String): Unit = {
-    setSender(senderName, !messageData.editTime.isEpoch)
+    setSender(senderName, messageData.isEdited)
 
     messageData.msgType match {
       case Type.TEXT | Type.TEXT_EMOJI_ONLY | Type.RICH_MEDIA =>

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -251,8 +251,8 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
   def onApproveEditMessage(): Unit =
     for {
       cId <- conversationController.currentConvId.head
-      cs <- zms.head.map(_.convsUi)
-      m <- editingMsg.head if m.isDefined
+      cs  <- zms.head.map(_.convsUi)
+      m   <- editingMsg.head if m.isDefined
       msg = m.get
       (CursorText(text, mentions), _) <- enteredText.head
     } {

--- a/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
@@ -205,7 +205,7 @@ object MessageBottomSheetDialog {
     case object Edit extends MessageAction(R.id.message_bottom_menu_item_edit, R.string.glyph__edit, R.string.message_bottom_menu_action_edit) {
       override def enabled(msg: MessageData, zms: ZMessaging, p: Params, assets: AssetsController): Signal[Boolean] =
         msg.msgType match {
-          case TEXT_EMOJI_ONLY | TEXT | RICH_MEDIA if !msg.isEphemeral && msg.userId == zms.selfUserId =>
+          case TEXT_EMOJI_ONLY | TEXT | RICH_MEDIA if !msg.isEphemeral && msg.userId == zms.selfUserId && !msg.isFailed =>
             if (p.collection) Signal const false
             else isMemberOfConversation(msg.convId, zms)
           case _ =>

--- a/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageView.scala
@@ -174,7 +174,7 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
   private def shouldShowChathead(msg: MessageData, prev: Option[MessageData]) = {
     val userChanged = prev.forall(m => m.userId != msg.userId || systemMessage(m))
     val recalled = msg.msgType == Message.Type.RECALLED
-    val edited = !msg.editTime.isEpoch
+    val edited = msg.isEdited
     val knock = msg.msgType == Message.Type.KNOCK
 
     !knock && !systemMessage(msg) && (recalled || edited || userChanged)
@@ -184,7 +184,7 @@ class MessageView(context: Context, attrs: AttributeSet, style: Int)
     mAndL.likes.nonEmpty ||
       selection.isFocused(mAndL.message.id) ||
       opts.isLastSelf ||
-      mAndL.message.state == Message.Status.FAILED || mAndL.message.state == Message.Status.FAILED_READ
+      mAndL.message.isFailed
   }
 
   def getFooter = listParts.lastOption.collect { case footer: FooterPartView => footer }

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -213,7 +213,7 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
 
   private val stateGlyph = message map {
     case m if m.msgType == Message.Type.RECALLED => Some(R.string.glyph__trash)
-    case m if !m.editTime.isEpoch => Some(R.string.glyph__edit)
+    case m if m.isEdited => Some(R.string.glyph__edit)
     case _ => None
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
@@ -111,7 +111,7 @@ abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int)
     .map(getTimeStamp)
     .onUi(timestamp.setText)
 
-  quotedMessage.map(!_.editTime.isEpoch).onUi { edited =>
+  quotedMessage.map(_.isEdited).onUi { edited =>
     name.setEndCompoundDrawable(if (edited) Some(WireStyleKit.drawEdit) else None)
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -106,11 +106,12 @@ case class MessageData(override val id:   MessageId              = MessageId(),
     copy(quote = Some(QuoteContent(quoteId, validity = true, None)), protos = newProtos)
   }
 
-  def isLocal = state == Message.Status.DEFAULT || state == Message.Status.PENDING || state == Message.Status.FAILED || state == Message.Status.FAILED_READ
+  lazy val isLocal: Boolean = state == Message.Status.DEFAULT || state == Message.Status.PENDING || state == Message.Status.FAILED || state == Message.Status.FAILED_READ
+  lazy val isDeleted: Boolean = msgType == Message.Type.RECALLED
+  lazy val isFailed: Boolean = state == Message.Status.FAILED || state == Message.Status.FAILED_READ
+  lazy val isEdited: Boolean = !editTime.isEpoch
 
-  def isDeleted = msgType == Message.Type.RECALLED
-
-  lazy val mentions = content.flatMap(_.mentions)
+  lazy val mentions: Seq[Mention] = content.flatMap(_.mentions)
 
   def hasMentionOf(userId: UserId): Boolean = mentions.exists(_.userId.forall(_ == userId)) // a mention with userId == None is a "mention" of everyone, so it counts
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -216,8 +216,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
     } yield Some(msg)
   }
 
-  override def updateMessage(convId: ConvId, id: MessageId, text: String, mentions: Seq[Mention] = Nil): Future[Option[MessageData]] = {
-    verbose(l"updateMessage($convId, $id, $mentions")
+  override def updateMessage(convId: ConvId, id: MessageId, text: String, mentions: Seq[Mention] = Nil): Future[Option[MessageData]] =
     messagesStorage.update(id, {
       case m if m.convId == convId && m.userId == selfUserId =>
         val (tpe, ct) = MessageData.messageContent(text, mentions, weblinkEnabled = true)
@@ -236,7 +235,6 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
       case Some((_, m)) => sync.postMessage(m.id, m.convId, m.editTime) map { _ => Some(m) } // using PostMessage sync request to use the same logic for failures and retrying
       case None => Future successful None
     }
-  }
 
   override def deleteMessage(convId: ConvId, id: MessageId): Future[Unit] = for {
     _ <- messagesContent.deleteOnUserRequest(Seq(id))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -454,7 +454,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
   override def addSuccessfulCallMessage(convId: ConvId, from: UserId, time: RemoteInstant, duration: FiniteDuration) =
     updater.addMessage(MessageData(MessageId(), convId, Message.Type.SUCCESSFUL_CALL, from, time = time, duration = Some(duration)))
 
-  def messageDeliveryFailed(convId: ConvId, msg: MessageData, error: ErrorResponse): Future[Option[MessageData]] =
+  override def messageDeliveryFailed(convId: ConvId, msg: MessageData, error: ErrorResponse): Future[Option[MessageData]] =
     updateMessageState(convId, msg.id, Message.Status.FAILED) andThen {
       case Success(Some(m)) => storage.onMessageFailed ! (m, error)
     }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6703

After the user edits a message, the app tries to send it immediately, and if it fails, it changes
the state of the message to FAILED. That should mean that in the conversation the message footer should display the "Resend" link so that the user can try again. But there was a bug: the fact that the message was edited had priority so the footer displayed the "Edited: [time]" info, and without the "Resend" link it was not possible to resend the message. The PR fixes that.

A different problem arises when the user tries to edit a message which was never send. Then, when the message is resent, it carries to the receiver the information that it's an edited version of an original message, but the original message is not found on the receiver's side, so the edited version is ignored (this is by design). To make it consistent with other platforms, we decided to simply prevent the user from editing unsent messages. I removed the "edit" button from the list of possible actions in such case.

Note that the PR does not implement automatic resending of message when the device goes online. We could do it, but that's a new functionality really, not just bug fixing. Another ticket will
address it.
#### APK
[Download build #1680](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1680/artifact/build/artifact/wire-dev-PR2727-1680.apk)