### PR TITLE
Feat: Back up - Part 5 : Convert Iterator to suspendable one with Either

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jp.leafytree.android-scala'
 apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
 apply from: 'config/quality.gradle'
+apply plugin: 'kotlinx-serialization'
 
 //region avs
 //TODO: Migrate this configuration to new dependency system
@@ -415,6 +416,9 @@ dependencies {
     // RxJava
     implementation BuildDependencies.rxJava.rxKotlin
     implementation BuildDependencies.rxJava.rxAndroid
+
+    //JSON
+    implementation BuildDependencies.kotlinXSerialization
 
     //third party libraries
     implementation BuildDependencies.androidJob

--- a/app/src/main/kotlin/com/waz/zclient/core/exception/Failure.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/exception/Failure.kt
@@ -29,5 +29,7 @@ object DatabaseError : DatabaseFailure()
 //TODO: Improve to a more sufficient error propagation for Flow "data flows"
 data class GenericUseCaseError(val throwable: Throwable) : Failure()
 
+data class IOFailure(val reason: Exception) : Failure()
+
 /** * Extend this class for UseCase specific failures.*/
 abstract class FeatureFailure : Failure()

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/Components.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/Components.kt
@@ -1,8 +1,12 @@
 package com.waz.zclient.feature.backup
 
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.feature.backup.io.BatchReader
+
 interface BackUpIOHandler<T> {
-    fun write(iterator: Iterator<T>)
-    fun readIterator(): Iterator<T>
+    suspend fun write(iterator: BatchReader<T>): Either<Failure, Unit>
+    fun readIterator(): BatchReader<T>
 }
 
 interface BackUpDataMapper<T, E> {

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/BatchReader.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/BatchReader.kt
@@ -1,0 +1,41 @@
+package com.waz.zclient.feature.backup.io
+
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.extension.foldSuspendable
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.functional.map
+
+interface BatchReader<T> {
+    /**
+     * Reads next item from source and returns the result.
+     *
+     * @return Either.Left(Failure) if there is an error,
+     * Either.Right(t) if next item is read successfully,
+     * Either.Right(null) if there are no more items to read.
+     */
+    suspend fun readNext(): Either<Failure, T?>
+}
+
+/**
+ * Reads all items sequentially and applies given [action] to each of them.
+ * If [com.waz.zclient.feature.backup.io.BatchReader.readNext] or [action] fails, stops reading
+ * more items and immediately returns that [Failure].
+ *
+ * @return Either.Right(Unit) if all items are read and actions are applied successfully,
+ * Either.Left(Failure) otherwise
+ */
+suspend fun <T> BatchReader<T>.forEach(action: suspend (T) -> Either<Failure, Unit>): Either<Failure, Unit> {
+    var next = readNext()
+
+    while (next.fold({ false }) { it != null }!!) {
+        next.foldSuspendable({}) {
+            action(it!!).foldSuspendable({
+                next = Either.Left(it)
+            }) {
+                next = readNext()
+                Unit
+            }
+        }
+    }
+    return next.map { Unit }
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
@@ -1,43 +1,45 @@
 package com.waz.zclient.feature.backup.io.database
 
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.network.requestDatabase
 import com.waz.zclient.feature.backup.BackUpIOHandler
+import com.waz.zclient.feature.backup.io.BatchReader
+import com.waz.zclient.feature.backup.io.forEach
 
 class BatchDatabaseIOHandler<E>(private val batchReadableDao: BatchReadableDao<E>, private val batchSize: Int) : BackUpIOHandler<E> {
 
-    override fun write(iterator: Iterator<E>) {
-        while (iterator.hasNext()) {
-            batchReadableDao.insert(iterator.next())
+    override suspend fun write(iterator: BatchReader<E>): Either<Failure, Unit> =
+        iterator.forEach {
+            requestDatabase {
+                //TODO write in batches with a buffered approach (for performance)
+                batchReadableDao.insert(it)
+            }
         }
-    }
 
-    override fun readIterator(): Iterator<E> = object : Iterator<E> {
+    override fun readIterator(): BatchReader<E> = object : BatchReader<E> {
         var count = 0
         val currentBatch = mutableListOf<E>()
 
-        override fun hasNext(): Boolean = count < batchReadableDao.count()
-
-        //TODO map NoSuchElementException to Either domain.
-        override fun next(): E =
-            if (!hasNext()) throw NoSuchElementException()
-            else {
-                if (count % batchSize == 0) {
-                    currentBatch.clear()
-                    currentBatch.addAll(batchReadableDao.getNextBatch(
-                        start = count,
-                        batchSize = (batchReadableDao.count() - count).coerceAtMost(batchSize))
-                    )
-                }
-                currentBatch[count % batchSize].also {
-                    count++
-                }
+        override suspend fun readNext(): Either<Failure, E?> = requestDatabase {
+            if (count % batchSize == 0) {
+                currentBatch.clear()
+                currentBatch.addAll(batchReadableDao.getNextBatch(
+                    start = count,
+                    batchSize = (batchReadableDao.count() - count).coerceAtMost(batchSize))
+                )
             }
+            currentBatch[count % batchSize].also {
+                count++
+            }
+        }
     }
 }
 
 interface BatchReadableDao<E> {
-    fun count(): Int
+    suspend fun count(): Int
 
-    fun getNextBatch(start: Int, batchSize: Int): List<E>
+    suspend fun getNextBatch(start: Int, batchSize: Int): List<E>
 
-    fun insert(item: E)
+    suspend fun insert(item: E)
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandler.kt
@@ -1,0 +1,43 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.feature.backup.BackUpIOHandler
+
+class BatchDatabaseIOHandler<E>(private val batchReadableDao: BatchReadableDao<E>, private val batchSize: Int) : BackUpIOHandler<E> {
+
+    override fun write(iterator: Iterator<E>) {
+        while (iterator.hasNext()) {
+            batchReadableDao.insert(iterator.next())
+        }
+    }
+
+    override fun readIterator(): Iterator<E> = object : Iterator<E> {
+        var count = 0
+        val currentBatch = mutableListOf<E>()
+
+        override fun hasNext(): Boolean = count < batchReadableDao.count()
+
+        //TODO map NoSuchElementException to Either domain.
+        override fun next(): E =
+            if (!hasNext()) throw NoSuchElementException()
+            else {
+                if (count % batchSize == 0) {
+                    currentBatch.clear()
+                    currentBatch.addAll(batchReadableDao.getNextBatch(
+                        start = count,
+                        batchSize = (batchReadableDao.count() - count).coerceAtMost(batchSize))
+                    )
+                }
+                currentBatch[count % batchSize].also {
+                    count++
+                }
+            }
+    }
+}
+
+interface BatchReadableDao<E> {
+    fun count(): Int
+
+    fun getNextBatch(start: Int, batchSize: Int): List<E>
+
+    fun insert(item: E)
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/SingleReadDatabaseIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/database/SingleReadDatabaseIOHandler.kt
@@ -1,0 +1,26 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.feature.backup.BackUpIOHandler
+
+class SingleReadDatabaseIOHandler<T>(private val singleReadDao: SingleReadDao<T>) : BackUpIOHandler<T> {
+
+    override fun write(iterator: Iterator<T>) {
+        while (iterator.hasNext()) {
+            singleReadDao.insert(iterator.next())
+        }
+    }
+
+    @Suppress("IteratorNotThrowingNoSuchElementException") //listIterator throws it
+    override fun readIterator() = object : Iterator<T> {
+        val listIterator by lazy { singleReadDao.getAll().iterator() }
+
+        override fun hasNext(): Boolean = listIterator.hasNext()
+
+        override fun next(): T = listIterator.next()
+    }
+}
+
+interface SingleReadDao<T> {
+    fun insert(item: T)
+    fun getAll(): List<T>
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
@@ -8,6 +8,9 @@ import com.waz.zclient.feature.backup.io.BatchReader
 import com.waz.zclient.feature.backup.io.forEach
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import java.io.File
 
 class BackUpFileIOHandler<T>(
@@ -52,12 +55,10 @@ class BackUpFileIOHandler<T>(
     }
 }
 
-class JsonConverter<T> {
-    fun fromJson(jsonString: String): T {
-        TODO("add kotlinx.serialization")
-    }
+class JsonConverter<T>(private val serializer: KSerializer<T>) {
+    private val json by lazy { Json(JsonConfiguration.Stable) }
 
-    fun toJson(model: T): String {
-        TODO("add kotlinx.serialization")
-    }
+    fun fromJson(jsonString: String): T = json.parse(serializer, jsonString)
+
+    fun toJson(model: T): String = json.stringify(serializer, model)
 }

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
@@ -1,0 +1,51 @@
+package com.waz.zclient.feature.backup.io.file
+
+import com.waz.zclient.feature.backup.BackUpIOHandler
+import java.io.File
+
+class BackUpFileIOHandler<T>(
+    private val fileName: String,
+    private val jsonConverter: JsonConverter<T>
+) : BackUpIOHandler<T> {
+
+    override fun write(iterator: Iterator<T>) {
+        val file = File(fileName).also {
+            it.delete()
+            it.createNewFile()
+        }
+        while (iterator.hasNext()) {
+            val jsonStr = jsonConverter.toJson(iterator.next())
+            file.appendText("$jsonStr\n")
+        }
+    }
+
+    //TODO close bufferedReader in case of exception, error, etc.
+    @Suppress("IteratorNotThrowingNoSuchElementException") //lineIterator already throws it
+    override fun readIterator(): Iterator<T> {
+        val reader = File(fileName).bufferedReader()
+        val lineIterator = reader.lineSequence().iterator()
+
+        return object : Iterator<T> {
+            var closeReaderAfterNext = false
+
+            override fun hasNext(): Boolean = lineIterator.hasNext().also { hasNext ->
+                if (!hasNext) closeReaderAfterNext = true
+            }
+
+            override fun next(): T = lineIterator.next().let {
+                if (closeReaderAfterNext) reader.close()
+                jsonConverter.fromJson(it)
+            }
+        }
+    }
+}
+
+class JsonConverter<T> {
+    fun fromJson(jsonString: String): T {
+        TODO("add kotlinx.serialization")
+    }
+
+    fun toJson(model: T): String {
+        TODO("add kotlinx.serialization")
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/BatchReaderTestHelpers.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/BatchReaderTestHelpers.kt
@@ -1,0 +1,30 @@
+package com.waz.zclient.feature.backup
+
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.feature.backup.io.BatchReader
+import com.waz.zclient.feature.backup.io.forEach
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.mockito.Mockito.`when`
+
+suspend fun <T> BatchReader<T>.mockNextItems(items: List<T>) {
+    val itemsArray = items.map { Either.Right(it) }.plus(Either.Right(null)).toTypedArray()
+    `when`(this.readNext()).thenReturn(itemsArray[0], *itemsArray.sliceArray(1 until itemsArray.size))
+}
+
+suspend fun <T> BatchReader<T>.assertItems(expectedItems: List<T>) {
+    var count = 0
+
+    this.forEach { next ->
+        when {
+            count < expectedItems.size -> {
+                val expectedItem = expectedItems.getOrNull(count)
+                expectedItem?.let { assertEquals(it, next) }
+            }
+            count == expectedItems.size -> assertEquals(null, next)
+            else -> fail("Expected ${expectedItems.size} iterations but got ${count + 1}")
+        }
+        count++
+        Either.Right(Unit)
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/BatchReaderExtensionsTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/BatchReaderExtensionsTest.kt
@@ -1,0 +1,76 @@
+package com.waz.zclient.feature.backup.io
+
+import com.waz.zclient.UnitTest
+import com.waz.zclient.core.exception.DatabaseError
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.feature.backup.assertItems
+import com.waz.zclient.feature.backup.mockNextItems
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class BatchReaderExtensionsTest : UnitTest() {
+
+    @Mock
+    private lateinit var batchReader: BatchReader<String>
+
+    @Test
+    fun `given forEach is called, when all items are read successfully and actions are successful, then returns Right(Unit)`() {
+        runBlocking {
+            val items = listOf("a", "b", "c")
+            batchReader.mockNextItems(items)
+
+            val nextItems = mutableListOf<String>()
+
+            val result = batchReader.forEach {
+                nextItems.add(it)
+                Either.Right(Unit)
+            }
+
+            assertEquals(items, nextItems)
+            assertEquals(Either.Right(null), batchReader.readNext())
+            assertEquals(Either.Right(Unit), result)
+        }
+    }
+
+    @Test
+    fun `given forEach is called, when all items are read successfully but an action fails, then returns action's failure and does not read any more`() {
+        runBlocking {
+            val items = listOf("a", "b", "c")
+            batchReader.mockNextItems(items)
+
+            val result = batchReader.forEach {
+                when (it) {
+                    "a" -> Either.Right(Unit)
+                    "b" -> Either.Left(DatabaseError)
+                    else -> throw AssertionError("Unexpected value $it")
+                }
+            }
+
+            verify(batchReader, times(2)).readNext()
+
+            assertEquals(Either.Left(DatabaseError), result)
+        }
+    }
+
+    @Test
+    fun `given forEach is called, when readNext() fails, then returns that failure immediately and does not read any more`() {
+        runBlocking {
+            `when`(batchReader.readNext()).thenReturn(Either.Right("a"), Either.Left(DatabaseError))
+
+            val result = batchReader.forEach {
+                assertEquals("a", it)
+                Either.Right(Unit)
+            }
+
+            verify(batchReader, times(2)).readNext()
+
+            assertEquals(Either.Left(DatabaseError), result)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
@@ -2,10 +2,16 @@ package com.waz.zclient.feature.backup.io.database
 
 import com.waz.zclient.UnitTest
 import com.waz.zclient.any
+import com.waz.zclient.core.functional.Either
 import com.waz.zclient.eq
-import org.junit.Assert.assertEquals
+import com.waz.zclient.feature.backup.assertItems
+import com.waz.zclient.feature.backup.io.BatchReader
+import com.waz.zclient.feature.backup.io.forEach
+import com.waz.zclient.feature.backup.mockNextItems
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
@@ -14,6 +20,9 @@ import org.mockito.Mockito.verify
 class BatchDatabaseIOHandlerTest : UnitTest() {
 
     private lateinit var batchReadableDao: BatchReadableDao<Int>
+
+    @Mock
+    private lateinit var batchReader: BatchReader<Int>
 
     private lateinit var batchDatabaseIOHandler: BatchDatabaseIOHandler<Int>
 
@@ -25,52 +34,55 @@ class BatchDatabaseIOHandlerTest : UnitTest() {
         batchReadableDao = spy(batchReadableDaoOf(allItems))
         batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
 
-        batchDatabaseIOHandler.readIterator().let { iterator ->
-            iterator.withIndex().forEach {
-                assertEquals(allItems[it.index], it.value)
-            }
+        runBlocking {
+            batchDatabaseIOHandler.readIterator().assertItems(allItems)
+            verify(batchReadableDao, times(4)).getNextBatch(anyInt(), eq(batchSize))
         }
-        verify(batchReadableDao, times(4)).getNextBatch(anyInt(), eq(batchSize))
     }
 
     @Test
     fun `given a readIterator(), when next() is called, does not request a batch with size more than the remaining count`() {
-        val allItems = mutableListOf(1, 2, 3, 4, 5 ,6, 7)
-        val batchSize = 3
+        runBlocking {
+            val allItems = mutableListOf(1, 2, 3, 4, 5, 6, 7)
+            val batchSize = 3
 
-        batchReadableDao = spy(batchReadableDaoOf(allItems))
-        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
+            batchReadableDao = spy(batchReadableDaoOf(allItems))
+            batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
 
-        batchDatabaseIOHandler.readIterator().forEach { /* just consume all */}
+            batchDatabaseIOHandler.readIterator().forEach { Either.Right(Unit)/* just consume all */}
 
-        //[1, 2, 3], [4, 5, 6]
-        verify(batchReadableDao, times(2)).getNextBatch(anyInt(), eq(batchSize))
-        //[7]
-        verify(batchReadableDao).getNextBatch(anyInt(), eq(1))
+            //[1, 2, 3], [4, 5, 6]
+            verify(batchReadableDao, times(2)).getNextBatch(anyInt(), eq(batchSize))
+            //[7]
+            verify(batchReadableDao).getNextBatch(anyInt(), eq(1))
+        }
     }
 
     @Test
     fun `given a dao, when write() is called with an iterator, then inserts each next item of the iterator to dao`() {
-        batchReadableDao = mock(BatchReadableDao::class.java) as BatchReadableDao<Int>
-        val allItems = mutableListOf(1, 2, 3, 4, 5)
+        runBlocking {
+            batchReadableDao = mock(BatchReadableDao::class.java) as BatchReadableDao<Int>
+            val allItems = mutableListOf(1, 2, 3, 4, 5)
+            batchReader.mockNextItems(allItems)
 
-        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, 3)
+            batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, 3)
 
-        batchDatabaseIOHandler.write(allItems.listIterator())
+            batchDatabaseIOHandler.write(batchReader)
 
-        verify(batchReadableDao, times(allItems.size)).insert(any())
-        allItems.listIterator().forEach {
-            verify(batchReadableDao).insert(it)
+            verify(batchReadableDao, times(allItems.size)).insert(any())
+            allItems.listIterator().forEach {
+                verify(batchReadableDao).insert(it)
+            }
         }
     }
 
     companion object {
         private fun batchReadableDaoOf(list: List<Int>) = object : BatchReadableDao<Int> {
-            override fun count(): Int = list.size
+            override suspend fun count(): Int = list.size
 
-            override fun getNextBatch(start: Int, batchSize: Int): List<Int> = list.subList(start, (start + batchSize))
+            override suspend fun getNextBatch(start: Int, batchSize: Int): List<Int> = list.subList(start, (start + batchSize))
 
-            override fun insert(item: Int) { /*not needed*/ }
+            override suspend fun insert(item: Int) { /*not needed*/ }
         }
     }
 }

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/BatchDatabaseIOHandlerTest.kt
@@ -1,0 +1,76 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.UnitTest
+import com.waz.zclient.any
+import com.waz.zclient.eq
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class BatchDatabaseIOHandlerTest : UnitTest() {
+
+    private lateinit var batchReadableDao: BatchReadableDao<Int>
+
+    private lateinit var batchDatabaseIOHandler: BatchDatabaseIOHandler<Int>
+
+    @Test
+    fun `given a batchReadableDao, when readIterator() is called, returns an iterator which reads in batches`() {
+        val allItems = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        val batchSize = 3
+
+        batchReadableDao = spy(batchReadableDaoOf(allItems))
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
+
+        batchDatabaseIOHandler.readIterator().let { iterator ->
+            iterator.withIndex().forEach {
+                assertEquals(allItems[it.index], it.value)
+            }
+        }
+        verify(batchReadableDao, times(4)).getNextBatch(anyInt(), eq(batchSize))
+    }
+
+    @Test
+    fun `given a readIterator(), when next() is called, does not request a batch with size more than the remaining count`() {
+        val allItems = mutableListOf(1, 2, 3, 4, 5 ,6, 7)
+        val batchSize = 3
+
+        batchReadableDao = spy(batchReadableDaoOf(allItems))
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, batchSize)
+
+        batchDatabaseIOHandler.readIterator().forEach { /* just consume all */}
+
+        //[1, 2, 3], [4, 5, 6]
+        verify(batchReadableDao, times(2)).getNextBatch(anyInt(), eq(batchSize))
+        //[7]
+        verify(batchReadableDao).getNextBatch(anyInt(), eq(1))
+    }
+
+    @Test
+    fun `given a dao, when write() is called with an iterator, then inserts each next item of the iterator to dao`() {
+        batchReadableDao = mock(BatchReadableDao::class.java) as BatchReadableDao<Int>
+        val allItems = mutableListOf(1, 2, 3, 4, 5)
+
+        batchDatabaseIOHandler = BatchDatabaseIOHandler(batchReadableDao, 3)
+
+        batchDatabaseIOHandler.write(allItems.listIterator())
+
+        verify(batchReadableDao, times(allItems.size)).insert(any())
+        allItems.listIterator().forEach {
+            verify(batchReadableDao).insert(it)
+        }
+    }
+
+    companion object {
+        private fun batchReadableDaoOf(list: List<Int>) = object : BatchReadableDao<Int> {
+            override fun count(): Int = list.size
+
+            override fun getNextBatch(start: Int, batchSize: Int): List<Int> = list.subList(start, (start + batchSize))
+
+            override fun insert(item: Int) { /*not needed*/ }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/SingleReadDatabaseIOHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/database/SingleReadDatabaseIOHandlerTest.kt
@@ -1,0 +1,52 @@
+package com.waz.zclient.feature.backup.io.database
+
+import com.waz.zclient.UnitTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class SingleReadDatabaseIOHandlerTest : UnitTest() {
+
+    @Mock
+    private lateinit var singleReadDao: SingleReadDao<Int>
+
+    private lateinit var singleReadDatabaseIOHandler: SingleReadDatabaseIOHandler<Int>
+
+    @Before
+    fun setUp() {
+        singleReadDatabaseIOHandler = SingleReadDatabaseIOHandler(singleReadDao)
+    }
+
+    @Test
+    fun `given an iterator, when write() is called, then inserts every item received into dao`() {
+        val items = listOf(1, 2, 3)
+
+        singleReadDatabaseIOHandler.write(items.iterator())
+
+        verify(singleReadDao, times(items.size)).insert(anyInt())
+        items.forEach {
+            verify(singleReadDao).insert(it)
+        }
+    }
+
+    @Test
+    fun `given a singleReadDao, when readIterator() is called, then fetches all items at once and returns the proper iterator`() {
+        val allItems = listOf(1, 2, 3, 4)
+        `when`(singleReadDao.getAll()).thenReturn(allItems)
+
+        val readIterator = singleReadDatabaseIOHandler.readIterator()
+
+        readIterator.withIndex().forEach {
+            assertEquals(allItems[it.index], it.value)
+        }
+        assertFalse(readIterator.hasNext())
+
+        verify(singleReadDao).getAll()
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandlerTest.kt
@@ -1,0 +1,86 @@
+package com.waz.zclient.feature.backup.io.file
+
+import com.waz.zclient.UnitTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import java.io.File
+
+class BackUpFileIOHandlerTest : UnitTest() {
+
+    @Mock
+    private lateinit var jsonConverter: JsonConverter<Int>
+
+    private lateinit var backUpFileIOHandler: BackUpFileIOHandler<Int>
+
+    @Test
+    fun `given an iterator, when write() is called, then creates a new file and writes contents to it`() =
+        runTestWithFile(uniqueFileName()) {
+            testFileWrite(it)
+        }
+
+    @Test
+    fun `given an existing file, when write() is called, then erases the file's contents and writes on top of it`() =
+        runTestWithFile(uniqueFileName()) {
+
+            File(it).writeText("Some dummy \ntext 123..%x&")
+
+            testFileWrite(it)
+        }
+
+    private fun testFileWrite(uniqueFileName: String) {
+        val items = listOf(1, 2, 3)
+        `when`(jsonConverter.toJson(1)).thenReturn("line 1")
+        `when`(jsonConverter.toJson(2)).thenReturn("line 2")
+        `when`(jsonConverter.toJson(3)).thenReturn("line 3")
+
+        backUpFileIOHandler = BackUpFileIOHandler(uniqueFileName, jsonConverter)
+
+        backUpFileIOHandler.write(items.listIterator())
+
+        with(File(uniqueFileName)) {
+            useLines { seq ->
+                seq.iterator().withIndex().forEach {
+                    assertEquals("line ${it.index + 1}", it.value)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `given an existing file, when readIterator() is called, then returns an iterator which reads it line by line`() =
+        runTestWithFile(uniqueFileName()) { fileName ->
+
+            File(fileName).also {
+                it.delete()
+                it.createNewFile()
+                it.writeText("line 1\nline 2\nline 3\n")
+            }
+
+            `when`(jsonConverter.fromJson("line 1")).thenReturn(1)
+            `when`(jsonConverter.fromJson("line 2")).thenReturn(2)
+            `when`(jsonConverter.fromJson("line 3")).thenReturn(3)
+
+            backUpFileIOHandler = BackUpFileIOHandler(fileName, jsonConverter)
+
+            backUpFileIOHandler.readIterator().withIndex().forEach {
+                assertEquals(it.index + 1, it.value)
+            }
+        }
+
+    private fun runTestWithFile(fileName: String, testWithFile: (String) -> Unit): Unit {
+        try {
+            testWithFile(fileName)
+        } catch (ex: Exception) {
+            fail("Exception occured: $ex")
+        } finally {
+            File(fileName).deleteOnExit()
+        }
+    }
+
+    companion object {
+        private fun uniqueFileName() = "backUpFileIOHandlerTest_${System.currentTimeMillis()}.txt"
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/io/file/JsonConverterTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/io/file/JsonConverterTest.kt
@@ -1,0 +1,52 @@
+package com.waz.zclient.feature.backup.io.file
+
+import com.waz.zclient.UnitTest
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class JsonConverterTest : UnitTest() {
+
+    @Serializable
+    private data class TestPerson(
+        val name: String,
+        val age: Int,
+        val children: List<String>
+    )
+
+    private lateinit var jsonConverter: JsonConverter<TestPerson>
+
+    @Before
+    fun setUp() {
+        jsonConverter = JsonConverter(TestPerson.serializer())
+    }
+
+    @Test
+    fun `given an object, when toJson is called, creates a json string`() {
+        val jsonStr = jsonConverter.toJson(TEST_PERSON)
+
+        assertEquals(TEST_PERSON_STRING, jsonStr)
+    }
+
+    @Test
+    fun `given a json string, when fromJson is called, parses the model`() {
+        val model = jsonConverter.fromJson(TEST_PERSON_STRING)
+
+        assertEquals(TEST_PERSON, model)
+    }
+
+    companion object {
+        private const val TEST_NAME = "John"
+        private const val CHILD1 = "Amy"
+        private const val CHILD2 = "Bob"
+        private val TEST_CHILDREN = listOf(CHILD1, CHILD2)
+        private const val TEST_AGE = 35
+
+        private val TEST_PERSON_STRING = """
+            {"name":"$TEST_NAME","age":$TEST_AGE,"children":["$CHILD1","$CHILD2"]}
+        """.trimIndent()
+
+        private val TEST_PERSON = TestPerson(name = TEST_NAME, age = TEST_AGE, children = TEST_CHILDREN)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT}"
         classpath "org.jacoco:org.jacoco.core:${Versions.JACOCO}"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:${Versions.KOTLIN}"
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     const val ANDROID_CLIENT_MAJOR_VERSION = "3.52."
 
     //core
-    const val KOTLIN = "1.3.60"
+    const val KOTLIN = "1.3.72"
     const val WIRE_TRANSLATIONS = "1.+"
     val AVS = System.getenv("AVS_VERSION") ?: "5.3.191@aar"
     val WIRE_AUDIO = System.getenv("AUDIO_VERSION") ?: "1.209.0@aar"
@@ -43,6 +43,7 @@ object Versions {
     const val KOIN = "2.0.1"
     const val RX_KOTLIN = "2.3.0"
     const val RX_ANDROID = "2.1.1"
+    const val KOTLINX_SERIALIZATION = "0.20.0"
     const val ANDROID_JOB = "1.2.6"
     const val THREE_TEN_BP_ANDROID = "1.1.0"
     const val THREE_TEN_BP_JAVA = "1.3.8"
@@ -125,6 +126,7 @@ object BuildDependencies {
         "rxKotlin" to "io.reactivex.rxjava2:rxkotlin:${Versions.RX_KOTLIN}",
         "rxAndroid" to "io.reactivex.rxjava2:rxandroid:${Versions.RX_ANDROID}"
     ))
+    val kotlinXSerialization = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:${Versions.KOTLINX_SERIALIZATION}"
     val androidJob = "com.evernote:android-job:${Versions.ANDROID_JOB}"
     val threetenbpAndroid = "com.jakewharton.threetenabp:threetenabp:${Versions.THREE_TEN_BP_ANDROID}"
     val threetenbpJava = "org.threeten:threetenbp:${Versions.THREE_TEN_BP_JAVA}"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Kotlin's Iterator does not support suspend functions and throws exceptions when something goes wrong.

```
public interface Iterator<out T> {
    public operator fun next(): T     <-- not a `suspend fun`, returns the next item or throws exception
    public operator fun hasNext(): Boolean
}
```
Most `next()` operations such as reading items from the database are implemented as `suspend` functions in our project. Also, we try to avoid throwing exceptions and want to encapsulate them in `Either` structure. 

### Solutions

This PR creates a new Iterator, `BatchReader`, that has a `suspend` function which returns an `Either`. There is also a `forEach` operation provided, which iterates over all items in the iterator as long as there is no `Failure`.

```
interface BatchReader<T> {
    suspend fun readNext(): Either<Failure, T?>
}
```

### Testing

Unit tests are added for BatchReader, and affected ones are updated.

#### Notes
#2951 was merged into this PR. 

#### APK
[Download build #2396](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2396/artifact/build/artifact/wire-dev-PR2950-2396.apk)
[Download build #2406](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2406/artifact/build/artifact/wire-dev-PR2950-2406.apk)
[Download build #2413](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2413/artifact/build/artifact/wire-dev-PR2950-2413.apk)
[Download build #2415](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2415/artifact/build/artifact/wire-dev-PR2950-2415.apk)