### PR TITLE
New backups: Enforce strong password validation for backups

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
@@ -37,6 +37,7 @@ import com.waz.zclient.common.views.MenuRowButton
 import com.waz.zclient.preferences.dialogs.BackupPasswordDialog
 import com.waz.zclient.utils.{BackStackKey, ContextUtils, ExternalFileSharing, ViewUtils}
 import com.waz.zclient._
+import com.waz.zclient.preferences.dialogs.BackupPasswordDialog.SetPasswordMode
 
 import scala.concurrent.Future
 
@@ -60,9 +61,10 @@ class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
   backupButton.setOnClickProcess(requestPassword())
 
   def requestPassword(): Future[Unit] = {
-    val fragment = returning(new BackupPasswordDialog) { dialog =>
-      dialog.onPasswordEntered(backupData)
+    val fragment = returning(BackupPasswordDialog.newInstance(SetPasswordMode)) {
+      _.onPasswordEntered(backupData)
     }
+
     context.asInstanceOf[BaseActivity]
       .getSupportFragmentManager
       .beginTransaction


### PR DESCRIPTION
Until now for backup passwords we only required them to be non-empty. The strong validation (at least 8 characters + numbers + uppercase + lowercase + special characters) worked on custom builds only. Now, we require strong validation for all new passwords.

#### APK
[Download build #2740](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2740/artifact/build/artifact/wire-dev-PR3017-2740.apk)