### PR TITLE
fix: Exact match search

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -53,7 +53,7 @@ trait UserSearchService {
   def syncSearchResults(query: SearchQuery): Unit
   def updateSearchResults(query: SearchQuery, results: UserSearchResponse): Future[Unit]
   def updateSearchResults(remoteUsers: Map[UserId, (UserInfo, Option[TeamMember])]): Unit
-  def updateExactMatch(result: UserSearchResponse.User): Unit
+  def updateExactMatch(info: UserInfo): Unit
 }
 
 class UserSearchServiceImpl(selfUserId:           UserId,
@@ -285,9 +285,9 @@ class UserSearchServiceImpl(selfUserId:           UserId,
     exactMatchUser.mutate(_.map(userUpdate))
   }
 
-  override def updateExactMatch(result: UserSearchResponse.User): Unit = {
-    verbose(l"updateExactMatch(${result.id})")
-    val userData = UserData(UserSearchEntry(result))
+  override def updateExactMatch(info: UserInfo): Unit = {
+    verbose(l"updateExactMatch(${info.id})")
+    val userData = UserData(info)
     exactMatchUser ! Some(userData)
     sync.syncSearchResults(Set(userData.id))
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -21,7 +21,6 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model._
-import com.waz.service.tracking.TrackingService.NoReporting
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 import com.waz.znet2.AuthRequestInterceptor
@@ -34,6 +33,7 @@ import scala.util.Right
 
 trait UsersClient {
   def loadUsers(ids: Seq[UserId]): ErrorOrResponse[Seq[UserInfo]]
+  def loadByHandle(handle: Handle): ErrorOrResponse[Option[UserInfo]]
   def loadSelf(): ErrorOrResponse[UserInfo]
   def loadRichInfo(user: UserId): ErrorOrResponse[Seq[UserField]]
   def updateSelf(info: UserInfo): ErrorOrResponse[Unit]
@@ -66,6 +66,15 @@ class UsersClientImpl(implicit
 
       CancellableFuture.lift(result)
     }
+  }
+
+  override def loadByHandle(handle: Handle): ErrorOrResponse[Option[UserInfo]] = {
+    Request.Get(relativePath = UsersPath, queryParameters = queryParameters("handles" -> handle))
+      .withResultType[Seq[UserInfo]]
+      .withErrorType[ErrorResponse]
+      .execute
+      .map(res => Right(res.headOption))
+      .recover { case e: ErrorResponse => Left(e) }
   }
 
   override def loadSelf(): ErrorOrResponse[UserInfo] = {
@@ -122,8 +131,4 @@ object UsersClient {
       v.password foreach (o.put("password", _))
     }
   }
-
-  class FailedLoadUsersResponse(val error: ErrorResponse)
-    extends RuntimeException(s"loading users failed with: $error") with NoReporting
-
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -22,13 +22,15 @@ import com.waz.log.LogSE._
 import com.waz.model.Handle
 import com.waz.service.{SearchQuery, UserSearchService}
 import com.waz.sync.SyncResult
-import com.waz.sync.client.UserSearchClient
+import com.waz.sync.client.{UserSearchClient, UsersClient}
 import com.waz.threading.Threading
 
 import scala.concurrent.Future
 
-class UserSearchSyncHandler(userSearch: UserSearchService,
-                            client:     UserSearchClient)
+class UserSearchSyncHandler(userSearch:  UserSearchService,
+                            client:      UserSearchClient,
+                            usersClient: UsersClient
+                           )
   extends DerivedLogTag {
 
   import Threading.Implicits.Background
@@ -42,7 +44,7 @@ class UserSearchSyncHandler(userSearch: UserSearchService,
       SyncResult(error)
   }
 
-  def exactMatchHandle(handle: Handle): Future[SyncResult] = client.exactMatchHandle(handle).future.map {
+  def exactMatchHandle(handle: Handle): Future[SyncResult] = usersClient.loadByHandle(handle).future.map {
     case Right(Some(user)) =>
       debug(l"exactMatchHandle, got: ${user.id} for the handle $handle")
       userSearch.updateExactMatch(user)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6884

There was a bug in the exact match searching - we tried to parse the response from BE as wrong case class. The bug was there even before Large Teams. The right way to get the exact match is very similar to how we look for users by ids, so I decided to move that client functionality from UserSearchClient to UsersClient.

#### APK
[Download build #2024](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2024/artifact/build/artifact/wire-dev-PR2812-2024.apk)