### PR TITLE
fix: Avoid displaying 'Default' as the username in system messages

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,10 +163,17 @@
 
     <!-- Remove people -->
     <string name="content__system__other_removed_other">[[%1$s]] removed %2$s</string>
+    <string name="content__system__other_removed_someone">[[%1$s]] removed someone</string>
+    <string name="content__system__someone_removed_other">Someone removed %2$s</string>
     <string name="content__system__other_removed_you">[[%1$s]] removed you</string>
+    <string name="content__system__someone_removed_you">Someone removed you</string>
     <string name="content__system__you_removed_other">You removed %1$s</string>
+    <string name="content__system__you_removed_someone">You removed someone</string>
     <string name="content__system__you_left">[[You]] left</string>
     <string name="content__system__other_left">[[%1$s]] left</string>
+    <string name="content__system__someone_left">Someone left</string>
+    <string name="content__system__other_was_removed">%1$s was removed</string>
+    <string name="content__system__someone_was_removed">Someone was removed</string>
 
     <!-- Create conversation -->
     <string name="content__system__you_started_conversation">You started the conversation</string>

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -61,7 +61,7 @@ class UsersController(implicit injector: Injector, context: Context)
 
   // this is the same as ConversationController.DefaultDeletedName but it's possible just as well
   // that the default name for a conversation is different from the default name for a user
-  private lazy val DefaultDeletedName: Name = Name(getString(R.string.default_deleted_username))
+  lazy val DefaultDeletedName: Name = Name(getString(R.string.default_deleted_username))
 
   def displayName(id: UserId): Signal[DisplayName] = selfUserId.flatMap {
     case selfId if selfId == id =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -221,12 +221,15 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       } yield ()
 
     case MemberLeaveEvent(_, time, from, userIds) =>
+      val userIdSet = userIds.toSet
       for {
-        _              <- deleteMembers(conv.id, userIds.toSet, Some(from), sendSystemMessage = true)
-        selfUserLeaves =  userIds.contains(selfUserId)
+        syncId         <- users.syncIfNeeded(userIdSet)
+        _              <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
+        _              <- deleteMembers(conv.id, userIdSet, Some(from), sendSystemMessage = true)
+        selfUserLeaves =  userIdSet.contains(selfUserId)
         _              <- if (selfUserLeaves) content.setConvActive(conv.id, active = false) else Future.successful(())
                           // if the user removed themselves from another device, archived on this device
-        _              <- if (selfUserLeaves && from.equals(selfUserId))
+        _              <- if (selfUserLeaves && from == selfUserId)
                             content.updateConversationState(conv.id, ConversationState(Option(true), Option(time)))
                           else
                             Future.successful(None)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -223,7 +223,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     case MemberLeaveEvent(_, time, from, userIds) =>
       val userIdSet = userIds.toSet
       for {
-        syncId         <- users.syncIfNeeded(userIdSet)
+        syncId         <- users.syncIfNeeded(userIdSet -- Set(selfUserId))
         _              <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
         _              <- deleteMembers(conv.id, userIdSet, Some(from), sendSystemMessage = true)
         selfUserLeaves =  userIdSet.contains(selfUserId)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -149,6 +149,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val events = Seq(
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(selfUserId))
       )
+      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
 
       // check if the self is still in any conversation (they are - with self)
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
@@ -199,6 +200,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), removerId, Seq(selfUserId))
       )
 
+      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)))
       )
@@ -244,6 +246,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(otherUserId))
       )
 
+      (users.syncIfNeeded _).expects(Set(otherUserId), *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(otherUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(otherUserId, convId, ConversationRole.MemberRole)))
       )
@@ -765,6 +768,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
       (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.wrap(membersOnChanged))
       (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
       (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>
         members.head.map { ms =>


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6873
fixes https://wearezeta.atlassian.net/browse/AN-6859

In some cases, when the user is removed from the team or the conversation, we may not know their name and "Default" is displayed in the system message. To avoid that, I added "sync if needed" to the `MemberLeave` event handling, just as it is done for `MemberJoin`. I also added new strings which are used if we still don't know the name of the user even after syncing (might happen for example when the user is removed from the team).

#### APK
[Download build #2286](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2286/artifact/build/artifact/wire-dev-PR2906-2286.apk)