### PR TITLE
Inject dispatchers for testing purposes

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/async/DispatcherProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/core/async/DispatcherProvider.kt
@@ -1,0 +1,18 @@
+package com.wire.android.core.async
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+interface DispatcherProvider {
+    fun main(): CoroutineDispatcher
+    fun io(): CoroutineDispatcher
+    fun default(): CoroutineDispatcher
+    fun unconfined(): CoroutineDispatcher
+}
+
+class DefaultDispatcherProvider : DispatcherProvider {
+    override fun main() = Dispatchers.Main
+    override fun io() = Dispatchers.IO
+    override fun default() = Dispatchers.Default
+    override fun unconfined() = Dispatchers.Unconfined
+}

--- a/app/src/main/kotlin/com/wire/android/core/di/CoreModule.kt
+++ b/app/src/main/kotlin/com/wire/android/core/di/CoreModule.kt
@@ -5,6 +5,8 @@ import android.view.accessibility.AccessibilityManager
 import com.wire.android.core.accessibility.Accessibility
 import com.wire.android.core.accessibility.AccessibilityConfig
 import com.wire.android.core.accessibility.InputFocusViewModel
+import com.wire.android.core.async.DefaultDispatcherProvider
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.compatibility.Compatibility
 import com.wire.android.core.locale.LocaleConfig
 import org.koin.android.ext.koin.androidContext
@@ -25,4 +27,8 @@ val compatibilityModule: Module = module {
 
 val localeModule: Module = module {
     factory { LocaleConfig(androidContext()) }
+}
+
+val asyncModule: Module = module {
+    single<DispatcherProvider> { DefaultDispatcherProvider() }
 }

--- a/app/src/main/kotlin/com/wire/android/core/di/Injector.kt
+++ b/app/src/main/kotlin/com/wire/android/core/di/Injector.kt
@@ -11,6 +11,7 @@ import org.koin.core.module.Module
 object Injector {
 
     private val coreModules: List<Module> = listOf(
+        asyncModule,
         accessibilityModule,
         networkModule,
         compatibilityModule,

--- a/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
@@ -1,23 +1,25 @@
 package com.wire.android.core.usecase
 
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 interface UseCaseExecutor {
+    val dispatcherProvider: DispatcherProvider
+
     operator fun <T, P> UseCase<T, P>.invoke(
         scope: CoroutineScope,
         params: P,
-        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        dispatcher: CoroutineDispatcher = dispatcherProvider.io(),
         onResult: (Either<Failure, T>) -> Unit = {}
     )
 }
 
-class DefaultUseCaseExecutor : UseCaseExecutor {
+class DefaultUseCaseExecutor(override val dispatcherProvider: DispatcherProvider) : UseCaseExecutor {
 
     override operator fun <T, P> UseCase<T, P>.invoke(
         scope: CoroutineScope,

--- a/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
@@ -45,31 +45,31 @@ private val createAccountModule = module {
 }
 
 private val createPersonalAccountModule = module {
-    viewModel { CreatePersonalAccountEmailViewModel(get(), get()) }
+    viewModel { CreatePersonalAccountEmailViewModel(get(), get(), get()) }
     factory { ValidateEmailUseCase() }
     factory { SendEmailActivationCodeUseCase(get()) }
     single<ActivationRepository> { ActivationDataSource(get()) }
     single { ActivationRemoteDataSource(get(), get()) }
     factory { get<NetworkClient>().create(ActivationApi::class.java) }
 
-    viewModel { CreatePersonalAccountEmailCodeViewModel(get()) }
+    viewModel { CreatePersonalAccountEmailCodeViewModel(get(), get()) }
     factory { ActivateEmailUseCase(get()) }
 
-    viewModel { CreatePersonalAccountEmailNameViewModel(get()) }
+    viewModel { CreatePersonalAccountEmailNameViewModel(get(), get()) }
 
-    viewModel { CreatePersonalAccountEmailPasswordViewModel(get(), get()) }
+    viewModel { CreatePersonalAccountEmailPasswordViewModel(get(), get(), get()) }
     factory { RegisterPersonalAccountWithEmailUseCase(get()) }
 }
 
 private val createProAccountModule = module {
-    viewModel { CreateProAccountTeamNameViewModel(get(), get()) }
+    viewModel { CreateProAccountTeamNameViewModel(get(), get(), get()) }
     factory { GetTeamNameUseCase(get()) }
     factory { UpdateTeamNameUseCase(get()) }
     single { TeamDataSource() as TeamsRepository }
 }
 
 private val loginModule = module {
-    viewModel { LoginWithEmailViewModel(get(), get()) }
+    viewModel { LoginWithEmailViewModel(get(), get(), get()) }
     factory { LoginWithEmailUseCase(get()) }
     single<LoginRepository> { LoginDataSource() }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.extension.failure
 import com.wire.android.core.extension.success
@@ -17,12 +18,12 @@ import com.wire.android.feature.auth.login.email.usecase.LoginWithEmailUseCase
 import com.wire.android.feature.auth.login.email.usecase.LoginWithEmailUseCaseParams
 import com.wire.android.shared.user.email.ValidateEmailParams
 import com.wire.android.shared.user.email.ValidateEmailUseCase
-import kotlinx.coroutines.Dispatchers
 
 class LoginWithEmailViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val validateEmailUseCase: ValidateEmailUseCase,
     private val loginWithEmailUseCase: LoginWithEmailUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val isValidEmailLiveData = SingleLiveEvent<Boolean>()
     private val isValidPasswordLiveData = SingleLiveEvent<Boolean>()
@@ -35,7 +36,7 @@ class LoginWithEmailViewModel(
     val loginResultLiveData: LiveData<Either<Failure, Unit>> = _loginResultLiveData
 
     fun validateEmail(email: String) =
-        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), Dispatchers.Default) { result ->
+        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), dispatcherProvider.default()) { result ->
             isValidEmailLiveData.value = result.isRight
         }
 

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailCodeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.exception.ErrorMessage
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.exception.NetworkConnection
@@ -18,8 +19,9 @@ import com.wire.android.feature.auth.registration.personal.email.usecase.Activat
 import com.wire.android.feature.auth.registration.personal.email.usecase.InvalidEmailCode
 
 class CreatePersonalAccountEmailCodeViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val activateEmailUseCase: ActivateEmailUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val _networkConnectionErrorLiveData = SingleLiveEvent<Unit>()
     val networkConnectionErrorLiveData: LiveData<Unit> = _networkConnectionErrorLiveData

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailNameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailNameViewModel.kt
@@ -3,6 +3,7 @@ package com.wire.android.feature.auth.registration.personal.email
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.ui.SingleLiveEvent
 import com.wire.android.core.usecase.DefaultUseCaseExecutor
 import com.wire.android.core.usecase.UseCaseExecutor
@@ -10,8 +11,9 @@ import com.wire.android.shared.user.name.ValidateNameParams
 import com.wire.android.shared.user.name.ValidateNameUseCase
 
 class CreatePersonalAccountEmailNameViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val validateNameUseCase: ValidateNameUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val _continueEnabled = SingleLiveEvent<Boolean>()
     val continueEnabled: LiveData<Boolean> = _continueEnabled

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailPasswordViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.exception.ErrorMessage
 import com.wire.android.core.exception.NetworkConnection
 import com.wire.android.core.extension.failure
@@ -23,9 +24,10 @@ import com.wire.android.shared.user.password.ValidatePasswordParams
 import com.wire.android.shared.user.password.ValidatePasswordUseCase
 
 class CreatePersonalAccountEmailPasswordViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val validatePasswordUseCase: ValidatePasswordUseCase,
     private val registerUseCase: RegisterPersonalAccountWithEmailUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val _continueEnabledLiveData = SingleLiveEvent<Boolean>()
     val continueEnabledLiveData: LiveData<Boolean> = _continueEnabledLiveData

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
-import com.wire.android.core.accessibility.Accessibility
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.exception.ErrorMessage
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.exception.NetworkConnection
@@ -22,12 +22,12 @@ import com.wire.android.feature.auth.activation.usecase.SendEmailActivationCodeU
 import com.wire.android.shared.user.email.ValidateEmailError
 import com.wire.android.shared.user.email.ValidateEmailParams
 import com.wire.android.shared.user.email.ValidateEmailUseCase
-import kotlinx.coroutines.Dispatchers
 
 class CreatePersonalAccountEmailViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val validateEmailUseCase: ValidateEmailUseCase,
     private val sendActivationUseCase: SendEmailActivationCodeUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val _isValidEmailLiveData = MutableLiveData<Boolean>()
     val isValidEmailLiveData: LiveData<Boolean> = _isValidEmailLiveData
@@ -39,7 +39,7 @@ class CreatePersonalAccountEmailViewModel(
     val networkConnectionErrorLiveData: LiveData<Unit> = _networkConnectionErrorLiveData
 
     fun validateEmail(email: String) =
-        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), Dispatchers.Default) {
+        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), dispatcherProvider.default()) {
             it.fold(::validateEmailFailure) { updateEmailValidationStatus(true) }
         }
 

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.functional.onSuccess
 import com.wire.android.core.usecase.DefaultUseCaseExecutor
 import com.wire.android.core.usecase.UseCaseExecutor
@@ -12,9 +13,10 @@ import com.wire.android.feature.auth.registration.pro.team.usecase.UpdateTeamNam
 import com.wire.android.feature.auth.registration.pro.team.usecase.UpdateTeamNameUseCase
 
 class CreateProAccountTeamNameViewModel(
+    override val dispatcherProvider: DispatcherProvider,
     private val getTeamNameUseCase: GetTeamNameUseCase,
     private val updateTeamNameUseCase: UpdateTeamNameUseCase
-) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor(dispatcherProvider) {
 
     private val _urlLiveData = MutableLiveData<String>()
     val urlLiveData: LiveData<String> = _urlLiveData

--- a/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
@@ -1,8 +1,9 @@
 package com.wire.android.core.usecase
 
 import com.wire.android.UnitTest
+import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.functional.Either
-import kotlinx.coroutines.Dispatchers
+import com.wire.android.framework.coroutines.TestDispatcherProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -19,9 +20,12 @@ class DefaultUseCaseExecutorTest : UnitTest() {
     @Mock
     private lateinit var useCase: UseCase<String, Int>
 
+    private lateinit var dispatcherProvider: DispatcherProvider
+
     @Before
     fun setUp() {
-        executor = DefaultUseCaseExecutor()
+        dispatcherProvider = TestDispatcherProvider()
+        executor = DefaultUseCaseExecutor(dispatcherProvider)
     }
 
     @Test
@@ -32,7 +36,7 @@ class DefaultUseCaseExecutorTest : UnitTest() {
             `when`(useCase.run(param)).thenReturn(result)
 
             with(executor) {
-                useCase.invoke(this@runBlocking, param, Dispatchers.IO) {
+                useCase.invoke(this@runBlocking, param, dispatcherProvider.io()) {
                     assertThat(it).isEqualTo(result)
                 }
             }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
@@ -13,7 +13,6 @@ import com.wire.android.shared.user.email.EmailInvalid
 import com.wire.android.shared.user.email.ValidateEmailParams
 import com.wire.android.shared.user.email.ValidateEmailUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -37,12 +36,14 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Before
     fun setUp() {
-        loginWithEmailViewModel = LoginWithEmailViewModel(validateEmailUseCase, loginWithEmailUseCase)
+        loginWithEmailViewModel = LoginWithEmailViewModel(
+            coroutinesTestRule.dispatcherProvider, validateEmailUseCase, loginWithEmailUseCase
+        )
     }
 
     @Test
-    fun `given a valid email with no password, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+    fun `given a valid email with no password, then sets continueEnabledLiveData to false`() =
+        coroutinesTestRule.runTest {
             mockEmailValidation(true)
 
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
@@ -50,11 +51,10 @@ class LoginWithEmailViewModelTest : UnitTest() {
             assertThat(loginWithEmailViewModel.continueEnabledLiveData.awaitValue()).isFalse()
             verify(validateEmailUseCase).run(ValidateEmailParams(TEST_EMAIL))
         }
-    }
 
     @Test
     fun `given a valid email but an empty password, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             mockEmailValidation(true)
 
             loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
@@ -69,7 +69,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given a valid password with no email, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
 
             assertThat(loginWithEmailViewModel.continueEnabledLiveData.awaitValue()).isFalse()
@@ -79,7 +79,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given a valid password but an invalid email, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             mockEmailValidation(false)
 
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
@@ -94,7 +94,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given an invalid email and an empty password, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             mockEmailValidation(false)
 
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
@@ -109,7 +109,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given a valid email and a non-empty password, then sets continueEnabledLiveData to true`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             mockEmailValidation(true)
 
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
@@ -124,7 +124,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given login is called, when loginWithEmailUseCase returns success, then sets success to loginResultLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             val params = LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_VALID_PASSWORD)
             `when`(loginWithEmailUseCase.run(params)).thenReturn(Either.Right(Unit))
 
@@ -137,7 +137,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given login is called, when loginWithEmailUseCase returns error, then sets that error to loginResultLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             val params = LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_VALID_PASSWORD)
             `when`(loginWithEmailUseCase.run(params)).thenReturn(Either.Left(ServerError))
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailCodeViewModelTest.kt
@@ -12,7 +12,6 @@ import com.wire.android.framework.functional.assertLeft
 import com.wire.android.framework.functional.assertRight
 import com.wire.android.framework.livedata.awaitValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -20,10 +19,10 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 
+@ExperimentalCoroutinesApi
 class CreatePersonalAccountEmailCodeViewModelTest : UnitTest() {
 
     @get:Rule
-    @ExperimentalCoroutinesApi
     val coroutinesTestRule = CoroutinesTestRule()
 
     @Mock
@@ -33,12 +32,12 @@ class CreatePersonalAccountEmailCodeViewModelTest : UnitTest() {
 
     @Before
     fun setUp() {
-        emailCodeViewModel = CreatePersonalAccountEmailCodeViewModel(activateEmailUseCase)
+        emailCodeViewModel = CreatePersonalAccountEmailCodeViewModel(coroutinesTestRule.dispatcherProvider, activateEmailUseCase)
     }
 
     @Test
     fun `given activateEmail is called, when activateEmailUseCase returns success, then notifies success to activateEmailLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(activateEmailUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             emailCodeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
@@ -52,7 +51,7 @@ class CreatePersonalAccountEmailCodeViewModelTest : UnitTest() {
     @Test
     fun `given activateEmail is called, when activateEmailUseCase returns InvalidEmailCode, sets ErrorMessage to activateEmailLiveData`() {
         //TODO: separate feature failures
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(activateEmailUseCase.run(any())).thenReturn(Either.Left(InvalidEmailCode))
 
             emailCodeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
@@ -65,7 +64,7 @@ class CreatePersonalAccountEmailCodeViewModelTest : UnitTest() {
 
     @Test
     fun `given activateEmail is called, when activateEmailUseCase returns NetworkConnection, notifies networkConnectionErrorLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(activateEmailUseCase.run(any())).thenReturn(Either.Left(NetworkConnection))
 
             emailCodeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailNameViewModelTest.kt
@@ -8,7 +8,6 @@ import com.wire.android.shared.user.name.NameTooShort
 import com.wire.android.shared.user.name.ValidateNameParams
 import com.wire.android.shared.user.name.ValidateNameUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -29,12 +28,12 @@ class CreatePersonalAccountEmailNameViewModelTest : UnitTest() {
     private lateinit var nameViewModel: CreatePersonalAccountEmailNameViewModel
     @Before
     fun setUp() {
-        nameViewModel = CreatePersonalAccountEmailNameViewModel(validateNameUseCase)
+        nameViewModel = CreatePersonalAccountEmailNameViewModel(coroutinesTestRule.dispatcherProvider, validateNameUseCase)
     }
 
     @Test
     fun `given validateName() is called with a name, when use case returns success, then sets continueEnabled to true`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validateNameUseCase.run(ValidateNameParams(TEST_NAME))).thenReturn(Either.Right(Unit))
 
             nameViewModel.validateName(TEST_NAME)
@@ -46,7 +45,7 @@ class CreatePersonalAccountEmailNameViewModelTest : UnitTest() {
 
     @Test
     fun `given validateName() is called with a name, when use case fails, then sets continueEnabled to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validateNameUseCase.run(ValidateNameParams(TEST_NAME))).thenReturn(Either.Left(NameTooShort))
 
             nameViewModel.validateName(TEST_NAME)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailPasswordViewModelTest.kt
@@ -19,7 +19,6 @@ import com.wire.android.shared.user.password.InvalidPasswordFailure
 import com.wire.android.shared.user.password.ValidatePasswordParams
 import com.wire.android.shared.user.password.ValidatePasswordUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -43,7 +42,9 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Before
     fun setUp() {
-        viewModel = CreatePersonalAccountEmailPasswordViewModel(validatePasswordUseCase, registerUseCase)
+        viewModel = CreatePersonalAccountEmailPasswordViewModel(
+            coroutinesTestRule.dispatcherProvider, validatePasswordUseCase, registerUseCase
+        )
     }
 
     @Test
@@ -57,7 +58,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given a password, when validatePassword is called, then calls validatePasswordUseCase with correct params`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validatePasswordUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             viewModel.validatePassword(TEST_PASSWORD)
@@ -69,7 +70,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given validatePassword is called, when useCase returns success, then sets continueEnabledLiveData to true`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validatePasswordUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             viewModel.validatePassword(TEST_PASSWORD)
@@ -80,7 +81,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given validatePassword is called, when useCase returns InvalidPasswordFailure, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validatePasswordUseCase.run(any())).thenReturn(Either.Left(InvalidPasswordFailure))
 
             viewModel.validatePassword(TEST_PASSWORD)
@@ -91,7 +92,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given validatePassword is called, when useCase returns general Failure, then sets continueEnabledLiveData to false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             val failure = mock(Failure::class.java)
             `when`(validatePasswordUseCase.run(any())).thenReturn(Either.Left(failure))
 
@@ -103,7 +104,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given params, when registerUser is called, then calls registerUseCase with correct params`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
@@ -123,7 +124,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given registerUser is called, when use case returns success, then sets success to registerStatusLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
@@ -134,7 +135,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given registerUser is called, when use case returns NetworkConnection error, then sets error to networkConnectionErrorLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Left(NetworkConnection))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
@@ -145,7 +146,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given registerUser is called, when use case returns UnauthorizedEmail error, then sets error message to registerStatusLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Left(UnauthorizedEmail))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
@@ -158,7 +159,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given registerUser is called, when use case returns InvalidEmailActivationCode, then sets error msg to registerStatusLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Left(InvalidEmailActivationCode))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
@@ -171,7 +172,7 @@ class CreatePersonalAccountEmailPasswordViewModelTest : UnitTest() {
 
     @Test
     fun `given registerUser is called, when use case returns EmailInUse error, then sets error message to registerStatusLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(registerUseCase.run(any())).thenReturn(Either.Left(EmailInUse))
 
             viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
@@ -17,7 +17,6 @@ import com.wire.android.shared.user.email.EmailInvalid
 import com.wire.android.shared.user.email.EmailTooShort
 import com.wire.android.shared.user.email.ValidateEmailUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -42,12 +41,14 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Before
     fun setUp() {
-        emailViewModel = CreatePersonalAccountEmailViewModel(validateEmailUseCase, sendActivationCodeUseCase)
+        emailViewModel = CreatePersonalAccountEmailViewModel(
+            coroutinesTestRule.dispatcherProvider, validateEmailUseCase, sendActivationCodeUseCase
+        )
     }
 
     @Test
     fun `given validateEmail is called, when the validation succeeds then isValidEmail should be true`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             emailViewModel.validateEmail(TEST_EMAIL)
@@ -58,7 +59,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given validateEmail is called, when the validation fails with EmailTooShort error then isValidEmail should be false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailTooShort))
 
             emailViewModel.validateEmail(TEST_EMAIL)
@@ -69,7 +70,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given validateEmail is called, when the validation fails with EmailInvalid error then isValidEmail should be false`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailInvalid))
 
             emailViewModel.validateEmail(TEST_EMAIL)
@@ -80,7 +81,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given sendActivation is called, then calls SendEmailActivationCodeUseCase`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             val params = SendEmailActivationCodeParams(TEST_EMAIL)
             `when`(sendActivationCodeUseCase.run(params)).thenReturn(Either.Right(Unit))
 
@@ -93,7 +94,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given sendActivation is called, when use case is successful, then sets email to sendActivationCodeLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Right(Unit))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -106,7 +107,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given sendActivation is called, when use case returns networkError, then updates networkConnectionErrorLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(NetworkConnection))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -117,7 +118,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given sendActivation is called, when use case returns EmailBlacklisted, then sets error message to sendActivationCodeLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(EmailBlacklisted))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)
@@ -130,7 +131,7 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given sendActivation is called, when use case returns EmailInUse, then sets error message to sendActivationCodeLiveData`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             `when`(sendActivationCodeUseCase.run(any())).thenReturn(Either.Left(EmailInUse))
 
             emailViewModel.sendActivationCode(TEST_EMAIL)

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
@@ -33,19 +33,19 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
     @Before
     fun setup() {
         runBlocking { `when`(getTeamNameUseCase.run(Unit)).thenReturn(Either.Right(TEST_TEAM_NAME)) }
-        viewModel = CreateProAccountTeamNameViewModel(getTeamNameUseCase, updateTeamNameUseCase)
+        viewModel = CreateProAccountTeamNameViewModel(coroutinesTestRule.dispatcherProvider, getTeamNameUseCase, updateTeamNameUseCase)
     }
 
     @Test
     fun `given viewModel is initialised, when teamName is available, propagate teamName up to the view`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             assertThat(viewModel.teamNameLiveData.awaitValue()).isEqualTo(TEST_TEAM_NAME)
         }
     }
 
     @Test
     fun `given about button is clicked, when url is provided, propagate url back to the view`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             viewModel.onAboutButtonClicked()
             assertThat(viewModel.urlLiveData.awaitValue()).isEqualTo("$CONFIG_URL$TEAM_ABOUT_URL_SUFFIX")
         }
@@ -53,7 +53,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be disabled`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             viewModel.onTeamNameTextChanged(String.EMPTY)
             assertThat(viewModel.confirmationButtonEnabled.awaitValue()).isFalse()
         }
@@ -61,7 +61,7 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be enabled`() {
-        runBlocking {
+        coroutinesTestRule.runTest {
             viewModel.onTeamNameTextChanged(TEST_TEAM_NAME)
             assertThat(viewModel.confirmationButtonEnabled.awaitValue()).isTrue()
         }

--- a/app/src/test/kotlin/com/wire/android/framework/coroutines/CoroutinesTestRule.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/coroutines/CoroutinesTestRule.kt
@@ -2,25 +2,32 @@ package com.wire.android.framework.coroutines
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutinesTestRule(
-    private val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+    val dispatcherProvider: TestDispatcherProvider = TestDispatcherProvider()
 ) : TestWatcher() {
+
+    private val mainDispatcher by lazy { dispatcherProvider.main() }
 
     override fun starting(description: Description?) {
         super.starting(description)
-        Dispatchers.setMain(testDispatcher)
+        Dispatchers.setMain(mainDispatcher)
     }
 
     override fun finished(description: Description?) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
+        mainDispatcher.cleanupTestCoroutines()
+    }
+
+    fun runTest(test: suspend TestCoroutineScope.() -> Unit) = dispatcherProvider.dispatcher.runBlockingTest {
+        test(this)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/framework/coroutines/TestDispatcherProvider.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/coroutines/TestDispatcherProvider.kt
@@ -1,0 +1,13 @@
+package com.wire.android.framework.coroutines
+
+import com.wire.android.core.async.DispatcherProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+
+@ExperimentalCoroutinesApi
+class TestDispatcherProvider(val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()) : DispatcherProvider {
+    override fun main() = dispatcher
+    override fun io() = dispatcher
+    override fun default() = dispatcher
+    override fun unconfined() = dispatcher
+}


### PR DESCRIPTION
- Introduces `DispatcherProvider` which provides coroutine dispatchers to be used for Dispatcher injection.
- Introduces `TestDispatcherProvider` concrete class which (hopefully) resolves threading and async operation issues in tests by running the tests on a `TestCoroutineDispatcher`.

The ideas are based on Google's [coroutines testing presentation](https://youtu.be/KMb0Fs8rCRs?t=465)