### PR TITLE
Kotlin OkHttp Logger: Do not log "password" fields

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/extension/Json.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/extension/Json.kt
@@ -1,0 +1,9 @@
+package com.waz.zclient.core.extension
+
+import org.json.JSONObject
+
+fun JSONObject.replaceValue(key: String, value: Any?) {
+    if (has(key)) {
+        put(key, value)
+    }
+}

--- a/app/src/main/kotlin/com/waz/zclient/core/network/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import com.waz.zclient.core.network.connection.ConnectionSpecsFactory
 import com.waz.zclient.core.network.di.NetworkDependencyProvider.createHttpClient
 import com.waz.zclient.core.network.di.NetworkDependencyProvider.createHttpClientForToken
 import com.waz.zclient.core.network.di.NetworkDependencyProvider.retrofit
+import com.waz.zclient.core.network.logger.RedactedMessageLogger
 import com.waz.zclient.core.network.pinning.CertificatePinnerFactory
 import com.waz.zclient.core.network.proxy.HttpProxyFactory
 import com.waz.zclient.core.network.useragent.UserAgentConfig
@@ -83,7 +84,7 @@ object NetworkDependencyProvider {
 
     private fun OkHttpClient.Builder.addLoggingInterceptor() = this.apply {
         if (BuildConfig.DEBUG) {
-            addInterceptor(HttpLoggingInterceptor().setLevel(Level.BODY))
+            addInterceptor(HttpLoggingInterceptor(RedactedMessageLogger()).setLevel(Level.BODY))
         }
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLogger.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLogger.kt
@@ -8,6 +8,7 @@ class RedactedMessageLogger(
     private val defaultLogger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT
 ) : HttpLoggingInterceptor.Logger {
 
+    @Suppress("TooGenericExceptionCaught")
     override fun log(message: String) {
         try {
             //TODO: only searches in direct children. should we convert to recursive?

--- a/app/src/main/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLogger.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLogger.kt
@@ -1,0 +1,29 @@
+package com.waz.zclient.core.network.logger
+
+import com.waz.zclient.core.extension.replaceValue
+import okhttp3.logging.HttpLoggingInterceptor
+import org.json.JSONObject
+
+class RedactedMessageLogger(
+    private val defaultLogger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT
+) : HttpLoggingInterceptor.Logger {
+
+    override fun log(message: String) {
+        try {
+            //TODO: only searches in direct children. should we convert to recursive?
+            val messageJson = JSONObject(message).apply {
+                replaceValue(FIELD_PASSWORD, REDACTED_VALUE)
+            }
+            logMessageDefault(messageJson.toString())
+        } catch (ex: Exception) {
+            logMessageDefault(message)
+        }
+    }
+
+    private fun logMessageDefault(message: String) = defaultLogger.log(message)
+
+    companion object {
+        private const val FIELD_PASSWORD = "password"
+        private const val REDACTED_VALUE = "*hidden*"
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/core/extension/JsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/extension/JsonExtensionsTest.kt
@@ -1,0 +1,38 @@
+package com.waz.zclient.core.extension
+
+import com.waz.zclient.UnitTest
+import org.amshove.kluent.shouldBe
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JsonExtensionsTest: UnitTest() {
+
+    @Test
+    fun `given JSONObject contains a key, when replaceValue is called with that key, then replaces key's value`() {
+        val key = "hello"
+        val newValue = "world"
+        val json = """
+            { "$key" : "value" }
+        """
+        val jsonObject = JSONObject(json)
+
+        jsonObject.replaceValue(key, newValue)
+
+        jsonObject.get(key) shouldBe newValue
+    }
+
+    @Test
+    fun `given JSONObject does not contains the key, when replaceValue is called with that key, then does not change jsonOnject`() {
+        val key = "hello"
+        val newValue = "world"
+        val json = """
+            { "key1" : "value" }
+        """
+        val jsonObject = JSONObject(json)
+
+        jsonObject.replaceValue(key, newValue)
+
+        assertEquals(jsonObject.toString(), JSONObject(json).toString())
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLoggerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/network/logger/RedactedMessageLoggerTest.kt
@@ -1,0 +1,75 @@
+package com.waz.zclient.core.network.logger
+
+import com.google.gson.JsonParser
+import com.waz.zclient.UnitTest
+import com.waz.zclient.capture
+import okhttp3.logging.HttpLoggingInterceptor
+import org.amshove.kluent.shouldBe
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+
+class RedactedMessageLoggerTest : UnitTest() {
+
+    @Mock
+    private lateinit var defaultLogger: HttpLoggingInterceptor.Logger
+
+    @Captor
+    private lateinit var messageCaptor: ArgumentCaptor<String>
+
+    private lateinit var redactedMessageLogger: RedactedMessageLogger
+
+    @Before
+    fun setUp() {
+        redactedMessageLogger = RedactedMessageLogger(defaultLogger)
+    }
+
+    @Test
+    fun `given a message in non-json format, when log is called, then logs the message as it is`() {
+        redactedMessageLogger.log(NON_JSON_MESSAGE)
+
+        verify(defaultLogger).log(capture(messageCaptor))
+        messageCaptor.value shouldBe NON_JSON_MESSAGE
+    }
+
+    @Test
+    fun `given a message with password in it, when log is called, then hides password value`() {
+        redactedMessageLogger.log(messageWithPassword("123456"))
+
+        verify(defaultLogger).log(capture(messageCaptor))
+        assertContentsEqual(messageCaptor.value, messageWithPassword(HIDDEN_VALUE))
+    }
+
+    @Test
+    fun `given a message without any field to hide in it, when log is called, then logs message directly`() {
+        redactedMessageLogger.log(MESSAGE_WITHOUT_HIDDEN_KEY)
+
+        verify(defaultLogger).log(capture(messageCaptor))
+        assertContentsEqual(messageCaptor.value, MESSAGE_WITHOUT_HIDDEN_KEY)
+    }
+
+    private fun assertContentsEqual(result: String, expected: String) {
+        val parser = JsonParser()
+        assert(parser.parse(result) == parser.parse(expected))
+    }
+
+    companion object {
+        private const val NON_JSON_MESSAGE = "qwertyui123! xx5"
+        private const val HIDDEN_VALUE = "*hidden*"
+        private const val MESSAGE_WITHOUT_HIDDEN_KEY = """
+            {
+                "key" : "value"
+            }
+        """
+
+        private fun messageWithPassword(value: String) = """
+            {
+                "key" : "value",
+                "password" : "$value"
+            }
+        """
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6829

### Issues

OkHttp Logging Interceptor should not log "password" information even if the app is on the debug configuration. A similar implementation can be found at `OkHttpLoggingInterceptor.scala`.

### Solutions

I implemented the same logic that has been implemented in Scala network layer (`OkHttpLoggingInterceptor`), which simply redacts the "password" field values with **\*hidden\***. A more elegant and general-purpose solution can be implemented later.

### Testing

Unit tests are added.

## Notes

Because of time constraints, I did not put more effort into implementing a general purpose solution. Security-wise, it is sufficient enough having the exact same implementation as Scala-side in the Network part. However, this solution alone is not enough and requires additional measures. I have made other [jira tasks](https://wearezeta.atlassian.net/browse/AN-6826) ready for them. We can all have a brainstorming session about this together, along with how to restrict other logs that user has consented.
