### PR TITLE
Fix AVS test after introducing new participant parameter

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Calling.scala
@@ -169,7 +169,8 @@ object Calling {
     //              "userid": "3f49da1d-0d52-4696-9ef3-0dd181383e8a",
     //              "clientid": "24cc758f602fb1f4",
     //              "aestab": 1,
-    //              "vrecv": 0
+    //              "vrecv": 0,
+    //              "muted": 0
     //          }
     //      ]
     //}

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/AvsSpec.scala
@@ -37,13 +37,15 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
         |      "userid": "3f49da1d-0d52-4696-9ef3-0dd181383e8a",
         |      "clientid": "24cc758f602fb1f4",
         |      "aestab": 1,
-        |      "vrecv": 0
+        |      "vrecv": 0,
+        |      "muted": 1
         |    },
         |    {
         |      "userid": "7cc36a2e-88d3-ac76-86ba-d02faca478ed",
         |      "clientid": "64ca916f366fcc56",
         |      "aestab": 0,
-        |      "vrecv": 1
+        |      "vrecv": 1,
+        |      "muted": 0
         |    }
         |  ]
         |}
@@ -62,12 +64,14 @@ class AvsSpec extends AndroidFreeSpec with DerivedLogTag  {
     member1.clientid shouldEqual ClientId("24cc758f602fb1f4")
     member1.aestab shouldEqual 1
     member1.vrecv shouldEqual 0
+    member1.muted shouldEqual 1
 
     val member2 = result.get.members.last
     member2.userid shouldEqual UserId("7cc36a2e-88d3-ac76-86ba-d02faca478ed")
     member2.clientid shouldEqual ClientId("64ca916f366fcc56")
     member2.aestab shouldEqual 0
     member2.vrecv shouldEqual 1
+    member2.muted shouldEqual 0
   }
 
   scenario("Client list can be encoded") {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Since #2967 `AvsSpec` was failing because of the new `muted` parameter. The decoder expects to have this parameter, and as we discussed with @mejdoo we'll always have this parameter in the JSON for AVS version > 6.

### Solutions

Add the parameter to JSON string.


#### APK
[Download build #2560](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2560/artifact/build/artifact/wire-dev-PR2986-2560.apk)