### PR TITLE
Fix flaky tests due to runBlockingTest

### DIFF
--- a/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/ActivationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/ActivationDataSourceTest.kt
@@ -7,7 +7,7 @@ import com.wire.android.feature.auth.activation.datasource.remote.ActivationRemo
 import com.wire.android.framework.functional.assertLeft
 import com.wire.android.framework.functional.assertRight
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 
@@ -30,7 +30,7 @@ class ActivationDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `Given sendEmailActivationCode() is called and remote request fails then return failure`() = runBlockingTest {
+    fun `Given sendEmailActivationCode() is called and remote request fails then return failure`() = runBlocking {
         `when`(remoteDataSource.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Left(ServerError))
 
         val response = activationDataSource.sendEmailActivationCode(TEST_EMAIL)
@@ -40,7 +40,7 @@ class ActivationDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `Given sendEmailActivationCode() is called and remote request is success, then return success`() = runBlockingTest {
+    fun `Given sendEmailActivationCode() is called and remote request is success, then return success`() = runBlocking {
         `when`(remoteDataSource.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Right(Unit))
 
         val response = activationDataSource.sendEmailActivationCode(TEST_EMAIL)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/activation/usecase/SendEmailActivationCodeUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/activation/usecase/SendEmailActivationCodeUseCaseTest.kt
@@ -7,7 +7,7 @@ import com.wire.android.feature.auth.activation.ActivationRepository
 import com.wire.android.framework.functional.assertLeft
 import com.wire.android.framework.functional.assertRight
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 
@@ -33,7 +33,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given use case is run, when repository returns Forbidden error, then return EmailBlackListed`() = runBlockingTest {
+    fun `given use case is run, when repository returns Forbidden error, then return EmailBlackListed`() = runBlocking {
         `when`(activationRepository.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Left(Forbidden))
 
         val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
@@ -45,7 +45,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given use case is run, when repository returns Conflict error, then return EmailInUse`() = runBlockingTest {
+    fun `given use case is run, when repository returns Conflict error, then return EmailInUse`() = runBlocking {
         `when`(activationRepository.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Left(Conflict))
 
         val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
@@ -57,7 +57,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given use case is run, when repository returns any other error, then return this error`() = runBlockingTest {
+    fun `given use case is run, when repository returns any other error, then return this error`() = runBlocking {
         val mockFailure = mock(Failure::class.java)
         `when`(activationRepository.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Left(mockFailure))
 
@@ -70,7 +70,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given send email activation code use case is executed, when there is no error then return success`() = runBlockingTest {
+    fun `given send email activation code use case is executed, when there is no error then return success`() = runBlocking {
         `when`(activationRepository.sendEmailActivationCode(TEST_EMAIL)).thenReturn(Either.Right(Unit))
 
         val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountViewModelTest.kt
@@ -3,7 +3,7 @@ package com.wire.android.feature.auth.registration.personal
 import com.wire.android.UnitTest
 import com.wire.android.core.accessibility.Accessibility
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -25,7 +25,7 @@ class CreatePersonalAccountViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldShowKeyboard is queried, when talkback is not enabled, then return true `() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(false)
 
             assertThat(createPersonalAccountViewModel.shouldShowKeyboard()).isEqualTo(true)
@@ -34,7 +34,7 @@ class CreatePersonalAccountViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldShowKeyboard is queried, when talkback is enabled, then return false `() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(true)
             assertThat(createPersonalAccountViewModel.shouldShowKeyboard()).isEqualTo(false)
         }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
@@ -20,7 +20,6 @@ import com.wire.android.shared.user.email.EmailTooShort
 import com.wire.android.shared.user.email.ValidateEmailUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -60,7 +59,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldFocusInput is queried, when talkback is not enabled, then return true`() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(false)
             assertThat(emailViewModel.shouldFocusInput()).isEqualTo(true)
         }
@@ -68,55 +67,59 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldFocusInput is queried, when talkback is enabled, then return false `() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(true)
             assertThat(emailViewModel.shouldFocusInput()).isEqualTo(false)
         }
     }
 
     @Test
-    fun `given validateEmail is called, when the validation succeeds then isValidEmail should be true`() =
-        runBlockingTest {
+    fun `given validateEmail is called, when the validation succeeds then isValidEmail should be true`() {
+        runBlocking {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             emailViewModel.validateEmail(TEST_EMAIL)
 
             assertThat(emailViewModel.isValidEmailLiveData.awaitValue()).isTrue()
         }
+    }
 
     @Test
-    fun `given validateEmail is called, when the validation fails with EmailTooShort error then isValidEmail should be false`() =
-        runBlockingTest {
+    fun `given validateEmail is called, when the validation fails with EmailTooShort error then isValidEmail should be false`() {
+        runBlocking {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailTooShort))
 
             emailViewModel.validateEmail(TEST_EMAIL)
 
             assertThat(emailViewModel.isValidEmailLiveData.awaitValue()).isFalse()
         }
+    }
 
     @Test
-    fun `given validateEmail is called, when the validation fails with EmailInvalid error then isValidEmail should be false`() =
-        runBlockingTest {
+    fun `given validateEmail is called, when the validation fails with EmailInvalid error then isValidEmail should be false`() {
+        runBlocking {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailInvalid))
 
             emailViewModel.validateEmail(TEST_EMAIL)
 
             assertThat(emailViewModel.isValidEmailLiveData.awaitValue()).isFalse()
         }
+    }
 
     @Test
-    fun `given sendActivation is called, then calls SendEmailActivationCodeUseCase`() =
-        runBlockingTest {
+    fun `given sendActivation is called, then calls SendEmailActivationCodeUseCase`() {
+        runBlocking {
             val params = SendEmailActivationCodeParams(TEST_EMAIL)
             `when`(sendActivationCodeUseCase.run(params)).thenReturn(Either.Right(Unit))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
             verify(sendActivationCodeUseCase).run(params)
         }
+    }
 
     @Test
-    fun `given sendActivation is called, when use case is successful, then sets email to sendActivationCodeLiveData`() =
-        runBlockingTest {
+    fun `given sendActivation is called, when use case is successful, then sets email to sendActivationCodeLiveData`() {
+        runBlocking {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -125,20 +128,22 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
                 assertThat(it).isEqualTo(TEST_EMAIL)
             }
         }
+    }
 
     @Test
-    fun `given sendActivation is called, when use case returns networkError, then updates networkConnectionErrorLiveData`() =
-        runBlockingTest {
+    fun `given sendActivation is called, when use case returns networkError, then updates networkConnectionErrorLiveData`() {
+        runBlocking {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(NetworkConnection))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
 
             assertThat(emailViewModel.networkConnectionErrorLiveData.awaitValue()).isEqualTo(Unit)
         }
+    }
 
     @Test
-    fun `given sendActivation is called, when use case returns EmailBlacklisted, then sets error message to sendActivationCodeLiveData`() =
-        runBlockingTest {
+    fun `given sendActivation is called, when use case returns EmailBlacklisted, then sets error message to sendActivationCodeLiveData`() {
+        runBlocking {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(EmailBlacklisted))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -147,10 +152,11 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
                 assertThat(it.message).isEqualTo(R.string.create_personal_account_with_email_email_blacklisted_error)
             }
         }
+    }
 
     @Test
-    fun `given sendActivation is called, when use case returns EmailInUse, then sets error message to sendActivationCodeLiveData`() =
-        runBlockingTest {
+    fun `given sendActivation is called, when use case returns EmailInUse, then sets error message to sendActivationCodeLiveData`() {
+        runBlocking {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(EmailInUse))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -159,6 +165,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
                 assertThat(it.message).isEqualTo(R.string.create_personal_account_with_email_email_in_use_error)
             }
         }
+    }
 
     companion object {
         private const val TEST_EMAIL = "test@wire.com"

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
@@ -13,7 +13,6 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -54,7 +53,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldFocusInput is queried, when talkback is not enabled, then return true`() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(false)
             assertThat(viewModel.shouldFocusInput()).isEqualTo(true)
         }
@@ -62,7 +61,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given shouldFocusInput is queried, when talkback is enabled, then return false `() {
-        runBlockingTest {
+        runBlocking {
             `when`(accessibility.isTalkbackEnabled()).thenReturn(true)
             assertThat(viewModel.shouldFocusInput()).isEqualTo(false)
         }
@@ -70,14 +69,14 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given viewModel is initialised, when teamName is available, propagate teamName up to the view`() {
-        runBlockingTest {
+        runBlocking {
             assertEquals(TEST_TEAM_NAME, viewModel.teamNameLiveData.awaitValue())
         }
     }
 
     @Test
     fun `given about button is clicked, when url is provided, propagate url back to the view`() {
-        runBlockingTest {
+        runBlocking {
             viewModel.onAboutButtonClicked()
             assertEquals("$CONFIG_URL$TEAM_ABOUT_URL_SUFFIX", viewModel.urlLiveData.awaitValue())
         }
@@ -85,7 +84,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be disabled`() {
-        runBlockingTest {
+        runBlocking {
             viewModel.onTeamNameTextChanged(String.EMPTY)
             assertFalse(viewModel.confirmationButtonEnabled.awaitValue())
         }
@@ -93,7 +92,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be enabled`() {
-        runBlockingTest {
+        runBlocking {
             viewModel.onTeamNameTextChanged(TEST_TEAM_NAME)
             assertTrue(viewModel.confirmationButtonEnabled.awaitValue())
         }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/data/TeamDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/data/TeamDataSourceTest.kt
@@ -3,7 +3,7 @@ package com.wire.android.feature.auth.registration.pro.team.data
 import com.wire.android.UnitTest
 import com.wire.android.framework.functional.assertRight
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -20,7 +20,7 @@ class TeamDataSourceTest : UnitTest() {
 
     @Test
     fun `given team name, when cache is updated, then check if name is correct`() {
-        runBlockingTest {
+        runBlocking {
             teamsRepository.updateTeamName(TEST_TEAM_NAME)
 
             teamsRepository.teamName().assertRight {

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/usecase/GetTeamNameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/usecase/GetTeamNameUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.wire.android.feature.auth.registration.pro.team.usecase
 import com.wire.android.UnitTest
 import com.wire.android.feature.auth.registration.pro.team.data.TeamsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -24,7 +24,7 @@ class GetTeamNameUseCaseTest : UnitTest() {
 
     @Test
     fun `given teamName is request, then request repository for team name`() {
-        runBlockingTest {
+        runBlocking {
             getTeamNameUseCase.run(Unit)
 
             verify(teamsRepository).teamName()

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/usecase/UpdateTeamNameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/usecase/UpdateTeamNameUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.wire.android.UnitTest
 import com.wire.android.eq
 import com.wire.android.feature.auth.registration.pro.team.data.TeamsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -25,7 +25,7 @@ class UpdateTeamNameUseCaseTest : UnitTest() {
 
     @Test
     fun `given team name, then request update to repository`() {
-        runBlockingTest {
+        runBlocking {
             val params = UpdateTeamNameParams(TEST_TEAM_NAME)
 
             updateTeamNameUseCase.run(params)

--- a/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
@@ -3,7 +3,6 @@ package com.wire.android.shared.user.email
 import com.wire.android.UnitTest
 import com.wire.android.core.functional.Either
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +26,7 @@ class ValidateEmailUseCaseTest : UnitTest() {
     fun `Given run is executed, when email doesn't match regex, then return EmailInvalid failure`() {
         `when`(validateEmailParams.email).thenReturn("email")
 
-        runBlockingTest {
+        runBlocking {
             assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Left(EmailInvalid))
         }
     }
@@ -37,7 +36,7 @@ class ValidateEmailUseCaseTest : UnitTest() {
         val email = "t"
         `when`(validateEmailParams.email).thenReturn(email)
 
-        runBlockingTest {
+        runBlocking {
             assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Left(EmailTooShort))
         }
     }
@@ -46,7 +45,7 @@ class ValidateEmailUseCaseTest : UnitTest() {
     fun `Given run is executed, when email matches regex and email fits requirements then return success`() {
         `when`(validateEmailParams.email).thenReturn(VALID_TEST_EMAIL)
 
-        runBlockingTest {
+        runBlocking {
             assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Right(Unit))
         }
     }


### PR DESCRIPTION
**Problem:**
Some unit tests were failing with error:
java.lang.IllegalStateException: This job has not completed yet

**Cause:**
That's because [runBlockingTest does not wait tasks to complete](https://github.com/Kotlin/kotlinx.coroutines/issues/1204), if there's a switch of threads.

**Solution:**
Replace all `runBlockingTest` usages with `runBlocking`

