### PR TITLE
Android Functional(UI) Testing: Introducing Espresso 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,7 +93,7 @@ android {
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
         versionName = (System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION) + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
-        testInstrumentationRunner "com.waz.background.TestRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [
             customURLScheme   : buildtimeConfiguration.configuration.custom_url_scheme,
@@ -439,6 +439,8 @@ dependencies {
     androidTestImplementation TestDependencies.jUnit
     androidTestImplementation TestDependencies.mockito.core
     androidTestImplementation TestDependencies.kluent
+    androidTestImplementation TestDependencies.androidX.testRunner
+    androidTestImplementation TestDependencies.androidX.espressoCore
     androidTestImplementation TestDependencies.androidX.testJunit
     androidTestImplementation TestDependencies.androidX.testRules
     androidTestImplementation TestDependencies.androidX.testWorkManager

--- a/app/src/androidTest/kotlin/com/waz/zclient/FunctionalTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/FunctionalTest.kt
@@ -1,0 +1,21 @@
+package com.waz.zclient
+
+import android.app.Activity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+abstract class FunctionalTest(clazz: Class<*>) {
+
+    @get:Rule
+    var activityRule = activityTestRule(clazz)
+
+    private fun activityTestRule(activityClass: Class<*>): ActivityTestRule<out Activity> {
+        require(activityClass is Activity) { "Wrong class type: Use Android Activity type." }
+        return ActivityTestRule(activityClass.asSubclass(Activity::class.java))
+    }
+}

--- a/app/src/androidTest/kotlin/com/waz/zclient/feature/settings/about/SettingsAboutActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/feature/settings/about/SettingsAboutActivityTest.kt
@@ -1,0 +1,19 @@
+package com.waz.zclient.feature.settings.about
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.waz.zclient.FunctionalTest
+import com.waz.zclient.R
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SettingsAboutActivityTest : FunctionalTest(SettingsAboutActivity::class.java) {
+
+    @Test
+    fun checkToolbar() {
+        onView(withId(R.id.toolbar)).check(matches(isDisplayed()));
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/FunctionalTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/FunctionalTest.kt
@@ -1,0 +1,4 @@
+package com.waz.zclient
+
+class FunctionalTest {
+}

--- a/app/src/test/kotlin/com/waz/zclient/FunctionalTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/FunctionalTest.kt
@@ -1,4 +1,0 @@
-package com.waz.zclient
-
-class FunctionalTest {
-}

--- a/app/src/test/kotlin/com/waz/zclient/UnitTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/UnitTest.kt
@@ -34,5 +34,4 @@ abstract class UnitTest {
 
     @get:Rule
     val rule = InstantTaskExecutorRule()
-
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -56,6 +56,8 @@ object Versions {
     const val JUNIT = "4.12"
     const val MOCKITO = "3.1.0"
     const val KLUENT = "1.14"
+    const val ESPRESSO_CORE = "3.2.0"
+    const val ANDROIDX_TEST_RUNNER = "1.1.0"
     const val ANDROIDX_TEST_CORE = "2.1.0"
     const val ANDROIDX_TEST_JUNIT = "1.1.1"
     const val ROBOLECTRIC = "5.0.0_r2-robolectric-1"
@@ -151,6 +153,8 @@ object TestDependencies {
         "inline" to "org.mockito:mockito-inline:${Versions.MOCKITO}"
     ))
     val androidX = AndroidXTestDependencyMap(mapOf(
+        "espressoCore" to "androidx.test.espresso:espresso-core:${Versions.ESPRESSO_CORE}",
+        "testRunner" to "androidx.test:runner:${Versions.ANDROIDX_TEST_RUNNER}",
         "testCore" to "androidx.arch.core:core-testing:${Versions.ANDROIDX_TEST_CORE}",
         "testJunit" to "androidx.test.ext:junit:${Versions.ANDROIDX_TEST_JUNIT}",
         "testRules" to "androidx.test:rules:${Versions.ANDROIDX_TEST_JUNIT}",

--- a/buildSrc/src/main/kotlin/DependencyMap.kt
+++ b/buildSrc/src/main/kotlin/DependencyMap.kt
@@ -83,6 +83,8 @@ class RxJavaDependencyMap(map: Map<String, String>) {
 }
 
 class AndroidXTestDependencyMap(map: Map<String, String>) {
+    val espressoCore: String by map
+    val testRunner: String by map
     val testCore: String by map
     val testJunit: String by map
     val testRules: String by map


### PR DESCRIPTION
## What's new in this PR?

In an effort to improve the quality of our android client and in hand with the creation of a new android infrastructure system, this PR aims to introduce [Espresso](https://developer.android.com/training/testing/espresso) as our framework for testing UI components and workflow. 

## Blockers

At the time being and due to our current codebase using a Scala Plugin for compilation which leads to the following issue because of the usage of an older ```gradle``` version:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:transformClassesWithDexBuilderForDevDebugAndroidTest'.
> com.android.build.api.transform.TransformException: 
java.lang.UnsupportedOperationException: 
java.lang.UnsupportedOperationException: This feature requires ASM6
```

## Running tests

```
./gradlew connectedDevDebugAndroidTest
```
## Notes
There are existing Instrumentation tests not in usage that need to be checked:
 - Package: [com.waz.zclient.markdown](https://github.com/wireapp/wire-android/tree/develop/app/src/androidTest/kotlin/com/waz/zclient/markdown)

## Useful Links
 - https://developer.android.com/training/testing/espresso
 - https://developer.android.com/training/testing/espresso/setup
 - https://developer.android.com/training/testing/ui-testing/espresso-testing
#### APK
[Download build #2047](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2047/artifact/build/artifact/wire-dev-PR2828-2047.apk)