### PR TITLE
New backups (16): Metadata handler

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/Components.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/Components.kt
@@ -1,8 +1,10 @@
 package com.waz.zclient.feature.backup
 
 import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.exception.FeatureFailure
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.feature.backup.io.BatchReader
+import kotlinx.serialization.SerializationException
 
 interface BackUpIOHandler<T, R> {
     suspend fun write(iterator: BatchReader<List<T>>): Either<Failure, List<R>>
@@ -13,3 +15,5 @@ interface BackUpDataMapper<T, E> {
     fun fromEntity(entity: E): T
     fun toEntity(model: T): E
 }
+
+data class SerializationFailure(val ex: SerializationException) : FeatureFailure()

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/di/BackUpModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/di/BackUpModule.kt
@@ -38,6 +38,9 @@ import com.waz.zclient.feature.backup.messages.LikesBackupMapper
 import com.waz.zclient.feature.backup.messages.MessagesBackUpDataSource
 import com.waz.zclient.feature.backup.messages.MessagesBackUpModel
 import com.waz.zclient.feature.backup.messages.MessagesBackUpDataMapper
+import com.waz.zclient.feature.backup.metadata.BackupMetaData
+import com.waz.zclient.feature.backup.metadata.MetaDataHandler
+import com.waz.zclient.feature.backup.metadata.MetaDataHandlerDataSource
 import com.waz.zclient.feature.backup.properties.PropertiesBackUpDataSource
 import com.waz.zclient.feature.backup.properties.PropertiesBackUpMapper
 import com.waz.zclient.feature.backup.properties.PropertiesBackUpModel
@@ -68,6 +71,8 @@ private const val PROPERTIES_FILE_NAME = "Properties"
 private const val READ_RECEIPTS_FILE_NAME = "ReadReceipts"
 private const val USERS_FILE_NAME = "Users"
 
+private const val BACKUP_VERSION = 1
+
 val backupModules: List<Module>
     get() = listOf(backUpModule)
 
@@ -76,7 +81,11 @@ val backUpModule = module {
     single { ZipHandlerDataSource(get()) } bind ZipHandler::class
     single { EncryptionHandlerDataSource() } bind EncryptionHandler::class
 
-    factory { CreateBackUpUseCase(getAll(), get(), get()) } //this resolves all instances of type BackUpRepository
+    factory { CreateBackUpUseCase(getAll(), get(), get(), get()) } //this resolves all instances of type BackUpRepository
+
+    // MetaData
+    factory { JsonConverter(BackupMetaData.serializer()) }
+    factory { MetaDataHandlerDataSource(BACKUP_VERSION, get(), get()) } bind MetaDataHandler::class
 
     // KeyValues
     factory { BatchDatabaseIOHandler((get<UserDatabase>()).keyValuesDao()) }

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/io/file/BackUpFileIOHandler.kt
@@ -5,10 +5,12 @@ import com.waz.zclient.core.exception.IOFailure
 import com.waz.zclient.core.functional.Either
 import com.waz.zclient.core.utilities.converters.JsonConverter
 import com.waz.zclient.feature.backup.BackUpIOHandler
+import com.waz.zclient.feature.backup.SerializationFailure
 import com.waz.zclient.feature.backup.io.BatchReader
 import com.waz.zclient.feature.backup.io.mapRight
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import java.io.File
 import java.io.IOException
 
@@ -33,6 +35,8 @@ class BackUpFileIOHandler<T>(
                 Either.Right(file)
             } catch (ex: IOException) {
                 Either.Left(IOFailure(ex))
+            } catch (ex: SerializationException) {
+                Either.Left(SerializationFailure(ex))
             }
         }
     }
@@ -51,6 +55,8 @@ class BackUpFileIOHandler<T>(
                 }
             } catch (ex: IOException) {
                 Either.Left(IOFailure(ex))
+            } catch (ex: SerializationException) {
+                Either.Left(SerializationFailure(ex))
             }
 
         override suspend fun hasNext(): Boolean = getFile(index).exists()

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/BackupMetaData.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/BackupMetaData.kt
@@ -1,0 +1,11 @@
+package com.waz.zclient.feature.backup.metadata
+
+import com.waz.zclient.core.extension.empty
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackupMetaData(
+    val userId: String = String.empty(),
+    val userHandle: String = String.empty(),
+    val backUpVersion: Int = 0
+)

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandler.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandler.kt
@@ -1,0 +1,11 @@
+package com.waz.zclient.feature.backup.metadata
+
+import com.waz.model.UserId
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.functional.Either
+import java.io.File
+
+interface MetaDataHandler {
+    fun generateMetaDataFile(userId: UserId, userHandle: String): Either<Failure, File>
+    fun readMetaData(file: File): Either<Failure, BackupMetaData>
+}

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandlerDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandlerDataSource.kt
@@ -1,0 +1,48 @@
+package com.waz.zclient.feature.backup.metadata
+
+import com.waz.model.UserId
+import com.waz.zclient.core.exception.Failure
+import com.waz.zclient.core.exception.IOFailure
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.utilities.converters.JsonConverter
+import com.waz.zclient.feature.backup.SerializationFailure
+import kotlinx.serialization.SerializationException
+import java.io.File
+import java.io.IOException
+
+class MetaDataHandlerDataSource(
+    private val backUpVersion: Int,
+    private val jsonConverter: JsonConverter<BackupMetaData>,
+    private val targetDir: File
+) : MetaDataHandler {
+    override fun generateMetaDataFile(userId: UserId, userHandle: String): Either<Failure, File> =
+        try {
+            val metaData = BackupMetaData(userId.str(), userHandle, backUpVersion)
+            val jsonStr = jsonConverter.toJson(metaData)
+            val file = File(targetDir, FILENAME).apply {
+                delete()
+                createNewFile()
+                deleteOnExit()
+                writeText(jsonStr)
+            }
+            Either.Right(file)
+        } catch (ex: IOException) {
+            Either.Left(IOFailure(ex))
+        } catch (ex: SerializationException) {
+            Either.Left(SerializationFailure(ex))
+        }
+
+    override fun readMetaData(file: File): Either<Failure, BackupMetaData> =
+        try {
+            val jsonStr = file.bufferedReader().readText()
+            Either.Right(jsonConverter.fromJson(jsonStr))
+        } catch (ex: IOException) {
+            Either.Left(IOFailure(ex))
+        } catch (ex: SerializationException) {
+            Either.Left(SerializationFailure(ex))
+        }
+
+    companion object {
+        const val FILENAME: String = "metadata.json"
+    }
+}

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandlerTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/metadata/MetaDataHandlerTest.kt
@@ -1,0 +1,86 @@
+package com.waz.zclient.feature.backup.metadata
+
+import com.waz.model.UserId
+import com.waz.zclient.UnitTest
+import com.waz.zclient.core.functional.Either
+import com.waz.zclient.core.utilities.converters.JsonConverter
+import com.waz.zclient.feature.backup.SerializationFailure
+import kotlinx.serialization.SerializationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class MetaDataHandlerTest : UnitTest() {
+
+    @Mock
+    private lateinit var jsonConverter: JsonConverter<BackupMetaData>
+
+    private val backUpVersion = 0
+    private val userId = UserId.apply(UUID.randomUUID().toString())
+    private val userHandle = "user"
+
+    private val metaData = BackupMetaData(userId.str(), userHandle, backUpVersion)
+    private val metaDataJson =
+        """
+            {
+                "userId": "${userId.str()}",
+                "userHandle": "$userHandle",
+                "backUpVersion": $backUpVersion
+            }
+        """.trimIndent()
+
+    @Test
+    fun `given the user's id, the handle, and the backup version, when the metadata json file is created, then it consists of correct json string`() {
+        val tempDir = createTempDir()
+        val metaDataHandler = MetaDataHandlerDataSource(backUpVersion, jsonConverter, tempDir)
+
+        `when`(jsonConverter.toJson(metaData)).thenReturn(metaDataJson)
+
+        when (val res = metaDataHandler.generateMetaDataFile(userId, userHandle)) {
+            is Either.Left -> fail(res.a.toString())
+            is Either.Right -> {
+                val contents = res.b.readText()
+                assertEquals(metaDataJson, contents)
+            }
+        }
+    }
+
+    @Test
+    fun `given a valid metadata json, when it is read, return userId, handle, and backup version`() {
+        val tempDir = createTempDir()
+        val metadataFile = createTempFile("metadata", ".json", tempDir)
+        metadataFile.writeText(metaDataJson)
+        val metaDataHandler = MetaDataHandlerDataSource(backUpVersion, jsonConverter, tempDir)
+
+        `when`(jsonConverter.fromJson(metaDataJson)).thenReturn(metaData)
+
+        when (val res = metaDataHandler.readMetaData(metadataFile)) {
+            is Either.Left -> fail(res.a.toString())
+            is Either.Right -> {
+                assertEquals(userId.str(), res.b.userId)
+                assertEquals(userHandle, res.b.userHandle)
+                assertEquals(backUpVersion, res.b.backUpVersion)
+            }
+        }
+    }
+
+    @Test
+    fun `given an invalid metadata json, when it is read, return a serialization failure`() {
+        val invalidJson = "error"
+        val serializationException = SerializationException("invalid json")
+
+        val tempDir = createTempDir()
+        val metadataFile = createTempFile("metadata", ".json", tempDir)
+        metadataFile.writeText(invalidJson)
+
+        val metaDataHandler = MetaDataHandlerDataSource(backUpVersion, jsonConverter, tempDir)
+
+        `when`(jsonConverter.fromJson(invalidJson)).thenThrow(serializationException)
+
+        val res = metaDataHandler.readMetaData(metadataFile)
+        assertEquals(Either.Left(SerializationFailure(serializationException)), res)
+    }
+}


### PR DESCRIPTION
Adds to the list of json backup files one more small file with metadata, `metadata.json`.
The current contents of the file are as following:
```
            {
                "userId": <UUID>,
                "userHandle": <username>,
                "backUpVersion": <version number>
            }
```

I decided to include `userId` and `userHandle` in the file for easier identification of the user performing backup. Maybe we would like to check if the userId is as expected or maybe display a dialog to the user and address the user with the handle. Bu it is also possible that it will not be necessary.

The field which is necessary for sure is `backupVersion`. This is similar to the migration version in DB. Right now it's "1" and we can ignore it, but when in the future we will change the schema, we will bump this number. Then, when someone will try to restore a backup from the past, with a lower number than the current one, we will have to provide a converter between that older and newer schema. For now we don't have to worry about it, but I'd like to have this already in the backup.
#### APK
[Download build #2552](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2552/artifact/build/artifact/wire-dev-PR2983-2552.apk)
[Download build #2553](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2553/artifact/build/artifact/wire-dev-PR2983-2553.apk)