### PR TITLE
fix: Text highlight function may crash on empty strings

### DIFF
--- a/app/src/main/java/com/waz/zclient/ui/utils/TextViewUtils.java
+++ b/app/src/main/java/com/waz/zclient/ui/utils/TextViewUtils.java
@@ -142,18 +142,27 @@ public class TextViewUtils {
 
     private static CharSequence getTypefaceHighlightText(Context context, String string, @StringRes int typefaceRes,
                                                          Integer highlightColor, int colorHighlightStart, int colorHighlightEnd) {
+        if (string == null || string.isEmpty())  {
+            Logger.error(TAG, "Failed to highlight text - getTypefaceHighlightText called on an empty or null string");
+            return new SpannableString("");
+        }
+
         List<Pair<Integer, Integer>> spanPositions = new ArrayList<>();
         int highlightStart;
         int highlightEnd = 0;
 
-        while (string.substring(highlightEnd, string.length()).contains("[[")) {
+        while (string.length() > highlightEnd && string.substring(highlightEnd).contains("[[")) {
             highlightStart = string.indexOf("[[");
             highlightEnd = string.indexOf("]]") - 2;
-            spanPositions.add(new Pair<>(highlightStart, highlightEnd));
-            string = string.replaceFirst("\\[\\[", "").replaceFirst("]]", "");
-            if (highlightColor != null && colorHighlightStart <= highlightStart && colorHighlightEnd >= highlightEnd) {
-                // need to deduct the [[ and ]] from the color span
-                colorHighlightEnd -= 4;
+            if (highlightEnd > highlightStart) {
+                spanPositions.add(new Pair<>(highlightStart, highlightEnd));
+                string = string.replaceFirst("\\[\\[", "").replaceFirst("]]", "");
+                if (highlightColor != null && colorHighlightStart <= highlightStart && colorHighlightEnd >= highlightEnd) {
+                    // need to deduct the [[ and ]] from the color span
+                    colorHighlightEnd -= 4;
+                }
+            } else {
+                Logger.error(TAG, "Malformed string: " + string);
             }
         }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
@@ -117,7 +117,7 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
       case (MEMBER_LEAVE, Other(name), _)                                                  => getString(R.string.content__system__other_removed_other, name, namesListString)
 
       case _ =>
-        verbose(l"Unexpected system message format: (${msg.msgType} from $displayName with ${msg.members.toSeq})")
+        warn(l"Unexpected system message format: (${msg.msgType} from $displayName with ${msg.members.toSeq})")
         ""
     }
   }


### PR DESCRIPTION
https://play.google.com/apps/publish/?account=7098984309886892484#AndroidMetricsErrorsPlace:p=com.wire&appid=4973241010395499500&appVersion=PRODUCTION&clusterName=apps/com.wire/clusters/2184fe40&detailsAppVersion=PRODUCTION&detailsSpan=7

In Google Play Console we see reports of crashes connected to highlighted strings. We use such strings in system messages where we highlight user names. The reports are not enough to see what is exactly happening (and I'm not able to reproduce the bug), so I decided to add a few safety checks and error/warn log statements. Maybe it will be enough or maybe we will be able to learn something from logs if it happens again.
#### APK
[Download build #2181](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2181/artifact/build/artifact/wire-dev-PR2875-2181.apk)