### PR TITLE
Backups: Liberal JSON Configuration

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/utilities/converters/JsonConverter.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/utilities/converters/JsonConverter.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 
 class JsonConverter<T>(private val serializer: KSerializer<T>) {
-    private val json by lazy { Json(JsonConfiguration.Stable) }
+    private val json by lazy { Json(JsonConfiguration.Stable.copy(isLenient = true, ignoreUnknownKeys = true)) }
 
     fun fromJson(jsonString: String): T = json.parse(serializer, jsonString)
 


### PR DESCRIPTION
This is a one-line PR to make reading backups more flexible.

Imagine we change the data class and remove a field, but then we use a backup made from before the change was made.
If the only difference between the two is a missing field, and the `ignoreMissingKeys` flag is set, no migration will
be needed - Kotlinx will just ignore the value for that field in the backup JSON.
(To make us safe the other way, when we add new fields to entities, we should set default values for in the respective
data models).

The other flag, `isLenient`, may help us in reading cross-platform backups in the future, and for now it can help us in
unit tests. It makes Kotlinx tolerate JSON strings which are slightly malformed.
