### PR TITLE
New backups: Encryption handler

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -433,6 +433,8 @@ dependencies {
 
     implementation BuildDependencies.wireSignals
 
+    implementation BuildDependencies.libSodium
+
     // Unit Tests
     testImplementation TestDependencies.jUnit
     testImplementation TestDependencies.mockito.core

--- a/app/src/androidTest/kotlin/com/waz/zclient/feature/backup/EncryptionHandlerTest.kt
+++ b/app/src/androidTest/kotlin/com/waz/zclient/feature/backup/EncryptionHandlerTest.kt
@@ -1,0 +1,62 @@
+package com.waz.zclient.feature.backup
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.waz.model.UserId
+import com.waz.zclient.core.functional.Either.Left
+import com.waz.zclient.core.functional.Either.Right
+import org.amshove.kluent.shouldEqual
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.Base64
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class EncryptionHandlerTest {
+
+    @Test
+    fun given_a_file_when_encrypted_and_decrypted_with_password_and_userId_then_decrypted_contents_are_the_same_as_original() {
+        val tempDir = createTempDir()
+        val textFile = createTextFile(tempDir)
+        val originalContents = textFile.readText()
+        val password = generateText(8)
+        val userId = UserId.apply()
+
+        val encryptionHandler = EncryptionHandler()
+
+        when (val res1 = encryptionHandler.encrypt(textFile, password, userId)) {
+            is Left -> fail(res1.a.toString())
+            is Right -> {
+                val encryptedFile = res1.b
+                println(encryptedFile.absolutePath)
+                when (val res2 = encryptionHandler.decrypt(encryptedFile, password, userId)) {
+                    is Left -> fail(res2.a.toString())
+                    is Right -> {
+                        val decryptedFile = res2.b
+                        val unzippedContents = decryptedFile.readText()
+                        unzippedContents shouldEqual originalContents
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createTextFile(dir: File, length: Int = 100): File =
+        File(dir, uniqueTextFileName()).apply {
+            bufferedWriter().use { it.write(generateText(length)) }
+        }
+
+    private fun generateText(length: Int): String = Base64.getEncoder().encodeToString(Random.Default.nextBytes(length))
+
+    private fun createTempDir(): File = File.createTempFile("temp", System.currentTimeMillis().toString()).apply {
+        delete()
+        mkdirs()
+        deleteOnExit()
+    }
+
+    private fun uniqueTextFileName(): String {
+        Thread.sleep(1)
+        return "ZipHandlerTest_${System.currentTimeMillis()}.txt"
+    }
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/EncryptionHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/EncryptionHandler.kt
@@ -1,0 +1,300 @@
+package com.waz.zclient.feature.backup
+
+import com.waz.model.UserId
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.exception.FeatureFailure
+import com.waz.zclient.core.exception.GenericUseCaseError
+import com.waz.zclient.core.exception.IOFailure
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.functional.Either.Left
+import com.waz.zclient.core.functional.Either.Right
+import com.waz.zclient.core.functional.flatMap
+import com.waz.zclient.core.functional.map
+import com.waz.zclient.core.logging.Logger.Companion.error
+import com.waz.zclient.core.logging.Logger.Companion.warn
+import com.waz.zclient.core.logging.Logger.Companion.verbose
+import org.libsodium.jni.NaCl
+import org.libsodium.jni.Sodium
+import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.security.SecureRandom
+
+class EncryptionHandler {
+    fun encrypt(backup: File, password: String, userId: UserId): Either<Failure, File> =
+        try {
+            loadLibrary
+
+            val salt = generateSalt()
+
+            getMetaDataBytes(salt, userId).flatMap { meta ->
+                val backupBytes = backup.readBytes()
+                encrypt(backupBytes, password, salt).map { encryptedBytes ->
+                    val encryptedFile = File(backup.parentFile, backup.name + "_encrypted").apply {
+                        writeBytes(meta)
+                        writeBytes(encryptedBytes)
+                    }
+                    encryptedFile
+                }
+            }
+        } catch (ex: IOException) {
+            Left(IOFailure(ex))
+        }
+
+    fun decrypt(file: File, password: String, userId: UserId): Either<Failure, File> {
+        loadLibrary
+
+        val metadata = EncryptedBackupHeader.readEncryptedMetadata(file)
+        return if (metadata != null) {
+            val hash = hash(userId.str(), metadata.salt)
+            if (hash != null && hash.contentEquals(metadata.uuidHash)) {
+                val encryptedBackupBytes = ByteArray(EncryptedBackupHeader.totalHeaderLength)
+                file.inputStream().buffered().read(encryptedBackupBytes)
+                decrypt(encryptedBackupBytes, password, metadata.salt).map { decryptedBackupBytes ->
+                    File.createTempFile("wire_backup", ".zip").apply { writeBytes(decryptedBackupBytes) }
+                }
+            } else if (hash != null) {
+                Left(EncryptionFailure("Uuid hashes don't match"))
+            } else {
+                Left(EncryptionFailure("Uuid hashing failed"))
+            }
+        } else {
+            Left(EncryptionFailure("metadata could not be read"))
+        }
+    }
+
+    private fun generateSalt(): ByteArray {
+        val count = Sodium.crypto_pwhash_saltbytes()
+        val buffer = ByteArray(count)
+
+        when (loadLibrary) {
+            is Right -> Sodium.randombytes(buffer, count)
+            is Left -> {
+                warn(TAG, "Libsodium failed to generate $count random bytes. Falling back to SecureRandom")
+                secureRandom.nextBytes(buffer)
+            }
+        }
+
+        return buffer
+    }
+
+    private fun encrypt(msg: ByteArray, password: String, salt: ByteArray): Either<Failure, ByteArray> {
+        val key = hash(password, salt)
+
+        return if (key != null) {
+            val expectedKeySize = Sodium.crypto_aead_chacha20poly1305_keybytes()
+            if (key.size != expectedKeySize) {
+                verbose(TAG, "Key length invalid: ${key.size} did not match $expectedKeySize")
+            }
+
+            val header = ByteArray(Sodium.crypto_secretstream_xchacha20poly1305_headerbytes())
+            val s = initPush(key, header)
+            if (s != null) {
+                val cipherText = ByteArray(msg.size + Sodium.crypto_secretstream_xchacha20poly1305_abytes())
+                val ret = Sodium.crypto_secretstream_xchacha20poly1305_push(
+                    s,
+                    cipherText,
+                    emptyArray<Int>().toIntArray(),
+                    msg,
+                    msg.size,
+                    emptyArray<Byte>().toByteArray(),
+                    0,
+                    Sodium.crypto_secretstream_xchacha20poly1305_tag_final().toShort()
+                )
+                if (ret == 0) {
+                    Right(header + cipherText)
+                } else {
+                    Left(EncryptionFailure("Failed to hash backup"))
+                }
+            } else {
+                Left(EncryptionFailure("Failed to init encrypt"))
+            }
+        } else {
+            Left(EncryptionFailure("Couldn't derive key from password"))
+        }
+    }
+
+    private fun decrypt(input: ByteArray, password: String, salt: ByteArray): Either<Failure, ByteArray> {
+        val key = hash(password, salt)
+        return if (key != null) {
+            val expectedKeyBytes = Sodium.crypto_secretstream_xchacha20poly1305_keybytes()
+
+            if (key.size != expectedKeyBytes) {
+                verbose(TAG, "Key length invalid: ${key.size} did not match $expectedKeyBytes")
+            }
+
+            val header = input.take(streamHeaderLength).toByteArray()
+            val s = initPull(key, header)
+            if (s != null) {
+                val cipherText = input.drop(streamHeaderLength).toByteArray()
+                val decrypted = ByteArray(cipherText.size + Sodium.crypto_secretstream_xchacha20poly1305_abytes())
+                val tag = ByteArray(1)
+                val ret: Int = Sodium.crypto_secretstream_xchacha20poly1305_pull(
+                    s, decrypted, IntArray(0), tag, cipherText, cipherText.size, ByteArray(0), 0
+                )
+                if (ret == 0) {
+                    Right(decrypted)
+                } else {
+                    Left(EncryptionFailure("Failed to decrypt backup, got code $ret"))
+                }
+            } else {
+                Left(EncryptionFailure("Failed to init decrypt"))
+            }
+        } else {
+            Left(EncryptionFailure("Couldn't derive key from password"))
+        }
+    }
+
+    //This method returns the metadata in the format described here:
+    //https://github.com/wearezeta/documentation/blob/master/topics/backup/use-cases/001-export-history.md
+    private fun getMetaDataBytes(salt: ByteArray, userId: UserId): Either<Failure, ByteArray> {
+        val uuidHash = hash(userId.str(), salt)
+        return if (uuidHash != null && uuidHash.size == EncryptedBackupHeader.uuidHashLength) {
+            val header = EncryptedBackupHeader(EncryptedBackupHeader.currentVersion, salt, uuidHash, opsLimit(), memLimit())
+            Right(EncryptedBackupHeader.toByteArray(header))
+        } else if (uuidHash != null) {
+            Left(EncryptionFailure("uuidHash length invalid, expected: ${EncryptedBackupHeader.uuidHashLength}, got: ${uuidHash.size}"))
+        } else {
+            Left(EncryptionFailure("Failed to hash account id for backup"))
+        }
+    }
+
+    private fun hash(input: String, salt: ByteArray): ByteArray? {
+        val output = ByteArray(Sodium.crypto_secretstream_xchacha20poly1305_keybytes())
+        val passBytes = input.toByteArray()
+        val ret = Sodium.crypto_pwhash(
+            output,
+            output.size,
+            passBytes,
+            passBytes.size,
+            salt,
+            opsLimit(),
+            memLimit(),
+            Sodium.crypto_pwhash_alg_default()
+        )
+
+        return if (ret == 0) output else null
+    }
+
+    private fun initializeState(key: ByteArray, header: ByteArray, init: (ByteArray, ByteArray, ByteArray) -> Int): ByteArray? =
+        if (header.size != Sodium.crypto_secretstream_xchacha20poly1305_headerbytes()) {
+            error(TAG, "Invalid header length")
+            null
+        } else if (key.size != Sodium.crypto_secretstream_xchacha20poly1305_keybytes()) {
+            error(TAG, "Invalid key length")
+            null
+        } else {
+            val state = ByteArray(stateByteArraySize)
+            if (init(state, header, key) != 0) {
+                error(TAG, "error whilst initializing push")
+                null
+            } else {
+                state
+            }
+        }
+
+    private fun initPush(key: ByteArray, header: ByteArray): ByteArray? = initializeState(key, header) {
+        s: ByteArray, h: ByteArray, k: ByteArray -> Sodium.crypto_secretstream_xchacha20poly1305_init_push(s, h, k)
+    }
+
+    private fun initPull(key: ByteArray, header: ByteArray): ByteArray? = initializeState(key, header) {
+        s: ByteArray, h: ByteArray, k: ByteArray -> Sodium.crypto_secretstream_xchacha20poly1305_init_pull(s, h, k)
+    }
+
+    companion object {
+        data class EncryptionFailure(val msg: String) : FeatureFailure()
+
+        const val TAG = "EncryptionHandler"
+
+        //Got this magic number from https://github.com/joshjdevl/libsodium-jni/blob/master/src/test/java/org/libsodium/jni/crypto/SecretStreamTest.java#L48
+        private const val stateByteArraySize = 52
+
+        private val secureRandom: SecureRandom by lazy { SecureRandom() }
+
+        private val streamHeaderLength = Sodium.crypto_secretstream_xchacha20poly1305_headerbytes()
+
+        private val loadLibrary: Either<Failure, Unit> by lazy {
+            try {
+                NaCl.sodium() // dynamically load the libsodium library
+                System.loadLibrary("sodium")
+                System.loadLibrary("randombytes")
+                Right(Unit)
+            } catch (ex: UnsatisfiedLinkError) {
+                Left(GenericUseCaseError(ex))
+            }
+        }
+
+        private fun opsLimit(): Int = Sodium.crypto_pwhash_opslimit_interactive()
+        private fun memLimit(): Int = Sodium.crypto_pwhash_memlimit_interactive()
+    }
+}
+
+data class EncryptedBackupHeader(
+    val version: Short = currentVersion,
+    val salt: ByteArray,
+    val uuidHash: ByteArray,
+    val opsLimit: Int,
+    val memLimit: Int
+) {
+    companion object {
+        const val TAG = "EncryptedBackupHeader"
+
+        private const val androidMagicNumber: String = "WBUA"
+        const val currentVersion: Short = 2
+        private const val saltLength = 16
+        const val uuidHashLength = 32
+
+        private const val androidMagicNumberLength = 4
+        const val totalHeaderLength = androidMagicNumberLength + 1 + 2 + saltLength + uuidHashLength + 4 + 4
+
+        fun toByteArray(header: EncryptedBackupHeader): ByteArray =
+            ByteBuffer.allocate(totalHeaderLength).apply {
+                put(androidMagicNumber.toByteArray())
+                put(0.toByte())
+                putShort(header.version)
+                put(header.salt)
+                put(header.uuidHash)
+                putInt(header.opsLimit)
+                putInt(header.memLimit)
+            }.array()
+
+        fun readEncryptedMetadata(encryptedBackup: File): EncryptedBackupHeader? =
+            if (encryptedBackup.length() > totalHeaderLength) {
+                val encryptedMetadataBytes = ByteArray(totalHeaderLength)
+                encryptedBackup.inputStream().buffered().read(encryptedMetadataBytes)
+                fromByteArray(encryptedMetadataBytes)
+            } else {
+                error(TAG, "Backup file header corrupted or invalid")
+                null
+            }
+
+        private fun fromByteArray(bytes: ByteArray): EncryptedBackupHeader? =
+            if (bytes.size == totalHeaderLength) {
+                val buffer = ByteBuffer.wrap(bytes)
+                val magicNumber = ByteArray(androidMagicNumberLength)
+                buffer.get(magicNumber)
+                if (magicNumber.map { it.toChar() }.joinToString() == androidMagicNumber) {
+                    buffer.get() //skip null byte
+                    val version = buffer.short
+                    if (version == currentVersion) {
+                        val salt = ByteArray(saltLength)
+                        buffer.get(salt)
+                        val uuidHash = ByteArray(uuidHashLength)
+                        buffer.get(uuidHash)
+                        val opslimit = buffer.int
+                        val memlimit = buffer.int
+                        EncryptedBackupHeader(currentVersion, salt, uuidHash, opslimit, memlimit)
+                    } else {
+                        error(TAG, "Unsupported backup version")
+                        null
+                    }
+                } else {
+                    error(TAG, "archive has incorrect magic number")
+                    null
+                }
+            } else {
+                error(TAG, "Invalid header length")
+                null
+            }
+    }
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/di/BackUpModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/di/BackUpModule.kt
@@ -4,6 +4,7 @@ import android.os.Environment
 import com.waz.zclient.core.utilities.converters.JsonConverter
 import com.waz.zclient.feature.backup.BackUpRepository
 import com.waz.zclient.feature.backup.ZipHandler
+import com.waz.zclient.feature.backup.EncryptionHandler
 import com.waz.zclient.feature.backup.assets.AssetsBackUpModel
 import com.waz.zclient.feature.backup.assets.AssetsBackupDataSource
 import com.waz.zclient.feature.backup.assets.AssetsBackupMapper
@@ -71,6 +72,7 @@ val backupModules: List<Module>
 val backUpModule = module {
     single { Environment.getExternalStorageDirectory() }
     single { ZipHandler(get()) }
+    single { EncryptionHandler() }
 
     factory { CreateBackUpUseCase(getAll()) } //this resolves all instances of type BackUpRepository
 

--- a/app/src/test/kotlin/com/waz/zclient/feature/FileTestHelpers.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/FileTestHelpers.kt
@@ -1,0 +1,28 @@
+package com.waz.zclient.feature
+
+import java.io.File
+import java.util.Base64
+import kotlin.random.Random
+
+fun generateText(length: Int): String = Base64.getEncoder().encodeToString(Random.Default.nextBytes(length))
+
+fun createTempDir(): File = File.createTempFile("temp", System.currentTimeMillis().toString()).apply {
+    delete()
+    mkdirs()
+    deleteOnExit()
+}
+
+fun uniqueTextFileName(): String {
+    Thread.sleep(1)
+    return "ZipHandlerTest_${System.currentTimeMillis()}.txt"
+}
+
+fun uniqueZipFileName(): String {
+    Thread.sleep(1)
+    return "ZipHandlerTest_${System.currentTimeMillis()}.zip"
+}
+
+fun createTextFile(dir: File, length: Int = 100): File =
+    File(dir, uniqueTextFileName()).apply {
+        bufferedWriter().use { it.write(generateText(length)) }
+    }

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/ZipHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/ZipHandlerTest.kt
@@ -2,6 +2,8 @@ package com.waz.zclient.feature.backup
 
 import com.waz.zclient.UnitTest
 import com.waz.zclient.core.functional.Either
+import com.waz.zclient.feature.createTextFile
+import com.waz.zclient.feature.uniqueZipFileName
 import org.amshove.kluent.`should be greater than`
 import org.amshove.kluent.shouldEqual
 import org.junit.Assert.fail
@@ -11,29 +13,6 @@ import java.util.Base64
 import kotlin.random.Random
 
 class ZipHandlerTest : UnitTest() {
-
-    private fun generateText(length: Int): String = Base64.getEncoder().encodeToString(Random.Default.nextBytes(length))
-
-    private fun createTempDir(): File = File.createTempFile("temp", System.currentTimeMillis().toString()).apply {
-        delete()
-        mkdirs()
-        deleteOnExit()
-    }
-
-    private fun uniqueTextFileName(): String {
-        Thread.sleep(1)
-        return "ZipHandlerTest_${System.currentTimeMillis()}.txt"
-    }
-
-    private fun uniqueZipFileName(): String {
-        Thread.sleep(1)
-        return "ZipHandlerTest_${System.currentTimeMillis()}.zip"
-    }
-
-    private fun createTextFile(dir: File, length: Int = 100): File =
-            File(dir, uniqueTextFileName()).apply {
-                bufferedWriter().use { it.write(generateText(length)) }
-            }
 
     @Test
     fun `given a non-empty input text file, when zipped, then return a zipped non-empty file`() {
@@ -114,8 +93,8 @@ class ZipHandlerTest : UnitTest() {
         val originalFile2 = createTextFile(tempDir)
         val originalContents2 = originalFile2.readText()
         val originalContents = mapOf(
-                originalFile1.name to originalContents1,
-                originalFile2.name to originalContents2
+            originalFile1.name to originalContents1,
+            originalFile2.name to originalContents2
         )
 
         val zipHandler = ZipHandler(tempDir)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -52,6 +52,7 @@ object Versions {
     const val JNA = "4.4.0@aar"
     const val LIB_PHONE_NUMBER = "7.1.1" // 7.2.x breaks protobuf
     const val PIN_EDITTEXT = "1.2.1"
+    const val LIB_SODIUM = "2.0.2"
 
     //testing
     const val JUNIT = "4.12"
@@ -135,6 +136,7 @@ object BuildDependencies {
     val jna = "net.java.dev.jna:jna:${Versions.JNA}"
     val libPhoneNumber = "com.googlecode.libphonenumber:libphonenumber:${Versions.LIB_PHONE_NUMBER}"
     val pinEditText = "com.poovam:pin-edittext-field:${Versions.PIN_EDITTEXT}"
+    val libSodium = "com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:${Versions.LIB_SODIUM}"
 
     val wireSignals = "com.wire:wire-signals_${LegacyDependencies.SCALA_MAJOR_VERSION}:${LegacyDependencies.WIRE_SIGNALS}"
 }

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -94,8 +94,8 @@ dependencies {
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "com.wire:icu4j-shrunk:57.1"
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
-    implementation "com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:2.0.2"
     implementation BuildDependencies.wireSignals
+    implementation BuildDependencies.libSodium
 
     //Provided dependencies
     compileOnly "com.softwaremill.macwire:macros_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"


### PR DESCRIPTION
Work in progress.

The handler is for now written in one file. First I want to make it working, test it, and then discussr how to split it into smaller chunks. 

It's not possible to write unit tests for it, because the handler uses Sodium, a dynamically loaded library which needs a device or an emulator to work. I put the test in the `androidTest` directory, but currently when I run it I get an error:
```
> Task :app:transformClassesWithDexBuilderForAvsDebugAndroidTest FAILED
java.lang.UnsupportedOperationException: java.lang.UnsupportedOperationException: This feature requires ASM6
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
...
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

Caused by: java.lang.UnsupportedOperationException: This feature requires ASM6
```
#### APK
[Download build #2545](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2545/artifact/build/artifact/wire-dev-PR2970-2545.apk)