### PR TITLE
AN-6806 Fix: About screen crash 

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -136,3 +136,6 @@
   **[] $VALUES;
   public *;
 }
+
+# Coroutines
+-keep class kotlinx.coroutines.experimental.android.AndroidExceptionPreHandler { *; }


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6806

### Problem statement

About screen was working as normal on debug builds, but, when we generate a release which minify's resources using proguard it removes a critical exception handling class for co-routines.  

### Solution reference
https://github.com/Kotlin/kotlinx.coroutines/issues/214

### Stacktrace

> java.lang.IllegalStateException: Module with the Main dispatcher had failed to initialize
>         at kotlinx.coroutines.internal.MissingMainCoroutineDispatcher.missing(MainDispatchers.kt:96)
>         at kotlinx.coroutines.internal.MissingMainCoroutineDispatcher.isDispatchNeeded(MainDispatchers.kt:71)
>         at kotlinx.coroutines.DispatchedKt.resumeCancellable(Dispatched.kt:420)
>         at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
>         at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:1109)
>         at kotlinx.coroutines.BuildersKt.launch(Unknown Source:2054)
>         at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default$28f1ba1(Builders.common.kt:47)
>         at kotlinx.coroutines.BuildersKt.launch$default$28f1ba1(Unknown Source:1)
>         at com.waz.zclient.core.usecase.ObservableUseCase.invoke(ObservableUseCase.kt:26)
>         at com.waz.zclient.core.ui.backgroundasset.BackgroundAssetViewModel.fetchBackgroundAsset(BackgroundAssetViewModel.kt:20)
>         at com.waz.zclient.core.ui.backgroundasset.ActivityBackgroundAssetObserver.loadBackground(BackgroundAssetObserver.kt:26)
>         at com.waz.zclient.settings.about.SettingsAboutActivity.onCreate(SettingsAboutActivity.kt:3000)
>         at android.app.Activity.performCreate(Activity.java:7815)
>         at android.app.Activity.performCreate(Activity.java:7804)
>         at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1318)
>         at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3349)
>         at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3513)
>         at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
>         at android.app.servertransacxtion.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
>         at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
>         at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2109)
>         at android.os.Handler.dispatchMessage(Handler.java:107)
>         at android.os.Looper.loop(Looper.java:214)
>         at android.app.ActivityThread.main(ActivityThread.java:7682)
>         at java.lang.reflect.Method.invoke(Native Method)
>         at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
>         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
>      Caused by: java.util.ServiceConfigurationError: kotlinx.coroutines.internal.MainDispatcherFactory: Provider kotlinx.coroutines.android.AndroidDispatcherFactory not found
>         at java.util.ServiceLoader.fail(ServiceLoader.java:233)
> ...

### Notes

This doesn't crash with `kotlinSettings = false` on a release build whereas it did before, but, it does beg the question as to why this will crash at runtime when we have no clear dependency on coroutines in the original Scala codebase? I'll have to investigate further for this, but, my assumption is because the background asset code is delegated at the class level it causes the issue with finding classes that need to be compiled to "run" even though it never will be. 
#### APK
[Download build #1765](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1765/artifact/build/artifact/wire-dev-PR2743-1765.apk)