### PR TITLE
fix: Team data gets updated but new team data is not stored

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -26,7 +26,6 @@ import android.view.View.OnClickListener
 import android.widget.{ImageView, LinearLayout}
 import com.bumptech.glide.request.RequestOptions
 import com.waz.content.UserPreferences
-import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.otr.Client
 import com.waz.model.{AccentColor, Availability, Picture, TeamData, UserPermissions}
 import com.waz.service.teams.TeamsService
@@ -138,13 +137,9 @@ class ProfileViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
 
   override def setAccentColor(color: Int): Unit = {}
 
-  override def setTeamName(name: Option[String]) = {
-    name match {
-      case Some(teamName) =>
-        teamNameText.setText(context.getString(R.string.preferences_profile_in_team, teamName))
-      case None =>
-        teamNameText.setText("")
-    }
+  override def setTeamName(name: Option[String]): Unit = name match {
+    case Some(teamName) => teamNameText.setText(context.getString(R.string.preferences_profile_in_team, teamName))
+    case None           => teamNameText.setText("")
   }
 
   override def setManageTeamEnabled(enabled: Boolean): Unit = {
@@ -242,7 +237,7 @@ case class ProfileBackStackKey(args: Bundle = new Bundle()) extends BackStackKey
 }
 
 class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: EventContext)
-  extends Injectable with DerivedLogTag {
+  extends Injectable {
 
   import ProfileViewController._
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -72,8 +72,7 @@ class TeamsSyncHandlerImpl(userId:    UserId,
     case None     => Future.successful(SyncResult.Success)
     case Some(id) =>
       client.getTeamData(id).future.flatMap {
-        case Right(data) =>
-          service.onTeamUpdated(id, Some(data.name), data.icon).map(_ => SyncResult.Success)
+        case Right(data) => service.onTeamUpdated(data).map(_ => SyncResult.Success)
         case Left(err)   => Future.successful(SyncResult(err))
       }
   }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-6857

I introduced this bug a few weeks ago when I was working on team data updates - I removed the possibility to receive a completely new team data. This PR fixes that. The side-effect, which led to discovering the bug, was that the team name didn't appear on the profile view for new team members.

#### APK
[Download build #2280](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2280/artifact/build/artifact/wire-dev-PR2907-2280.apk)
[Download build #2281](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2281/artifact/build/artifact/wire-dev-PR2907-2281.apk)