### PR TITLE
Revert: A partner team member should not be found in Group creation #2820

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -274,7 +274,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
       }
 
       val directoryTeamMembers = currentUser.map(_.teamId) match {
-        case Some(_)      => directoryResults.filter(u => u.teamId == teamId)
+        case Some(_)      => directoryResults.filter(_.teamId == teamId)
         case None         => Nil
       }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -278,7 +278,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
         case None         => Nil
       }
 
-      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id).filter(!_.isExternal(teamId))
+      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id)
       val integrationResults = res match {
         case Services(ss) => ss
         case _ => Seq.empty

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -274,11 +274,11 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
       }
 
       val directoryTeamMembers = currentUser.map(_.teamId) match {
-        case Some(_)      => directoryResults.filter(_.teamId == teamId)
+        case Some(_)      => directoryResults.filter(u => u.teamId == teamId)
         case None         => Nil
       }
 
-      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id)
+      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id).filter(!_.isExternal(teamId))
       val integrationResults = res match {
         case Services(ss) => ss
         case _ => Seq.empty

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -57,9 +57,9 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
               case None => search.usersForNewConversation(query, teamOnly)
             }
           } yield
-            if (results.isEmpty)
+            if (results.isEmpty) {
               if (filter.isEmpty) NoUsers else NoUsersFound
-            else Users(results)
+            } else Users(results)
         case Tab.Services =>
           servicesService.flatMap { svc =>
             Signal

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -20,7 +20,7 @@ package com.waz.service
 import com.waz.content.UserPreferences.SelfPermissions
 import com.waz.content._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.log.LogSE.{info, _}
+import com.waz.log.LogSE._
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model.UserPermissions.{ExternalPermissions, decodeBitmask}
 import com.waz.model._
@@ -117,7 +117,10 @@ class UserSearchServiceImpl(selfUserId:           UserId,
         query,
         searchLocal(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
       )
-      remoteResults     <- directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      remoteResults     <- filterForExternal(
+        query,
+        directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      )
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def usersToAddToConversation(query: SearchQuery, toConv: ConvId): Signal[SearchResults] =
@@ -125,7 +128,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       curr              <- membersStorage.activeMembers(toConv)
       conv              <- convsStorage.signal(toConv)
       localResults      <- filterForExternal(query, searchLocal(query, curr).map(_.filter(conv.isUserAllowed)))
-      remoteResults     <- directoryResults(query).map(_.filter(conv.isUserAllowed))
+      remoteResults     <- filterForExternal(query, directoryResults(query).map(_.filter(conv.isUserAllowed)))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def mentionsSearchUsersInConversation(convId: ConvId, filter: String, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -113,9 +113,11 @@ class UserSearchServiceImpl(selfUserId:           UserId,
 
   override def usersForNewConversation(query: SearchQuery, teamOnly: Boolean): Signal[SearchResults] =
     for {
-      localResults      <- filterForExternal(query, searchLocal(query)
-                          .map(_.filter(u => !(u.isGuest(teamId) && teamOnly))))
-      remoteResults     <- directoryResults(query)
+      localResults      <- filterForExternal(
+        query,
+        searchLocal(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      )
+      remoteResults     <- directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def usersToAddToConversation(query: SearchQuery, toConv: ConvId): Signal[SearchResults] =
@@ -123,7 +125,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       curr              <- membersStorage.activeMembers(toConv)
       conv              <- convsStorage.signal(toConv)
       localResults      <- filterForExternal(query, searchLocal(query, curr).map(_.filter(conv.isUserAllowed)))
-      remoteResults     <- directoryResults(query)
+      remoteResults     <- directoryResults(query).map(_.filter(conv.isUserAllowed))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def mentionsSearchUsersInConversation(convId: ConvId, filter: String, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -117,10 +117,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
         query,
         searchLocal(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
       )
-      remoteResults     <- filterForExternal(
-        query,
-        directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
-      )
+      remoteResults     <- directoryResults(query).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def usersToAddToConversation(query: SearchQuery, toConv: ConvId): Signal[SearchResults] =
@@ -128,7 +125,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       curr              <- membersStorage.activeMembers(toConv)
       conv              <- convsStorage.signal(toConv)
       localResults      <- filterForExternal(query, searchLocal(query, curr).map(_.filter(conv.isUserAllowed)))
-      remoteResults     <- filterForExternal(query, directoryResults(query).map(_.filter(conv.isUserAllowed)))
+      remoteResults     <- directoryResults(query).map(_.filter(conv.isUserAllowed))
     } yield SearchResults(local = localResults, dir = remoteResults)
 
   override def mentionsSearchUsersInConversation(convId: ConvId, filter: String, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =


### PR DESCRIPTION
## What's new in this PR?

### Issues

Changes in https://github.com/wireapp/wire-android/pull/2820 has broke working functionality and another bug that was fixed previously in https://github.com/wireapp/wire-android/pull/2818

### Causes

Filtering for external changes has broken exact match functionality in the add participant fragment. 

### Solutions

Reverse commit until a new solution is implemented. 

### Testing

#### Scenario 1: 
1. Sign into your team account 
2. Connect with a non-team account (personal account) to get a guest
3. Open search UI 
4. Click create group
5. Enter search name 
6. Turn OFF allow guests and services 
7. Search for your guest
8. It should no results message on screen

#### Scenario 2: 
1. Sign into your team account 
2. Connect with a non-team account (personal account) to get a guest
3. Open search UI 
4. Click create group
5. Enter search name 
6. Turn ON allow guests and services 
7. Search for your guest
8. It should display your guest on the screen 
#### APK
[Download build #2034](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2034/artifact/build/artifact/wire-dev-PR2823-2034.apk)
[Download build #2035](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2035/artifact/build/artifact/wire-dev-PR2823-2035.apk)