### PR TITLE
[Fix] Restore calling tests

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -110,6 +110,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
   private implicit val dispatcher = new SerialDispatchQueue(name = "ZMessaging")
 
+  val httpProxy: Option[Proxy] = ZMessaging.httpProxy
   val conferenceCallingEnabled: Boolean = ZMessaging.conferenceCallingEnabled
 
   val clock = ZMessaging.clock

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -18,6 +18,7 @@
 package com.waz.service.call
 
 import java.net.InetSocketAddress
+import java.net.Proxy
 
 import android.Manifest.permission.CAMERA
 import com.sun.jna.Pointer
@@ -170,6 +171,7 @@ class CallingServiceImpl(val accountId:       UserId,
                          permissions:         PermissionsService,
                          userStorage:         UsersStorage,
                          tracking:            TrackingService,
+                         httpProxy:           Option[Proxy],
                          conferenceCallingEnabled: Boolean)(implicit accountContext: AccountContext) extends CallingService with DerivedLogTag with SafeToLog { self =>
 
   import CallingService._
@@ -182,7 +184,7 @@ class CallingServiceImpl(val accountId:       UserId,
 
   private[call] val callProfile = Signal(CallProfile.Empty)
 
-  ZMessaging.currentGlobal.httpProxy.foreach { proxy =>
+  httpProxy.foreach { proxy =>
      val proxyAddress = proxy.address().asInstanceOf[InetSocketAddress]
      avs.setProxy(proxyAddress.getHostName, proxyAddress.getPort)
   }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -47,7 +47,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-//fixme: solve native library loading problem
 class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   implicit val executionContext = new SerialDispatchQueue(name = "CallingServiceSpec")
@@ -1141,7 +1140,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     val s = new CallingServiceImpl(
       selfUserId, selfClientId, null, context, avs, convs, convsService, members, null,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, conferenceCallingEnabled = false
+      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, httpProxy = None, conferenceCallingEnabled = false
     )
     result(s.wCall)
     s

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -41,7 +41,6 @@ import com.waz.utils.RichInstant
 import com.wire.signals.Signal
 import com.waz.utils.jna.Uint32_t
 import com.waz.utils.wrappers.Context
-import org.junit.Ignore
 import org.threeten.bp.{Duration, Instant}
 
 import scala.concurrent.Future
@@ -49,7 +48,6 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 //fixme: solve native library loading problem
-@Ignore
 class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   implicit val executionContext = new SerialDispatchQueue(name = "CallingServiceSpec")

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -90,7 +90,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   lazy val service: CallingServiceImpl = initCallingService()
 
   scenario("CallingService intialization") {
-    val handle = 1.asInstanceOf[Uint32_t]
+    val handle = Uint32_t(1)
     val service = initCallingService(handle)
     result(service.wCall) shouldEqual handle
   }
@@ -908,7 +908,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(signal.filter(test).head)
   }
 
-  def initCallingService(wCall: WCall = 1.asInstanceOf[Uint32_t]) = {
+  def initCallingService(wCall: WCall = Uint32_t(1)) = {
     val prefs = new TestUserPreferences()
 
     (convs.convByRemoteId _).expects(*).anyNumberOfTimes().onCall { id: RConvId =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -109,11 +109,18 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       clock.advance(10.seconds)
 
+      (convsService.activeMembersData _).expects(_1to1Conv.id).once().returning(
+        Signal(Seq(ConversationMemberData(otherUserId, _1to1Conv.id, "member")))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       val callJoined = Signal(false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         callJoined.filter(identity).head.foreach { _ =>
           clock.advance(10.seconds)
           service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
+          service.onParticipantsChanged(_1to1Conv.remoteId, Set(otherUser))
         }
       }
 
@@ -197,11 +204,18 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       clock.advance(10.seconds)
 
+      (convsService.activeMembersData _).expects(team1to1Conv.id).once().returning(
+        Signal(Seq(ConversationMemberData(otherUserId, team1to1Conv.id, "member")))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       val callJoined = Signal(false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         callJoined.filter(identity).head.foreach { _ =>
           clock.advance(10.seconds)
           service.onEstablishedCall(team1to1Conv.remoteId, otherUserId)
+          service.onParticipantsChanged(team1to1Conv.remoteId, Set(otherUser))
         }
       }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -447,6 +447,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       awaitCP(checkpoint1)
 
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUserId)
         service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
@@ -463,6 +472,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint3 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfConnected && cur.caller == selfUserId && cur.otherParticipants.keySet == Set(otherUser)))
       val checkpoint4 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfConnected && cur.caller == selfUserId && cur.otherParticipants.keySet == Set(otherUser, otherUser2)))
 
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       (avs.startCall _).expects(*, *, *, *, *).once().returning(Future(0))
 
       service.startCall(groupConv.id)
@@ -471,8 +489,8 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onOtherSideAnsweredCall(groupConv.remoteId)
       awaitCP(checkpoint2)
 
-      //TODO which user from a group conversation gets passed down here?
       service.onEstablishedCall(groupConv.remoteId, otherUserId)
+      service.onParticipantsChanged(groupConv.remoteId, Set(otherUser))
       awaitCP(checkpoint3)
 
       service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
@@ -485,6 +503,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint3 = callCheckpoint(_.contains(teamGroupConv.id), _.exists(cur => cur.convId == teamGroupConv.id && cur.state == SelfConnected && cur.caller == selfUserId && cur.otherParticipants.keySet == Set(otherUser)))
       val checkpoint4 = callCheckpoint(_.contains(teamGroupConv.id), _.exists(cur => cur.convId == teamGroupConv.id && cur.state == SelfConnected && cur.caller == selfUserId && cur.otherParticipants.keySet == Set(otherUser, otherUser2)))
 
+      (convsService.activeMembersData _).expects(teamGroupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, teamGroupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, teamGroupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       (avs.startCall _).expects(*, *, *, *, *).once().returning(Future(0))
 
       service.startCall(teamGroupConv.id)
@@ -494,6 +521,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       awaitCP(checkpoint2)
 
       service.onEstablishedCall(teamGroupConv.remoteId, otherUserId)
+      service.onParticipantsChanged(teamGroupConv.remoteId, Set(otherUser))
       awaitCP(checkpoint3)
 
       service.onParticipantsChanged(teamGroupConv.remoteId, Set(otherUser, otherUser2))
@@ -509,6 +537,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
 
       clock + 10.seconds
+
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUserId)
@@ -541,6 +578,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     scenario("Cancel outgoing group call should set it to Ended") {
       val checkpoint1 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfCalling && cur.caller == selfUserId))
       val checkpoint2 = callCheckpoint(_.get(groupConv.id).exists(c => c.state == Ended && c.endReason.contains(AvsClosedReason.Normal)), _.isEmpty)
+
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
 
       (avs.startCall _).expects(*, *, *, *, *).once().returning(Future(0))
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -622,6 +622,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       awaitCP(checkpoint1)
 
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
+
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUserId)
         service.onParticipantsChanged(groupConv.remoteId, Set(otherUser, otherUser2))
@@ -648,6 +657,15 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
 
       awaitCP(checkpoint1)
+
+      (convsService.activeMembersData _).expects(groupConv.id).once().returning(
+        Signal(Seq(
+          ConversationMemberData(otherUserId, groupConv.id, "member"),
+          ConversationMemberData(otherUser2Id, groupConv.id, "member")
+        ))
+      )
+
+      (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
 
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(groupConv.remoteId, otherUserId)
@@ -679,6 +697,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     scenario("If a user joins an ongoing group call in the background, it shouldn't be bumped to active") {
       await(globalPrefs(SkipTerminatingState) := true)
       service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onParticipantsChanged(groupConv.remoteId, Set(otherUser))
 
       service.endCall(groupConv.id)
       service.dismissCall()


### PR DESCRIPTION
## What's new in this PR?

### Issues

`CallingServiceSpec` is ignored. When it is not ignored, almost all tests failed.

### Causes

It appears there were some issues with the test with the sync engine was migrated to the ui project. Over time, some changes to the code base have made the tests fail in various ways, such as new methods are being called that aren't being mocked, accessing the global module and not calling participant changed handler.

### Solutions

Mock all unmocked methods. Inject dependencies rather than access the global module. Invoke the handler.

#### APK
[Download build #2311](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2311/artifact/build/artifact/wire-dev-PR2918-2311.apk)