### PR TITLE
fix: Open User Profile when clicking on user search results not in storage

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -268,7 +268,6 @@ class ConversationListManagerFragment extends Fragment
 
   override def onShowUserProfile(userId: UserId, fromDeepLink: Boolean) =
     if (!pickUserController.isShowingUserProfile) {
-
       def show(fragment: Fragment, tag: String): Unit = {
         getChildFragmentManager
           .beginTransaction
@@ -291,10 +290,8 @@ class ConversationListManagerFragment extends Fragment
         import com.waz.api.ConnectionStatus._
         userData.connection match {
           case CANCELLED | UNCONNECTED =>
-            if (!userData.isConnected) {
               show(SendConnectRequestFragment.newInstance(userId, userRequester), SendConnectRequestFragment.Tag)
               navController.setLeftPage(Page.SEND_CONNECT_REQUEST, Tag)
-            }
 
           case PENDING_FROM_OTHER  =>
             show(

--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -20,10 +20,9 @@ package com.waz.zclient.conversationlist.adapters
 import android.content.Context
 import android.view.{View, ViewGroup}
 import androidx.recyclerview.widget.{DiffUtil, RecyclerView}
-import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{ConvId, ConversationData, FolderId, TeamId}
-import com.waz.utils.events.{EventContext, EventStream, Signal, SourceStream}
+import com.waz.model.{ConvId, ConversationData, FolderId}
+import com.waz.utils.events.{EventContext, EventStream, SourceStream}
 import com.waz.utils.returning
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter.{ConversationRowViewHolder, _}
 import com.waz.zclient.conversationlist.views.{ConversationFolderListRow, ConversationListRow, IncomingConversationListRow, NormalConversationListRow}
@@ -40,9 +39,6 @@ abstract class ConversationListAdapter (implicit context: Context, eventContext:
     with Injectable {
 
   setHasStableIds(true)
-
-  private lazy val usersStorage = inject[Signal[UsersStorage]]
-  private lazy val teamId = inject[Signal[Option[TeamId]]]
 
   val onConversationClick: SourceStream[ConvId] = EventStream[ConvId]()
   val onConversationLongClick: SourceStream[ConversationData] = EventStream[ConversationData]()

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIAdapter.scala
@@ -129,7 +129,7 @@ object SearchUIAdapter {
 
     def onGroupsExpanded(): Unit
 
-    def onUserClicked(userId: UserId): Unit
+    def onUserClicked(user: UserData): Unit
 
     def onIntegrationClicked(data: IntegrationData): Unit
 
@@ -212,7 +212,7 @@ object SearchUIAdapter {
     class TopUserViewHolder(view: TopUserChathead, callback: Callback) extends RecyclerView.ViewHolder(view) {
       private var user = Option.empty[UserData]
 
-      view.onClick(user.map(_.id).foreach(callback.onUserClicked))
+      view.onClick(user.foreach(callback.onUserClicked))
 
       def bind(user: UserData): Unit = {
         this.user = Some(user)
@@ -225,7 +225,7 @@ object SearchUIAdapter {
   class UserViewHolder(view: SingleUserRowView, callback: Callback) extends RecyclerView.ViewHolder(view) {
     private var userData = Option.empty[UserData]
 
-    view.onClick(userData.map(_.id).foreach(callback.onUserClicked))
+    view.onClick(userData.foreach(callback.onUserClicked))
     view.showArrow(false)
     view.showCheckbox(false)
     view.setTheme(Theme.Dark, background = false)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6870

We missed that because the user search results are now not saved in the storage immediately,
we should either pass the whole user data around or put it in the storage before we open any
view which uses that user data. That means especially profiles of unconnected users.
