### PR TITLE
fix: Re-add hanfling of team.member-join events

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -385,6 +385,7 @@ object TeamEvent extends DerivedLogTag {
   sealed trait MemberEvent extends TeamEvent {
     val userId: UserId
   }
+  case class MemberJoin(teamId: TeamId, userId: UserId) extends MemberEvent
   case class MemberLeave(teamId: TeamId, userId: UserId) extends MemberEvent
   case class MemberUpdate(teamId: TeamId, userId: UserId) extends MemberEvent
 
@@ -399,6 +400,7 @@ object TeamEvent extends DerivedLogTag {
     override def apply(implicit js: JSONObject): TeamEvent =
       decodeString('type) match {
         case "team.update"              => Update('team, decodeOptName('name)('data), AssetId(decodeString('icon)('data)))
+        case "team.member-join"         => MemberJoin('team, UserId(decodeString('user)('data)))
         case "team.member-leave"        => MemberLeave('team, UserId(decodeString('user)('data)))
         case "team.member-update"       => MemberUpdate('team, UserId(decodeString('user)('data)))
         case _ =>


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6896

At one point in the Large Teams feature implementation we removed the code for handling incoming events of new members joining the team. Later design changes reverted that decision but the code was not reintroduced, resulting in that, for example, new team members are initially invisible in SearchUI.

This PR reintroduces a few lines which sync new team members if the event comes.

#### APK
[Download build #2108](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2108/artifact/build/artifact/wire-dev-PR2845-2108.apk)