### PR TITLE
Fetch client list and pass to AVS (conference calling part 1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.0.36@aar'
+    customAvsVersion = '6.0.39@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -179,9 +179,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
       val clientsRequestHandler = new ClientsRequestHandler {
-        override def onClientsRequest(convId: String, arg: Pointer): Unit = {
-          cs.onClientsRequest(ConvId(convId))
-        }
+        override def onClientsRequest(convId: String, arg: Pointer): Unit = cs.onClientsRequest(ConvId(convId))
       }
 
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
@@ -240,15 +238,13 @@ class AvsImpl() extends Avs with DerivedLogTag {
   override def onClientsRequest(wCall: WCall, convId: RConvId, userClients: Map[UserId, Seq[ClientId]]): Unit = {
     import ClientListEncoder._
 
-    val clients = userClients.flatMap { pair =>
-      val (userId, clientIds) = pair
+    val clients = userClients.flatMap { case (userId, clientIds) =>
       clientIds.map { clientId =>
         Client(userId.str, clientId.str)
       }
     }
 
-    val clientList  = ClientList(clients.toSeq)
-    val json = encode(clientList)
+    val json = encode(ClientList(clients.toSeq))
     withAvs(wcall_set_clients_for_conv(wCall, convId.str, json))
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -48,6 +48,7 @@ trait Avs {
   def setVideoSendState(wCall: WCall, convId: RConvId, state: VideoState.Value): Unit
   def setCallMuted(wCall: WCall, muted: Boolean): Unit
   def setProxy(host: String, port: Int): Unit
+  def onClientsRequest(wCall: WCall, convId: RConvId, userClients: Map[UserId, Seq[ClientId]]): Unit
 }
 
 /**
@@ -178,8 +179,9 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
       val clientsRequestHandler = new ClientsRequestHandler {
-        // TODO: Fetch list of clients in the conversation
-        override def onClientsRequest(convId: String, arg: Pointer): Unit = Unit
+        override def onClientsRequest(convId: String, arg: Pointer): Unit = {
+          cs.onClientsRequest(ConvId(convId))
+        }
       }
 
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
@@ -234,6 +236,22 @@ class AvsImpl() extends Avs with DerivedLogTag {
 
   override def setProxy(host: String, port: Int): Unit =
     withAvs(wcall_set_proxy(host, port))
+
+  override def onClientsRequest(wCall: WCall, convId: RConvId, userClients: Map[UserId, Seq[ClientId]]): Unit = {
+    import ClientListEncoder._
+
+    val clients = userClients.flatMap { pair =>
+      val (userId, clientIds) = pair
+      clientIds.map { clientId =>
+        Client(userId.str, clientId.str)
+      }
+    }
+
+    val clientList  = ClientList(clients.toSeq)
+    val json = encode(clientList)
+    withAvs(wcall_set_clients_for_conv(wCall, convId.str, json))
+  }
+
 }
 
 object Avs extends DerivedLogTag {
@@ -364,4 +382,18 @@ object Avs extends DerivedLogTag {
     def decode(json: String): Option[AvsParticipantsChange] =
       parser.decode(json)(decoder).right.toOption
   }
+
+  object ClientListEncoder extends CirceJSONSupport {
+
+    import io.circe.Encoder
+
+    case class ClientList(clients: Seq[Client])
+    case class Client(userid: String, clientid: String)
+
+    private lazy val encoder: Encoder[ClientList] = Encoder.apply
+
+    def encode(clientList: ClientList): String = encoder(clientList).toString
+
+  }
+
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -179,7 +179,8 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
       val clientsRequestHandler = new ClientsRequestHandler {
-        override def onClientsRequest(convId: String, arg: Pointer): Unit = cs.onClientsRequest(ConvId(convId))
+        override def onClientsRequest(inst: Calling.Handle, convId: String, arg: Pointer): Unit =
+          cs.onClientsRequest(ConvId(convId))
       }
 
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -200,7 +200,7 @@ object Calling {
   }
 
   trait ClientsRequestHandler extends Callback {
-    def onClientsRequest(convId: String, arg: Pointer): Unit
+    def onClientsRequest(inst: Handle, convId: String, arg: Pointer): Unit
   }
 
   trait SFTRequestHandler extends Callback {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -391,6 +391,17 @@ class CallingServiceImpl(val accountId:       UserId,
   def onNetworkQualityChanged(convId: ConvId, participant: Participant, quality: NetworkQuality): Future[Unit] =
     Future.successful(())
 
+  def onClientsRequest(convId: ConvId): Future[Unit] = {
+    withConv(convId) { (wCall, conv) =>
+      otrSyncHandler.postClientDiscoveryMessage(convId).map {
+        case Right(clients) =>
+          avs.onClientsRequest(wCall, conv.remoteId, clients)
+        case Left(errorResponse) =>
+          warn(l"Could not post client discovery message: $errorResponse")
+      }
+    }
+  }
+
   override def startCall(convId: ConvId, isVideo: Boolean = false, forceOption: Boolean = false) =
     Serialized.future(self) {
       verbose(l"startCall $convId, isVideo: $isVideo, forceOption: $forceOption")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -391,7 +391,7 @@ class CallingServiceImpl(val accountId:       UserId,
   def onNetworkQualityChanged(convId: ConvId, participant: Participant, quality: NetworkQuality): Future[Unit] =
     Future.successful(())
 
-  def onClientsRequest(convId: ConvId): Future[Unit] = {
+  def onClientsRequest(convId: ConvId): Future[Unit] =
     withConv(convId) { (wCall, conv) =>
       otrSyncHandler.postClientDiscoveryMessage(convId).map {
         case Right(clients) =>
@@ -400,7 +400,6 @@ class CallingServiceImpl(val accountId:       UserId,
           warn(l"Could not post client discovery message: $errorResponse")
       }
     }
-  }
 
   override def startCall(convId: ConvId, isVideo: Boolean = false, forceOption: Boolean = false) =
     Serialized.future(self) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -228,7 +228,6 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
 
   override def postClientDiscoveryMessage(convId: ConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]] = {
     for {
-      _ <- push.waitProcessing
       Some(conv) <- convStorage.get(convId)
       message = OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
       response <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -22,7 +22,7 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.internalError
 import com.waz.content.{ConversationStorage, MembersStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.log.LogSE._
+import com.waz.log.LogSE.{error, _}
 import com.waz.model._
 import com.waz.model.otr.ClientId
 import com.waz.service.conversation.ConversationsService
@@ -231,8 +231,11 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       Some(conv) <- convStorage.get(convId)
       message = OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
       response <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
-    } yield {
-      response.fold(identity, _.missing)
+    } yield response match {
+      case Left(error) =>
+        Left(error)
+      case Right(messageResponse) =>
+        Right(messageResponse.missing)
     }
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -232,7 +232,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       message = OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
       response <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
     } yield {
-      response.right.map(_.missing)
+      response.fold(identity, _.missing)
     }
   }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
@@ -20,6 +20,7 @@ package com.waz.service.call
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.otr.ClientId
 import com.waz.model.{ConvId, UserId}
+import com.waz.service.call.Avs.ClientListEncoder._
 import com.waz.specs.AndroidFreeSpec
 
 class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
@@ -67,4 +68,47 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
     member2.aestab shouldEqual 0
     member2.vrecv shouldEqual 1
   }
+
+  scenario("Client list can be encoded") {
+    // Given
+    val clientList = ClientList(Seq(
+      Client("user1", "client1"),
+      Client("user1", "client2"),
+      Client("user2", "client1"),
+      Client("user3", "client1"),
+      Client("user3", "client2")
+    ))
+
+    // When
+    val result = encode(clientList)
+
+    // Then
+    result shouldEqual
+      """
+        |{
+        |  "clients" : [
+        |    {
+        |      "userid" : "user1",
+        |      "clientid : "client1"
+        |    },
+        |    {
+        |      "userid" : "user1",
+        |      "clientid : "client2"
+        |    },
+        |    {
+        |      "userid" : "user2",
+        |      "clientid : "client1"
+        |    },
+        |    {
+        |      "userid" : "user3",
+        |      "clientid : "client1"
+        |    },
+        |    {
+        |      "userid" : "user3",
+        |      "clientid : "client2"
+        |    }
+        |  ]
+        |}""".stripMargin
+  }
+
 }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
@@ -83,32 +83,34 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
     val result = encode(clientList)
 
     // Then
-    result shouldEqual
+    minify(result) shouldEqual minify(
       """
         |{
         |  "clients" : [
         |    {
         |      "userid" : "user1",
-        |      "clientid : "client1"
+        |      "clientid" : "client1"
         |    },
         |    {
         |      "userid" : "user1",
-        |      "clientid : "client2"
+        |      "clientid" : "client2"
         |    },
         |    {
         |      "userid" : "user2",
-        |      "clientid : "client1"
+        |      "clientid" : "client1"
         |    },
         |    {
         |      "userid" : "user3",
-        |      "clientid : "client1"
+        |      "clientid" : "client1"
         |    },
         |    {
         |      "userid" : "user3",
-        |      "clientid : "client2"
+        |      "clientid" : "client2"
         |    }
         |  ]
-        |}""".stripMargin
+        |}""".stripMargin)
   }
+
+  private def minify(text: String): String = text.replaceAll("\\s", "")
 
 }


### PR DESCRIPTION
## What's new in this PR?

This PR adds support for client discovery messages and implements the `ClientsRequestHandler`.

When connecting to a conference call, AVS will ask the client for a list of all clients (devices) in the conversation. This request is made by invoking the `ClientsRequestHandler`. 

The app will then proceed to post a [client discovery message](https://github.com/wearezeta/documentation/blob/master/topics/calling/use-cases/001-provide-avs-with-client-list.md) into the conversation, which is used to retrieve an up-to-date list of clients from the backend. This result is then encoded into a Json string and passed to AVS via the `wcall_set_clients_for_conv` function.

### Testing

Two tests have been included:

- assert that posting a client discovery message returns the correct list of clients
- assert that the client list can be encoded to a Json string


#### APK
[Download build #2245](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2245/artifact/build/artifact/wire-dev-PR2895-2245.apk)
[Download build #2250](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2250/artifact/build/artifact/wire-dev-PR2895-2250.apk)