### PR TITLE
Potential fix for black screen 

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val ANDROIDX_CARD_VIEW = "1.0.0"
     const val ANDROIDX_GRID_LAYOUT = "1.0.0"
     const val ANDROIDX_CONSTRAINT_LAYOUT = "1.1.3"
-    const val ANDROIDX_PAGING_RUNTIME = "2.1.1"
+    const val ANDROIDX_PAGING_RUNTIME = "2.1.2"
     const val ANDROIDX_EXIF_INTERFACE = "1.0.0"
     const val ANDROIDX_MEDIA = "1.0.0"
     const val ANDROIDX_LIFECYCLE = "2.2.0-rc03"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -85,7 +85,7 @@ object Preferences {
           s.publish(v, Threading.Background)
         }.recoverWith { case exception =>
           error(l"Error while getting signal with preference key $key. Exception is: $exception")
-          throw exception
+          Future.failed(exception)
         }
       }
     }


### PR DESCRIPTION
## What's new in this PR?

Issue: https://github.com/wireapp/wire-android/issues/2756

### Problem Statement
There was a fix put out for the Exception below which followed the solid recommendations in [this answer](https://stackoverflow.com/questions/55546116/room-livedata-with-paging-getting-indexoutofboundsexception-in-some-devices/56873666#56873666). But, google didn't cherry pick it properly over their paging release for 2.1.1, so they fixed it properly in 2.1.2 as noted in their [release notes](https://developer.android.com/jetpack/androidx/releases/paging): 

> Paging 2.1.2 contains the load-centering fix originally released in 2.1.1, but this time correctly cherry-picked atop the 2.1.0 release. It is strongly recommended to upgrade to this release, if you are currently on 2.1.1.

We also, just log and throw the exception inside Preferences.scala:

```
 lazy val signal: SourceSignal[A] = {
      returning(Signal[A]()) { s =>
        apply().map { v =>
          s.publish(v, Threading.Background)
        }.recoverWith { case exception =>
          error(l"Error while getting signal with preference key $key. Exception is: $exception")
          throw exception
        }
      }
    }
```

Which in theory could cause a black screen for any exception not just migrations. 

### Stacktrace

`03-25 18:51:39.472 16883 16883 E AndroidRuntime: java.lang.IndexOutOfBoundsException: Index out of bounds - passed position = 20, old list size = 20
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at androidx.paging.PagedStorageDiffHelper.transformAnchorIndex(PagedStorageDiffHelper.java:1672)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at androidx.paging.AsyncPagedListDiffer$2$1.run(AsyncPagedListDiffer.java:1346)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:873)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:193)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6718)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
03-25 18:51:39.472 16883 16883 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)`

#### APK
[Download build #1806](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1806/artifact/build/artifact/wire-dev-PR2759-1806.apk)