### PR TITLE
Fix false positive tests related to UseCases on Kotlin side - Solution #2

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/usecase/UseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/usecase/UseCase.kt
@@ -12,6 +12,7 @@ abstract class UseCase<out Type, in Params> where Type : Any {
 
     abstract suspend fun run(params: Params): Either<Failure, Type>
 
+    //All the references to this will be replaced by runUseCase
     open operator fun invoke(
         scope: CoroutineScope,
         params: Params,
@@ -21,4 +22,14 @@ abstract class UseCase<out Type, in Params> where Type : Any {
         val backgroundJob = scope.async(dispatcher) { run(params) }
         scope.launch { onResult(backgroundJob.await()) }
     }
+}
+
+fun <T, P> CoroutineScope.runUseCase(
+    useCase: UseCase<T, P>,
+    params: P, dispatcher:
+    CoroutineDispatcher = Dispatchers.IO,
+    onResult: ((Either<Failure, T>) -> Unit) = {}) where T: Any {
+
+    val backgroundJob = async(dispatcher) { useCase.run(params) }
+    launch { onResult(backgroundJob.await()) }
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
@@ -5,11 +5,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.waz.zclient.shared.accounts.ActiveAccount
-import com.waz.zclient.shared.accounts.usecase.GetActiveAccountUseCase
 import com.waz.zclient.core.config.AccountUrlConfig
 import com.waz.zclient.core.exception.Failure
 import com.waz.zclient.core.extension.empty
+import com.waz.zclient.core.usecase.runUseCase
+import com.waz.zclient.shared.accounts.ActiveAccount
+import com.waz.zclient.shared.accounts.usecase.GetActiveAccountUseCase
 import com.waz.zclient.shared.user.User
 import com.waz.zclient.shared.user.email.ChangeEmailParams
 import com.waz.zclient.shared.user.email.ChangeEmailUseCase
@@ -75,7 +76,7 @@ class SettingsAccountViewModel(
     }
 
     fun updateName(name: String) {
-        changeNameUseCase(viewModelScope, ChangeNameParams(name)) {
+        viewModelScope.runUseCase(changeNameUseCase, ChangeNameParams(name)) {
             it.fold(::handleError) {}
         }
     }

--- a/app/src/test/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModelTest.kt
@@ -1,11 +1,12 @@
 package com.waz.zclient.feature.settings.account
 
 import com.waz.zclient.UnitTest
-import com.waz.zclient.shared.accounts.usecase.GetActiveAccountUseCase
 import com.waz.zclient.core.config.AccountUrlConfig
 import com.waz.zclient.core.exception.ServerError
 import com.waz.zclient.core.functional.Either
+import com.waz.zclient.framework.coroutines.CoroutinesTestRule
 import com.waz.zclient.framework.livedata.observeOnce
+import com.waz.zclient.shared.accounts.usecase.GetActiveAccountUseCase
 import com.waz.zclient.shared.user.User
 import com.waz.zclient.shared.user.email.ChangeEmailParams
 import com.waz.zclient.shared.user.email.ChangeEmailUseCase
@@ -20,15 +21,20 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBe
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.lenient
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 class SettingsAccountViewModelTest : UnitTest() {
+
+    @get:Rule
+    val coroutinesTestRule = CoroutinesTestRule()
 
     private lateinit var viewModel: SettingsAccountViewModel
 
@@ -149,16 +155,18 @@ class SettingsAccountViewModelTest : UnitTest() {
 
     @Test
     fun `given account name is updated and fails with HttpError, then error observer is notified`() {
-        val changeNameParams = mock(ChangeNameParams::class.java)
+        val changeNameParams = ChangeNameParams(TEST_NAME)
 
         runBlockingTest {
-            lenient().`when`(changeNameUseCase.run(changeNameParams)).thenReturn(Either.Left(ServerError))
-        }
+            `when`(changeNameUseCase.run(changeNameParams)).thenReturn(Either.Left(ServerError))
 
-        viewModel.updateName(TEST_NAME)
+            viewModel.updateName(TEST_NAME)
 
-        viewModel.errorLiveData.observeOnce {
-            it shouldBe "Failure: $ServerError"
+            verify(changeNameUseCase).run(changeNameParams)
+
+            viewModel.errorLiveData.observeOnce {
+                assert(it == "Failure: $ServerError")
+            }
         }
 
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Our unit test cases which rely on `when(useCase.run(...)).thenReturn(...)` condition result in **false positives**. 

The fact that tests result in false positives can be verified by 2 different ways:

1. adding a simple `verify(useCase).run(any())` check to test case. You'll see that the test fails, saying `useCase.run(...)` method is never executed.

2. change the test assertion to something else to deliberately fail the case. I have run my tests with `given account name is updated and fails with HttpError, then error observer is notified` test case in `SettingsAccountViewModelTest`. I have changed the `shouldBe` assertion to `it shouldBe "sd;lfks;dkf"` and nothing failed. You can even throw an exception from there, and nothing will fail, because the test never gets to the point that `observeOnce { } `block is executed.

The key point here is: **If there is no assertion that fails in you test case, your test will be successful, even if there's no assertion at all**. Try writing an empty test function, it will be successful in test results, even if nothing is there to succeed.

This PR proposes a solution to fix our tests, so they fail when something's indeed wrong. Another solution is proposed in #2782 . We will proceed with either one of them.

### Causes

With the old setting, the requirement `when(useCase.run(...)).thenReturn(...)` is not even executed. I did not confirm by evidence, but if I have to guess, I would say that this is because a `UseCase` execution (`run()` method) is handled in `UseCase` class again, in its `invoke` method. However, in order to test viewModels, we have to mock our UseCases. A method on a mocked object cannot be really run. So, the `run()` method does not get executed in our test cases at all, since `invoke()` is not run.

### Solutions

The proposed solution here takes the responsibility of running the useCase from UseCase class itself, and gives it to CoroutineScope via an extension function.

### Testing

Currently, it's only tested in 1 test case and it seems to work. The method indeed fails if the assertion fails. 

## Notes

We still need to see the effects of this on UseCase unit tests. This solution also requires a change in ViewModel class code, but that's trivial. The test cases are more self-explanatory compared to Solution 1. Also, I discovered that kluent assertions do not work and I had to switch to `assert()` function.
