### PR TITLE
Bump AVS version to 6.3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.3.1@aar'
+    customAvsVersion = '6.3.4@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.2.28@aar'
+    customAvsVersion = '6.3.1@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

- Bump AVS to the latest version 6.3.4
#### APK
[Download build #2743](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2743/artifact/build/artifact/wire-dev-PR3015-2743.apk)