### PR TITLE
[Chore] Remove video call restrictions

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1333,7 +1333,7 @@
     <string name="backup_import_error_wrong_account">You cannot restore history from a different account.</string>
     <string name="video_paused">Video paused</string>
     <string name="calling_degraded_title">New device</string>
-    <string name="call_info_text">Up to %1$s people can join a group conversation. Video calls work with up to 3 other people and you.</string>
+    <string name="call_info_text">Up to %1$s people can join a group conversation. Video calls work with up to %2$s other people and you.</string>
 
     <string name="markdown_link_dialog_title">Visit Link</string>
     <string name="markdown_link_dialog_message">This will take you to\n%1$s</string>

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -24,6 +24,7 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{CompoundButton, ImageView, TextView}
 import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.appcompat.widget.SwitchCompat
+import com.waz.service.call.CallingService
 import com.wire.signals.Signal
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.UserAccountsController

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -47,7 +47,7 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
   private lazy val convOptions = view[View](R.id.create_conv_options)
   private lazy val convOptionsArrow = view[ImageView](R.id.create_conv_options_icon)
   private lazy val callInfo = returning(view[TextView](R.id.call_info)) { vh =>
-    vh.foreach(_.setText(getString(R.string.call_info_text, ConversationController.MaxParticipants.toString)))
+    vh.foreach(_.setText(getString(R.string.call_info_text, ConversationController.MaxParticipants.toString, CallingService.videoCallMaxMembersExcludingSelf.toString)))
   }
 
   private lazy val readReceiptsToggle  = returning(view[SwitchCompat](R.id.read_receipts_toggle)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -448,7 +448,7 @@ object ParticipantsAdapter {
         Selection.removeSelection(editText.getText)
       }
 
-      callInfo.setText(if (isTeam) getString(R.string.call_info_text, ConversationController.MaxParticipants.toString) else getString(R.string.empty_string))
+      callInfo.setText(if (isTeam) getString(R.string.call_info_text, ConversationController.MaxParticipants.toString, CallingService.videoCallMaxMembersExcludingSelf.toString) else getString(R.string.empty_string))
       callInfo.setMarginTop(getDimenPx(if (isTeam) R.dimen.wire__padding__16 else R.dimen.wire__padding__8)(view.getContext))
       callInfo.setMarginBottom(getDimenPx(if (isTeam) R.dimen.wire__padding__16 else R.dimen.wire__padding__8)(view.getContext))
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -33,6 +33,7 @@ import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.SearchQuery
+import com.waz.service.call.CallingService
 import com.wire.signals._
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -80,7 +80,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
 import com.waz.zclient.views.e2ee.ShieldView
-import com.waz.zclient.{ErrorsController, FragmentHelper, R}
+import com.waz.zclient.{BuildConfig, ErrorsController, FragmentHelper, R}
 
 import scala.collection.immutable.ListSet
 import scala.concurrent.Future
@@ -220,7 +220,7 @@ class ConversationFragment extends FragmentHelper {
     } yield {
       if (isCallActive || !isConvActive || participantsNumber <= 1)
         Option.empty[Int]
-      else if (!isGroup || (isTeam && participantsNumber <= CallingService.VideoCallMaxMembers))
+      else if (!isGroup || ((isTeam || BuildConfig.CONFERENCE_CALLING) && participantsNumber <= CallingService.VideoCallMaxMembers))
         Some(R.menu.conversation_header_menu_video)
       else
         Some(R.menu.conversation_header_menu_audio)

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,6 @@ ext {
     kotlinSettings = false
     kotlinRegistration = false
     kotlinCore = kotlinSettings || kotlinRegistration
-
-    // Internal feature flags
-    conferenceCalling = false
 }
 
 class BuildtimeConfiguration {

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ ext {
     kotlinSettings = false
     kotlinRegistration = false
     kotlinCore = kotlinSettings || kotlinRegistration
+
+    // Internal feature flags
+    conferenceCalling = false
 }
 
 class BuildtimeConfiguration {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -431,6 +431,8 @@ object ZMessaging extends DerivedLogTag { self =>
       this.fileRestrictionList = fileRestrictionList
       this.conferenceCallingEnabled = conferenceCallingEnabled
 
+      if (conferenceCallingEnabled) CallingService.VideoCallMaxMembers = 100
+
       currentUi = ui
       currentGlobal = _global
       currentAccounts = currentGlobal.accountsService

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -109,7 +109,8 @@ trait CallingService {
 
 object CallingService {
 
-  val VideoCallMaxMembers: Int = 4
+  var VideoCallMaxMembers: Int = 4
+  def videoCallMaxMembersExcludingSelf: Int = VideoCallMaxMembers - 1
 
   trait AbstractCallProfile[A] {
 


### PR DESCRIPTION
## What's new in this PR?

This PR removes two restrictions related to video calls:

1. Non team users are now able to start video conferences. 
2. The maximum number of participants in a video conference has been raised to 100. This is an arbitrarily high number to allow for stress testing the client. At a later date, a more suitable limit will be imposed.

### Testing

Log into a non team account, start a video call in a group conversation with more than 4 participants.


#### APK
[Download build #2274](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2274/artifact/build/artifact/wire-dev-PR2905-2274.apk)
[Download build #2275](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2275/artifact/build/artifact/wire-dev-PR2905-2275.apk)
[Download build #2282](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2282/artifact/build/artifact/wire-dev-PR2905-2282.apk)