### PR TITLE
[Feature] AVS error alert

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,11 @@
     <string name="call_banner_incoming_group">%1$s \u30FB %2$s is calling…</string>
     <string name="call_banner_tap_to_return_to_call">Tap to return to call \u30FB %1$s</string>
 
+    <string name="call_error_unsupported_version_title">Please update Wire</string>
+    <string name="call_error_unsupported_version_message">You received a call that isn\'t supported by this version of Wire.\n\nGet the latest version in the Play Store.</string>
+    <string name="call_error_unsupported_version_button_ok">Go to Play Store</string>
+    <string name="call_error_unsupported_version_button_dismiss">Later</string>
+
     <string name="calling_ongoing_call_title">Ongoing call</string>
 
     <string name="calling_ongoing_call_start_message">A call is active in another conversation.\nCalling here will hang up the other call.</string>

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -204,5 +204,7 @@
     <string translatable="false" name="url_contact_support">https://support.wire.com/hc/requests/new</string>
     <string translatable="false" name="url_invalid_email_help">https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-</string>
     <string translatable="false" name="url_teams_set_email_about">https://support.wire.com/hc/en-us/articles/115004082129</string>
+
+    <string translatable="false" name="url_play_store_listing">http://play.google.com/store/apps/details?id=com.wire</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -18,12 +18,11 @@
 package com.waz.zclient
 
 import android.app.Activity
+import android.content.Intent
 import android.content.res.Configuration
-import android.content.{DialogInterface, Intent}
 import android.graphics.drawable.ColorDrawable
 import android.graphics.{Color, Paint, PixelFormat}
 import android.os.{Build, Bundle}
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.{Fragment, FragmentTransaction}
 import com.waz.content.UserPreferences._
 import com.waz.content.{TeamsStorage, UserPreferences}
@@ -33,7 +32,6 @@ import com.waz.model._
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
 import com.waz.service.AccountsService.UserInitiated
 import com.waz.service.ZMessaging.clock
-import com.waz.service.call.Avs.AvsCallError
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
@@ -228,18 +226,20 @@ class MainActivity extends BaseActivity
         startFirstFragment()
     }
 
-    callController.onCallError.onUi {
-      case AvsCallError.UnknownProtocol =>
-        new AlertDialog.Builder(this)
-          .setTitle(R.string.call_error_unsupported_version_title)
-          .setMessage(R.string.call_error_unsupported_version_message)
-          .setPositiveButton(R.string.call_error_unsupported_version_button_ok, new DialogInterface.OnClickListener {
-            override def onClick(dialog: DialogInterface, which: AvsCallError): Unit = inject[BrowserController].openPlayStoreListing()
-          })
-          .setNegativeButton(R.string.call_error_unsupported_version_button_dismiss, null)
-          .show()
-      case _ =>
+    userPreferences.flatMap(_.preference[Boolean](UserPreferences.ShouldWarnAVSUpgrade).signal).onUi { shouldWarn =>
+      if (shouldWarn) {
+        accentColorController.accentColor.foreach { accentColor =>
+          showAVSUpgradeWarning(accentColor) { didConfirm =>
+            if (didConfirm) inject[BrowserController].openPlayStoreListing()
+          }
+        }
+
+        userPreferences.foreach { prefs =>
+          prefs(UserPreferences.ShouldWarnAVSUpgrade) := false
+        }
+      }
     }
+
   }
 
   override def onStart(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -228,14 +228,13 @@ class MainActivity extends BaseActivity
 
     userPreferences.flatMap(_.preference[Boolean](UserPreferences.ShouldWarnAVSUpgrade).signal).onUi { shouldWarn =>
       if (shouldWarn) {
-        accentColorController.accentColor.foreach { accentColor =>
+        accentColorController.accentColor.head.foreach { accentColor =>
           showAVSUpgradeWarning(accentColor) { didConfirm =>
             if (didConfirm) inject[BrowserController].openPlayStoreListing()
+            userPreferences.head.foreach { prefs =>
+              prefs(UserPreferences.ShouldWarnAVSUpgrade) := false
+            }
           }
-        }
-
-        userPreferences.foreach { prefs =>
-          prefs(UserPreferences.ShouldWarnAVSUpgrade) := false
         }
       }
     }

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -18,11 +18,12 @@
 package com.waz.zclient
 
 import android.app.Activity
-import android.content.Intent
 import android.content.res.Configuration
+import android.content.{DialogInterface, Intent}
 import android.graphics.drawable.ColorDrawable
 import android.graphics.{Color, Paint, PixelFormat}
 import android.os.{Build, Bundle}
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.{Fragment, FragmentTransaction}
 import com.waz.content.UserPreferences._
 import com.waz.content.{TeamsStorage, UserPreferences}
@@ -32,6 +33,7 @@ import com.waz.model._
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
 import com.waz.service.AccountsService.UserInitiated
 import com.waz.service.ZMessaging.clock
+import com.waz.service.call.Avs.AvsCallError
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.utils.events.Signal
@@ -40,7 +42,7 @@ import com.waz.zclient.Intents.{RichIntent, _}
 import com.waz.zclient.SpinnerController.{Hide, Show}
 import com.waz.zclient.appentry.AppEntryActivity
 import com.waz.zclient.common.controllers.global.{AccentColorController, KeyboardController, PasswordController}
-import com.waz.zclient.common.controllers.{SharingController, UserAccountsController}
+import com.waz.zclient.common.controllers.{BrowserController, SharingController, UserAccountsController}
 import com.waz.zclient.controllers.navigation.{NavigationControllerObserver, Page}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
@@ -224,6 +226,19 @@ class MainActivity extends BaseActivity
       case Some(_) =>
         verbose(l"the default path (no deep link, or a link handled later)")
         startFirstFragment()
+    }
+
+    callController.onCallError.onUi {
+      case AvsCallError.UnknownProtocol =>
+        new AlertDialog.Builder(this)
+          .setTitle(R.string.call_error_unsupported_version_title)
+          .setMessage(R.string.call_error_unsupported_version_message)
+          .setPositiveButton(R.string.call_error_unsupported_version_button_ok, new DialogInterface.OnClickListener {
+            override def onClick(dialog: DialogInterface, which: AvsCallError): Unit = inject[BrowserController].openPlayStoreListing()
+          })
+          .setNegativeButton(R.string.call_error_unsupported_version_button_dismiss, null)
+          .show()
+      case _ =>
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -25,7 +25,7 @@ import com.waz.content.GlobalPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.ZMessaging.clock
-import com.waz.service.call.Avs.{AvsCallError, VideoState}
+import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo.CallState.{SelfJoining, _}
 import com.waz.service.call.CallInfo.Participant
 import com.waz.service.call.{CallInfo, CallingService, GlobalCallingService}
@@ -187,11 +187,6 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       cs <- callingService
       c  <- callConvId
     } yield (cs, c)
-
-  val onCallError = callingService
-    .flatMap(_.callError)
-    .onChanged
-    .filter { _ != AvsCallError.None }
 
   private val zmsConvId = callingZms.zip(callConvId)
   val conversation: Signal[ConversationData] = zmsConvId.flatMap { case (z, cId) => z.convsStorage.signal(cId) }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -25,7 +25,7 @@ import com.waz.content.GlobalPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.ZMessaging.clock
-import com.waz.service.call.Avs.VideoState
+import com.waz.service.call.Avs.{AvsCallError, VideoState}
 import com.waz.service.call.CallInfo.CallState.{SelfJoining, _}
 import com.waz.service.call.CallInfo.Participant
 import com.waz.service.call.{CallInfo, CallingService, GlobalCallingService}
@@ -188,6 +188,10 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       c  <- callConvId
     } yield (cs, c)
 
+  val onCallError = callingService
+    .flatMap(_.callError)
+    .onChanged
+    .filter { _ != AvsCallError.None }
 
   private val zmsConvId = callingZms.zip(callConvId)
   val conversation: Signal[ConversationData] = zmsConvId.flatMap { case (z, cId) => z.convsStorage.signal(cId) }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/BrowserController.scala
@@ -58,6 +58,9 @@ class BrowserController(implicit context: Context, injector: Injector) extends I
       location.getZoom,
       location.getName)) foreach { context.startActivity }
 
+  def openPlayStoreListing(): Unit =
+    openUrl(getString(R.string.url_play_store_listing))
+
   // Accounts
 
   def openForgotPassword(): Try[Unit] =

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -325,4 +325,14 @@ object ContextUtils {
       Future.successful(())
     }
   }
+
+  def showAVSUpgradeWarning(color: AccentColor)(onConfirm: Boolean => Unit)(implicit ex: ExecutionContext, context: Context): Unit = {
+    showConfirmationDialog(
+      title = getString(R.string.call_error_unsupported_version_title),
+      msg = getString(R.string.call_error_unsupported_version_message),
+      positiveRes = R.string.call_error_unsupported_version_button_ok,
+      negativeRes = R.string.call_error_unsupported_version_button_dismiss,
+      color
+    ).foreach(onConfirm)
+  }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -498,4 +498,6 @@ object UserPreferences {
   lazy val ConversationFoldersUiState = PrefKey[Map[FolderId, Boolean]]("conversation_folders_ui_state", customDefault = Map.empty)
 
   lazy val FailedPasswordAttempts = PrefKey[Int]("failed_password_attempts", customDefault = 0)
+
+  lazy val ShouldWarnAVSUpgrade = PrefKey[Boolean]("should_warn_avs_upgrade", customDefault = false)
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -42,7 +42,7 @@ trait Avs {
   def answerCall(wCall: WCall, convId: RConvId, callType: WCallType.Value, cbrEnabled: Boolean): Unit
   def onHttpResponse(wCall: WCall, status: Int, reason: String, arg: Pointer): Future[Unit]
   def onConfigRequest(wCall: WCall, error: Int, json: String): Future[Unit]
-  def onReceiveMessage(wCall: WCall, msg: String, currTime: LocalInstant, msgTime: RemoteInstant, convId: RConvId, userId: UserId, clientId: ClientId): Unit
+  def onReceiveMessage(wCall: WCall, msg: String, currTime: LocalInstant, msgTime: RemoteInstant, convId: RConvId, userId: UserId, clientId: ClientId): Future[Int]
   def endCall(wCall: WCall, convId: RConvId): Unit
   def rejectCall(wCall: WCall, convId: RConvId): Unit
   def setVideoSendState(wCall: WCall, convId: RConvId, state: VideoState.Value): Unit
@@ -183,9 +183,9 @@ class AvsImpl() extends Avs with DerivedLogTag {
   override def onHttpResponse(wCall: WCall, status: Int, reason: String, arg: Pointer) =
     withAvs(wcall_resp(wCall, status, reason, arg))
 
-  override def onReceiveMessage(wCall: WCall, msg: String, currTime: LocalInstant, msgTime: RemoteInstant, convId: RConvId, from: UserId, sender: ClientId) = {
+  override def onReceiveMessage(wCall: WCall, msg: String, currTime: LocalInstant, msgTime: RemoteInstant, convId: RConvId, from: UserId, sender: ClientId): Future[Int] = {
     val bytes = msg.getBytes("UTF-8")
-    withAvs(wcall_recv_msg(wCall, bytes, bytes.length, uint32_tTime(currTime.instant), uint32_tTime(msgTime.instant), convId.str, from.str, sender.str))
+    withAvsReturning(wcall_recv_msg(wCall, bytes, bytes.length, uint32_tTime(currTime.instant), uint32_tTime(msgTime.instant), convId.str, from.str, sender.str), onFailure = 0)
   }
 
   override def onConfigRequest(wCall: WCall, error: Int, json: String): Future[Unit] =
@@ -217,6 +217,12 @@ object Avs extends DerivedLogTag {
 
   def uint32_tTime(instant: Instant) =
     returning(Uint32_t((instant.toEpochMilli / 1000).toInt))(t => verbose(l"uint32_tTime for $instant = ${t.value}"))
+
+  type AvsCallError = Int
+  object AvsCallError {
+    val None = 0
+    val UnknownProtocol = 1000
+  }
 
   /**
     * NOTE: All values should be kept up to date as defined in:

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -528,7 +528,7 @@ class CallingServiceImpl(val accountId:       UserId,
       val curTime = LocalInstant(clock.instant + drift)
       verbose(l"Received msg for avs: localTime: ${clock.instant} curTime: $curTime, drift: $drift, msgTime: $msgTime")
       avs.onReceiveMessage(w, msg, curTime, msgTime, convId, from, sender).foreach { result =>
-        userPrefs(UserPreferences.ShouldWarnAVSUpgrade) := result == AvsCallError.UnknownProtocol
+        userPrefs(UserPreferences.ShouldWarnAVSUpgrade).mutate(_ | result == AvsCallError.UnknownProtocol)
       }
     }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -25,8 +25,8 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.content.GlobalPreferences.SkipTerminatingState
 import com.waz.content.{GlobalPreferences, MembersStorage, UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.log.LogShow.SafeToLog
 import com.waz.log.LogSE._
+import com.waz.log.LogShow.SafeToLog
 import com.waz.model.otr.ClientId
 import com.waz.model.{ConvId, RConvId, UserId, _}
 import com.waz.permissions.PermissionsService
@@ -35,9 +35,9 @@ import com.waz.service.ZMessaging.clock
 import com.waz.service._
 import com.waz.service.call.Avs.AvsClosedReason.{StillOngoing, reasonString}
 import com.waz.service.call.Avs.VideoState._
-import com.waz.service.call.Avs.{AvsClosedReason, VideoState, WCall}
-import com.waz.service.call.CallInfo.{CallState, Participant}
+import com.waz.service.call.Avs.{AvsCallError, AvsClosedReason, VideoState, WCall}
 import com.waz.service.call.CallInfo.CallState._
+import com.waz.service.call.CallInfo.{CallState, Participant}
 import com.waz.service.call.CallingService.GlobalCallProfile
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService}
 import com.waz.service.messages.MessagesService
@@ -78,6 +78,7 @@ trait CallingService {
   def calls:          Signal[Map[ConvId, CallInfo]]
   def joinableCalls:  Signal[Map[ConvId, CallInfo]]
   def currentCall:    Signal[Option[CallInfo]]
+  def callError:      Signal[AvsCallError]
 
   /**
     * @param skipTerminating Used to skip the terminating state when the self user ends the call
@@ -190,8 +191,9 @@ class CallingServiceImpl(val accountId:       UserId,
   override val calls          = callProfile.map(_.calls).disableAutowiring() //all calls
   override val joinableCalls  = callProfile.map(_.joinableCalls).disableAutowiring() //any call a user can potentially join in the UI
   override val currentCall    = callProfile.map(_.activeCall).disableAutowiring() //state about any call for which we should show the CallingActivity
-  val joinableCallsNotMuted   = joinableCalls.map(_.filter { case (_, call) => call.shouldRing })
+  override val callError    = Signal(AvsCallError.None)
 
+  val joinableCallsNotMuted   = joinableCalls.map(_.filter { case (_, call) => call.shouldRing })
 
   //exposed for tests only
   private[call] lazy val wCall = returningF(avs.registerAccount(this)) { call =>
@@ -527,7 +529,9 @@ class CallingServiceImpl(val accountId:       UserId,
       val drift = pushService.beDrift.currentValue.getOrElse(Duration.ZERO)
       val curTime = LocalInstant(clock.instant + drift)
       verbose(l"Received msg for avs: localTime: ${clock.instant} curTime: $curTime, drift: $drift, msgTime: $msgTime")
-      avs.onReceiveMessage(w, msg, curTime, msgTime, convId, from, sender)
+      avs.onReceiveMessage(w, msg, curTime, msgTime, convId, from, sender).foreach { result =>
+        callError ! result
+      }
     }
 
   private def withConv(convId: RConvId)(f: (WCall, ConversationData) => Unit) =


### PR DESCRIPTION
## What's in this PR?

In preparation for conference calls, we need to handle the case where an older client receives a conference call. Since the old client can not connect to the call, we display an alert dialog informing the user to update the client.

When we receive an incoming call message, we pass it along to AVS. If AVS detects that it is a conference call and the current client version does not support it, it will return an error code `1000` corresponding to `WCALL_ERROR_UNKNOWN_PROTOCOL`. When this happens, we need to propagate the event up to the UI and display the alert.

There are two cases in which the alert is shown:

1. If the app is in the foreground, it will be displayed as soon as the error occurs.
2. If the app is in the background, it will be displayed as soon as the app comes back to the foreground.
#### APK
[Download build #2171](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2171/artifact/build/artifact/wire-dev-PR2862-2171.apk)
[Download build #2172](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2172/artifact/build/artifact/wire-dev-PR2862-2172.apk)