### PR TITLE
[Refactor] Targeted messages

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -191,7 +191,7 @@ class OtrServiceImpl(selfUserId:     UserId,
       warn(l"can not decrypt gcm, no signaling key found: $c")
       None
   }
-  // We can get rid of this
+
   def encryptTargetedMessage(user: UserId, client: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]] = {
     val msgData = GenericMessage.toByteArray(msg)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.sync.handler
 
-import com.waz.log.LogSE._
 import com.waz.content.ConversationStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.GenericContent.LastRead
@@ -26,6 +25,7 @@ import com.waz.service.MetaDataService
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.{Failure, Success}
 import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
 import com.waz.utils.RichWireInstant
 
 import scala.concurrent.Future
@@ -45,7 +45,7 @@ class LastReadSyncHandler(selfUserId: UserId,
       case Some(conv) =>
         val msg = GenericMessage(Uid(), LastRead(conv.remoteId, time))
         otrSync
-          .postOtrMessage(ConvId(selfUserId.str), msg, recipients = Some(Set(selfUserId)))
+          .postOtrMessage(ConvId(selfUserId.str), msg, TargetRecipients.SpecificUsers(Set(selfUserId)))
           .map(SyncResult(_))
       case None =>
         Future.successful(Failure(s"No conversation found for id: $convId"))

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -30,8 +30,8 @@ import com.waz.model.GenericMessage.TextMessage
 import com.waz.model._
 import com.waz.model.errors._
 import com.waz.model.sync.ReceiptType
-import com.waz.service.assets.{AssetService, AssetStorage, PreviewEmpty, PreviewNotReady, PreviewNotUploaded, PreviewUploaded, UploadAsset, UploadAssetStatus, UploadAssetStorage}
 import com.waz.service.assets.Asset.{General, Image}
+import com.waz.service.assets._
 import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.otr.OtrClientsService
@@ -41,10 +41,11 @@ import com.waz.sync.SyncHandler.RequestInfo
 import com.waz.sync.SyncResult.Failure
 import com.waz.sync.client.ErrorOrResponse
 import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
 import com.waz.sync.{SyncResult, SyncServiceHandle}
-import com.wire.signals.CancellableFuture
 import com.waz.utils._
 import com.waz.znet2.http.ResponseCode
+import com.wire.signals.CancellableFuture
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -104,7 +105,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         }
 
         otrSync
-          .postOtrMessage(conv.id, msg, recipients = Some(recipients), nativePush = false)
+          .postOtrMessage(conv.id, msg, TargetRecipients.SpecificUsers(recipients), nativePush = false)
           .map(SyncResult(_))
       case None =>
         successful(Failure("conversation not found"))
@@ -117,7 +118,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         result <- otrSync.postOtrMessage(
                     msg.convId,
                     GenericMessage(Uid(), ButtonAction(buttonId.str, messageId.str)),
-                    recipients = Option(Set(senderId)),
+                    TargetRecipients.SpecificUsers(Set(senderId)),
                     enforceIgnoreMissing = true)
         _      <- result.fold(_ => service.setButtonError(messageId, buttonId), _ => Future.successful(()))
       } yield SyncResult(result)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -184,7 +184,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
 
       broadcastRecipients.flatMap { recp =>
         for {
-          content  <- service.encryptForUsers(recp, message, useFakeOnError = retry > 0, previous)
+          content  <- service.encryptMessageForUsers(message, recp, useFakeOnError = retry > 0, previous)
           response <- otrClient.broadcastMessage(
                         OtrMessage(selfClientId, content, report_missing = Some(recp)),
                         ignoreMissing = retry > 1

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -20,7 +20,7 @@ package com.waz.sync.otr
 import com.waz.api.Verification
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.internalError
-import com.waz.content.{ConversationStorage, MembersStorage, UsersStorage}
+import com.waz.content.{ConversationStorage, MembersStorage, OtrClientsStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model._
@@ -33,6 +33,9 @@ import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.Failure
 import com.waz.sync.client.OtrClient.{ClientMismatch, EncryptedContent, MessageResponse}
 import com.waz.sync.client._
+import com.waz.sync.otr.OtrSyncHandler.MissingClientsStrategy._
+import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
+import com.waz.sync.otr.OtrSyncHandler.TargetRecipients._
 import com.waz.utils.crypto.AESUtils
 
 import scala.concurrent.Future
@@ -42,10 +45,11 @@ import scala.util.control.NonFatal
 trait OtrSyncHandler {
   def postOtrMessage(convId:               ConvId,
                      message:              GenericMessage,
-                     recipients:           Option[Set[UserId]] = None,
+                     targetRecipients:     TargetRecipients = ConversationParticipants,
                      nativePush:           Boolean = true,
                      enforceIgnoreMissing: Boolean = false
                     ): Future[Either[ErrorResponse, RemoteInstant]]
+
   def postSessionReset(convId: ConvId, user: UserId, client: ClientId): Future[SyncResult]
   def broadcastMessage(message:    GenericMessage,
                        retry:      Int = 0,
@@ -67,14 +71,15 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
                          errors:             ErrorsService,
                          clientsSyncHandler: OtrClientsSyncHandler,
                          push:               PushService,
-                         usersStorage:       UsersStorage) extends OtrSyncHandler with DerivedLogTag {
+                         usersStorage:       UsersStorage,
+                         clientsStorage:     OtrClientsStorage) extends OtrSyncHandler with DerivedLogTag {
 
   import OtrSyncHandler._
   import com.waz.threading.Threading.Implicits.Background
 
   override def postOtrMessage(convId:               ConvId,
                               message:              GenericMessage,
-                              recipients:           Option[Set[UserId]] = None,
+                              targetRecipients:     TargetRecipients = ConversationParticipants,
                               nativePush:           Boolean = true,
                               enforceIgnoreMissing: Boolean = false
                              ): Future[Either[ErrorResponse, RemoteInstant]] = {
@@ -89,15 +94,21 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         _          <- push.waitProcessing
         Some(conv) <- convStorage.get(convId)
         _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
-        us         <- recipients.fold(members.getActiveUsers(convId).map(_.toSet))(rs => Future.successful(rs))
-        content    <- service.encryptForUsers(us, msg, retries > 0, previous)
-        resp       <- if (content.estimatedSize < MaxContentSize)
+        recipients <- clientsMap(targetRecipients, convId)
+        content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
+        resp       <- if (content.estimatedSize < MaxContentSize) {
+                        val (shouldIgnoreMissingClients, targetUsers) = missingClientsStrategy(targetRecipients) match {
+                          case DoNotIgnoreMissingClients                    => (false, None)
+                          case IgnoreMissingClientsExceptFromUsers(userIds) => (false, Some(userIds))
+                          case IgnoreMissingClients                         => (true, None)
+                        }
+
                         msgClient.postMessage(
                           conv.remoteId,
-                          OtrMessage(selfClientId, content, external, nativePush, recipients),
-                          ignoreMissing = enforceIgnoreMissing || retries > 1
+                          OtrMessage(selfClientId, content, external, nativePush, report_missing = targetUsers),
+                          ignoreMissing = shouldIgnoreMissingClients || enforceIgnoreMissing || retries > 1
                         ).future
-                      else {
+                      } else {
                         verbose(l"Message content too big, will post as External. Estimated size: ${content.estimatedSize}")
                         val key = AESKey()
                         val (sha, data) = AESUtils.encrypt(key, GenericMessage.toByteArray(msg))
@@ -128,6 +139,29 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case NonFatal(e) =>
         Left(ErrorResponse.internalError(e.getMessage))
     }.mapRight(_.mismatch.time)
+  }
+
+  private def missingClientsStrategy(targetRecipients: TargetRecipients): MissingClientsStrategy =
+    targetRecipients match {
+      case ConversationParticipants => DoNotIgnoreMissingClients
+      case SpecificUsers(userIds)   => IgnoreMissingClientsExceptFromUsers(userIds)
+      case SpecificClients(_)       => IgnoreMissingClients
+    }
+
+  private def clientsMap(targetRecipients: TargetRecipients, convId: ConvId): Future[Map[UserId, Set[ClientId]]] = {
+    def clientIds(userIds: Set[UserId]): Future[Map[UserId, Set[ClientId]]] = {
+      Future.traverse(userIds) { userId =>
+        clientsStorage.getClients(userId).map { clients =>
+          userId -> clients.map(_.id).filterNot(_ == selfClientId).toSet
+        }
+      }.map(_.toMap)
+    }
+
+    targetRecipients match {
+      case ConversationParticipants       => members.getActiveUsers(convId).map(_.toSet).flatMap(clientIds)
+      case SpecificUsers(userIds)         => clientIds(userIds)
+      case SpecificClients(clientsByUser) => Future.successful(clientsByUser)
+    }
   }
 
   override def broadcastMessage(message:    GenericMessage,
@@ -253,4 +287,33 @@ object OtrSyncHandler {
 
   val MaxInlineSize  = 10 * 1024
   val MaxContentSize = 256 * 1024 // backend accepts 256KB for otr messages, but we would prefer to send less
+
+  /// Describes who should receive a message.
+  sealed trait TargetRecipients
+
+  object TargetRecipients {
+    /// All participants (and all their clients) should receive the message.
+    object ConversationParticipants extends TargetRecipients
+
+    /// All clients of the given users should receive the message.
+    case class SpecificUsers(userIds: Set[UserId]) extends TargetRecipients
+
+    /// These exact clients should receive the message.
+    case class SpecificClients(clientsByUser: Map[UserId, Set[ClientId]]) extends TargetRecipients
+  }
+
+  /// Describes how missing clients should be handled.
+  sealed trait MissingClientsStrategy
+
+  object MissingClientsStrategy {
+    /// Fetch missing clients and resend the message.
+    object DoNotIgnoreMissingClients extends MissingClientsStrategy
+
+    /// Send the message without fetching missing clients.
+    object IgnoreMissingClients extends MissingClientsStrategy
+
+    /// Only fetch missing clients from the given users and resend the message.
+    case class IgnoreMissingClientsExceptFromUsers(userIds: Set[UserId]) extends MissingClientsStrategy
+  }
+
 }


### PR DESCRIPTION
## What's new in this PR?

This PR contains some changes to facilitate sending targeted messages. The existing code allows to send an encrypted message to:

- all clients participating in a given conversation
- a set of users and all their clients
- a specific client belong to a specific user

The changes in this PR preserve this functionality and additionally allow more fined grained control of who is a recipient to an encrypted message:

- `OtrService` now has a method to encrypt a message for map of user clients: `Map[UserId, Set[ClientId]]`. This allows us to send a message to specific clients belonging to specific users.
- The `OtrSyncHandler` method `postOtrMessage` now accepts an argument of type `TargetRecipients`, which is an enum describing who the recipients should be.

#### APK
[Download build #2343](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2343/artifact/build/artifact/wire-dev-PR2933-2343.apk)
[Download build #2345](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2345/artifact/build/artifact/wire-dev-PR2933-2345.apk)
[Download build #2350](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2350/artifact/build/artifact/wire-dev-PR2933-2350.apk)