### PR TITLE
Scala: About & Support screen rollback. 

### DIFF
--- a/app/src/main/res/layout/preferences_about.xml
+++ b/app/src/main/res/layout/preferences_about.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+
+    Wire
+    Copyright (C) 2020 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<com.waz.zclient.preferences.pages.AboutView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" />

--- a/app/src/main/res/layout/preferences_about_layout.xml
+++ b/app/src/main/res/layout/preferences_about_layout.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+
+    Wire
+    Copyright (C) 2020 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_website"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_website_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_terms"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_tos_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_privacy"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_privacy_policy_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_license"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_licenses_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_version"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_version_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_about_copyright"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_about_copyright_title" />
+
+        </LinearLayout>
+    </ScrollView>
+</merge>

--- a/app/src/main/res/layout/preferences_support.xml
+++ b/app/src/main/res/layout/preferences_support.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+
+    Wire
+    Copyright (C) 2020 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<com.waz.zclient.preferences.pages.SupportView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" />

--- a/app/src/main/res/layout/preferences_support_layout.xml
+++ b/app/src/main/res/layout/preferences_support_layout.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+
+    Wire
+    Copyright (C) 2020 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/settings_support_website"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_support_website_title" />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/settings_support_contact"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:title="@string/pref_support_contact_title" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</merge>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
@@ -1,0 +1,114 @@
+/**
+ * Wire
+ * Copyright (C) 2020 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.zclient.preferences.pages
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.service.{MetaDataService, ZMessaging}
+import com.waz.utils.events.Signal
+import com.waz.zclient.common.controllers.BrowserController
+import com.waz.zclient.preferences.pages.AboutView._
+import com.waz.zclient.preferences.views.TextButton
+import com.waz.zclient.utils.BackStackKey
+import com.waz.zclient.utils.ContextUtils._
+import com.waz.zclient.{R, ViewHelper}
+
+class AboutView(context: Context, attrs: AttributeSet, style: Int)
+  extends LinearLayout(context, attrs, style)
+    with ViewHelper
+    with DerivedLogTag {
+  
+  def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
+  def this(context: Context) = this(context, null, 0)
+
+  inflate(R.layout.preferences_about_layout)
+
+  private var versionClickCounter: Int = 0
+
+  private lazy val browser = inject[BrowserController]
+
+  val websiteButton       = findById[TextButton](R.id.preferences_about_website)
+  val termsButton         = findById[TextButton](R.id.preferences_about_terms)
+  val privacyPolicyButton = findById[TextButton](R.id.preferences_about_privacy)
+  val licenseButton       = findById[TextButton](R.id.preferences_about_license)
+
+  val versionTextButton = findById[TextButton](R.id.preferences_about_version)
+  val copyrightButton = findById[TextButton](R.id.preferences_about_copyright)
+
+  websiteButton.onClickEvent { _ => browser.openAboutWebsite() }
+  termsButton.onClickEvent { _ =>
+    if (inject[Signal[Option[ZMessaging]]].map(_.flatMap(_.teamId)).currentValue.flatten.isDefined)
+      browser.openTeamsTermsOfService()
+    else
+      browser.openPersonalTermsOfService()
+  }
+  privacyPolicyButton.onClickEvent { _ => browser.openPrivacyPolicy() }
+  licenseButton.onClickEvent {_ => browser.openThirdPartyLicenses() }
+
+  versionTextButton.onClickEvent{ _ =>
+    versionClickCounter += 1
+    if (versionClickCounter >= A_BUNCH_OF_CLICKS_TO_PREVENT_ACCIDENTAL_TRIGGERING) {
+      versionClickCounter = 0
+      showToast(getVersion)
+    }
+  }
+
+  def setVersion(version: String) = versionTextButton.setTitle(getString(R.string.pref_about_version_title, version))
+
+  def getVersion(implicit context: Context): String = {
+    val md = inject[MetaDataService]
+    val translationId = getResources.getIdentifier("wiretranslations_version", "string", context.getPackageName)
+    val translationLibVersion = if(translationId == 0) "n/a" else getString(translationId)
+    s"""
+      |Version:             ${md.versionName} (${md.appVersion}
+      |AVS:                 ${getString(R.string.avs_version)}
+      |Audio-notifications: ${getString(R.string.audio_notifications_version)}
+      |Translations:        $translationLibVersion
+      |Locale:              $getLocale
+    """.stripMargin
+  }
+}
+
+object AboutView {
+  val A_BUNCH_OF_CLICKS_TO_PREVENT_ACCIDENTAL_TRIGGERING = 10
+}
+
+case class AboutBackStackKey(args: Bundle = new Bundle()) extends BackStackKey(args) {
+  override def nameId: Int = R.string.pref_about_screen_title
+
+  override def layoutId = R.layout.preferences_about
+
+  override def onViewAttached(v: View) = {
+    Option(v.asInstanceOf[AboutView]).foreach { view =>
+      val version =
+        try {
+          view.wContext.getPackageManager.getPackageInfo(view.wContext.getPackageName, 0).versionName
+        } catch {
+          case _: PackageManager.NameNotFoundException => ""
+        }
+      view.setVersion(version)
+    }
+  }
+
+  override def onViewDetached() = {}
+}

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -1,6 +1,6 @@
 /**
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2020 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,12 +60,24 @@ class SettingsViewImpl(context: Context, attrs: AttributeSet, style: Int) extend
   val avsButton = findById[TextButton](R.id.settings_avs)
   val inviteButton = findById[FlatWireButton](R.id.profile_invite)
 
-  accountButton.onClickEvent.on(Threading.Ui) { _ =>navigator.goTo(AccountBackStackKey())}
+  accountButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(AccountBackStackKey()) }
   devicesButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(DevicesBackStackKey())}
   optionsButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(OptionsBackStackKey()) }
   advancedButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(AdvancedBackStackKey()) }
-  supportButton.onClickEvent.on(Threading.Ui) { _ => context.startActivity(SettingsSupportActivity.newIntent(context))}
-  aboutButton.onClickEvent.on(Threading.Ui) { _ => context.startActivity(SettingsAboutActivity.newIntent(context)) }
+  supportButton.onClickEvent.on(Threading.Ui) { _ =>
+    if (BuildConfig.KOTLIN_SETTINGS) {
+      context.startActivity(SettingsSupportActivity.newIntent(context))
+    } else {
+      navigator.goTo(SupportBackStackKey())
+    }
+  }
+  aboutButton.onClickEvent.on(Threading.Ui) { _ =>
+    if (BuildConfig.KOTLIN_SETTINGS) {
+      context.startActivity(SettingsAboutActivity.newIntent(context))
+    } else {
+      navigator.goTo(AboutBackStackKey())
+    }
+  }
   devButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(DevSettingsBackStackKey()) }
   avsButton.onClickEvent.on(Threading.Ui) { _ => navigator.goTo(AvsBackStackKey()) }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
@@ -1,0 +1,51 @@
+/**
+  * Wire
+  * Copyright (C) 2020 Wire Swiss GmbH
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
+package com.waz.zclient.preferences.pages
+
+import android.content.Context
+import android.os.Bundle
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.waz.zclient.common.controllers.BrowserController
+import com.waz.zclient.preferences.views.TextButton
+import com.waz.zclient.{R, ViewHelper}
+import com.waz.zclient.utils.BackStackKey
+
+class SupportView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with ViewHelper {
+  def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
+  def this(context: Context) = this(context, null, 0)
+
+  inflate(R.layout.preferences_support_layout)
+
+  val websiteButton = findById[TextButton](R.id.settings_support_website)
+  val contactButton = findById[TextButton](R.id.settings_support_contact)
+
+  websiteButton.onClickEvent{ _ => inject[BrowserController].openSupportPage() }
+  contactButton.onClickEvent{ _ => inject[BrowserController].openContactSupport() }
+}
+
+case class SupportBackStackKey(args: Bundle = new Bundle()) extends BackStackKey(args) {
+  override def nameId: Int = R.string.pref_support_screen_title
+
+  override def layoutId = R.layout.preferences_support
+
+  override def onViewAttached(v: View) = {}
+
+  override def onViewDetached() = {}
+}


### PR DESCRIPTION
## What's new in this PR?

Due to the ongoing issues with the Networking component, we are unable to definitively release two new Kotlin screens. This PR restores the old support and about screens to their former glory in Scala. 

#### APK
[Download build #1741](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1741/artifact/build/artifact/wire-dev-PR2738-1741.apk)