### PR TITLE
Dialog to notify users around discontinued support for android 5 & 6

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1555,5 +1555,11 @@
     <string name="start_sso_leaving_wire">Redirecting…</string>
     <string name="start_sso_redirected_to">You are being redirected to your dedicated enterprise service.</string>
     <string name="start_sso_notice">Provide credentials only if you\'re sure this is your organization\'s login.</string>
+
+    <!--TODO: remove after release 3.53-->
+    <string name="discontinued_support_warning_title">Wire 5.53 is the last version that can be installed on Android 5 and 6.</string>
+    <string name="discontinued_support_warning_message">To be able to install later versions, please update to Android 7.0 or higher.</string>
+    <string name="discontinued_support_warning_action_ok">OK</string>
+    <string name="discontinued_support_warning_action_do_not_show_again">Don\'t show again</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1557,7 +1557,7 @@
     <string name="start_sso_notice">Provide credentials only if you\'re sure this is your organization\'s login.</string>
 
     <!--TODO: remove after release 3.53-->
-    <string name="discontinued_support_warning_title">Wire 5.53 is the last version that can be installed on Android 5 and 6.</string>
+    <string name="discontinued_support_warning_title">Wire 3.53 is the last version that can be installed on Android 5 and 6.</string>
     <string name="discontinued_support_warning_message">To be able to install later versions, please update to Android 7.0 or higher.</string>
     <string name="discontinued_support_warning_action_ok">OK</string>
     <string name="discontinued_support_warning_action_do_not_show_again">Don\'t show again</string>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -549,6 +549,7 @@ class MainActivity extends BaseActivity
 
   override def onUsernameSet(): Unit = replaceMainFragment(new MainPhoneFragment, MainPhoneFragment.Tag, addToBackStack = false)
 
+  // TODO: remove after release 3.53
   private def shouldShowDiscontinuedDialog() =
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
       showDiscontinuedSupportDialog()
@@ -556,12 +557,14 @@ class MainActivity extends BaseActivity
 
   // TODO: remove after release 3.53
   def showDiscontinuedSupportDialog() : Future[Unit] = {
+
     def showDialog(accentColor: AccentColor): Future[Boolean] = showConfirmationDialog(
       getString(R.string.discontinued_support_warning_title),
       getString(R.string.discontinued_support_warning_message),
       R.string.discontinued_support_warning_action_ok,
       R.string.discontinued_support_warning_action_do_not_show_again,
-      accentColor)
+      accentColor
+    )
 
     val prefs = inject[GlobalPreferences]
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -102,7 +102,7 @@ class MainActivity extends BaseActivity
     Option(getActionBar).foreach(_.hide())
     super.onCreate(savedInstanceState)
 
-    shouldShowDiscontinuedDialog()
+    showDiscontiniuedSupportDialogIfNeeded()
 
     //Prevent drawing the default background to reduce overdraw
     getWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT))
@@ -550,14 +550,13 @@ class MainActivity extends BaseActivity
   override def onUsernameSet(): Unit = replaceMainFragment(new MainPhoneFragment, MainPhoneFragment.Tag, addToBackStack = false)
 
   // TODO: remove after release 3.53
-  private def shouldShowDiscontinuedDialog() =
+  private def showDiscontiniuedSupportDialogIfNeeded() =
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
       showDiscontinuedSupportDialog()
     }
 
   // TODO: remove after release 3.53
   def showDiscontinuedSupportDialog() : Future[Unit] = {
-
     def showDialog(accentColor: AccentColor): Future[Boolean] = showConfirmationDialog(
       getString(R.string.discontinued_support_warning_title),
       getString(R.string.discontinued_support_warning_message),

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -384,6 +384,9 @@ object GlobalPreferences {
 
   lazy val BackendDrift = PrefKey[Duration]("backend_drift")
 
+  // TODO: remove after release 3.53
+  lazy val ShouldWarnAndroid5And6Users = PrefKey[Boolean]( "should_warn_android_5_and_6_users", customDefault = true)
+
   //TODO think of a nicer way of ensuring that these key values are used in UI - right now, we need to manually check they're correct
   lazy val AutoAnswerCallPrefKey = PrefKey[Boolean]("PREF_KEY_AUTO_ANSWER_ENABLED")
   lazy val V31AssetsEnabledKey = PrefKey[Boolean]("PREF_V31_ASSETS_ENABLED")


### PR DESCRIPTION
## What's new in this PR?

### Issues

We're dropping support for Android 5 and 6 in v 3.54.

### Solutions

For the best user experience, we should notify the users of this change. 

### Testing

Scenario 1:
1. Log in with user a on Android 5 / 6 device 
2. Dialog notifying you around support should display 
3. Click ok 
4. Log out 
5. Login as a user a again 
6. Should see dialog again 

Scenario 2:
1. Log in with user a on Android 5 / 6 device 
2. Dialog notifying you around support should display 
3. Click do not show again 
4. Log out 
5. Login as a user a again 
6. Should not see a new dialog

Scenario 3:
1. Log in with user a on Android 7+ device
2. Dialog notifying you around support should not display at all 

## Notes

Will be looking to bump the `minSdkVersion` in 3.54

#### APK
[Download build #2367](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2367/artifact/build/artifact/wire-dev-PR2940-2367.apk)
[Download build #2368](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2368/artifact/build/artifact/wire-dev-PR2940-2368.apk)
[Download build #2369](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2369/artifact/build/artifact/wire-dev-PR2940-2369.apk)
[Download build #2375](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2375/artifact/build/artifact/wire-dev-PR2940-2375.apk)