### PR TITLE
feat: Large Teams: Move the list of recipients from URL to the request's body

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/MessagesClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/MessagesClient.scala
@@ -32,12 +32,7 @@ import com.waz.znet2.http._
 import com.wire.messages.nano.Otr
 
 trait MessagesClient {
-  def postMessage(
-      conv: RConvId,
-      content: OtrMessage,
-      ignoreMissing: Boolean,
-      receivers: Option[Set[UserId]] = None
-  ): ErrorOrResponse[MessageResponse]
+  def postMessage(conv: RConvId, content: OtrMessage, ignoreMissing: Boolean): ErrorOrResponse[MessageResponse]
 }
 
 class MessagesClientImpl(implicit
@@ -50,13 +45,8 @@ class MessagesClientImpl(implicit
   import MessagesClient._
   import com.waz.threading.Threading.Implicits.Background
 
-  override def postMessage(
-      conv: RConvId,
-      content: OtrMessage,
-      ignoreMissing: Boolean,
-      receivers: Option[Set[UserId]] = None
-  ): ErrorOrResponse[MessageResponse] = {
-    Request.Post(relativePath = convMessagesPath(conv, ignoreMissing, receivers), body = content)
+  override def postMessage(conv: RConvId, content: OtrMessage, ignoreMissing: Boolean): ErrorOrResponse[MessageResponse] =
+    Request.Post(relativePath = convMessagesPath(conv, ignoreMissing), body = content)
       .withResultHttpCodes(ResponseCode.SuccessCodes + ResponseCode.PreconditionFailed)
       .withResultType[Response[ClientMismatch]]
       .withErrorType[ErrorResponse]
@@ -64,15 +54,13 @@ class MessagesClientImpl(implicit
         if (code == ResponseCode.PreconditionFailed) MessageResponse.Failure(body)
         else MessageResponse.Success(body)
       }
-  }
 }
 
 object MessagesClient extends DerivedLogTag {
 
-  def convMessagesPath(conv: RConvId, ignoreMissing: Boolean, receivers: Option[Set[UserId]] = None): String = {
+  def convMessagesPath(conv: RConvId, ignoreMissing: Boolean): String = {
     val base = s"/conversations/$conv/otr/messages"
-    if (ignoreMissing) s"$base?ignore_missing=true"
-    else receivers.fold2(base, uids => s"$base?report_missing=${uids.iterator.map(_.str).mkString(",")}")
+    if (ignoreMissing) s"$base?ignore_missing=true" else base
   }
 
   implicit val OtrMessageSerializer: RawBodySerializer[OtrMessage] = RawBodySerializer.create { m =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -50,7 +50,7 @@ trait OtrClient {
   def postClient(userId: UserId, client: Client, lastKey: PreKey, keys: Seq[PreKey], password: Option[Password]): ErrorOrResponse[Client]
   def postClientLabel(id: ClientId, label: String): ErrorOrResponse[Unit]
   def updateKeys(id: ClientId, prekeys: Option[Seq[PreKey]] = None, lastKey: Option[PreKey] = None, sigKey: Option[SignalingKey] = None): ErrorOrResponse[Unit]
-  def broadcastMessage(content: OtrMessage, ignoreMissing: Boolean, receivers: Set[UserId] = Set.empty): ErrorOrResponse[MessageResponse]
+  def broadcastMessage(content: OtrMessage, ignoreMissing: Boolean): ErrorOrResponse[MessageResponse]
 }
 
 class OtrClientImpl(implicit
@@ -173,11 +173,11 @@ class OtrClientImpl(implicit
       .executeSafe
   }
 
-  override def broadcastMessage(content: OtrMessage, ignoreMissing: Boolean, receivers: Set[UserId] = Set.empty): ErrorOrResponse[MessageResponse] = {
+  override def broadcastMessage(content: OtrMessage, ignoreMissing: Boolean): ErrorOrResponse[MessageResponse] = {
     Request
       .Post(
         relativePath = BroadcastPath,
-        queryParameters = queryParameters("ignore_missing" -> ignoreMissing, "report_missing" -> receivers.mkString(",")),
+        queryParameters = queryParameters("ignore_missing" -> ignoreMissing),
         body = content
       )
       .withResultHttpCodes(ResponseCode.SuccessCodes + ResponseCode.PreconditionFailed)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
@@ -75,7 +75,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       .returning(Future.successful(encryptedContent))
 
     (msgClient.postMessage _)
-      .expects(conv.remoteId, OtrMessage(selfClientId, encryptedContent, nativePush = true), *, Option.empty[Set[UserId]])
+      .expects(conv.remoteId, OtrMessage(selfClientId, encryptedContent), *)
       .returning(CancellableFuture.successful(Right(MessageResponse.Success(ClientMismatch(time = RemoteInstant.Epoch)))))
 
     (service.deleteClients _)
@@ -167,9 +167,9 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
 
     var callsToPostMessage = 0
     (msgClient.postMessage _)
-      .expects(conv.remoteId, *, *, Option.empty[Set[UserId]])
+      .expects(conv.remoteId, *, *)
       .twice()
-      .onCall { (_, msg, ignoreMissing: Boolean, _) =>
+      .onCall { (_, msg, ignoreMissing: Boolean) =>
         CancellableFuture.successful(Right {
           callsToPostMessage += 1
           ignoreMissing shouldEqual false


### PR DESCRIPTION
implements https://wearezeta.atlassian.net/browse/AN-6841

For the Large Teams feature it's only important to have the list of recipients for updating the availability status, but to be consistent, I made the same change for all other messages.