### PR TITLE
Add dialog for new backup warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,6 +226,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'false'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'true'
         }
 
         candidate {
@@ -238,6 +239,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', "$buildtimeConfiguration.configuration.loggingEnabled"
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'false'
         }
 
         prod {
@@ -249,6 +251,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'false'
             buildConfigField 'boolean', 'LOGGING_ENABLED', "$buildtimeConfiguration.configuration.loggingEnabled"
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'true'
         }
 
         internal {
@@ -261,6 +264,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'false'
         }
 
         experimental {
@@ -273,6 +277,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', 'true'
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'false'
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1564,10 +1564,10 @@
     <string name="start_sso_redirected_to">You are being redirected to your dedicated enterprise service.</string>
     <string name="start_sso_notice">Provide credentials only if you\'re sure this is your organization\'s login.</string>
 
-    <!--TODO: remove after release 3.53-->
-    <string name="discontinued_support_warning_title">Wire 3.53 is the last version that can be installed on Android 5 and 6.</string>
-    <string name="discontinued_support_warning_message">To be able to install later versions, please update to Android 7.0 or higher.</string>
-    <string name="discontinued_support_warning_action_ok">OK</string>
-    <string name="discontinued_support_warning_action_do_not_show_again">Don\'t show again</string>
+    <!--TODO: proper copy-->
+    <string name="back_up_incompatibility_title">We\'re changing our back up mechanism</string>
+    <string name="back_up_incompatibility_message">As of next release, back ups created in older versions of Wire won\'t be supported.</string>
+    <string name="back_up_incompatibility_action_ok">OK</string>
+    <string name="back_up_incompatibility_action_do_not_show_again">Don\'t show again</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1564,10 +1564,9 @@
     <string name="start_sso_redirected_to">You are being redirected to your dedicated enterprise service.</string>
     <string name="start_sso_notice">Provide credentials only if you\'re sure this is your organization\'s login.</string>
 
-    <!--TODO: proper copy-->
-    <string name="back_up_incompatibility_title">We\'re changing our back up mechanism</string>
-    <string name="back_up_incompatibility_message">As of next release, back ups created in older versions of Wire won\'t be supported.</string>
+    <string name="back_up_incompatibility_title">New and improved backups are coming</string>
+    <string name="back_up_incompatibility_message">The next version of Wire (3.55) will contain a redesigned backup system. You will not be able to restore an existing backup file, so make sure to restore any backups before updating.</string>
     <string name="back_up_incompatibility_action_ok">OK</string>
-    <string name="back_up_incompatibility_action_do_not_show_again">Don\'t show again</string>
+    <string name="back_up_incompatibility_action_do_not_show_again">Do not show again</string>
 </resources>
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -384,8 +384,7 @@ object GlobalPreferences {
 
   lazy val BackendDrift = PrefKey[Duration]("backend_drift")
 
-  // TODO: remove after release 3.53
-  lazy val ShouldWarnAndroid5And6Users = PrefKey[Boolean]( "should_warn_android_5_and_6_users", customDefault = true)
+  lazy val ShouldWarnBackUpIncompatibility = PrefKey[Boolean]( "should_warn_back_up_incompatibility", customDefault = true)
 
   //TODO think of a nicer way of ensuring that these key values are used in UI - right now, we need to manually check they're correct
   lazy val AutoAnswerCallPrefKey = PrefKey[Boolean]("PREF_KEY_AUTO_ANSWER_ENABLED")


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/AN-7076


### Issues

With 3.55 version, we're going to release new back up functionality. However, new back ups aren't backward compatible. Therefore, we need to warn users beforehand about this update.


### Testing

Manually tested.

## Notes

- This PR also deletes Android min sdk warning dialog
- The pop up display is disabled for `internal` and `candidate` builds for easier QA automation tests. Once the RC package gets a green light, the `candidate` flag will be enabled for manual QA tests.
- This dialog is going to be removed in the next release. An [issue](https://wearezeta.atlassian.net/browse/AN-7079) is created for that purpose.


#### APK
[Download build #2683](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2683/artifact/build/artifact/wire-dev-PR3006-2683.apk)
[Download build #2689](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2689/artifact/build/artifact/wire-dev-PR3006-2689.apk)
[Download build #2692](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2692/artifact/build/artifact/wire-dev-PR3006-2692.apk)