### PR TITLE
Gradle task: static code analysis

### DIFF
--- a/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
@@ -1,6 +1,8 @@
 package scripts
 
-import scripts.Variants_gradle.*
+import BuildPlugins
+import scripts.Variants_gradle.BuildTypes
+import scripts.Variants_gradle.ProductFlavors
 import java.util.*
 
 private object Default {
@@ -10,13 +12,18 @@ private object Default {
     val VARIANT = "${BUILD_FLAVOR.capitalize()}${BUILD_TYPE.capitalize()}"
 }
 
-tasks.register("clean", Delete::class){
+tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
 
 tasks.named<Wrapper>("wrapper") {
     gradleVersion = BuildPlugins.Versions.gradleVersion
     distributionType = Wrapper.DistributionType.ALL
+}
+
+tasks.register("staticCodeAnalysis") {
+    description = "Analyses code within the Wire Android codebase"
+    dependsOn("detektAll")
 }
 
 tasks.register("runUnitTests") {
@@ -48,7 +55,7 @@ tasks.register("runApp", Exec::class) {
         localProperties.inputStream().use { properties.load(it) }
         val sdkDir = properties["sdk.dir"]
         val adb = "${sdkDir}/platform-tools/adb"
-        
+
         val applicationPackage = "com.wire.android.${Default.BUILD_FLAVOR}.${Default.BUILD_TYPE}"
         val launchActivity = "com.wire.android.feature.auth.registration.CreateAccountActivity"
 


### PR DESCRIPTION
Added a gradle task in the project to allow the Jenkins pipeline to be agnostic to what static code analysis framework we're using, so if in the future we change our we analyse our code, we don't have to keep updating the pipeline. 