### PR TITLE
Bugfix : Redirection for QA Demo custom backend

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/network/connection/ConnectionSpecsFactory.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/connection/ConnectionSpecsFactory.kt
@@ -16,7 +16,9 @@ class ConnectionSpecsFactory private constructor() {
                 .tlsVersions(TlsVersion.TLS_1_2)
                 .cipherSuites(
                     CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                    CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                    CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
                 )
                 .build()
     }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/HttpClientOkHttpImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/HttpClientOkHttpImpl.scala
@@ -134,7 +134,9 @@ object HttpClientOkHttpImpl {
       .tlsVersions(TlsVersion.TLS_1_2)
       .cipherSuites(
         CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
       )
       .build()
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The redirection to qa-demo custom backend is failing with an SSL handshake exception.

2020-08-04 14:23:43.749 30772-30772/com.waz.zclient.dev E/AppEntryActivity: error trying to download backend config.
ErrorResponse(code: 598, message: connection error: javax.net.ssl.SSLHandshakeException: Handshake failed, label: )

### Causes

Missing ECDSA cipher suites in TLS configuration.

### Solutions

Adding the missing cipher suites:

**CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384**

### Testing
 - Click on Enterprise Login
 - Enter mailaddress test@qa-demo.com
 - Click on Login
- You should be redirected to the custom backend.

## Notes

This issue is occurring only with QA Demo custom backend, no problem for example with orange custom backend.

https://wearezeta.atlassian.net/browse/AN-7046

#### APK
[Download build #2444](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2444/artifact/build/artifact/wire-dev-PR2960-2444.apk)
[Download build #2445](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2445/artifact/build/artifact/wire-dev-PR2960-2445.apk)