### PR TITLE
AN-6869: Enterprise login: registered domain + no fixed sso user cannot login

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOFragment.scala
@@ -120,10 +120,10 @@ trait SSOFragment extends FragmentHelper with DerivedLogTag {
         userAccountsController.ssoToken ! None
         result match {
           case Right(true)  => goToSsoWebView(token.toString)
-          case Right(false) => showSsoDialogFuture
+          case Right(false) => showSsoDialogFuture()
           case Left(ErrorResponse(ConnectionErrorCode | TimeoutCode, _, _)) =>
             showErrorDialog(GenericDialogErrorMessage(ConnectionErrorCode))
-          case Left(_)      => showSsoDialogFuture
+          case Left(_)      => showSsoDialogFuture()
         }
       }(Threading.Ui)
     }
@@ -136,9 +136,7 @@ trait SSOFragment extends FragmentHelper with DerivedLogTag {
         onVerifyingToken(false)
         userAccountsController.ssoToken ! None
         result match {
-          case Right(true) =>
-            dismissSsoDialog()
-            showSsoWebView(token.toString)
+          case Right(true) => goToSsoWebView(token.toString)
           case Right(false) => showInlineSsoError(getString(R.string.sso_signin_wrong_code_message))
           case Left(errorResponse) => handleVerificationError(errorResponse)
         }

--- a/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
@@ -26,18 +26,18 @@ class StartSSOFragment extends SSOFragment {
 
   private def fetchSsoToken(): Unit =
     userAccountsController.ssoToken.head.foreach {
-      case Some(token) => verifySsoCode(token)
+      case Some(token) => verifyCode(token)
       case None =>
         ssoService.fetchSSO().flatMap {
           case Right(SSOFound(ssoCode)) => startSsoFlow(ssoCode)
-          case Right(_)                 => showSsoDialogFuture()
+          case Right(_)                 => Future.successful(activity.showCustomBackendLoginScreen())
           case Left(ErrorResponse(ConnectionErrorCode | TimeoutCode, _, _)) =>
             showErrorDialog(GenericDialogErrorMessage(ConnectionErrorCode))
-          case Left(_)                  => showSsoDialogFuture()
+          case Left(_)                  => Future.successful(activity.showCustomBackendLoginScreen())
         }
     }
 
-  override def verifySsoCode(input: String): Future[Unit] =
+  private def verifyCode(input: String): Future[Unit] =
     ssoService.extractUUID(input).fold(Future.successful(())) { token =>
       onVerifyingToken(true)
       ssoService.verifyToken(token).flatMap { result =>


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6869

### Issues

Enterprise user cannot login

### Causes

If we user has a registered domain but doesn't have a verified SSO code, it'll show them an SSO dialog prompt

### Solutions

To avoid blocking them from logging in we replaced the prompt with a welcome screen. 

### Testing

Scenario 1: (from enterprise login)
1. Install internal 3.47.1920
2. Choose "qa-demo" in backend selection popup
3. Tap "Enterprise Login"
4. Enter "johndoe@staging.com"
5. Tap login

Scenario 2: (from deeplink)
1. Install internql 3.47.1920
2. Choose "production" in backend selection popup
3. Minimize the app
4. Open deeplink to point to staging wire://access/?config=https://s3-eu-west-1.amazonaws.com/wire-taco-test/custom_backend_staging.json
Actual --> There is a popup prompts to enter SSO code

#### APK
[Download build #2004](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2004/artifact/build/artifact/wire-dev-PR2802-2004.apk)