### PR TITLE
Bugfix : Android 10 Incoming Call Notification

### DIFF
--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -39,7 +39,6 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
       startForeground(not.convId.str.hashCode, builder.build())
     case _ =>
       stopForeground(true)
-      stopSelf()
   }
 
   override def onBind(intent: Intent): IBinder = null

--- a/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
@@ -21,7 +21,6 @@ import android.content.{Context, Intent}
 import android.os.{Build, Bundle}
 import android.view.WindowManager
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.services.calling.CallingNotificationsService
 import com.waz.threading.Threading
 import com.waz.zclient._
 import com.waz.zclient.calling.controllers.CallController
@@ -72,7 +71,6 @@ class CallingActivity extends BaseActivity {
 
   override def onResume() = {
     super.onResume()
-    stopService(new Intent(this, classOf[CallingNotificationsService]))
     controller.setVideoPause(pause = false)
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Android comes with new restrictions on starting activities from the background.
https://developer.android.com/guide/components/activities/background-starts

That's why it's impossible to keep the same calling experience of the android versions prior to Android 10 in terms of how an incoming call is signaled.
 
The expected calling experience for incoming calls in Android 10 : 
1. Device unlocked, app in foreground: Wire calling UI
2. Device locked, app in foreground: Wire calling UI
3. Device unlocked, app in background: Push notification
4. Device locked, app in background: Wire calling UI

Actually, our client is not working as expected, specially when the app is in the background, sometimes the phone is ringing but no notification is appearing.


### Causes

Killing `CallingNotificationsService` manually.

### Solutions

Avoid stopping `CallingNotificationsService` manually. Let the Android system to do it.

### Testing

Check the expected behaviour in the top.

## Notes

This problem is described in many calling tickets in different ways.

https://wearezeta.atlassian.net/browse/AN-6677
https://wearezeta.atlassian.net/browse/AN-6536
https://wearezeta.atlassian.net/browse/AN-6676

#### APK
[Download build #2268](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2268/artifact/build/artifact/wire-dev-PR2902-2268.apk)