### PR TITLE
fix: Display websites' previews on Android 9-10

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
@@ -81,6 +81,8 @@ object ErrorResponse {
           ErrorResponse(response.code, label = "Decoding error", message = s"Decoding body error: $err")
         case HttpClient.ConnectionError(err) =>
           ErrorResponse(ErrorResponse.ConnectionErrorCode, message = s"connection error: $err", label = "")
+        case HttpClient.UnknownServiceError(ex) =>
+          ErrorResponse.InternalError.copy(message = s"Unknown service exception: $ex")
         case HttpClient.UnknownError(err) =>
           ErrorResponse.InternalError.copy(message = s"Unknown error: $err")
       }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/HttpClientOkHttpImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/HttpClientOkHttpImpl.scala
@@ -20,7 +20,7 @@ package com.waz.znet2
 import java.io.{ByteArrayInputStream, InputStream}
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
-import java.net.Proxy
+import java.net.{Proxy, UnknownServiceException}
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
@@ -63,6 +63,9 @@ class HttpClientOkHttpImpl(client: OkHttpClient)(implicit protected val ec: Exec
         CancellableFuture.lift(
           future = Future { okCall.execute() }
             .recoverWith {
+              case ex: UnknownServiceException =>
+                error(l"failure while getting okHttp response, unknown service.", ex)
+                Future.failed(UnknownServiceError(ex))
               case err =>
                 error(l"failure while getting okHttp response.", err)
                 Future.failed(ConnectionError(err))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
@@ -17,6 +17,8 @@
  */
 package com.waz.znet2.http
 
+import java.net.UnknownServiceException
+
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.threading.CancellableFuture
@@ -67,6 +69,7 @@ object HttpClient {
   case class EncodingError(err: Throwable)                                extends HttpClientError
   case class DecodingError(err: Throwable, response: Response[EmptyBody]) extends HttpClientError
   case class ConnectionError(err: Throwable)                              extends HttpClientError
+  case class UnknownServiceError(ex: UnknownServiceException)             extends HttpClientError
   case class UnknownError(err: Throwable)                                 extends HttpClientError
 
   trait CustomErrorConstructor[E] {


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6685

Since version 9, Android by default disallows cleartext traffic and if the website uses that  we get an exception:
```
java.net.UnknownServiceException: CLEARTEXT communication to heise.de not permitted by network security policy
```
One way to fix it would be to disable this security check and allow cleartext again, but I don't want to do that. Instead, I decided to handle that specific exception and if it happens, retry the request with "https://" instead of "http://". In many cases that will  be enough. In the others, it simply means that the problem is on the website's side and we won't show the preview.

The weblink itself is not affected - if the user clicks on it, the webpage starting with "http://" will be opened.
#### APK
[Download build #1696](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1696/artifact/build/artifact/wire-dev-PR2731-1696.apk)