### PR TITLE
Revert team member sync

### DIFF
--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -52,7 +52,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
             _           <- Signal(search.syncSearchResults(query))
             convId      <- createConvController.convId
             teamOnly    <- createConvController.teamOnly
-            results <- convId match {
+            results     <- convId match {
               case Some(cId) => search.usersToAddToConversation(query, cId)
               case None => search.usersForNewConversation(query, teamOnly)
             }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -20,14 +20,14 @@ package com.waz.sync.client
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.UserPermissions.PermissionsMasks
 import com.waz.model._
-import com.waz.sync.client.TeamsClient.TeamMember
+import com.waz.sync.client.TeamsClient.{TeamMember, TeamMembers}
 import com.waz.utils.CirceJSONSupport
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http.{HttpClient, Request}
 
 trait TeamsClient {
-  def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]]
+  def getTeamMembers(id: TeamId): ErrorOrResponse[TeamMembers]
   def getTeamData(id: TeamId): ErrorOrResponse[TeamData]
   def getPermissions(teamId: TeamId, userId: UserId): ErrorOrResponse[Option[PermissionsMasks]]
   def getTeamMember(teamId: TeamId, userId: UserId): ErrorOrResponse[TeamMember]
@@ -45,11 +45,11 @@ class TeamsClientImpl(implicit
   import TeamsClient._
   import com.waz.threading.Threading.Implicits.Background
 
-  override def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]] = {
+  override def getTeamMembers(id: TeamId): ErrorOrResponse[TeamMembers] = {
     Request.Get(relativePath = teamMembersPath(id))
       .withResultType[TeamMembers]
       .withErrorType[ErrorResponse]
-      .executeSafe(_.members)
+      .executeSafe
   }
 
   override def getTeamData(id: TeamId): ErrorOrResponse[TeamData] = {
@@ -108,7 +108,7 @@ object TeamsClient {
 
   def teamConversationPath(id: TeamId, cid: RConvId): String = s"$TeamsPath/${id.str}/conversations/${cid.str}"
 
-  case class TeamMembers(members: Seq[TeamMember])
+  case class TeamMembers(members: Seq[TeamMember], has_more: Boolean)
 
   case class TeamMember(user: UserId, permissions: Option[Permissions], created_by: Option[UserId])
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -46,21 +46,24 @@ class TeamsSyncHandlerImpl(userId:    UserId,
 
   import Threading.Implicits.Background
 
-  // TODO: rewrite with for/yield
   override def syncTeam(): Future[SyncResult] = teamId match {
-    case Some(id) => client.getTeamData(id).future.flatMap {
-      case Right(data) => client.getTeamMembers(id).future.flatMap {
-        case Right(membersData) => client.getTeamRoles(id).future.flatMap {
-          case Right(roles) =>
-            val members = if (membersData.has_more) Seq.empty[TeamMember] else membersData.members
-            service.onTeamSynced(data, members, roles).map(_ => SyncResult.Success)
-          case Left(error) => Future.successful(SyncResult(error))
-        }
-        case Left(error) => Future.successful(SyncResult(error))
+    case None     => Future.successful(SyncResult.Success)
+    case Some(id) =>
+
+      def flatten[T](res: Future[Either[ErrorResponse, T]]): Future[T] = res.flatMap {
+        case Left(err) => Future.failed(err)
+        case Right(t)  => Future.successful(t)
       }
-      case Left(error) => Future.successful(SyncResult(error))
-    }
-    case None => Future.successful(SyncResult.Success)
+
+      (for {
+        data        <- flatten(client.getTeamData(id))
+        membersData <- flatten(client.getTeamMembers(id))
+        roles       <- flatten(client.getTeamRoles(id))
+        members     =  if (membersData.has_more) Seq.empty[TeamMember] else membersData.members
+        _           <- service.onTeamSynced(data, members, roles)
+      } yield SyncResult.Success).recover {
+        case err: ErrorResponse => SyncResult(err)
+      }
   }
 
   override def syncMember(uId: UserId) = teamId match {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -76,7 +76,9 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
             {
               "user":"f3f4f763-ccee-4b3d-b450-582e2c99f8be"
             }
-            ]}"""
+          ],
+          "has_more": false
+        }"""
 
       // when
       val result = decode[TeamMembers](response)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -37,41 +37,12 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
 
   feature("Sync all teams") {
 
-    scenario("Basic single team with members less than 1500 sync") {
-
-      val teamId = TeamId()
-      val teamData = TeamData(teamId, "name", UserId(), AssetId())
-      val members = Seq(
-        TeamMember(UserId(), Option(Permissions(0L, 0L)), None),
-        TeamMember(UserId(), Option(Permissions(0L, 0L)), None)
-      )
-      val teamMembersData = TeamMembers(members, has_more = false)
-
-      (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))
-      (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(teamMembersData)))
-      (client.getTeamRoles _).expects(teamId).once().returning(CancellableFuture.successful(Right(ConversationRole.defaultRoles)))
-      (service.onTeamSynced _).expects(teamData, members, ConversationRole.defaultRoles).once().returning(Future.successful({}))
-
-      result(initHandler(Some(teamId)).syncTeam()) shouldEqual SyncResult.Success
-
+    scenario("Basic single team with members that has less than 1500 sync") {
+      verifyTeamSync(has_more = false)
     }
 
-    scenario("Basic single team with members over 2000 sync") {
-
-      val teamId = TeamId()
-      val teamData = TeamData(teamId, "name", UserId(), AssetId())
-      val members = Seq(
-        TeamMember(UserId(), Option(Permissions(0L, 0L)), None),
-        TeamMember(UserId(), Option(Permissions(0L, 0L)), None)
-      )
-      val teamMembersData = TeamMembers(members, has_more = true)
-
-      (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))
-      (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(teamMembersData)))
-      (client.getTeamRoles _).expects(teamId).once().returning(CancellableFuture.successful(Right(ConversationRole.defaultRoles)))
-      (service.onTeamSynced _).expects(teamData, Seq.empty[TeamMember], ConversationRole.defaultRoles).once().returning(Future.successful({}))
-
-      result(initHandler(Some(teamId)).syncTeam()) shouldEqual SyncResult.Success
+    scenario("Basic single team with members that has more than 1500 sync") {
+      verifyTeamSync(has_more = true)
 
     }
 
@@ -114,6 +85,24 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
 
       result(initHandler(Some(teamId)).syncMember(userId)) shouldEqual SyncResult(timeoutError)
     }
+  }
+
+
+  private def verifyTeamSync(has_more: Boolean) {
+    val teamId = TeamId()
+    val teamData = TeamData(teamId, "name", UserId(), AssetId())
+    val members = Seq(
+      TeamMember(UserId(), Option(Permissions(0L, 0L)), None),
+      TeamMember(UserId(), Option(Permissions(0L, 0L)), None)
+    )
+    val teamMembersData = TeamMembers(members, has_more)
+
+    (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))
+    (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(teamMembersData)))
+    (client.getTeamRoles _).expects(teamId).once().returning(CancellableFuture.successful(Right(ConversationRole.defaultRoles)))
+    (service.onTeamSynced _).expects(teamData, if (has_more) Seq.empty[TeamMember] else members, ConversationRole.defaultRoles).once().returning(Future.successful({}))
+
+    result(initHandler(Some(teamId)).syncTeam()) shouldEqual SyncResult.Success
   }
 
   def initHandler(teamId: Option[TeamId]) = new TeamsSyncHandlerImpl(account1Id, prefs, teamId, client, service)


### PR DESCRIPTION
## What's new in this PR?

Revert slow sync and update based on team size: https://wearezeta.atlassian.net/browse/AN-6842
Copy change: https://wearezeta.atlassian.net/browse/AN-6844

### Issues

After a in-depth discussion with Backend, it became clear that the current issues with the search are not fixable in a matter of days.

The issue is that you can not find people in your team at all if there are enough privte users matching the same query. For example, if you look for "Marco", you will not find Marco in your team but instead the first 100 (or whatever the threshold is) "Marco" private users. The search results will be truncated there, and you will never find your team mate. The private user have "pushed out" your team mates.

This is an issue only for backends that have consumers (i.e. our cloud version). On an on-prem backend, all results will be from your team anyway because there are no consumer. So if you get 100 Marco, it can only be because you have 100 Marco in your team, which is the desired result.

This is fixable on the backend, but it will take weeks, waaaay longer than expected. We need to come up with plan B.

### Solutions

We previously removed the behavior from clients to fetch the entire team. However clients were already successfully fetching teams up to 1,500, so they can handle it.

If we implement fetching the entire team on the client, then they will be able to perform local search for teams up to 1,500, and for teams that are larger than that, they will rely on backend results. Right now those results are brokens, but since we won't have teams larger than 1,500 on cloud, the user won't notice as they have everyone locally anyway. Only when the backend fixes the search, then the backend can remove the team limit on cloud too.

What does it mean for the client code?

Clients should re-add fetching the entire team on slow sync. If the response payload has a flag that indicates that there are more members than those returned ("has_more" is true), then we can ignore those - we are on a on-prem backend or even on the cloud after the search has been fixed. If the response payload contains the entire team ("has_more" is false), then store those results in the local DB and use them later for local search.
#### APK
[Download build #1936](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1936/artifact/build/artifact/wire-dev-PR2785-1936.apk)
[Download build #1937](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1937/artifact/build/artifact/wire-dev-PR2785-1937.apk)