### PR TITLE
fix: Generating the conversation name crashes if user data is missing

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -414,7 +414,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       }
 
     def getUserNames(userIds: Set[UserId]): Future[Seq[Name]] =
-      users.userNames.map(names => userIds.toSeq.map(names).sortBy(_.str)).head
+      users.userNames.map(names => userIds.toSeq.flatMap(names.get).sortBy(_.str)).head
 
     def isConversationNameEmpty: Future[Boolean] =
       convsStorage.get(convId).map {
@@ -499,7 +499,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         for {
           members   <- activeMembersData(conv.id)
           memberIds =  members.filterNot(_.userId == selfUserId).take(4).map(_.userId).toSet
-          userNames <- users.userNames.map(names => memberIds.map(names))
+          userNames <- users.userNames.map(names => memberIds.flatMap(names.get))
         } yield
           createConversationName(userNames.toSeq)
     }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6923

The code used to generate conversation names assumed that asking for a name with UserId means we have the name in the local storage. It doesn't have to be so if the team is not synced, and then we will have a crash on trying to get the username from Map[UserId, Name] without providing the failsafe.
The PR changes that so now if the map does not have the name for the given userId, we will ignore it.
#### APK
[Download build #2185](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2185/artifact/build/artifact/wire-dev-PR2876-2185.apk)
[Download build #2186](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2186/artifact/build/artifact/wire-dev-PR2876-2186.apk)