### PR TITLE
Bugfix : fingerprint text cut off in device details screen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -114,6 +114,7 @@ class DeviceDetailsViewImpl(context: Context, attrs: AttributeSet, style: Int) e
     this.fingerprint = fingerprint
     fingerprintView.setTitle(DevicesPreferencesUtil.getFormattedFingerprint(context, fingerprint).toString)
     fingerprintView.title.foreach(TextViewUtils.boldText)
+    fingerprintView.setTitleMaxLines(2)
   }
 
   override def setActionsVisible(visible: Boolean) = {

--- a/app/src/main/scala/com/waz/zclient/preferences/views/TextButton.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/views/TextButton.scala
@@ -74,6 +74,9 @@ class TextButton(context: Context, attrs: AttributeSet, style: Int) extends Rela
   def setTitle(text: String): Unit =
     title.foreach(_.setText(text))
 
+  def setTitleMaxLines(maxLines: Int): Unit =
+    title.foreach(_.setMaxLines(maxLines))
+
   def setSubtitle(text: String): Unit =
     subtitle.foreach(subtitle => setOptionText(subtitle, Some(text)))
 


### PR DESCRIPTION
## What's new in this PR?

### Issues
 
The key Fingerprint for devices is cut off in device details screen.

https://wearezeta.atlassian.net/browse/AN-7054

### Causes

The title in the customView `TextButton` is ellipsized with a single line.

```
android:lines="1"
android:ellipsize="end" 
```

### Solutions

Adding a method to change the max lines and set it to 2 in this case.

### Testing

Go go settings -> Devices -> Select any device -> Check key fingerprint 


#### APK
[Download build #2582](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2582/artifact/build/artifact/wire-dev-PR2995-2582.apk)