### PR TITLE
[Feature] Start a conference call

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -227,8 +227,8 @@ android {
                                     applicationIcon        : "@mipmap/ic_launcher_wire_dev",
                                     sharedUserId           : ""]
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING', 'false'
             buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
@@ -240,8 +240,8 @@ android {
                                     sharedUserId           : ""]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$buildtimeConfiguration.configuration.loggingEnabled"
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED', "$buildtimeConfiguration.configuration.loggingEnabled"
+            buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
         }
 
         prod {
@@ -251,8 +251,8 @@ android {
                                     sharedUserId           : buildtimeConfiguration.configuration.userId]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        "$buildtimeConfiguration.configuration.loggingEnabled"
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED', "$buildtimeConfiguration.configuration.loggingEnabled"
+            buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
         }
 
         internal {
@@ -262,9 +262,9 @@ android {
                                     applicationIcon  : "@mipmap/ic_launcher_wire_internal",
                                     sharedUserId     : ""]
 
-            buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
             buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
@@ -276,8 +276,8 @@ android {
                                     sharedUserId           : ""]
 
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
-            buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
-            buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
+            buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
             buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,8 +145,8 @@ android {
         buildConfigField 'boolean', 'KOTLIN_REGISTRATION', "$rootProject.ext.kotlinRegistration"
         buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
 
-        // Internal feature flags
-        buildConfigField 'boolean', 'CONFERENCE_CALLING', "$rootProject.ext.conferenceCalling"
+        // Internal feature flags to override in productFlavors
+        buildConfigField 'boolean', 'CONFERENCE_CALLING', 'false'
     }
 
     packagingOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,9 @@ android {
         buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"
         buildConfigField 'boolean', 'KOTLIN_REGISTRATION', "$rootProject.ext.kotlinRegistration"
         buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
+
+        // Internal feature flags
+        buildConfigField 'boolean', 'CONFERENCE_CALLING', "$rootProject.ext.conferenceCalling"
     }
 
     packagingOptions {
@@ -226,6 +229,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
             buildConfigField 'boolean', 'SAFE_LOGGING',     'false'
+            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
         candidate {
@@ -261,6 +265,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED',    'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
             buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
         experimental {
@@ -273,6 +278,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED',        'true'
             buildConfigField 'boolean', 'SAFE_LOGGING',     'true'
+            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
     }
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -440,7 +440,8 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
       null, //TODO: Use sync engine's version for now
       inject[MessageNotificationsController],
       assets2Module,
-      inject[FileRestrictionList]
+      inject[FileRestrictionList],
+      BuildConfig.CONFERENCE_CALLING
     )
 
     val activityLifecycleCallback = inject[ActivityLifecycleCallback]

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,6 @@ ext {
     kotlinSettings = false
     kotlinRegistration = false
     kotlinCore = kotlinSettings || kotlinRegistration
-
-    // Internal feature flags
-    conferenceCalling = false
 }
 
 class BuildtimeConfiguration {

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ ext {
     kotlinSettings = false
     kotlinRegistration = false
     kotlinCore = kotlinSettings || kotlinRegistration
+
+    // Internal feature flags
+    conferenceCalling = false
 }
 
 class BuildtimeConfiguration {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -109,6 +109,8 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
   private implicit val dispatcher = new SerialDispatchQueue(name = "ZMessaging")
 
+  val conferenceCallingEnabled: Boolean = ZMessaging.conferenceCallingEnabled
+
   val clock = ZMessaging.clock
 
   val global     = account.global
@@ -380,6 +382,7 @@ object ZMessaging extends DerivedLogTag { self =>
   private var notificationsUi:     NotificationUiController = _
   private var assets2Module:       Assets2Module = _
   private var fileRestrictionList: FileRestrictionList = _
+  private var conferenceCallingEnabled: Boolean = _
 
   //var for tests - and set here so that it is globally available without the need for DI
   var clock = Clock.systemUTC()
@@ -410,7 +413,8 @@ object ZMessaging extends DerivedLogTag { self =>
                syncRequests:        SyncRequestService,
                notificationUi:      NotificationUiController,
                assets2:             Assets2Module,
-               fileRestrictionList: FileRestrictionList
+               fileRestrictionList: FileRestrictionList,
+               conferenceCallingEnabled: Boolean
               ) = {
     Threading.assertUiThread()
 
@@ -424,6 +428,7 @@ object ZMessaging extends DerivedLogTag { self =>
       this.notificationsUi = notificationUi
       this.assets2Module = assets2
       this.fileRestrictionList = fileRestrictionList
+      this.conferenceCallingEnabled = conferenceCallingEnabled
 
       currentUi = ui
       currentGlobal = _global

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -424,7 +424,10 @@ class CallingServiceImpl(val accountId:       UserId,
           if (convSize > VideoCallMaxMembers) Avs.WCallType.ForcedAudio
           else if (isVideo) Avs.WCallType.Video
           else Avs.WCallType.Normal
-        convType = if (isGroup) Avs.WCallConvType.Group else Avs.WCallConvType.OneOnOne
+        convType =
+          if (isGroup && conferenceCallingEnabled) Avs.WCallConvType.Conference
+          else if (isGroup && !conferenceCallingEnabled) Avs.WCallConvType.Group
+          else Avs.WCallConvType.OneOnOne
         _ <- permissions.ensurePermissions(ListSet(android.Manifest.permission.RECORD_AUDIO) ++ (if(forceOption && isVideo) ListSet(android.Manifest.permission.CAMERA) else ListSet()))
         _ <-
           profile.activeCall match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -169,7 +169,8 @@ class CallingServiceImpl(val accountId:       UserId,
                          globalPrefs:         GlobalPreferences,
                          permissions:         PermissionsService,
                          userStorage:         UsersStorage,
-                         tracking:            TrackingService)(implicit accountContext: AccountContext) extends CallingService with DerivedLogTag with SafeToLog { self =>
+                         tracking:            TrackingService,
+                         conferenceCallingEnabled: Boolean)(implicit accountContext: AccountContext) extends CallingService with DerivedLogTag with SafeToLog { self =>
 
   import CallingService._
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -973,7 +973,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     val s = new CallingServiceImpl(
       selfUserId, selfClientId, null, context, avs, convs, convsService, members, null,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking
+      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, conferenceCallingEnabled = false
     )
     result(s.wCall)
     s


### PR DESCRIPTION
## What's new in this PR?

This PR enables the app to start both audio and video conference calls. This feature is behind a new feature flag `CONFERENCE_CALLING`. The feature flag is `false` by default, and `true` only for the `dev`, `internal` and `experimental` build flavors.
### Testing

1. Make a build with one of the aforementioned flavors.
2. Start a call in a group conversation.
3. The call should connect to the SFT server, and you should be the only participant in the call.

## Notes

This feature flag is temporary and will be after the feature is officially launched.
#### APK
[Download build #2272](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2272/artifact/build/artifact/wire-dev-PR2903-2272.apk)
[Download build #2273](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2273/artifact/build/artifact/wire-dev-PR2903-2273.apk)