### PR TITLE
fix: Open the profile from a mention

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -259,6 +259,7 @@ class ConversationManagerFragment extends FragmentHelper
         }
         keyboard.hideKeyboardIfVisible()
         navigationController.setRightPage(Page.PARTICIPANT, ConversationManagerFragment.Tag)
+        participantsController.selectedParticipant ! Some(userId)
         showFragment(fragment, ParticipantFragment.TAG)
     }
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.google.android.material.tabs.TabLayout
 import com.waz.model.UserField
-import com.waz.service.{UserService, ZMessaging}
+import com.waz.service.ZMessaging
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils._
 import com.waz.utils.events.{ClockSignal, Signal, Subscription}
@@ -255,16 +255,7 @@ class SingleParticipantFragment extends FragmentHelper {
 
   override def onViewCreated(v: View, @Nullable savedInstanceState: Bundle): Unit = {
     super.onViewCreated(v, savedInstanceState)
-    syncParticipant()
     initViews(savedInstanceState)
-  }
-
-  def syncParticipant() = for {
-    userService <- inject[Signal[UserService]]
-    id <- participantsController.otherParticipantId
-  } yield id match {
-    case Some(userId) => userService.syncIfNeeded(Set(userId))
-    case None         =>
   }
 
   protected def initViews(savedInstanceState: Bundle): Unit = {


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6908

In the Large Team feature we refactored how a single participant profile is being opened. We left out that it's possible to open it also from tapping a mention. It almost worked by itself, but the selected participant was not set which led to displaying a blank screen - the adapter didn't know where to look for contents.

Also, I removed the `syncParticipant` method from `SingleParticipantFragment` - syncing is done differently now.
#### APK
[Download build #2174](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2174/artifact/build/artifact/wire-dev-PR2872-2174.apk)