### PR TITLE
Make request to SFT server (conference part 2)

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -254,7 +254,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
 
   override def onSftResponse(wCall: WCall, data: Option[Array[Byte]], ctx: Pointer): Unit =
     withAvs {
-      val errorCode = if (data.isDefined) 0 else 1
+      val errorCode = if (data.isDefined) AvsSftError.None else AvsSftError.NoResponseData
       val responseData = data.getOrElse(Array())
       wcall_sft_resp(wCall, errorCode, responseData, responseData.length, ctx)
     }
@@ -275,6 +275,12 @@ object Avs extends DerivedLogTag {
   object AvsCallError {
     val None = 0
     val UnknownProtocol = 1000
+  }
+
+  type AvsSftError = Int
+  object AvsSftError {
+    val None = 0
+    val NoResponseData = 1
   }
 
   /**

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -106,7 +106,7 @@ object Calling {
 
   @native def wcall_set_clients_for_conv(inst: Handle, convId: String, clientsJson: String): Int
 
-  @native def wcall_sft_resp(inst: Handle, error: Int, data: Pointer, length: Size_t, ctx: Pointer): Unit
+  @native def wcall_sft_resp(inst: Handle, error: Int, data: Array[Byte], length: Int, ctx: Pointer): Unit
 
   /* This will be called when the calling system is ready for calling.
      * The version parameter specifies the config obtained version to use

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -217,8 +217,8 @@ class CallingServiceImpl(val accountId:       UserId,
 
   def onSftRequest(ctx: Pointer, url: String, data: String): Unit =
     callingClient.connectToSft(url, data).foreach {
-      case Left(error) =>
-        error(l"Could not connect to sft server", error)
+      case Left(responseError) =>
+        error(l"Could not connect to sft server", responseError)
         wCall.foreach(avs.onSftResponse(_, None, ctx))
       case Right(responseData) =>
         wCall.foreach(avs.onSftResponse(_, Some(responseData), ctx))


### PR DESCRIPTION
## What's new in this PR?

With this PR the app is able to contact the SFT server to connect to a conference call.

When starting or joining a conference call, AVS will request the client to make a request to the SFT server on their behalf. They do this by invoking the `SFTRequestHandler`, passing the url of the server and a payload to post. The client then schedules the request and when it receives the response, it passes along the body of the response back to AVS via the `wcall_sft_resp` function.

## Testing

1. Receive an incoming conference call
2. Accept
3. See the call connects
#### APK
[Download build #2252](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2252/artifact/build/artifact/wire-dev-PR2896-2252.apk)
[Download build #2253](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2253/artifact/build/artifact/wire-dev-PR2896-2253.apk)