### PR TITLE
[Fix] Allow call to be promoted to video for non team user

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -35,7 +35,7 @@ import com.waz.zclient.log.LogUI._
 import com.waz.zclient.paintcode._
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.RichView
-import com.waz.zclient.{R, ViewHelper}
+import com.waz.zclient.{BuildConfig, R, ViewHelper}
 import com.waz.threading.Threading._
 
 import scala.async.Async._
@@ -85,7 +85,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
       established    <- controller.isCallEstablished
       showVideo      <- controller.isVideoCall
       members        <- controller.conversationMembers.map(_.size)
-    } yield members <= CallingService.VideoCallMaxMembers && ((established && (isTeam || !isGroup)) || showVideo)).onUi(button.setEnabled)
+    } yield members <= CallingService.VideoCallMaxMembers && ((established && (BuildConfig.CONFERENCE_CALLING || isTeam || !isGroup)) || showVideo)).onUi(button.setEnabled)
   }
 
   returning(findById[CallControlButtonView](R.id.speaker_flip_call)) { button =>


### PR DESCRIPTION
## What's new in this PR?

In https://github.com/wireapp/wire-android/pull/2905 I removed the restrictions around video calls, but I missed one small case.

### Issues

If a non team user is in a group audio call, then this user can no enabled video until another recipient enables video.

### Causes

This is expected for the old logic, where video calling is a team only feature, however a non team user could still participate in a video call if someone else promotes the call to video.

### Solutions

Use the `CONFERENCE_CALLING` feature flag to override this restriction.

### Testing

1. As a non team user
2. Be in an group audio call
3. Be the first to enable video





#### APK
[Download build #2284](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2284/artifact/build/artifact/wire-dev-PR2908-2284.apk)