### PR TITLE
fix: System messages on the user being removed/leaving the conversation or team

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -454,6 +454,9 @@ object MessageData extends
     def findSystemMessage(conv: ConvId, serverTime: RemoteInstant, tpe: Message.Type, sender: UserId)(implicit db: DB) =
       iterating(db.query(table.name, null, s"${Conv.name} = '${conv.str}' and ${Time.name} = ${Time(serverTime)} and ${Type.name} = '${Type(tpe)}' and ${User.name} = '${User(sender)}'", null, null, null, s"${Time.name} DESC"))
 
+    def findLastSystemMessage(conv: ConvId, tpe: Message.Type, sender: UserId)(implicit db: DB) =
+      iterating(db.query(table.name, null, s"${Conv.name} = '${conv.str}' and ${Type.name} = '${Type(tpe)}' and ${User.name} = '${User(sender)}'", null, null, null, s"${Time.name} DESC LIMIT 1"))
+
     def getAssetIds(messageIds: Set[MessageId])(implicit db:DB) = {
       val idList = messageIds.map(t => s"'${Id(t)}'").mkString("(", "," , ")")
       iteratingWithReader(AssetIdReader)(db.rawQuery(s"SELECT ${AssetId.name} FROM ${table.name} WHERE ${Id.name} IN $idList"))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -29,6 +29,7 @@ import com.waz.service.UserSearchService.UserSearchEntry
 import com.waz.service.UserService._
 import com.waz.service.assets.{AssetService, AssetStorage, Content, ContentForUpload, NoEncryption}
 import com.waz.service.conversation.SelectedConversationService
+import com.waz.service.messages.MessagesService
 import com.waz.service.push.PushService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.AssetClient.Retention
@@ -100,7 +101,9 @@ class UserServiceImpl(selfUserId:        UserId,
                       sync:              SyncServiceHandle,
                       assetsStorage:     AssetStorage,
                       credentialsClient: CredentialsUpdateClient,
-                      selectedConv:      SelectedConversationService) extends UserService with DerivedLogTag {
+                      selectedConv:      SelectedConversationService,
+                      messages:          MessagesService
+                     ) extends UserService with DerivedLogTag {
 
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
@@ -163,6 +166,7 @@ class UserServiceImpl(selfUserId:        UserId,
     for {
       members <- membersStorage.getByUsers(ids)
       _       <- membersStorage.removeAll(members.map(_.id).toSet)
+      _       <- Future.sequence(members.map(m => messages.addMemberLeaveMessage(m.convId, selfUserId, m.userId)))
       _       <- usersStorage.updateAll2(ids, _.copy(deleted = true))
     } yield ()
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -62,7 +62,7 @@ trait MessagesService {
 
   //TODO forceCreate is a hacky workaround for a bug where previous system messages are not marked as SENT. Do NOT use!
   def addMemberJoinMessage(convId: ConvId, creator: UserId, users: Set[UserId], firstMessage: Boolean = false, forceCreate: Boolean = false): Future[Option[MessageData]]
-  def addMemberLeaveMessage(convId: ConvId, selfUserId: UserId, user: UserId): Future[Any]
+  def addMemberLeaveMessage(convId: ConvId, remover: UserId, user: UserId): Future[Any]
   def addRenameConversationMessage(convId: ConvId, selfUserId: UserId, name: Name): Future[Option[MessageData]]
   def addReceiptModeChangeMessage(convId: ConvId, from: UserId, receiptMode: Int): Future[Option[MessageData]]
   def addTimerChangedMessage(convId: ConvId, from: UserId, duration: Option[FiniteDuration], time: RemoteInstant): Future[Unit]
@@ -364,7 +364,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
     }
 
     // check if we have local leave message with same users
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_LEAVE) flatMap {
+    storage.lastLocalMessage(convId, Message.Type.MEMBER_LEAVE).flatMap {
       case Some(msg) if users.exists(msg.members) =>
         val toRemove = msg.members -- users
         val toAdd = users -- msg.members
@@ -377,8 +377,8 @@ class MessagesServiceImpl(selfUserId:      UserId,
     }
   }
 
-  def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Any] = {
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN) flatMap {
+  def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Any] =
+    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN).flatMap {
       case Some(msg) =>
         val members = msg.members -- users
         if (members.isEmpty) {
@@ -390,20 +390,17 @@ class MessagesServiceImpl(selfUserId:      UserId,
         warn(l"removeLocalMemberJoinMessage: no local join message found")
         CancellableFuture.successful(())
     }
-  }
 
-  override def addMemberLeaveMessage(convId: ConvId, selfUserId: UserId, user: UserId) = {
+  override def addMemberLeaveMessage(convId: ConvId, remover: UserId, user: UserId): Future[Any] =
     // check if we have local join message with this user and just remove him from the list
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN) flatMap {
+    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN).flatMap {
       case Some(msg) if msg.members == Set(user) => updater.deleteMessage(msg) // FIXME: race condition
       case Some(msg) if msg.members(user) => updater.updateMessage(msg.id)(_.copy(members = msg.members - user)) // FIXME: race condition
       case _ =>
-        // check for local MemberLeave message before creating new one
-        def newMessage = MessageData(MessageId(), convId, Message.Type.MEMBER_LEAVE, selfUserId, members = Set(user))
+        val newMessage = MessageData(MessageId(), convId, Message.Type.MEMBER_LEAVE, remover, members = Set(user))
         def update(msg: MessageData) = msg.copy(members = msg.members + user)
         updater.updateOrCreateLocalMessage(convId, Message.Type.MEMBER_LEAVE, update, newMessage)
     }
-  }
 
   override def addOtrVerifiedMessage(convId: ConvId) =
     storage.getLastMessage(convId) flatMap {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -105,7 +105,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       val event = MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap)
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, MEMBER_JOIN, sender).returning(Future.successful(false))
-      (storage.lastLocalMessage _).expects(conv.id, MEMBER_JOIN).returning(Future.successful(None))
+      (storage.getLastSystemMessage _).expects(conv.id, MEMBER_JOIN, sender).returning(Future.successful(None))
       (storage.addMessage _).expects(*).once().onCall { m: MessageData =>
         messagesInStorage.mutate(_ ++ Seq(m))
         Future.successful(m)
@@ -163,7 +163,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       val event = RenameConversationEvent(conv.remoteId, RemoteInstant(clock.instant()), selfUserId, Name("new name"))
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, RENAME, selfUserId).returning(Future.successful(false))
-      (storage.lastLocalMessage _).expects(conv.id, RENAME).returning(Future.successful(Some(localMsg)))
+      (storage.getLastSystemMessage _).expects(conv.id, RENAME, selfUserId).returning(Future.successful(Some(localMsg)))
       (storage.remove (_: MessageId)).expects(localMsg.id).returning(Future.successful({}))
       (storage.addMessage _).expects(*).onCall { msg : MessageData =>
         messagesInStorage.mutate(_ ++ Seq(msg))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
@@ -151,6 +151,10 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(*, *)
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
+      (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
+      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, selfUserId).atLeastOnce().returning(
+        Future.successful(())
+      )
 
       // EXPECT
       (content.updateConversationState _).expects(where { (id, state) =>
@@ -175,8 +179,9 @@ class ConversationServiceSpec extends AndroidFreeSpec {
         muted = MuteSet.AllMuted
       )
 
+      val remover = UserId()
       val events = Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), UserId(), Seq(selfUserId))
+        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), remover, Seq(selfUserId))
       )
 
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
@@ -188,6 +193,10 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(*, *)
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
+      (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
+      (messages.addMemberLeaveMessage _).expects(convId, remover, selfUserId).atLeastOnce().returning(
+        Future.successful(())
+      )
 
       // EXPECT
       (content.updateConversationState _).expects(*, *).never()
@@ -226,6 +235,10 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
       (messages.getAssetIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
+      (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
+      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, otherUserId).atLeastOnce().returning(
+        Future.successful(())
+      )
 
       // EXPECT
       (content.updateConversationState _).expects(*, *).never()


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6859
fixes https://wearezeta.atlassian.net/browse/AN-6909

In the past, when a user was removed from a conversation, a `MemberLeaveEvent` should have come and only in the response to that event we should have displayed a system message "User left" or "User was removed" or "You removed user" or "Another user removed user". Now the situation became more complex: We can no longer rely on events and a user may be removed
from the conversation because they were removed from the team entirely (which we can discover either because of another event type, `MemberEvent.MemberLeave` or in a few different ways.

This PR ensures that we display system messages when we discover that the user left or was
removed from the conversation in any of those ways and also tries to find out if we don't
do it more than once.

#### APK
[Download build #2139](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2139/artifact/build/artifact/wire-dev-PR2859-2139.apk)
[Download build #2157](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2157/artifact/build/artifact/wire-dev-PR2859-2157.apk)