### PR TITLE
AN-6876: A partner team member should not be found in Group creation

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -274,7 +274,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
       }
 
       val directoryTeamMembers = currentUser.map(_.teamId) match {
-        case Some(_)      => directoryResults.filter(u => u.teamId == teamId)
+        case Some(_)      => directoryResults.filter(_.teamId == teamId)
         case None         => Nil
       }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -274,11 +274,11 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
       }
 
       val directoryTeamMembers = currentUser.map(_.teamId) match {
-        case Some(_)      => directoryResults.filter(_.teamId == teamId)
+        case Some(_)      => directoryResults.filter(u => u.teamId == teamId)
         case None         => Nil
       }
 
-      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id)
+      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id).filter(!_.isExternal(teamId))
       val integrationResults = res match {
         case Services(ss) => ss
         case _ => Seq.empty

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -20,7 +20,7 @@ package com.waz.service
 import com.waz.content.UserPreferences.SelfPermissions
 import com.waz.content._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.log.LogSE.{info, _}
+import com.waz.log.LogSE._
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model.UserPermissions.{ExternalPermissions, decodeBitmask}
 import com.waz.model._
@@ -117,7 +117,10 @@ class UserSearchServiceImpl(selfUserId:           UserId,
         query,
         searchLocal(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
       )
-      remoteResults     <- directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      remoteResults     <- filterForExternal(
+        query,
+        directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      )
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def usersToAddToConversation(query: SearchQuery, toConv: ConvId): Signal[SearchResults] =
@@ -125,7 +128,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       curr              <- membersStorage.activeMembers(toConv)
       conv              <- convsStorage.signal(toConv)
       localResults      <- filterForExternal(query, searchLocal(query, curr).map(_.filter(conv.isUserAllowed)))
-      remoteResults     <- directoryResults(query).map(_.filter(conv.isUserAllowed))
+      remoteResults     <- filterForExternal(query, directoryResults(query).map(_.filter(conv.isUserAllowed)))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def mentionsSearchUsersInConversation(convId: ConvId, filter: String, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6876

### Issues

When you create a group or add a participant to a group conversation, once you search for users to add you don't want an external partner to be displayed. 

### Causes

Due to changes around getting remote results. 

### Solutions

Filter the final list based on whether the user is external or not. 
#### APK
[Download build #2031](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2031/artifact/build/artifact/wire-dev-PR2820-2031.apk)