### PR TITLE
Bugfix : Login Button does not react on Enterprise Login Page

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -126,7 +126,7 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
 
     closeButton.onClick(abortAddAccount())
 
-    showFragment()
+    showWelcomeScreen()
 
     skipButton.setVisibility(View.GONE)
     getSupportFragmentManager.addOnBackStackChangedListener(new OnBackStackChangedListener {
@@ -235,7 +235,7 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
      showFragment(customBackendLoginFragment, CustomBackendLoginFragment.TAG, animated = false)
   }
 
-  private def showFragment(): Unit =
+  def showWelcomeScreen(): Unit =
     if (backendController.hasCustomBackend) {
       getSupportFragmentManager.popBackStackImmediate(CustomBackendLoginFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
       showCustomBackendLoginScreen()

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -24,7 +24,6 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import android.webkit.WebView
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.FragmentManager
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
@@ -34,7 +33,7 @@ import com.waz.zclient.appentry.DialogErrorMessage.EmailError
 import com.waz.zclient.appentry.SSOWebViewWrapper.SSOResponse
 import com.waz.zclient.appentry.fragments.FirstLaunchAfterLoginFragment
 import com.waz.zclient.common.controllers.UserAccountsController
-import com.waz.zclient.utils.{BackendController, ContextUtils, ViewUtils}
+import com.waz.zclient.utils.{ ContextUtils, ViewUtils}
 import com.waz.zclient.{FragmentHelper, R}
 
 import scala.concurrent.Future
@@ -42,7 +41,6 @@ import scala.concurrent.Future
 class SSOWebViewFragment extends FragmentHelper {
   import Threading.Implicits.Ui
 
-  private lazy val backendController = inject[BackendController]
   private lazy val webView = view[WebView](R.id.web_view)
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View = {
@@ -88,7 +86,7 @@ class SSOWebViewFragment extends FragmentHelper {
   }
 
   override def onBackPressed(): Boolean = {
-    showWelcomeScreen()
+    activity.showWelcomeScreen()
     inject[UserAccountsController].ssoToken ! None
     true
   }
@@ -120,15 +118,6 @@ class SSOWebViewFragment extends FragmentHelper {
       webView.clearFormData
       webView.clearHistory
 
-    }
-  }
-
-  private def showWelcomeScreen(): Unit = {
-    activity.getSupportFragmentManager.popBackStackImmediate(SSOWebViewFragment.Tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-    if (backendController.hasCustomBackend) {
-      activity.showFragment(new CustomBackendLoginFragment, CustomBackendLoginFragment.TAG, animated = false)
-    } else {
-      activity.showFragment(WelcomeFragment(), WelcomeFragment.Tag, animated = false)
     }
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Causes

With this fix  #2920, the "Log in with email" button was broken.

### Solutions

Refactor the code to use the same logic of `AppEntryActivity`

### Testing

- I click on Enterprise login and I enter en email address ending with @qa-demo.com.
- I'm redirected to the custom backend.
- I click the back arrow in the top left corner.
- I should see the Enterprise Welcome screen, not the standard one.
- Pressing "Log in with email" button, should redirect me to the login screen.

### Jira ticket

https://wearezeta.atlassian.net/browse/AN-7023





#### APK
[Download build #2317](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2317/artifact/build/artifact/wire-dev-PR2924-2317.apk)
[Download build #2318](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2318/artifact/build/artifact/wire-dev-PR2924-2318.apk)
[Download build #2319](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2319/artifact/build/artifact/wire-dev-PR2924-2319.apk)