### PR TITLE
Fix: AVS logs within debug report 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.5.11@aar'
+    customAvsVersion = '5.5.13@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -126,7 +126,7 @@ class BufferedLogOutput(baseDir: String,
 
 object BufferedLogOutput {
 
-  val DefMaxBufferSize = 256L * 1024L
+  val DefMaxBufferSize = 512L * 1024L
   val DefMaxFileSize = 4L * DefMaxBufferSize
   val DefMaxRollFiles = 10
   val DefFileName = "internalLog"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -126,7 +126,7 @@ class BufferedLogOutput(baseDir: String,
 
 object BufferedLogOutput {
 
-  val DefMaxBufferSize = 512L * 1024L
+  val DefMaxBufferSize = 256L * 1024L
   val DefMaxFileSize = 4L * DefMaxBufferSize
   val DefMaxRollFiles = 10
   val DefFileName = "internalLog"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -64,7 +64,8 @@ class AvsImpl() extends Avs with DerivedLogTag {
     returning(Calling.wcall_init(Calling.WCALL_ENV_DEFAULT)) { res =>
       Calling.wcall_set_log_handler(new LogHandler {
         override def onLog(level: Int, msg: String, arg: Pointer): Unit = {
-          val log = l"${showString(msg)}"
+          val newMsg = msg.split('\n').map(_.trim.filter(_ >= ' ')).mkString
+          val log = l"${showString(newMsg)}"
           level match {
             case LogLevelDebug => debug(log)(AvsLogTag)
             case LogLevelInfo  => info(log)(AvsLogTag)
@@ -209,7 +210,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
 
 object Avs extends DerivedLogTag {
 
-  val AvsLogTag: LogTag = LogTag("AVS")
+  val AvsLogTag: LogTag = LogTag("AVS-N")
 
   type WCall = Calling.Handle
 


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6767

### Issues

AVS logs aren't being displayed in the debug report sent by users 

### Investigation

In AVS `5.5.11` the API was using an old way to logging `__android_write_log` and totally ignored the new `wcall` API. This means AVS was writing the logs directly and the Android client wasn't handling them. So, this led to the issue of the logs not appearing. The Android was ready for the wcall API but the code was commented out on the AVS side.

We did a version bump from `5.5.12` which then revealed the logs as the Android code had already implemented the new `wcall` api, however, it was only showing warning logs due to AVS having the default `log-level` as warn (unsure of the implementation details), which meant we needed to do another version bump to `5.5.13`

We then had an issue with formatting because the messages from AVS come back with a new line attached, so, from the Android side we needed a version bump for AVS and some formatting done from the new API testing. 

### Testing

1. Log in as a user A
2. Login in as user B
3. Start a call from User A to User B 
4. Share screen + video call to produce more logs 
5. End call 
6. Go to Settings > Advanced > Create debug report 
7.  Search for AVS-N and logs should be displayed for the call you just made 

#### APK
[Download build #2164](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2164/artifact/build/artifact/wire-dev-PR2868-2164.apk)