### PR TITLE
fix: An error is JSON deserialization in team/[tid]/members

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -122,7 +122,7 @@ object TeamsClient {
 
   def teamConversationPath(id: TeamId, cid: RConvId): String = s"$TeamsPath/${id.str}/conversations/${cid.str}"
 
-  case class TeamMembers(members: Seq[TeamMember], has_more: Boolean)
+  case class TeamMembers(members: Seq[TeamMember], hasMore: Boolean)
 
   case class TeamMember(user: UserId, permissions: Option[Permissions], created_by: Option[UserId]) {
     lazy val permissionMasks: PermissionsMasks = permissions.fold((0L, 0L))(_.toMasks)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -60,7 +60,7 @@ class TeamsSyncHandlerImpl(userId:    UserId,
         data        <- flatten(client.getTeamData(id))
         membersData <- flatten(client.getTeamMembers(id))
         roles       <- flatten(client.getTeamRoles(id))
-        members     =  if (membersData.has_more) Seq.empty[TeamMember] else membersData.members
+        members     =  if (membersData.hasMore) Seq.empty[TeamMember] else membersData.members
         _           <- service.onTeamSynced(data, members, roles)
       } yield SyncResult.Success).recover {
         case err: ErrorResponse => SyncResult(err)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -77,7 +77,7 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
               "user":"f3f4f763-ccee-4b3d-b450-582e2c99f8be"
             }
           ],
-          "has_more": false
+          "hasMore": false
         }"""
 
       // when


### PR DESCRIPTION
The name for the "has more" field should be `hasMore`, not `has_more`.
This led to a crash when syncing team members.

#### APK
[Download build #2006](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2006/artifact/build/artifact/wire-dev-PR2804-2006.apk)