### PR TITLE
Enterprise login: Enter a valid SSO code doesn't open SSO login page for registered domain+no fixed SSO code user

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1472,7 +1472,7 @@
     <!-- SSO Login -->
     <string name="sso_login_dialog_title">Enterprise Login</string>
     <string name="sso_login_dialog_message">Please enter your SSO code:</string>
-    <string name="email_sso_login_dialog_message">Please enter your email or SSO code. If your email matches an enterprise installation of Wire, this app will connect to that server:</string>
+    <string name="email_sso_login_dialog_message">Please enter your email or SSO code. If your email matches an enterprise installation of Wire, this app will connect to that server.</string>
 
     <!-- Welcome -->
     <string name="welcome_to_wire">Welcome to Wire</string>

--- a/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
@@ -29,7 +29,7 @@ class StartSSOFragment extends SSOFragment {
       case Some(token) => verifyCode(token)
       case None =>
         ssoService.fetchSSO().flatMap {
-          case Right(SSOFound(ssoCode)) => startSsoFlow(ssoCode)
+          case Right(SSOFound(ssoCode)) => startSsoFlow(ssoCode, fromStart = true)
           case Right(_)                 => Future.successful(activity.showCustomBackendLoginScreen())
           case Left(ErrorResponse(ConnectionErrorCode | TimeoutCode, _, _)) =>
             showErrorDialog(GenericDialogErrorMessage(ConnectionErrorCode))
@@ -44,7 +44,7 @@ class StartSSOFragment extends SSOFragment {
         onVerifyingToken(false)
         userAccountsController.ssoToken ! None
         result match {
-          case Right(true)  => goToSsoWebView(token.toString)
+          case Right(true)  => goToSsoWebView(token.toString, fromStart = true)
           case Right(false) => Future.successful(activity.showCustomBackendLoginScreen())
           case Left(_)      => Future.successful(activity.showCustomBackendLoginScreen())
         }


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6881

### Issues

Can't log in with a valid SSO because the webview won't start 

### Causes

I'm assuming it's because we pop the back stack fo the main activity (to remove the start fragment in the new flow) 

### Solutions

Don't pop the back stack and let it behave as it did before 

### Testing

Prereq: a valid SSO code on staging backend. It's difficult to get one manually, however QA can verify using automation when there is a fix
Scenario 1 (enterprise login button)
1. Install EXP.3.47.9468 and launch the app pointing to "qa-demo" backend
2. Tap enterprise login
3. Input "johndoe@staging.com"
4. Tap login with SSO button
5. Input a valid SSO code
6. Tap Login button

Scenario 2 (from deeplink)
1. Install EXP.3.47.9468 and launch the app pointing to "production" backend
2. Minimize the app
3. Open deeplink to point to staging wire://access/?config=https://s3-eu-west-1.amazonaws.com/wire-taco-test/custom_backend_staging.json
4. Tap login with SSO button
5. Input a valid SSO code
6. Tap Login button
