### PR TITLE
fix: Unable to open Group Participants View after removing a user

### DIFF
--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -260,6 +260,7 @@ class ConversationManagerFragment extends FragmentHelper
             participantsController.selectedParticipant ! Some(p.userId)
             showFragment(ParticipantFragment.newInstance(p.userId, p.fromDeepLink), ParticipantFragment.TAG)
           case Left(page) =>
+            participantsController.selectedParticipant ! None
             showFragment(ParticipantFragment.newInstance(page), ParticipantFragment.TAG)
         }
     }

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -89,9 +89,8 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
     selfId       <- selfId
     usersStorage <- usersStorage
     tId          <- team
-    convId       <- convController.currentConvId
     participants <- participants
-    users        <- usersStorage.listSignal(participants.keys.toList)
+    users        <- usersStorage.listSignal(participants.keys)
     f            <- filter
   } yield
     users

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -59,12 +59,13 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   lazy val isGroup: Signal[Boolean]                                 = convController.currentConvIsGroup
   lazy val selfRole: Signal[ConversationRole]                       = convController.selfRole
 
-  lazy val otherParticipantId: Signal[Option[UserId]] = otherParticipants.flatMap {
-    case others if others.size == 1 => Signal.const(others.headOption.map(_._1))
-    case others                     => selectedParticipant
+  lazy val otherParticipantId: Signal[Option[UserId]] = Signal(otherParticipants, selectedParticipant).map {
+    case (others, _) if others.size == 1                               => others.headOption.map(_._1)
+    case (others, selected) if selected.exists(others.keySet.contains) => selected
+    case _                                                             => None
   }
 
-  lazy val otherParticipant = for {
+  lazy val otherParticipant: Signal[UserData] = for {
     z        <- zms
     Some(id) <- otherParticipantId
     user     <- z.usersStorage.signal(id)
@@ -135,6 +136,10 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
           override def positiveButtonClicked(checkboxIsSelected: Boolean): Unit = {
             screenController.hideUser()
             convController.removeMember(userId)
+            selectedParticipant.mutate {
+              case Some(uId) if uId == userId => None
+              case other                      => other
+            }
           }
 
           override def negativeButtonClicked(): Unit = {}


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6934

I made the `selectedParticipant` signal update to `None` on removing the selected user from the conversation and also on explicitely opening the Group Conversation View (as sometimes we can open the Group view while having the participant selected - this is not a bug, but may lead to some misunderstandings).
Also, I changed the `otherParticipantId` signal to such that it will never point to a user removed from the conversation. Just to be sure.

#### APK
[Download build #2229](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2229/artifact/build/artifact/wire-dev-PR2890-2229.apk)