### PR TITLE
Conversation search: Duplicated message + won't scroll when selected. 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/collection/fragments/CollectionFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/fragments/CollectionFragment.scala
@@ -112,7 +112,7 @@ class CollectionFragment extends BaseFragment[CollectionFragment.Container] with
     messageActionsController.onMessageAction.on(Threading.Ui){
       case (MessageAction.Reveal, _) =>
         KeyboardUtils.closeKeyboardIfShown(getActivity)
-        controller.closeCollection
+        controller.closeCollection()
         controller.focusedItem.mutate {
           case Some(m) if m.msgType == Message.Type.IMAGE_ASSET => None
           case m => m

--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -89,7 +89,7 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
     canHaveLink             = isGroup && cTeam.exists(z.teamId.contains(_)) && !teamOnly
     cursor                  <- RefreshingSignal(loadCursor(cId), cursorRefreshEvent(z, cId))
     _ = verbose(l"cursor changed")
-    list                    = PagedListWrapper(getPagedList(cursor))
+    list                    =  PagedListWrapper(getPagedList(cursor))
     lastRead                <- convController.currentConv.map(_.lastRead)
     messageToReveal         <- messageActionsController.messageToReveal.map(_.map(_.id))
   } yield (MessageAdapterData(cId, lastRead, isGroup, canHaveLink, z.selfUserId, z.teamId), list, messageToReveal)

--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -97,14 +97,10 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
 
 object MessagePagedListController {
   case class PagedListConfig(pageSize: Int, initialLoadSizeHint: Int, prefetchDistance: Int) {
-    /**
-     * The reason why placeholders are disabled is taken from this Stackoverflow answer to a bug:
-     * https://stackoverflow.com/a/56873666/2975925
-     */
     lazy val config = new PagedList.Config.Builder()
       .setPageSize(pageSize)
       .setInitialLoadSizeHint(initialLoadSizeHint)
-      .setEnablePlaceholders(false)
+      .setEnablePlaceholders(true)
       .setPrefetchDistance(prefetchDistance)
       .build()
   }

--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -229,7 +229,7 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   }
 
   private def revealMessageInConversation(message: MessageData) = {
-    zms.head.flatMap(z => z.messagesStorage.get(message.id)).onComplete{
+    zms.head.flatMap(z => z.messagesStorage.get(message.id)).onComplete {
       case Success(msg) =>  messageToReveal ! msg
       case _ =>
     }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
@@ -29,7 +29,6 @@ import com.waz.api.{ContentSearchQuery, Message}
 import com.waz.model.{Mention, MessageContent, MessageData}
 import com.waz.service.messages.MessageAndLikes
 import com.waz.service.tracking.TrackingService
-import com.waz.threading.Threading
 import com.waz.utils.events.Signal
 import com.waz.zclient.collection.controllers.{CollectionController, CollectionUtils}
 import com.waz.zclient.common.controllers.global.AccentColorController
@@ -87,7 +86,7 @@ class TextPartView(context: Context, attrs: AttributeSet, style: Int)
   } yield
     CollectionUtils.getHighlightedSpannableString(content, ContentSearchQuery.transliterated(content), query.elements, ColorUtils.injectAlpha(0.5f, color.color))._1
 
-  searchResultText.on(Threading.Ui) { textView.setText }
+  searchResultText.onUi { textView.setText }
 
   private def setText(text: String): Unit = { // TODO: remove try/catch blocks when the bug is fixed
     try {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/ContentSearchQuery.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/ContentSearchQuery.scala
@@ -19,7 +19,7 @@ package com.waz.api
 
 import com.waz.utils.Locales
 
-case class ContentSearchQuery(originalString: String){
+case class ContentSearchQuery(originalString: String) {
   import ContentSearchQuery._
 
   lazy val elements : Set[String] =
@@ -31,7 +31,8 @@ case class ContentSearchQuery(originalString: String){
       .toSet
 
   override def toString = elements.mkString(" ")
-  def toFtsQuery = elements.map(_ + "*").mkString(" ")
+
+  def toFtsQuery = toString.concat("*")
 
   def isEmpty = elements.isEmpty
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -68,8 +68,7 @@ class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorag
       cursor <- storage.read(MessageContentIndexDao.findContent(contentSearchQuery, convId)(_)) // find messages
       _ <- getAll(CursorIterator.list[MessageId](cursor, close = false)(MsgIdReader)) // prefetch index entries to ensure following get calls are fast
       lastRead <- convId.fold2(Future.successful(None), conversationStorage.get(_).map(_.map(_.lastRead)))
-    } yield
-      new MessagesCursor(cursor, 0, lastRead.getOrElse(RemoteInstant.Epoch), loader, tracking)(MessagesCursor.Descending)
+    } yield new MessagesCursor(cursor, 0, lastRead.getOrElse(RemoteInstant.Epoch), loader, tracking)(MessagesCursor.Descending)
 
   def matchingMessages(contentSearchQuery: ContentSearchQuery, convId: Option[ConvId]): Future[Set[MessageId]] =
     storage.read { implicit db =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are two issues resolved in this PR around message search: 

1. Duplicated messages when you selected a searched message (refer to the image in Notes) 

2. Message list doesn't scroll to the selected message from the search ([refer to the JIRA ticket](https://wearezeta.atlassian.net/browse/AN-6748))

### Causes

1. Is caused by the way we query special characters in the FTS4 `MessageContentIndex` table. Previously, we were adding an (*) to to help the `MATCH` query after every word or element. 

2. When we made changes in the past around https://github.com/wireapp/wire-android/pull/2673, we were fixing an `IndexOutOfBoundsException` caused in the way we scroll endlessly. However, this introduced the bug for not being able to automatically scroll when we select a searched message. 

### Solutions

1. Instead of adding an (*) for wildcard symbols after every element, we now add it after the full query is created so that we can still tell the query to look out of wildcard characters without confusing the reference we return from said query. 

2. Reverting the changes from https://github.com/wireapp/wire-android/pull/2673 and also upgrading the paging library to 2.1.2 as according to the [release notes](https://developer.android.com/jetpack/androidx/releases/paging#version_212_3) fixes this issue and may also fix the `IndexOutOfBoundsException` we were facing previously. 

The release notes state:

> Fix for IndexOutOfBoundsException in rare cases when converting a position during invalidation.

### Testing

We need to test 3 things here: 

1. When we search a message in a conversation it scrolls to that particular message when we select it 

2. When we search a message in a conversation that it doesn't show a duplicated message at the bottom and the original position like it does in the screenshot below 

3. We also need to confirm this change doesn't reintroduce the `IndexOutOfBoundsException` we faced previously. 

## Notes

Screenshot of the first issue: 

![duplicated_searched_message](https://user-images.githubusercontent.com/57259490/82792094-1f2fb480-9e6f-11ea-81f6-4d45d9068f42.png)


#### APK
[Download build #2124](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2124/artifact/build/artifact/wire-dev-PR2856-2124.apk)