### PR TITLE
Bugfix: Calling notification not displayed when the app is moving to the background

### DIFF
--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -20,7 +20,6 @@ package com.waz.services.calling
 import android.app.Service
 import android.content.{Context, Intent}
 import android.os.IBinder
-import android.util.Log
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
 import com.waz.zclient.ServiceHelper

--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -20,11 +20,13 @@ package com.waz.services.calling
 import android.app.Service
 import android.content.{Context, Intent}
 import android.os.IBinder
+import android.util.Log
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
 import com.waz.zclient.ServiceHelper
 import com.waz.zclient.notifications.controllers.CallingNotificationsController
 import com.waz.threading.Threading._
+import com.wire.signals.Signal
 
 class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
 
@@ -34,8 +36,11 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
 
   implicit lazy val cxt: Context = getApplicationContext
 
-  private lazy val sub = callNCtrl.notifications.map(_.find(_.isMainCall)).onUi {
-    case Some(not) if shouldShowNotification(not) =>
+  private lazy val sub = Signal(
+    callNCtrl.notifications.map(_.find(_.isMainCall)),
+    ZMessaging.currentGlobal.lifecycle.uiActive
+  ).onUi {
+    case (Some(not),false) =>
       val builder = androidNotificationBuilder(not, treatAsIncomingCall = isAndroid10OrAbove)
       startForeground(not.convId.str.hashCode, builder.build())
     case _ =>
@@ -48,14 +53,5 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
     super.onStartCommand(intent, flags, startId)
     sub
     Service.START_STICKY
-  }
-
-  // Since Android 10 we can't start the calling activity from the background, so instead we
-  // show a calling notification.
-  private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)
-
-  private def shouldShowNotification(notification: CallNotification): Boolean = {
-    val notificationHasAction = notification.action != NotificationAction.Nothing
-    notificationHasAction && (isAndroid10OrAbove && !isUiActive)
   }
 }

--- a/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallingNotificationsService.scala
@@ -22,9 +22,9 @@ import android.content.{Context, Intent}
 import android.os.IBinder
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
+import com.waz.threading.Threading._
 import com.waz.zclient.ServiceHelper
 import com.waz.zclient.notifications.controllers.CallingNotificationsController
-import com.waz.threading.Threading._
 import com.wire.signals.Signal
 
 class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
@@ -39,7 +39,7 @@ class CallingNotificationsService extends ServiceHelper with DerivedLogTag {
     callNCtrl.notifications.map(_.find(_.isMainCall)),
     ZMessaging.currentGlobal.lifecycle.uiActive
   ).onUi {
-    case (Some(not),false) =>
+    case (Some(not), false) =>
       val builder = androidNotificationBuilder(not, treatAsIncomingCall = isAndroid10OrAbove)
       startForeground(not.convId.str.hashCode, builder.build())
     case _ =>


### PR DESCRIPTION
## What's new in this PR?

## Issues
When we move the app to the background during a call, the calling notification disappears and we can't track the status of the current call.

## Causes

Checking if the UI is active only once via: ` private def isUiActive: Boolean = ZMessaging.currentGlobal.lifecycle.uiActive.currentValue.getOrElse(false)`

## Solutions
Observe `ZMessaging.currentGlobal.lifecycle.uiActive` value using`onUi()`

## Testing
- Start a call
- Move the app to the background

## Notes
This is not a specific case for Android 10. We should always show a notification when the app is moving to the background.

This PR fixes at once many related tickets:

https://wearezeta.atlassian.net/browse/AN-6535
https://wearezeta.atlassian.net/browse/AN-7007
https://wearezeta.atlassian.net/browse/AN-6666

#### APK
[Download build #2742](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2742/artifact/build/artifact/wire-dev-PR3018-2742.apk)
[Download build #2747](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2747/artifact/build/artifact/wire-dev-PR3018-2747.apk)