### PR TITLE
fix : slide in/slide out animation for settings screens

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/about/SettingsAboutActivity.kt
@@ -28,6 +28,7 @@ class SettingsAboutActivity : AppCompatActivity(R.layout.activity_settings_about
         setSupportActionBar(activitySettingsAboutToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(R.id.activitySettingsAboutLayoutContainer, SettingsAboutFragment.newInstance(), false)
+        overridePendingTransition(R.anim.slide_in_left, 0)
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -35,13 +36,18 @@ class SettingsAboutActivity : AppCompatActivity(R.layout.activity_settings_about
         return true
     }
 
-    companion object {
-        @JvmStatic
-        fun newIntent(context: Context) = Intent(context, SettingsAboutActivity::class.java)
+    override fun onBackPressed() {
+        super.onBackPressed()
+        overridePendingTransition(0, R.anim.slide_out_right)
     }
 
     override fun onDestroy() {
         super.onDestroy()
         scope.close()
+    }
+
+    companion object {
+        @JvmStatic
+        fun newIntent(context: Context) = Intent(context, SettingsAboutActivity::class.java)
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
+++ b/app/src/main/kotlin/com/waz/zclient/settings/support/SettingsSupportActivity.kt
@@ -28,6 +28,7 @@ class SettingsSupportActivity : AppCompatActivity(R.layout.activity_settings_sup
         setSupportActionBar(activitySettingsSupportToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(R.id.activitySettingsSupportLayoutContainer, SettingsSupportFragment.newInstance(), false)
+        overridePendingTransition(R.anim.slide_in_left, 0)
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -35,13 +36,18 @@ class SettingsSupportActivity : AppCompatActivity(R.layout.activity_settings_sup
         return true
     }
 
-    companion object {
-        @JvmStatic
-        fun newIntent(context: Context) = Intent(context, SettingsSupportActivity::class.java)
+    override fun onBackPressed() {
+        super.onBackPressed()
+        overridePendingTransition(0, R.anim.slide_out_right)
     }
 
     override fun onDestroy() {
         super.onDestroy()
         scope.close()
+    }
+
+    companion object {
+        @JvmStatic
+        fun newIntent(context: Context) = Intent(context, SettingsSupportActivity::class.java)
     }
 }

--- a/app/src/main/res/anim/slide_in_left.xml
+++ b/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="200"
+        android:fromXDelta="100%"
+        android:toXDelta="0%"></translate>
+</set>

--- a/app/src/main/res/anim/slide_in_left.xml
+++ b/app/src/main/res/anim/slide_in_left.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <translate
-        android:duration="200"
+        android:duration="@integer/animation_duration_medium_rare"
         android:fromXDelta="100%"
-        android:toXDelta="0%"></translate>
+        android:toXDelta="0%"/>
 </set>

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="200"
+        android:fromXDelta="0%"
+        android:toXDelta="100%"></translate>
+</set>

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <translate
-        android:duration="200"
+        android:duration="@integer/animation_duration_medium_rare"
         android:fromXDelta="0%"
-        android:toXDelta="100%"></translate>
+        android:toXDelta="100%"/>
 </set>


### PR DESCRIPTION
## What's new in this PR?

### Issues

By introducing the new Kotlin settings screens (about and support), we missed to add a slide in/ slide out transition animation for those screens.

https://wearezeta.atlassian.net/browse/AN-6752

### Solutions

I tried to mimic the current scala animation but still not exactly the same because we are calling the Kotlin activities from Scala (Activity transition animation). In the scala code, it's implemented a as a view animation. 

### Note

We can unify animations once we are done with settings screens migration to Kotlin.

### Testing

Run the app with those flags :
```
kotlinSettings = false
kotlinRegistration = false
```

Go to : Support/About screens
#### APK
[Download build #1682](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1682/artifact/build/artifact/wire-dev-PR2728-1682.apk)
[Download build #1723](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1723/artifact/build/artifact/wire-dev-PR2728-1723.apk)