### PR TITLE
Enable back up dialog for candidate builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,7 +239,7 @@ android {
             buildConfigField 'boolean', 'DEVELOPER_FEATURES_ENABLED', 'true'
             buildConfigField 'boolean', 'LOGGING_ENABLED', "$buildtimeConfiguration.configuration.loggingEnabled"
             buildConfigField 'boolean', 'SAFE_LOGGING', 'true'
-            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'false'
+            buildConfigField 'boolean', 'SHOW_BACK_UP_INCOMPATIBILITY_DIALOG', 'true'
         }
 
         prod {


### PR DESCRIPTION
## What's new in this PR?

Enables the backup dialog introduced in #3006 for candidate builds so that QA can manually test it.
