### PR TITLE
Fix: App crash on Android 5 and 6 devices

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/images/transformations/DarkenTransformation.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/images/transformations/DarkenTransformation.kt
@@ -9,6 +9,7 @@ import android.graphics.Paint
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
 import java.security.MessageDigest
+import java.util.Objects
 
 data class DarkenTransformation(
     private val alphaValue: Int,
@@ -42,4 +43,12 @@ data class DarkenTransformation(
 
         return bitmap
     }
+
+    override fun hashCode(): Int = Objects.hash(alphaValue, saturation)
+
+    override fun equals(other: Any?): Boolean =
+        other === this ||
+            (other is DarkenTransformation &&
+                other.alphaValue == this.alphaValue &&
+                other.saturation == this.saturation)
 }

--- a/app/src/main/kotlin/com/waz/zclient/core/images/transformations/ScaleTransformation.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/images/transformations/ScaleTransformation.kt
@@ -7,6 +7,7 @@ import android.graphics.Paint
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
 import java.security.MessageDigest
+import java.util.Objects
 
 data class ScaleTransformation(
     private val scaleX: Float,
@@ -35,6 +36,14 @@ data class ScaleTransformation(
 
         return bitmap
     }
+
+    override fun hashCode(): Int = Objects.hash(scaleX, scaleY)
+
+    override fun equals(other: Any?): Boolean =
+        other === this ||
+            (other is ScaleTransformation &&
+                other.scaleX == this.scaleX &&
+                other.scaleY == this.scaleY)
 
     companion object {
         private const val SCALE_HALF = 0.5F


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6865

### Issues

The app crashes on start when running on Android 5 and 6 devices.

### Causes

There's an incompatibility between Android Gradle Plugin and Kotlin compiler. The auto-generated `hashCode()` method of `data class`es are not compatible with Android 5&6.

### Solutions

Override equals and hashCode manually

### Testing

Manual testing is done on an emulator running Android 6.0

## Notes

[Google issue](https://issuetracker.google.com/issues/129730297)
[JetBrains issue](https://youtrack.jetbrains.com/issue/KT-31027)
[StackOverflow explanation](https://stackoverflow.com/a/45939508/3696682)
#### APK
[Download build #2007](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2007/artifact/build/artifact/wire-dev-PR2805-2007.apk)