### PR TITLE
Bump AVS to 6.0.36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.0.33@aar'
+    customAvsVersion = '6.0.36@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '5.6.15@aar'
+    customAvsVersion = '6.0.33@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -107,6 +107,9 @@ class AvsImpl() extends Avs with DerivedLogTag {
           0
         }
       },
+      new SFTRequestHandler {
+        override def onSFTRequest(ctx: Pointer, url: String, data: Pointer, length: Size_t, arg: Pointer): Int = 0
+      },
       new IncomingCallHandler {
         override def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, convType: Int, arg: Pointer) =
           cs.onIncomingCall(RConvId(convId), UserId(userId), isVideoCall, shouldRing)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -107,7 +107,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
           0
         }
       },
-      // TODO: Implement
+      // TODO: Invoke CallingService method to make the SFT request.
       new SFTRequestHandler {
         override def onSFTRequest(ctx: Pointer, url: String, data: Pointer, length: Size_t, arg: Pointer): Int = 0
       },
@@ -178,7 +178,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
       val clientsRequestHandler = new ClientsRequestHandler {
-        // TODO: Implement
+        // TODO: Fetch list of clients in the conversation
         override def onClientsRequest(convId: String, arg: Pointer): Unit = Unit
       }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -108,7 +108,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
         }
       },
       new IncomingCallHandler {
-        override def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, arg: Pointer) =
+        override def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, convType: Int, arg: Pointer) =
           cs.onIncomingCall(RConvId(convId), UserId(userId), isVideoCall, shouldRing)
       },
       new MissedCallHandler {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -176,6 +176,13 @@ class AvsImpl() extends Avs with DerivedLogTag {
 
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
+      val clientsRequestHandler = new ClientsRequestHandler {
+        // TODO: Implement
+        override def onClientsRequest(convId: String, arg: Pointer): Unit = Unit
+      }
+
+      Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
+
       wCall
     }
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -107,6 +107,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
           0
         }
       },
+      // TODO: Implement
       new SFTRequestHandler {
         override def onSFTRequest(ctx: Pointer, url: String, data: Pointer, length: Size_t, arg: Pointer): Int = 0
       },

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -196,4 +196,8 @@ object Calling {
     def onConfigRequest(inst: Handle, arg: Pointer): Int
   }
 
+  trait ClientsRequestHandler extends Callback {
+    def onClientsRequest(convId: String, arg: Pointer): Unit
+  }
+
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -52,6 +52,7 @@ object Calling {
                            clientid:  String,
                            readyh:    ReadyHandler,
                            sendh:     SendHandler,
+                           sftreqh:   SFTRequestHandler,
                            incomingh: IncomingCallHandler,
                            missedh:   MissedCallHandler,
                            answeredh: AnsweredCallHandler,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -122,7 +122,7 @@ object Calling {
 
   /* Incoming call */
   trait IncomingCallHandler extends Callback {
-    def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, arg: Pointer): Unit
+    def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, convType: Int, arg: Pointer): Unit
   }
 
   /* Missed call */

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -202,4 +202,8 @@ object Calling {
     def onClientsRequest(convId: String, arg: Pointer): Unit
   }
 
+  trait SFTRequestHandler extends Callback {
+    def onSFTRequest(ctx: Pointer, url: String, data: Pointer, length: Size_t, arg: Pointer): Int
+  }
+
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -101,6 +101,10 @@ object Calling {
 
   @native def wcall_set_network_quality_handler(inst: Handle, wcall_network_quality_h: NetworkQualityChangedHandler, intervalInSeconds: Int, arg: Pointer): Int
 
+  @native def wcall_set_req_clients_handler(inst: Handle,  wcall_req_clients_h: ClientsRequestHandler): Unit
+
+  @native def wcall_set_clients_for_conv(inst: Handle, convId: String, clientsJson: String): Int
+
   /* This will be called when the calling system is ready for calling.
      * The version parameter specifies the config obtained version to use
      * for calling.

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -105,6 +105,8 @@ object Calling {
 
   @native def wcall_set_clients_for_conv(inst: Handle, convId: String, clientsJson: String): Int
 
+  @native def wcall_sft_resp(inst: Handle, error: Int, data: Pointer, length: Size_t, ctx: Pointer): Unit
+
   /* This will be called when the calling system is ready for calling.
      * The version parameter specifies the config obtained version to use
      * for calling.


### PR DESCRIPTION
## What's new in this PR?

This PR contains a major bump to AVS 6.0.36. Changes include:

- Native bindings for new functions (`wcall_set_req_clients_handler`, `wcall_set_clients_for_conv`, and `wcall_sft_resp`)
- New handlers for `wcall_req_clients_h` and `wcall_sft_req_h`
- New `convType` argument in `wcall_incoming_h`
- Pass dummy `SFTRequestHandler` to `wcall_create`
- Add `ClientsRequestHandler` stub

More information about API changes can be found [here](https://github.com/wearezeta/avs/blob/master/docs/api/api_changes_6.0.txt)

#### APK
[Download build #2232](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2232/artifact/build/artifact/wire-dev-PR2892-2232.apk)
[Download build #2237](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2237/artifact/build/artifact/wire-dev-PR2892-2237.apk)