### PR TITLE
No unencrypted traffic to Wire

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -19,6 +19,10 @@
 
 -->
 <network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">wire.com</domain>
+        <domain includeSubdomains="true">zinfra.io</domain>
+    </domain-config>
     <debug-overrides>
         <trust-anchors>
             <!-- Trust user added CAs while debuggable only -->


### PR DESCRIPTION
While Android < 9 is still supported something like this should be added (ideally for all URLs, not just Wire).
Also see https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted.
#### APK
[Download build #2577](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2577/artifact/build/artifact/wire-dev-PR2993-2577.apk)