### PR TITLE
Fixed the crash related to Android lollipop due to the API 23 minimum…

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
@@ -97,28 +97,25 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
 
   def currentTonePrefs: (String, String, String) = tonePrefs.currentValue.getOrElse((null, null, null))
 
-  private def matchCallToneSettings(callToneSetting: Int, shouldPrioritise: Boolean = false): Boolean = callToneSetting match {
-    case NotificationManager.INTERRUPTION_FILTER_ALL      =>
-      true
-    case NotificationManager.INTERRUPTION_FILTER_PRIORITY =>
-      if (shouldPrioritise) { val policy = notificationManager.getNotificationPolicy
-      (policy.priorityCallSenders == NotificationManager.Policy.PRIORITY_SENDERS_ANY
-        || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_CALLS
-        || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_REPEAT_CALLERS)
-      } else true
-    case NotificationManager.INTERRUPTION_FILTER_UNKNOWN  =>
-      true
-    case NotificationManager.INTERRUPTION_FILTER_ALARMS   =>
-      false
-    case NotificationManager.INTERRUPTION_FILTER_NONE     =>
-      true
-  }
-
   private def shouldPlayCallTone: Boolean = if (Build.VERSION.SDK_INT >= 23) {
     matchCallToneSettings(notificationManager.getCurrentInterruptionFilter, shouldPrioritise = true)
   } else {
     matchCallToneSettings(Settings.Global.getInt(cxt.getContentResolver, "zen_mode"))
   }
+
+  private def matchCallToneSettings(callToneSetting: Int, shouldPrioritise: Boolean = false): Boolean = callToneSetting match {
+      case NotificationManager.INTERRUPTION_FILTER_ALL      => true
+      case NotificationManager.INTERRUPTION_FILTER_PRIORITY => if (shouldPrioritise) {
+        val policy = notificationManager.getNotificationPolicy
+        (policy.priorityCallSenders == NotificationManager.Policy.PRIORITY_SENDERS_ANY
+          || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_CALLS
+          || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_REPEAT_CALLERS)
+      } else true
+      case NotificationManager.INTERRUPTION_FILTER_UNKNOWN  => true
+      case NotificationManager.INTERRUPTION_FILTER_ALARMS   => false
+      case NotificationManager.INTERRUPTION_FILTER_NONE     => true
+      case _                                                => true
+    }
 
   private val tonePrefs = (for {
     zms <- zms

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
@@ -21,7 +21,8 @@ import android.app.NotificationManager
 import android.content.Context
 import android.media.AudioManager
 import android.net.Uri
-import android.os.Vibrator
+import android.os.{Build, Vibrator}
+import android.provider.Settings
 import android.text.TextUtils
 import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag
@@ -96,20 +97,27 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
 
   def currentTonePrefs: (String, String, String) = tonePrefs.currentValue.getOrElse((null, null, null))
 
-  private def shouldPlayCallTone = notificationManager.getCurrentInterruptionFilter match {
+  private def matchCallToneSettings(callToneSetting: Int, shouldPrioritise: Boolean = false): Boolean = callToneSetting match {
     case NotificationManager.INTERRUPTION_FILTER_ALL      =>
       true
     case NotificationManager.INTERRUPTION_FILTER_PRIORITY =>
-      val policy = notificationManager.getNotificationPolicy
+      if (shouldPrioritise) { val policy = notificationManager.getNotificationPolicy
       (policy.priorityCallSenders == NotificationManager.Policy.PRIORITY_SENDERS_ANY
         || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_CALLS
         || policy.priorityCategories == NotificationManager.Policy.PRIORITY_CATEGORY_REPEAT_CALLERS)
+      } else true
     case NotificationManager.INTERRUPTION_FILTER_UNKNOWN  =>
       true
     case NotificationManager.INTERRUPTION_FILTER_ALARMS   =>
       false
     case NotificationManager.INTERRUPTION_FILTER_NONE     =>
       true
+  }
+
+  private def shouldPlayCallTone: Boolean = if (Build.VERSION.SDK_INT >= 23) {
+    matchCallToneSettings(notificationManager.getCurrentInterruptionFilter, shouldPrioritise = true)
+  } else {
+    matchCallToneSettings(Settings.Global.getInt(cxt.getContentResolver, "zen_mode"))
   }
 
   private val tonePrefs = (for {


### PR DESCRIPTION
… for interruption filter

## What's new in this PR?

### Issues

Crash on 5.0 and 5.1 reported on the Google Play Console

### Causes

Calling a method that was introduced in API 23 

### Solutions

Have current functionality work with API 23 or above check in place and have 5.0 + 5.1 work with DND settings without priority configurations in place. 

### Testing

Android 5.0 + 5.1 

Scenario 1: Phone is on silent
1. Go to sound settings settings + put phone on silent
2. Sign in to User A on any device 
3. Sign in to User B on Android device 
4. Leave app in background 
5. User A should ring User B
6. No ringtone should be triggered but a banner notification will still appear (depending on manufacturer) 

Scenario 2 Phone is on loud 
1.  Go to Sound settings and toggle ring volume up 
2. Only accept interruptions from everyone who is calling 
3. Sign in to User A on any device 
4. Sign in to User B on Android device 
5. Leave app in background 
6. User A should ring User B
7. Ringtone should be triggered and banner notification will appear from the top down and in the banner notification box
