### PR TITLE
Feat: Back up - Part 2: Add batch reader for big database tables

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
@@ -1,0 +1,43 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.feature.backup.BackUpIOHandler
+
+class BatchDatabaseIOHandler<E>(private val batchReadableDao: BatchReadableDao<E>, private val batchSize: Int) : BackUpIOHandler<E> {
+
+    override fun write(iterator: Iterator<E>) {
+        while (iterator.hasNext()) {
+            batchReadableDao.insert(iterator.next())
+        }
+    }
+
+    override fun readIterator(): Iterator<E> = object : Iterator<E> {
+        var count = 0
+        val currentBatch = mutableListOf<E>()
+
+        override fun hasNext(): Boolean = count < batchReadableDao.count()
+
+        //TODO map NoSuchElementException to Either domain.
+        override fun next(): E =
+            if (!hasNext()) throw NoSuchElementException()
+            else {
+                if (count % batchSize == 0) {
+                    currentBatch.clear()
+                    currentBatch.addAll(batchReadableDao.getNextBatch(
+                        start = count,
+                        batchSize = (batchReadableDao.count() - count).coerceAtMost(batchSize))
+                    )
+                }
+                currentBatch[count % batchSize].also {
+                    count++
+                }
+            }
+    }
+}
+
+interface BatchReadableDao<E> {
+    fun count(): Int
+
+    fun getNextBatch(start: Int, batchSize: Int): List<E>
+
+    fun insert(item: E)
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
@@ -1,0 +1,76 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.UnitTest
+import com.waz.zclient.any
+import com.waz.zclient.eq
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class BatchDatabaseIOHandlerTest : UnitTest() {
+
+    private lateinit var batchReadableDao: BatchReadableDao<Int>
+
+    private lateinit var batchDatabaseIOHandler: BatchDatabaseIOHandler<Int>
+
+    @Test
+    fun `given a batchReadableDao, when readIterator() is called, returns an iterator which reads in batches`() {
+        val allItems = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        val batchSize = 3
+
+        batchReadableDao = spy(batchReadableDaoOf(allItems))
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
+
+        batchDatabaseIOHandler.readIterator().let { iterator ->
+            iterator.withIndex().forEach {
+                assertEquals(allItems[it.index], it.value)
+            }
+        }
+        verify(batchReadableDao, times(4)).getNextBatch(anyInt(), eq(batchSize))
+    }
+
+    @Test
+    fun `given a readIterator(), when next() is called, does not request a batch with size more than the remaining count`() {
+        val allItems = mutableListOf(1, 2, 3, 4, 5 ,6, 7)
+        val batchSize = 3
+
+        batchReadableDao = spy(batchReadableDaoOf(allItems))
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
+
+        batchDatabaseIOHandler.readIterator().forEach { /* just consume all */}
+
+        //[1, 2, 3], [4, 5, 6]
+        verify(batchReadableDao, times(2)).getNextBatch(anyInt(), eq(batchSize))
+        //[7]
+        verify(batchReadableDao).getNextBatch(anyInt(), eq(1))
+    }
+
+    @Test
+    fun `given a dao, when write() is called with an iterator, then inserts each next item of the iterator to dao`() {
+        batchReadableDao = mock(BatchReadableDao::class.java) as BatchReadableDao<Int>
+        val allItems = mutableListOf(1, 2, 3, 4, 5)
+
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, 3)
+
+        batchDatabaseIOHandler.write(allItems.listIterator())
+
+        verify(batchReadableDao, times(allItems.size)).insert(any())
+        allItems.listIterator().forEach {
+            verify(batchReadableDao).insert(it)
+        }
+    }
+
+    companion object {
+        private fun batchReadableDaoOf(list: List<Int>) = object : BatchReadableDao<Int> {
+            override fun count(): Int = list.size
+
+            override fun getNextBatch(start: Int, batchSize: Int): List<Int> = list.subList(start, (start + batchSize))
+
+            override fun insert(item: Int) { /*not needed*/ }
+        }
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some database tables might be too big, and reading all the elements at once can result in OOM exceptions.

### Solutions

Implement a batch reader structure for such tables. 

**Usage:**

Simply pass an instance of `BatchDatabaseIOHandler` as `backUpLocalDataSource` parameter to `BackUpDataSource` class.

### Testing

Implemented unit tests for BatchDatabaseIOHandler.


#### APK
[Download build #2386](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2386/artifact/build/artifact/wire-dev-PR2946-2386.apk)