### PR TITLE
fix: Global database changes moved to a new migration

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/GlobalDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/GlobalDatabase.kt
@@ -5,8 +5,9 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.waz.zclient.storage.db.accountdata.AccessTokenConverter
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
-import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import com.waz.zclient.storage.db.accountdata.GLOBAL_DATABASE_MIGRATION_24_25
+import com.waz.zclient.storage.db.accountdata.GLOBAL_DATABASE_MIGRATION_25_26
+import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import com.waz.zclient.storage.db.accountdata.SsoIdConverter
 import com.waz.zclient.storage.db.cache.CacheEntryDao
 import com.waz.zclient.storage.db.cache.CacheEntryEntity
@@ -27,9 +28,9 @@ abstract class GlobalDatabase : RoomDatabase() {
 
     companion object {
         const val DB_NAME = "ZGlobal.db"
-        const val VERSION = 25
+        const val VERSION = 26
 
         @JvmStatic
-        val migrations = arrayOf(GLOBAL_DATABASE_MIGRATION_24_25)
+        val migrations = arrayOf(GLOBAL_DATABASE_MIGRATION_24_25, GLOBAL_DATABASE_MIGRATION_25_26)
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/GlobalDatabaseMigration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/GlobalDatabaseMigration.kt
@@ -1,12 +1,17 @@
+
 package com.waz.zclient.storage.db.accountdata
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-const val START_VERSION = 24
-const val END_VERSION = 25
+@Suppress("MagicNumber")
+val GLOBAL_DATABASE_MIGRATION_24_25 = object : Migration(24, 25) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+    }
+}
 
-val GLOBAL_DATABASE_MIGRATION_24_25 = object : Migration(START_VERSION, END_VERSION) {
+@Suppress("MagicNumber")
+val GLOBAL_DATABASE_MIGRATION_25_26 = object : Migration(25, 26) {
 
     override fun migrate(database: SupportSQLiteDatabase) {
         migrateActiveAccounts(database)
@@ -51,12 +56,12 @@ val GLOBAL_DATABASE_MIGRATION_24_25 = object : Migration(START_VERSION, END_VERS
         val originalTableName = "ActiveAccounts"
         val createTempTable = """
             CREATE TABLE IF NOT EXISTS $tempTableName (
-            `_id` TEXT PRIMARY KEY NOT NULL, 
-            `team_id` TEXT, 
-            `cookie` TEXT NOT NULL DEFAULT '', 
-            `access_token` TEXT, 
-            `registered_push` TEXT,
-            `sso_id` TEXT DEFAULT NULL)
+            _id TEXT PRIMARY KEY NOT NULL, 
+            team_id TEXT, 
+            cookie TEXT NOT NULL DEFAULT '', 
+            access_token TEXT, 
+            registered_push TEXT,
+            sso_id TEXT DEFAULT NULL)
             """.trimIndent()
         executeSimpleMigration(database, originalTableName, tempTableName, createTempTable)
     }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase127To128Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase127To128Migration.kt
@@ -747,6 +747,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
     }
 
     private fun createButtonsTable(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP TABLE IF EXISTS Buttons")
         database.execSQL("""
             CREATE TABLE IF NOT EXISTS Buttons (
                 message_id TEXT NOT NULL DEFAULT '', 


### PR DESCRIPTION
This is similar to what we did with the user database: all changes since the 3.47 version with the bug in migrations were moved to a new migration, so that people with the faulty 3.47 may have a chance for a fix.
Please test by both going back to 3.46 and updating to this one, and by going back to the faulty 3.47 and updating.

There's also one small change to the Buttons table migration as I ran into a problem with it while working on this fix. It's possible that the Buttons table schema created by the faulty 3.47 is different than what we have now. It can be fixed by simply deleting the old table - Buttons is a new feature and the table should be empty.
#### APK
[Download build #1922](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1922/artifact/build/artifact/wire-dev-PR2780-1922.apk)