### PR TITLE
Feat: Logout functionality in Kotlin - Part 4

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -153,6 +153,11 @@
                 <category android:name="android.intent.category.VIEW" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="com.wire.ACTION_CURRENT_USER_CHANGED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+
         </activity>
 
         <activity
@@ -213,8 +218,12 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.Dark"
             android:windowSoftInputMode="stateHidden|adjustResize"
-            android:exported="false"
-            />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.wire.ACTION_NO_USER_LEFT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ForceUpdateActivity"

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountFragment.kt
@@ -1,5 +1,6 @@
 package com.waz.zclient.feature.settings.account
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -119,17 +120,27 @@ class SettingsAccountFragment : Fragment(R.layout.fragment_settings_account) {
     }
 
     private fun initLogout() {
+        observeLogoutNavigation()
         observeLogoutData()
         initLogoutButtonListener()
+    }
+
+    private fun observeLogoutNavigation() {
+        settingsAccountViewModel.logoutNavigationAction.observe(viewLifecycleOwner) {
+            startActivity(Intent()
+                .setAction(it)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
     }
 
     private fun observeLogoutData() {
         with(logoutViewModel) {
             successLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Logged out", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLoggedOut(it)
             }
             errorLiveData.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "Failed with $it", LENGTH_LONG).show()
+                settingsAccountViewModel.onUserLogoutError(it)
             }
         }
     }

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
@@ -70,7 +70,6 @@ class SettingsAccountViewModel(
     val resetPasswordUrlLiveData: LiveData<String> = _resetPasswordUrlLiveData
     val logoutNavigationAction: MutableLiveData<String> = _logoutNavigationAction
 
-
     fun loadProfileDetails() {
         getActiveAccountUseCase(viewModelScope, Unit) {
             it.fold(::handleError, ::handleActiveAccountSuccess)

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/SettingsAccountViewModel.kt
@@ -8,6 +8,10 @@ import androidx.lifecycle.viewModelScope
 import com.waz.zclient.core.config.AccountUrlConfig
 import com.waz.zclient.core.exception.Failure
 import com.waz.zclient.core.extension.empty
+import com.waz.zclient.feature.settings.account.logout.AnotherAccountExists
+import com.waz.zclient.feature.settings.account.logout.CouldNotReadRemainingAccounts
+import com.waz.zclient.feature.settings.account.logout.LogoutStatus
+import com.waz.zclient.feature.settings.account.logout.NoAccountsLeft
 import com.waz.zclient.shared.accounts.ActiveAccount
 import com.waz.zclient.shared.accounts.usecase.GetActiveAccountUseCase
 import com.waz.zclient.shared.user.User
@@ -34,6 +38,7 @@ class SettingsAccountViewModel(
     private val _resetPasswordUrlLiveData = MutableLiveData<String>()
     private val _phoneDialogLiveData = MutableLiveData<PhoneDialogDetail>()
     private val _deleteAccountDialogLiveData = MutableLiveData<DeleteAccountDialogDetail>()
+    private val _logoutNavigationAction = MutableLiveData<String>()
 
     val nameLiveData: LiveData<String> = Transformations.map(profileLiveData) {
         it.name
@@ -63,6 +68,8 @@ class SettingsAccountViewModel(
     val phoneDialogLiveData: LiveData<PhoneDialogDetail> = _phoneDialogLiveData
     val deleteAccountDialogLiveData: LiveData<DeleteAccountDialogDetail> = _deleteAccountDialogLiveData
     val resetPasswordUrlLiveData: LiveData<String> = _resetPasswordUrlLiveData
+    val logoutNavigationAction: MutableLiveData<String> = _logoutNavigationAction
+
 
     fun loadProfileDetails() {
         getActiveAccountUseCase(viewModelScope, Unit) {
@@ -131,8 +138,28 @@ class SettingsAccountViewModel(
         }
     }
 
+    fun onUserLoggedOut(logoutStatus: LogoutStatus) = when (logoutStatus) {
+        CouldNotReadRemainingAccounts, NoAccountsLeft -> handleNoActiveUserLeft()
+        AnotherAccountExists -> handleCurrentUserChange()
+    }
+
+    private fun handleNoActiveUserLeft() {
+        _logoutNavigationAction.value = ACTION_LOGOUT_NO_USER_LEFT
+    }
+
+    private fun handleCurrentUserChange() {
+        _logoutNavigationAction.value = ACTION_LOGOUT_CURRENT_USER_CHANGED
+    }
+
+    fun onUserLogoutError(failure: Failure) {
+        _errorLiveData.value = "Error logging out: $failure"
+    }
+
     companion object {
         private const val RESET_PASSWORD_URL_SUFFIX = "/forgot/"
+
+        private const val ACTION_LOGOUT_CURRENT_USER_CHANGED = "com.wire.ACTION_CURRENT_USER_CHANGED"
+        private const val ACTION_LOGOUT_NO_USER_LEFT = "com.wire.ACTION_NO_USER_LEFT"
     }
 }
 

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutUseCase.kt
@@ -15,7 +15,7 @@ class LogoutUseCase(
 ) : UseCase<LogoutStatus, Unit>() {
 
     override suspend fun run(params: Unit): Either<Failure, LogoutStatus> {
-        logout()
+        logout() //TODO check w/ backend team what is the side effect if this call fails
         return deleteLoggedOutAccountData()
     }
 

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutViewModel.kt
@@ -8,19 +8,17 @@ import com.waz.zclient.core.exception.Failure
 
 class LogoutViewModel(private val logoutUseCase: LogoutUseCase) : ViewModel() {
 
-    private var _successLiveData = MutableLiveData<Unit>()
+    private var _successLiveData = MutableLiveData<LogoutStatus>()
     private var _errorLiveData = MutableLiveData<Failure>()
 
     val errorLiveData: LiveData<Failure> = _errorLiveData
-    val successLiveData: LiveData<Unit> = _successLiveData
+    val successLiveData: LiveData<LogoutStatus> = _successLiveData
 
-    fun onVerifyButtonClicked() {
-        logoutUseCase(viewModelScope, Unit) {
-            it.fold(::logoutFailed) { logoutSuccess() }
-        }
+    fun onVerifyButtonClicked() = logoutUseCase(viewModelScope, Unit) {
+        it.fold(::logoutFailed, ::logoutSuccess)
     }
 
-    private fun logoutSuccess() = _successLiveData.postValue(Unit)
+    private fun logoutSuccess(status: LogoutStatus) = _successLiveData.postValue(status)
 
     private fun logoutFailed(failure: Failure) = _errorLiveData.postValue(failure)
 }

--- a/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/accounts/usecase/GetActiveAccountUseCase.kt
@@ -2,7 +2,6 @@ package com.waz.zclient.shared.accounts.usecase
 
 import com.waz.zclient.core.exception.Failure
 import com.waz.zclient.core.exception.FeatureFailure
-import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.functional.flatMap
 import com.waz.zclient.core.usecase.UseCase
@@ -21,7 +20,7 @@ class GetActiveAccountUseCase(
 
     override suspend fun run(params: Unit): Either<Failure, ActiveAccount> =
         userRepository.currentUserId().let {
-            if (it == String.empty()) Either.Left(CannotFindActiveAccount)
+            if (it.isEmpty()) Either.Left(CannotFindActiveAccount)
             else activeAccountById(it)
         }
 


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6797

### Issues

This part handles navigation after a user logs out.

When user (User1) logs out,
- if there are no users left, direct to Login Screen
- if there is another user (User2), direct to Conversation List screen for User2

### Solutions

Since we cannot directly call Scala classes from Kotlin classes, I had to make a trick and trigger an implicit Intent. This intent will be resolved by the operating system.

### Testing

Manually tested and unit tests are also added. Whether the correct intent is resolved can also be detected by QA's integration tests.
#### APK
[Download build #2058](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2058/artifact/build/artifact/wire-dev-PR2813-2058.apk)
[Download build #2059](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2059/artifact/build/artifact/wire-dev-PR2813-2059.apk)