### PR TITLE
fix : revert MessageContentIndex table to fix search content with special characters

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -197,6 +197,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[ConversationFoldersStorage]]    to inject[Signal[ZMessaging]].map(_.conversationFoldersStorage)
     bind [Signal[FoldersService]]                to inject[Signal[ZMessaging]].map(_.foldersService)
     bind [Signal[TeamsService]]                  to inject[Signal[ZMessaging]].map(_.teams)
+    bind [Signal[MessageIndexStorage]]           to inject[Signal[ZMessaging]].map(_.messagesIndexStorage)
     bind [Signal[ConnectionService]]             to inject[Signal[ZMessaging]].map(_.connection)
     bind [Signal[ButtonsStorage]]                to inject[Signal[ZMessaging]].map(_.buttonsStorage)
 

--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
@@ -66,7 +66,7 @@ class CollectionController(implicit injector: Injector)
     convId <- convController.currentConvId
     query <- contentSearchQuery
     res <- if (query.isEmpty) Signal.const(Set.empty[MessageId])
-           else Signal.future(z.messagesStorage.matchingMessages(query, Some(convId)))
+    else Signal future z.messagesIndexStorage.matchingMessages(query, Some(convId))
   } yield res
 
   def openCollection() = observers foreach { _.openCollection() }

--- a/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultRowView.scala
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.waz.api.ContentSearchQuery
-import com.waz.content.MessagesStorage
+import com.waz.content.MessageIndexStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
@@ -53,14 +53,14 @@ class TextSearchResultRowView(context: Context, attrs: AttributeSet, style: Int)
 
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
-  
+
   override val tpe: MsgPart = Text
 
   inflate(R.layout.search_text_result_row)
   setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getResources.getDimensionPixelSize(R.dimen.search__result__height)))
   setOrientation(LinearLayout.HORIZONTAL)
 
-  private lazy val messagesStorage          = inject[Signal[MessagesStorage]]
+  private lazy val messagesIndexStorage     = inject[Signal[MessageIndexStorage]]
   private lazy val accentColorController    = inject[AccentColorController]
   private lazy val usersController          = inject[UsersController]
 
@@ -70,11 +70,11 @@ class TextSearchResultRowView(context: Context, attrs: AttributeSet, style: Int)
   private lazy val resultsCount    = ViewUtils.getView(this, R.id.search_result_count).asInstanceOf[TypefaceTextView]
 
   (for {
-    storage  <- messagesStorage
+    mis      <- messagesIndexStorage
     color    <- accentColorController.accentColor
     m        <- message
     q        <- searchedQuery if q.toString().nonEmpty
-    nContent <- Signal.future(storage.getNormalizedContentForMessage(m.id))
+    nContent <- Signal.future(mis.getNormalizedContentForMessage(m.id))
   } yield (m, q, color, nContent)).onUi {
     case (msg, query, color, Some(normalizedContent)) =>
       val spannableString = CollectionUtils.getHighlightedSpannableString(msg.contentString, normalizedContent, query.elements, ColorUtils.injectAlpha(0.5f, color.color), StartEllipsisThreshold)

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/UserDatabaseHelper.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/UserDatabaseHelper.kt
@@ -18,7 +18,6 @@ class UserDatabaseHelper {
     private val contactsOnWireTableQuery = """CREATE TABLE IF NOT EXISTS ContactsOnWire (user TEXT , contact TEXT , PRIMARY KEY (user, contact))""".trimIndent()
     private val clientsTableQuery = """CREATE TABLE IF NOT EXISTS Clients (_id TEXT PRIMARY KEY, data TEXT )""".trimIndent()
     private val likingsTableQuery = """CREATE TABLE IF NOT EXISTS Likings (message_id TEXT , user_id TEXT , timestamp INTEGER , action INTEGER , PRIMARY KEY (message_id, user_id))""".trimIndent()
-    private val clientTableQuery = """CREATE TABLE IF NOT EXISTS 'client' ('id' TEXT NOT NULL,'time' TEXT NOT NULL, 'label' TEXT NOT NULL, 'type' TEXT NOT NULL, 'class' TEXT NOT NULL, 'model' TEXT NOT NULL, 'lat' REAL NOT NULL, 'lon' REAL NOT NULL, 'locationName' TEXT, 'verification' TEXT NOT NULL, 'encKey' TEXT NOT NULL, 'macKey' TEXT NOT NULL, PRIMARY KEY('id'))""".trimIndent()
     private val contactsTableQuery = """CREATE TABLE IF NOT EXISTS Contacts (_id TEXT PRIMARY KEY, name TEXT , name_source INTEGER , sort_key TEXT , search_key TEXT )""".trimIndent()
     private val emailAddressesTableQuery = """CREATE TABLE IF NOT EXISTS EmailAddresses (contact TEXT , email_address TEXT )""".trimIndent()
     private val phoneNumbersTableQuery = """CREATE TABLE IF NOT EXISTS PhoneNumbers (contact TEXT , phone_number TEXT )""".trimIndent()
@@ -35,14 +34,14 @@ class UserDatabaseHelper {
     private val foldersTableQuery = """CREATE TABLE IF NOT EXISTS Folders (_id TEXT PRIMARY KEY, name TEXT , type INTEGER )""".trimIndent()
     private val conversationFoldersTableQuery = """CREATE TABLE IF NOT EXISTS ConversationFolders (conv_id TEXT , folder_id TEXT , PRIMARY KEY (conv_id, folder_id))""".trimIndent()
     private val conversationRoleActionTableQuery = """CREATE TABLE IF NOT EXISTS ConversationRoleAction (label TEXT , action TEXT , conv_id TEXT , PRIMARY KEY (label, action, conv_id))""".trimIndent()
-    private val messageContentIndexQuery = """CREATE VIRTUAL TABLE MessageContentIndex using fts3( message_id TEXT PRIMARY KEY, conv_id TEXT, content TEXT, time INTEGER)""".trimIndent()
+    private val messageContentIndexQuery = """CREATE VIRTUAL TABLE MessageContentIndex using fts4(message_id TEXT, conv_id TEXT, content TEXT, time INTEGER)""".trimIndent()
 
     private val createQueries = arrayOf(
         userTableQuery, assetsTableQuery, conversationsTableQuery,
         conversationMembersTableQuery, messagesTableQuery, keyValuesTableQuery,
         syncJobsTableQuery, errorsTableQuery, notificationDataTableQuery,
         contactHashesTableQuery, contactsOnWireTableQuery, contactsOnWireTableQuery,
-        clientsTableQuery, likingsTableQuery, clientTableQuery, contactsTableQuery, emailAddressesTableQuery,
+        clientsTableQuery, likingsTableQuery, contactsTableQuery, emailAddressesTableQuery,
         phoneNumbersTableQuery, msgDeletionTableQuery, editHistoryTableQuery,
         pushNotificationEventsTableQuery, readReceiptsTableQuery, propertiesTableQuery,
         uploadAssetsTableQuery, downloadAssetsTableQuery, assets2TableQuery,

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessageContentIndexTableTestHelper.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessageContentIndexTableTestHelper.kt
@@ -1,0 +1,35 @@
+package com.waz.zclient.storage.userdatabase.messages
+
+import android.content.ContentValues
+import com.waz.zclient.storage.DbSQLiteOpenHelper
+
+
+class MessageContentIndexTableTestHelper private constructor() {
+
+    companion object {
+        private const val MESSAGES_CONTENT_INDEX_TABLE_NAME = "MessageContentIndex"
+        private const val MESSAGES_CONTENT_INDEX_MESSAGE_ID_COL = "message_id"
+        private const val MESSAGES_CONTENT_INDEX_CONV_ID_COL = "conv_id"
+        private const val MESSAGES_CONTENT_INDEX_CONTENT_COL = "content"
+        private const val MESSAGES_CONTENT_INDEX_TIME_COL = "time"
+
+        fun insertMessageContentIndex(messageId: String,
+                                      conversationId: String,
+                                      content: String,
+                                      timestamp: Int, openHelper: DbSQLiteOpenHelper) {
+
+            val contentValues = ContentValues().also {
+                it.put(MESSAGES_CONTENT_INDEX_MESSAGE_ID_COL, messageId)
+                it.put(MESSAGES_CONTENT_INDEX_CONV_ID_COL, conversationId)
+                it.put(MESSAGES_CONTENT_INDEX_CONTENT_COL, content)
+                it.put(MESSAGES_CONTENT_INDEX_TIME_COL, timestamp)
+
+            }
+
+            openHelper.insertWithOnConflict(
+                tableName = MESSAGES_CONTENT_INDEX_TABLE_NAME,
+                contentValues = contentValues
+            )
+        }
+    }
+}

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessagesTables126to127MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessagesTables126to127MigrationTest.kt
@@ -143,6 +143,34 @@ class MessagesTables126to127MigrationTest : UserDatabaseMigrationTest(126, 127) 
         }
     }
 
+    @Test
+    fun givenMessageContentIndexInsertedIntoMessageContentIndexTableVersion126_whenMigratedToVersion127_thenAssertDataIsStillIntact() {
+
+        val messageId = "testMessageId"
+        val conversationId = "testConversationId"
+        val content = "content"
+        val timestamp = 1584710479
+
+        MessageContentIndexTableTestHelper.insertMessageContentIndex(
+            messageId = messageId,
+            conversationId = conversationId,
+            content = content,
+            timestamp = timestamp,
+            openHelper = testOpenHelper
+        )
+
+        validateMigration(USER_DATABASE_MIGRATION_126_TO_127)
+
+        runBlocking {
+            with(allMessageContentIndexes()[0]) {
+                assert(this.messageId == messageId)
+                assert(this.convId == conversationId)
+                assert(this.content == content)
+                assert(this.timestamp == timestamp)
+            }
+        }
+    }
+
     private suspend fun allMessages() =
         getDatabase().messagesDao().allMessages()
 
@@ -150,4 +178,7 @@ class MessagesTables126to127MigrationTest : UserDatabaseMigrationTest(126, 127) 
         getDatabase().messagesDeletionDao().allMessageDeletions()
 
     private suspend fun allLikes() = getDatabase().likesDao().allLikes()
+
+    private suspend fun allMessageContentIndexes() =
+        getDatabase().messageContentIndexDao().allMessageContentIndexes()
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -34,6 +34,8 @@ import com.waz.zclient.storage.db.history.EditHistoryDao
 import com.waz.zclient.storage.db.history.EditHistoryEntity
 import com.waz.zclient.storage.db.messages.LikesDao
 import com.waz.zclient.storage.db.messages.LikesEntity
+import com.waz.zclient.storage.db.messages.MessageContentIndexDao
+import com.waz.zclient.storage.db.messages.MessageContentIndexEntity
 import com.waz.zclient.storage.db.messages.MessageDeletionEntity
 import com.waz.zclient.storage.db.messages.MessagesDao
 import com.waz.zclient.storage.db.messages.MessagesDeletionDao
@@ -72,7 +74,8 @@ import com.waz.zclient.storage.db.users.service.UserDao
         ConversationFoldersEntity::class, FoldersEntity::class, CloudNotificationStatsEntity::class,
         CloudNotificationsEntity::class, AssetsEntity::class, DownloadAssetsEntity::class,
         UploadAssetsEntity::class, PropertiesEntity::class, ReadReceiptsEntity::class,
-        PushNotificationEventEntity::class, EditHistoryEntity::class, ButtonEntity::class],
+        PushNotificationEventEntity::class, EditHistoryEntity::class, ButtonEntity::class,
+        MessageContentIndexEntity::class],
     version = UserDatabase.VERSION
 )
 
@@ -108,6 +111,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun foldersDao(): FoldersDao
     abstract fun readReceiptsDao(): ReadReceiptsDao
     abstract fun editHistoryDao(): EditHistoryDao
+    abstract fun messageContentIndexDao(): MessageContentIndexDao
 
     companion object {
         const val VERSION = 127

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/messages/MessageContentIndexDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/messages/MessageContentIndexDao.kt
@@ -1,0 +1,10 @@
+package com.waz.zclient.storage.db.messages
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface MessageContentIndexDao {
+    @Query("SELECT * FROM MessageContentIndex")
+    suspend fun allMessageContentIndexes(): List<MessageContentIndexEntity>
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/messages/MessageContentIndexEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/messages/MessageContentIndexEntity.kt
@@ -1,0 +1,22 @@
+package com.waz.zclient.storage.db.messages
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4
+@Entity(tableName = "MessageContentIndex")
+data class MessageContentIndexEntity(
+
+    @ColumnInfo(name = "message_id")
+    val messageId: String,
+
+    @ColumnInfo(name = "conv_id")
+    val convId: String,
+
+    @ColumnInfo(name = "content")
+    val content: String,
+
+    @ColumnInfo(name = "time")
+    val timestamp: Int
+)

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase126To127Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase126To127Migration.kt
@@ -754,6 +754,29 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(126, 127) {
         )
     }
 
+    private fun migrateMessageContentIndexTable(database: SupportSQLiteDatabase) {
+        val tempTableName = "MessageContentIndexTemp"
+        val originalTableName = "MessageContentIndex"
+        val messageId = "message_id"
+        val convId = "conv_id"
+        val content = "content"
+        val time = "time"
+        val createTempTable = """
+              CREATE VIRTUAL TABLE $tempTableName using fts4(
+              $messageId TEXT NOT NULL,
+              $convId TEXT NOT NULL,
+              $content TEXT NOT NULL,
+              $time INTEGER NOT NULL,
+              )""".trimIndent()
+
+        executeSimpleMigration(
+            database = database,
+            originalTableName = originalTableName,
+            tempTableName = tempTableName,
+            createTempTable = createTempTable
+        )
+    }
+
     private fun executeSimpleMigration(
         database: SupportSQLiteDatabase,
         originalTableName: String,
@@ -786,34 +809,6 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(126, 127) {
                 PRIMARY KEY(`message_id`, `button_id`)
             )""".trimIndent()
         )
-    }
-
-    private fun migrateMessageContentIndexTable(database: SupportSQLiteDatabase) {
-        val tempTableName = "MessageContentIndexTemp"
-        val originalTableName = "MessageContentIndex"
-        val messageId = "message_id"
-        val convId = "conv_id"
-        val content = "content"
-        val time = "time"
-        val createTempTable = """
-              CREATE VIRTUAL TABLE $tempTableName using fts4(
-              $messageId TEXT NOT NULL,
-              $convId TEXT NOT NULL,
-              $content TEXT NOT NULL,
-              $time INTEGER NOT NULL,
-              )""".trimIndent()
-
-        val copyAll = """INSERT INTO $tempTableName ($messageId, $convId, $content, $time)
-         SELECT $messageId, $convId, $content, $time FROM $originalTableName""".trimIndent()
-
-        val dropOldTable = "DROP TABLE $originalTableName"
-        val renameTableBack = "ALTER TABLE $tempTableName RENAME TO $originalTableName"
-        with(database) {
-            execSQL(createTempTable)
-            execSQL(copyAll)
-            execSQL(dropOldTable)
-            execSQL(renameTableBack)
-        }
     }
 
     //TODO still needs determining what to do with this one.

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase126To127Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase126To127Migration.kt
@@ -59,6 +59,7 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(126, 127) {
         migrateFoldersTable(database)
         migrateConversationFoldersTable(database)
         migrateConversationRoleActionTable(database)
+        migrateMessageContentIndexTable(database)
 
         //TODO Move this to 127 - 128 Migration when finished with migration bug
         createButtonsTable(database)
@@ -785,6 +786,34 @@ val USER_DATABASE_MIGRATION_126_TO_127 = object : Migration(126, 127) {
                 PRIMARY KEY(`message_id`, `button_id`)
             )""".trimIndent()
         )
+    }
+
+    private fun migrateMessageContentIndexTable(database: SupportSQLiteDatabase) {
+        val tempTableName = "MessageContentIndexTemp"
+        val originalTableName = "MessageContentIndex"
+        val messageId = "message_id"
+        val convId = "conv_id"
+        val content = "content"
+        val time = "time"
+        val createTempTable = """
+              CREATE VIRTUAL TABLE $tempTableName using fts4(
+              $messageId TEXT NOT NULL,
+              $convId TEXT NOT NULL,
+              $content TEXT NOT NULL,
+              $time INTEGER NOT NULL,
+              )""".trimIndent()
+
+        val copyAll = """INSERT INTO $tempTableName ($messageId, $convId, $content, $time)
+         SELECT $messageId, $convId, $content, $time FROM $originalTableName""".trimIndent()
+
+        val dropOldTable = "DROP TABLE $originalTableName"
+        val renameTableBack = "ALTER TABLE $tempTableName RENAME TO $originalTableName"
+        with(database) {
+            execSQL(createTempTable)
+            execSQL(copyAll)
+            execSQL(dropOldTable)
+            execSQL(renameTableBack)
+        }
     }
 
     //TODO still needs determining what to do with this one.

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/ContentSearchQuery.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/ContentSearchQuery.scala
@@ -30,9 +30,8 @@ case class ContentSearchQuery(originalString: String){
       .map(transliterated)
       .toSet
 
-  lazy val query = toString
-
   override def toString = elements.mkString(" ")
+  def toFtsQuery = elements.map(_ + "*").mkString(" ")
 
   def isEmpty = elements.isEmpty
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -33,15 +33,14 @@ import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class ConvMessagesIndex(convId:      ConvId,
-                        messages:    MessagesStorage,
-                        selfUserId:  UserId,
-                        users:       UsersStorage,
-                        convs:       ConversationStorage,
+class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl,
+                        selfUserId: UserId, users: UsersStorage,
+                        convs: ConversationStorage,
                         msgAndLikes: MessageAndLikesStorage,
-                        storage:     ZmsDatabase,
-                        tracking:    TrackingService,
-                        filter:      Option[MessageFilter] = None) { self =>
+                        storage: ZmsDatabase,
+                        tracking: TrackingService,
+                        filter: Option[MessageFilter] = None) {
+  self =>
 
   private implicit val tag: LogTag = LogTag(s"ConvMessagesIndex_$convId")
 
@@ -117,7 +116,7 @@ class ConvMessagesIndex(convId:      ConvId,
     storage.read { implicit db =>
       val (cursor, order) = filter match {
         //TODO: this ignores other filter types if the content query is on. they should all be considered...
-        case Some(MessageFilter(_, Some(query), _)) => (MessageDataDao.findContent(query, Some(convId)), MessagesCursor.Descending)
+        case Some(MessageFilter(_, Some(query), _)) => (MessageContentIndexDao.findContent(query, Some(convId)), MessagesCursor.Descending)
         case Some(MessageFilter(Some(types), _, limit)) => (MessageDataDao.msgIndexCursorFiltered(convId, types, limit), MessagesCursor.Descending)
         case _ => (MessageDataDao.msgIndexCursor(convId), MessagesCursor.Ascending)
       }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -33,13 +33,10 @@ import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl,
-                        selfUserId: UserId, users: UsersStorage,
-                        convs: ConversationStorage,
-                        msgAndLikes: MessageAndLikesStorage,
-                        storage: ZmsDatabase,
-                        tracking: TrackingService,
-                        filter: Option[MessageFilter] = None) {
+class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserId: UserId,
+                        users: UsersStorage, convs: ConversationStorage,
+                        msgAndLikes: MessageAndLikesStorage, storage: ZmsDatabase,
+                        tracking: TrackingService, filter: Option[MessageFilter] = None) {
   self =>
 
   private implicit val tag: LogTag = LogTag(s"ConvMessagesIndex_$convId")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -1,0 +1,89 @@
+/*
+  * Wire
+  * Copyright (C) 2016 Wire Swiss GmbH
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+package com.waz.content
+
+import java.util.concurrent.TimeUnit
+
+import android.content.Context
+import com.waz.api.ContentSearchQuery
+import com.waz.db.{CursorIterator, Reader}
+import com.waz.log.BasicLogging.LogTag
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.model._
+import com.waz.service.tracking.TrackingService
+import com.waz.threading.SerialDispatchQueue
+import com.waz.utils.TrimmingLruCache.Fixed
+import com.waz.utils.wrappers.DBCursor
+import com.waz.utils.{CachedStorageImpl, TrimmingLruCache}
+import com.waz.utils._
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorage: MessagesStorage, loader: MessageAndLikesStorage, tracking: TrackingService, conversationStorage: ConversationStorage)
+  extends CachedStorageImpl[MessageId, MessageContentIndexEntry](new TrimmingLruCache(context, Fixed(MessageContentIndex.MaxSearchResults)), storage)(MessageContentIndexDao, LogTag("MessageIndexStorage_Cached"))
+    with DerivedLogTag {
+
+  import MessageIndexStorage._
+  import MessageContentIndex.TextMessageTypes
+  import com.waz.utils.events.EventContext.Implicits.global
+
+  private implicit val dispatcher = new SerialDispatchQueue(name = "MessageIndexStorage")
+
+  private def entry(m: MessageData) =
+    MessageContentIndexEntry(m.id, m.convId, ContentSearchQuery.transliterated(m.contentString), m.time)
+
+  messagesStorage.onAdded { added =>
+    insertAll(added.filter(m => TextMessageTypes.contains(m.msgType) && !m.isEphemeral).map(entry))
+  }
+
+  messagesStorage.onUpdated { updated =>
+    val entries = updated.collect { case (_, m) if TextMessageTypes.contains(m.msgType) && !m.isEphemeral => entry(m) }
+    //FTS tables ignore UNIQUE or PKEY constraints so we have to force the replace
+    removeAll(entries.map(_.messageId))
+    insertAll(entries)
+  }
+
+  messagesStorage.onDeleted { removed =>
+    if (removed.nonEmpty) removeAll(removed)
+  }
+
+  def searchText(contentSearchQuery: ContentSearchQuery, convId: Option[ConvId]): Future[MessagesCursor] =
+    for {
+      cursor <- storage.read(MessageContentIndexDao.findContent(contentSearchQuery, convId)(_)) // find messages
+      _ <- getAll(CursorIterator.list[MessageId](cursor, close = false)(MsgIdReader)) // prefetch index entries to ensure following get calls are fast
+      lastRead <- convId.fold2(Future.successful(None), conversationStorage.get(_).map(_.map(_.lastRead)))
+    } yield
+      new MessagesCursor(cursor, 0, lastRead.getOrElse(RemoteInstant.Epoch), loader, tracking)(MessagesCursor.Descending)
+
+  def matchingMessages(contentSearchQuery: ContentSearchQuery, convId: Option[ConvId]): Future[Set[MessageId]] =
+    storage.read { implicit db =>
+      CursorIterator.list[MessageId](MessageContentIndexDao.findContent(contentSearchQuery, convId))(MsgIdReader).toSet
+    }
+
+  def getNormalizedContentForMessage(messageId: MessageId): Future[Option[String]] =
+    get(messageId).map(_.map(_.content))
+}
+
+object MessageIndexStorage {
+  val UpdateOldMessagesThrottle = FiniteDuration(1, TimeUnit.SECONDS)
+
+  implicit object MsgIdReader extends Reader[MessageId] {
+    override def apply(implicit c: DBCursor): MessageId = MessageId(c.getString(0))
+  }
+}

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -75,7 +75,7 @@ object ZMessagingDB {
     PhoneNumbersDao, MsgDeletionDao, EditHistoryDao,
     PushNotificationEventsDao, ReadReceiptDao, PropertiesDao, UploadAssetDao, DownloadAssetDao,
     AssetDao, FCMNotificationsDao, FCMNotificationStatsDao, FolderDataDao, ConversationFolderDataDao,
-    ConversationRoleActionDao, ButtonDataDao
+    ConversationRoleActionDao, ButtonDataDao,MessageContentIndexDao
   )
 
   lazy val migrations = Seq(

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageContentIndexDao.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageContentIndexDao.scala
@@ -1,0 +1,73 @@
+/*
+  * Wire
+  * Copyright (C) 2016 Wire Swiss GmbH
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+package com.waz.model
+
+import com.waz.api.{ContentSearchQuery, Message}
+import com.waz.db.Col._
+import com.waz.db.Dao
+import com.waz.log.BasicLogging.LogTag
+import com.waz.utils.Identifiable
+import com.waz.utils.wrappers.{DB, DBCursor}
+
+case class MessageContentIndexEntry(messageId: MessageId, convId: ConvId, content: String, time: RemoteInstant) extends Identifiable[MessageId] {
+  override val id: MessageId = messageId
+}
+
+object MessageContentIndexDao extends Dao[MessageContentIndexEntry, MessageId] {
+  import MessageContentIndex._
+  private implicit val tag: LogTag = LogTag("MessageContentIndex")
+
+  val MessageId = id[MessageId]('message_id).apply(_.messageId)
+  val Conv = id[ConvId]('conv_id).apply(_.convId)
+  val Content = text('content)(_.content)
+  val Time = remoteTimestamp('time)(_.time)
+
+  override def onCreate(db: DB) = {
+    db.execSQL(table.createFtsSql)
+  }
+  override val idCol = MessageId
+  override val table = Table("MessageContentIndex", MessageId, Conv, Content, Time)
+
+  override def apply(implicit c: DBCursor): MessageContentIndexEntry =
+    MessageContentIndexEntry(MessageId, Conv, Content, Time)
+
+  private val IndexColumns = Array(MessageId.name, Time.name)
+
+  def findContent(contentSearchQuery: ContentSearchQuery, convId: Option[ConvId])(implicit db: DB): DBCursor ={
+    findContentFts(contentSearchQuery.toFtsQuery, convId)
+  }
+
+  def deleteForConv(id: ConvId)(implicit db: DB) = delete(Conv, id)
+
+  def deleteUpTo(id: ConvId, upTo: RemoteInstant)(implicit db: DB) = db.delete(table.name, s"${Conv.name} = '${id.str}' AND ${Time.name} <= ${Time(upTo)}", null)
+
+  def findContentFts(queryText: String, convId: Option[ConvId])(implicit db: DB): DBCursor = {
+    convId match {
+      case Some(conv) =>
+        db.query(table.name, IndexColumns, s"${Conv.name} = '$conv' AND ${Content.name} MATCH '$queryText'", null, null, null, s"${Time.name} DESC", SearchLimit)
+      case _ =>
+        db.query(table.name, IndexColumns, s"${Content.name} MATCH '$queryText'", null, null, null, s"${Time.name} DESC", SearchLimit)
+    }
+  }
+}
+
+object MessageContentIndex {
+  val MaxSearchResults = 1024 // don't want to read whole db on common search query
+  val SearchLimit = MaxSearchResults.toString
+  val TextMessageTypes = Set(Message.Type.TEXT, Message.Type.TEXT_EMOJI_ONLY, Message.Type.RICH_MEDIA, Message.Type.COMPOSITE)
+}

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -181,6 +181,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
   lazy val messagesStorage: MessagesStorage                       = wire[MessagesStorageImpl]
   lazy val msgAndLikes: MessageAndLikesStorageImpl                = wire[MessageAndLikesStorageImpl]
+  lazy val messagesIndexStorage: MessageIndexStorage              = wire[MessageIndexStorage]
   lazy val eventStorage: PushNotificationEventsStorage            = wire[PushNotificationEventsStorageImpl]
   lazy val readReceiptsStorage: ReadReceiptsStorage               = wire[ReadReceiptsStorageImpl]
   lazy val foldersStorage: FoldersStorage                         = wire[FoldersStorageImpl]
@@ -358,9 +359,8 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
     tempFiles
     recordAndPlay
-
+    messagesIndexStorage
     verificationUpdater
-
     propertiesService
 
     rolesService.ensureDefaultRoles()


### PR DESCRIPTION
## What's new in this PR?

I reverted back the virtual FTS table `MessageContentIndex` to fix the issues related to content search with special characters.

https://wearezeta.atlassian.net/browse/AN-6804
https://wearezeta.atlassian.net/browse/AN-6805


### Testing

- Fresh Install the version 3.46
- Login and write some messages 
- Install the version 3.47 -> No crash/No stuck
- Search for content with special characters in your conversations i.e umlauts "aa" or "ää" or "oo" or "öö"
