### PR TITLE
Revert "[Chore] Bump AVS to 6.2.7 (#2931)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
 
     // proprietary avs artifact configuration
     customAvsVersion = '6.1.9@aar'
-    customAvsInternalVersion = '6.2.7@aar'
+    customAvsInternalVersion = '6.0.43@aar'
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 }


### PR DESCRIPTION
## What's new in this PR?

This reverts commit 001e97385be467a2b917ac7dd98f038256253397. We are reverting because the web team encountered a blocker and is not able to push a new internal with the same AVS bump.


#### APK
[Download build #2335](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2335/artifact/build/artifact/wire-dev-PR2932-2335.apk)