### PR TITLE
Kotlin Backend - Part 2: Scope backend configuration for dynamic change

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/backend/BackendRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/backend/BackendRepository.kt
@@ -13,7 +13,7 @@ interface BackendRepository {
      * Returns the base url that should be used for network requests in the future, overriding Retrofit's base url.
      *
      * Note that, if the app is running on a custom backend which is configured before, this method also returns null,
-     * since [backendConfig] returns that backend as the default config.
+     * since custom backend is fetched as the default config when app starts.
      *
      * @return the new url if configured during app's lifetime, null o/w
      */
@@ -23,4 +23,9 @@ interface BackendRepository {
      * Returns the current [BackendItem] encapsulating the endpoints to be used to perform network requests.
      */
     fun backendConfig(): BackendItem
+
+    /**
+     * Fetches a new instance of the [BackendItem] from data sources.
+     */
+    fun fetchBackendConfig(): BackendItem
 }

--- a/app/src/main/kotlin/com/waz/zclient/core/backend/di/BackendConfigScopeManager.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/backend/di/BackendConfigScopeManager.kt
@@ -1,0 +1,35 @@
+package com.waz.zclient.core.backend.di
+
+import com.waz.zclient.core.backend.BackendItem
+import org.koin.core.KoinComponent
+import org.koin.core.qualifier.named
+
+class BackendConfigScopeManager : KoinComponent {
+
+    private var scope = getOrCreateScope(DEFAULT_CONFIG_ID)
+
+    /**
+     * Returns whether the app is still running on the same network configurations as the ones it was first started.
+     */
+    fun isDefaultConfig(): Boolean = scope.id == DEFAULT_CONFIG_ID
+
+    /**
+     * Deletes the old scope and creates a new one for the new configuration.
+     */
+    fun onConfigChanged(id: String) {
+        scope.close()
+        scope = getOrCreateScope(id)
+    }
+
+    /**
+     * Returns the [BackendItem] instance that lives in current scope, if any.
+     */
+    fun backendItem(): BackendItem = scope.get()
+
+    private fun getOrCreateScope(id: String) = getKoin().getOrCreateScope(id, named(SCOPE_NAME))
+
+    companion object {
+        const val SCOPE_NAME = "backendConfigScope"
+        private const val DEFAULT_CONFIG_ID = "defaultBackendConfigId"
+    }
+}

--- a/app/src/main/kotlin/com/waz/zclient/core/backend/di/BackendModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/backend/di/BackendModule.kt
@@ -8,10 +8,17 @@ import com.waz.zclient.core.backend.datasources.remote.BackendApiService
 import com.waz.zclient.core.backend.datasources.remote.BackendRemoteDataSource
 import com.waz.zclient.core.backend.mapper.BackendMapper
 import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
+object BackendModule {
+    //TODO: we won't need this once whole app uses BackendRepository for setting up custom backends
+    @JvmStatic
+    val backendConfigScopeManager = BackendConfigScopeManager()
+}
+
 val backendModule: Module = module {
-    single { BackendDataSource(get(), get(), get(), get()) as BackendRepository }
+    single { BackendDataSource(get(), get(), get(), get(), get()) as BackendRepository }
 
     factory { BackendClient() }
     single { BackendRemoteDataSource(get()) }
@@ -19,5 +26,11 @@ val backendModule: Module = module {
     factory { BackendApiService(get(), get()) }
     factory { BackendLocalDataSource(get()) }
     factory { BackendMapper() }
+
+    single { BackendModule.backendConfigScopeManager }
+    scope(named(BackendConfigScopeManager.SCOPE_NAME)) {
+        scoped { get<BackendRepository>().fetchBackendConfig() }
+    }
+
     factory { get<BackendRepository>().backendConfig() }
 }

--- a/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/BackendController.scala
@@ -24,6 +24,7 @@ import android.preference.PreferenceManager
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{BackendConfig, GlobalModule}
 import com.waz.sync.client.CustomBackendClient.BackendConfigResponse
+import com.waz.zclient.core.backend.di.BackendModule
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{Backend, BuildConfig}
 
@@ -48,7 +49,7 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
     val teamsUrl = getStringPreference(TEAMS_URL_PREF)
     val accountsUrl = getStringPreference(ACCOUNTS_URL_PREF)
     val websiteUrl = getStringPreference(WEBSITE_URL_PREF)
-    
+
     (environment, baseUrl, websocketUrl, blackListHost, teamsUrl, accountsUrl, websiteUrl) match {
       case (Some(env), Some(base), Some(web), Some(black), Some(teams), Some(accounts), Some(website)) =>
         info(l"Retrieved stored backend config for environment: ${redactedString(env)}")
@@ -91,6 +92,8 @@ class BackendController(implicit context: Context) extends DerivedLogTag {
     setStoredBackendConfig(globalModule.backend)
 
     prefs.edit().putString(CONFIG_URL_PREF, configUrl.toString).commit()
+
+    BackendModule.getBackendConfigScopeManager.onConfigChanged(configResponse.title)
   }
 
   def shouldShowBackendSelector: Boolean =

--- a/app/src/test/kotlin/com/waz/zclient/core/backend/BackendDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/backend/BackendDataSourceTest.kt
@@ -7,6 +7,7 @@ import com.waz.zclient.core.backend.datasources.local.BackendLocalDataSource
 import com.waz.zclient.core.backend.datasources.local.CustomBackendPreferences
 import com.waz.zclient.core.backend.datasources.remote.BackendRemoteDataSource
 import com.waz.zclient.core.backend.datasources.remote.CustomBackendResponse
+import com.waz.zclient.core.backend.di.BackendConfigScopeManager
 import com.waz.zclient.core.backend.di.BackendRemoteDataSourceProvider
 import com.waz.zclient.core.backend.mapper.BackendMapper
 import com.waz.zclient.core.exception.ServerError
@@ -45,21 +46,54 @@ class BackendDataSourceTest : UnitTest() {
     private lateinit var backendMapper: BackendMapper
 
     @Mock
+    private lateinit var scopeManager: BackendConfigScopeManager
+
+    @Mock
     private lateinit var backendItem: BackendItem
 
     @Before
     fun setup() {
         `when`(remoteDataSourceProvider.backendRemoteDataSource()).thenReturn(remoteDataSource)
-        backendDataSource = BackendDataSource(remoteDataSourceProvider, localDataSource, backendClient, backendMapper)
+        backendDataSource =
+            BackendDataSource(remoteDataSourceProvider, localDataSource, backendClient, backendMapper, scopeManager)
     }
 
     @Test
-    fun `Given localDataSource has a config, when backendConfig is called, returns local config as backend item`() {
+    fun `Given app's running with the default config, when configuredUrl is called, then returns null`() {
+        `when`(scopeManager.isDefaultConfig()).thenReturn(true)
+
+        val url = backendDataSource.configuredUrl()
+
+        url shouldBe null
+    }
+
+    @Test
+    fun `Given app's running with a new config, when configuredUrl is called, then returns current backend config's url`() {
+        `when`(backendItem.baseUrl).thenReturn(TEST_URL)
+        `when`(scopeManager.backendItem()).thenReturn(backendItem)
+        `when`(scopeManager.isDefaultConfig()).thenReturn(false)
+
+        val url = backendDataSource.configuredUrl()
+
+        verify(scopeManager).backendItem()
+        verify(backendItem).baseUrl
+        url shouldBe TEST_URL
+    }
+
+    @Test
+    fun `Given a scopeManager, when backendConfig is called, then returns scopeManager's backendItem`() {
+        backendDataSource.backendConfig()
+
+        verify(scopeManager).backendItem()
+    }
+
+    @Test
+    fun `Given localDataSource has a config, when fetchBackendConfig is called, returns local config as backend item`() {
         val preference = mock(CustomBackendPreferences::class)
         `when`(localDataSource.backendConfig()).thenReturn(Either.Right(preference))
         `when`(backendMapper.toBackendItem(preference)).thenReturn(backendItem)
 
-        val backendConfig = backendDataSource.backendConfig()
+        val backendConfig = backendDataSource.fetchBackendConfig()
 
         verify(localDataSource).backendConfig()
         verify(backendMapper).toBackendItem(preference)
@@ -67,14 +101,14 @@ class BackendDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `Given localDataSource doesn't have a config, when backendConfig is called, returns backendClient's backend item`() {
+    fun `Given localDataSource doesn't have a config, when fetchBackendConfig is called, returns backendClient's backend item`() {
         `when`(localDataSource.backendConfig()).thenReturn(Either.Left(ServerError))
 
         val environment = "Environment"
         `when`(localDataSource.environment()).thenReturn(environment)
         `when`(backendClient.get(environment)).thenReturn(backendItem)
 
-        val backendConfig = backendDataSource.backendConfig()
+        val backendConfig = backendDataSource.fetchBackendConfig()
 
         verify(localDataSource).backendConfig()
         verify(backendMapper, never()).toBackendItem(any<CustomBackendPreferences>())
@@ -99,11 +133,16 @@ class BackendDataSourceTest : UnitTest() {
         }
 
     @Test
-    fun `Given a url, when loadBackendConfig is called and remote call succeeds, stores response to local storage`() =
+    fun `Given a url, when loadBackendConfig is called and remote call succeeds, stores response locally`() =
         runBlockingTest {
+            val environment = "Environment"
+            `when`(backendItem.environment).thenReturn(environment)
+
             val response = mock(CustomBackendResponse::class)
             `when`(remoteDataSource.getCustomBackendConfig(TEST_URL)).thenReturn(Either.Right(response))
+
             `when`(backendMapper.toBackendItem(response)).thenReturn(backendItem)
+
             val backendPreference = mock(CustomBackendPreferences::class)
             `when`(backendMapper.toPreference(backendItem)).thenReturn(backendPreference)
 
@@ -112,6 +151,7 @@ class BackendDataSourceTest : UnitTest() {
             verify(remoteDataSource).getCustomBackendConfig(eq(TEST_URL))
             verify(backendMapper).toPreference(backendItem)
             verify(localDataSource).updateBackendConfig(TEST_URL, backendPreference)
+            verify(scopeManager).onConfigChanged(environment)
         }
 
     @Test
@@ -123,6 +163,7 @@ class BackendDataSourceTest : UnitTest() {
 
             verifyNoInteractions(backendMapper)
             verifyNoInteractions(localDataSource)
+            verifyNoInteractions(scopeManager)
             result.fold({
                 it shouldBe ServerError
             }) { assert(false) }


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6762

### Issues

The previous implementation was accessing to local storage before every network request to see whether base url has changed (see [CustomBackendInterceptor](https://github.com/wireapp/wire-android/pull/2724/files#diff-5e8085afd568ae2c5238f4803d633805)). This I/O access is not very efficient and is prone to having some performance issues. 

### Solutions

In this PR, I created a scope per backend configuration, so the local storage is only accessed once per scope. A BackendItem instance for a scope is created  by BackendRepository by reading from local storage. Every next request to access the current BackendItem will receive the instance living in the current scope, without having to read from local storage.

Summary in 2 scenarios:

1. App starts
2. Default scope is created -> BackendItem is read from storage
3. No config change happened during app lifetime
4. The same BackendItem lives throughout whole app lifecycle
---
1. App starts 
2. Default scope is created -> BackendItem is read from storage
3. A backend config change happened (Enterprise Login)
4. Default scope is destroyed.
5. A new scope is created -> BackendItem is read from storage and restored
6. App continues to operate on new BackendItem


### Testing

Unit tests are added/updated. Manual testing is also done to verify that scopes are created/destroyed properly.

#### APK
[Download build #1779](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1779/artifact/build/artifact/wire-dev-PR2750-1779.apk)
[Download build #1814](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1814/artifact/build/artifact/wire-dev-PR2750-1814.apk)