### PR TITLE
feature : Conf Calling - Limit the number of video previews to 12

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -143,7 +143,7 @@ class CallingFragment extends FragmentHelper {
 
   private lazy val videoGrid = returning(view[GridLayout](R.id.video_grid)) { vh =>
     Signal(
-      controller.allVideoReceiveStates,
+      controller.allVideoReceiveStates.map{ _.take(maxVideoPreviews)},
       controller.callingZms.map(zms => Participant(zms.selfUserId, zms.clientId)),
       controller.isVideoCall,
       controller.isCallIncoming)
@@ -204,11 +204,11 @@ class CallingFragment extends FragmentHelper {
             case 1                                                          => (0, 1, 1)
             // The max number of columns is 2 and the max number of rows is undefined
             // if the index of the video preview is odd, display it in row n/2, column 1 , span 1
-            case n if (n % 2 != 0) && (n < maxVideoPreviews)                => (n / 2, 1, 1)
+            case n if (n % 2 != 0)                                          => (n / 2, 1, 1)
             // else if the gridViews size is n+1 , display it in row n/2, column 0 , span 2
-            case n if (gridViews.size == n + 1) && (n < maxVideoPreviews)   => (n / 2, 0, 2)
+            case n if (gridViews.size == n + 1)                             => (n / 2, 0, 2)
             // else display it in row n/2, column 0 , span 1
-            case n if n < maxVideoPreviews                                  => (n / 2, 0, 1)
+            case n                                                          => (n / 2, 0, 1)
           }
           r.setLayoutParams(returning(new GridLayout.LayoutParams()) { params =>
             params.width      = 0

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -133,6 +133,7 @@ class OtherVideoView(context: Context, participant: Participant) extends UserVid
 
 class CallingFragment extends FragmentHelper {
 
+  private val maxVideoPreviews = 12
   private lazy val controller       = inject[CallController]
   private lazy val themeController  = inject[ThemeController]
   private lazy val controlsFragment = ControlsFragment.newInstance
@@ -197,17 +198,17 @@ class CallingFragment extends FragmentHelper {
 
         gridViews.zipWithIndex.foreach { case (r, index) =>
           val (row, col, span) = index match {
-            case 0 if !isVideoBeingSent && gridViews.size == 2 => (0, 0, 2)
-            case 0                                             => (0, 0, 1)
-            case 1 if !isVideoBeingSent && gridViews.size == 2 => (1, 0, 2)
-            case 1                                             => (0, 1, 1)
+            case 0 if !isVideoBeingSent && gridViews.size == 2              => (0, 0, 2)
+            case 0                                                          => (0, 0, 1)
+            case 1 if !isVideoBeingSent && gridViews.size == 2              => (1, 0, 2)
+            case 1                                                          => (0, 1, 1)
             // The max number of columns is 2 and the max number of rows is undefined
             // if the index of the video preview is odd, display it in row n/2, column 1 , span 1
-            case n if n % 2 != 0                               => (n / 2, 1, 1)
+            case n if (n % 2 != 0) && (n < maxVideoPreviews)                => (n / 2, 1, 1)
             // else if the gridViews size is n+1 , display it in row n/2, column 0 , span 2
-            case n if gridViews.size == n + 1                  => (n / 2, 0, 2)
+            case n if (gridViews.size == n + 1) && (n < maxVideoPreviews)   => (n / 2, 0, 2)
             // else display it in row n/2, column 0 , span 1
-            case n                                             => (n / 2, 0, 1)
+            case n if n < maxVideoPreviews                                  => (n / 2, 0, 1)
           }
           r.setLayoutParams(returning(new GridLayout.LayoutParams()) { params =>
             params.width      = 0

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -204,9 +204,9 @@ class CallingFragment extends FragmentHelper {
             case 1                                                          => (0, 1, 1)
             // The max number of columns is 2 and the max number of rows is undefined
             // if the index of the video preview is odd, display it in row n/2, column 1 , span 1
-            case n if (n % 2 != 0)                                          => (n / 2, 1, 1)
+            case n if n % 2 != 0                                            => (n / 2, 1, 1)
             // else if the gridViews size is n+1 , display it in row n/2, column 0 , span 2
-            case n if (gridViews.size == n + 1)                             => (n / 2, 0, 2)
+            case n if gridViews.size == n + 1                               => (n / 2, 0, 2)
             // else display it in row n/2, column 0 , span 1
             case n                                                          => (n / 2, 0, 1)
           }


### PR DESCRIPTION
## What's new in this PR?

There are no restrictions to the number of people in a group video call. However, due to the limited screen real estate of mobile devices, we should limit the number of visible video tiles to 12.
The 12 video tiles to be shown are simply the first 12 streams from the sorted participant list.

https://wearezeta.atlassian.net/browse/AN-7015

#### APK
[Download build #2313](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2313/artifact/build/artifact/wire-dev-PR2922-2313.apk)
[Download build #2408](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2408/artifact/build/artifact/wire-dev-PR2922-2408.apk)
[Download build #2409](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2409/artifact/build/artifact/wire-dev-PR2922-2409.apk)