### PR TITLE
Fix false-positives in integration tests

### DIFF
--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
@@ -10,6 +10,8 @@ import com.waz.zclient.storage.db.accountdata.SsoIdEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -40,9 +42,9 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         activeAccountsDao.insertActiveAccount(activeAccount)
 
         val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        assert(accessToken?.token == TEST_ACTIVE_ACCOUNT_COOKIE)
-        assert(accessToken?.tokenType == TEST_ACCESS_TOKEN_TYPE)
-        assert(accessToken?.expiresInMillis == TEST_ACCESS_TOKEN_EXPIRATION_TIME)
+        assertEquals(accessToken?.token, TEST_ACTIVE_ACCOUNT_COOKIE)
+        assertEquals(accessToken?.tokenType, TEST_ACCESS_TOKEN_TYPE)
+        assertEquals(accessToken?.expiresInMillis, TEST_ACCESS_TOKEN_EXPIRATION_TIME)
     }
 
     @Test
@@ -51,7 +53,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         activeAccountsDao.insertActiveAccount(activeAccount)
 
         val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        assert(accessToken == null)
+        assertEquals(accessToken, null)
     }
 
     @Test
@@ -67,9 +69,9 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         )
 
         val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        assert(accessToken?.token == TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
-        assert(accessToken?.tokenType == TEST_ACCESS_TOKEN_TYPE)
-        assert(accessToken?.expiresInMillis == TEST_ACCESS_TOKEN_EXPIRATION_TIME)
+        assertEquals(accessToken?.token, TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
+        assertEquals(accessToken?.tokenType, TEST_ACCESS_TOKEN_TYPE)
+        assertEquals(accessToken?.expiresInMillis, TEST_ACCESS_TOKEN_EXPIRATION_TIME)
     }
 
     @Test
@@ -84,7 +86,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
             )
 
             val refreshToken = activeAccountsDao.refreshToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-            assert(refreshToken == TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
+            assertEquals(refreshToken, TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
         }
 
     @Test
@@ -95,13 +97,13 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         }
 
         val roomActiveAccounts = activeAccountsDao.activeAccounts()
-        assert(roomActiveAccounts.size == 2)
+        assertEquals(roomActiveAccounts.size, 2)
 
         val firstAccount = roomActiveAccounts[0]
-        assert(firstAccount.id == TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
+        assertEquals(firstAccount.id, TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
 
         val secondAccount = roomActiveAccounts[1]
-        assert(secondAccount.id == TEST_ACTIVE_ACCOUNT_ID_INACTIVE)
+        assertEquals(secondAccount.id, TEST_ACTIVE_ACCOUNT_ID_INACTIVE)
     }
 
     @Test
@@ -116,7 +118,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
             activeAccountsDao.removeAccount(it)
         }
 
-        assert(activeAccountsDao.activeAccounts().isEmpty())
+        assertTrue(activeAccountsDao.activeAccounts().isEmpty())
     }
 
     private fun createActiveAccount(

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/CacheEntryDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/CacheEntryDaoTest.kt
@@ -8,6 +8,7 @@ import com.waz.zclient.storage.db.cache.CacheEntryEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -44,15 +45,15 @@ class CacheEntryDaoTest : IntegrationTest() {
         assert(roomActiveAccounts[1].key == TEST_CACHE_ENTRY_SECOND_ID)
         assert(roomActiveAccounts.size == 2)
         roomActiveAccounts.map {
-            assert(it.fileId == TEST_CACHE_ENTRY_FILE_ID)
-            assert(it.data == null)
-            assert(it.lastUsed == TEST_CACHE_ENTRY_LAST_USED)
-            assert(it.timeout == TEST_CACHE_ENTRY_TIME_OUT)
-            assert(it.filePath == TEST_CACHE_ENTRY_FILE_PATH)
-            assert(it.fileName == TEST_CACHE_ENTRY_FILE_NAME)
-            assert(it.mime == TEST_CACHE_ENTRY_MIME)
-            assert(it.encKey == TEST_CACHE_ENTRY_ENC_KEY)
-            assert(it.length == TEST_CACHE_ENTRY_LENGTH)
+            assertEquals(it.fileId, TEST_CACHE_ENTRY_FILE_ID)
+            assertEquals(it.data, null)
+            assertEquals(it.lastUsed, TEST_CACHE_ENTRY_LAST_USED)
+            assertEquals(it.timeout, TEST_CACHE_ENTRY_TIME_OUT)
+            assertEquals(it.filePath, TEST_CACHE_ENTRY_FILE_PATH)
+            assertEquals(it.fileName, TEST_CACHE_ENTRY_FILE_NAME)
+            assertEquals(it.mime, TEST_CACHE_ENTRY_MIME)
+            assertEquals(it.encKey, TEST_CACHE_ENTRY_ENC_KEY)
+            assertEquals(it.length, TEST_CACHE_ENTRY_LENGTH)
         }
         Unit
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/TeamsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/TeamsDaoTest.kt
@@ -8,6 +8,7 @@ import com.waz.zclient.storage.db.teams.TeamsEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -40,13 +41,13 @@ class TeamsDaoTest : IntegrationTest() {
         }
 
         val roomActiveAccounts = teamsDao.allTeams()
-        assert(roomActiveAccounts[0].teamId == TEST_TEAM_FIRST_ID)
-        assert(roomActiveAccounts[1].teamId == TEST_TEAM_SECOND_ID)
-        assert(roomActiveAccounts.size == 2)
+        assertEquals(roomActiveAccounts[0].teamId, TEST_TEAM_FIRST_ID)
+        assertEquals(roomActiveAccounts[1].teamId, TEST_TEAM_SECOND_ID)
+        assertEquals(roomActiveAccounts.size, 2)
         roomActiveAccounts.map {
-            assert(it.teamName == TEST_TEAM_NAME)
-            assert(it.creatorId == TEST_TEAM_CREATOR)
-            assert(it.iconId == TEST_TEAM_ICON)
+            assertEquals(it.teamName, TEST_TEAM_NAME)
+            assertEquals(it.creatorId, TEST_TEAM_CREATOR)
+            assertEquals(it.iconId, TEST_TEAM_ICON)
         }
         Unit
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/globaldatabase/GlobalDatabase24to25MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/globaldatabase/GlobalDatabase24to25MigrationTest.kt
@@ -6,11 +6,11 @@ import com.waz.zclient.storage.MigrationTestHelper
 import com.waz.zclient.storage.db.GlobalDatabase
 import com.waz.zclient.storage.db.accountdata.GLOBAL_DATABASE_MIGRATION_24_25
 import com.waz.zclient.storage.di.StorageModule.getGlobalDatabase
-import junit.framework.Assert.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -59,12 +59,12 @@ class GlobalDatabase24to25MigrationTest : IntegrationTest() {
         runBlocking {
             val activeAccounts = getActiveAccounts()
             with(activeAccounts[0]) {
-                assert(id == testActiveAccountId)
-                assert(teamId == null)
-                assert(accessToken?.token == testActiveAccountCookie)
-                assert(accessToken?.tokenType == testAccessTokenType)
-                assert(accessToken?.expiresInMillis == 1582896705028)
-                assert(refreshToken == testActiveAccountCookie)
+                assertEquals(id, testActiveAccountId)
+                assertEquals(teamId, null)
+                assertEquals(accessToken?.token, testActiveAccountCookie)
+                assertEquals(accessToken?.tokenType, testAccessTokenType)
+                assertEquals(accessToken?.expiresInMillis, 1582896705028)
+                assertEquals(refreshToken, testActiveAccountCookie)
             }
         }
     }
@@ -89,10 +89,10 @@ class GlobalDatabase24to25MigrationTest : IntegrationTest() {
         runBlocking {
             val teams = getTeams()
             with(teams[0]) {
-                assert(teamId == testTeamId)
-                assert(creatorId == testTeamCreator)
-                assert(iconId == testTeamIcon)
-                assert(teamName == testTeamName)
+                assertEquals(teamId, testTeamId)
+                assertEquals(creatorId, testTeamCreator)
+                assertEquals(iconId, testTeamIcon)
+                assertEquals(teamName, testTeamName)
             }
         }
     }
@@ -129,15 +129,15 @@ class GlobalDatabase24to25MigrationTest : IntegrationTest() {
         runBlocking {
             val cachedEntries = getCacheEntries()
             with(cachedEntries[0]) {
-                assert(key == testCacheEntryId)
-                assert(fileId == testCacheEntryFileId)
-                assertNull(data)
-                assert(lastUsed == testCacheEntryLastUsed)
-                assert(timeout == testCacheEntryTimeout)
-                assert(filePath == testCacheEntryFilePath)
-                assert(mime == testCacheEntryMime)
-                assert(encKey == testCacheEntryEncKey)
-                assert(length == testCacheEntryLength)
+                assertEquals(key, testCacheEntryId)
+                assertEquals(fileId, testCacheEntryFileId)
+                assertEquals(data, null)
+                assertEquals(lastUsed, testCacheEntryLastUsed)
+                assertEquals(timeout, testCacheEntryTimeout)
+                assertEquals(filePath, testCacheEntryFilePath)
+                assertEquals(mime, testCacheEntryMime)
+                assertEquals(encKey, testCacheEntryEncKey)
+                assertEquals(length, testCacheEntryLength)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetTables126to128MigrationTests.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetTables126to128MigrationTests.kt
@@ -4,6 +4,8 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
@@ -25,9 +27,9 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(getV1Assets()[0]) {
-                assert(this.id == assetId)
-                assert(this.assetType == assetType)
-                assert(this.data == assetData)
+                assertEquals(this.id, assetId)
+                assertEquals(this.assetType, assetType)
+                assertEquals(this.data, assetData)
             }
         }
     }
@@ -65,17 +67,17 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(getV2Assets()[0]) {
-                assert(this.id == assetId)
-                assert(this.token == assetToken)
-                assert(this.name == assetName)
-                assert(this.encryption == encryption)
-                assert(this.mime == mime)
-                assert(this.sha?.contentEquals(sha) ?: false)
-                assert(this.size == size)
-                assert(this.source == source)
-                assert(this.preview == preview)
-                assert(this.details == details)
-                assert(this.conversationId == conversationId)
+                assertEquals(this.id, assetId)
+                assertEquals(this.token, assetToken)
+                assertEquals(this.name, assetName)
+                assertEquals(this.encryption, encryption)
+                assertEquals(this.mime, mime)
+                assertTrue(this.sha?.contentEquals(sha) ?: false)
+                assertEquals(this.size, size)
+                assertEquals(this.source, source)
+                assertEquals(this.preview, preview)
+                assertEquals(this.details, details)
+                assertEquals(this.conversationId, conversationId)
             }
         }
     }
@@ -108,14 +110,14 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(getDownloadAssets()[0]) {
-                assert(this.id == assetId)
-                assert(this.mime == mime)
-                assert(this.downloaded == downloaded)
-                assert(this.size == size)
-                assert(this.name == assetName)
-                assert(this.preview == preview)
-                assert(this.details == details)
-                assert(this.status == status)
+                assertEquals(this.id, assetId)
+                assertEquals(this.mime, mime)
+                assertEquals(this.downloaded, downloaded)
+                assertEquals(this.size, size)
+                assertEquals(this.name, name)
+                assertEquals(this.preview, preview)
+                assertEquals(this.details, details)
+                assertEquals(this.status, status)
             }
         }
     }
@@ -163,23 +165,23 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(getUploadAssets()[0]) {
-                assert(this.id == uploadAssetId)
-                assert(this.source == assetToken)
-                assert(this.name == assetName)
-                assert(this.encryption == encryption)
-                assert(this.mime == mime)
-                assert(this.sha?.contentEquals(sha) ?: false)
-                assert(this.md5?.contentEquals(md5) ?: false)
-                assert(this.size == size)
-                assert(this.source == source)
-                assert(this.preview == preview)
-                assert(this.details == details)
-                assert(this.uploadStatus == uploadStatus)
-                assert(this.isPublic == isPublic)
-                assert(this.uploaded == uploaded)
-                assert(this.retention == retention)
-                assert(this.assetId == assetId)
-                assert(this.encryptionSalt == null)
+                assertEquals(this.id, uploadAssetId)
+                assertEquals(this.source, source)
+                assertEquals(this.name, assetName)
+                assertEquals(this.encryption, encryption)
+                assertEquals(this.mime, mime)
+                assertTrue(this.sha?.contentEquals(sha) ?: false)
+                assertTrue(this.md5?.contentEquals(md5) ?: false)
+                assertEquals(this.size, size)
+                assertEquals(this.source, source)
+                assertEquals(this.preview, preview)
+                assertEquals(this.details, details)
+                assertEquals(this.uploadStatus, uploadStatus)
+                assertEquals(this.isPublic, isPublic)
+                assertEquals(this.uploaded, uploaded)
+                assertEquals(this.retention, retention)
+                assertEquals(this.assetId, assetId)
+                assertEquals(this.encryptionSalt, null)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/clients/ClientsTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/clients/ClientsTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -26,8 +27,8 @@ class ClientsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allClients()[0]) {
-                assert(this.id == id)
-                assert(this.data == data)
+                assertEquals(this.id, id)
+                assertEquals(this.data, data)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/contact/ContactTables126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/contact/ContactTables126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -31,10 +32,10 @@ class ContactTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allContacts()[0]) {
-                assert(this.id == id)
-                assert(this.name == name)
-                assert(this.sortKey == sortKey)
-                assert(this.searchKey == searchKey)
+                assertEquals(this.id, id)
+                assertEquals(this.name, name)
+                assertEquals(this.sortKey, sortKey)
+                assertEquals(this.searchKey, searchKey)
             }
         }
     }
@@ -55,8 +56,8 @@ class ContactTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allContactOnWire()[0]) {
-                assert(this.userId == userId)
-                assert(this.contactId == contactId)
+                assertEquals(this.userId, userId)
+                assertEquals(this.contactId, contactId)
             }
         }
     }
@@ -77,8 +78,8 @@ class ContactTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allContactHashes()[0]) {
-                assert(this.id == id)
-                assert(this.hashes == hashes)
+                assertEquals(this.id, id)
+                assertEquals(this.hashes, hashes)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationTables126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationTables126to128MigrationTest.kt
@@ -4,6 +4,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
@@ -23,8 +24,8 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
 
         runBlocking {
             with(allConversationFolders()[0]) {
-                assert(this.convId == conversationId)
-                assert(this.folderId == folderId)
+                assertEquals(this.convId, conversationId)
+                assertEquals(this.folderId, folderId)
             }
         }
     }
@@ -46,9 +47,9 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
 
         runBlocking {
             with(allConversationMembers()[0]) {
-                assert(this.userId == userId)
-                assert(this.conversationId == convId)
-                assert(this.role == roleId)
+                assertEquals(this.userId, userId)
+                assertEquals(this.conversationId, convId)
+                assertEquals(this.role, roleId)
             }
         }
     }
@@ -70,9 +71,9 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
 
         runBlocking {
             with(allConversationRoleActions()[0]) {
-                assert(this.convId == convId)
-                assert(this.label == label)
-                assert(this.action == action)
+                assertEquals(this.convId, convId)
+                assertEquals(this.label, label)
+                assertEquals(this.action, action)
             }
         }
     }
@@ -153,39 +154,39 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
 
         runBlocking {
             with(allConversations()[0]) {
-                assert(this.id == convId)
-                assert(this.remoteId == remoteId)
-                assert(this.name == name)
-                assert(this.creator == creator)
-                assert(this.conversationType == conversationType)
-                assert(this.team == team)
-                assert(this.managed == managed)
-                assert(this.lastEventTime == lastEventTime)
-                assert(this.active == active)
-                assert(this.lastRead == lastRead)
-                assert(this.mutedStatus == mutedStatus)
-                assert(this.muteTime == muteTime)
-                assert(this.archived == archived)
-                assert(this.archiveTime == archiveTime)
-                assert(this.cleared == cleared)
-                assert(this.generatedName == generatedName)
-                assert(this.searchKey == searchKey)
-                assert(this.unreadCount == unreadCount)
-                assert(this.unsentCount == unsentCount)
-                assert(this.hidden == hidden)
-                assert(this.missedCall == missedCall)
-                assert(this.incomingKnock == incomingKnock)
-                assert(this.verified == verified)
-                assert(this.ephemeral == ephemeral)
-                assert(this.globalEphemeral == globalEphemeral)
-                assert(this.unreadCallCount == unreadCallCount)
-                assert(this.unreadPingCount == unreadPingCount)
-                assert(this.access == access)
-                assert(this.accessRole == accessRole)
-                assert(this.link == null)
-                assert(this.unreadMentionsCount == unreadMentionsCount)
-                assert(this.unreadQuoteCount == unreadQuoteCount)
-                assert(this.receiptMode == receiptMode)
+                assertEquals(this.id, convId)
+                assertEquals(this.remoteId, remoteId)
+                assertEquals(this.name, name)
+                assertEquals(this.creator, creator)
+                assertEquals(this.conversationType, conversationType)
+                assertEquals(this.team, team)
+                assertEquals(this.managed, managed)
+                assertEquals(this.lastEventTime, lastEventTime)
+                assertEquals(this.active, active)
+                assertEquals(this.lastRead, lastRead)
+                assertEquals(this.mutedStatus, mutedStatus)
+                assertEquals(this.muteTime, muteTime)
+                assertEquals(this.archived, archived)
+                assertEquals(this.archiveTime, archiveTime)
+                assertEquals(this.cleared, cleared)
+                assertEquals(this.generatedName, generatedName)
+                assertEquals(this.searchKey, searchKey)
+                assertEquals(this.unreadCount, unreadCount)
+                assertEquals(this.unsentCount, unsentCount)
+                assertEquals(this.hidden, hidden)
+                assertEquals(this.missedCall, missedCall)
+                assertEquals(this.incomingKnock, incomingKnock)
+                assertEquals(this.verified, verified)
+                assertEquals(this.ephemeral, ephemeral)
+                assertEquals(this.globalEphemeral, globalEphemeral)
+                assertEquals(this.unreadCallCount, unreadCallCount)
+                assertEquals(this.unreadPingCount, unreadPingCount)
+                assertEquals(this.access, access)
+                assertEquals(this.accessRole, accessRole)
+                assertEquals(this.link, null)
+                assertEquals(this.unreadMentionsCount, unreadMentionsCount)
+                assertEquals(this.unreadQuoteCount, unreadQuoteCount)
+                assertEquals(this.receiptMode, receiptMode)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/email/EmailAddressesTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/email/EmailAddressesTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -27,8 +28,8 @@ class EmailAddressesTable126to128MigrationTest : UserDatabaseMigrationTest(126, 
 
         runBlocking {
             with(allEmailAddresses()[0]) {
-                assert(this.contactId == contactId)
-                assert(this.emailAddress == email)
+                assertEquals(this.contactId, contactId)
+                assertEquals(this.emailAddress, email)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/errors/ErrorsTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/errors/ErrorsTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -41,15 +42,15 @@ class ErrorsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
         runBlocking {
             val syncJob = allErrors()[0]
             with(syncJob) {
-                assert(this.id == id)
-                assert(this.errorType == type)
-                assert(this.users == users)
-                assert(this.messages == message)
-                assert(this.conversationId == conversationId)
-                assert(this.responseCode == resCode)
-                assert(this.responseMessage == resMessage)
-                assert(this.responseLabel == resLabel)
-                assert(this.time == timestamp)
+                assertEquals(this.id, id)
+                assertEquals(this.errorType, type)
+                assertEquals(this.users, users)
+                assertEquals(this.messages, message)
+                assertEquals(this.conversationId, conversationId)
+                assertEquals(this.responseCode, resCode)
+                assertEquals(this.responseMessage, resMessage)
+                assertEquals(this.responseLabel, resLabel)
+                assertEquals(this.time, timestamp)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -28,9 +29,9 @@ class FoldersTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allFolders()[0]) {
-                assert(this.id == id)
-                assert(this.name == name)
-                assert(this.type == type)
+                assertEquals(this.id, id)
+                assertEquals(this.name, name)
+                assertEquals(this.type, type)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -28,9 +29,9 @@ class EditHistoryTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128
 
         runBlocking {
             with(allHistory()[0]) {
-                assert(this.originalId == originalId)
-                assert(this.updatedId == updatedId)
-                assert(this.timestamp == timestamp)
+                assertEquals(this.originalId, originalId)
+                assertEquals(this.updatedId, updatedId)
+                assertEquals(this.timestamp, timestamp)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessagesTables126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/messages/MessagesTables126to128MigrationTest.kt
@@ -5,6 +5,8 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -66,29 +68,29 @@ class MessagesTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allMessages()[0]) {
-                assert(this.id == id)
-                assert(this.conversationId == conversationId)
-                assert(this.messageType == messageType)
-                assert(this.userId == userId)
-                assert(this.content == content)
-                assert(this.protos!!.contentEquals(protos!!))
-                assert(this.time == time)
-                assert(firstMessage == message)
-                assert(this.members == members)
-                assert(this.recipient == recipient)
-                assert(this.email == email)
-                assert(this.name == name)
-                assert(this.messageState == messageState)
-                assert(this.contentSize == contentSize)
-                assert(this.editTime == editTime)
-                assert(this.ephemeral == ephemeral)
-                assert(this.expiryTime == expiryTime)
-                assert(this.expired == expired)
-                assert(this.duration == duration)
-                assert(this.quote == quote)
-                assert(this.quoteValidity == quoteValidity)
-                assert(this.forceReadReceipts == forceReadReceipts)
-                assert(this.assetId == assetId)
+                assertEquals(this.id, id)
+                assertEquals(this.conversationId, conversationId)
+                assertEquals(this.messageType, messageType)
+                assertEquals(this.userId, userId)
+                assertEquals(this.content, content)
+                assertTrue(this.protos!!.contentEquals(protos!!))
+                assertEquals(this.time, time)
+                assertEquals(firstMessage, message)
+                assertEquals(this.members, members)
+                assertEquals(this.recipient, recipient)
+                assertEquals(this.email, email)
+                assertEquals(this.name, name)
+                assertEquals(this.messageState, messageState)
+                assertEquals(this.contentSize, contentSize)
+                assertEquals(this.editTime, editTime)
+                assertEquals(this.ephemeral, ephemeral)
+                assertEquals(this.expiryTime, expiryTime)
+                assertEquals(this.expired, expired)
+                assertEquals(this.duration, duration)
+                assertEquals(this.quote, quote)
+                assertEquals(this.quoteValidity, quoteValidity)
+                assertEquals(this.forceReadReceipts, forceReadReceipts)
+                assertEquals(this.assetId, assetId)
             }
         }
     }
@@ -109,8 +111,8 @@ class MessagesTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allMessageDeletions()[0]) {
-                assert(this.messageId == messageId)
-                assert(this.timestamp == timestamp)
+                assertEquals(this.messageId, messageId)
+                assertEquals(this.timestamp, timestamp)
             }
         }
     }
@@ -136,10 +138,10 @@ class MessagesTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allLikes()[0]) {
-                assert(this.messageId == messageId)
-                assert(this.userId == userId)
-                assert(this.timeStamp == timestamp)
-                assert(this.action == action)
+                assertEquals(this.messageId, messageId)
+                assertEquals(this.userId, userId)
+                assertEquals(this.timeStamp, timestamp)
+                assertEquals(this.action, action)
             }
         }
     }
@@ -164,10 +166,10 @@ class MessagesTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allMessageContentIndexes()[0]) {
-                assert(this.messageId == messageId)
-                assert(this.convId == conversationId)
-                assert(this.content == content)
-                assert(this.timestamp == timestamp)
+                assertEquals(this.messageId, messageId)
+                assertEquals(this.convId, conversationId)
+                assertEquals(this.content, content)
+                assertEquals(this.timestamp, timestamp)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/notifications/NotificationsTables126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/notifications/NotificationsTables126to128MigrationTest.kt
@@ -5,6 +5,8 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -25,10 +27,10 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
 
         runBlocking {
             with(allCloudNotificationStats()[0]) {
-                assert(this.stage == stage)
-                assert(this.firstBucket == firstBucket)
-                assert(this.secondBucket == secondBucket)
-                assert(this.thirdBucket == thirdBucket)
+                assertEquals(this.stage, stage)
+                assertEquals(this.firstBucket, firstBucket)
+                assertEquals(this.secondBucket, secondBucket)
+                assertEquals(this.thirdBucket, thirdBucket)
             }
         }
     }
@@ -48,9 +50,9 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
 
         runBlocking {
             with(allCloudNotifications()[0]) {
-                assert(this.id == id)
-                assert(this.stage == stage)
-                assert(this.stageStartTime == stageStartTime)
+                assertEquals(this.id, id)
+                assertEquals(this.stage, stage)
+                assertEquals(this.stageStartTime, stageStartTime)
             }
         }
     }
@@ -71,8 +73,8 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
 
         runBlocking {
             with(allNotificationsData()[0]) {
-                assert(this.id == id)
-                assert(this.data == data)
+                assertEquals(this.id, id)
+                assertEquals(this.data, data)
             }
         }
     }
@@ -102,12 +104,12 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
 
         runBlocking {
             with(allPushNotificationEvents()[0]) {
-                assert(this.eventIndex == eventIndex)
-                assert(this.pushId == pushId)
-                assert(this.isDecrypted == isDecrypted)
-                assert(this.eventJson == eventJson)
-                this.plain?.let { assert(it.contentEquals(plain)) }
-                assert(this.isTransient == isTransient)
+                assertEquals(this.eventIndex, eventIndex)
+                assertEquals(this.pushId, pushId)
+                assertEquals(this.isDecrypted, isDecrypted)
+                assertEquals(this.eventJson, eventJson)
+                this.plain?.let { assertTrue(it.contentEquals(plain)) }
+                assertEquals(this.isTransient, isTransient)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/phone/PhoneNumbersTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/phone/PhoneNumbersTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -26,8 +27,8 @@ class PhoneNumbersTable126to128MigrationTest : UserDatabaseMigrationTest(126, 12
 
         runBlocking {
             with(allPhoneNumbers()[0]) {
-                assert(this.contactId == contactId)
-                assert(this.phoneNumber == phone)
+                assertEquals(this.contactId, contactId)
+                assertEquals(this.phoneNumber, phone)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/property/PropertyTables126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/property/PropertyTables126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -25,8 +26,8 @@ class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allKeyValues()[0]) {
-                assert(this.key == key)
-                assert(this.value == value)
+                assertEquals(this.key, key)
+                assertEquals(this.value, value)
             }
         }
     }
@@ -47,8 +48,8 @@ class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
 
         runBlocking {
             with(allProperties()[0]) {
-                assert(this.key == key)
-                assert(this.value == value)
+                assertEquals(this.key, key)
+                assertEquals(this.value, value)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -28,9 +29,9 @@ class ReadReceiptsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 12
 
         runBlocking {
             with(allReceipts()[0]) {
-                assert(this.messageId == messageId)
-                assert(this.userId == userId)
-                assert(this.timestamp == timestamp)
+                assertEquals(this.messageId, messageId)
+                assertEquals(this.userId, userId)
+                assertEquals(this.timestamp, timestamp)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/sync/SyncJobsTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/sync/SyncJobsTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -26,8 +27,8 @@ class SyncJobsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(allSyncJobs()[0]) {
-                assert(this.id == id)
-                assert(this.data == data)
+                assertEquals(this.id, id)
+                assertEquals(this.data, data)
             }
         }
     }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UserTable126to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UserTable126to128MigrationTest.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -74,32 +75,32 @@ class UserTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
 
         runBlocking {
             with(getAllUsers()[0]) {
-                assert(this.id == id)
-                assert(this.teamId == teamId)
-                assert(this.name == name)
-                assert(this.email == email)
-                assert(this.phone == phone)
-                assert(this.trackingId == trackingId)
-                assert(this.picture == picture)
-                assert(this.accentId == accentId)
-                assert(this.sKey == sKey)
-                assert(this.connection == connection)
-                assert(this.connectionTimestamp == connectionTimestamp)
-                assert(this.connectionMessage == connectionMessage)
-                assert(this.conversation == conversation)
-                assert(this.relation == relation)
-                assert(this.timestamp == timestamp)
-                assert(this.verified == verified)
-                assert(this.deleted == deleted)
-                assert(this.availability == availability)
-                assert(this.handle == handle)
-                assert(this.providerId == providerId)
-                assert(this.integrationId == integrationId)
-                assert(this.expiresAt == expiresAt)
-                assert(this.managedBy == managedBy)
-                assert(this.selfPermission == selfPermission)
-                assert(this.copyPermission == copyPermission)
-                assert(this.createdBy == createdBy)
+                assertEquals(this.id, id)
+                assertEquals(this.teamId, teamId)
+                assertEquals(this.name, name)
+                assertEquals(this.email, email)
+                assertEquals(this.phone, phone)
+                assertEquals(this.trackingId, trackingId)
+                assertEquals(this.picture, picture)
+                assertEquals(this.accentId, accentId)
+                assertEquals(this.sKey, sKey)
+                assertEquals(this.connection, connection)
+                assertEquals(this.connectionTimestamp, connectionTimestamp)
+                assertEquals(this.connectionMessage, connectionMessage)
+                assertEquals(this.conversation, conversation)
+                assertEquals(this.relation, relation)
+                assertEquals(this.timestamp, timestamp)
+                assertEquals(this.verified, verified)
+                assertEquals(this.deleted, deleted)
+                assertEquals(this.availability, availability)
+                assertEquals(this.handle, handle)
+                assertEquals(this.providerId, providerId)
+                assertEquals(this.integrationId, integrationId)
+                assertEquals(this.expiresAt, expiresAt)
+                assertEquals(this.managedBy, managedBy)
+                assertEquals(this.selfPermission, selfPermission)
+                assertEquals(this.copyPermission, copyPermission)
+                assertEquals(this.createdBy, createdBy)
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The current way we make the assertions in integration tests do not fail the test when the assertion is false.

For example:

```
class MyTest : IntegrationTest() {

    @Test
    fun asd() {
        assert(3 == 5)
    }
}
```

such a test results in success currently.

### Causes

The assertion method was from AssertionsJVM.kt, which was not intended for test case assertions.

### Solutions

Replace all `assert()` calls from AssertionsJVM with respective `org.junit.Assert` calls.

### Testing

Since our CI pipeline cannot run integration tests yet, I ran the tests locally. I also tried to fail them with false assertions, and they failed as expected.

## Notes

The `GlobalDatabase24to25MigrationTest` fails, but I didn't include the fix here, since it's not this PR's responsibility.

Another assertion library can be used in the future. I tried assertJ, but had some problems compiling the project with it.

#### APK
[Download build #1969](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1969/artifact/build/artifact/wire-dev-PR2793-1969.apk)