### PR TITLE
fix: Migrate data only if the original table exists

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/MigrationUtils.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/MigrationUtils.kt
@@ -1,21 +1,17 @@
 package com.waz.zclient.storage.db.users.migration
 
 import androidx.sqlite.db.SupportSQLiteDatabase
+import android.util.Log
 
 object MigrationUtils {
     private fun tableExists(database: SupportSQLiteDatabase, tableName: String): Boolean {
         val query = "SELECT DISTINCT tbl_name FROM sqlite_master WHERE tbl_name = '$tableName'"
         database.query(query).use { cursor ->
-            if (cursor != null) {
-                if (cursor.count > 0) {
-                    return true
-                }
-            }
-            return false
+            return cursor != null && cursor.count > 0
         }
     }
 
-    fun executeSimpleMigration(
+    fun recreateAndTryMigrate(
         database: SupportSQLiteDatabase,
         originalTableName: String,
         tempTableName: String,
@@ -32,6 +28,8 @@ object MigrationUtils {
             if (tableExists(database, originalTableName)) {
                 execSQL(copyAll)
                 execSQL(dropOldTable)
+            } else {
+                Log.w("MigrationUtils", "The original database table is missing: $originalTableName")
             }
             execSQL(renameTableBack)
             indicesCalls.forEach {

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/MigrationUtils.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/MigrationUtils.kt
@@ -3,6 +3,18 @@ package com.waz.zclient.storage.db.users.migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 object MigrationUtils {
+    private fun tableExists(database: SupportSQLiteDatabase, tableName: String): Boolean {
+        val query = "SELECT DISTINCT tbl_name FROM sqlite_master WHERE tbl_name = '$tableName'"
+        database.query(query).use { cursor ->
+            if (cursor != null) {
+                if (cursor.count > 0) {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+
     fun executeSimpleMigration(
         database: SupportSQLiteDatabase,
         originalTableName: String,
@@ -17,8 +29,10 @@ object MigrationUtils {
         with(database) {
             execSQL(dropTempTableIfExists)
             execSQL(createTempTable)
-            execSQL(copyAll)
-            execSQL(dropOldTable)
+            if (tableExists(database, originalTableName)) {
+                execSQL(copyAll)
+                execSQL(dropOldTable)
+            }
             execSQL(renameTableBack)
             indicesCalls.forEach {
                 execSQL(it)

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase127To128Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase127To128Migration.kt
@@ -3,7 +3,7 @@ package com.waz.zclient.storage.db.users.migration
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.waz.zclient.storage.db.users.migration.MigrationUtils.executeSimpleMigration
+import com.waz.zclient.storage.db.users.migration.MigrationUtils.recreateAndTryMigrate
 
 val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
     override fun migrate(database: SupportSQLiteDatabase) {
@@ -78,7 +78,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
 
         val conversationIdIndex = "CREATE INDEX IF NOT EXISTS Conversation_id on $originalTableName ($primaryKey)"
         val searchKeyIndex = "CREATE INDEX IF NOT EXISTS UserData_search_key on $originalTableName ($searchKey)"
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -98,7 +98,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
                 data TEXT NOT NULL DEFAULT ''
                 )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -149,7 +149,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
         val conversationSearchKeyIndex = """
             CREATE INDEX IF NOT EXISTS Conversation_search_key on $originalTableName ($searchKey)
             """.trimIndent()
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -174,7 +174,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
         val conversationIdIndex = "CREATE INDEX IF NOT EXISTS ConversationMembers_conv on $originalTableName ($convid)"
         val userIdIndex = "CREATE INDEX IF NOT EXISTS ConversationMembers_userid on $originalTableName ($userId)"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -218,7 +218,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
                )""".trimIndent()
         val convAndTimeIndex = "CREATE INDEX IF NOT EXISTS Messages_conv_time on $originalTableName ($convId, $time)"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -236,7 +236,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
                 value TEXT NOT NULL DEFAULT ''
                )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -253,7 +253,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
                 data TEXT NOT NULL DEFAULT ''
                )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -277,7 +277,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
                 time INTEGER NOT NULL DEFAULT 0
                 )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -294,7 +294,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
             data TEXT NOT NULL DEFAULT ''
             )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -311,7 +311,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              hashes TEXT
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -332,7 +332,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
 
         val contactIndex = "CREATE INDEX IF NOT EXISTS ContactsOnWire_contact on $originalTableName ( $contact )"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -350,7 +350,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              data TEXT NOT NULL DEFAULT ''
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -370,7 +370,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              PRIMARY KEY (message_id, user_id)
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -393,7 +393,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
 
         val contactSortingIndex = "CREATE INDEX IF NOT EXISTS Contacts_sorting on $originalTableName ( $sorting )"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -417,7 +417,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
         val contactIndex = "CREATE INDEX IF NOT EXISTS EmailAddresses_contact on EmailAddresses ($contact)"
         val emailIndex = "CREATE INDEX IF NOT EXISTS EmailAddresses_email on EmailAddresses ($emailAddress)"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -442,7 +442,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
         val contactIndex = "CREATE INDEX IF NOT EXISTS PhoneNumbers_contact on $originalTableName ($contact)"
         val phoneIndex = "CREATE INDEX IF NOT EXISTS PhoneNumbers_phone on $originalTableName ($phoneNumber)"
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -461,7 +461,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              timestamp INTEGER NOT NULL DEFAULT 0
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -479,7 +479,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              timestamp INTEGER NOT NULL DEFAULT 0
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -500,7 +500,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              transient INTEGER NOT NULL DEFAULT 0
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -519,7 +519,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              PRIMARY KEY (message_id, user_id)
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -536,7 +536,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              value TEXT NOT NULL DEFAULT ''
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -567,7 +567,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
              asset_id TEXT
              )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -590,7 +590,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               status INTEGER NOT NULL DEFAULT 0
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -616,7 +616,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               conversation_id TEXT
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -635,7 +635,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               PRIMARY KEY (_id, stage)
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -654,7 +654,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               bucket3 INTEGER NOT NULL DEFAULT 0
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -672,7 +672,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               type INTEGER NOT NULL DEFAULT 0
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -690,7 +690,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               PRIMARY KEY (conv_id, folder_id)
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,
@@ -714,7 +714,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
             CREATE INDEX IF NOT EXISTS ConversationRoleAction_convid on $originalTableName ($convId)
             """.trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database,
                 originalTableName,
                 tempTableName,
@@ -738,7 +738,7 @@ val USER_DATABASE_MIGRATION_127_TO_128 = object : Migration(127, 128) {
               $time INTEGER NOT NULL DEFAULT 0,
               )""".trimIndent()
 
-        executeSimpleMigration(
+        recreateAndTryMigrate(
                 database = database,
                 originalTableName = originalTableName,
                 tempTableName = tempTableName,


### PR DESCRIPTION
I tested updating from 3.46 to the current head of develop and encountered the black screen. The error in the logs was:
```
2020-05-05 17:28:14.410 5508-5714/com.waz.zclient.dev E/SQLiteLog: (1) no such table: MessageContentIndex
2020-05-05 17:28:14.427 5508-5694/com.waz.zclient.dev E/Preference: Error while getting signal with preference key dark_theme (def: false). Exception is: android.database.sqlite.SQLiteException: no such table: MessageContentIndex (code 1 SQLITE_ERROR): , while compiling: INSERT OR IGNORE INTO MessageContentIndexTemp SELECT * FROM MessageContentIndex
```

I found out that in the migration 127->128 we migrate data in the table `MessageContentIndex`. It's a virtual table and it was handled differently in Scala in previous versions and in Kotlin/Room right now. I don't know enough about Room to dig deeper at the moment, but I came up with a simple fix: Before migrating data, check if the original table exists.

I don't think it's **the** cause of our "black screen issue". What we call "black screen" is a side-effect of a failed migration which makes the app unusable. This fix might help with some cases of such failed migrations, but there's no way to know for sure.

I also bumped the Wire version. Sorry for doing it in the same PR (but a separate commit). There's just not much time.
#### APK
[Download build #2043](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2043/artifact/build/artifact/wire-dev-PR2826-2043.apk)
[Download build #2045](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2045/artifact/build/artifact/wire-dev-PR2826-2045.apk)
[Download build #2053](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2053/artifact/build/artifact/wire-dev-PR2826-2053.apk)