### PR TITLE
fix: Update team data

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/wire-android-sync-engine/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -26,6 +26,7 @@ public enum SyncCommand {
     DeleteAccount("delete-account"),
     SyncConversations("sync-convs"),
     SyncTeam("sync-team"),
+    SyncTeamData("sync-team-data"),
     SyncTeamMember("sync-team-member"),
     SyncConnections("sync-connections"),
     SyncConversation("sync-conv"),

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -78,6 +78,7 @@ object SyncRequest {
   case object SyncSelfPermissions extends BaseRequest(Cmd.SyncSelfPermissions)
   case object SyncClientsLocation extends BaseRequest(Cmd.SyncClientLocation)
   case object SyncTeam            extends BaseRequest(Cmd.SyncTeam)
+  case object SyncTeamData        extends BaseRequest(Cmd.SyncTeamData)
   case object SyncProperties      extends BaseRequest(Cmd.SyncProperties)
   case object PostFolders         extends BaseRequest(Cmd.PostFolders)
   case object SyncFolders         extends BaseRequest(Cmd.SyncFolders)
@@ -401,6 +402,7 @@ object SyncRequest {
           case Cmd.DeleteAccount             => DeleteAccount
           case Cmd.SyncConversations         => SyncConversations
           case Cmd.SyncTeam                  => SyncTeam
+          case Cmd.SyncTeamData              => SyncTeamData
           case Cmd.SyncTeamMember            => SyncTeamMember(userId)
           case Cmd.SyncConnections           => SyncConnections
           case Cmd.RegisterPushToken         => RegisterPushToken(decodeId[PushToken]('token))
@@ -549,7 +551,7 @@ object SyncRequest {
         case PostStringProperty(key, value) =>
           o.put("key", key)
           o.put("value", value)
-        case PostFolders | SyncFolders | SyncSelf | SyncTeam | DeleteAccount | SyncConversations | SyncConnections |
+        case PostFolders | SyncFolders | SyncSelf | SyncTeam | SyncTeamData | DeleteAccount | SyncConversations | SyncConnections |
              SyncSelfClients | SyncSelfPermissions | SyncClientsLocation | SyncProperties | Unknown => () // nothing to do
         case DeleteGroupConversation(teamId, rConvId)  =>
           o.put("teamId", teamId.str)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -47,6 +47,7 @@ trait SyncServiceHandle {
   def syncConversations(ids: Set[ConvId] = Set.empty, dependsOn: Option[SyncId] = None): Future[SyncId]
   def syncConvLink(id: ConvId): Future[SyncId]
   def syncTeam(dependsOn: Option[SyncId] = None): Future[SyncId]
+  def syncTeamData(): Future[SyncId]
   def syncTeamMember(id: UserId): Future[SyncId]
   def syncConnections(dependsOn: Option[SyncId] = None): Future[SyncId]
   def syncRichMedia(id: MessageId, priority: Int = Priority.MinPriority): Future[SyncId]
@@ -147,6 +148,7 @@ class AndroidSyncServiceHandle(account:         UserId,
     else              addRequest(SyncConversations,     priority = Priority.High,   dependsOn = dependsOn.toSeq)
   def syncConvLink(id: ConvId) = addRequest(SyncConvLink(id))
   def syncTeam(dependsOn: Option[SyncId] = None): Future[SyncId] = addRequest(SyncTeam, priority = Priority.High, dependsOn = dependsOn.toSeq)
+  def syncTeamData(): Future[SyncId] = addRequest(SyncTeamData)
   def syncTeamMember(id: UserId): Future[SyncId] = addRequest(SyncTeamMember(id))
   def syncConnections(dependsOn: Option[SyncId]) = addRequest(SyncConnections, dependsOn = dependsOn.toSeq)
   def syncRichMedia(id: MessageId, priority: Int = Priority.MinPriority) = addRequest(SyncRichMedia(id), priority = priority)
@@ -268,6 +270,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostConnection(userId, name, message)           => zms.connectionsSync.postConnection(userId, name, message)
           case PostConnectionStatus(userId, status)            => zms.connectionsSync.postConnectionStatus(userId, status)
           case SyncTeam                                        => zms.teamsSync.syncTeam()
+          case SyncTeamData                                    => zms.teamsSync.syncTeamData()
           case SyncTeamMember(userId)                          => zms.teamsSync.syncMember(userId)
           case SyncConnections                                 => zms.connectionsSync.syncConnections()
           case SyncSelf                                        => zms.usersSync.syncSelfUser()


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6857

The team data is now updated in real time on receiving an update event - until now the data in storage was updated, but UI displayed it with some delay. Also, because in case of large teams the event may not come, now every time we go to the profile, the app refreshes team data. It had to be done with a separate call than `syncTeam`, because `syncTeam` also retrieved members and roles.
#### APK
[Download build #2211](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2211/artifact/build/artifact/wire-dev-PR2883-2211.apk)