### PR TITLE
fix: Bottom dialog in Group Participant View shows only one option

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -253,14 +253,15 @@ class ConversationManagerFragment extends FragmentHelper
       case (None, None) =>
         warn(l"Trying to show a non-existing user with id $userId")
       case _ =>
-        val fragment = request match {
-          case Right(p)   => ParticipantFragment.newInstance(p.userId, p.fromDeepLink)
-          case Left(page) => ParticipantFragment.newInstance(page)
-        }
         keyboard.hideKeyboardIfVisible()
         navigationController.setRightPage(Page.PARTICIPANT, ConversationManagerFragment.Tag)
-        participantsController.selectedParticipant ! Some(userId)
-        showFragment(fragment, ParticipantFragment.TAG)
+        request match {
+          case Right(p)   =>
+            participantsController.selectedParticipant ! Some(p.userId)
+            showFragment(ParticipantFragment.newInstance(p.userId, p.fromDeepLink), ParticipantFragment.TAG)
+          case Left(page) =>
+            showFragment(ParticipantFragment.newInstance(page), ParticipantFragment.TAG)
+        }
     }
 
   private def showFragment(fragment: Fragment, tag: String): Unit =


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6922

ConversationOptionsMenuController implements complex logic to decide what options should be displayed in the bottom dialog. Some of the checks are not straightforward - for example, to check if the bottom dialog is opened on the group or single participant view, it checks if `selectedParticipant` is set, and that's a field which usually is used for something very
different. So, if we open Group Participant view, `selectedParticipant` should be `None`, and if open Single Participant view then it should be `Some(<user id of the participant>)`. In one of previous PRs I started to set this field to `Some(...)` even when we opened the Group Participant view, because I thought it was harmless and it made the code a bit simpler.

It would be great to rethink the logic (I'd suggest to split it into a few branches depending directly on what screen is displayed) but for now I just reverted my previous change.

#### APK
[Download build #2196](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2196/artifact/build/artifact/wire-dev-PR2879-2196.apk)