### PR TITLE
Large teams: user search chatheads

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -106,7 +106,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
   def setUserData(userData:       UserData,
                   teamId:         Option[TeamId],
                   createSubtitle: (UserData) => String = SingleUserRowView.defaultSubtitle): Unit = {
-    chathead.loadUser(userData.id)
+    chathead.setUserData(userData, userData.isInTeam(teamId))
     setTitle(userData.name, userData.isSelf)
     setAvailability(if (teamId.isDefined) userData.availability else Availability.None)
     setVerified(userData.isVerified)

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -52,7 +52,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
             _           <- Signal(search.syncSearchResults(query))
             convId      <- createConvController.convId
             teamOnly    <- createConvController.teamOnly
-            results <- convId match {
+            results     <- convId match {
               case Some(cId) => search.usersToAddToConversation(query, cId)
               case None => search.usersForNewConversation(query, teamOnly)
             }

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -86,9 +86,9 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
             results     <- search.search(filter)
             _ = verbose(l"results: $results")
           } yield
-            if (results.isEmpty)
+            if (results.isEmpty) {
               if (filter.isEmpty) NoUsers else NoUsersFound
-            else Users(results)
+            } else Users(results)
         case Tab.Services =>
           servicesService.flatMap { svc =>
             Signal

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -43,7 +43,7 @@ class SearchUIAdapter(adapterCallback: Callback) extends RecyclerView.Adapter[Re
   import SearchUIAdapter._
   import SearchViewItem._
 
-  private var results = mutable.ListBuffer[SearchViewItem]()
+  private val results = mutable.ListBuffer[SearchViewItem]()
 
   setHasStableIds(true)
 
@@ -111,7 +111,8 @@ class SearchUIAdapter(adapterCallback: Callback) extends RecyclerView.Adapter[Re
   }
 
   def updateResults(results: mutable.ListBuffer[SearchViewItem]): Unit = {
-    this.results = results
+    this.results.clear()
+    this.results.insertAll(0, results)
     notifyDataSetChanged()
   }
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -43,7 +43,7 @@ class SearchUIAdapter(adapterCallback: Callback) extends RecyclerView.Adapter[Re
   import SearchUIAdapter._
   import SearchViewItem._
 
-  private val results = mutable.ListBuffer[SearchViewItem]()
+  private val results = mutable.ArrayBuffer[SearchViewItem]()
 
   setHasStableIds(true)
 
@@ -81,20 +81,15 @@ class SearchUIAdapter(adapterCallback: Callback) extends RecyclerView.Adapter[Re
     val item: SearchViewItem = results(position)
     item.itemType match {
       case TopUsers =>
-        val topUserData = item.asInstanceOf[TopUserViewItem].data
-        holder.asInstanceOf[TopUsersViewHolder].bind(topUserData)
+        holder.asInstanceOf[TopUsersViewHolder].bind(item.asInstanceOf[TopUserViewItem])
       case GroupConversation =>
-        val groupConversationData = item.asInstanceOf[GroupConversationViewItem].data
-        holder.asInstanceOf[ConversationViewHolder].bind(groupConversationData)
+        holder.asInstanceOf[ConversationViewHolder].bind(item.asInstanceOf[GroupConversationViewItem])
       case ConnectedUser | UnconnectedUser =>
-        val userConnectionData = item.asInstanceOf[ConnectionViewItem].data
-        holder.asInstanceOf[UserViewHolder].bind(userConnectionData)
+        holder.asInstanceOf[UserViewHolder].bind(item.asInstanceOf[ConnectionViewItem])
       case SectionHeader =>
-        val sectionData = item.asInstanceOf[SectionViewItem].data
-        holder.asInstanceOf[SectionHeaderViewHolder].bind(sectionData)
+        holder.asInstanceOf[SectionHeaderViewHolder].bind(item.asInstanceOf[SectionViewItem])
       case Expand =>
-        val expandData = item.asInstanceOf[ExpandViewItem].data
-        holder.asInstanceOf[SectionExpanderViewHolder].bind(expandData, new View.OnClickListener {
+        holder.asInstanceOf[SectionExpanderViewHolder].bind(item.asInstanceOf[ExpandViewItem], new View.OnClickListener {
           override def onClick(view: View): Unit = {
             if (item.section == SectionViewItem.ContactsSection) {
               adapterCallback.onContactsExpanded()
@@ -104,15 +99,14 @@ class SearchUIAdapter(adapterCallback: Callback) extends RecyclerView.Adapter[Re
           }
         })
       case Integration =>
-        val integrationData = item.asInstanceOf[IntegrationViewItem].data
-        holder.asInstanceOf[IntegrationViewHolder].bind(integrationData)
+        holder.asInstanceOf[IntegrationViewHolder].bind(item.asInstanceOf[IntegrationViewItem])
       case _ =>
     }
   }
 
-  def updateResults(results: mutable.ListBuffer[SearchViewItem]): Unit = {
+  def updateResults(results: List[SearchViewItem]): Unit = {
     this.results.clear()
-    this.results.insertAll(0, results)
+    this.results ++= results
     notifyDataSetChanged()
   }
 
@@ -192,7 +186,7 @@ object SearchUIAdapter {
     topUsersRecyclerView.setHasFixedSize(false)
     topUsersRecyclerView.setAdapter(this.topUserAdapter)
 
-    def bind(topUserViewModel: TopUserViewModel): Unit = topUserAdapter.setTopUsers(topUserViewModel.topUsers)
+    def bind(item: TopUserViewItem): Unit = topUserAdapter.setTopUsers(item.topUsers)
   }
 
   object TopUsersViewHolder {
@@ -236,11 +230,9 @@ object SearchUIAdapter {
     view.showCheckbox(false)
     view.setTheme(Theme.Dark, background = false)
 
-    def bind(connectionViewModel: ConnectionViewModel): Unit = {
-      val userData = connectionViewModel.results(connectionViewModel.indexVal)
-      this.userData = Some(userData)
-      val teamId = connectionViewModel.team.map(_.id)
-      view.setUserData(userData, teamId)
+    def bind(item: ConnectionViewItem): Unit = {
+      this.userData = Some(item.user)
+      view.setUserData(item.user, item.selfTeamId)
     }
   }
 
@@ -251,10 +243,9 @@ object SearchUIAdapter {
     view.onClick(conversation.foreach(callback.onConversationClicked))
     conversationRowView.applyDarkTheme()
 
-    def bind(groupConversationViewModel: GroupConversationViewModel): Unit = {
-      val conversationData = groupConversationViewModel.conversations(groupConversationViewModel.indexVal)
-      conversation = Some(conversationData)
-      conversationRowView.setConversation(conversationData)
+    def bind(item: GroupConversationViewItem): Unit = {
+      conversation = Some(item.conversation)
+      conversationRowView.setConversation(item.conversation)
     }
   }
 
@@ -267,19 +258,17 @@ object SearchUIAdapter {
     view.setTheme(Theme.Dark, background = false)
     view.setSeparatorVisible(true)
 
-    def bind(integrationViewModel: IntegrationViewModel): Unit = {
-      val integrationData = integrationViewModel.integrations(integrationViewModel.indexVal)
-      this.integrationData = Some(integrationData)
-      view.setIntegration(integrationData)
+    def bind(item: IntegrationViewItem): Unit = {
+      this.integrationData = Some(item.integration)
+      view.setIntegration(item.integration)
     }
   }
 
   class SectionExpanderViewHolder(val view: View) extends RecyclerView.ViewHolder(view) {
     private val viewAllTextView = ViewUtils.getView[TypefaceTextView](view, R.id.ttv_startui_section_header)
 
-    def bind(expandViewModel: ExpandViewModel, clickListener: View.OnClickListener): Unit = {
-      val itemCount = expandViewModel.itemCount
-      val title = getString(R.string.people_picker__search_result__expander_title, Integer.toString(itemCount))(view.getContext)
+    def bind(item: ExpandViewItem, clickListener: View.OnClickListener): Unit = {
+      val title = getString(R.string.people_picker__search_result__expander_title, Integer.toString(item.itemCount))(view.getContext)
       viewAllTextView.setText(title)
       viewAllTextView.setOnClickListener(clickListener)
     }
@@ -290,21 +279,17 @@ object SearchUIAdapter {
 
     private implicit val context: Context = sectionHeaderView.getContext
 
-    def bind(sectionViewModel: SectionViewModel): Unit = {
-      val section = sectionViewModel.section
-      val teamName = sectionViewModel.name
-      val title = section match {
-        case TopUsersSection                               => getString(R.string.people_picker__top_users_header_title)
-        case GroupConversationsSection if teamName.isEmpty => getString(R.string.people_picker__search_result_conversations_header_title)
-        case GroupConversationsSection                     => getString(R.string.people_picker__search_result_team_conversations_header_title, teamName)
-        case ContactsSection                               => getString(sectionViewModel.title)
-        case DirectorySection                              => getString(R.string.people_picker__search_result_others_header_title)
-        case IntegrationsSection                           => getString(R.string.integrations_picker__section_title)
+    def bind(item: SectionViewItem): Unit = sectionHeaderView.setText(
+      item.section match {
+        case TopUsersSection                                => getString(R.string.people_picker__top_users_header_title)
+        case GroupConversationsSection if item.name.isEmpty => getString(R.string.people_picker__search_result_conversations_header_title)
+        case GroupConversationsSection                      => getString(R.string.people_picker__search_result_team_conversations_header_title, item.name)
+        case ContactsSection                                => getString(item.title)
+        case DirectorySection                               => getString(R.string.people_picker__search_result_others_header_title)
+        case IntegrationsSection                            => getString(R.string.integrations_picker__section_title)
       }
-      sectionHeaderView.setText(title)
-    }
+    )
   }
-
 }
 
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -285,7 +285,7 @@ class SearchUIFragment extends BaseFragment[Container]
       isExternal <- userAccountsController.isExternal
     } yield isTeam && !isExternal).onUi(tabs.setVisible)
 
-    searchController.filter! ""
+    searchController.filter ! ""
 
     containerSub = Some((for {
       kb <- keyboard.isKeyboardVisible

--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -17,12 +17,10 @@
   */
 package com.waz.zclient.usersearch.domain
 
-import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.zclient.common.controllers.UserAccountsController
-import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.search.SearchController
 import com.waz.zclient.search.SearchController.{SearchUserListState, Tab}
@@ -38,7 +36,6 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   import SectionViewItem._
 
   private val userAccountsController    = inject[UserAccountsController]
-  private val convController            = inject[ConversationController]
   private val searchController          = inject[SearchController]
 
   private var mergedResult              = mutable.ListBuffer[SearchViewItem]()
@@ -54,8 +51,6 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   private var currentUser               = Option.empty[UserData]
   private var currentUserCanAddServices = false
   private var noServices                = false
-
-  private lazy val usersStorage      = inject[Signal[UsersStorage]]
 
   val resultsData = Signal(mergedResult)
 
@@ -222,6 +217,8 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
       addGroupConversations()
       addConnections()
     }
+
+    verbose(l"Merged results have been updated ${mergedResult.map(_.name)}")
     resultsData ! mergedResult
   }
 }

--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -38,7 +38,6 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   private val userAccountsController    = inject[UserAccountsController]
   private val searchController          = inject[SearchController]
 
-  private var mergedResult              = mutable.ListBuffer[SearchViewItem]()
   private var collapsedContacts         = true
   private var collapsedGroups           = true
 
@@ -52,7 +51,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   private var currentUserCanAddServices = false
   private var noServices                = false
 
-  val resultsData = Signal(mergedResult)
+  val resultsData = Signal(List.empty[SearchViewItem])
 
   (for {
     curUser  <- userAccountsController.currentUser
@@ -102,17 +101,13 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
   }
 
   private def updateMergedResults(): Unit = {
-    mergedResult = mutable.ListBuffer[SearchViewItem]()
+    val mergedResult = mutable.ListBuffer[SearchViewItem]()
 
     val teamName = team.map(_.name).getOrElse(Name.Empty)
 
-    def addTopPeople(): Unit = {
-      if (topUsers.nonEmpty) {
-        val topUserSectionHeader = SectionViewItem(SectionViewModel(TopUsersSection, 0))
-        val topUsersListItem = TopUserViewItem(TopUserViewModel(0, topUsers))
-        mergedResult = mergedResult ++ Seq(topUserSectionHeader)
-        mergedResult = mergedResult ++ Seq(topUsersListItem)
-      }
+    def addTopPeople(): Unit = if (topUsers.nonEmpty) {
+      mergedResult += SectionViewItem(TopUsersSection, 0)
+      mergedResult += TopUserViewItem(0, topUsers)
     }
 
     def addContacts(): Unit = {
@@ -128,73 +123,61 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
           R.string.people_picker__search_result_connections_searched_header_title
         }
 
-        val contactsSectionHeader = new SectionViewItem(SectionViewModel(ContactsSection, 0, teamName, contactsSectionTitle))
-        mergedResult = mergedResult ++ Seq(contactsSectionHeader)
-        var contactsSection = Seq[SearchViewItem]()
+        mergedResult += SectionViewItem(ContactsSection, 0, teamName, contactsSectionTitle)
 
-        contactsSection = contactsSection ++ contactsList.indices.map { i =>
-          ConnectionViewItem(ConnectionViewModel(i, contactsList(i).id.str.hashCode, isConnected = true, contactsList, contactsList(i).name, team))
+        val contactsSection = contactsList.zipWithIndex.map { case (user, index) =>
+          ConnectionViewItem(index, user, team.map(_.id), connected = true)
         }
 
         val shouldCollapse = searchController.filter.currentValue.exists(_.nonEmpty) && collapsedContacts && contactsSection.size > CollapsedContacts
 
-        contactsSection = contactsSection.sortBy(_.name.str).take(if (shouldCollapse) CollapsedContacts else contactsSection.size)
-
-        mergedResult = mergedResult ++ contactsSection
-        if (shouldCollapse) {
-          val expandViewItem = ExpandViewItem(ExpandViewModel(ContactsSection, 0, contactsList.size))
-          mergedResult = mergedResult ++ Seq(expandViewItem)
-        }
+        mergedResult ++= contactsSection.sortBy(_.name.str).take(if (shouldCollapse) CollapsedContacts else contactsSection.size)
+        if (shouldCollapse)
+          mergedResult += ExpandViewItem(ContactsSection, 0, contactsList.size)
       }
     }
 
-    def addGroupConversations(): Unit = {
-      if (conversations.nonEmpty) {
-        val groupConversationSectionHeader = SectionViewItem(SectionViewModel(GroupConversationsSection, 0, teamName))
-        mergedResult = mergedResult ++ Seq(groupConversationSectionHeader)
+    def addGroupConversations(): Unit = if (conversations.nonEmpty) {
+      mergedResult += SectionViewItem(GroupConversationsSection, 0, teamName)
 
-        val shouldCollapse = collapsedGroups && conversations.size > CollapsedGroups
+      val shouldCollapse = collapsedGroups && conversations.size > CollapsedGroups
 
-        mergedResult = mergedResult ++ conversations.indices.map { i =>
-          GroupConversationViewItem(GroupConversationViewModel(i, conversations(i).id.str.hashCode, conversations))
-        }.take(if (shouldCollapse) CollapsedGroups else conversations.size)
-        if (shouldCollapse) {
-          val expandViewItem = ExpandViewItem(ExpandViewModel(GroupConversationsSection, 0, conversations.size))
-          mergedResult = mergedResult ++ Seq(expandViewItem)
-        }
-      }
+      mergedResult ++= conversations.zipWithIndex.map { case (conv, index) =>
+        GroupConversationViewItem(index, conv)
+      }.take(if (shouldCollapse) CollapsedGroups else conversations.size)
+      if (shouldCollapse)
+        mergedResult += ExpandViewItem(GroupConversationsSection, 0, conversations.size)
     }
 
     def addConnections(): Unit = {
       val directoryExternalMembers = currentUser.map(_.teamId) match {
         case Some(teamId) => directoryResults.filterNot(_.teamId == teamId)
-        case None => Nil
+        case None         => Nil
       }
       if (directoryExternalMembers.nonEmpty) {
-        val directorySectionHeader = SectionViewItem(SectionViewModel(DirectorySection, 0))
-        mergedResult = mergedResult ++ Seq(directorySectionHeader)
-        mergedResult = mergedResult ++ directoryResults.indices.map { i =>
-          ConnectionViewItem(ConnectionViewModel(i, directoryResults(i).id.str.hashCode, isConnected = false, directoryResults, team = team))
+        mergedResult += SectionViewItem(DirectorySection, 0)
+        mergedResult ++= directoryResults.zipWithIndex.map { case (user, index) =>
+          ConnectionViewItem(index, user, team.map(_.id), connected = false)
         }
       }
     }
 
     def addIntegrations(): Unit = {
       if (integrations.nonEmpty) {
-        mergedResult = mergedResult ++ integrations.indices.map { i =>
-          IntegrationViewItem(IntegrationViewModel(i, integrations(i).id.str.hashCode, integrations))
+        mergedResult ++= integrations.zipWithIndex.map { case (integration, index) =>
+          IntegrationViewItem(index, integration)
         }
       }
     }
 
     def addGroupCreationButton(): Unit =
-      mergedResult = mergedResult ++ Seq(TopUserButtonViewItem(TopUserButtonViewModel(NewConversation, TopUsersSection, 0)))
+      mergedResult += TopUserButtonViewItem(NewConversation, TopUsersSection, 0)
 
     def addGuestRoomCreationButton(): Unit =
-      mergedResult = mergedResult ++ Seq(TopUserButtonViewItem(TopUserButtonViewModel(NewGuestRoom, TopUsersSection, 0)))
+      mergedResult += TopUserButtonViewItem(NewGuestRoom, TopUsersSection, 0)
 
     def addManageServicesButton(): Unit =
-      mergedResult = mergedResult ++ Seq(TopUserButtonViewItem(TopUserButtonViewModel(ManageServices, TopUsersSection, 0)))
+      mergedResult += TopUserButtonViewItem(ManageServices, TopUsersSection, 0)
 
     if (team.isDefined) {
       if (searchController.tab.currentValue.contains(Tab.Services)) {
@@ -218,7 +201,6 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
       addConnections()
     }
 
-    verbose(l"Merged results have been updated ${mergedResult.map(_.name)}")
-    resultsData ! mergedResult
+    resultsData ! mergedResult.toList
   }
 }

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/ConnectionViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/ConnectionViewItem.scala
@@ -18,27 +18,18 @@
 package com.waz.zclient.usersearch.listitems
 
 import com.waz.model
-import com.waz.model.{Name, TeamData, UserData}
+import com.waz.model.{TeamId, UserData}
 
-case class ConnectionViewItem(data: ConnectionViewModel) extends SearchViewItem {
-
+case class ConnectionViewItem(override val index: Int,
+                              user:               UserData,
+                              selfTeamId:         Option[TeamId],
+                              connected:          Boolean
+                             ) extends SearchViewItem {
   import SearchViewItem._
   import SectionViewItem._
 
-  override def section: Int = if (data.isConnected) ContactsSection else DirectorySection
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = if (data.isConnected) ConnectedUser else UnconnectedUser
-
-  override def id: Long = data.idVal
-
-  override def name: model.Name = if (data.isConnected) data.name else super.name
+  override val id: Long         = user.id.str.hashCode
+  override val section: Int     = if (connected) ContactsSection else DirectorySection
+  override val itemType: Int    = if (connected) ConnectedUser else UnconnectedUser
+  override val name: model.Name = if (connected) user.name else super.name
 }
-
-case class ConnectionViewModel(indexVal:              Int,
-                               idVal:                 Long,
-                               isConnected:           Boolean,
-                               results:               Seq[UserData],
-                               name:                  Name = Name.Empty,
-                               team:                  Option[TeamData])

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/ExpandViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/ExpandViewItem.scala
@@ -17,17 +17,12 @@
   */
 package com.waz.zclient.usersearch.listitems
 
-case class ExpandViewItem(data: ExpandViewModel) extends SearchViewItem {
-
+case class ExpandViewItem(override val index:   Int,
+                          override val section: Int,
+                          itemCount:            Int
+                         ) extends SearchViewItem {
   import SearchViewItem._
 
-  override def section: Int = data.section
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = Expand
+  override val itemType: Int = Expand
 }
 
-case class ExpandViewModel(indexVal:  Int,
-                           section:   Int,
-                           itemCount: Int)

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/GroupConversationViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/GroupConversationViewItem.scala
@@ -19,20 +19,13 @@ package com.waz.zclient.usersearch.listitems
 
 import com.waz.model.ConversationData
 
-case class GroupConversationViewItem(data: GroupConversationViewModel) extends SearchViewItem {
-
+case class GroupConversationViewItem(override val index: Int, conversation: ConversationData)
+  extends SearchViewItem {
   import SearchViewItem._
   import SectionViewItem._
 
-  override def section: Int = GroupConversationsSection
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = GroupConversation
-
-  override def id: Long = data.idVal
+  override val id: Long      = conversation.id.str.hashCode
+  override val section: Int  = GroupConversationsSection
+  override val itemType: Int = GroupConversation
 }
 
-case class GroupConversationViewModel(indexVal:      Int,
-                                      idVal:         Long,
-                                      conversations: Seq[ConversationData])

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/IntegrationViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/IntegrationViewItem.scala
@@ -19,20 +19,13 @@ package com.waz.zclient.usersearch.listitems
 
 import com.waz.model.IntegrationData
 
-case class IntegrationViewItem(data: IntegrationViewModel) extends SearchViewItem {
-
+case class IntegrationViewItem(override val index: Int, integration: IntegrationData)
+  extends SearchViewItem {
   import SearchViewItem._
   import SectionViewItem._
 
-  override def section: Int = IntegrationsSection
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = Integration
-
-  override def id: Long = data.idVal
+  override val id: Long      = integration.id.str.hashCode
+  override val section: Int  = IntegrationsSection
+  override val itemType: Int = Integration
 }
 
-case class IntegrationViewModel(indexVal:     Int,
-                                idVal:        Long,
-                                integrations: Seq[IntegrationData])

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/SearchViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/SearchViewItem.scala
@@ -20,15 +20,11 @@ package com.waz.zclient.usersearch.listitems
 import com.waz.model.Name
 
 trait SearchViewItem {
-
   def section: Int
-
   def index: Int
-
   def itemType: Int
 
   def id: Long = itemType + section + index
-
   def name: Name = Name.Empty
 }
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/SectionViewItem.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/SectionViewItem.scala
@@ -17,20 +17,16 @@
   */
 package com.waz.zclient.usersearch.listitems
 
-import com.waz.model
 import com.waz.model.Name
 
-case class SectionViewItem(data: SectionViewModel) extends SearchViewItem {
-
+case class SectionViewItem(override val section: Int,
+                           override val index:   Int,
+                           override val name:    Name = Name.Empty,
+                           title:                Int = 0)
+  extends SearchViewItem {
   import SearchViewItem._
 
-  override def section: Int = data.section
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = SectionHeader
-
-  override def name: model.Name = data.name
+  override val itemType: Int = SectionHeader
 }
 
 case class SectionViewModel(section:  Int,

--- a/app/src/main/scala/com/waz/zclient/usersearch/listitems/TopUserViewItems.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/listitems/TopUserViewItems.scala
@@ -19,30 +19,15 @@ package com.waz.zclient.usersearch.listitems
 
 import com.waz.model.UserData
 
-case class TopUserViewItem(data: TopUserViewModel) extends SearchViewItem {
-
+case class TopUserViewItem(override val index: Int, topUsers: Seq[UserData]) extends SearchViewItem {
   import SearchViewItem._
   import SectionViewItem._
 
-  override def section: Int = TopUsersSection
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = TopUsers
+  override val section: Int = TopUsersSection
+  override val itemType: Int = TopUsers
 }
 
-case class TopUserViewModel(indexVal: Int,
-                            topUsers: Seq[UserData])
+case class TopUserButtonViewItem(override val itemType: Int,
+                                 override val section:  Int,
+                                 override val index:    Int) extends SearchViewItem
 
-case class TopUserButtonViewItem(data: TopUserButtonViewModel) extends SearchViewItem {
-
-  override def section: Int = data.section
-
-  override def index: Int = data.indexVal
-
-  override def itemType: Int = data.itemType
-}
-
-case class TopUserButtonViewModel(itemType: Int,
-                                  section: Int,
-                                  indexVal: Int)

--- a/wire-android-sync-engine/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/wire-android-sync-engine/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -31,6 +31,7 @@ public enum SyncCommand {
     SyncConversation("sync-conv"),
     SyncConvLink("sync-conv-link"),
     SyncSearchQuery("sync-search"),
+    SyncSearchResults("sync-search-results"),
     SyncProperties("sync-properties"),
     ExactMatchHandle("exact-match"),
     PostConv("post-conv"),

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.model.sync
 
-import android.util.Log
 import com.waz.api.IConversation.{Access, AccessRole}
 import com.waz.model.AddressBook.AddressBookDecoder
 import com.waz.model.UserData.ConnectionStatus
@@ -373,8 +372,6 @@ object SyncRequest {
       def teamId = decodeId[TeamId]('teamId)
       def users = decodeUserIdSeq('users).toSet
       val cmd = js.getString("cmd")
-
-      Log.e("SyncRequest", js.toString())
 
       try {
         SyncCommand.fromName(cmd) match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -63,7 +63,7 @@ class UserSearchService(selfUserId:           UserId,
   import timeouts.search._
 
   private val exactMatchUser = Signal(Option.empty[UserData])
-  val userSearchResult = Signal(IndexedSeq.empty[UserData])
+  private val userSearchResult = Signal(IndexedSeq.empty[UserData])
 
   private lazy val isExternal = userPrefs(SelfPermissions).apply()
     .map(decodeBitmask)
@@ -226,7 +226,6 @@ class UserSearchService(selfUserId:           UserId,
       convs      <- conversations
       isExternal <- Signal.future(isExternal)
       dir        <- filterForExternal(query, if (isExternal) Signal.const(IndexedSeq.empty[UserData]) else directorySearch)
-      _ = verbose(l"dir results: $dir")
     } yield SearchResults(top, local, convs, dir)
   }
 
@@ -252,31 +251,25 @@ class UserSearchService(selfUserId:           UserId,
 
   def updateSearchResults(query: SearchQuery, results: UserSearchResponse): Unit = {
     val users = unapply(results)
-    debug(l"update search results got: ${users.map(_.id)}")
-
     userSearchResult ! users.map(UserData.apply).toIndexedSeq
-
     sync.syncSearchResults(users.map(_.id).toSet)
   }
 
-  def updateResults(info: Seq[UserInfo]) = {
-    verbose(l"updateResultHasBeenCalled${info.map(_.picture.map(_.head))}")
+  def updateSearchResults(info: Seq[UserInfo]): Unit = {
     userSearchResult.mutate(_.map(user => info.find(_.id == user.id).fold(user)(user.updated)))
+    exactMatchUser.mutate(_.map(user => info.find(_.id == user.id).fold(user)(user.updated)))
   }
 
   def updateExactMatch(result: UserSearchResponse.User): Unit = {
     verbose(l"updateExactMatch(${result.id})")
     val userData = UserData(UserSearchEntry(result))
     exactMatchUser ! Some(userData)
-  }
-
-  private def localSearch(query: SearchQuery) = {
-    val predicate = if (query.handleOnly) recommendedHandlePredicate(query.str) else recommendedPredicate(query.str)
-    usersStorage.find[UserData, Vector[UserData]](predicate, db => UserDataDao.recommendedPeople(query.str)(db), identity)
+    sync.syncSearchResults(Set(userData.id))
   }
 
   private def topPeople = {
-    def messageCount(u: UserData) = messages.countLaterThan(ConvId(u.id.str), LocalInstant.Now.toRemote(Duration.Zero) - topPeopleMessageInterval)
+    def messageCount(u: UserData) =
+      messages.countLaterThan(ConvId(u.id.str), LocalInstant.Now.toRemote(Duration.Zero) - topPeopleMessageInterval)
 
     val loadTopUsers = (for {
       conns         <- usersStorage.find[UserData, Vector[UserData]](topPeoplePredicate, db => UserDataDao.topPeople(db), identity)
@@ -289,16 +282,6 @@ class UserSearchService(selfUserId:           UserId,
   }
 
   private val topPeoplePredicate: UserData => Boolean = u => ! u.deleted && u.connection == ConnectionStatus.Accepted
-
-  private def recommendedPredicate(prefix: String): UserData => Boolean = {
-    val key = SearchKey(prefix)
-    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.handle.exists(_.startsWithQuery(prefix)))
-  }
-
-  private def recommendedHandlePredicate(prefix: String): UserData => Boolean = {
-    u => ! u.deleted && ! u.isConnected && u.handle.exists(_.startsWithQuery(prefix))
-  }
-
 }
 
 object UserSearchService {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -220,7 +220,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val reporting                                  = new ZmsReportingService(selfUserId, global.reporting)
   lazy val wsFactory                                  = new OkHttpWebSocketFactory(account.global.httpProxy)
   lazy val wsPushService: WSPushService               = wireWith(WSPushServiceImpl.apply _)
-  lazy val userSearch                                 = wire[UserSearchService]
+  lazy val userSearch: UserSearchService              = wire[UserSearchServiceImpl]
   lazy val users: UserService                         = wire[UserServiceImpl]
   lazy val conversations: ConversationsService        = wire[ConversationsServiceImpl]
   lazy val convOrder: ConversationOrderEventsService  = wire[ConversationOrderEventsService]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -138,7 +138,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   private def addRequest(req: SyncRequest, priority: Int = Priority.Normal, dependsOn: Seq[SyncId] = Nil, forceRetry: Boolean = false, delay: FiniteDuration = Duration.Zero): Future[SyncId] =
     service.addRequest(account, req, priority, dependsOn, forceRetry, delay)
 
-  def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users), priority = Priority.High)
+  def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users))
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
   def syncUsers(ids: Set[UserId]) = addRequest(SyncUser(ids))
   def exactMatchHandle(handle: Handle) = addRequest(ExactMatchHandle(handle), priority = Priority.High)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -39,6 +39,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 trait SyncServiceHandle {
+  def syncSearchResults(ids: Set[UserId]): Future[SyncId]
   def syncSearchQuery(query: SearchQuery): Future[SyncId]
   def exactMatchHandle(handle: Handle): Future[SyncId]
   def syncUsers(ids: Set[UserId]): Future[SyncId]
@@ -137,6 +138,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   private def addRequest(req: SyncRequest, priority: Int = Priority.Normal, dependsOn: Seq[SyncId] = Nil, forceRetry: Boolean = false, delay: FiniteDuration = Duration.Zero): Future[SyncId] =
     service.addRequest(account, req, priority, dependsOn, forceRetry, delay)
 
+  def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users), priority = Priority.High)
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
   def syncUsers(ids: Set[UserId]) = addRequest(SyncUser(ids))
   def exactMatchHandle(handle: Handle) = addRequest(ExactMatchHandle(handle), priority = Priority.High)
@@ -261,6 +263,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case SyncConversations                               => zms.conversationSync.syncConversations()
           case SyncConvLink(conv)                              => zms.conversationSync.syncConvLink(conv)
           case SyncUser(u)                                     => zms.usersSync.syncUsers(u.toSeq: _*)
+          case SyncSearchResults(u)                            => zms.usersSync.syncSearchResults(u.toSeq: _*)
           case SyncSearchQuery(query)                          => zms.usersearchSync.syncSearchQuery(query)
           case ExactMatchHandle(query)                         => zms.usersearchSync.exactMatchHandle(query)
           case SyncRichMedia(messageId)                        => zms.richmediaSync.syncRichMedia(messageId)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -19,7 +19,7 @@ package com.waz.sync.handler
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.Handle
+import com.waz.model.{Handle, UserId}
 import com.waz.service.{SearchQuery, UserSearchService}
 import com.waz.sync.SyncResult
 import com.waz.sync.client.UserSearchClient

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -36,6 +36,7 @@ import scala.concurrent.Future
 
 trait UsersSyncHandler {
   def syncUsers(ids: UserId*): Future[SyncResult]
+  def syncSearchResults(ids: UserId*): Future[SyncResult]
   def syncSelfUser(): Future[SyncResult]
   def postSelfName(name: Name): Future[SyncResult]
   def postSelfAccentColor(color: AccentColor): Future[SyncResult]
@@ -63,7 +64,7 @@ class UsersSyncHandlerImpl(userService:  UserService,
         Future.successful(SyncResult(error))
   }
 
-  def syncSearchResults(ids: UserId*): Future[SyncResult] = usersClient.loadUsers(ids).future.map {
+  override def syncSearchResults(ids: UserId*): Future[SyncResult] = usersClient.loadUsers(ids).future.map {
     case Right(users) =>
       searchService.updateSearchResults(users)
       SyncResult.Success

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -65,9 +65,10 @@ class UsersSyncHandlerImpl(userService:  UserService,
 
   def syncSearchResults(ids: UserId*): Future[SyncResult] = usersClient.loadUsers(ids).future.map {
     case Right(users) =>
-      searchService.updateResults(users)
+      searchService.updateSearchResults(users)
       SyncResult.Success
-    case Left(error)  => SyncResult(error)
+    case Left(error)  =>
+      SyncResult(error)
   }
 
   def syncSelfUser(): Future[SyncResult] = usersClient.loadSelf().future flatMap {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/Generators.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/Generators.scala
@@ -181,6 +181,7 @@ object Generators {
       arbitrary[RequestForUser],
       arbitrary[RequestForConversation],
       arbitrary[SyncUser],
+      arbitrary[SyncSearchResults],
       arbitrary[SyncConversation],
       arbitrary[SyncSearchQuery],
       arbitrary[SyncRichMedia],
@@ -210,6 +211,7 @@ object Generators {
     lazy val arbSimpleSyncRequest: Arbitrary[SyncRequest] = Arbitrary(oneOf(SyncSelf, DeleteAccount, SyncConversations, SyncConnections))
 
     implicit lazy val arbUsersSyncRequest: Arbitrary[SyncUser] = Arbitrary(listOf(arbitrary[UserId]) map { u => SyncUser(u.toSet) })
+    implicit lazy val arbSearchResultSyncRequest: Arbitrary[SyncSearchResults] = Arbitrary(listOf(arbitrary[UserId]) map { u => SyncSearchResults(u.toSet) })
     implicit lazy val arbConvsSyncRequest: Arbitrary[SyncConversation] = Arbitrary(listOf(arbitrary[ConvId]) map { c => SyncConversation(c.toSet) })
     implicit lazy val arbSearchSyncRequest: Arbitrary[SyncSearchQuery] = Arbitrary(resultOf(SyncSearchQuery))
     implicit lazy val arbSelfPictureSyncRequest: Arbitrary[PostSelfPicture] = Arbitrary(resultOf(PostSelfPicture))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -599,8 +599,8 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     }
   }
 
-  def getService(inTeam: Boolean, selfId: UserId) = {
-    new UserSearchService(
+  def getService(inTeam: Boolean, selfId: UserId): UserSearchService =
+    new UserSearchServiceImpl(
       selfId,
       if (inTeam) teamId else emptyTeamId,
       userService,
@@ -615,6 +615,5 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       convs,
       userPrefs
     )
-  }
 
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -3,7 +3,7 @@ package com.waz.sync.handler
 import com.waz.content.UsersStorage
 import com.waz.model.nano.Messages
 import com.waz.model._
-import com.waz.service.UserService
+import com.waz.service.{UserSearchService, UserService}
 import com.waz.service.assets.AssetService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.OtrClient.EncryptedContent
@@ -19,6 +19,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
   private val userService  = mock[UserService]
   private val usersStorage = mock[UsersStorage]
   private val assetService = mock[AssetService]
+  private val searchSevice = mock[UserSearchService]
   private val usersClient  = mock[UsersClient]
   private val otrSync      = mock[OtrSyncHandler]
 
@@ -26,7 +27,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
   val teamId = TeamId()
 
   def handler: UsersSyncHandler = new UsersSyncHandlerImpl(
-    userService, usersStorage, assetService, usersClient, otrSync
+    userService, usersStorage, assetService, searchSevice, usersClient, otrSync
   )
 
   feature("Post availability status") {


### PR DESCRIPTION
User search now bypasses the storage. Originally the process to display search results and their chatheads looked like that:
1. A request to the backend for search results.
2. Search results are put in the storage without the picture ids.
3. New users are synced which updates them with picture ids.
4. The chathead loads the user data from the storage.
5. The chathead uses the picture id to download the picture.

Now point 2, 3 and 4 are removed. Instead, we had to implement our own logic for getting picture ids directly to UserSearchService, so the chathead still can use the picture id to download the picture. Those pictures are cached, but the results themselves are not. So if the next search will give us the same result, the user will have to be synced in order to get their picture id, but if we already have a picture for this id, we won't have to download it again.

I also refactored the code a bit. There were two layers of case classes for each search result. I merged them.
#### APK
[Download build #1827](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1827/artifact/build/artifact/wire-dev-PR2760-1827.apk)