### PR TITLE
fix: Race condition on conversation list click while reloading the list

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/adapters/ConversationFolderListAdapter.scala
@@ -30,6 +30,8 @@ import com.waz.zclient.conversationlist.adapters.ConversationFolderListAdapter._
 import com.waz.zclient.conversationlist.adapters.ConversationListAdapter._
 import com.waz.zclient.utils.ContextUtils.getString
 
+import scala.util.Try
+
 /**
   * A list adapter for displaying conversations grouped into folders.
   */
@@ -89,7 +91,7 @@ class ConversationFolderListAdapter(implicit context: Context, eventContext: Eve
       case (folderData, conversations) => Folder(folderData, conversations)
     }.sortBy(_.title.toLowerCase(Locale.getDefault))
 
-  override def onClick(position: Int): Unit = items(position) match {
+  override def onClick(position: Int): Unit = Try(items(position)).foreach {
     case header: Item.Header => collapseOrExpand(header, position)
     case _                   => super.onClick(position)
   }


### PR DESCRIPTION
fixes a bug reported in Google Play Console
https://play.google.com/apps/publish/?account=7098984309886892484#AndroidMetricsErrorsPlace:p=com.wire&appid=4973241010395499500&appVersion=PRODUCTION&clusterName=apps/com.wire/clusters/9e255feb&detailsAppVersion=PRODUCTION&detailsSpan=7

We use a mutable list for items and in rare cases it may lead to a situation when a click is executed while the list is refreshing. Rare, but it results in a crash. The ideal solution to this would be to change the items into an immutable list (but held in a `var`
instead of `val`) but that messes up with how we put items in folders and I don't want to spend time on this right now. Instead, I wrapped the `onClick` methods in `Try`. This way the worst what will happen is that the user will have to click again.
#### APK
[Download build #2193](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2193/artifact/build/artifact/wire-dev-PR2878-2193.apk)