### PR TITLE
Bugfix :  Unable to connect to Conf calls - newly created conversation

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -208,9 +208,9 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_network_quality_handler(wCall, networkQualityHandler, intervalInSeconds = 5, arg = null)
 
       val clientsRequestHandler = new ClientsRequestHandler {
-        override def onClientsRequest(inst: Calling.Handle, convId: String, arg: Pointer): Unit =
-          cs.onClientsRequest(ConvId(convId))
-      }
+        override def onClientsRequest(inst: Calling.Handle, convId: String, arg: Pointer): Unit = {
+          cs.onClientsRequest(RConvId(convId))
+      }}
 
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -411,7 +411,7 @@ class CallingServiceImpl(val accountId:       UserId,
   def onNetworkQualityChanged(convId: ConvId, participant: Participant, quality: NetworkQuality): Future[Unit] =
     Future.successful(())
 
-  def onClientsRequest(convId: ConvId): Future[Unit] =
+  def onClientsRequest(convId: RConvId): Future[Unit] =
     withConv(convId) { (wCall, conv) =>
       otrSyncHandler.postClientDiscoveryMessage(convId).map {
         case Right(clients) =>
@@ -585,6 +585,7 @@ class CallingServiceImpl(val accountId:       UserId,
     atomicWithConv(convs.convByRemoteId(convId), f, s"Unknown remote convId: $convId")
 
   private def withConv(convId: ConvId)(f: (WCall, ConversationData) => Unit): Future[Unit] = {
+    Log.i("hammadi1",convId.str)
     atomicWithConv(convs.convById(convId), f, s"Could not find conversation: $convId")
   }
 
@@ -628,6 +629,9 @@ class CallingServiceImpl(val accountId:       UserId,
   private def updateActiveCallAsync(f: (WCall, ConversationData, CallInfo) => CallInfo)(caller: String): Future[Unit] =
     Serialized.future(self) {
       currentCall.currentValue.flatten.map(_.convId).fold(Future.successful({})) { convId =>
+
+        Log.i("hammadi2",convId.str)
+
         wCall.flatMap { w =>
           convs.convById(convId).map {
             case Some(conv) => updateCallInfo(convId, f(w, conv, _))(caller)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -628,9 +628,6 @@ class CallingServiceImpl(val accountId:       UserId,
   private def updateActiveCallAsync(f: (WCall, ConversationData, CallInfo) => CallInfo)(caller: String): Future[Unit] =
     Serialized.future(self) {
       currentCall.currentValue.flatten.map(_.convId).fold(Future.successful({})) { convId =>
-
-        Log.i("hammadi2",convId.str)
-
         wCall.flatMap { w =>
           convs.convById(convId).map {
             case Some(conv) => updateCallInfo(convId, f(w, conv, _))(caller)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -585,7 +585,6 @@ class CallingServiceImpl(val accountId:       UserId,
     atomicWithConv(convs.convByRemoteId(convId), f, s"Unknown remote convId: $convId")
 
   private def withConv(convId: ConvId)(f: (WCall, ConversationData) => Unit): Future[Unit] = {
-    Log.i("hammadi1",convId.str)
     atomicWithConv(convs.convById(convId), f, s"Could not find conversation: $convId")
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -56,7 +56,7 @@ trait OtrSyncHandler {
                        previous:   EncryptedContent = EncryptedContent.Empty,
                        recipients: Option[Set[UserId]] = None
                       ): Future[Either[ErrorResponse, RemoteInstant]]
-  def postClientDiscoveryMessage(convId: ConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]]
+  def postClientDiscoveryMessage(convId: RConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]]
 }
 
 class OtrSyncHandlerImpl(teamId:             Option[TeamId],
@@ -260,9 +260,9 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
     }
   }
 
-  override def postClientDiscoveryMessage(convId: ConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]] = {
+  override def postClientDiscoveryMessage(convId: RConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]] = {
     for {
-      Some(conv) <- convStorage.get(convId)
+      Some(conv) <- convStorage.getByRemoteId(convId)
       message = OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
       response <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
     } yield response match {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
@@ -284,8 +284,8 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       UserId("user2") -> Seq(ClientId("client1"), ClientId("client2"))
     )
 
-    (convStorage.get _)
-      .expects(conv.id)
+    (convStorage.getByRemoteId _)
+      .expects(conv.remoteId)
       .returning(Future.successful(Some(conv)))
 
     (msgClient.postMessage _)
@@ -298,7 +298,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       ))))
 
     val sh = getSyncHandler
-    result(sh.postClientDiscoveryMessage(conv.id)) shouldEqual Right(missingClients)
+    result(sh.postClientDiscoveryMessage(conv.remoteId)) shouldEqual Right(missingClients)
   }
 
   def getSyncHandler = {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The android client is trying to connect to a newly created conference with a wrong conversation id.

https://wearezeta.atlassian.net/browse/AN-7059

### Causes

The client is trying to connect to with AVS using the wrong conversation ID : local conversation ID

### Solutions

We should use the **remote conversation ID** instead of the **local ID**.

### Testing

- Enable beta program for conference calling
- Create a new group call.
- Start the call using the Android client
- Answer using Chrome.
- The Android client should see two participants and can hear audio


## Notes

I wonder why we have two ids for a conversation. It would make more sense to get rid of one them.

#### APK
[Download build #2601](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2601/artifact/build/artifact/wire-dev-PR2996-2601.apk)