### PR TITLE
Bump AVS version to 6.2.28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.2.27@aar'
+    customAvsVersion = '6.2.28@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

Bump AVS to the latest version to 6.2.28

#### APK
[Download build #2595](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2595/artifact/build/artifact/wire-dev-PR2997-2595.apk)