### PR TITLE
Fix AndroidJUnitRunner configuration

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/FunctionalTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/FunctionalTest.kt
@@ -1,25 +1,25 @@
 package com.wire.android
 
 import android.app.Activity
-import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.runner.RunWith
 
-open class FunctionalActivityTest(clazz: Class<out Activity>) : FunctionalTest() {
+@Suppress("UnnecessaryAbstractClass")
+abstract class FunctionalActivityTest(clazz: Class<out Activity>) : FunctionalTest() {
 
     @get:Rule
     val activityRule = ActivityTestRule(clazz)
 }
 
+@Suppress("UnnecessaryAbstractClass")
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-open class FunctionalTest {
+abstract class FunctionalTest {
 
     val uiDevice = UiDevice.getInstance(getInstrumentation())
 
@@ -27,15 +27,5 @@ open class FunctionalTest {
         setOrientationLeft()
         block()
         setOrientationNatural()
-    }
-
-    companion object {
-        @BeforeClass
-        @JvmStatic
-        fun enableAllChecks() {
-            AccessibilityChecks.enable()
-                .setRunChecksFromRootView(true)
-                .setThrowExceptionForErrors(false)
-        }
     }
 }


### PR DESCRIPTION
### Problem:

When we run all integration tests at once via `./gradlew runAcceptanceTests` or `./gradlew :app:connectedDevDebugAndroidTest` we run into two problems:

1)   > java.lang.RuntimeException: Delegate runner 'androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner' for AndroidJUnit4 could not be loaded.

2)    > Tests on Pixel - 9 failed: Test run failed to complete. Expected 23 tests, received 10


### Reason:

1) Base classes `FunctionalTest` and `FunctionalActivityTest` do not contain any `@Test` method. Every concrete class annotated with `@RunWith(AndroidJUnit4::class)` must have a test method. 

2) I don't know but I opened [an issue](https://wearezeta.atlassian.net/browse/AN-7082) for investigation.

### Solution:

1) Make those classes abstract. Now `detekt` should complain that abstract classes must have at least 1 abstract method/property, but it's OK to suppress it.

2) Removing the `@BeforeClass` set up along with Accessibility configuration seems to resolve the problem.



