### PR TITLE
Bump android min sdk version to 24

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object BuildPlugins {
 }
 
 object AndroidSdk {
-    const val min = 21
+    const val min = 24
     const val compile = 29
     const val target = compile
 


### PR DESCRIPTION
After discussions with different teams and areas in the company, a decision of dropping android **5.0** and **6.0** has been made. 

### Reasons behind
 - SFT release will definitely not make it on these old devices: Android 5 & 6 run on old hardware, which makes the functionality unusable due to the 10 video grids on screen which is computing intensive.
 - Business: we need to be aligned with company's goals in the Enterprise, which means, only 1% of our customers are using either Android 5 or 6, which means a very low number of them will be affected by this change. Public version of the android client has 10% of the users but this is not the primary goal of the company. 
 - Given the decision there is no longer support from QA for this hardware, which might bring problems if we introduce bugs. 

### Benefits
 - Less functional paths in the codebase which decreases complexity.  
 - Less overhead in terms of android fragmentation.
 - Make usage of neuer apis. 

### Solution
 - This PR aims to bump min sdk level to 24 (Android 7.0)
 