### PR TITLE
[Chore] Bump AVS to 6.1.9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.0.39@aar'
+    customAvsVersion = '6.1.9@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conference calling features were not fully disabled for upcoming release.

### Causes

The AVS library still allowed to accept conference calls.

### Solutions

Bump to a version of AVS which specifically disables conference calling for this release.

### Testing

1. Receive a conference call (in a group conversation)
2. Confirm that a alert dialog is shown indicating the user to update the app.


#### APK
[Download build #2299](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2299/artifact/build/artifact/wire-dev-PR2917-2299.apk)