### PR TITLE
fix: Remove file restrictions on file pickers

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -26,12 +26,10 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.MediaStore;
-import android.webkit.MimeTypeMap;
 
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
 
-import com.waz.service.ZMessaging;
 import com.waz.utils.IoUtils;
 import com.waz.utils.wrappers.AndroidURI;
 import com.waz.utils.wrappers.AndroidURIUtil;
@@ -39,7 +37,6 @@ import com.waz.utils.wrappers.URI;
 import com.waz.zclient.BuildConfig;
 import com.waz.zclient.Intents;
 import com.waz.zclient.core.logging.Logger;
-import com.waz.service.assets.FileRestrictionList;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,7 +103,10 @@ public class AssetIntentsManager {
 
     public void openFileSharing() {
         final Set<String> mimeTypes = new HashSet<>();
-        FileRestrictionList fileRestrictions = ZMessaging.currentGlobal().fileRestrictionList();
+        // FIXME: For now we let the user choose from all files and we check restrictions before sending
+        // The reason is, restricting access to files via intent make some file pickers restrict also
+        // access to certain folders, while other file pickers ignore the restrictions altogether.
+        /*FileRestrictionList fileRestrictions = ZMessaging.currentGlobal().fileRestrictionList();
         if (!fileRestrictions.getEnabled()) {
             mimeTypes.add(INTENT_ALL_TYPES);
         } else {
@@ -119,7 +119,8 @@ public class AssetIntentsManager {
                     mimeTypes.add("application/" + ext);
                 }
             }
-        }
+        }*/
+        mimeTypes.add(INTENT_ALL_TYPES);
         openDocument(mimeTypes, IntentType.FILE_SHARING, true);
     }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
@@ -109,7 +109,7 @@ class OtrMsgPartView(context: Context, attrs: AttributeSet, style: Int)
       Signal(affectedUserName, message.map(_.name)).map {
         case (Other(name), _)     => getString(R.string.file_restrictions__receiver_error, name)
         case (_, Some(Name(ext))) => getString(R.string.file_restrictions__sender_error, ext)
-        case (user, name)         => ""
+        case _                    => getString(R.string.file_restrictions__sender_error, "")
       }
     case _ =>
       Signal.const("")


### PR DESCRIPTION
When we open a file picker from inside Wire, and try to force it to hide some of the files basing on their extensions,
some file pickers end up restricking access to whole folders (e.g. Huawei phones, Android 8.0). Until we find out
how to handle it better, we decided not to restrict the file picker. The user will be allowed to choose any file,
and only then Wire will prevent the file from being sent. The code that adds the list of allowed MIME types to the intent
will stay commented out in case we change this decision.

I also moved the dialog with the error message a bit to make sure it is displayed (there was a report that it doesn't
appear on one device). And I fixed a bug when the error system message was displayed with empty text when the extension is unknown (rare, but possible).

fixes https://wearezeta.atlassian.net/browse/AN-6941
#### APK
[Download build #2263](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2263/artifact/build/artifact/wire-dev-PR2897-2263.apk)