### PR TITLE
Deleted conversation names

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -223,7 +223,8 @@ class TeamsServiceImpl(selfUser:           UserId,
       warn(l"Self user removed from team")
       Future.successful {}
     } else
-      userService.deleteUsers(members)
+    // remove users from convs before deleting them so we still have their data when generating system messages
+      convsService.deleteMembersFromConversations(members).flatMap(_ => userService.deleteUsers(members))
   }
   
   //So far, a member update just means we need to check the permissions for that user, and we only care about permissions

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationServiceSpec.scala
@@ -155,6 +155,8 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (messages.addMemberLeaveMessage _).expects(convId, selfUserId, selfUserId).atLeastOnce().returning(
         Future.successful(())
       )
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
+      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
 
       // EXPECT
       (content.updateConversationState _).expects(where { (id, state) =>
@@ -197,6 +199,8 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (messages.addMemberLeaveMessage _).expects(convId, remover, selfUserId).atLeastOnce().returning(
         Future.successful(())
       )
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
+      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
 
       // EXPECT
       (content.updateConversationState _).expects(*, *).never()
@@ -389,6 +393,9 @@ class ConversationServiceSpec extends AndroidFreeSpec {
         Future.successful(userIds.map(uId => ConversationMemberData(uId, convId, AdminRole)).toIndexedSeq)
       }
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conversationData)))
+      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
+
 
       //EXPECT
       (receiptStorage.removeAllForMessages _).expects(Set(messageId)).once().returning(Future.successful(()))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -38,7 +38,7 @@ import org.threeten.bp.Instant
 
 import scala.concurrent.Future
 
-class ConversationServiceSpec extends AndroidFreeSpec {
+class ConversationsServiceSpec extends AndroidFreeSpec {
   import ConversationRole._
 
   private lazy val content        = mock[ConversationsContentUpdater]
@@ -137,13 +137,19 @@ class ConversationServiceSpec extends AndroidFreeSpec {
         archived = false,
         muted = MuteSet.AllMuted
       )
+      val selfMember = ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)
 
       val events = Seq(
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(selfUserId))
       )
 
+      // check if the self is still in any conversation (they are - with self)
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
-        Future.successful(IndexedSeq(ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)))
+        Future.successful(IndexedSeq(selfMember))
+      )
+      // check if anyone is still in the conversation (no)
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(
+        Future.successful(IndexedSeq.empty)
       )
       (content.convByRemoteId _).expects(*).anyNumberOfTimes().onCall { _: RConvId =>
         Future.successful(Some(convData))
@@ -181,26 +187,29 @@ class ConversationServiceSpec extends AndroidFreeSpec {
         muted = MuteSet.AllMuted
       )
 
-      val remover = UserId()
+      val removerId = UserId()
       val events = Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), remover, Seq(selfUserId))
+        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), removerId, Seq(selfUserId))
       )
 
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)))
       )
-      (content.convByRemoteId _).expects(*).anyNumberOfTimes().onCall { id: RConvId =>
+      (content.convByRemoteId _).expects(*).anyNumberOfTimes().onCall { _: RConvId =>
         Future.successful(Some(convData))
       }
       (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(*, *)
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
-      (messages.addMemberLeaveMessage _).expects(convId, remover, selfUserId).atLeastOnce().returning(
+      (messages.addMemberLeaveMessage _).expects(convId, removerId, selfUserId).atLeastOnce().returning(
         Future.successful(())
       )
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
       (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(
+        Future.successful(IndexedSeq(removerId))
+      )
 
       // EXPECT
       (content.updateConversationState _).expects(*, *).never()
@@ -243,6 +252,10 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       (messages.addMemberLeaveMessage _).expects(convId, selfUserId, otherUserId).atLeastOnce().returning(
         Future.successful(())
       )
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(
+        Future.successful(IndexedSeq(selfUserId))
+      )
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
 
       // EXPECT
       (content.updateConversationState _).expects(*, *).never()
@@ -259,11 +272,19 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       val conversationData = ConversationData(convId, rConvId)
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes()
         .returning(Future.successful(Some(conversationData)))
-      (messages.findMessageIds _).expects(convId).once().returning(Future.successful(Set.empty))
+      (messages.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set.empty))
+      (msgStorage.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set.empty))
+      (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
       (messages.getAssetIds _).expects(*).returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.remove _).expects(convId).once().returning(Future.successful(()))
-      (membersStorage.getActiveUsers _).expects(convId).once().returning(Future.successful(Seq.empty))
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(convId, *).anyNumberOfTimes().returning(Future.successful(Set.empty))
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(None))
+      (membersStorage.getByUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(IndexedSeq.empty))
+      (receiptStorage.removeAllForMessages _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
+      (folders.removeConversationFromAll _).expects(convId, *).anyNumberOfTimes().returning(Future.successful(()))
+      (rolesService.removeByConvId _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
 
       val dummyUserId = UserId()
       val events = Seq(
@@ -289,13 +310,18 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
-      (messages.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
-      (msgStorage.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (messages.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (msgStorage.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
       (messages.getAssetIds _).expects(*).returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
-      (membersStorage.getActiveUsers _).expects(convId).once().returning(Future.successful(Seq.empty))
-
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(convId, *).anyNumberOfTimes().returning(Future.successful(Set.empty))
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(None))
+      (membersStorage.getByUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(IndexedSeq.empty))
+      (receiptStorage.removeAllForMessages _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
+      (folders.removeConversationFromAll _).expects(convId, *).anyNumberOfTimes().returning(Future.successful(()))
+      (rolesService.removeByConvId _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
       //EXPECT
       (convsStorage.remove _).expects(convId).once().returning(Future.successful(()))
 
@@ -314,18 +340,20 @@ class ConversationServiceSpec extends AndroidFreeSpec {
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
-      (messages.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
-      (msgStorage.findMessageIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (messages.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
+      (msgStorage.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set[MessageId]()))
       (messages.getAssetIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set[GeneralAssetId]()))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.remove _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
-      (membersStorage.delete _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
       (receiptStorage.removeAllForMessages _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (folders.removeConversationFromAll _).expects(convId, false).anyNumberOfTimes().returning(Future.successful(()))
       (rolesService.rolesByConvId _).expects(convId).anyNumberOfTimes().returning(Signal.const(Set.empty))
-      (membersStorage.getActiveUsers _).expects(convId).once().returning(Future.successful(Seq.empty))
-
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conversationData)))
+      (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(convId, *).anyNumberOfTimes().returning(Future.successful(Set.empty))
+      (membersStorage.getByUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(IndexedSeq.empty))
+      (rolesService.removeByConvId _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
       // WHEN
       result(service.convStateEventProcessingStage.apply(rConvId, events))
     }
@@ -344,19 +372,25 @@ class ConversationServiceSpec extends AndroidFreeSpec {
 
       val assetId: GeneralAssetId = AssetId()
       val messageId = MessageId()
-      (messages.findMessageIds _).expects(convId).anyNumberOfTimes()
-        .returning(Future.successful(Set(messageId)))
+      (messages.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set(messageId)))
+      (msgStorage.findMessageIds _).expects(convId).anyNumberOfTimes().returning(Future.successful(Set(messageId)))
       (convsStorage.remove _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (membersStorage.remove(_: ConvId, _: Iterable[UserId])).expects(*, *)
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (membersStorage.getByUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Set[UserId] =>
         Future.successful(userIds.map(uId => ConversationMemberData(uId, convId, AdminRole)).toIndexedSeq)
       }
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(IndexedSeq.empty))
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conversationData)))
+      (msgStorage.deleteAll _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
+      (buttons.deleteAllForMessage _).expects(messageId).anyNumberOfTimes().returning(Future.successful(()))
+      (receiptStorage.removeAllForMessages _).expects(Set(messageId)).anyNumberOfTimes().returning(Future.successful(()))
+      (folders.removeConversationFromAll _).expects(convId, *).anyNumberOfTimes().returning(Future.successful(()))
+      (rolesService.removeByConvId _).expects(convId).anyNumberOfTimes().returning(Future.successful(()))
 
       //EXPECT
       (messages.getAssetIds _).expects(Set(messageId)).once().returning(Future.successful(Set(assetId)))
       (assets.deleteAll _).expects(Set(assetId)).once().returning(Future.successful(()))
-      (membersStorage.getActiveUsers _).expects(convId).once().returning(Future.successful(Seq.empty))
 
       // WHEN
       result(service.convStateEventProcessingStage.apply(rConvId, events))
@@ -669,6 +703,79 @@ class ConversationServiceSpec extends AndroidFreeSpec {
 
       val generatedName = Name(List(user2, user3).map(_.name).mkString(", "))
       result(service.conversationName(convId).head) shouldEqual generatedName
+    }
+
+    scenario("Preserve the name after the last other user leaves the conversation") {
+      import com.waz.threading.Threading.Implicits.Background
+
+      val self = UserData(selfUserId.str)
+      val user2 = UserData(name = Name("user2"))
+      val user3 = UserData(name = Name("user3"))
+      val convSignal = Signal(Option(ConversationData(
+        id = convId,
+        remoteId = rConvId,
+        name = None,
+        convType = ConversationType.Group
+      )))
+
+      val userNames = Map(selfUserId -> self.name, user2.id -> user2.name, user3.id -> user3.name)
+
+      val mSelf = ConversationMemberData(self.id,  convId, ConversationRole.AdminRole)
+      val m2    = ConversationMemberData(user2.id, convId, ConversationRole.AdminRole)
+      val m3    = ConversationMemberData(user3.id, convId, ConversationRole.AdminRole)
+
+      val members = Signal(IndexedSeq(mSelf, m2, m3))
+      val membersOnChanged = Signal[Seq[ConversationMemberData]]()
+
+      (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(convSignal)
+      (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head.map(_.map(_.userId)) }
+      (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
+      (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.wrap(membersOnChanged))
+      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
+      (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>
+        members.head.map { ms =>
+          val idSet = userIds.toSet
+          val (removed, left) = ms.partition(m => idSet.contains(m.userId))
+          members ! left
+          membersOnChanged ! left
+          removed.toSet
+        }
+      }
+
+      (membersStorage.getByUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Set[UserId] =>
+        members.head.map(_.filter(m => userIds.contains(m.userId)))
+      }
+      (usersStorage.updateAll2 _).expects(*, *).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+
+      (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(convSignal.head)
+      (content.updateConversationName _).expects(convId, *).once().onCall { (_: ConvId, name: Name) =>
+        convSignal.head.collect { case Some(conv) =>
+          val newConv = conv.copy(name = Some(name))
+          convSignal ! Some(newConv)
+          Some((conv, newConv))
+        }
+      }
+      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, *).anyNumberOfTimes().returning(Future.successful(()))
+
+      val service = this.service
+
+      result(service.conversationName(convId).head) shouldEqual Name(List(user2, user3).map(_.name).mkString(", "))
+
+      result(service.convStateEventProcessingStage.apply(rConvId, Seq(
+        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(user3.id))
+      )))
+      awaitAllTasks
+      result(members.head.map(_.size)) shouldEqual 2
+      result(service.conversationName(convId).head) shouldEqual user2.name
+
+      result(service.convStateEventProcessingStage.apply(rConvId, Seq(
+        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(user2.id))
+      )))
+      awaitAllTasks
+      result(members.head.map(_.size)) shouldEqual 1
+      result(members.head.map(_.head.userId)) shouldEqual selfUserId
+      result(service.conversationName(convId).head) shouldEqual user2.name
     }
   }
 }


### PR DESCRIPTION
Right now we decide on conversation names basing on either that they have their own names or on usernames of its members. This creates a problem with fake 1:1 conversations, and some old group conversations, when the other user leaves. We no longer have information about the other member of the conversation, but also the conversation doesn't have its own name. On the other hand, we don't want to just set the name of the conversation for every such conversation, because it's more intuitive if the conversation name constructed of user names changes along with the user names. 

For example, if I'm talking to the user "Gandalf the Grey" in a fake 1:1, the conversation name displays "Gandalf the Grey", but if he changes his name to "Gandalf the White", the conversation name should also change. Only when Gandalf leaves, we have the problem - what should be the name of the conversation now? Right now, it's changed to "Default". With this PR we will preserve the last generated name as the own name of the conversation.

It sounds like a small thing, but in fact, the current situation means that a lot of old conversations, which people may keep to go through their history, are now called "Default", leading to a very bad user experience. We can't do anything about those old conversations, but we can prevent it from happening in the future.

It also open the doors to a small feature many users requested: Locally edited conversation names. 

EDIT: I also fixed unit tests in `ConversationsService`. Most of them test some aspects of the conversation name functionality. I also added one bigger unit test for exactly the case of all other members leaving a conversation. Together, I believe we have it covered pretty well.
 
#### APK
[Download build #2147](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2147/artifact/build/artifact/wire-dev-PR2863-2147.apk)
[Download build #2160](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2160/artifact/build/artifact/wire-dev-PR2863-2160.apk)
[Download build #2162](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2162/artifact/build/artifact/wire-dev-PR2863-2162.apk)
[Download build #2166](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2166/artifact/build/artifact/wire-dev-PR2863-2166.apk)
[Download build #2170](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2170/artifact/build/artifact/wire-dev-PR2863-2170.apk)