### PR TITLE
Bugfix: wrong db versions used by the scala code

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -34,7 +34,7 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.utils.wrappers.DB
 import com.waz.utils.{JsonDecoder, JsonEncoder, Resource}
-import com.waz.zclient.storage.db.{GlobalDatabase, UserDatabase}
+import com.waz.zclient.storage.db.{GlobalDatabase}
 
 class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingService)
   extends DaoDB(context.getApplicationContext, DbName + dbNameSuffix, DbVersion, daos, ZGlobalDB.migrations, tracking)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -34,6 +34,7 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.utils.wrappers.DB
 import com.waz.utils.{JsonDecoder, JsonEncoder, Resource}
+import com.waz.zclient.storage.db.{GlobalDatabase, UserDatabase}
 
 class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingService)
   extends DaoDB(context.getApplicationContext, DbName + dbNameSuffix, DbVersion, daos, ZGlobalDB.migrations, tracking)
@@ -53,7 +54,7 @@ class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingS
 
 object ZGlobalDB {
   val DbName = "ZGlobal.db"
-  val DbVersion = 24
+  val DbVersion =  GlobalDatabase.VERSION
 
   lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDao)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -52,6 +52,7 @@ import com.waz.service.assets.AssetStorageImpl.AssetDao
 import com.waz.service.assets.DownloadAssetStorage.DownloadAssetDao
 import com.waz.service.assets.UploadAssetStorage.UploadAssetDao
 import com.waz.service.tracking.TrackingService
+import com.waz.zclient.storage.db.UserDatabase
 
 import scala.util.{Success, Try}
 
@@ -66,7 +67,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = 126
+  val DbVersion = UserDatabase.VERSION
 
   lazy val daos = Seq (
     UserDataDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,


### PR DESCRIPTION
## What's new in this PR?

This could be a potential fix the migration bug.  

`ZGlobalDB.Version` and `ZMessagingDB.DbVersion` should be the same versions as Room `GlobalDatabase` and `UserDatabase`
