### PR TITLE
Fix : Wrong welcome screen shown while being connected to a custom backend

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -88,12 +88,7 @@ class SSOWebViewFragment extends FragmentHelper {
   }
 
   override def onBackPressed(): Boolean = {
-    activity.getSupportFragmentManager.popBackStackImmediate(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-    if (backendController.hasCustomBackend) {
-      activity.showFragment(new CustomBackendLoginFragment, CustomBackendLoginFragment.TAG, animated = false)
-    } else {
-      activity.showFragment(WelcomeFragment(), WelcomeFragment.Tag, animated = false)
-    }
+    showWelcomeScreen()
     inject[UserAccountsController].ssoToken ! None
     true
   }
@@ -125,6 +120,15 @@ class SSOWebViewFragment extends FragmentHelper {
       webView.clearFormData
       webView.clearHistory
 
+    }
+  }
+
+  private def showWelcomeScreen(): Unit = {
+    activity.getSupportFragmentManager.popBackStackImmediate(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    if (backendController.hasCustomBackend) {
+      activity.showFragment(new CustomBackendLoginFragment, CustomBackendLoginFragment.TAG, animated = false)
+    } else {
+      activity.showFragment(WelcomeFragment(), WelcomeFragment.Tag, animated = false)
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/StartSSOFragment.scala
@@ -9,7 +9,6 @@ import com.waz.model2.transport.responses.SSOFound
 import com.waz.threading.Threading
 import com.waz.zclient.R
 import com.waz.zclient.appentry.DialogErrorMessage.GenericDialogErrorMessage
-import com.waz.zclient.utils.BackendController
 import com.waz.zclient.utils.ContextUtils.showErrorDialog
 
 import scala.concurrent.Future
@@ -22,7 +21,6 @@ class StartSSOFragment extends SSOFragment {
   private val COUNTDOWN_INTERVAL: Int = 1000
   private val FULL_PERCENTAGE: Int = 100
   private lazy val progressBar = view[ProgressBar](R.id.startSsoProgressBar)
-  private lazy val backendController = inject[BackendController]
 
   private lazy val timer = new CountDownTimer(TIME_TO_WAIT, COUNTDOWN_INTERVAL) {
     def onTick(millisUntilFinished: Long): Unit = {


### PR DESCRIPTION
## What's new in this PR?

### Issues

A customer reported that his users are able to create an account or a new team on their custom backend.

https://wearezeta.atlassian.net/browse/AN-6988

### Causes

Clicking on the back button in OKTA webview always redirects the user to the standard welcome screen. When the user is already connected to a custom backend, he should be redirected to Enterprise welcome screen. 

### Solutions

Checking if the user is connected to a custom backend and show the right welcome screen in `SSOWebViewFragment`.

### Testing

- I click on Enterprise login and I enter en email address ending with @qa-demo.com. 
- I'm redirected to the custom backend.
- I click the back arrow in the top left corner. 
- I should see the Enterprise Welcome screen, not the standard one.
#### APK
[Download build #2308](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2308/artifact/build/artifact/wire-dev-PR2920-2308.apk)