### PR TITLE
Feat: Logout functionality in Kotlin - Part 3

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -153,6 +153,11 @@
                 <category android:name="android.intent.category.VIEW" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="com.wire.ACTION_CURRENT_USER_CHANGED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+
         </activity>
 
         <activity
@@ -213,8 +218,12 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.Dark"
             android:windowSoftInputMode="stateHidden|adjustResize"
-            android:exported="false"
-            />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.wire.ACTION_NO_USER_LEFT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ForceUpdateActivity"

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.feature.settings.account
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -119,17 +120,27 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
     }
 
     private fun initLogout() {
+        observeLogoutNavigation()
         observeLogoutData()
         initLogoutButtonListener()
+    }
+
+    private fun observeLogoutNavigation() {
+        settingsAccountViewModel.logoutNavigationAction.observe(viewLifecycleOwner) {
+            startActivity(Intent()
+                .setAction(it)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
     }
 
     private fun observeLogoutData() {
         with(logoutViewModel) {
             successLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Logged out", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLoggedOut(it)
             }
             errorLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Failed with $it", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLogoutError(it)
             }
         }
     }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
@@ -1,17 +1,45 @@
 package com.waz.zclient.feature.settings.account.logout
 
 import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.accesstoken.AccessTokenRepository
 import com.waz.zclient.core.usecase.UseCase
 import com.waz.zclient.shared.accounts.AccountsRepository
+import com.waz.zclient.shared.user.UsersRepository
 
 class LogoutUseCase(
     private val accountsRepository: AccountsRepository,
-    private val accessTokenRepository: AccessTokenRepository
+    private val accessTokenRepository: AccessTokenRepository,
+    private val usersRepository: UsersRepository
 ) : UseCase<Unit, Unit>() {
 
-    override suspend fun run(params: Unit): Either<Failure, Unit> = with(accessTokenRepository) {
-        accountsRepository.logout(refreshToken().token, accessToken().token)
+    override suspend fun run(params: Unit): Either<Failure, Unit> {
+        logout()
+        return deleteLoggedOutAccountData()
     }
+
+    private suspend fun logout() {
+        val refreshToken = accessTokenRepository.refreshToken().token
+        val accessToken = accessTokenRepository.accessToken().token
+        accountsRepository.logout(refreshToken, accessToken)
+    }
+
+    private suspend fun deleteLoggedOutAccountData(): Either<Failure, Unit> =
+        usersRepository.currentUserId().let {
+            accountsRepository.deleteAccountFromDevice(it) //TODO should we log failure somehow?
+            updateCurrentUserId(it)
+        }
+
+    private suspend fun updateCurrentUserId(loggedOutUserId: String): Either<Failure, Unit> =
+        accountsRepository.activeAccounts().fold({
+            clearCurrentUserId()
+            Either.Right(Unit) //TODO should we log failure somehow?
+        }) {
+            val remainingAccountId = it.firstOrNull { it.id != loggedOutUserId }?.id
+            remainingAccountId?.let { usersRepository.setCurrentUserId(it) } ?: clearCurrentUserId()
+            Either.Right(Unit)
+        }!!
+
+    private fun clearCurrentUserId() = usersRepository.setCurrentUserId(String.empty())
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
@@ -12,10 +12,10 @@ class LogoutUseCase(
     private val accountsRepository: AccountsRepository,
     private val accessTokenRepository: AccessTokenRepository,
     private val usersRepository: UsersRepository
-) : UseCase<Unit, Unit>() {
+) : UseCase<LogoutStatus, Unit>() {
 
-    override suspend fun run(params: Unit): Either<Failure, Unit> {
-        logout()
+    override suspend fun run(params: Unit): Either<Failure, LogoutStatus> {
+        logout() //TODO check w/ backend team what is the side effect if this call fails
         return deleteLoggedOutAccountData()
     }
 
@@ -25,21 +25,32 @@ class LogoutUseCase(
         accountsRepository.logout(refreshToken, accessToken)
     }
 
-    private suspend fun deleteLoggedOutAccountData(): Either<Failure, Unit> =
+    private suspend fun deleteLoggedOutAccountData(): Either<Failure, LogoutStatus> =
         usersRepository.currentUserId().let {
             accountsRepository.deleteAccountFromDevice(it) //TODO should we log failure somehow?
             updateCurrentUserId(it)
         }
 
-    private suspend fun updateCurrentUserId(loggedOutUserId: String): Either<Failure, Unit> =
+    private suspend fun updateCurrentUserId(loggedOutUserId: String): Either<Failure, LogoutStatus> =
         accountsRepository.activeAccounts().fold({
             clearCurrentUserId()
-            Either.Right(Unit) //TODO should we log failure somehow?
+            Either.Right(CouldNotReadRemainingAccounts)
         }) {
             val remainingAccountId = it.firstOrNull { it.id != loggedOutUserId }?.id
-            remainingAccountId?.let { usersRepository.setCurrentUserId(it) } ?: clearCurrentUserId()
-            Either.Right(Unit)
+            val status = if (remainingAccountId == null) {
+                clearCurrentUserId()
+                NoAccountsLeft
+            } else {
+                usersRepository.setCurrentUserId(remainingAccountId)
+                AnotherAccountExists
+            }
+            Either.Right(status)
         }!!
 
     private fun clearCurrentUserId() = usersRepository.setCurrentUserId(String.empty())
 }
+
+sealed class LogoutStatus
+object NoAccountsLeft : LogoutStatus()
+object AnotherAccountExists : LogoutStatus()
+object CouldNotReadRemainingAccounts : LogoutStatus()

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
@@ -8,23 +8,19 @@ import com.waz.zclient.core.exception.Failure
 
 class LogoutViewModel(private val logoutUseCase: LogoutUseCase) : ViewModel() {
 
-    private var _successLiveData = MutableLiveData<Boolean>()
+    private var _successLiveData = MutableLiveData<Unit>()
     private var _errorLiveData = MutableLiveData<Failure>()
 
     val errorLiveData: LiveData<Failure> = _errorLiveData
-    val successLiveData: LiveData<Boolean> = _successLiveData
+    val successLiveData: LiveData<Unit> = _successLiveData
 
     fun onVerifyButtonClicked() {
         logoutUseCase(viewModelScope, Unit) {
-            it.fold(::logoutFailed, ::logoutSuccess)
+            it.fold(::logoutFailed) { logoutSuccess() }
         }
     }
 
-    private fun logoutSuccess(unit: Unit) {
-        _successLiveData.postValue(true)
-    }
+    private fun logoutSuccess() = _successLiveData.postValue(Unit)
 
-    private fun logoutFailed(failure: Failure) {
-        _errorLiveData.postValue(failure)
-    }
+    private fun logoutFailed(failure: Failure) = _errorLiveData.postValue(failure)
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
@@ -8,19 +8,17 @@ import com.waz.zclient.core.exception.Failure
 
 class LogoutViewModel(private val logoutUseCase: LogoutUseCase) : ViewModel() {
 
-    private var _successLiveData = MutableLiveData<Unit>()
+    private var _successLiveData = MutableLiveData<LogoutStatus>()
     private var _errorLiveData = MutableLiveData<Failure>()
 
     val errorLiveData: LiveData<Failure> = _errorLiveData
-    val successLiveData: LiveData<Unit> = _successLiveData
+    val successLiveData: LiveData<LogoutStatus> = _successLiveData
 
-    fun onVerifyButtonClicked() {
-        logoutUseCase(viewModelScope, Unit) {
-            it.fold(::logoutFailed) { logoutSuccess() }
-        }
+    fun onVerifyButtonClicked() = logoutUseCase(viewModelScope, Unit) {
+        it.fold(::logoutFailed, ::logoutSuccess)
     }
 
-    private fun logoutSuccess() = _successLiveData.postValue(Unit)
+    private fun logoutSuccess(status: LogoutStatus) = _successLiveData.postValue(status)
 
     private fun logoutFailed(failure: Failure) = _errorLiveData.postValue(failure)
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/di/SettingsModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/di/SettingsModule.kt
@@ -100,6 +100,6 @@ val settingsAccountModule: Module = module {
         factory { ChangeEmailUseCase(get()) }
         factory { DeleteAccountUseCase(get()) }
 
-        factory { LogoutUseCase(get(), get()) }
+        factory { LogoutUseCase(get(), get(), get()) }
     }
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/AccountsRepository.kt
@@ -7,6 +7,6 @@ interface AccountsRepository {
     suspend fun activeAccounts(): Either<Failure, List<ActiveAccount>>
     suspend fun activeAccountById(accountId: String): Either<Failure, ActiveAccount?>
     suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit>
-    suspend fun deleteAccountFromDevice(account: ActiveAccount): Either<Failure, Unit>
+    suspend fun deleteAccountFromDevice(accountId: String): Either<Failure, Unit>
     suspend fun deleteAccountPermanently(): Either<Failure, Unit>
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSource.kt
@@ -28,8 +28,8 @@ class AccountsDataSource(
     override suspend fun logout(refreshToken: String, accessToken: String): Either<Failure, Unit> =
         accountsRemoteDataSource.logout(refreshToken, accessToken)
 
-    override suspend fun deleteAccountFromDevice(account: ActiveAccount) =
-        accountsLocalDataSource.removeAccount(accountMapper.toEntity(account))
+    override suspend fun deleteAccountFromDevice(accountId: String): Either<Failure, Unit> =
+        accountsLocalDataSource.removeAccount(accountId)
 
     override suspend fun deleteAccountPermanently(): Either<Failure, Unit> =
         usersRemoteDataSource.deleteAccountPermanently()

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSource.kt
@@ -18,8 +18,8 @@ class AccountsLocalDataSource(private val activeAccountsDao: ActiveAccountsDao) 
             activeAccountsDao.activeAccountById(accountId)
         }
 
-    suspend fun removeAccount(account: ActiveAccountsEntity) =
+    suspend fun removeAccount(accountId: String) =
         requestDatabase {
-            activeAccountsDao.removeAccount(account)
+            activeAccountsDao.removeAccount(accountId)
         }
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
@@ -2,7 +2,6 @@ package com.waz.zclient.shared.accounts.usecase
 
 import com.waz.zclient.core.exception.Failure
 import com.waz.zclient.core.exception.FeatureFailure
-import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.functional.flatMap
 import com.waz.zclient.core.usecase.UseCase
@@ -21,7 +20,7 @@ class GetActiveAccountUseCase(
 
     override suspend fun run(params: Unit): Either<Failure, ActiveAccount> =
         userRepository.currentUserId().let {
-            if (it == String.empty()) Either.Left(CannotFindActiveAccount)
+            if (it.isEmpty()) Either.Left(CannotFindActiveAccount)
             else activeAccountById(it)
         }
 

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
@@ -20,7 +20,7 @@ class GetActiveAccountUseCase(
 ) : UseCase<ActiveAccount, Unit>() {
 
     override suspend fun run(params: Unit): Either<Failure, ActiveAccount> =
-        userRepository.currentUserId().flatMap {
+        userRepository.currentUserId().let {
             if (it == String.empty()) Either.Left(CannotFindActiveAccount)
             else activeAccountById(it)
         }

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/UsersRepository.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/UsersRepository.kt
@@ -8,5 +8,6 @@ interface UsersRepository {
     suspend fun profileDetails(): Flow<User>
     suspend fun changeName(name: String): Either<Failure, Any>
     suspend fun changeEmail(email: String): Either<Failure, Any>
-    suspend fun currentUserId(): Either<Failure, String>
+    fun currentUserId(): String
+    fun setCurrentUserId(userId: String)
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/UsersDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/UsersDataSource.kt
@@ -52,7 +52,9 @@ class UsersDataSource(
     override suspend fun changeEmail(email: String) = changeEmailRemotely(email)
         .onSuccess { runBlocking { changeEmailLocally(email) } }
 
-    override suspend fun currentUserId() = usersLocalDataSource.currentUserId()
+    override fun currentUserId(): String = usersLocalDataSource.currentUserId()
+
+    override fun setCurrentUserId(userId: String) = usersLocalDataSource.setCurrentUserId(userId)
 
     private suspend fun changeEmailRemotely(email: String) = usersRemoteDataSource.changeEmail(email)
 

--- a/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/local/UsersLocalDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/datasources/local/UsersLocalDataSource.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.shared.user.datasources.local
 
 import com.waz.zclient.core.extension.empty
-import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.requestDatabase
 import com.waz.zclient.storage.db.users.model.UserEntity
 import com.waz.zclient.storage.db.users.service.UserDao
@@ -10,10 +9,11 @@ import kotlinx.coroutines.flow.Flow
 
 class UsersLocalDataSource constructor(
     private val userDao: UserDao,
-    globalPreferences: GlobalPreferences
+    private val globalPreferences: GlobalPreferences
 ) {
 
-    private val userId = globalPreferences.activeUserId
+    private val userId: String
+        get() = globalPreferences.activeUserId
 
     fun profileDetails(): Flow<UserEntity> = userDao.byId(userId)
 
@@ -29,5 +29,9 @@ class UsersLocalDataSource constructor(
 
     suspend fun deletePhone() = requestDatabase { userDao.updatePhone(userId, String.empty()) }
 
-    fun currentUserId() = Either.Right(userId)
+    fun currentUserId() = userId
+
+    fun setCurrentUserId(userId: String) {
+        globalPreferences.activeUserId = userId
+    }
 }

--- a/app/src/test/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCaseTest.kt
@@ -1,17 +1,27 @@
 package com.waz.zclient.feature.settings.account.logout
 
 import com.waz.zclient.UnitTest
+import com.waz.zclient.any
+import com.waz.zclient.core.exception.DatabaseError
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.exception.Forbidden
+import com.waz.zclient.core.extension.empty
+import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.network.accesstoken.AccessToken
 import com.waz.zclient.core.network.accesstoken.AccessTokenRepository
 import com.waz.zclient.core.network.accesstoken.RefreshToken
 import com.waz.zclient.shared.accounts.AccountsRepository
+import com.waz.zclient.shared.accounts.ActiveAccount
+import com.waz.zclient.shared.user.UsersRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
-import org.amshove.kluent.mock
+import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
@@ -23,24 +33,34 @@ class LogoutUseCaseTest : UnitTest() {
     @Mock
     private lateinit var accessTokenRepository: AccessTokenRepository
 
+    @Mock
+    private lateinit var usersRepository: UsersRepository
+
+    @Mock
+    private lateinit var accessToken: AccessToken
+
+    @Mock
+    private lateinit var refreshToken: RefreshToken
+
     private lateinit var logoutUseCase: LogoutUseCase
 
     @Before
     fun setUp() {
-        logoutUseCase = LogoutUseCase(accountsRepository, accessTokenRepository)
+        `when`(accessToken.token).thenReturn(ACCESS_TOKEN_STRING)
+        `when`(refreshToken.token).thenReturn(REFRESH_TOKEN_STRING)
+        runBlocking {
+            `when`(accessTokenRepository.accessToken()).thenReturn(accessToken)
+            `when`(accessTokenRepository.refreshToken()).thenReturn(refreshToken)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(emptyList()))
+        }
+        `when`(usersRepository.currentUserId()).thenReturn(TEST_USER_ID)
+
+        logoutUseCase = LogoutUseCase(accountsRepository, accessTokenRepository, usersRepository)
     }
 
     @Test
-    fun `given accessTokenRepo, when run is called, then calls accountsRepo's logout method with access and refresh tokens`() =
+    fun `given accessTokenRepo, when run is called, then calls accountsRepo's logout method with correct tokens from accessTokenRepo`() =
         runBlockingTest {
-            val accessToken = mock(AccessToken::class)
-            `when`(accessToken.token).thenReturn(ACCESS_TOKEN_STRING)
-            val refreshToken = mock(RefreshToken::class)
-            `when`(refreshToken.token).thenReturn(REFRESH_TOKEN_STRING)
-
-            `when`(accessTokenRepository.accessToken()).thenReturn(accessToken)
-            `when`(accessTokenRepository.refreshToken()).thenReturn(refreshToken)
-
             logoutUseCase.run(Unit)
 
             verify(accessTokenRepository).accessToken()
@@ -49,8 +69,117 @@ class LogoutUseCaseTest : UnitTest() {
             verify(accountsRepository).logout(REFRESH_TOKEN_STRING, ACCESS_TOKEN_STRING)
         }
 
+    @Test
+    fun `given use case is run, when logout operation returns success, then proceeds to account deletion`() =
+        runBlockingTest {
+            `when`(accountsRepository.logout(any(), any())).thenReturn(Either.Right(Unit))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).deleteAccountFromDevice(TEST_USER_ID)
+        }
+
+    @Test
+    fun `given use case is run, when logout operation fails, then proceeds to account deletion`() =
+        runBlockingTest {
+            `when`(accountsRepository.logout(any(), any())).thenReturn(Either.Left(Forbidden))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).deleteAccountFromDevice(TEST_USER_ID)
+        }
+
+    @Test
+    fun `given use case is run, when account deletion is successful, then proceeds to checking remaining accounts`() =
+        runBlockingTest {
+            `when`(accountsRepository.deleteAccountFromDevice(TEST_USER_ID)).thenReturn(Either.Right(Unit))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).activeAccounts()
+        }
+
+    @Test
+    fun `given use case is run, when account deletion fails, then proceeds to checking remaining accounts`() =
+        runBlockingTest {
+            `when`(accountsRepository.deleteAccountFromDevice(TEST_USER_ID)).thenReturn(Either.Left(DatabaseError))
+
+            logoutUseCase.run(Unit)
+
+            verify(accountsRepository).activeAccounts()
+        }
+
+    @Test
+    fun `given account is deleted and there's no accounts left, then clears currentUserId and returns success`() =
+        runBlockingTest {
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(emptyList()))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
+    @Test
+    fun `given account is deleted and there's another account left, then updates currentUserId with new id and returns success`() =
+        runBlockingTest {
+            val id = "otherAccountId"
+            val otherAccount = mockAccount(id)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(otherAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            verify(usersRepository).setCurrentUserId(id)
+        }
+
+    @Test
+    fun `given account deletion fails and the account still exists, when there's no other account, then clears currentUserId and returns success`() =
+        runBlockingTest {
+            val activeAccount = mockAccount(TEST_USER_ID)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(activeAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
+    @Test
+    fun `given account deletion fails and the account still exists, when there's another account, then updates currentUserId with other's id`() =
+        runBlockingTest {
+            val loggedOutAccount = mockAccount(TEST_USER_ID)
+            val newId = "newActiveId"
+            val newActiveAccount = mockAccount(newId)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Right(listOf(loggedOutAccount, newActiveAccount)))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            verify(usersRepository).setCurrentUserId(newId)
+        }
+
+    @Test
+    fun `given remaining active accounts check fails, then clears current user id and returns success`() =
+        runBlockingTest {
+            val failure = mock(Failure::class.java)
+            `when`(accountsRepository.activeAccounts()).thenReturn(Either.Left(failure))
+
+            val result = logoutUseCase.run(Unit)
+
+            result.isRight shouldBe true
+            verify(usersRepository).setCurrentUserId(String.empty())
+        }
+
     companion object {
+        private const val TEST_USER_ID = "testUser_id"
         private const val ACCESS_TOKEN_STRING = "accessToken"
         private const val REFRESH_TOKEN_STRING = "refreshToken"
+
+        private fun mockAccount(id: String): ActiveAccount {
+            val account = mock(ActiveAccount::class.java)
+            `when`(account.id).thenReturn(id)
+            return account
+        }
     }
 }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/AccountsDataSourceTest.kt
@@ -139,12 +139,10 @@ class AccountsDataSourceTest : UnitTest() {
         }
 
     @Test
-    fun `given deleteAcountFromDevice is called, then local data source should remove account from database`() = runBlockingTest {
-        val account = mockActiveAccount()
+    fun `given deleteAccountFromDevice is called with an id, then calls local data source with given id`() = runBlockingTest {
+        accountsDataSource.deleteAccountFromDevice(TEST_ID)
 
-        accountsDataSource.deleteAccountFromDevice(account)
-
-        verify(localDataSource).removeAccount(accountMapper.toEntity(account))
+        verify(localDataSource).removeAccount(TEST_ID)
         verifyNoMoreInteractions(localDataSource)
         verifyNoInteractions(usersRemoteDataSource)
     }

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/datasources/local/AccountsLocalDataSourceTest.kt
@@ -2,7 +2,6 @@ package com.waz.zclient.shared.accounts.datasources.local
 
 import com.waz.zclient.UnitTest
 import com.waz.zclient.core.functional.map
-import com.waz.zclient.eq
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsDao
 import com.waz.zclient.storage.db.accountdata.ActiveAccountsEntity
 import kotlinx.coroutines.CancellationException
@@ -110,9 +109,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test
     fun `Given removeAccount is called, when dao result is successful, then return success`() {
         runBlockingTest {
-            val result = accountsLocalDataSource.removeAccount(mockEntity)
+            val result = accountsLocalDataSource.removeAccount(TEST_ID)
 
-            verify(activeAccountsDao).removeAccount(eq(mockEntity))
+            verify(activeAccountsDao).removeAccount(TEST_ID)
 
             result.isRight shouldBe true
         }
@@ -121,9 +120,9 @@ class AccountsLocalDataSourceTest : UnitTest() {
     @Test(expected = CancellationException::class)
     fun `Given removeAccount is called, when dao result is cancelled, then returns error`() {
         runBlockingTest {
-            accountsLocalDataSource.removeAccount(mockEntity)
+            accountsLocalDataSource.removeAccount(TEST_ID)
 
-            val result = accountsLocalDataSource.removeAccount(mockEntity)
+            val result = accountsLocalDataSource.removeAccount(TEST_ID)
 
             cancel(CancellationException(TEST_EXCEPTION_MESSAGE))
 

--- a/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     @Test
     fun `given use-case is executed, when currentUserId is empty, then returns CannotFindActiveAccount directly`() =
         runBlockingTest {
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(String.empty()))
+            `when`(userRepository.currentUserId()).thenReturn(String.empty())
 
             val result = getActiveAccountUseCase.run(Unit)
 
@@ -55,7 +55,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
         runBlockingTest {
             val activeAccount = mock(ActiveAccount::class)
 
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(activeAccount))
 
             val result = getActiveAccountUseCase.run(Unit)
@@ -70,7 +70,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     @Test
     fun `given use-case is executed, when no active account with id exists in database, then return CannotFindActiveAccount`() =
         runBlockingTest {
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Right(null))
 
             val result = getActiveAccountUseCase.run(Unit)
@@ -86,7 +86,7 @@ class GetActiveAccountUseCaseTest : UnitTest() {
     fun `given use-case is executed, when failure is returned from data layer, then return failure`() =
         runBlockingTest {
             val failure = mock(Failure::class)
-            `when`(userRepository.currentUserId()).thenReturn(Either.Right(TEST_USER_ID))
+            `when`(userRepository.currentUserId()).thenReturn(TEST_USER_ID)
             `when`(accountsRepository.activeAccountById(TEST_USER_ID)).thenReturn(Either.Left(failure))
 
             val result = getActiveAccountUseCase.run(Unit)

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
@@ -142,7 +142,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
         val activeAccount = createActiveAccount(TEST_USER_ID)
         activeAccountsDao.insertActiveAccount(activeAccount)
 
-        activeAccountsDao.removeAccount(activeAccount)
+        activeAccountsDao.removeAccount(TEST_USER_ID)
 
         assertTrue(activeAccountsDao.activeAccountById(TEST_USER_ID) == null)
     }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/accountdata/ActiveAccountsDao.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.storage.db.accountdata
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 
@@ -30,6 +29,6 @@ interface ActiveAccountsDao {
     @Insert
     suspend fun insertActiveAccount(activeAccountsEntity: ActiveAccountsEntity)
 
-    @Delete
-    suspend fun removeAccount(account: ActiveAccountsEntity)
+    @Query("DELETE from ActiveAccounts WHERE _id = :id")
+    suspend fun removeAccount(id: String)
 }


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6797

### Issues

Part 3 of user initiated logout. 

In this part, we delete the logged out user from ActiveAccounts table, and update the currently active user id in SharedPreferences.

Currently, the user still stays on the Settings screen. In Part 4, I will navigate the user to either Login or Conversation list page, depending on whether there are any other accounts left.

### Testing

Unit tests are added/updated.

## Notes

Up to this point everything goes aligned with the Scala implementation. However, I discovered some differences from the iOS implementation. For instance, in iOS, they also delete the user's database. I'm going to explore the iOS code base and address other changes (we also need to consult Raphael) in a later part, if necessary.

#### APK
[Download build #2021](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2021/artifact/build/artifact/wire-dev-PR2810-2021.apk)
[Download build #2060](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2060/artifact/build/artifact/wire-dev-PR2810-2060.apk)