### PR TITLE
Feat: Logout functionality in Kotlin - Part 2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -153,6 +153,11 @@
                 <category android:name="android.intent.category.VIEW" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="com.wire.ACTION_CURRENT_USER_CHANGED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+
         </activity>
 
         <activity
@@ -213,8 +218,12 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.Dark"
             android:windowSoftInputMode="stateHidden|adjustResize"
-            android:exported="false"
-            />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.wire.ACTION_NO_USER_LEFT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ForceUpdateActivity"

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.feature.settings.account
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -119,17 +120,27 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
     }
 
     private fun initLogout() {
+        observeLogoutNavigation()
         observeLogoutData()
         initLogoutButtonListener()
+    }
+
+    private fun observeLogoutNavigation() {
+        settingsAccountViewModel.logoutNavigationAction.observe(viewLifecycleOwner) {
+            startActivity(Intent()
+                .setAction(it)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
     }
 
     private fun observeLogoutData() {
         with(logoutViewModel) {
             successLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Logged out", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLoggedOut(it)
             }
             errorLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Failed with $it", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLogoutError(it)
             }
         }
     }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
@@ -1,17 +1,56 @@
 package com.waz.zclient.feature.settings.account.logout
 
 import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.accesstoken.AccessTokenRepository
 import com.waz.zclient.core.usecase.UseCase
 import com.waz.zclient.shared.accounts.AccountsRepository
+import com.waz.zclient.shared.user.UsersRepository
 
 class LogoutUseCase(
     private val accountsRepository: AccountsRepository,
-    private val accessTokenRepository: AccessTokenRepository
-) : UseCase<Unit, Unit>() {
+    private val accessTokenRepository: AccessTokenRepository,
+    private val usersRepository: UsersRepository
+) : UseCase<LogoutStatus, Unit>() {
 
-    override suspend fun run(params: Unit): Either<Failure, Unit> = with(accessTokenRepository) {
-        accountsRepository.logout(refreshToken().token, accessToken().token)
+    override suspend fun run(params: Unit): Either<Failure, LogoutStatus> {
+        logout() //TODO check w/ backend team what is the side effect if this call fails
+        return deleteLoggedOutAccountData()
     }
+
+    private suspend fun logout() {
+        val refreshToken = accessTokenRepository.refreshToken().token
+        val accessToken = accessTokenRepository.accessToken().token
+        accountsRepository.logout(refreshToken, accessToken)
+    }
+
+    private suspend fun deleteLoggedOutAccountData(): Either<Failure, LogoutStatus> =
+        usersRepository.currentUserId().let {
+            accountsRepository.deleteAccountFromDevice(it) //TODO should we log failure somehow?
+            updateCurrentUserId(it)
+        }
+
+    private suspend fun updateCurrentUserId(loggedOutUserId: String): Either<Failure, LogoutStatus> =
+        accountsRepository.activeAccounts().fold({
+            clearCurrentUserId()
+            Either.Right(CouldNotReadRemainingAccounts)
+        }) {
+            val remainingAccountId = it.firstOrNull { it.id != loggedOutUserId }?.id
+            val status = if (remainingAccountId == null) {
+                clearCurrentUserId()
+                NoAccountsLeft
+            } else {
+                usersRepository.setCurrentUserId(remainingAccountId)
+                AnotherAccountExists
+            }
+            Either.Right(status)
+        }!!
+
+    private fun clearCurrentUserId() = usersRepository.setCurrentUserId(String.empty())
 }
+
+sealed class LogoutStatus
+object NoAccountsLeft : LogoutStatus()
+object AnotherAccountExists : LogoutStatus()
+object CouldNotReadRemainingAccounts : LogoutStatus()

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
@@ -8,23 +8,17 @@ import com.waz.zclient.core.exception.Failure
 
 class LogoutViewModel(private val logoutUseCase: LogoutUseCase) : ViewModel() {
 
-    private var _successLiveData = MutableLiveData<Boolean>()
+    private var _successLiveData = MutableLiveData<LogoutStatus>()
     private var _errorLiveData = MutableLiveData<Failure>()
 
     val errorLiveData: LiveData<Failure> = _errorLiveData
-    val successLiveData: LiveData<Boolean> = _successLiveData
+    val successLiveData: LiveData<LogoutStatus> = _successLiveData
 
-    fun onVerifyButtonClicked() {
-        logoutUseCase(viewModelScope, Unit) {
-            it.fold(::logoutFailed, ::logoutSuccess)
-        }
+    fun onVerifyButtonClicked() = logoutUseCase(viewModelScope, Unit) {
+        it.fold(::logoutFailed, ::logoutSuccess)
     }
 
-    private fun logoutSuccess(unit: Unit) {
-        _successLiveData.postValue(true)
-    }
+    private fun logoutSuccess(status: LogoutStatus) = _successLiveData.postValue(status)
 
-    private fun logoutFailed(failure: Failure) {
-        _errorLiveData.postValue(failure)
-    }
+    private fun logoutFailed(failure: Failure) = _errorLiveData.postValue(failure)
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/di/SettingsModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/di/SettingsModule.kt
@@ -100,6 +100,6 @@ val settingsAccountModule: Module = module {
         factory { ChangeEmailUseCase(get()) }
         factory { DeleteAccountUseCase(get()) }
 
-        factory { LogoutUseCase(get(), get()) }
+        factory { LogoutUseCase(get(), get(), get()) }
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
@@ -5,6 +5,7 @@ import com.waz.zclient.core.functional.Either
 
 interface AccountsRepository {
     suspend fun activeAccounts(): Either<Failure, List<ActiveAccount>>
+    suspend fun activeAccountById(accountId: String): Either<Failure, ActiveAccount?>
     suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit>
     suspend fun deleteAccountFromDevice(account: ActiveAccount): Either<Failure, Unit>
     suspend fun deleteAccountPermanently(): Either<Failure, Unit>

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
@@ -7,6 +7,6 @@ interface AccountsRepository {
     suspend fun activeAccounts(): Either<Failure, List<ActiveAccount>>
     suspend fun activeAccountById(accountId: String): Either<Failure, ActiveAccount?>
     suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit>
-    suspend fun deleteAccountFromDevice(account: ActiveAccount): Either<Failure, Unit>
+    suspend fun deleteAccountFromDevice(accountId: String): Either<Failure, Unit>
     suspend fun deleteAccountPermanently(): Either<Failure, Unit>
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
@@ -28,8 +28,8 @@ class AccountsDataSource(
     override suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit> =
         accountsRemoteDataSource.logout(refreshToken, accessToken)
 
-    override suspend fun deleteAccountFromDevice(account: ActiveAccount) =
-        accountsLocalDataSource.removeAccount(accountMapper.toEntity(account))
+    override suspend fun deleteAccountFromDevice(accountId: String): Either<Failure, Unit> =
+        accountsLocalDataSource.removeAccount(accountId)
 
     override suspend fun deleteAccountPermanently(): Either<Failure, Unit> =
         usersRemoteDataSource.deleteAccountPermanently()

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
@@ -20,6 +20,11 @@ class AccountsDataSource(
     override suspend fun activeAccounts() = accountsLocalDataSource.activeAccounts()
         .map { entityList -> entityList.map { accountMapper.from(it) } }
 
+    override suspend fun activeAccountById(accountId: String): Either<Failure, ActiveAccount?> =
+        accountsLocalDataSource.activeAccountById(accountId).map { entity ->
+            entity?.let { accountMapper.from(it) }
+        }
+
     override suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit> =
         accountsRemoteDataSource.logout(refreshToken, accessToken)
 

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
@@ -18,8 +18,8 @@ class AccountsLocalDataSource(private val activeAccountsDao: ActiveAccountsDao) 
             activeAccountsDao.activeAccountById(accountId)
         }
 
-    suspend fun removeAccount(account: ActiveAccountsEntity) =
+    suspend fun removeAccount(accountId: String) =
         requestDatabase {
-            activeAccountsDao.removeAccount(account)
+            activeAccountsDao.removeAccount(accountId)
         }
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
@@ -1,5 +1,7 @@
 package com.waz.zclient.shared.accounts.datasources.local
 
+import com.waz.zclient.core.exception.DatabaseFailure
+import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.requestDatabase
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
@@ -9,6 +11,11 @@ class AccountsLocalDataSource(private val activeAccountsDao: ActiveAccountsDao) 
     suspend fun activeAccounts() =
         requestDatabase {
             activeAccountsDao.activeAccounts()
+        }
+
+    suspend fun activeAccountById(accountId: String): Either<DatabaseFailure, ActiveAccountsEntity?> =
+        requestDatabase {
+            activeAccountsDao.activeAccountById(accountId)
         }
 
     suspend fun removeAccount(account: ActiveAccountsEntity) =

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
@@ -2,7 +2,6 @@ package com.waz.zclient.shared.accounts.usecase
 
 import com.waz.zclient.core.exception.Failure
 import com.waz.zclient.core.exception.FeatureFailure
-import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.functional.flatMap
 import com.waz.zclient.core.usecase.UseCase
@@ -20,8 +19,8 @@ class GetActiveAccountUseCase(
 ) : UseCase<ActiveAccount, Unit>() {
 
     override suspend fun run(params: Unit): Either<Failure, ActiveAccount> =
-        userRepository.currentUserId().flatMap {
-            if (it == String.empty()) Either.Left(CannotFindActiveAccount)
+        userRepository.currentUserId().let {
+            if (it.isEmpty()) Either.Left(CannotFindActiveAccount)
             else activeAccountById(it)
         }
 

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/UsersRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/UsersRepository.kt
@@ -8,5 +8,6 @@ interface UsersRepository {
     suspend fun profileDetails(): Flow<User>
     suspend fun changeName(name: String): Either<Failure, Any>
     suspend fun changeEmail(email: String): Either<Failure, Any>
-    suspend fun currentUserId(): Either<Failure, String>
+    fun currentUserId(): String
+    fun setCurrentUserId(userId: String)
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/UsersDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/UsersDataSource.kt
@@ -52,7 +52,9 @@ class UsersDataSource(
     override suspend fun changeEmail(email: String) = changeEmailRemotely(email)
         .onSuccess { runBlocking { changeEmailLocally(email) } }
 
-    override suspend fun currentUserId() = usersLocalDataSource.currentUserId()
+    override fun currentUserId(): String = usersLocalDataSource.currentUserId()
+
+    override fun setCurrentUserId(userId: String) = usersLocalDataSource.setCurrentUserId(userId)
 
     private suspend fun changeEmailRemotely(email: String) = usersRemoteDataSource.changeEmail(email)
 

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/local/UsersLocalDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/local/UsersLocalDataSource.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.shared.user.datasources.local
 
 import com.waz.zclient.core.extension.empty
-import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.requestDatabase
 import com.waz.zclient.storage.db.users.model.UserEntity
 import com.waz.zclient.storage.db.users.service.UserDao
@@ -10,10 +9,11 @@ import kotlinx.coroutines.flow.Flow
 
 class UsersLocalDataSource constructor(
     private val userDao: UserDao,
-    globalPreferences: GlobalPreferences
+    private val globalPreferences: GlobalPreferences
 ) {
 
-    private val userId = globalPreferences.activeUserId
+    private val userId: String
+        get() = globalPreferences.activeUserId
 
     fun profileDetails(): Flow<UserEntity> = userDao.byId(userId)
 
@@ -29,5 +29,9 @@ class UsersLocalDataSource constructor(
 
     suspend fun deletePhone() = requestDatabase { userDao.updatePhone(userId, String.empty()) }
 
-    fun currentUserId() = Either.Right(userId)
+    fun currentUserId() = userId
+
+    fun setCurrentUserId(userId: String) {
+        globalPreferences.activeUserId = userId
+    }
 }

--- a/app/src/test/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCaseTest.kt
@@ -1,17 +1,28 @@
 package com.waz.zclient.feature.settings.account.logout
 
 import com.waz.zclient.UnitTest
+import com.waz.zclient.any
+import com.waz.zclient.core.exception.DatabaseError
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.exception.Forbidden
+import com.waz.zclient.core.extension.empty
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.functional.map
 import com.waz.zclient.core.network.accesstoken.AccessToken
 import com.waz.zclient.core.network.accesstoken.AccessTokenRepository
 import com.waz.zclient.core.network.accesstoken.RefreshToken
 import com.waz.zclient.shared.accounts.AccountsRepository
+import com.waz.zclient.shared.accounts.ActiveAccount
+import com.waz.zclient.shared.user.UsersRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
-import org.amshove.kluent.mock
+import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
@@ -23,24 +34,34 @@ class LogoutUseCaseTest : UnitTest() {
     @Mock
     private lateinit var accessTokenRepository: AccessTokenRepository
 
+    @Mock
+    private lateinit var usersRepository: UsersRepository
+
+    @Mock
+    private lateinit var accessToken: AccessToken
+
+    @Mock
+    private lateinit var refreshToken: RefreshToken
+
     private lateinit var logoutUseCase: LogoutUseCase
 
     @Before
     fun setUp() {
-        logoutUseCase = LogoutUseCase(accountsRepository, accessTokenRepository)
+        `when`(accessToken.token).thenReturn(ACCESS_TOKEN_STRING)
+        `when`(refreshToken.token).thenReturn(REFRESH_TOKEN_STRING)
+        runBlocking {
+            `when`(accessTokenRepository.accessToken()).thenReturn(accessToken)
+            `when`(accessTokenRepository.refreshToken()).thenReturn(refreshToken)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(emptyList()))
+        }
+        `when`(usersRepository.currentUserId()).thenReturn(TEST_USER_ID)
+
+        logoutUseCase = LogoutUseCase(accountsRepository, accessTokenRepository, usersRepository)
     }
 
     @Test
-    fun `given accessTokenRepo, when run is called, then calls accountsRepo's logout method with access and refresh tokens`() =
+    fun `given accessTokenRepo, when run is called, then calls accountsRepo's logout method with correct tokens from accessTokenRepo`() =
         runBlockingTest {
-            val accessToken = mock(AccessToken::class)
-            `when`(accessToken.token).thenReturn(ACCESS_TOKEN_STRING)
-            val refreshToken = mock(RefreshToken::class)
-            `when`(refreshToken.token).thenReturn(REFRESH_TOKEN_STRING)
-
-            `when`(accessTokenRepository.accessToken()).thenReturn(accessToken)
-            `when`(accessTokenRepository.refreshToken()).thenReturn(refreshToken)
-
             logoutUseCase.run(Unit)
 
             verify(accessTokenRepository).accessToken()
@@ -49,8 +70,122 @@ class LogoutUseCaseTest : UnitTest() {
             verify(accountsRepository).logout(REFRESH_TOKEN_STRING, ACCESS_TOKEN_STRING)
         }
 
+    @Test
+    fun `given use case is run, when logout operation returns success, then proceeds to account deletion`() =
+        runBlockingTest {
+            `when`(accountsRepository.logout(any(), any())).thenReturn(Either.Right(Unit))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).deleteAccountFromDevice(TEST_USER_ID)
+        }
+
+    @Test
+    fun `given use case is run, when logout operation fails, then proceeds to account deletion`() =
+        runBlockingTest {
+            `when`(accountsRepository.logout(any(), any())).thenReturn(Either.Left(Forbidden))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).deleteAccountFromDevice(TEST_USER_ID)
+        }
+
+    @Test
+    fun `given use case is run, when account deletion is successful, then proceeds to checking remaining accounts`() =
+        runBlockingTest {
+            `when`(accountsRepository.deleteAccountFromDevice(TEST_USER_ID)).thenReturn(Either.Right(Unit))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).activeAccounts()
+        }
+
+    @Test
+    fun `given use case is run, when account deletion fails, then proceeds to checking remaining accounts`() =
+        runBlockingTest {
+            `when`(accountsRepository.deleteAccountFromDevice(TEST_USER_ID)).thenReturn(Either.Left(DatabaseError))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).activeAccounts()
+        }
+
+    @Test
+    fun `given account is deleted and there's no accounts left, then clears currentUserId and returns NoAccountsLeft`() =
+        runBlockingTest {
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(emptyList()))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe NoAccountsLeft }
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
+    @Test
+    fun `given account is deleted and there's another account left, then updates currentUserId with new id and returns AnotherAccountExists`() =
+        runBlockingTest {
+            val id = "otherAccountId"
+            val otherAccount = mockAccount(id)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(otherAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe AnotherAccountExists }
+            verify(usersRepository).setCurrentUserId(id)
+        }
+
+    @Test
+    fun `given account deletion fails and the account still exists, when there's no other account, then clears currentUserId and returns NoAccountsLeft`() =
+        runBlockingTest {
+            val activeAccount = mockAccount(TEST_USER_ID)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(activeAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe NoAccountsLeft }
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
+    @Test
+    fun `given account deletion fails and the account still exists, when there's another account, then updates currentUserId and returns AnotherAccountExists`() =
+        runBlockingTest {
+            val loggedOutAccount = mockAccount(TEST_USER_ID)
+            val newId = "newActiveId"
+            val newActiveAccount = mockAccount(newId)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(loggedOutAccount, newActiveAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe AnotherAccountExists }
+            verify(usersRepository).setCurrentUserId(newId)
+        }
+
+    @Test
+    fun `given remaining active accounts check fails, then clears current user id and returns CouldNotReadRemainingAccounts`() =
+        runBlockingTest {
+            val failure = mock(Failure::class.java)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Left(failure))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe CouldNotReadRemainingAccounts }
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
     companion object {
+        private const val TEST_USER_ID = "testUser_id"
         private const val ACCESS_TOKEN_STRING = "accessToken"
         private const val REFRESH_TOKEN_STRING = "refreshToken"
+
+        private fun mockAccount(id: String): ActiveAccount {
+            val account = mock(ActiveAccount::class.java)
+            `when`(account.id).thenReturn(id)
+            return account
+        }
     }
 }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
@@ -139,12 +139,10 @@ class AccountsDataSourceTest : UnitTest() {
         }
 
     @Test
-    fun `given deleteAcountFromDevice is called, then local data source should remove account from database`() = runBlockingTest {
-        val account = mockActiveAccount()
+    fun `given deleteAccountFromDevice is called with an id, then calls local data source with given id`() = runBlockingTest {
+        accountsDataSource.deleteAccountFromDevice(TEST_ID)
 
-        accountsDataSource.deleteAccountFromDevice(account)
-
-        verify(localDataSource).removeAccount(accountMapper.toEntity(account))
+        verify(localDataSource).removeAccount(TEST_ID)
         verifyNoMoreInteractions(localDataSource)
         verifyNoInteractions(usersRemoteDataSource)
     }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
@@ -1,8 +1,11 @@
 package com.waz.zclient.shared.accounts.datasources
 
 import com.waz.zclient.UnitTest
+import com.waz.zclient.any
+import com.waz.zclient.core.exception.DatabaseFailure
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.functional.map
+import com.waz.zclient.core.functional.onFailure
 import com.waz.zclient.shared.accounts.AccountMapper
 import com.waz.zclient.shared.accounts.ActiveAccount
 import com.waz.zclient.shared.accounts.datasources.local.AccountsLocalDataSource
@@ -11,6 +14,8 @@ import com.waz.zclient.shared.user.datasources.remote.UsersRemoteDataSource
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.shouldBe
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -46,18 +51,90 @@ class AccountsDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given active accounts is called, when results are mapped, then should return a list of domain active accounts`() =
+    fun `given activeAccounts is called, when localDataSource returns entities, then maps the entities and returns them`() =
         runBlockingTest {
-            `when`(localDataSource.activeAccounts()).thenReturn(Either.Right(mockListOfEntities()))
+            val entity1 = mockActiveAccountEntity()
+            val entity2 = mockActiveAccountEntity()
+            val activeAccount1 = mockActiveAccount()
+            val activeAccount2 = mockActiveAccount()
 
-            accountsDataSource.activeAccounts()
+            `when`(accountMapper.from(entity1)).thenReturn(activeAccount1)
+            `when`(accountMapper.from(entity2)).thenReturn(activeAccount2)
+            `when`(localDataSource.activeAccounts()).thenReturn(Either.Right(listOf(entity1, entity2)))
 
+            val result = accountsDataSource.activeAccounts()
+
+            result.isRight shouldBe true
+            result.map {
+                assertEquals(it, listOf(activeAccount1, activeAccount2))
+            }
             verify(localDataSource).activeAccounts()
+            verify(accountMapper, times(2)).from(any())
+        }
 
-            localDataSource.activeAccounts().map { activeAccounts ->
-                activeAccounts.map {
-                    verify(accountMapper, times(activeAccounts.size)).from(it)
-                }
+    @Test
+    fun `given activeAccounts is called, when localDataSource returns failure, then directly returns that failure`() =
+        runBlockingTest {
+            val failure = mock(DatabaseFailure::class.java)
+            `when`(localDataSource.activeAccounts()).thenReturn(Either.Left(failure))
+
+            val result = accountsDataSource.activeAccounts()
+
+            result.isLeft shouldBe true
+            result.onFailure {
+                it shouldBe failure
+            }
+            verify(localDataSource).activeAccounts()
+            verifyNoInteractions(accountMapper)
+        }
+
+    @Test
+    fun `given activeAccountsById is called, when localDataSource returns an entity, then maps the entity and returns it`() =
+        runBlockingTest {
+            val activeAccountsEntity = mock(ActiveAccountsEntity::class.java)
+            val activeAccount = mockActiveAccount()
+            `when`(accountMapper.from(activeAccountsEntity)).thenReturn(activeAccount)
+
+            `when`(localDataSource.activeAccountById(TEST_ID)).thenReturn(Either.Right(activeAccountsEntity))
+
+            val result = accountsDataSource.activeAccountById(TEST_ID)
+
+            verify(localDataSource).activeAccountById(TEST_ID)
+            verify(accountMapper).from(activeAccountsEntity)
+            result.isRight shouldBe true
+            result.map {
+                it shouldBe activeAccount
+            }
+        }
+
+    @Test
+    fun `given activeAccountsById is called, when localDataSource returns null, then directly returns null`() =
+        runBlockingTest {
+            `when`(localDataSource.activeAccountById(TEST_ID)).thenReturn(Either.Right(null))
+
+            val result = accountsDataSource.activeAccountById(TEST_ID)
+
+            verify(localDataSource).activeAccountById(TEST_ID)
+            verifyNoInteractions(accountMapper)
+            result.isRight shouldBe true
+            result.map {
+                it shouldBe null
+            }
+        }
+
+    @Test
+    fun `given activeAccountsById is called, when localDataSource returns failure, then directly returns that failure`() =
+        runBlockingTest {
+            val failure = mock(DatabaseFailure::class.java)
+            `when`(localDataSource.activeAccountById(TEST_ID)).thenReturn(Either.Left(failure))
+
+            val result = accountsDataSource.activeAccountById(TEST_ID)
+
+            verify(localDataSource).activeAccountById(TEST_ID)
+            verifyNoInteractions(accountMapper)
+            result.isLeft shouldBe true
+            result.onFailure {
+                it shouldBe failure
             }
         }
 
@@ -92,10 +169,11 @@ class AccountsDataSourceTest : UnitTest() {
             verify(remoteDataSource).logout(refreshToken, accessToken)
         }
 
-    private fun mockActiveAccount() = mock(ActiveAccount::class.java)
+    companion object {
+        private const val TEST_ID = "testId"
 
-    private fun mockListOfEntities(): List<ActiveAccountsEntity> {
-        val activeAccountMock = mock(ActiveAccountsEntity::class.java)
-        return listOf(activeAccountMock, activeAccountMock, activeAccountMock)
+        private fun mockActiveAccount() = mock(ActiveAccount::class.java)
+
+        private fun mockActiveAccountEntity()= mock(ActiveAccountsEntity::class.java)
     }
 }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
@@ -2,7 +2,6 @@ package com.waz.zclient.shared.accounts.datasources.local
 
 import com.waz.zclient.UnitTest
 import com.waz.zclient.core.functional.map
-import com.waz.zclient.eq
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import kotlinx.coroutines.CancellationException
@@ -110,9 +109,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test
     fun `Given removeAccount is called, when dao result is successful, then return success`() {
         runBlockingTest {
-            val result = accountsLocalDataSource.removeAccount(mockEntity)
+            val result = accountsLocalDataSource.removeAccount(TEST_ID)
 
-            verify(activeAccountsDao).removeAccount(eq(mockEntity))
+            verify(activeAccountsDao).removeAccount(TEST_ID)
 
             result.isRight shouldBe true
         }
@@ -121,9 +120,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test(expected = CancellationException::class)
     fun `Given removeAccount is called, when dao result is cancelled, then returns error`() {
         runBlockingTest {
-            accountsLocalDataSource.removeAccount(mockEntity)
+            accountsLocalDataSource.removeAccount(TEST_ID)
 
-            val result = accountsLocalDataSource.removeAccount(mockEntity)
+            val result = accountsLocalDataSource.removeAccount(TEST_ID)
 
             cancel(CancellationException(TEST_EXCEPTION_MESSAGE))
 

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.waz.zclient.shared.accounts.datasources.local
 
 import com.waz.zclient.UnitTest
+import com.waz.zclient.core.functional.map
 import com.waz.zclient.eq
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
@@ -14,6 +15,7 @@ import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
@@ -24,6 +26,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Mock
     private lateinit var activeAccountsDao: ActiveAccountsDao
 
+    @Mock
+    private lateinit var mockEntity: ActiveAccountsEntity
+
     @Before
     fun setup() {
         accountsLocalDataSource = AccountsLocalDataSource(activeAccountsDao)
@@ -32,11 +37,16 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test
     fun `Given activeAccounts is called, when dao result is successful, then return the data`() {
         runBlockingTest {
+            `when`(activeAccountsDao.activeAccounts()).thenReturn(listOf(mockEntity))
+
             val result = accountsLocalDataSource.activeAccounts()
 
             verify(activeAccountsDao).activeAccounts()
 
             result.isRight shouldBe true
+            result.map {
+                it[0] shouldBe mockEntity
+            }
         }
     }
 
@@ -56,13 +66,53 @@ class AccountsLocalDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `Given removeAccount is called, when dao result is successful, then return the data`() {
+    fun `Given activeAccountById is called, when dao returns an entity, then return the data`() {
         runBlockingTest {
-            val mockAccount = mock(ActiveAccountsEntity::class)
+            val entity = mock(ActiveAccountsEntity::class)
+            `when`(activeAccountsDao.activeAccountById(TEST_ID)).thenReturn(entity)
 
-            val result = accountsLocalDataSource.removeAccount(mockAccount)
+            val result = accountsLocalDataSource.activeAccountById(TEST_ID)
 
-            verify(activeAccountsDao).removeAccount(eq(mockAccount))
+            result.isRight shouldBe true
+            result.map { it shouldBe entity }
+            verify(activeAccountsDao).activeAccountById(TEST_ID)
+        }
+    }
+
+    @Test
+    fun `Given activeAccountById is called, when dao returns null, then return null with success`() {
+        runBlockingTest {
+            `when`(activeAccountsDao.activeAccountById(TEST_ID)).thenReturn(null)
+
+            val result = accountsLocalDataSource.activeAccountById(TEST_ID)
+
+            result.isRight shouldBe true
+            result.map { it shouldBe null }
+            verify(activeAccountsDao).activeAccountById(TEST_ID)
+        }
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `Given activeAccountById is called, when dao result is cancelled, then returns error`() {
+        runBlockingTest {
+            val result = accountsLocalDataSource.activeAccountById(TEST_ID)
+
+            verify(activeAccountsDao).activeAccountById(TEST_ID)
+
+            cancel(CancellationException(TEST_EXCEPTION_MESSAGE))
+
+            delay(CANCELLATION_DELAY)
+
+            result.isRight shouldBe false
+        }
+    }
+
+    @Test
+    fun `Given removeAccount is called, when dao result is successful, then return success`() {
+        runBlockingTest {
+            val result = accountsLocalDataSource.removeAccount(mockEntity)
+
+            verify(activeAccountsDao).removeAccount(eq(mockEntity))
 
             result.isRight shouldBe true
         }
@@ -71,10 +121,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test(expected = CancellationException::class)
     fun `Given removeAccount is called, when dao result is cancelled, then returns error`() {
         runBlockingTest {
-            val mockAccount = mock(ActiveAccountsEntity::class)
-            accountsLocalDataSource.removeAccount(mockAccount)
+            accountsLocalDataSource.removeAccount(mockEntity)
 
-            val result = accountsLocalDataSource.removeAccount(mockAccount)
+            val result = accountsLocalDataSource.removeAccount(mockEntity)
 
             cancel(CancellationException(TEST_EXCEPTION_MESSAGE))
 
@@ -85,6 +134,7 @@ class AccountsLocalDataSourceTest : UnitTest() {
     }
 
     companion object {
+        private const val TEST_ID = "testId"
         private const val CANCELLATION_DELAY = 200L
         private const val TEST_EXCEPTION_MESSAGE = "This is a test exception message."
     }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     @Test
     fun `given use-case is executed, when currentUserId is empty, then returns CannotFindActiveAccount directly`() =
         runBlockingTest {
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(String.empty()))
+            `when`(userRepository.currentUserId()).thenReturn(String.empty())
 
             val result = getActiveAccountUseCase.run(Unit)
 
@@ -55,7 +55,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
         runBlockingTest {
             val activeAccount = mock(ActiveAccount::class)
 
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(activeAccount))
 
             val result = getActiveAccountUseCase.run(Unit)
@@ -70,7 +70,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     @Test
     fun `given use-case is executed, when no active account with id exists in database, then return CannotFindActiveAccount`() =
         runBlockingTest {
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(null))
 
             val result = getActiveAccountUseCase.run(Unit)
@@ -86,7 +86,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     fun `given use-case is executed, when failure is returned from data layer, then return failure`() =
         runBlockingTest {
             val failure = mock(Failure::class)
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Left(failure))
 
             val result = getActiveAccountUseCase.run(Unit)

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
@@ -2,8 +2,10 @@ package com.waz.zclient.shared.accounts.usecase
 
 import com.waz.zclient.UnitTest
 import com.waz.zclient.core.exception.Failure
-import com.waz.zclient.core.exception.ServerError
+import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.functional.map
+import com.waz.zclient.core.functional.onFailure
 import com.waz.zclient.shared.accounts.AccountsRepository
 import com.waz.zclient.shared.accounts.ActiveAccount
 import com.waz.zclient.shared.user.UsersRepository
@@ -15,7 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.lenient
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 
 @ExperimentalCoroutinesApi
@@ -35,48 +37,67 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given use-case is executed, when active account exists in list, then should return filteredAccount`() = runBlockingTest {
-        val mockListOfAccounts = successListOfAccounts()
+    fun `given use-case is executed, when currentUserId is empty, then returns CannotFindActiveAccount directly`() =
+        runBlockingTest {
+            `when`(userRepository.currentUserId()).thenReturn(Either.Right(String.empty()))
 
-        `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_ACTIVE_USER_ID))
-        `when`(accountsRepository.activeAccounts()).thenReturn(mockListOfAccounts)
+            val result = getActiveAccountUseCase.run(Unit)
 
-        val result = getActiveAccountUseCase.run(Unit)
-
-        result.isRight shouldBe true
-    }
-
-    @Test
-    fun `given use-case is executed, when active account does not exist in list, then should return error`() = runBlockingTest {
-        val mockListOfAccounts = successListOfAccounts()
-
-        `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_NON_ACTIVE_USER_ID))
-        `when`(accountsRepository.activeAccounts()).thenReturn(mockListOfAccounts)
-
-        val result = getActiveAccountUseCase.run(Unit)
-
-        result.isLeft shouldBe true
-    }
+            result.isLeft shouldBe true
+            result.onFailure {
+                it shouldBe CannotFindActiveAccount
+            }
+            verifyNoInteractions(accountsRepository)
+        }
 
     @Test
-    fun `given use-case is executed, when failure is returned from data layer, then return failure`() = runBlockingTest {
-        `when`(accountsRepository.activeAccounts()).thenReturn(Either.Left(ServerError))
+    fun `given use-case is executed, when an active account with id exists in database, then return that account`() =
+        runBlockingTest {
+            val activeAccount = mock(ActiveAccount::class)
 
-        val result = getActiveAccountUseCase.run(Unit)
+            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(activeAccount))
 
-        result.isLeft shouldBe true
+            val result = getActiveAccountUseCase.run(Unit)
 
-        verifyNoInteractions(userRepository)
-    }
+            result.isRight shouldBe true
+            result.map {
+                it shouldBe activeAccount
+            }
+            verify(accountsRepository).activeAccountById(TEST_USER_ID)
+        }
 
-    private fun successListOfAccounts(): Either<Failure, List<ActiveAccount>>? {
-        val activeAccount = mock(ActiveAccount::class)
-        lenient().`when`(activeAccount.id).thenReturn(TEST_ACTIVE_USER_ID)
-        return Either.Right(listOf(activeAccount))
-    }
+    @Test
+    fun `given use-case is executed, when no active account with id exists in database, then return CannotFindActiveAccount`() =
+        runBlockingTest {
+            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(null))
+
+            val result = getActiveAccountUseCase.run(Unit)
+
+            result.isLeft shouldBe true
+            result.onFailure {
+                it shouldBe CannotFindActiveAccount
+            }
+            verify(accountsRepository).activeAccountById(TEST_USER_ID)
+        }
+
+    @Test
+    fun `given use-case is executed, when failure is returned from data layer, then return failure`() =
+        runBlockingTest {
+            val failure = mock(Failure::class)
+            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Left(failure))
+
+            val result = getActiveAccountUseCase.run(Unit)
+
+            result.isLeft shouldBe true
+            result.onFailure {
+                it shouldBe failure
+            }
+        }
 
     companion object {
-        private const val TEST_NON_ACTIVE_USER_ID = "wrongUserId"
-        private const val TEST_ACTIVE_USER_ID = "testUserId"
+        private const val TEST_USER_ID = "testUserId"
     }
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
@@ -37,61 +37,71 @@ class ActiveAccountsDaoTest : IntegrationTest() {
     }
 
     @Test
-    fun givenAnActiveAccount_whenAccessTokenIsCalledWithUserIdThatIsActiveUser_thenDataShouldBeTheSame() = runBlocking {
-        val activeAccount = createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
+    fun givenAnActiveAccountWithAccessToken_whenAccessTokenIsCalledForThatAccount_thenReturnsAccessToken() = runBlocking {
+        val token = createAccessTokenEntity()
+        val activeAccount = createActiveAccount(TEST_USER_ID, accessToken = token)
         activeAccountsDao.insertActiveAccount(activeAccount)
 
-        val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        assertEquals(accessToken?.token, TEST_ACTIVE_ACCOUNT_COOKIE)
-        assertEquals(accessToken?.tokenType, TEST_ACCESS_TOKEN_TYPE)
-        assertEquals(accessToken?.expiresInMillis, TEST_ACCESS_TOKEN_EXPIRATION_TIME)
+        val accessToken = activeAccountsDao.accessToken(TEST_USER_ID)
+
+        assertEquals(accessToken?.token, token.token)
+        assertEquals(accessToken?.tokenType, token.tokenType)
+        assertEquals(accessToken?.expiresInMillis, token.expiresInMillis)
     }
 
     @Test
-    fun givenAnActiveAccount_whenAccessTokenIsCalledWithUserIdThatIsNotAnActiveUser_thenDataShouldBeTheSame() = runBlocking {
-        val activeAccount = createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_INACTIVE)
+    fun givenAnActiveAccountWithoutAccessToken_whenAccessTokenIsCalledForThatAccount_thenReturnsNull() = runBlocking {
+        val activeAccount = createActiveAccount(TEST_USER_ID, accessToken = null)
         activeAccountsDao.insertActiveAccount(activeAccount)
 
-        val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
+        val accessToken = activeAccountsDao.accessToken(TEST_USER_ID)
         assertEquals(accessToken, null)
     }
 
     @Test
-    fun givenAnActiveAccount_whenUpdateAccessTokenIsCalledWithNewToken_thenDataShouldBeTheSameAsInserted() = runBlocking {
-        val activeAccount = createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        activeAccountsDao.insertActiveAccount(activeAccount)
-
-        activeAccountsDao.updateAccessToken(
-            TEST_ACTIVE_ACCOUNT_ID_ACTIVE,
-            createAccessTokenEntity(
-                token = TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED
-            )
-        )
-
-        val accessToken = activeAccountsDao.accessToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-        assertEquals(accessToken?.token, TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
-        assertEquals(accessToken?.tokenType, TEST_ACCESS_TOKEN_TYPE)
-        assertEquals(accessToken?.expiresInMillis, TEST_ACCESS_TOKEN_EXPIRATION_TIME)
+    fun givenAnActiveAccountWithAccessToken_whenUpdateAccessTokenIsCalledWithNewToken_thenUpdatesExistingToken() {
+        val initialToken = AccessTokenEntity("oldToken", "oldTokenType", 12345L)
+        testAccessTokenUpdated(initialToken)
     }
 
     @Test
-    fun givenAnActiveAccount_whenUpdateRefreshTokenIsCalledAndUserIdIsActiveUser_thenDataShouldBeTheSameAsInserted() =
+    fun givenAnActiveAccountWithNoAccessToken_whenUpdateAccessTokenIsCalledWithNewToken_thenUpdatesExistingToken() {
+        testAccessTokenUpdated(initialToken = null)
+    }
+
+    private fun testAccessTokenUpdated(initialToken: AccessTokenEntity?) = runBlocking {
+        val activeAccount = createActiveAccount(TEST_USER_ID, accessToken = initialToken)
+        activeAccountsDao.insertActiveAccount(activeAccount)
+
+        val newAccessToken = AccessTokenEntity("newToken", "newTokenType", 3459834L)
+        activeAccountsDao.updateAccessToken(TEST_USER_ID, newAccessToken)
+
+        val accessToken = activeAccountsDao.accessToken(TEST_USER_ID)
+
+        assertEquals(accessToken?.token, newAccessToken.token)
+        assertEquals(accessToken?.tokenType, newAccessToken.tokenType)
+        assertEquals(accessToken?.expiresInMillis, newAccessToken.expiresInMillis)
+    }
+
+    @Test
+    fun givenAnActiveAccountWithRefreshToken_whenUpdateRefreshTokenIsCalled_thenUpdatesExistingRefreshToken() =
         runBlocking {
-            val activeAccount = createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
+            val oldRefreshToken = "oldToken"
+            val activeAccount = createActiveAccount(TEST_USER_ID, refreshToken = oldRefreshToken)
             activeAccountsDao.insertActiveAccount(activeAccount)
 
-            activeAccountsDao.updateRefreshToken(
-                TEST_ACTIVE_ACCOUNT_ID_ACTIVE,
-                TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED
-            )
+            val newRefreshToken = "newToken"
+            activeAccountsDao.updateRefreshToken(TEST_USER_ID, newRefreshToken)
 
-            val refreshToken = activeAccountsDao.refreshToken(TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
-            assertEquals(refreshToken, TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED)
+            val refreshToken = activeAccountsDao.refreshToken(TEST_USER_ID)
+            assertEquals(refreshToken, newRefreshToken)
         }
 
     @Test
-    fun givenAnActiveAccount_withGetAllAccountsIsCalled_thenDataShouldBeSameAsInserted() = runBlocking {
-        val activeAccounts = createActiveAccountsList()
+    fun givenTableHasActiveAccounts_whenAllAccountsIsCalled_thenReturnsAllAccounts() = runBlocking {
+        val account1 = createActiveAccount("id1")
+        val account2 = createActiveAccount("id2")
+        val activeAccounts = listOf(account1, account2)
         activeAccounts.map {
             activeAccountsDao.insertActiveAccount(it)
         }
@@ -100,66 +110,76 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         assertEquals(roomActiveAccounts.size, 2)
 
         val firstAccount = roomActiveAccounts[0]
-        assertEquals(firstAccount.id, TEST_ACTIVE_ACCOUNT_ID_ACTIVE)
+        assertEquals(firstAccount, account1)
 
         val secondAccount = roomActiveAccounts[1]
-        assertEquals(secondAccount.id, TEST_ACTIVE_ACCOUNT_ID_INACTIVE)
+        assertEquals(secondAccount, account2)
     }
 
     @Test
-    fun givenAnActiveAccount_whenDeleteAccountsWithThatAccount_thenRemoveAccountFromDatabase() = runBlocking {
-        val activeAccounts = createActiveAccountsList()
-        activeAccounts.map {
-            activeAccountsDao.insertActiveAccount(it)
+    fun givenAnActiveAccountInDatabase_whenActiveAccountByIdIsCalledWithItsId_thenReturnsThatAccount() =
+        runBlocking {
+            val activeAccount = createActiveAccount(TEST_USER_ID)
+            activeAccountsDao.insertActiveAccount(activeAccount)
+
+            val retrievedAccount = activeAccountsDao.activeAccountById(TEST_USER_ID)
+
+            assertEquals(activeAccount, retrievedAccount)
         }
 
-        val roomActiveAccounts = activeAccountsDao.activeAccounts()
-        roomActiveAccounts.map {
-            activeAccountsDao.removeAccount(it)
+    @Test
+    fun givenNoActiveAccountInDatabaseWithGivenId_whenActiveAccountByIdIsCalled_thenReturnsNull() =
+        runBlocking {
+            activeAccountsDao.insertActiveAccount(createActiveAccount(TEST_USER_ID))
+
+            val retrievedAccount = activeAccountsDao.activeAccountById("someOtherUserId")
+
+            assertEquals(retrievedAccount, null)
         }
 
-        assertTrue(activeAccountsDao.activeAccounts().isEmpty())
+    @Test
+    fun givenAnActiveAccount_whenRemoveAccountIsCalledForThatAccount_thenRemovesAccount() = runBlocking {
+        val activeAccount = createActiveAccount(TEST_USER_ID)
+        activeAccountsDao.insertActiveAccount(activeAccount)
+
+        activeAccountsDao.removeAccount(activeAccount)
+
+        assertTrue(activeAccountsDao.activeAccountById(TEST_USER_ID) == null)
     }
 
-    private fun createActiveAccount(
-        userId: String
-    ) = ActiveAccountsEntity(
-        id = userId,
-        teamId = TEST_ACTIVE_ACCOUNT_TEAM_ID,
-        refreshToken = TEST_ACTIVE_ACCOUNT_COOKIE,
-        accessToken = createAccessTokenEntity(
-            TEST_ACTIVE_ACCOUNT_COOKIE
-        ),
-        pushToken = TEST_ACTIVE_ACCOUNT_REGISTERED_PUSH,
-        ssoId = SsoIdEntity(
-            TEST_ACTIVE_ACCOUNT_SSO_ID_TENANT,
-            TEST_ACTIVE_ACCOUNT_SSO_ID_SUBJECT
-        )
-    )
-
-    private fun createAccessTokenEntity(
-        token: String,
-        tokenType: String = TEST_ACCESS_TOKEN_TYPE,
-        expiration: Long = TEST_ACCESS_TOKEN_EXPIRATION_TIME
-    ): AccessTokenEntity = AccessTokenEntity(token, tokenType, expiration)
-
-    private fun createActiveAccountsList() =
-        listOf(
-            createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_ACTIVE),
-            createActiveAccount(TEST_ACTIVE_ACCOUNT_ID_INACTIVE)
-        )
-
     companion object {
-        private const val TEST_ACTIVE_ACCOUNT_ID_ACTIVE = "101"
-        private const val TEST_ACTIVE_ACCOUNT_ID_INACTIVE = "102"
+        private const val TEST_USER_ID = "userId"
         private const val TEST_ACTIVE_ACCOUNT_TEAM_ID = "1000229992"
         private const val TEST_ACTIVE_ACCOUNT_COOKIE = "111122333"
-        private const val TEST_ACTIVE_ACCOUNT_COOKIE_UPDATED = "111122333444"
         private const val TEST_ACTIVE_ACCOUNT_REGISTERED_PUSH = "11111122222"
+        private const val TEST_ACCESS_TOKEN_STRING = "accessToken123"
         private const val TEST_ACCESS_TOKEN_TYPE = "Bearer"
         private const val TEST_ACCESS_TOKEN_EXPIRATION_TIME = 1582896705028
         private const val TEST_ACTIVE_ACCOUNT_SSO_ID_TENANT = "ssoIdTenant"
         private const val TEST_ACTIVE_ACCOUNT_SSO_ID_SUBJECT = "ssoIdSubject"
+
+        private fun createActiveAccount(
+            userId: String,
+            accessToken: AccessTokenEntity? = createAccessTokenEntity(),
+            refreshToken: String = TEST_ACTIVE_ACCOUNT_COOKIE
+        ) = ActiveAccountsEntity(
+            id = userId,
+            teamId = TEST_ACTIVE_ACCOUNT_TEAM_ID,
+            refreshToken = refreshToken,
+            accessToken = accessToken,
+            pushToken = TEST_ACTIVE_ACCOUNT_REGISTERED_PUSH,
+            ssoId = SsoIdEntity(
+                TEST_ACTIVE_ACCOUNT_SSO_ID_TENANT,
+                TEST_ACTIVE_ACCOUNT_SSO_ID_SUBJECT
+            )
+        )
+
+        private fun createActiveAccountList(vararg userIds: String): List<ActiveAccountsEntity> =
+            userIds.map { createActiveAccount(it) }
+
+        private fun createAccessTokenEntity() = AccessTokenEntity(
+            TEST_ACCESS_TOKEN_STRING, TEST_ACCESS_TOKEN_TYPE, TEST_ACCESS_TOKEN_EXPIRATION_TIME
+        )
     }
 
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
@@ -142,7 +142,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         val activeAccount = createActiveAccount(TEST_USER_ID)
         activeAccountsDao.insertActiveAccount(activeAccount)
 
-        activeAccountsDao.removeAccount(activeAccount)
+        activeAccountsDao.removeAccount(TEST_USER_ID)
 
         assertTrue(activeAccountsDao.activeAccountById(TEST_USER_ID) == null)
     }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/AccessTokenEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/AccessTokenEntity.kt
@@ -26,14 +26,16 @@ class AccessTokenConverter {
     }
 
     @TypeConverter
-    fun accessTokenToString(entity: AccessTokenEntity): String =
-        """
+    fun accessTokenToString(entity: AccessTokenEntity?): String? =
+        entity?.let {
+            """
             {
-                "$KEY_TOKEN": "${entity.token}",
-                "$KEY_TOKEN_TYPE": "${entity.tokenType}",
-                "$KEY_EXPIRY": ${entity.expiresInMillis}
+                "$KEY_TOKEN": "${it.token}",
+                "$KEY_TOKEN_TYPE": "${it.tokenType}",
+                "$KEY_EXPIRY": ${it.expiresInMillis}
             }
         """.trimIndent()
+        }
 
     companion object {
         private const val KEY_TOKEN = "token"

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.storage.db.accountdata
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 
@@ -30,6 +29,6 @@ interface ActiveAccountsDao {
     @Insert
     suspend fun insertActiveAccount(activeAccountsEntity: ActiveAccountsEntity)
 
-    @Delete
-    suspend fun removeAccount(account: ActiveAccountsEntity)
+    @Query("DELETE from ActiveAccounts WHERE _id = :id")
+    suspend fun removeAccount(id: String)
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
@@ -24,6 +24,9 @@ interface ActiveAccountsDao {
     @Query("SELECT * from ActiveAccounts")
     suspend fun activeAccounts(): List<ActiveAccountsEntity>
 
+    @Query("SELECT * from ActiveAccounts WHERE _id = :id LIMIT 1")
+    suspend fun activeAccountById(id: String): ActiveAccountsEntity?
+
     @Insert
     suspend fun insertActiveAccount(activeAccountsEntity: ActiveAccountsEntity)
 


### PR DESCRIPTION
## What's new in this PR?

Jira ticket: https://wearezeta.atlassian.net/browse/AN-6797

This PR replaces `activeAccounts()` database call with `activeAccountById(String)` call in `GetActiveAccountUseCase`

### Issues

- Moved the filtering of the current account to database level.

before, the logic was roughly:

```
    activeAccountsRepository.activeAccounts().flatMap { accounts ->	        
       accounts.firstOrNull { it.id == currentUserId }
    }
```

now it is directly filtered by database query:

```
    activeAccountsRepository.activeAccountById(currentUserId)
```

- I also changed the names of some test cases in `ActiveAccountsDaoTest`. The test names were mentioning "active/inactive ids" which is more like a business domain logic and creating some confusion in dao level.

### Causes

The performance gain is not that much since there are at most 2 entries in ActiveAccounts table at once. The code is changed mostly for the sake of simplicity.

### Testing

Unit/integration tests are added for new operation.


#### APK
[Download build #1986](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1986/artifact/build/artifact/wire-dev-PR2797-1986.apk)
[Download build #1995](http://10.10.124.11:8080/job/Pull%20Request%20Builder/1995/artifact/build/artifact/wire-dev-PR2797-1995.apk)
[Download build #2001](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2001/artifact/build/artifact/wire-dev-PR2797-2001.apk)
[Download build #2062](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2062/artifact/build/artifact/wire-dev-PR2797-2062.apk)