### PR TITLE
fix: Dismiss associated notification when the conversation is opened

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -64,7 +64,7 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
 
   private lazy val notificationManager   = inject[NotificationManagerWrapper]
 
-  private lazy val selfId                = inject[Signal[UserId]]
+  private lazy val selfId                = inject[Signal[Option[UserId]]]
   private lazy val soundController       = inject[SoundController]
   private lazy val navigationController  = inject[NavigationController]
   private lazy val convController        = inject[ConversationController]
@@ -75,22 +75,36 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
 
   override val notificationsSourceVisible: Signal[Map[UserId, Set[ConvId]]] =
     for {
-      accs     <- inject[Signal[AccountsService]].flatMap(_.accountsWithManagers)
-      uiActive <- inject[UiLifeCycle].uiActive
-      selfId   <- selfId
-      convId   <- convController.currentConvIdOpt
-      convs    <- convsStorage.flatMap(_.contents.map(_.keySet))
-      page     <- navigationController.visiblePage
-    } yield
-      accs.map { accId =>
-        accId ->
-          (if (selfId != accId || !uiActive) Set.empty[ConvId]
-          else page match {
-            case Page.CONVERSATION_LIST => convs
-            case Page.MESSAGE_STREAM    => Set(convId).flatten
-            case _                      => Set.empty[ConvId]
-          })
-      }.toMap
+      accs         <- inject[Signal[AccountsService]].flatMap(_.accountsWithManagers)
+      uiActive     <- inject[UiLifeCycle].uiActive
+      Some(selfId) <- selfId
+      convId       <- convController.currentConvIdOpt
+      convs        <- convsStorage.flatMap(_.contents.map(_.keySet))
+      page         <- navigationController.visiblePage
+    } yield accs.map { accId =>
+      accId ->
+        (if (selfId != accId || !uiActive) Set.empty[ConvId]
+        else page match {
+          case Page.CONVERSATION_LIST => convs
+          case Page.MESSAGE_STREAM    => Set(convId).flatten
+          case _                      => Set.empty[ConvId]
+        })
+    }.toMap
+
+  /*
+  Clears notifications already displayed in the tray when the user opens the conversation associated
+  with those notifications. This is separate from removing notifications from the storage and may
+  sometimes be inconsistent (notifications in the tray may stay longer than in the storage).
+   */
+  Signal(selfId, notificationsSourceVisible).onUi {
+    case (Some(selfUserId), sources) =>
+      val notIds = sources.getOrElse(selfUserId, Set.empty).map(toNotificationConvId(selfUserId, _))
+      if (notIds.nonEmpty) notificationManager.cancelNotifications(notIds)
+      notificationManager.cancelNotifications(
+        Set(toNotificationGroupId(selfUserId), toEphemeralNotificationGroupId(selfUserId))
+      )
+    case _ =>
+  }
 
   override def onNotificationsChanged(accountId: UserId, nots: Set[NotificationData]): Future[Unit] = {
     verbose(l"onNotificationsChanged: $accountId, nots: $nots")
@@ -99,12 +113,10 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
       summaries <- createSummaryNotificationProps(accountId, nots, teamName).map(_.map(p => (toNotificationGroupId(accountId), p)))
       convNots  <- createConvNotifications(accountId, nots, teamName).map(_.toMap)
       _         <- Threading.Ui {
-        val nots = convNots ++ summaries
-        if (nots.isEmpty)
-          notificationManager.cancelNotifications(Set(toNotificationGroupId(accountId), toEphemeralNotificationGroupId(accountId)))
-        else
-          nots.foreach { case (id, props) => notificationManager.showNotification(id, props) }
-      }.future
+                     (convNots ++ summaries).foreach {
+                       case (id, props) => notificationManager.showNotification(id, props)
+                     }
+                   }.future
     } yield {}
   }
 
@@ -117,8 +129,8 @@ class MessageNotificationsController(bundleEnabled: Boolean = Build.VERSION.SDK_
       separator = ""
     )
     for {
-      accountId <- selfId.head
-      color     <- notificationColor(accountId)
+      Some(accountId) <- selfId.head
+      color           <- notificationColor(accountId)
     } yield {
       val props = NotificationProps(
         accountId,

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -576,12 +576,11 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val conv1 = ConversationData()
       val conv2 = ConversationData()
 
+      val not1 = NotificationData(hasBeenDisplayed = true, conv = conv1.id, time = RemoteInstant.apply(clock.instant))
+      val not2 = NotificationData(hasBeenDisplayed = true, conv = conv1.id, time = RemoteInstant.apply(clock.instant))
+      val not3 = NotificationData(hasBeenDisplayed = true, conv = conv2.id, time = RemoteInstant.apply(clock.instant)) //a different conv!
       //prefil notification storage
-      val previousNots = Set(
-        NotificationData(hasBeenDisplayed = true, conv = conv1.id, time = RemoteInstant.apply(clock.instant)),
-        NotificationData(hasBeenDisplayed = true, conv = conv1.id, time = RemoteInstant.apply(clock.instant)),
-        NotificationData(hasBeenDisplayed = true, conv = conv2.id, time = RemoteInstant.apply(clock.instant)) //a different conv!
-      )
+      val previousNots = Set(not1, not2, not3)
       storedNotifications ! previousNots
 
       processing ! true
@@ -594,13 +593,6 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         eventTime    = None
       )
 
-      (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
-        Future {
-          nots.size shouldEqual 1
-          nots.head.conv shouldEqual conv2.id
-        }
-      }
-
       getService
 
       notificationsSourceVisible ! Map(account1Id -> Set(conv1.id))
@@ -608,6 +600,8 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       processing ! false
 
       awaitAllTasks
+
+      result(storedNotifications.head) shouldEqual Set(not3)
     }
   }
 }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6822

While fixing the bug which processed the notifications in O(n^2), I accidentally removed the old way to dismiss notifications when the user opens the conversation associated with them. The old way was very convoluted: it tried to remove all displayed notifications and recreate them (and failed). Instead I made a simpler fix which just cancels notifications with matching ids. A notification id is created from the user id and the conversation id (no need for unique ids per message), plus there are "summary notifications" with ids based only on user ids). So if a conversation is opened by the user, we already know which notifications should be dismissed.
#### APK
[Download build #1770](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1770/artifact/build/artifact/wire-dev-PR2747-1770.apk)