### PR TITLE
fix: Perform full sync after update

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -483,7 +483,7 @@ object UserPreferences {
 
   //increment number to perform slow sync on particular type
   lazy val ShouldSyncConversations = PrefKey[Boolean]("should_sync_conversations_2", customDefault = true)
-  lazy val ShouldSyncInitial = PrefKey[Boolean]("should_sync_initial_1", customDefault = true)
+  lazy val ShouldSyncInitial = PrefKey[Boolean]("should_sync_initial_2", customDefault = true)
   lazy val ShouldSyncUsers = PrefKey[Boolean]("should_sync_users_1", customDefault = true)
   lazy val ShouldSyncTeam = PrefKey[Boolean]("should_sync_team_1", customDefault = true)
   lazy val ShouldSyncFolders = PrefKey[Boolean]("should_sync_folders", customDefault = true)


### PR DESCRIPTION
fixes https://github.com/wireapp/wire-android/issues/2799

With 3.47 we are getting reports of ConversationList being empty. It didn't happen in any of the tests and I don't see how it can be connected to our changes, but the fix is easy: perform full sync.
