### PR TITLE
feat: Update or delete UserData on sending messages and accessing profiles

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1254,6 +1254,7 @@
     <string name="ephemeral_explanation_text">Timed messages will be turned on for all the participants in this conversation</string>
     <string name="notifications_explanation_text">You can be notified about everything (including audio and video calls) or only when you are mentioned.</string>
     <string name="show_all_participants">Show all (%1$s)</string>
+    <string name="participant_was_removed_from_team">%s was removed from team</string>
 
     <string name="allow_guests_error_title">Something went wrong</string>
     <string name="allow_guests_error_body">Could not allow guests nor services. Please try again.</string>

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -70,6 +70,15 @@ class UsersController(implicit injector: Injector, context: Context)
       userService.flatMap(_.userNames.map(_.getOrElse(id, DefaultDeletedName)).map(Other(_)))
   }
 
+  def syncUserAndCheckIfDeleted(userId: UserId): Future[(Option[UserData], Option[UserData])] = {
+    import Threading.Implicits.Background
+    for {
+      service <- userService.head
+      oldUser <- service.findUser(userId)
+      newUser <- if (oldUser.nonEmpty) service.syncUser(userId) else Future.successful(None)
+    } yield (oldUser, newUser)
+  }
+
   lazy val availabilityVisible: Signal[Boolean] = for {
     selfId <- selfUserId
     self   <- user(selfId)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -59,6 +59,7 @@ trait UserService {
   def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): Future[Option[UserData]]
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
+  def syncUser(userId: UserId): Future[Option[UserData]]
   def acceptedOrBlockedUsers: Signal[Map[UserId, UserData]]
 
   def updateSyncedUsers(users: Seq[UserInfo], timestamp: LocalInstant = LocalInstant.Now): Future[Set[UserData]]
@@ -153,9 +154,16 @@ class UserServiceImpl(selfUserId:        UserId,
   override val userDeleteEventsStage: Stage.Atomic = EventScheduler.Stage[UserDeleteEvent] { (c, e) =>
     //TODO handle deleting db and stuff?
     Future.sequence(e.map(event => accounts.logout(event.user, reason = UserDeleted))).flatMap { _ =>
-      usersStorage.updateAll2(e.map(_.user)(breakOut), _.copy(deleted = true))
+      deleteUsers(e.map(_.user).toSet)
     }
   }
+
+  private def deleteUsers(ids: Set[UserId]) =
+    for {
+      members <- membersStorage.getByUsers(ids)
+      _       <- membersStorage.removeAll(members.map(_.id).toSet)
+      _       <- usersStorage.updateAll2(ids, _.copy(deleted = true))
+    } yield ()
 
   override lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] =
     new AggregatingSignal[Seq[UserData], Map[UserId, UserData]](
@@ -194,6 +202,16 @@ class UserServiceImpl(selfUserId:        UserId,
       case Left(error) => Future.failed(error)
     }
   }
+
+  override def syncUser(userId: UserId): Future[Option[UserData]] =
+    usersClient.loadUser(userId).future.flatMap {
+      case Left(e) =>
+        Future.failed(e)
+      case Right(Some(info)) =>
+        updateSyncedUsers(Seq(info)).map(_.headOption)
+      case Right(None) =>
+        deleteUsers(Set(userId)).map(_ => None)
+    }
 
   def syncSelfNow: Future[Option[UserData]] = Serialized.future("syncSelfNow", selfUserId) {
     usersClient.loadSelf().future.flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -238,7 +238,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val giphy: GiphyService                        = new GiphyServiceImpl(giphyClient)(Threading.Background)
   lazy val youtubeMedia                               = wire[YouTubeMediaService]
   lazy val googleMapsMediaService                     = wire[GoogleMapsMediaServiceImpl]
-  lazy val otrService: OtrServiceImpl                 = wire[OtrServiceImpl]
+  lazy val otrService: OtrService                     = wire[OtrServiceImpl]
   lazy val genericMsgs: GenericMessageService         = wire[GenericMessageService]
   lazy val reactions: ReactionsService                = wire[ReactionsService]
   lazy val notifications: NotificationService         = wire[NotificationServiceImpl]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -25,7 +25,7 @@ import com.waz.log.LogSE._
 import com.waz.model._
 import com.waz.service.EventScheduler.Stage
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService}
-import com.waz.service.{ConversationRolesService, ErrorsService, EventScheduler, SearchKey, SearchQuery}
+import com.waz.service.{ConversationRolesService, ErrorsService, EventScheduler, SearchKey, SearchQuery, UserService}
 import com.waz.sync.client.TeamsClient.TeamMember
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
@@ -62,6 +62,7 @@ trait TeamsService {
 class TeamsServiceImpl(selfUser:           UserId,
                        teamId:             Option[TeamId],
                        teamStorage:        TeamsStorage,
+                       userService:        UserService,
                        userStorage:        UsersStorage,
                        convsStorage:       ConversationStorage,
                        convMemberStorage:  MembersStorage,
@@ -216,19 +217,13 @@ class TeamsServiceImpl(selfUser:           UserId,
     } yield {}
   }
 
-  private def onMembersLeft(userIds: Set[UserId]) = {
-    verbose(l"onTeamMembersLeft: users: $userIds")
-    if (userIds.contains(selfUser)) {
+  private def onMembersLeft(members: Set[UserId]) = {
+    verbose(l"onMembersLeft: members: $members")
+    if (members.contains(selfUser)) {
       warn(l"Self user removed from team")
       Future.successful {}
-    } else {
-      // TODO: merge with UserService.deleteUsers
-      for {
-        members <- convMemberStorage.getByUsers(userIds)
-        _       <- convMemberStorage.removeAll(members.map(_.id).toSet)
-        _       <- userStorage.updateAll2(userIds, _.copy(deleted = true))
-      } yield {}
-    }
+    } else
+      userService.deleteUsers(members)
   }
   
   //So far, a member update just means we need to check the permissions for that user, and we only care about permissions

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -222,9 +222,10 @@ class TeamsServiceImpl(selfUser:           UserId,
       warn(l"Self user removed from team")
       Future.successful {}
     } else {
+      // TODO: merge with UserService.deleteUsers
       for {
         members <- convMemberStorage.getByUsers(userIds)
-        _       <- convMemberStorage.removeAll(members.map(_.id))
+        _       <- convMemberStorage.removeAll(members.map(_.id).toSet)
         _       <- userStorage.updateAll2(userIds, _.copy(deleted = true))
       } yield {}
     }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
@@ -32,7 +32,6 @@ import com.waz.model._
 import com.waz.model.errors._
 import com.waz.service.assets.{AES_CBC_Encryption, AssetService, Content, ContentForUpload, Asset => Asset2}
 import com.waz.service.messages.MessagesService
-import com.waz.service.otr.OtrServiceImpl
 import com.waz.sync.SyncResult
 import com.waz.sync.client.AssetClient.Retention
 import com.waz.sync.client.OpenGraphClient.OpenGraphData
@@ -46,7 +45,6 @@ import scala.concurrent.Future
 
 class OpenGraphSyncHandler(convs:           ConversationStorage,
                            messages:        MessagesStorage,
-                           otrService:      OtrServiceImpl,
                            assets:          AssetService,
                            otrSync:         OtrSyncHandler,
                            client:          OpenGraphClient,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -145,6 +145,8 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
           } yield acceptedOrBlocked.keySet ++ myTeamIds
       }
 
+      import com.waz.utils.RichEither
+
       broadcastRecipients.flatMap { recp =>
         for {
           content  <- service.encryptForUsers(recp, message, useFakeOnError = retry > 0, previous)
@@ -152,6 +154,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
                         OtrMessage(selfClientId, content, report_missing = Some(recp)),
                         ignoreMissing = retry > 1
                       ).future
+          _        <- response.map(_.deleted).mapFuture(service.deleteClients)
           res      <- loopIfMissingClients(
                        response,
                        retry,

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -27,7 +27,7 @@ import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.{CredentialsUpdateClient, UsersClient}
 import com.waz.testutils.TestUserPreferences
-import com.waz.threading.Threading
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.{BgEventSource, Signal, SourceSignal}
 import org.threeten.bp.Instant
 
@@ -36,9 +36,10 @@ import scala.concurrent.Future
 class UserServiceSpec extends AndroidFreeSpec {
 
   private lazy val me = UserData(name = "me").updateConnectionStatus(ConnectionStatus.Self)
+  private lazy val user1 = UserData("other user 1")
   private lazy val meAccount = AccountData(me.id)
 
-  private lazy val users = Seq(me, UserData("other user 1"), UserData("other user 2"), UserData("some name"),
+  private lazy val users = Seq(me, user1, UserData("other user 2"), UserData("some name"),
     UserData("related user 1"), UserData("related user 2"), UserData("other related"),
     UserData("friend user 1"), UserData("friend user 2"), UserData("some other friend")
   )
@@ -61,7 +62,6 @@ class UserServiceSpec extends AndroidFreeSpec {
   (accountsService.accountsWithManagers _).expects().anyNumberOfTimes().returning(Signal.empty)
   (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal(Some(Instant.now())) with BgEventSource)
   (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
-  (usersStorage.updateOrCreateAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))
 
   private def getService = {
@@ -115,13 +115,44 @@ class UserServiceSpec extends AndroidFreeSpec {
   feature("load user") {
 
     scenario("update self user") {
-
       val id = users.head.id
+      (usersStorage.updateOrCreateAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
       (usersStorage.get _).expects(id).once().returning(Future.successful(users.headOption))
 
       val service = getService
       result(service.updateSyncedUsers(Seq(UserInfo(id))))
       result(service.getSelfUser).map(_.connection) shouldEqual Some(ConnectionStatus.Self)
+    }
+
+    scenario("check if user exists") {
+      val userInfo = UserInfo(user1.id)
+      (usersClient.loadUser _).expects(user1.id).anyNumberOfTimes().returning(
+        CancellableFuture.successful(Right(Option(userInfo)))
+      )
+      (usersStorage.updateOrCreateAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Set(user1)))
+
+      val service = getService
+      result(service.syncUser(user1.id)) shouldEqual Some(user1)
+    }
+
+    scenario("delete user locally if it the client says it's removed") {
+      val member = ConversationMemberData(user1.id, ConvId(), ConversationRole.AdminRole)
+      (usersClient.loadUser _).expects(user1.id).anyNumberOfTimes().returning(
+        CancellableFuture.successful(Right(None))
+      )
+      (usersStorage.updateOrCreateAll _).expects(*).never()
+      (membersStorage.getByUsers _).expects(Set(user1.id)).anyNumberOfTimes().returning(
+        Future.successful(IndexedSeq(member))
+      )
+      (membersStorage.removeAll _).expects(Set(member.id)).atLeastOnce().returning(
+        Future.successful(())
+      )
+      (usersStorage.updateAll2 _).expects(Set(user1.id), *).atLeastOnce().onCall { (_: Iterable[UserId], updater: UserData => UserData) =>
+        Future.successful(Seq((user1, updater(user1))))
+      }
+
+      val service = getService
+      result(service.syncUser(user1.id)) shouldEqual None
     }
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -24,7 +24,7 @@ import com.waz.content._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService}
-import com.waz.service.{ConversationRolesService, ErrorsService, SearchKey, SearchQuery}
+import com.waz.service.{ConversationRolesService, ErrorsService, SearchKey, SearchQuery, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.TeamsClient
 import com.waz.sync.client.TeamsClient.TeamMember
@@ -45,6 +45,7 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val teamId        = Some(TeamId())
   val teamStorage   = mock[TeamsStorage]
   val accStorage    = mock[AccountsStorageOld]
+  val userService   = mock[UserService]
   val userStorage   = mock[UsersStorage]
   val convsStorage  = mock[ConversationStorage]
   val convMembers   = mock[MembersStorage]
@@ -284,9 +285,10 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     }
   }
 
-  def createService = {
-    new TeamsServiceImpl(selfUser, teamId, teamStorage, userStorage, convsStorage, convMembers, convsContent, convsService,
-      sync, syncRequests, userPrefs, errorsService, rolesService)
-  }
+  def createService: TeamsService =
+    new TeamsServiceImpl(
+      selfUser, teamId, teamStorage, userService, userStorage, convsStorage, convMembers,
+      convsContent, convsService, sync, syncRequests, userPrefs, errorsService, rolesService
+    )
 
 }


### PR DESCRIPTION
This was cut from the original implementation of Large Teams.
Documentation: https://github.com/wearezeta/documentation/blob/master/topics/teams/use%20cases/clients/215-handle-absense-of-team-events.md
The implementation differ from the docs in that in Android we ignore redundant clients. (They will be eventually deleted).

fixes https://wearezeta.atlassian.net/browse/AN-6859
fixes https://wearezeta.atlassian.net/browse/AN-6866

#### APK
[Download build #2111](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2111/artifact/build/artifact/wire-dev-PR2848-2111.apk)
[Download build #2112](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2112/artifact/build/artifact/wire-dev-PR2848-2112.apk)