### PR TITLE
Refactor: Normal / Generic Error dialogs  

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/ui/dialog/WireDialog.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/ui/dialog/WireDialog.kt
@@ -1,0 +1,34 @@
+package com.waz.zclient.core.ui.dialog
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.DialogInterface
+
+sealed class DialogType(val block: AlertDialog.Builder.() -> Unit)
+internal class GenericError(errorMessage: String) : DialogType({
+    setTitle(errorMessage)
+    setPositiveButton("Ok", DialogOwner.NO_OP_LISTENER)
+})
+
+interface DialogOwner {
+    companion object {
+        val NO_OP_LISTENER = DialogInterface.OnClickListener { _, _ -> /*no-op*/ }
+    }
+
+    fun showDialog(context: Context, block: AlertDialog.Builder.() -> Unit) {
+        AlertDialog.Builder(context).apply(block).create().show()
+    }
+
+    fun showDialog(context: Context, type: DialogType) {
+        AlertDialog.Builder(context).apply(type.block).create().show()
+    }
+
+    fun createDialog(context: Context, block: AlertDialog.Builder.() -> Unit) =
+        AlertDialog.Builder(context).apply(block).create()
+
+    fun createDialog(context: Context, type: DialogType) =
+        AlertDialog.Builder(context).apply(type.block).create()
+
+    fun showErrorDialog(context: Context, errorMessage: String) =
+        showDialog(context, GenericError(errorMessage).block)
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/CreatePersonalAccountEmailFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/CreatePersonalAccountEmailFragment.kt
@@ -10,13 +10,14 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.email.code.CreatePersonalAccountEmailCodeFragment
 import kotlinx.android.synthetic.main.fragment_create_personal_account_email.*
 
 class CreatePersonalAccountEmailFragment : Fragment(
     R.layout.fragment_create_personal_account_email
-) {
+), DialogOwner {
 
     //TODO Add loading status
     private val emailViewModel: CreatePersonalAccountEmailViewModel
@@ -93,11 +94,10 @@ class CreatePersonalAccountEmailFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     companion object {
         fun newInstance() = CreatePersonalAccountEmailFragment()

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/code/CreatePersonalAccountEmailCodeFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/code/CreatePersonalAccountEmailCodeFragment.kt
@@ -11,6 +11,7 @@ import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.showKeyboard
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.email.CreatePersonalAccountEmailCredentialsViewModel
 import com.waz.zclient.feature.auth.registration.personal.email.name.CreatePersonalAccountEmailNameFragment
@@ -18,7 +19,7 @@ import kotlinx.android.synthetic.main.fragment_create_personal_account_email_cod
 
 class CreatePersonalAccountEmailCodeFragment : Fragment(
     R.layout.fragment_create_personal_account_email_code
-) {
+), DialogOwner {
 
     private val emailCodeViewModel: CreatePersonalAccountEmailCodeViewModel
         by viewModel(REGISTRATION_SCOPE_ID)
@@ -116,11 +117,10 @@ class CreatePersonalAccountEmailCodeFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     companion object {
         fun newInstance() = CreatePersonalAccountEmailCodeFragment()

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/password/CreatePersonalAccountPasswordFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/email/password/CreatePersonalAccountPasswordFragment.kt
@@ -11,13 +11,14 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.showKeyboard
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.email.CreatePersonalAccountEmailCredentialsViewModel
 import kotlinx.android.synthetic.main.fragment_create_personal_account_password.*
 
 class CreatePersonalAccountPasswordFragment : Fragment(
     R.layout.fragment_create_personal_account_password
-) {
+), DialogOwner {
 
     private val passwordViewModel: CreatePersonalAccountPasswordViewModel
         by viewModel(REGISTRATION_SCOPE_ID)
@@ -104,11 +105,10 @@ class CreatePersonalAccountPasswordFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     companion object {
         fun newInstance() = CreatePersonalAccountPasswordFragment()

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/CreatePersonalAccountPhoneFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/CreatePersonalAccountPhoneFragment.kt
@@ -11,6 +11,7 @@ import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.phone.code.CreatePersonalAccountPhoneCodeFragment
 import com.waz.zclient.shared.countrycode.Country
@@ -19,7 +20,7 @@ import kotlinx.android.synthetic.main.fragment_create_personal_account_phone.*
 
 class CreatePersonalAccountPhoneFragment : Fragment(
     R.layout.fragment_create_personal_account_phone
-) {
+), DialogOwner {
 
     //TODO Add loading status
     private val phoneViewModel: CreatePersonalAccountPhoneViewModel
@@ -119,11 +120,10 @@ class CreatePersonalAccountPhoneFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     private fun showCountryCodePickerDialog() {
         CountryCodePickerFragment.newInstance(

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/code/CreatePersonalAccountPhoneCodeFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/code/CreatePersonalAccountPhoneCodeFragment.kt
@@ -11,6 +11,7 @@ import com.waz.zclient.core.extension.replaceFragment
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.showKeyboard
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.phone.CreatePersonalAccountPhoneCredentialsViewModel
 import com.waz.zclient.feature.auth.registration.personal.phone.name.CreatePersonalAccountPhoneNameFragment
@@ -18,7 +19,7 @@ import kotlinx.android.synthetic.main.fragment_create_personal_account_phone_cod
 
 class CreatePersonalAccountPhoneCodeFragment : Fragment(
     R.layout.fragment_create_personal_account_phone_code
-) {
+), DialogOwner {
     private val phoneCodeViewModel: CreatePersonalAccountPhoneCodeViewModel
         by viewModel(REGISTRATION_SCOPE_ID)
 
@@ -108,11 +109,10 @@ class CreatePersonalAccountPhoneCodeFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     companion object {
         fun newInstance() = CreatePersonalAccountPhoneCodeFragment()

--- a/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/name/CreatePersonalAccountPhoneNameFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/auth/registration/personal/phone/name/CreatePersonalAccountPhoneNameFragment.kt
@@ -11,13 +11,14 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.showKeyboard
 import com.waz.zclient.core.extension.viewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.auth.registration.di.REGISTRATION_SCOPE_ID
 import com.waz.zclient.feature.auth.registration.personal.phone.CreatePersonalAccountPhoneCredentialsViewModel
 import kotlinx.android.synthetic.main.fragment_create_personal_account_name.*
 
 class CreatePersonalAccountPhoneNameFragment : Fragment(
     R.layout.fragment_create_personal_account_name
-) {
+), DialogOwner {
 
     private val nameViewModel: CreatePersonalAccountPhoneNameViewModel
         by viewModel(REGISTRATION_SCOPE_ID)
@@ -98,11 +99,10 @@ class CreatePersonalAccountPhoneNameFragment : Fragment(
         .create()
         .show()
 
-    private fun showGenericErrorDialog(messageResId: Int) = AlertDialog.Builder(context)
-        .setMessage(messageResId)
-        .setPositiveButton(android.R.string.ok) { _, _ -> }
-        .create()
-        .show()
+    private fun showGenericErrorDialog(messageResId: Int) = showErrorDialog(
+        requireContext(),
+        getString(messageResId)
+    )
 
     companion object {
         fun newInstance() = CreatePersonalAccountPhoneNameFragment()

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/deleteaccount/DeleteAccountDialogFragment.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.observe
 import com.waz.zclient.R
@@ -12,9 +11,10 @@ import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.toSpanned
 import com.waz.zclient.core.extension.withArgs
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.settings.di.SETTINGS_SCOPE_ID
 
-class DeleteAccountDialogFragment : DialogFragment() {
+class DeleteAccountDialogFragment : DialogFragment(), DialogOwner {
 
     private val deleteAccountViewModel by sharedViewModel<SettingsAccountDeleteAccountViewModel>(SETTINGS_SCOPE_ID)
 
@@ -37,14 +37,14 @@ class DeleteAccountDialogFragment : DialogFragment() {
             else -> String.empty()
         }.toSpanned()
 
-        return AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.pref_account_delete_warning_title))
-            .setMessage(message)
-            .setPositiveButton(getString(R.string.pref_account_delete_warning_verify)) { _, _ ->
+        return createDialog(requireContext()) {
+            setTitle(getString(R.string.pref_account_delete_warning_title))
+            setMessage(message)
+            setPositiveButton(getString(R.string.pref_account_delete_warning_verify)) { _, _ ->
                 deleteAccountViewModel.onDeleteAccountConfirmed()
             }
-            .setNegativeButton(getString(R.string.pref_account_delete_warning_cancel), null)
-            .create()
+            setNegativeButton(getString(R.string.pref_account_delete_warning_cancel), null)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/editphonenumber/DeletePhoneDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/editphonenumber/DeletePhoneDialogFragment.kt
@@ -4,15 +4,15 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.withArgs
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.settings.di.SETTINGS_SCOPE_ID
 
-class DeletePhoneDialogFragment : DialogFragment() {
+class DeletePhoneDialogFragment : DialogFragment(), DialogOwner {
 
     private val phoneViewModel by sharedViewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
 
@@ -21,17 +21,17 @@ class DeletePhoneDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        AlertDialog.Builder(requireActivity())
-            .setTitle(getString(R.string.pref__account_action__dialog__delete_phone_or_email__confirm__title))
-            .setMessage(
+        createDialog(requireContext()) {
+            setTitle(getString(R.string.pref__account_action__dialog__delete_phone_or_email__confirm__title))
+            setMessage(
                 getString(R.string.pref__account_action__dialog__delete_phone_or_email__confirm__message,
                     phoneNumber)
             )
-            .setPositiveButton(android.R.string.ok) { _, _ ->
+            setPositiveButton(android.R.string.ok) { _, _ ->
                 phoneViewModel.onDeleteNumberButtonConfirmed()
             }
-            .setNegativeButton(android.R.string.cancel, null)
-            .create()
+            setNegativeButton(android.R.string.cancel, null)
+        }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/editphonenumber/UpdatePhoneDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/editphonenumber/UpdatePhoneDialogFragment.kt
@@ -10,9 +10,10 @@ import com.waz.zclient.R
 import com.waz.zclient.core.extension.empty
 import com.waz.zclient.core.extension.sharedViewModel
 import com.waz.zclient.core.extension.withArgs
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.settings.di.SETTINGS_SCOPE_ID
 
-class UpdatePhoneDialogFragment : DialogFragment() {
+class UpdatePhoneDialogFragment : DialogFragment(), DialogOwner {
 
     private val viewModel by sharedViewModel<SettingsAccountPhoneNumberViewModel>(SETTINGS_SCOPE_ID)
 
@@ -21,14 +22,14 @@ class UpdatePhoneDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        AlertDialog.Builder(requireActivity())
-            .setTitle(getString(R.string.pref__account_action__dialog__add_phone__confirm__title))
-            .setMessage(getString(R.string.edit_phone_dialog_confirm_phone_confirmation, phoneNumber))
-            .setPositiveButton(android.R.string.ok) { _, _ ->
+        createDialog(requireContext()) {
+            setTitle(getString(R.string.pref__account_action__dialog__add_phone__confirm__title))
+            setMessage(getString(R.string.edit_phone_dialog_confirm_phone_confirmation, phoneNumber))
+            setPositiveButton(android.R.string.ok) { _, _ ->
                 viewModel.onPhoneNumberConfirmed(phoneNumber)
             }
-            .setNegativeButton(android.R.string.cancel, null)
-            .create()
+            setNegativeButton(android.R.string.cancel, null)
+        }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutDialogFragment.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/settings/account/logout/LogoutDialogFragment.kt
@@ -1,25 +1,25 @@
 package com.waz.zclient.feature.settings.account.logout
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.waz.zclient.R
 import com.waz.zclient.core.extension.sharedViewModel
+import com.waz.zclient.core.ui.dialog.DialogOwner
 import com.waz.zclient.feature.settings.di.SETTINGS_SCOPE_ID
 
-class LogoutDialogFragment : DialogFragment() {
+class LogoutDialogFragment : DialogFragment(), DialogOwner {
 
     private val logoutViewModel: LogoutViewModel by sharedViewModel(SETTINGS_SCOPE_ID)
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        AlertDialog.Builder(requireContext())
-            .setMessage(getString(R.string.pref_account_sign_out_warning_message))
-            .setPositiveButton(getString(R.string.pref_account_sign_out_warning_verify)) { _, _ ->
+        createDialog(requireContext()) {
+            setMessage(getString(R.string.pref_account_sign_out_warning_message))
+            setPositiveButton(getString(R.string.pref_account_sign_out_warning_verify)) { _, _ ->
                 logoutViewModel.onVerifyButtonClicked()
             }
-            .setNegativeButton(getString(R.string.pref_account_sign_out_warning_cancel), null)
-            .create()
+            setNegativeButton(getString(R.string.pref_account_sign_out_warning_cancel), null)
+        }
 
     companion object {
         fun newInstance() = LogoutDialogFragment()


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-6929

### Issues

This issue comes in **two** parts: 

This PR covers the generic error dialog / normal dialog aspects of the Kotlin codebase. The second part will cover the network connectivity issues. 

### Causes

Lots of duplicated code. 

### Solutions

Based  on a [discussion](https://github.com/wireapp/wire-android/pull/2816#discussion_r425665901) amongst the developers on a previous PR, we now have the fragments become a `DialogOwner` which has its own types rather than assuming the responsibility of creating and showing all dialogs without reusability. 