### PR TITLE
[Feature] Conference calling beta

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,9 +144,6 @@ android {
         buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"
         buildConfigField 'boolean', 'KOTLIN_REGISTRATION', "$rootProject.ext.kotlinRegistration"
         buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
-
-        // Internal feature flags to override in productFlavors
-        buildConfigField 'boolean', 'CONFERENCE_CALLING', 'false'
     }
 
     packagingOptions {
@@ -229,7 +226,6 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'false'
-            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
         candidate {
@@ -265,7 +261,6 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
-            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
 
         experimental {
@@ -278,7 +273,6 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
-            buildConfigField 'boolean', 'CONFERENCE_CALLING', 'true'
         }
     }
 

--- a/app/src/main/res/layout/preferences_options_layout.xml
+++ b/app/src/main/res/layout/preferences_options_layout.xml
@@ -55,6 +55,23 @@
             <com.waz.zclient.ui.text.TypefaceTextView
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"
+                android:text="@string/pref_options_conference_calls_category_title"
+                android:gravity="center_vertical"
+                android:paddingStart="@dimen/wire__padding__16"
+                android:paddingEnd="@dimen/wire__padding__16"
+                android:textColor="@color/accent_blue"/>
+
+            <com.waz.zclient.preferences.views.SwitchPreference
+                android:id="@+id/preferences_conference_calling"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:title="@string/pref_options_conference_calls_beta_program_title"
+                app:subtitle="@string/pref_options_conference_calls_beta_program_summary"
+                />
+
+            <com.waz.zclient.ui.text.TypefaceTextView
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
                 android:text="@string/pref_options_alerts_category_title"
                 android:gravity="center_vertical"
                 android:paddingStart="@dimen/wire__padding__16"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,6 +499,10 @@
     <string name="pref_options_incognito_keyboard">Incognito keyboard</string>
     <string name="pref_options_incognito_keyboard_summary">The keyboard will not show suggestions when typing messages</string>
 
+    <string name="pref_options_conference_calls_category_title">Conference Calls</string>
+    <string name="pref_options_conference_calls_beta_program_title">Beta Program</string>
+    <string name="pref_options_conference_calls_beta_program_summary">When this is on, audio and video conference calling is enabled, which allows a higher number of participants.</string>
+
     <!-- Devices -->
     <string name="pref_devices_screen_title">Devices</string>
     <string name="pref_devices_current_device_category_title">Current Device</string>

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -440,8 +440,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
       null, //TODO: Use sync engine's version for now
       inject[MessageNotificationsController],
       assets2Module,
-      inject[FileRestrictionList],
-      BuildConfig.CONFERENCE_CALLING
+      inject[FileRestrictionList]
     )
 
     val activityLifecycleCallback = inject[ActivityLifecycleCallback]

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -110,6 +110,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
   val cbrEnabled            = currentCall.map(_.isCbrEnabled)
   val duration              = currentCall.flatMap(_.durationFormatted)
   val otherParticipants     = currentCall.map(_.otherParticipants)
+  val isConferenceCall      = currentCall.map(_.isConferenceCall)
 
   val lastCallAccountId: SourceSignal[UserId] = Signal()
   currentCall.map(_.selfParticipant.userId) { selfUserId => lastCallAccountId ! selfUserId }

--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -89,9 +89,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
       members          <- controller.conversationMembers.map(_.size)
       isConferenceCall <- controller.isConferenceCall
     } yield {
-      if (isGroup && isConferenceCall) {
-        established
-      } else if (isGroup && !isConferenceCall) {
+      if (isGroup && !isConferenceCall) {
         (isTeam && established || showVideo) && members <= CallingService.LegacyVideoCallMaxMembers
       } else {
         established

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -70,6 +70,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   inflate(R.layout.preferences_options_layout)
 
   val vbrSwitch               = findById[SwitchPreference](R.id.preferences_vbr)
+  val conferenceCallingSwitch = findById[SwitchPreference](R.id.preferences_conference_calling)
   val vibrationSwitch         = findById[SwitchPreference](R.id.preferences_vibration)
   val darkThemeSwitch         = findById[SwitchPreference](R.id.preferences_dark_theme)
   val sendButtonSwitch        = findById[SwitchPreference](R.id.preferences_send_button)
@@ -77,7 +78,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   val soundsButton            = findById[TextButton](R.id.preferences_sounds)
   val downloadImagesSwitch    = findById[SwitchPreference](R.id.preferences_options_image_download)
   val hideScreenContentSwitch = findById[SwitchPreference](R.id.preferences_hide_screen)
-  val messagePreviewSwitch = findById[SwitchPreference](R.id.preferences_message_previews)
+  val messagePreviewSwitch    = findById[SwitchPreference](R.id.preferences_message_previews)
   val incognitoKeyboardSwitch = findById[SwitchPreference](R.id.preferences_incognito_keyboard)
 
   val ringToneButton         = findById[TextButton](R.id.preference_sounds_ringtone)
@@ -98,6 +99,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   downloadImagesSwitch.setPreference(DownloadImagesAlways)
   hideScreenContentSwitch.setPreference(HideScreenContent)
   vbrSwitch.setPreference(VBREnabled)
+  conferenceCallingSwitch.setPreference(ConferenceCallingEnabled)
   messagePreviewSwitch.setPreference(MessagePreview)
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -500,4 +500,5 @@ object UserPreferences {
   lazy val FailedPasswordAttempts = PrefKey[Int]("failed_password_attempts", customDefault = 0)
 
   lazy val ShouldWarnAVSUpgrade = PrefKey[Boolean]("should_warn_avs_upgrade", customDefault = false)
+  lazy val ConferenceCallingEnabled = PrefKey[Boolean]("conference_calling_enabled", customDefault = false)
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -111,7 +111,6 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   private implicit val dispatcher = new SerialDispatchQueue(name = "ZMessaging")
 
   val httpProxy: Option[Proxy] = ZMessaging.httpProxy
-  val conferenceCallingEnabled: Boolean = ZMessaging.conferenceCallingEnabled
 
   val clock = ZMessaging.clock
 
@@ -384,7 +383,6 @@ object ZMessaging extends DerivedLogTag { self =>
   private var notificationsUi:     NotificationUiController = _
   private var assets2Module:       Assets2Module = _
   private var fileRestrictionList: FileRestrictionList = _
-  private var conferenceCallingEnabled: Boolean = _
 
   //var for tests - and set here so that it is globally available without the need for DI
   var clock = Clock.systemUTC()
@@ -415,8 +413,7 @@ object ZMessaging extends DerivedLogTag { self =>
                syncRequests:        SyncRequestService,
                notificationUi:      NotificationUiController,
                assets2:             Assets2Module,
-               fileRestrictionList: FileRestrictionList,
-               conferenceCallingEnabled: Boolean
+               fileRestrictionList: FileRestrictionList
               ) = {
     Threading.assertUiThread()
 
@@ -430,9 +427,6 @@ object ZMessaging extends DerivedLogTag { self =>
       this.notificationsUi = notificationUi
       this.assets2Module = assets2
       this.fileRestrictionList = fileRestrictionList
-      this.conferenceCallingEnabled = conferenceCallingEnabled
-
-      if (conferenceCallingEnabled) CallingService.VideoCallMaxMembers = 100
 
       currentUi = ui
       currentGlobal = _global

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -143,7 +143,7 @@ class AvsImpl() extends Avs with DerivedLogTag {
       },
       new IncomingCallHandler {
         override def onIncomingCall(convId: String, msgTime: Uint32_t, userId: String, clientId: String, isVideoCall: Boolean, shouldRing: Boolean, convType: Int, arg: Pointer) =
-          cs.onIncomingCall(RConvId(convId), UserId(userId), isVideoCall, shouldRing)
+          cs.onIncomingCall(RConvId(convId), UserId(userId), isVideoCall, shouldRing, isConferenceCall = convType == WCallConvType.Conference.id)
       },
       new MissedCallHandler {
         override def onMissedCall(convId: String, msgTime: Uint32_t, userId: String, isVideoCall: Boolean, arg: Pointer): Unit =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -40,7 +40,7 @@ case class CallInfo(convId:             ConvId,
                     isGroup:            Boolean,
                     caller:             UserId,
                     state:              CallState,
-                    isConferenceCall:   Boolean,
+                    isConferenceCall:   Boolean                      = false,
                     prevState:          Option[CallState]            = None,
                     otherParticipants:  Set[Participant]             = Set.empty,
                     maxParticipants:    Int                          = 0, //maintains the largest number of users that were ever in the call (for tracking)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -40,6 +40,7 @@ case class CallInfo(convId:             ConvId,
                     isGroup:            Boolean,
                     caller:             UserId,
                     state:              CallState,
+                    isConferenceCall:   Boolean,
                     prevState:          Option[CallState]            = None,
                     otherParticipants:  Set[Participant]             = Set.empty,
                     maxParticipants:    Int                          = 0, //maintains the largest number of users that were ever in the call (for tracking)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -481,7 +481,7 @@ class CallingServiceImpl(val accountId:       UserId,
                         isGroup,
                         accountId,
                         SelfCalling,
-                        isConferenceCall = callType == WCallConvType.Conference,
+                        isConferenceCall = convType == WCallConvType.Conference,
                         startedAsVideoCall = isVideo,
                         videoSendState = if (isVideo) VideoState.Started else VideoState.Stopped)
                       callProfile.mutate(_.copy(calls = profile.calls + (newCall.convId -> newCall)))

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -107,7 +107,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     val checkpoint5 = callCheckpoint(_.get(_1to1Conv.id).exists(c => c.convId == _1to1Conv.id && c.state == Ended && c.endReason.contains(AvsClosedReason.Normal)      && c.endTime.contains(LocalInstant(Instant.EPOCH + 30.seconds))), _.isEmpty)
 
     def progressToSelfConnected(): Unit = {
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       awaitCP(checkpoint1)
 
       clock.advance(10.seconds)
@@ -202,7 +202,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint4 = callCheckpoint(_.contains(team1to1Conv.id), _.exists(c => c.convId == team1to1Conv.id && c.state == Terminating   && c.otherParticipants == Set(otherUser) && c.endTime.contains(LocalInstant(Instant.EPOCH + 30.seconds))))
       val checkpoint5 = callCheckpoint(_.get(team1to1Conv.id).exists(c => c.convId == team1to1Conv.id && c.state == Ended && c.endReason.contains(AvsClosedReason.Normal)      && c.endTime.contains(LocalInstant(Instant.EPOCH + 30.seconds))), _.isEmpty)
 
-      service.onIncomingCall(team1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(team1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       awaitCP(checkpoint1)
 
       clock.advance(10.seconds)
@@ -254,7 +254,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         case _ =>
       }
 
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       awaitCP(checkpoint1)
 
       (avs.rejectCall _).expects(*, *).once()
@@ -446,7 +446,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint2 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfJoining))
       val checkpoint3 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfConnected  && cur.otherParticipants == Set(otherUser, otherUser2)))
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
 
       awaitCP(checkpoint1)
 
@@ -537,7 +537,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint1 = callCheckpoint(_.contains(groupConv.id), _.exists(c => c.state == SelfConnected && c.estabTime.contains(estTime)))
       val checkpoint2 = callCheckpoint(_.get(groupConv.id).exists(c => c.state == Ongoing && c.estabTime.contains(estTime)), _.isEmpty)
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
 
       clock + 10.seconds
 
@@ -571,7 +571,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint1 = callCheckpoint(_.contains(groupConv.id), _.exists(_.state == OtherCalling))
       val checkpoint2 = callCheckpoint(_.get(groupConv.id).exists(c => c.state == Ended && c.endReason.contains(AvsClosedReason.AnsweredElsewhere)), _.isEmpty)
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       awaitCP(checkpoint1)
 
       service.onClosedCall(AnsweredElsewhere, groupConv.remoteId, RemoteInstant(clock.instant()), otherUserId)
@@ -621,7 +621,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     scenario("Leaving a group call with more than 1 other member should put the call into the Ongoing state if we skip terminating") {
       await(globalPrefs(SkipTerminatingState) := true)
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
 
       awaitCP(checkpoint1)
 
@@ -657,7 +657,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     }
 
     scenario("Leaving a group call with more than 1 other member should put the call into the Ongoing state after the terminating state") {
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
 
       awaitCP(checkpoint1)
 
@@ -699,7 +699,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     scenario("If a user joins an ongoing group call in the background, it shouldn't be bumped to active") {
       await(globalPrefs(SkipTerminatingState) := true)
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       service.onParticipantsChanged(groupConv.remoteId, Set(otherUser))
 
       service.endCall(groupConv.id)
@@ -712,7 +712,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       awaitCP(checkpoint8)
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = false) //Group check message gets triggered after a bit
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = false, isConferenceCall = false) //Group check message gets triggered after a bit
 
       awaitCP(checkpoint9)
     }
@@ -726,7 +726,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint2 = callCheckpoint(_.contains(_1to1Conv2.id), cur => cur.exists(_.state == SelfCalling) && cur.exists(_.otherParticipants.isEmpty))
       val checkpoint3 = callCheckpoint(_.contains(_1to1Conv2.id), cur => cur.exists(_.state == SelfConnected) && cur.exists(_.otherParticipants.contains(otherUser2)))
 
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
         service.onParticipantsChanged(_1to1Conv.remoteId, Set(otherUser))
@@ -858,7 +858,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       awaitCP(checkpoint5)
 
       clock.advance(10.seconds)
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       awaitCP(checkpoint6)
     }
   }
@@ -885,7 +885,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
 
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
         service.onParticipantsChanged(_1to1Conv.remoteId, Set(otherUser))
@@ -893,7 +893,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.startCall(_1to1Conv.id)
       awaitCP(checkpoint1)
 
-      service.onIncomingCall(_1to1Conv2.remoteId, otherUser2Id, videoCall = false, shouldRing = true) //Receive the second call after first is established
+      service.onIncomingCall(_1to1Conv2.remoteId, otherUser2Id, videoCall = false, shouldRing = true, isConferenceCall = false) //Receive the second call after first is established
       awaitCP(checkpoint2)
 
       (avs.endCall _).expects(*, _1to1Conv.remoteId).once().onCall { (_, _) =>
@@ -925,7 +925,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (permissions.ensurePermissions _).expects(*).once().returning(Future.successful(()))
 
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (_, _, _, _) =>
         service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
         service.onParticipantsChanged(_1to1Conv.remoteId, Set(otherUser))
@@ -933,7 +933,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.startCall(_1to1Conv.id)
       awaitCP(checkpoint1)
 
-      service.onIncomingCall(_1to1Conv2.remoteId, otherUser2Id, videoCall = false, shouldRing = true) //Receive the second call after first is established
+      service.onIncomingCall(_1to1Conv2.remoteId, otherUser2Id, videoCall = false, shouldRing = true, isConferenceCall = false) //Receive the second call after first is established
       awaitCP(checkpoint2)
 
       service.onClosedCall(Normal, _1to1Conv.remoteId, RemoteInstant(clock.instant()), otherUserId)
@@ -960,14 +960,14 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       //Join group call
       val checkpoint5 = callCheckpoint(_.contains(groupConv.id), _.exists(c => c.otherParticipants == Set(otherUser, otherUser2) && c.state == SelfConnected))
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       (avs.rejectCall _).expects(*, *).anyNumberOfTimes().onCall { (_, _) =>
         service.onClosedCall(StillOngoing, groupConv.remoteId, RemoteInstant(clock.instant()), otherUserId)
       }
       service.endCall(groupConv.id) //user rejects the group call
       awaitCP(checkpoint1)
 
-      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(_1to1Conv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
       (avs.answerCall _).expects(*, *, *, *).once().onCall { (rId, _, _, _) =>
         service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
         service.onParticipantsChanged(_1to1Conv.remoteId, Set(otherUser))
@@ -1060,7 +1060,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     def progressToSelfConnected(): Unit = {
       val checkpoint1 = callCheckpoint(_.contains(groupConv.id), _.exists(cur => cur.convId == groupConv.id && cur.state == SelfConnected  && cur.otherParticipants == Set(otherUser, otherUser2)))
 
-      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true)
+      service.onIncomingCall(groupConv.remoteId, otherUserId, videoCall = false, shouldRing = true, isConferenceCall = false)
 
       (convsService.activeMembersData _).expects(groupConv.id).once().returning(
         Signal(Seq(
@@ -1197,7 +1197,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     val s = new CallingServiceImpl(
       selfUserId, selfClientId, null, context, avs, convs, convsService, members, otrSyncHandler,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, httpProxy = None,
+      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, httpProxy = None
     )
     result(s.wCall)
     s

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -1197,7 +1197,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     val s = new CallingServiceImpl(
       selfUserId, selfClientId, null, context, avs, convs, convsService, members, otrSyncHandler,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, httpProxy = None, conferenceCallingEnabled = false
+      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking, httpProxy = None,
     )
     result(s.wCall)
     s


### PR DESCRIPTION
## What's new in this PR?

This PR introduces the beta program toggle for conference calling (replacing the previous feature flag in `BuildConfig`). The setting stored per account. When enabled, all outgoing group calls will be conference calls and group video restrictions are removed. By default, the beta program is disabled.

## Notes

The client is still able participate in conference calls even when it is not participating in the beta program. This is possible when it receives a conference call from another user.

#### APK
[Download build #2373](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2373/artifact/build/artifact/wire-dev-PR2942-2373.apk)