### PR TITLE
[Chore] Bump AVS to 6.2.12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.2.11@aar'
+    customAvsVersion = '6.2.12@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.1.9@aar'
-    customAvsInternalVersion = '6.2.10@aar'
+    customAvsVersion = '6.2.11@aar'
+    customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'
 }


### PR DESCRIPTION
## What's new in this PR?

Bump AVS to 6.2.12, which has targeted messaging enabled.
#### APK
[Download build #2371](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2371/artifact/build/artifact/wire-dev-PR2941-2371.apk)
[Download build #2374](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2374/artifact/build/artifact/wire-dev-PR2941-2374.apk)