### PR TITLE
Feat: Logout functionality in Kotlin - Part 5

### DIFF
--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -18,6 +18,7 @@ android {
         }
 
         buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
+        buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"
     }
 
     externalNativeBuild {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -127,7 +127,7 @@ class GlobalModuleImpl(val context:                 AContext,
   lazy val backupManager:       BackupManager                    = wire[BackupManagerImpl]
 
   lazy val ssoService:          SSOService                       = wire[SSOService]
-  lazy val accountsService:     AccountsService                  = new AccountsServiceImpl(this, backupManager)
+  lazy val accountsService:     AccountsService                  = new AccountsServiceImpl(this, backupManager, BuildConfig.KOTLIN_SETTINGS)
   lazy val syncHandler:         SyncHandler                      = new AccountSyncHandler(accountsService)
   lazy val calling:             GlobalCallingService             = new GlobalCallingService
 


### PR DESCRIPTION
## What's new in this PR?

Jira issue: https://wearezeta.atlassian.net/browse/AN-6797

### Issues

Even after a user logs out via Kotlin side, some screens in Scala side still shows information about the logged out account. They're unaware of the logout operation.

### Causes

On Scala side, the logout operation is handled by `AccountsServiceImpl`. This class has 
`val accountManagers = Signal[Set[AccountManager]]() `
signal that is observed throughout the app to react on any account state changes. The `logout(userId: UserId, reason: LogoutReason)` method in AccountsServiceImpl used to update this signal, but on Kotlin flow this method is not called.

### Solutions

This PR updates `accountManagers` value to notify the Scala components about the account deletion event caused by logout.

When a user logs out via `LogoutUseCase`, the `active_account` preference in `SharedPreferences` is updated via `UsersRepository`. Thanks to the observable structure on the Scala side, we can already observe the changes on a `SharedPreference` value. I made `AccountsServiceImpl` observe the `active_account` key, for the changes triggered from outside, and re-calculate its `accountManagers` so that it emits the updated value. 

### Testing

Manually tested.

Couldn't write a unit test because there are no existing unit tests for AccountsServiceImpl and trying to create from scratch takes too much effort.

## Notes

This logic could also be useful for registration flow.
#### APK
[Download build #2065](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2065/artifact/build/artifact/wire-dev-PR2815-2065.apk)