### PR TITLE
AN-6925: Connection results not being displayed in search 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -152,6 +152,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
 
       if (directoryExternalMembers.nonEmpty) {
         mergedResult += SectionViewItem(DirectorySection, 0)
+        //directoryResults needs to be zipped with Index not directoryExternalMembers here
         mergedResult ++= directoryResults.zipWithIndex.map { case (user, index) =>
           ConnectionViewItem(index, user, team.map(_.id), connected = false)
         }

--- a/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/domain/RetrieveSearchResults.scala
@@ -152,7 +152,7 @@ class RetrieveSearchResults()(implicit injector: Injector, eventContext: EventCo
 
       if (directoryExternalMembers.nonEmpty) {
         mergedResult += SectionViewItem(DirectorySection, 0)
-        mergedResult ++= directoryExternalMembers.zipWithIndex.map { case (user, index) =>
+        mergedResult ++= directoryResults.zipWithIndex.map { case (user, index) =>
           ConnectionViewItem(index, user, team.map(_.id), connected = false)
         }
       }


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6925

### Issues

Unable to view team member recently added to the team that comes from API 

### Causes

We were referencing the wrong collection when gathering the connections as we required the results from the directory search, not the results from external members search 

### Solutions

Changed the reference for the collection 

### Testing

Scenario:

1. Log in with team admin in team with 2000 + members
2. Invite User A
3. User A accepts invitation and joins team 
4. Login with Team admin 
5. Go to search UI, search for User A
6. We should see the results for User A from remote call 

#### APK
[Download build #2207](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2207/artifact/build/artifact/wire-dev-PR2882-2207.apk)