### PR TITLE
Fix back up warning dialog button click event handling

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -545,7 +545,7 @@ class MainActivity extends BaseActivity
   override def onUsernameSet(): Unit = replaceMainFragment(new MainPhoneFragment, MainPhoneFragment.Tag, addToBackStack = false)
 
   private def showBackUpIncompatibilityDialog() : Future[Unit] = {
-    def showDialog(accentColor: AccentColor): Future[Boolean] = showConfirmationDialog(
+    def showDialog(accentColor: AccentColor): Future[Option[Boolean]] = showWarningDialog(
       getString(R.string.back_up_incompatibility_title),
       getString(R.string.back_up_incompatibility_message),
       R.string.back_up_incompatibility_action_ok,
@@ -561,7 +561,10 @@ class MainActivity extends BaseActivity
       color <- accentColorController.accentColor.head
     } yield {
       if (shouldWarn) {
-        showDialog(color).foreach { doNotShowAgain => prefs(GlobalPreferences.ShouldWarnBackUpIncompatibility) := !doNotShowAgain }
+        showDialog(color).foreach {
+          case Some(false) => prefs(GlobalPreferences.ShouldWarnBackUpIncompatibility) := false
+          case _ =>
+        }
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -273,7 +273,41 @@ object ContextUtils {
     val dialog = builder.create()
 
     dialog.show()
+    setButtonAccentColors(dialog, color)
 
+    p.future
+  }
+
+  def showWarningDialog(title: String,
+                        msg:   String,
+                        positiveRes: Int,
+                        negativeRes: Int,
+                        color: AccentColor)
+                       (implicit context: Context): Future[Option[Boolean]] = {
+    val p = Promise[Option[Boolean]]()
+
+    val builder = new AlertDialog.Builder(context)
+      .setTitle(title)
+      .setMessage(msg)
+      .setPositiveButton(positiveRes, new DialogInterface.OnClickListener {
+        override def onClick(dialog: DialogInterface, which: Int) = p.tryComplete(Success(Some(true)))
+      })
+      .setNegativeButton(negativeRes, new DialogInterface.OnClickListener() {
+        def onClick(dialog: DialogInterface, which: Int): Unit = p.tryComplete(Success(Some(false)))
+      })
+      .setOnCancelListener(new DialogInterface.OnCancelListener {
+        override def onCancel(dialog: DialogInterface) = p.tryComplete(Success(None))
+      })
+
+    val dialog = builder.create()
+
+    dialog.show()
+    setButtonAccentColors(dialog, color)
+
+    p.future
+  }
+
+  private def setButtonAccentColors(dialog: AlertDialog, color : AccentColor): Unit = {
     Option(dialog.getButton(DialogInterface.BUTTON_POSITIVE)).foreach { button =>
       button.setTextColor(color.color)
       button.setTextAlignment(android.view.View.TEXT_ALIGNMENT_TEXT_END)
@@ -286,8 +320,6 @@ object ContextUtils {
       button.setTextColor(color.color)
       button.setTextAlignment(android.view.View.TEXT_ALIGNMENT_TEXT_END)
     }
-
-    p.future
   }
 
   def showStatusNotificationWarning(availability: Availability, color: AccentColor)


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. The buttons behave in the wrong way: When the user clicks on Do not show again, the pop up is displayed again the next time. When the user clicks on OK, then the pop up is not displayed the next time.

2. When the dialog is cancelled, the back up dialog behaves as if "Do not show again" button is clicked.

### Solutions

Created a new method `showWarningDialog` which sends different results for each dialog event, also changed the flag to be updated only when the negative button is clicked

### Testing

Tested manually for backup warning dialog


#### APK
[Download build #2704](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2704/artifact/build/artifact/wire-dev-PR3011-2704.apk)