### PR TITLE
versionName refactory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
-        versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode
+        versionName System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION
+        versionName versionName + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 
@@ -209,7 +210,7 @@ android {
     productFlavors {
         dev {
             applicationId "com.waz.zclient.dev"
-            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-dev"
+            versionName android.defaultConfig.versionName + "-dev"
             manifestPlaceholders = [applicationLabel       : "Wire Dev",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_dev",
                                     sharedUserId           : "",
@@ -221,7 +222,7 @@ android {
 
         candidate {
             applicationId "com.wire.candidate"
-            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-candidate"
+            versionName android.defaultConfig.versionName + "-candidate"
             manifestPlaceholders = [applicationLabel       : "Wire Candidate",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_candidate",
                                     sharedUserId           : "",
@@ -246,7 +247,7 @@ android {
 
         internal {
             applicationId "com.wire.internal"
-            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-internal"
+            versionName android.defaultConfig.versionName + "-internal"
             manifestPlaceholders = [applicationLabel : "Wire Internal",
                                     applicationIcon  : "@mipmap/ic_launcher_wire_internal",
                                     sharedUserId     : "",
@@ -259,7 +260,7 @@ android {
 
         experimental {
             applicationId "com.wire.x"
-            versionName Versions.ANDROID_CLIENT_MAJOR_VERSION + android.defaultConfig.versionCode + "-exp"
+            versionName android.defaultConfig.versionName + "-exp"
             manifestPlaceholders = [applicationLabel       : "Wire Exp",
                                     applicationIcon        : "@mipmap/ic_launcher_wire_playground",
                                     sharedUserId           : "",
@@ -486,9 +487,9 @@ android.applicationVariants.all { variant ->
     variant.outputs.each { output ->
         def newApkName
         if(buildtimeConfiguration.isCustomBuild()) {
-            newApkName = "${appName}-${buildtimeConfiguration.configuration.applicationId}-${output.baseName}-${Versions.ANDROID_CLIENT_MAJOR_VERSION}${android.defaultConfig.versionCode}.apk"
+            newApkName = "${appName}-${buildtimeConfiguration.configuration.applicationId}-${output.baseName}-${android.defaultConfig.versionName}.apk"
         } else {
-            newApkName = "${appName}-${output.baseName}-${Versions.ANDROID_CLIENT_MAJOR_VERSION}${android.defaultConfig.versionCode}.apk"
+            newApkName = "${appName}-${output.baseName}-${android.defaultConfig.versionName}.apk"
         }
         output.outputFileName = new File("../..", newApkName)
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,8 +91,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
-        versionName System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION
-        versionName versionName + android.defaultConfig.versionCode
+        versionName = (System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION) + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 


### PR DESCRIPTION
- implemented precondition check for System.env("CLIENT_VERSION")
- improved versionName addressing for Flavors
- improved naming for variants output
- clientversion is primarily set now via ci/cd pipeline with the env variable CLIENT_VERSION. if this doesn't exists, it uses the CLIENT_MAJOR_VERSION from the Dependencies.kt
#### APK
[Download build #1872](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1872/artifact/build/artifact/wire-dev-PR2771-1872.apk)