### PR TITLE
Fix crash in participants list page

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -43,7 +43,8 @@ import com.waz.zclient.views.AvailabilityView
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
 
-class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentHelper {
+class ParticipantHeaderFragment extends FragmentHelper {
+  import ParticipantHeaderFragment._
   import Threading.Implicits.Ui
 
   implicit def cxt: Context = getActivity
@@ -134,7 +135,7 @@ class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentH
 
       // This is a workaround: when dismissing the single participant fragment, we should
       // go directly back to the conversation list, not the underlying conversation.
-      if (fromDeepLink) CancellableFuture.delay(750.millis).map { _ =>
+      if (fromDeepLink()) CancellableFuture.delay(750.millis).map { _ =>
         navigationController.setVisiblePage(NavPage.CONVERSATION_LIST, MainPhoneFragment.Tag)
       }
     }
@@ -227,11 +228,19 @@ class ParticipantHeaderFragment(fromDeepLink: Boolean = false) extends FragmentH
     toolbar.foreach(_.setNavigationOnClickListener(null))
     super.onPause()
   }
+
+  private def fromDeepLink() = getBooleanArg(ARG_FROM_DEEP_LINK)
 }
 
 object ParticipantHeaderFragment {
   val TAG: String = classOf[ParticipantHeaderFragment].getName
 
+  private val ARG_FROM_DEEP_LINK = "ParticipantHeaderFromDeepLink"
+
   def newInstance(fromDeepLink: Boolean = false): ParticipantHeaderFragment =
-    new ParticipantHeaderFragment(fromDeepLink)
+    returning(new ParticipantHeaderFragment) { f =>
+      f.setArguments(returning(new Bundle) { b =>
+        b.putBoolean(ARG_FROM_DEEP_LINK, fromDeepLink)
+      })
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

[AN-6977](https://wearezeta.atlassian.net/browse/AN-6977)

As seen from Play Store reports, app crashes with exception:
```
java.lang.RuntimeException: 
  ...
Caused by: androidx.fragment.app.Fragment$InstantiationException: 
  ...
  at com.waz.zclient.participants.fragments.ParticipantFragment.onCreate (ParticipantFragment.scala:11312)
Caused by: java.lang.NoSuchMethodException: 
  at java.lang.Class.getConstructor0 (Class.java:2327)
  at java.lang.Class.getConstructor (Class.java:1725)
  at androidx.fragment.app.Fragment.instantiate$4cf48a77 (Fragment.java:523)
```

### Causes

`ParticipantFragment` has a child fragment `ParticipantHeaderFragment`, which doesn't have a no-arg constructor. When Android system destroys a fragment and tries to recreate it on its own, it needs a no-arg constructor. Therefore, any arguments that the fragment needs should not be passed as a constructor parameter, but as a " fragment argument" inside a `Bundle`.

### Solutions

Move the constructor parameter to fragment's Bundle.

### Testing

1. Enable "Do not keep activities" option from phone's Settings > Developer Options. 
2. Open the app, open any conversation
3. From Conversation header, go to Conversation Details
4. Click on "Add Participants" at the bottom.
5. While on Add Participants page, send the app to the background
6. Move the app to foreground

**Actual result:** 
App crashes

**Expected result:**
App shouldn't crash


### Notes

Even though there's still a cosmetic UI problem after bringing the fragment to the foreground again, I didn't fix it here since it's just a cosmetic problem and it could take too much time considering the value it adds.
