### PR TITLE
fix: Too many prekeys requests

### DIFF
--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
     api "com.wire:generic-message-proto:1.24.2"
-    implementation "com.wire:backend-api-proto:1.1"
+    implementation "com.wire:backend-api-proto:2.3"
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -479,7 +479,6 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
     }
 
   override def setLastRead(convId: ConvId, msg: MessageData): Future[Option[ConversationData]] = {
-
     def sendReadReceipts(from: RemoteInstant, to: RemoteInstant, readReceiptSettings: ReadReceiptSettings): Future[Seq[SyncId]] = {
       shouldSendReadReceipts(convId, readReceiptSettings).flatMap {
         case true =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -26,7 +26,6 @@ import com.waz.log.LogSE._
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.otr.ClientId
 import com.waz.model.sync.SyncJob.Priority
-import com.waz.model.sync.SyncRequest.PostConvRole
 import com.waz.model.sync._
 import com.waz.model.{AccentColor, Availability, _}
 import com.waz.service._

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/MessagesClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/MessagesClient.scala
@@ -25,7 +25,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.sync.client.OtrClient.{ClientMismatch, MessageResponse}
 import com.waz.sync.otr.OtrSyncHandler.OtrMessage
-import com.waz.utils._
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http._
@@ -69,6 +68,7 @@ object MessagesClient extends DerivedLogTag {
     msg.nativePush = m.nativePush
     msg.recipients = m.recipients.userEntries
     m.external foreach { msg.blob = _ }
+    m.report_missing.foreach(users => msg.reportMissing = users.map(OtrClient.userId).toArray)
 
     val bytes = MessageNano.toByteArray(msg)
     RawBody(mediaType = Some(MediaType.Protobuf), () => new ByteArrayInputStream(bytes), dataLength = Some(bytes.length))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -93,11 +93,10 @@ class OtrClientImpl(implicit
   override def loadPreKeys(users: Map[UserId, Seq[ClientId]]): ErrorOrResponse[Map[UserId, Seq[ClientKey]]] = {
     // TODO: request accepts up to 128 clients, we should make sure not to send more
     val data = JsonEncoder { o =>
-      users foreach { case (u, cs) =>
+      users.foreach { case (u, cs) =>
         o.put(u.str, JsonEncoder.arrString(cs.map(_.str)))
       }
     }
-    verbose(l"loadPreKeys: $users")
     Request.Post(relativePath = prekeysPath, body = data)
       .withResultType[PreKeysResponse]
       .withErrorType[ErrorResponse]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -38,19 +38,16 @@ class LastReadSyncHandler(selfUserId: UserId,
 
   import com.waz.threading.Threading.Implicits.Background
 
-  def postLastRead(convId: ConvId, time: RemoteInstant): Future[SyncResult] = {
-    verbose(l"postLastRead($convId, $time)")
-
+  def postLastRead(convId: ConvId, time: RemoteInstant): Future[SyncResult] =
     convs.get(convId).flatMap {
       case Some(conv) if conv.lastRead.isAfter(time) => // no need to send this msg as lastRead was already advanced
         Future.successful(Success)
       case Some(conv) =>
         val msg = GenericMessage(Uid(), LastRead(conv.remoteId, time))
         otrSync
-          .postOtrMessage(ConvId(selfUserId.str), msg)
+          .postOtrMessage(ConvId(selfUserId.str), msg, recipients = Some(Set(selfUserId)))
           .map(SyncResult(_))
       case None =>
         Future.successful(Failure(s"No conversation found for id: $convId"))
     }
-  }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -93,7 +93,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         resp       <- if (content.estimatedSize < MaxContentSize)
                         msgClient.postMessage(
                           conv.remoteId,
-                          OtrMessage(selfClientId, content, external, nativePush),
+                          OtrMessage(selfClientId, content, external, nativePush, recipients),
                           ignoreMissing = enforceIgnoreMissing || retries > 1
                         ).future
                       else {


### PR DESCRIPTION
With the Large Teams feature we changed the way we specify to what users should a message be sent. That led to error responses from the backend in some cases which in consequence trigger new prekeys requests. There are way too many prekeys requests coming from Android devices to the backend right now - basically at least one for every message received by a device with the new version if the user also has Wire on another device.

The message types which are affected are: last reads, delivery confirmations, and read receipts. In standard cases we want to send the message to all users in the conversation - and that works well - but in these three cases (*) we want them to be sent only to other self devices and to devices of the sender of the original message. So, we put those user ids on the list of
explicit recipients and later we put that list in the `report_missing` field of the OTR message. And here's something unclear starts to happen. In those three cases, sending the message to the conversation (`/conversations/[conv id]/otr/messages` endpoint) results in the error 412, Clients Mismatch with the data that a client is missing. In consequence, the Android app requests new prekeys for that client.

Before Large Teams, the error didn't happen, because the list of recipients wasn't put in the `report_missing` field at all (which means that the message is send to everyone in the conversation). So, it looks like the error happens when `report_missing` specifies the list of recipients, but the backend decides for some reason that the list is wrong.

**EDIT**:
It turned out the real reason was that Android uses an obsolete version of backend-api-proto. The new version was compiled and put on Bintray, and the version number in Android was bumped. In the new version we have the reportMissing field in OtrNewMessage. Our report_missing from OtrMessage has to be copied there.

I also made some indentation and other small changes to improve readability. It helps me think.

*) There are also button confirmations - but they go only ot the poll's owner, not to the other self devices, and there are ephemeral expirations, but they seemed to work well.

#### APK
[Download build #2071](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2071/artifact/build/artifact/wire-dev-PR2833-2071.apk)
[Download build #2072](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2072/artifact/build/artifact/wire-dev-PR2833-2072.apk)
[Download build #2075](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2075/artifact/build/artifact/wire-dev-PR2833-2075.apk)