### PR TITLE
AN-6883: I should see no results message on Add people page when search ends up not matching

### DIFF
--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -57,9 +57,9 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
               case None => search.usersForNewConversation(query, teamOnly)
             }
           } yield
-            if (results.isEmpty)
+            if (results.isEmpty) {
               if (filter.isEmpty) NoUsers else NoUsersFound
-            else Users(results)
+            } else Users(results)
         case Tab.Services =>
           servicesService.flatMap { svc =>
             Signal

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -113,9 +113,11 @@ class UserSearchServiceImpl(selfUserId:           UserId,
 
   override def usersForNewConversation(query: SearchQuery, teamOnly: Boolean): Signal[SearchResults] =
     for {
-      localResults      <- filterForExternal(query, searchLocal(query)
-                          .map(_.filter(u => !(u.isGuest(teamId) && teamOnly))))
-      remoteResults     <- directoryResults(query)
+      localResults      <- filterForExternal(
+        query,
+        searchLocal(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      )
+      remoteResults     <- directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def usersToAddToConversation(query: SearchQuery, toConv: ConvId): Signal[SearchResults] =
@@ -123,7 +125,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       curr              <- membersStorage.activeMembers(toConv)
       conv              <- convsStorage.signal(toConv)
       localResults      <- filterForExternal(query, searchLocal(query, curr).map(_.filter(conv.isUserAllowed)))
-      remoteResults     <- directoryResults(query)
+      remoteResults     <- directoryResults(query).map(_.filter(conv.isUserAllowed))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def mentionsSearchUsersInConversation(convId: ConvId, filter: String, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6883

### Issues

When adding a new participant to a current conversation or a new conversation it doesn't display the correct error scenario when searching for a guest in a group which doesn't allow guests. 

### Causes

The list wasn't being filtered correctly so the error scenario assumed there were users but for a different scenario to the one wanted. 

### Solutions

Filter the list so that the remote search results match the filtering of the local search results for consistency. 

### Testing

#### Scenario 1: 
1. Sign into your team account 
2. Connect with a non-team account (personal account) to get a guest
3. Open search UI 
4. Click create group
5. Enter search name 
6. Turn OFF allow guests and services 
7. Search for your guest
8. It should no results message on screen

#### Scenario 2: 
1. Sign into your team account 
2. Connect with a non-team account (personal account) to get a guest
3. Open search UI 
4. Click create group
5. Enter search name 
6. Turn ON allow guests and services 
7. Search for your guest
8. It should display your guest on the screen 

#### APK
[Download build #2029](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2029/artifact/build/artifact/wire-dev-PR2818-2029.apk)