### PR TITLE
chore: Remove unused "last accent color" preference

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/IUserPreferencesController.java
@@ -37,10 +37,7 @@ public interface IUserPreferencesController {
 
     void reset();
 
-    void setLastAccentColor(final int accentColor);
-
     boolean showContactsDialog();
-
 
     void setVerificationCode(String code);
 

--- a/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
+++ b/app/src/main/java/com/waz/zclient/controllers/userpreferences/UserPreferencesController.java
@@ -35,7 +35,6 @@ public class UserPreferencesController implements IUserPreferencesController {
     public static final String USER_PREFS_TAG = "com.wire.preferences";
 
     //TODO Move these preferences to the UserPreferences service in SE, since a lot of them are user-scoped anyway.
-    public static final String USER_PREFS_LAST_ACCENT_COLOR = "USER_PREFS_LAST_ACCENT_COLOR";
     public static final String USER_PREFS_REFERRAL_TOKEN = "USER_PREFS_REFERRAL_TOKEN";
     public static final String USER_PREFS_PERSONAL_INVITATION_TOKEN = "USER_PREFS_PERSONAL_INVITATION_TOKEN";
     private static final String USER_PREFS_SHOW_SHARE_CONTACTS_DIALOG = "USER_PREFS_SHOW_SHARE_CONTACTS_DIALOG ";
@@ -59,14 +58,6 @@ public class UserPreferencesController implements IUserPreferencesController {
     @Override
     public void reset() {
         // TODO: AN-2066 Should reset all preferences
-    }
-
-    public void setLastAccentColor(int accentColor) {
-        userPreferences.edit().putInt(USER_PREFS_LAST_ACCENT_COLOR, accentColor).apply();
-    }
-
-    public int getLastAccentColor() {
-        return userPreferences.getInt(USER_PREFS_LAST_ACCENT_COLOR, -1);
     }
 
     @Override

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -116,10 +116,6 @@ class MainActivity extends BaseActivity
       fragmentTransaction.commit
     } else getControllerFactory.getNavigationController.onActivityCreated(savedInstanceState)
 
-    accentColorController.accentColor.map(_.color).onUi(
-      getControllerFactory.getUserPreferencesController.setLastAccentColor
-    )
-
     handleIntent(getIntent)
 
     val currentlyDarkTheme = themeController.darkThemeSet.currentValue.contains(true)

--- a/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
@@ -93,10 +93,6 @@ class PreferencesActivity extends BaseActivity
       backStackNavigator.onRestore(findViewById(R.id.content).asInstanceOf[ViewGroup], savedInstanceState)
     }
 
-    accentColor.on(Threading.Ui) { color =>
-      getControllerFactory.getUserPreferencesController.setLastAccentColor(color.color)
-    }
-
     accountTabs.onTabClick.onUi { account =>
       val intent = new Intent()
       intent.putExtra(SwitchAccountExtra, account.id.str)


### PR DESCRIPTION
For a long time now we keep the accent color used by the current user in the storage.
In the past we used a preference for this and a bit of the code was left in the codebase:
the preference was set, but never read. I removed that code.
