### PR TITLE
Feature : Increase handle length

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/shared/user/handle/usecase/ValidateHandleUseCase.kt
+++ b/app/src/main/kotlin/com/waz/zclient/shared/user/handle/usecase/ValidateHandleUseCase.kt
@@ -30,7 +30,7 @@ class ValidateHandleUseCase : UseCase<String, ValidateHandleParams> {
         handle.length < HANDLE_MIN_LENGTH
 
     companion object {
-        private const val HANDLE_MAX_LENGTH = 21
+        private const val HANDLE_MAX_LENGTH = 256
         private const val HANDLE_MIN_LENGTH = 2
         private val HANDLE_REGEX = """^([a-z]|[0-9]|_)*""".toRegex()
     }

--- a/app/src/main/scala/com/waz/zclient/HandleLength.scala
+++ b/app/src/main/scala/com/waz/zclient/HandleLength.scala
@@ -1,0 +1,24 @@
+/**
+ * Wire
+ * Copyright (C) 2020 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.waz.zclient
+
+object HandleLength {
+  val HandleMaxLength = 256
+  val HandleMinLength = 2
+}

--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -64,7 +64,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
   private lazy val browser = inject[BrowserController]
 
-  private val USERNAME_MAX_LENGTH = 21
+  private val USERNAME_MAX_LENGTH = 256
   private val NORMAL_ATTEMPTS = 30
   private val RANDOM_ATTEMPTS = 20
   private val MAX_RANDOM_TRAILING_NUMBER = 1000

--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -64,7 +64,6 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
   private lazy val browser = inject[BrowserController]
 
-  private val USERNAME_MAX_LENGTH = 256
   private val NORMAL_ATTEMPTS = 30
   private val RANDOM_ATTEMPTS = 20
   private val MAX_RANDOM_TRAILING_NUMBER = 1000
@@ -174,7 +173,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
   private def getAttempts(base: String, attempts: Int): Seq[Handle] =
     (0 until attempts).map(getTrailingNumber).map { tN =>
-      Handle(StringUtils.truncate(base, USERNAME_MAX_LENGTH - tN.length) + tN)
+      Handle(StringUtils.truncate(base, HandleLength.HandleMaxLength - tN.length) + tN)
     }
 
   private def getTrailingNumber(attempt: Int): String = {

--- a/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
@@ -181,7 +181,7 @@ object InputBox {
   //TODO: Unify this code with the one from the change username fragment
   object UsernameValidator extends Validator({ t =>
     val ValidUsername = s"""^([a-z]|[0-9]|_)*""".r
-    val MaxLength = 21
+    val MaxLength = 256
     val MinLength = 2
     t match {
       case ValidUsername(_) =>

--- a/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/InputBox.scala
@@ -34,7 +34,7 @@ import com.waz.zclient.ui.cursor.CursorEditText
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.utils.TextViewUtils
 import com.waz.zclient.utils._
-import com.waz.zclient.{R, ViewHelper}
+import com.waz.zclient.{HandleLength, R, ViewHelper}
 
 import scala.concurrent.Future
 import com.waz.threading.Threading._
@@ -181,8 +181,8 @@ object InputBox {
   //TODO: Unify this code with the one from the change username fragment
   object UsernameValidator extends Validator({ t =>
     val ValidUsername = s"""^([a-z]|[0-9]|_)*""".r
-    val MaxLength = 256
-    val MinLength = 2
+    val MaxLength = HandleLength.HandleMaxLength
+    val MinLength = HandleLength.HandleMinLength
     t match {
       case ValidUsername(_) =>
         t.length match {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
@@ -256,7 +256,7 @@ object ChangeHandleFragment {
     val InvalidCharacters, AlreadyTaken, TooLong, TooShort, NoError = Value
   }
 
-  val MaxLength = 21
+  val MaxLength = 256
   val MinLength = 2
   val checkMultipleAvailabilityPath = "/users"
   val checkSingleAvailabilityPath = "/users/handles/"

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
@@ -33,7 +33,7 @@ import com.waz.threading.Threading
 import com.wire.signals.Signal
 import com.waz.utils.returning
 import com.waz.zclient.views.LoadingIndicatorView
-import com.waz.zclient.{FragmentHelper, R}
+import com.waz.zclient.{FragmentHelper, HandleLength, R}
 import com.waz.zclient.log.LogUI._
 
 import scala.util.Try
@@ -256,8 +256,8 @@ object ChangeHandleFragment {
     val InvalidCharacters, AlreadyTaken, TooLong, TooShort, NoError = Value
   }
 
-  val MaxLength = 256
-  val MinLength = 2
+  val MaxLength = HandleLength.HandleMaxLength
+  val MinLength = HandleLength.HandleMinLength
   val checkMultipleAvailabilityPath = "/users"
   val checkSingleAvailabilityPath = "/users/handles/"
   val handlesQuery = "handles"

--- a/app/src/test/kotlin/com/waz/zclient/shared/user/handle/usecase/ValidateHandleUseCaseTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/shared/user/handle/usecase/ValidateHandleUseCaseTest.kt
@@ -35,7 +35,7 @@ class ValidateHandleUseCaseTest : UnitTest() {
 
     @Test
     fun `Given run is executed, when handle matches regex and length is over max, then return failure`() {
-        val handle = "thisisalonghandlethatshouldnotbethislong"
+        val handle = "thisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislongthisisalonghandlethatshouldnotbethislong"
         verifyValidateUseCase(handle)
     }
 


### PR DESCRIPTION
## What's new in this PR?

Specific customers require user handles that are longer than 21 characters, because they add full names and departments (to avoid ambiguity with similar names) to the handle.  

Changes needed:
Expand the handle length limit, enforced when picking a new handle, to 256 characters.

https://wearezeta.atlassian.net/browse/AN-6985

#### APK
[Download build #2304](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2304/artifact/build/artifact/wire-dev-PR2916-2304.apk)