### PR TITLE
fix: System messages for member-join and member-left in conversations

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -398,8 +398,6 @@ object MessageData extends
 
     def lastFromSelf(conv: ConvId, selfUserId: UserId)(implicit db: DB) = single(db.query(table.name, null, s"${Conv.name} = '${Conv(conv)}' AND ${User.name} = '${User(selfUserId)}' AND $userContentPredicate", null, null, null, s"${Time.name} DESC", "1"))
 
-    def lastFromOther(conv: ConvId, selfUserId: UserId)(implicit db: DB) = single(db.query(table.name, null, s"${Conv.name} = '${Conv(conv)}' AND ${User.name} != '${User(selfUserId)}' AND $userContentPredicate", null, null, null, s"${Time.name} DESC", "1"))
-
     private val userContentPredicate = isUserContent.map(t => s"${Type.name} = '${Type(t)}'").mkString("(", " OR ", ")")
 
     def lastIncomingKnock(convId: ConvId, selfUser: UserId)(implicit db: DB): Option[MessageData] = single(
@@ -454,8 +452,8 @@ object MessageData extends
     def findSystemMessage(conv: ConvId, serverTime: RemoteInstant, tpe: Message.Type, sender: UserId)(implicit db: DB) =
       iterating(db.query(table.name, null, s"${Conv.name} = '${conv.str}' and ${Time.name} = ${Time(serverTime)} and ${Type.name} = '${Type(tpe)}' and ${User.name} = '${User(sender)}'", null, null, null, s"${Time.name} DESC"))
 
-    def findLastSystemMessage(conv: ConvId, tpe: Message.Type, sender: UserId)(implicit db: DB) =
-      iterating(db.query(table.name, null, s"${Conv.name} = '${conv.str}' and ${Type.name} = '${Type(tpe)}' and ${User.name} = '${User(sender)}'", null, null, null, s"${Time.name} DESC LIMIT 1"))
+    def findLastSystemMessage(conv: ConvId, tpe: Message.Type, noOlderThan: RemoteInstant)(implicit db: DB) =
+      iterating(db.query(table.name, null, s"${Conv.name} = '${conv.str}' and ${Type.name} = '${Type(tpe)}' and  ${Time.name} >= ${Time(noOlderThan)}", null, null, null, s"${Time.name} DESC LIMIT 1"))
 
     def getAssetIds(messageIds: Set[MessageId])(implicit db:DB) = {
       val idList = messageIds.map(t => s"'${Id(t)}'").mkString("(", "," , ")")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -130,7 +130,11 @@ case class UserData(override val id:       UserId,
 
   def matchesQuery(query: SearchQuery): Boolean =
       handle.exists(_.startsWithQuery(query.str)) ||
-        (!query.handleOnly && (SearchKey(query.str).isAtTheStartOfAnyWordIn(searchKey) || email.exists(e => query.str.trim.equalsIgnoreCase(e.str))))
+        (!query.handleOnly &&
+          (SearchKey(query.str).isAtTheStartOfAnyWordIn(searchKey) ||
+           email.exists(e => query.str.trim.equalsIgnoreCase(e.str))
+          )
+        )
 
   def matchesQuery(query: Option[SearchKey] = None, handleOnly: Boolean = false): Boolean = query match {
     case Some(q) =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -177,10 +177,13 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def deleteUsers(ids: Set[UserId]): Future[Unit] =
     for {
-      members <- membersStorage.getByUsers(ids)
-      _       <- membersStorage.removeAll(members.map(_.id).toSet)
-      _       <- Future.sequence(members.map(m => messages.addMemberLeaveMessage(m.convId, selfUserId, m.userId)))
-      _       <- usersStorage.updateAll2(ids, _.copy(deleted = true))
+      members       <- membersStorage.getByUsers(ids)
+      _             <- membersStorage.removeAll(members.map(_.id).toSet)
+      memberInConvs =  members.groupBy(_.convId)
+      _             <- Future.traverse(memberInConvs) {
+                         case (convId, ms) => messages.addMemberLeaveMessage(convId, selfUserId, ms.map(_.userId).toSet)
+                       }
+      _             <- usersStorage.updateAll2(ids, _.copy(deleted = true))
     } yield ()
 
   override lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -302,7 +302,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
       toDelete <- if (user != selfUserId) members.getByUsers(Set(user)).map(_.isEmpty)
                   else Future.successful(false)
       _        <- if (toDelete) usersStorage.remove(user) else Future.successful(())
-      _        <- messages.addMemberLeaveMessage(conv, selfUserId, user)
+      _        <- messages.addMemberLeaveMessage(conv, selfUserId, Set(user))
       syncId   <- sync.postConversationMemberLeave(conv, user)
     } yield Option(syncId))
       .recover {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -62,7 +62,7 @@ trait MessagesService {
 
   //TODO forceCreate is a hacky workaround for a bug where previous system messages are not marked as SENT. Do NOT use!
   def addMemberJoinMessage(convId: ConvId, creator: UserId, users: Set[UserId], firstMessage: Boolean = false, forceCreate: Boolean = false): Future[Option[MessageData]]
-  def addMemberLeaveMessage(convId: ConvId, remover: UserId, user: UserId): Future[Unit]
+  def addMemberLeaveMessage(convId: ConvId, remover: UserId, users: Set[UserId]): Future[Unit]
   def addRenameConversationMessage(convId: ConvId, selfUserId: UserId, name: Name): Future[Option[MessageData]]
   def addReceiptModeChangeMessage(convId: ConvId, from: UserId, receiptMode: Int): Future[Option[MessageData]]
   def addTimerChangedMessage(convId: ConvId, from: UserId, duration: Option[FiniteDuration], time: RemoteInstant): Future[Unit]
@@ -80,7 +80,7 @@ trait MessagesService {
   def recallMessage(convId: ConvId, msgId: MessageId, userId: UserId, systemMsgId: MessageId = MessageId(), time: RemoteInstant, state: Message.Status = Message.Status.PENDING): Future[Option[MessageData]]
   def applyMessageEdit(convId: ConvId, userId: UserId, time: RemoteInstant, gm: GenericMessage): Future[Option[MessageData]]
 
-  def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Any]
+  def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Unit]
 
   def messageSent(convId: ConvId, msgId: MessageId, newTime: RemoteInstant): Future[Option[MessageData]]
   def messageDeliveryFailed(convId: ConvId, msg: MessageData, error: ErrorResponse): Future[Option[MessageData]]
@@ -351,57 +351,29 @@ class MessagesServiceImpl(selfUserId:      UserId,
   }
 
   override def addMemberJoinMessage(convId: ConvId, creator: UserId, users: Set[UserId], firstMessage: Boolean = false, forceCreate: Boolean = false) = {
-    verbose(l"addMemberJoinMessage($convId, $creator, $users)")
+    def update(msg: MessageData) = msg.copy(members = msg.members ++ users)
+    def create = MessageData(MessageId(), convId, Message.Type.MEMBER_JOIN, creator, members = users, firstMessage = firstMessage)
 
-    def updateOrCreate(added: Set[UserId]) = {
-      def update(msg: MessageData) = msg.copy(members = msg.members ++ added)
-      def create = MessageData(MessageId(), convId, Message.Type.MEMBER_JOIN, creator, members = added, firstMessage = firstMessage)
-
-      if (forceCreate)
-        updater.addLocalSentMessage(create).map(Some(_))
-      else
-        updater.updateOrCreateLocalMessage(convId, Message.Type.MEMBER_JOIN, update, create)
-    }
-
-    // check if we have local leave message with same users
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_LEAVE).flatMap {
-      case Some(msg) if users.exists(msg.members) =>
-        val toRemove = msg.members -- users
-        val toAdd = users -- msg.members
-        if (toRemove.isEmpty) updater.deleteMessage(msg) // FIXME: race condition
-        else updater.updateMessage(msg.id)(_.copy(members = toRemove)) // FIXME: race condition
-
-        if (toAdd.isEmpty) successful(None) else updateOrCreate(toAdd)
-      case _ =>
-        updateOrCreate(users)
-    }
+    if (forceCreate) updater.addLocalSentMessage(create).map(Some(_))
+    else updater.updateOrCreateLocalMessage(convId, Message.Type.MEMBER_JOIN, update, create)
   }
 
-  def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Any] =
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN).flatMap {
-      case Some(msg) =>
+  override def removeLocalMemberJoinMessage(convId: ConvId, users: Set[UserId]): Future[Unit] =
+    storage.getLastSystemMessage(convId, Message.Type.MEMBER_JOIN).flatMap {
+      case Some(msg) if msg.isLocal =>
         val members = msg.members -- users
-        if (members.isEmpty) {
-          updater.deleteMessage(msg)
-        } else {
-          updater.updateMessage(msg.id) { _.copy(members = members) } // FIXME: possible race condition with addMemberJoinMessage or sync
-        }
+        if (members.isEmpty) updater.deleteMessage(msg)
+        else updater.updateMessage(msg.id) { _.copy(members = members) }.map(_ => ()) // FIXME: possible race condition with addMemberJoinMessage or sync
       case _ =>
-        warn(l"removeLocalMemberJoinMessage: no local join message found")
-        CancellableFuture.successful(())
+        Future.successful(())
     }
 
-  override def addMemberLeaveMessage(convId: ConvId, remover: UserId, user: UserId): Future[Unit] =
-    // check if we have local join message with this user and just remove him from the list
-    storage.lastLocalMessage(convId, Message.Type.MEMBER_JOIN).flatMap {
-      case Some(msg) if msg.members == Set(user) => updater.deleteMessage(msg) // FIXME: race condition
-      case Some(msg) if msg.members(user) =>
-        updater.updateMessage(msg.id)(_.copy(members = msg.members - user)) // FIXME: race condition
-      case _ =>
-        val newMessage = MessageData(MessageId(), convId, Message.Type.MEMBER_LEAVE, remover, members = Set(user))
-        def update(msg: MessageData) = msg.copy(members = msg.members + user)
-        updater.updateOrCreateLocalMessage(convId, Message.Type.MEMBER_LEAVE, update, newMessage)
-    }.map(_ => ())
+  override def addMemberLeaveMessage(convId: ConvId, remover: UserId, users: Set[UserId]): Future[Unit] = {
+    val newMessage = MessageData(MessageId(), convId, Message.Type.MEMBER_LEAVE, remover, members = users)
+    def update(msg: MessageData) = msg.copy(members = msg.members ++ users)
+    updater.updateOrCreateLocalMessage(convId, Message.Type.MEMBER_LEAVE, update, newMessage).map(_ => ())
+  }
+
 
   override def addOtrVerifiedMessage(convId: ConvId) =
     storage.getLastMessage(convId) flatMap {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -150,7 +150,7 @@ class UserServiceSpec extends AndroidFreeSpec {
       (membersStorage.removeAll _).expects(Set(member.id)).atLeastOnce().returning(
         Future.successful(())
       )
-      (messages.addMemberLeaveMessage _).expects(convId, *, user1.id).atLeastOnce().returning(
+      (messages.addMemberLeaveMessage _).expects(convId, *, Set(user1.id)).atLeastOnce().returning(
         Future.successful(())
       )
       (usersStorage.updateAll2 _).expects(Set(user1.id), *).atLeastOnce().onCall { (_: Iterable[UserId], updater: UserData => UserData) =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -166,7 +166,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
-      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, selfUserId).atLeastOnce().returning(
+      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, Set(selfUserId)).atLeastOnce().returning(
         Future.successful(())
       )
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
@@ -210,7 +210,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .anyNumberOfTimes().returning(Future.successful(Set[ConversationMemberData]()))
       (content.setConvActive _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
-      (messages.addMemberLeaveMessage _).expects(convId, removerId, selfUserId).atLeastOnce().returning(
+      (messages.addMemberLeaveMessage _).expects(convId, removerId, Set(selfUserId)).atLeastOnce().returning(
         Future.successful(())
       )
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
@@ -257,7 +257,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (messages.getAssetIds _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
       (assets.deleteAll _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(convData)))
-      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, otherUserId).atLeastOnce().returning(
+      (messages.addMemberLeaveMessage _).expects(convId, selfUserId, Set(otherUserId)).atLeastOnce().returning(
         Future.successful(())
       )
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6859
fixes https://wearezeta.atlassian.net/browse/AN-6873

I rewrote the logic behind displaying join/leave system messages in conversations. I simplified it a lot. The old system was confusing that probably led to failing tests in many cases. Now, system messages should be much more predictable.

#### APK
[Download build #2230](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2230/artifact/build/artifact/wire-dev-PR2891-2230.apk)