### PR TITLE
Spike: Codecov - part 1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jp.leafytree.android-scala'
 apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
-
 apply from: 'config/quality.gradle'
+apply from: "$rootProject.projectDir/jacoco/coverage.gradle"
 
 //region avs
 //TODO: Migrate this configuration to new dependency system
@@ -186,6 +186,7 @@ android {
 
     buildTypes {
         release {
+            testCoverageEnabled = false
             proguardFiles 'proguard-android-optimize-wire.txt', 'proguard-rules.txt'
             minifyEnabled true
             multiDexEnabled true
@@ -195,8 +196,7 @@ android {
         }
 
         debug {
-            // To get debugging properly working again - https://code.google.com/p/android/issues/detail?id=177480
-            testCoverageEnabled = System.getenv("JOB_NAME") == "full-test-coverage"
+            testCoverageEnabled = true
             versionNameSuffix = " " + getDate()
             multiDexEnabled true
             manifestPlaceholders = [applicationVmSafeMode: "true",

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jp.leafytree.android-scala'
 apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
 apply from: 'config/quality.gradle'
-apply from: "$rootProject.projectDir/jacoco/coverage.gradle"
+apply from: 'jacoco/coverage.gradle'
 
 //region avs
 //TODO: Migrate this configuration to new dependency system

--- a/app/jacoco/coverage.gradle
+++ b/app/jacoco/coverage.gradle
@@ -26,14 +26,14 @@ task jacocoTestReport(type: JacocoReport) {
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
     def kotlinTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/devDebug/com/waz/zclient", excludes: fileFilter)
-    def javaScalaTree =fileTree(dir: "$project.buildDir/intermediates/javac/devDebug/compileDevDebugJavaWithJavac/classes/com/waz", excludes: fileFilter)
+    def javaScalaTree = fileTree(dir: "$project.buildDir/intermediates/javac/devDebug/compileDevDebugJavaWithJavac/classes/com/waz", excludes: fileFilter)
 
     def kotlinSrc = "$project.projectDir/src/main/kotlin"
     def scalaSrc = "$project.projectDir/src/main/scala"
     def javaSrc = "$project.projectDir/src/main/java"
 
-    sourceDirectories = files([kotlinSrc,scalaSrc,javaSrc])
-    classDirectories = files([kotlinTree,javaScalaTree])
+    sourceDirectories = files([kotlinSrc, scalaSrc, javaSrc])
+    classDirectories = files([kotlinTree, javaScalaTree])
     executionData = fileTree(dir: project.buildDir, includes: [
         'jacoco/testDevDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
     ])

--- a/app/jacoco/coverage.gradle
+++ b/app/jacoco/coverage.gradle
@@ -17,7 +17,7 @@
  */
 apply plugin: 'jacoco'
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest']) {
+task jacocoTestReport(type: JacocoReport) {
 
     reports {
         xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         classpath 'org.ajoberstar.grgit:grgit-core:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT}"
+        classpath "org.jacoco:org.jacoco.core:0.8.5"
     }
 }
 
@@ -162,7 +163,8 @@ task ci(dependsOn: [
     ':app:assembleDevDebug',
     ':app:lintDevDebug',
     ':app:pmd',
-    ':detektAll'
+    ':detektAll',
+    ':app:jacocoTestReport'
 ]) {
 
     doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath 'org.ajoberstar.grgit:grgit-core:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT}"
-        classpath "org.jacoco:org.jacoco.core:0.8.5"
+        classpath "org.jacoco:org.jacoco.core:${Versions.JACOCO}"
     }
 }
 
@@ -163,8 +163,7 @@ task ci(dependsOn: [
     ':app:assembleDevDebug',
     ':app:lintDevDebug',
     ':app:pmd',
-    ':detektAll',
-    ':app:jacocoTestReport'
+    ':detektAll'
 ]) {
 
     doLast {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,6 +12,7 @@ object Versions {
 
     //plugins
     const val DETEKT = "1.2.2"
+    const val JACOCO = "0.8.5"
 
     //build
     const val COROUTINES = "1.3.2"

--- a/jacoco/coverage.gradle
+++ b/jacoco/coverage.gradle
@@ -1,0 +1,40 @@
+/**
+ * Wire
+ * Copyright (C) 2020 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+apply plugin: 'jacoco'
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def kotlinTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/devDebug/com/waz/zclient", excludes: fileFilter)
+    def javaScalaTree =fileTree(dir: "$project.buildDir/intermediates/javac/devDebug/compileDevDebugJavaWithJavac/classes/com/waz", excludes: fileFilter)
+
+    def kotlinSrc = "$project.projectDir/src/main/kotlin"
+    def scalaSrc = "$project.projectDir/src/main/scala"
+    def javaSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([kotlinSrc,scalaSrc,javaSrc])
+    classDirectories = files([kotlinTree,javaScalaTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+        'jacoco/testDevDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
+}


### PR DESCRIPTION
**Codecov provides highly integrated tools to group, merge, archive and compare coverage reports.**

We'd like to integrate Codecov to generate coverage report in our PR's. This could be done by  following those steps:

- Authorise Codecov GitHub app to access to **wire-android** repository : **DONE**
- Generate Jacoco **xml** report for code coverage  : **Goal of this PR**
- Send reports to Codecov using Jenkins  : **TO DO**

## What's new in this PR?

I created a gradle task `jacocoTestReport`to generate code coverage xml reports for **app module**.

https://wearezeta.atlassian.net/browse/AN-6766
#### APK
[Download build #1727](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1727/artifact/build/artifact/wire-dev-PR2733-1727.apk)