### PR TITLE
[Chore] Internally downgrade AVS to 6.0.43

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
 
     // proprietary avs artifact configuration
     customAvsVersion = '6.1.9@aar'
-    customAvsInternalVersion = customAvsVersion
+    customAvsInternalVersion = '6.0.43@aar'
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.1.9@aar'
+    customAvsVersion = '6.0.43@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.0.43@aar'
+    customAvsVersion = '6.1.9@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

AVS was bumped to 6.1.9 for the public release, however QA still needs to test 6.0.x versions. For this reason, we will downgrade AVS for the developmental and internal builds.

## Notes

If another public release is made before conference calling is to be release, we must release with AVS 6.1.9 again.

#### APK
[Download build #2307](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2307/artifact/build/artifact/wire-dev-PR2919-2307.apk)
[Download build #2310](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2310/artifact/build/artifact/wire-dev-PR2919-2310.apk)