### PR TITLE
Add logs to some signals and database operations

### DIFF
--- a/app/src/main/scala/com/waz/zclient/utils/package.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/package.scala
@@ -30,6 +30,7 @@ import android.view.{View, ViewGroup}
 import android.widget.{EditText, SeekBar, TextView}
 import androidx.preference.Preference
 import androidx.preference.Preference.{OnPreferenceChangeListener, OnPreferenceClickListener}
+import com.waz.log.BasicLogging.LogTag
 import com.waz.model.otr.Client
 import com.waz.utils.events.Signal
 import com.waz.utils.returning
@@ -313,8 +314,11 @@ package object utils {
   }
 
   implicit class RichEditText(val et: EditText) extends AnyVal {
+    import com.waz.zclient.log.LogUI._
     def afterTextChangedSignal(withInitialValue: Boolean = true): Signal[String] = new Signal[String]() {
       if (withInitialValue) publish(et.getText.toString)
+      else info(l"Did not publish RichEditText value")(LogTag("RichEditText"))
+
       private val textWatcher = new TextWatcher {
         override def onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int): Unit = ()
         override def afterTextChanged(editable: Editable): Unit = publish(editable.toString)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -104,6 +104,9 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
       Signal(signals.unreadCount, signals.failedCount, signals.lastMissedCall, signals.incomingKnock).throttle(500.millis) { case (unread, failed, missed, knock) =>
         convs.update(convId, _.copy(incomingKnockMessage = knock, missedCallMessage = missed, unreadCount = unread, failedCount = failed))
       }
+    }.recoverWith { case exception =>
+      error(l"Error while reading conversation messages from storage: $exception")
+      Future.failed(exception)
     }
   }.recoverWithLog()
   def updateLastRead(c: ConversationData) = lastReadTime.mutateOrDefault(_ max c.lastRead, c.lastRead)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -71,7 +71,12 @@ object Preferences {
 
     def apply(): Future[A] = prefs.getValue(key)
 
-    def update(value: A): Future[Unit] = prefs.setValue(key, value).map { _ => signal.publish(value, Threading.Background) }
+    def update(value: A): Future[Unit] = prefs.setValue(key, value)
+      .map { _ => signal.publish(value, Threading.Background) }
+      .recoverWith { case exception =>
+        error(l"Error while updating signal preference $key to value $value. Exception is: $exception")
+        Future.failed(exception)
+      }
 
     def :=(value: A): Future[Unit] = update(value)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/events/ClockSignal.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/events/ClockSignal.scala
@@ -21,12 +21,12 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.CancellableFuture
 import com.waz.threading.CancellableFuture.delayed
 import com.waz.threading.Threading.Background
-import org.threeten.bp.{Clock, Instant}
-import org.threeten.bp.Instant.now
 import com.waz.utils._
+import org.threeten.bp.Instant.now
+import org.threeten.bp.{Clock, Instant}
+import com.waz.log.LogSE._
 
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration._
+import scala.concurrent.duration.{FiniteDuration, _}
 
 case class ClockSignal(interval: FiniteDuration, clock: Clock = Clock.systemUTC())
   extends SourceSignal[Instant](Some(now(clock))) with DerivedLogTag {
@@ -37,6 +37,8 @@ case class ClockSignal(interval: FiniteDuration, clock: Clock = Clock.systemUTC(
     publish(now(clock))
     delay.cancel()
     delay = delayed(interval)(refresh)(Background)
+  } else {
+    info(l"Cannot publish ClockSignal value: not wired")
   }
 
   //To force a refresh in tests when clock is advanced


### PR DESCRIPTION
## What's new in this PR?

Related: https://wearezeta.atlassian.net/browse/AN-6839

### Issues

Sometimes, the exceptions thrown in some layer cannot make it up to upper layers, and the app halts instead of crashing. An example of this case is when we wait for an operation's result and want to publish it into a Signal:

```
    lazy val signal: SourceSignal[A] = {
      returning(Signal[A]()) { s =>
        someFunction().map { v =>
          s.publish(v, Threading.Background)
        }
      }
    }
```

If `someFunction()` is successful, we `map` the result and publish it to `signal`. However, if it fails, nothing gets published. In such a case, observers will be waiting forever to receive a value from the `signal`, unaware of the fact that an exception has occurred.

We think that the black screen problem in the Jira issue stems from something similar, possibly caused by a database transaction, and want to catch the exception.

### Solutions

Logically there is no way to fix this publish/infinite wait problem. What we can do is at least to listen for errors and log them, so that we can fix the underlying problem.

In this PR, I added logs to some Signal.publish() methods. I also added logs to all database operations in the lowest level since tracing through all signals that use them pollutes the code.


#### APK
[Download build #1897](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1897/artifact/build/artifact/wire-dev-PR2773-1897.apk)