### PR TITLE
fix: Show an external/partner user in the Add to Group screen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -263,14 +263,9 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
 
       import AddUserListState._
 
-      var localResults = IndexedSeq.empty[UserData]
-      var directoryResults = IndexedSeq.empty[UserData]
-
-      res match {
-        case AddUserListState.Users(search) =>
-          localResults = search.local
-          directoryResults = search.dir
-        case _ =>
+      val (localResults, directoryResults) = res match {
+        case AddUserListState.Users(search) => (search.local, search.dir)
+        case _ => (Nil, Nil)
       }
 
       val directoryTeamMembers = currentUser.map(_.teamId) match {
@@ -278,7 +273,7 @@ case class AddParticipantsAdapter(usersSelected: SourceSignal[Set[UserId]],
         case None         => Nil
       }
 
-      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id).filter(!_.isExternal(teamId))
+      val userResults = (localResults ++ directoryTeamMembers).distinctBy(_.id)
       val integrationResults = res match {
         case Services(ss) => ss
         case _ => Seq.empty


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6876 but also fixes the opposite case.
The external user should be visible in the search to the "invitor" before the invitor types in a query, but the external user should NOT be visible to non-invitors in the same situation.
Only when a non-invitor types in an exact match search, the external user appears in the result.
The behaviour is the same for normal user search and for Add to Group user search.
