### PR TITLE
fix: Update conversation names in real time

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationListAdapter.scala
@@ -254,8 +254,8 @@ object ConversationListAdapter {
       (oldList(oldItemPosition), newList(newItemPosition)) match {
         case (Header(_, title, isExpanded, oldCount), Header(_, newTitle, newIsExpanded, newCount)) =>
           title == newTitle && isExpanded && newIsExpanded && oldCount == newCount
-        case (Conversation(conv, _, _), Conversation(newConv, _, _)) =>
-          conv == newConv
+        case (Conversation(conv, name, _), Conversation(newConv, newName, _)) =>
+          conv == newConv && name == newName
         case (IncomingRequests(_, requests), IncomingRequests(_, newRequests)) =>
           requests == newRequests
         case _ =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -170,6 +170,12 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     case availability      => AvailabilityView.displayStartOfText(title, availability, title.getCurrentTextColor, pushDown = true)
   }
 
+  // conversation name
+  (for {
+    conv <- conversation
+    name <- controller.conversationName(conv.id)
+  } yield name).onUi(name => title.setText(name.str))
+
   avatarInfo.onUi {
     case (convId, isGroup, members, _, selfTeam) if conversationData.forall(_.id == convId) =>
       avatar.setMembers(members, convId, isGroup, selfTeam)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6903
fixes https://wearezeta.atlassian.net/browse/AN-6895

After the recent change in how we decide on conversation names, the conversation list adapter stopped responding to those changes in real time, at least in some cases:
1. After starting the app, the adapter displays "Default" as the conversation name before the storage is initialized. This should be changed to the actual name just after initialization, but the adapter was unresponsive (AN-6903).
2. If we get a user-update event with the new name, the data changes, but the adapter does not update (AN-6895).

This PR fixes both by adding a listener to the conversation name signal in the conversation list row. It's not the ideal solution but it's consistent with how conversation list rows update other data. I think that the underlying problem is that the conversation list row is right now a very complex entity which breaks the design pattern (it's a row in an adapter but it updates itself through signals instead of using the adapter). I don't want to refactor it now so I leave it as it is, but I think we should rewrite it in the future.

#### APK
[Download build #2109](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2109/artifact/build/artifact/wire-dev-PR2846-2109.apk)