### PR TITLE
fix: Bring back exact match search

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
@@ -25,7 +25,7 @@ import com.waz.log.LogSE._
 case class SearchQuery private (str: String, handleOnly: Boolean) {
   val isEmpty: Boolean = str.isEmpty
 
-  lazy val cacheKey = (if (handleOnly) SearchQuery.recommendedHandlePrefix else SearchQuery.recommendedPrefix) + str
+  lazy val cacheKey: String = (if (handleOnly) SearchQuery.recommendedHandlePrefix else SearchQuery.recommendedPrefix) + str
 }
 
 object SearchQuery {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -61,10 +61,7 @@ class UserSearchClientImpl(implicit
 
   override def exactMatchHandle(handle: Handle): ErrorOrResponse[Option[UserSearchResponse.User]] = {
     Request
-      .Get(
-        relativePath = HandlesPath,
-        queryParameters = queryParameters("handles" -> Handle.stripSymbol(handle.string))
-      )
+      .Get(relativePath = handlesPath(handle))
       .withResultType[UserSearchResponse.User]
       .withErrorType[ErrorResponse]
       .executeSafe
@@ -78,7 +75,9 @@ class UserSearchClientImpl(implicit
 
 object UserSearchClient extends DerivedLogTag {
   val ContactsPath = "/search/contacts"
-  val HandlesPath = "/users"
+  val HandlesPath = "/users/handles"
+
+  def handlesPath(handle: Handle): String = s"$HandlesPath/${Handle.stripSymbol(handle.string)}"
 
   val DefaultLimit = 10
 


### PR DESCRIPTION
Exact match search is not used often and it slipped our tests that the line in UserSearchService was deleted when we changed the code for Large Teams. I brought it back and I made a small change in the client to make it work according to the current Backend API.

#### APK
[Download build #2017](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2017/artifact/build/artifact/wire-dev-PR2809-2017.apk)