### PR TITLE
Introduce similar naming for wrapping signals and streams over data

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -68,7 +68,7 @@ class WebSocketController(implicit inj: Injector) extends Injectable {
     )
 
   lazy val notificationTitleRes: Signal[Option[Int]] =
-    Signal(serviceInForeground, global.network.isOnline, anyPushServiceConnected).map {
+    Signal.zip(serviceInForeground, global.network.isOnline, anyPushServiceConnected).map {
       case (true, true, true)  => Option(R.string.ws_foreground_notification_connecting_title)
       case (true, true, false) => Option(R.string.ws_foreground_notification_connected_title)
       case (true, false, _)    => Option(R.string.ws_foreground_notification_no_internet_title)
@@ -141,7 +141,7 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
   private lazy val notificationManager = inject[NotificationManager]
 
   private lazy val webSocketActiveSubscription =
-    Signal(controller.accountWebsocketStates, global.network.networkMode) {
+    Signal.zip(controller.accountWebsocketStates, global.network.networkMode) {
       case ((zmsWithWSActive, zmsWithWSInactive), networkMode) if NetworkModeService.isOnlineMode(networkMode) =>
         toggleWSPushServices(zmsWithWSActive, zmsWithWSInactive, stopIfNeeded = true)
       case ((zmsWithWSActive, zmsWithWSInactive), _) =>

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -133,7 +133,7 @@ object WireApplication extends DerivedLogTag {
     //SE Services
     bind [GlobalModule]                   to ZMessaging.currentGlobal
     bind [AccountsService]                to ZMessaging.currentAccounts
-    bind [Signal[AccountsService]]        to Signal.future(ZMessaging.accountsService) //use for early-initialised classes
+    bind [Signal[AccountsService]]        to Signal.from(ZMessaging.accountsService) //use for early-initialised classes
     bind [BackendConfig]                  to inject[GlobalModule].backend
     bind [AccountStorage]                 to inject[GlobalModule].accountsStorage
     bind [TeamsStorage]                   to inject[GlobalModule].teamsStorage

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -403,7 +403,7 @@ trait CallingBannerActivity extends ActivityHelper {
       callBanner.setVisibility(if (est) View.VISIBLE else View.GONE)
     }
 
-    Signal(callController.isMuted, callController.isCallEstablished).onUi {
+    Signal.zip(callController.isMuted, callController.isCallEstablished).onUi {
       case (true, true) =>
         mutedGlyph.setVisibility(View.VISIBLE)
         spacerGlyph.setVisibility(View.INVISIBLE)

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -91,7 +91,7 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
       CustomBackendLoginFragment.TAG
     )
 
-    Signal(accountsService.zmsInstances.map(_.nonEmpty), attachedFragment).map {
+    Signal.zip(accountsService.zmsInstances.map(_.nonEmpty), attachedFragment).map {
       case (false, _)                                          => View.GONE
       case (true, fragment) if fragmentTags.contains(fragment) => View.GONE
       case _                                                   => View.VISIBLE

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -86,7 +86,7 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     }
   }
 
-  Signal(
+  Signal.zip(
     controller.isGroupCall,
     controller.controlsVisible
   ).onUi {
@@ -113,7 +113,7 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     }
   }
 
-  Signal(controller.controlsVisible, shouldShowInfo, controller.isCallIncoming).onUi {
+  Signal.zip(controller.controlsVisible, shouldShowInfo, controller.isCallIncoming).onUi {
     case (_, true, true) |
          (false, true, _) => videoCallInfo.fadeIn()
     case _                => videoCallInfo.fadeOut()
@@ -138,7 +138,7 @@ class SelfVideoView(context: Context, participant: Participant)
     })
   }(Threading.Ui)
 
-  override lazy val shouldShowInfo = Signal(pausedTextVisible, controller.isMuted).map {
+  override lazy val shouldShowInfo = Signal.zip(pausedTextVisible, controller.isMuted).map {
     case (paused, muted) => paused || muted
   }
 }
@@ -170,14 +170,13 @@ class CallingFragment extends FragmentHelper {
   private var viewMap = Map[Participant, UserVideoView]()
 
   private lazy val videoGrid = returning(view[GridLayout](R.id.video_grid)) { vh =>
-    Signal(
+    Signal.zip(
       controller.allVideoReceiveStates,
       controller.callingZms.map(zms => Participant(zms.selfUserId, zms.clientId)),
       controller.isVideoCall,
       controller.isCallIncoming,
       controller.participantInfos()
-    )
-      .onUi { case (vrs, selfParticipant, videoCall, incoming, infos) =>
+    ).onUi { case (vrs, selfParticipant, videoCall, incoming, infos) =>
 
         def createView(participant: Participant): UserVideoView = returning {
           if (participant == selfParticipant) new SelfVideoView(getContext, participant)

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -86,13 +86,10 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     }
   }
 
-  Signal.zip(
-    controller.isGroupCall,
-    controller.controlsVisible
-  ).onUi {
-    case (true, false) => participantInfoCardView.setVisibility(View.VISIBLE)
-    case _ => participantInfoCardView.setVisibility(View.GONE)
-  }
+  Signal.zip(controller.isGroupCall, controller.controlsVisible).map {
+    case (true, false) => View.VISIBLE
+    case _             => View.GONE
+  }.onUi(participantInfoCardView.setVisibility)
 
   protected def registerHandler(view: View) = {
     controller.allVideoReceiveStates.map(_.getOrElse(participant, VideoState.Unknown)).onUi {

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingMiddleLayout.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingMiddleLayout.scala
@@ -44,11 +44,11 @@ class CallingMiddleLayout(val context: Context, val attrs: AttributeSet, val def
 
   lazy val onShowAllClicked: EventStream[Unit] = participants.onShowAllClicked
 
-  Signal(controller.callStateCollapseJoin, controller.isVideoCall, controller.isGroupCall).map {
-    case (_,                   false, false) => CallDisplay.Chathead
+  Signal.zip(controller.callStateCollapseJoin, controller.isVideoCall, controller.isGroupCall).map {
+    case (_,             false, false) => CallDisplay.Chathead
     case (OtherCalling,  false, true)  => CallDisplay.Chathead
     case (SelfConnected, _,     true)  => CallDisplay.Participants
-    case _                                   => CallDisplay.Empty
+    case _                             => CallDisplay.Empty
   }.onUi { display =>
     chathead.setVisible(display == CallDisplay.Chathead)
     participants.setVisible(display == CallDisplay.Participants)

--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -105,7 +105,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
       case false =>
         button.set(WireStyleKit.drawSpeaker, R.string.incoming__controls__ongoing__speaker, speaker)
     }
-    Signal(controller.speakerButton.buttonState, isVideoBeingSent).onUi {
+    Signal.zip(controller.speakerButton.buttonState, isVideoBeingSent).onUi {
       case (buttonState, false) => button.setActivated(buttonState)
       case _                    => button.setActivated(false)
     }

--- a/app/src/main/scala/com/waz/zclient/collection/adapters/CollectionAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/adapters/CollectionAdapter.scala
@@ -30,6 +30,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.ZMessaging
 import com.waz.threading.Threading
+import com.waz.threading.Threading.RichSignal
 import com.wire.signals.{EventContext, Signal}
 import com.waz.utils.returning
 import com.waz.zclient.collection.adapters.CollectionAdapter._
@@ -63,7 +64,7 @@ class CollectionAdapter(viewDim: Signal[Dim2])(implicit context: Context, inject
 
   val adapterState = Signal[AdapterState](AdapterState(contentMode.currentValue.get, 0, loading = true))
 
-  Signal(convController.currentConv, adapterState).on(Threading.Ui){
+  Signal.zip(convController.currentConv, adapterState).onUi{
     case (c, AdapterState(AllContent, 0, false)) => collectionController.openedCollection ! Some(CollectionInfo(c, empty = true))
     case (c, AdapterState(AllContent, count, false)) => collectionController.openedCollection ! Some(CollectionInfo(c, empty = false))
     case _ =>
@@ -99,7 +100,7 @@ class CollectionAdapter(viewDim: Signal[Dim2])(implicit context: Context, inject
 
   def messages = contentMode.currentValue.fold(Option.empty[RecyclerCursor])(collectionCursors(_))
 
-  Signal(contentMode, viewDim) .on(Threading.Ui){ _ =>
+  Signal.zip(contentMode, viewDim).onUi{ _ =>
     notifyDataSetChanged()
   }
 

--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
@@ -60,11 +60,11 @@ class CollectionController(implicit injector: Injector)
   val contentSearchQuery = Signal[ContentSearchQuery](ContentSearchQuery.empty)
 
   lazy val matchingTextSearchMessages = for {
-    z <- zms
+    z      <- zms
     convId <- convController.currentConvId
-    query <- contentSearchQuery
-    res <- if (query.isEmpty) Signal.const(Set.empty[MessageId])
-    else Signal future z.messagesIndexStorage.matchingMessages(query, Some(convId))
+    query  <- contentSearchQuery
+    res    <- if (query.isEmpty) Signal.const(Set.empty[MessageId])
+              else Signal.from(z.messagesIndexStorage.matchingMessages(query, Some(convId)))
   } yield res
 
   def openCollection() = observers foreach { _.openCollection() }

--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionScrollController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionScrollController.scala
@@ -56,12 +56,12 @@ class CollectionScrollController(adapter: RecyclerView.Adapter[ViewHolder], list
     }
   })
 
-  val onScroll = EventStream.union(
+  val onScroll = EventStream.zip(
     onListLoaded map { case UnreadIndex(pos) => Scroll(pos, smooth = false) },
     onScrollToBottomRequested.map(_ => Scroll(lastPosition, smooth = true)),
     listHeight.onChanged.filter(_ => shouldScrollToBottom).map(_ => Scroll(lastPosition, smooth = false)),
     onMessageAdded.filter(_ => shouldScrollToBottom).map(_ => Scroll(lastPosition, smooth = true))
-  ) .filter(_.position >= 0)
+  ).filter(_.position >= 0)
 }
 
 object CollectionScrollController {

--- a/app/src/main/scala/com/waz/zclient/collection/fragments/CollectionFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/fragments/CollectionFragment.scala
@@ -215,7 +215,7 @@ class CollectionFragment extends BaseFragment[CollectionFragment.Container] with
 
     controller.conversationName.onUi(name.setText(_))
 
-    Signal(collectionAdapter.adapterState, controller.focusedItem, controller.contentSearchQuery).on(Threading.Ui) {
+    Signal.zip(collectionAdapter.adapterState, controller.focusedItem, controller.contentSearchQuery).on(Threading.Ui) {
       case (AdapterState(_, _, _), Some(messageData), _) if messageData.msgType == Message.Type.IMAGE_ASSET =>
         setNavigationIconVisibility(true)
         timestamp.setVisibility(View.VISIBLE)
@@ -242,7 +242,7 @@ class CollectionFragment extends BaseFragment[CollectionFragment.Container] with
       case _ =>
     }
 
-    Signal(searchAdapter.cursor.flatMap(_.countSignal).orElse(Signal(-1)), controller.contentSearchQuery).on(Threading.Ui) {
+    Signal.zip(searchAdapter.cursor.flatMap(_.countSignal).orElse(Signal(-1)), controller.contentSearchQuery).onUi {
       case (0, query) if query.originalString.nonEmpty =>
         noSearchResultsText.setVisibility(View.VISIBLE)
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
@@ -57,10 +57,10 @@ trait CollectionItemView extends ViewHelper with EphemeralPartView with DerivedL
   val messageData: SourceSignal[MessageData] = Signal()
 
   val messageAndLikesResolver = for {
-    z <- civZms
-    mId <- messageData.map(_.id)
-    message <- z.messagesStorage.signal(mId)
-    msgAndLikes <- Signal.future(z.msgAndLikes.combineWithLikes(message))
+    z           <- civZms
+    mId         <- messageData.map(_.id)
+    message     <- z.messagesStorage.signal(mId)
+    msgAndLikes <- Signal.from(z.msgAndLikes.combineWithLikes(message))
   } yield msgAndLikes
 
   messageAndLikesResolver.disableAutowiring()
@@ -124,7 +124,7 @@ class CollectionImageView(context: Context) extends ImageView(context) with Coll
 
   private val target = new CustomImageViewTarget(this)
 
-  Signal(messageData.map(_.assetId), ephemeralColorDrawable).onUi {
+  Signal.zip(messageData.map(_.assetId), ephemeralColorDrawable).onUi {
     case (Some(id: AssetId), None) =>
       verbose(l"Set image asset $id")
       WireGlide(context)

--- a/app/src/main/scala/com/waz/zclient/collection/views/SingleImageViewToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/SingleImageViewToolbar.scala
@@ -72,7 +72,7 @@ class SingleImageViewToolbar(context: Context, attrs: AttributeSet, style: Int)
     downloadButton.getParent.asInstanceOf[View].setVisible(visible)
   }
 
-  val likedBySelf = Signal(collectionController.focusedItem, selfUserId, reactionsStorage) flatMap {
+  val likedBySelf = Signal.zip(collectionController.focusedItem, selfUserId, reactionsStorage) flatMap {
     case (Some(m), self, reactions) =>
       reactions.signal((m.id, self)).map(_.action == Liking.like).orElse(Signal const false)
     case _ => Signal.const(false)
@@ -87,7 +87,7 @@ class SingleImageViewToolbar(context: Context, attrs: AttributeSet, style: Int)
   Seq(likeButton, downloadButton, shareButton, deleteButton, viewButton)
     .foreach(_.setPressedBackgroundColor(getColor(R.color.light_graphite)))
 
-  likeButton.onClick( Signal(message, likedBySelf).head.foreach{
+  likeButton.onClick(Signal.zip(message, likedBySelf).head.foreach{
     case (msg, true) => messageActionsController.onMessageAction ! (Unlike, msg)
     case (msg, false) => messageActionsController.onMessageAction ! (Like, msg)
   })

--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -155,7 +155,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     (a.details, a) match {
       case (_: Audio, audioAsset: Asset) =>
         val file = new File(context.getCacheDir, s"${audioAsset.id.str}.m4a")
-        Signal.future((if (!file.exists()) {
+        Signal.from((if (!file.exists()) {
           file.createNewFile()
           assets.head.flatMap(_.loadContent(audioAsset).future).flatMap(ai => Future.fromTry(ai.toInputStream)).map { is =>
             IoUtils.copy(is, file)

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
@@ -82,7 +82,7 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
   private val notificationManager = inject[NotificationManager]
   private val ZenModeKey          = "zen_mode"
 
-  private val mediaManager   = zms.flatMap(z => Signal.future(z.mediamanager.mediaManager))
+  private val mediaManager   = zms.flatMap(z => Signal.from(z.mediamanager.mediaManager))
   private val soundIntensity = zms.flatMap(_.mediamanager.soundIntensity)
 
   private var _mediaManager = Option.empty[MediaManager]
@@ -136,7 +136,7 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
 
   override def isVibrationEnabled(userId: UserId): Boolean = {
     (for {
-      zms <- Signal.future(accountsService.getZms(userId)).collect { case Some(v) => v }
+      zms <- Signal.from(accountsService.getZms(userId)).collect { case Some(v) => v }
       isEnabled <- zms.userPrefs.preference(UserPreferences.VibrateEnabled).signal
     } yield isEnabled).headSync().getOrElse(false)
   }

--- a/app/src/main/scala/com/waz/zclient/common/drawables/TeamIconDrawable.scala
+++ b/app/src/main/scala/com/waz/zclient/common/drawables/TeamIconDrawable.scala
@@ -89,7 +89,7 @@ class TeamIconDrawable(implicit inj: Injector, eventContext: EventContext, ctx: 
   private val bitmap = for {
     bounds <- bounds
     asset <- imageAsset
-    bitmap <- Signal.future(
+    bitmap <- Signal.from(
       asset.fold(Future.successful(Option.empty[Bitmap])) { p =>
         Threading.ImageDispatcher {
           Option(WireGlide(ctx)

--- a/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
@@ -43,7 +43,7 @@ class ConnectivityFragment extends Fragment with FragmentHelper with Connectivit
   private lazy val network     = Option(ZMessaging.currentGlobal).map(_.network.networkMode).getOrElse(Signal.const(NetworkMode.UNKNOWN))
   private lazy val accentColor = inject[AccentColorController].accentColor
   private lazy val longProcess = inject[Signal[ZMessaging]].flatMap(_.push.processing).flatMap {
-    case true => Signal.future(CancellableFuture.delay(LongProcessingDelay)).map(_ => true).orElse(Signal.const(false))
+    case true => Signal.from(CancellableFuture.delay(LongProcessingDelay)).map(_ => true).orElse(Signal.const(false))
     case _ => Signal.const(false)
   }
 

--- a/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/AccountTabButton.scala
@@ -118,7 +118,7 @@ class AccountTabButton(val context: Context, val attrs: AttributeSet, val defSty
       drawable.setPicture(team.picture)
   }
 
-  Signal(unreadCount, selected).onUi {
+  Signal.zip(unreadCount, selected).onUi {
     case (c, false) if c > 0 =>
       unreadIndicatorIcon.setVisible(true)
       unreadIndicatorName.setVisible(true)

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -83,34 +83,34 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
   private val videoEnabled = Signal(false)
   private val screenShareEnabled = Signal(false)
 
-  Signal(videoEnabled, screenShareEnabled).map { case (v, s) => v || s }.onUi(videoIndicator.setVisible)
-  Signal(chosenCurrentTheme, videoEnabled, screenShareEnabled).onUi {
-    case (Theme.Light, true, _) => videoIndicator.setImageResource(R.drawable.ic_video_light_theme)
+  Signal.zip(videoEnabled, screenShareEnabled).map { case (v, s) => v || s }.onUi(videoIndicator.setVisible)
+  Signal.zip(chosenCurrentTheme, videoEnabled, screenShareEnabled).onUi {
+    case (Theme.Light, true, _)     => videoIndicator.setImageResource(R.drawable.ic_video_light_theme)
     case (Theme.Light, false, true) => videoIndicator.setImageResource(R.drawable.ic_screenshare_light_theme)
-    case (Theme.Dark, true, _) => videoIndicator.setImageResource(R.drawable.ic_video_dark_theme)
-    case (Theme.Dark, false, true) => videoIndicator.setImageResource(R.drawable.ic_screenshare_dark_theme)
+    case (Theme.Dark, true, _)      => videoIndicator.setImageResource(R.drawable.ic_video_dark_theme)
+    case (Theme.Dark, false, true)  => videoIndicator.setImageResource(R.drawable.ic_screenshare_dark_theme)
     case _ =>
   }
 
   private val isMuted = Signal(false)
   audioIndicator.setVisible(true)
-  Signal(chosenCurrentTheme, isMuted).onUi {
-    case (Theme.Light, true) => audioIndicator.setImageResource(R.drawable.ic_muted_light_theme)
+  Signal.zip(chosenCurrentTheme, isMuted).onUi {
+    case (Theme.Light, true)  => audioIndicator.setImageResource(R.drawable.ic_muted_light_theme)
     case (Theme.Light, false) => audioIndicator.setImageResource(R.drawable.ic_unmuted_light_theme)
-    case (Theme.Dark, true) => audioIndicator.setImageResource(R.drawable.ic_muted_dark_theme)
-    case (Theme.Dark, false) => audioIndicator.setImageResource(R.drawable.ic_unmuted_dark_theme)
+    case (Theme.Dark, true)   => audioIndicator.setImageResource(R.drawable.ic_muted_dark_theme)
+    case (Theme.Dark, false)  => audioIndicator.setImageResource(R.drawable.ic_unmuted_dark_theme)
     case _ =>
   }
 
   private val isGuest = Signal(false)
   private val isPartner = Signal(false)
 
-  Signal(isGuest, isPartner).map { case (v, s) => v || s }.onUi(guestPartnerIndicator.setVisible)
-  Signal(chosenCurrentTheme, isGuest, isPartner).onUi {
-    case (Theme.Light, true, _) => guestPartnerIndicator.setImageResource(R.drawable.ic_guest_light_theme)
+  Signal.zip(isGuest, isPartner).map { case (v, s) => v || s }.onUi(guestPartnerIndicator.setVisible)
+  Signal.zip(chosenCurrentTheme, isGuest, isPartner).onUi {
+    case (Theme.Light, true, _)     => guestPartnerIndicator.setImageResource(R.drawable.ic_guest_light_theme)
     case (Theme.Light, false, true) => guestPartnerIndicator.setImageResource(R.drawable.ic_partner_light_theme)
-    case (Theme.Dark, true, _) => guestPartnerIndicator.setImageResource(R.drawable.ic_guest_dark_theme)
-    case (Theme.Dark, false, true) => guestPartnerIndicator.setImageResource(R.drawable.ic_partner_dark_theme)
+    case (Theme.Dark, true, _)      => guestPartnerIndicator.setImageResource(R.drawable.ic_guest_dark_theme)
+    case (Theme.Dark, false, true)  => guestPartnerIndicator.setImageResource(R.drawable.ic_partner_dark_theme)
     case _ =>
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
@@ -68,7 +68,7 @@ class ImageFragment extends FragmentHelper {
   lazy val singleImageController    = inject[ISingleImageController]
   lazy val replyController          = inject[ReplyController]
 
-  lazy val likedBySelf = Signal(collectionController.focusedItem, selfUserId, reactionsStorage).flatMap {
+  lazy val likedBySelf = Signal.zip(collectionController.focusedItem, selfUserId, reactionsStorage).flatMap {
     case (Some(m), self, reactions) =>
       reactions.signal((m.id, self)).map(_.action == Liking.like).orElse(Signal.const(false))
     case _ => Signal.const(false)
@@ -131,7 +131,7 @@ class ImageFragment extends FragmentHelper {
 
     imageInput
 
-    EventStream.union(bottomToolbar.topToolbar.onCursorButtonClicked, bottomToolbar.bottomToolbar.onCursorButtonClicked) {
+    EventStream.zip(bottomToolbar.topToolbar.onCursorButtonClicked, bottomToolbar.bottomToolbar.onCursorButtonClicked) {
       case item: CursorActionToolbarItem =>
         import IDrawingController.DrawingMethod._
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageViewPager.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageViewPager.scala
@@ -138,7 +138,7 @@ class ImageSwipeAdapter(context: Context)(implicit injector: Injector, ev: Event
   def positionForMessage(msg: MessageData): Signal[Int] =
     for {
     c <- cursor
-    pos <- Signal.future(c.positionForMessage(msg))
+    pos <- Signal.from(c.positionForMessage(msg))
   } yield pos
 
   cursor.on(Threading.Ui) { c =>

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
@@ -52,7 +52,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     asset       <- assetsController.assetSignal(msg.assetId)
   } yield Option(ReplyContent(msg, asset, sender.name))).orElse(Signal.const(None))
 
-  messagesService.flatMap(ms => Signal.wrap(ms.msgEdited)) { case (from, to) =>
+  messagesService.flatMap(ms => Signal.from(ms.msgEdited)) { case (from, to) =>
     replyData.mutate { data =>
       data.find(_._2 == from).map(_._1).fold(data) { conv =>
         data + (conv -> to)
@@ -60,7 +60,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     }
   }
 
-  messagesStorage.flatMap(ms => Signal.wrap(ms.onDeleted)) { deletedIds =>
+  messagesStorage.flatMap(ms => Signal.from(ms.onDeleted)) { deletedIds =>
     replyData.mutate(_.filterNot(c => deletedIds.contains(c._2)))
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -71,7 +71,7 @@ class AddParticipantsFragment extends FragmentHelper {
   private lazy val adapter = AddParticipantsAdapter(newConvController.users, newConvController.integrations)
 
   private lazy val searchBox = returning(view[SearchEditText](R.id.search_box)) { vh =>
-    new FutureEventStream[(Either[UserId, (ProviderId, IntegrationId)], Boolean), (Pickable, Boolean)](adapter.onSelectionChanged, {
+    adapter.onSelectionChanged.mapAsync {
       case (Left(userId), selected) =>
         zms.head.flatMap(_.usersStorage.get(userId).collect {
           case Some(u) => (Pickable(userId.str, u.name), selected)
@@ -80,7 +80,7 @@ class AddParticipantsFragment extends FragmentHelper {
         zms.head.flatMap(_.integrations.getIntegration(pId, iId).collect {
           case Right(service) => (Pickable(iId.str, service.name), selected)
         })
-    }).onUi {
+    }.onUi {
       case (pu, selected) =>
         vh.foreach { v =>
           if (selected) v.addElement(pu) else v.removeElement(pu)

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationManagerFragment.scala
@@ -131,7 +131,7 @@ class CreateConversationManagerFragment extends DefaultToolbarFragment[NoOpConta
       R.id.fragment_create_conversation_manager_layout_container,
       new CreateConversationSettingsFragment, CreateConversationSettingsFragment.Tag)
 
-    Signal(currentPage, themeController.darkThemeSet).map {
+    Signal.zip(currentPage, themeController.darkThemeSet).map {
       case (PickerPage, true) => R.drawable.action_back_light
       case (PickerPage, false) => R.drawable.action_back_dark
       case (SettingsPage, false) => R.drawable.ic_action_close_dark

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -66,7 +66,7 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
       if (flag) getString(R.string.create_conv_options_subtitle_on)
       else getString(R.string.create_conv_options_subtitle_off)
 
-    Signal(createConversationController.teamOnly, createConversationController.readReceipts).onUi {
+    Signal.zip(createConversationController.teamOnly, createConversationController.readReceipts).onUi {
       case (teamOnly, readReceipts) =>
         vh.foreach(
           _.setText(s"${getString(R.string.create_conv_options_subtitle_allow_guests)}: ${onOffStr(!teamOnly)}, ${getString(R.string.create_conv_options_subtitle_read_receipts)}: ${onOffStr(readReceipts)}")
@@ -79,19 +79,19 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
 
 
   private lazy val guestsToggleRow = returning(view[View](R.id.guest_toggle_row)) { vh =>
-    Signal(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
+    Signal.zip(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
   }
 
   private lazy val guestsToggleDesc = returning(view[View](R.id.guest_toggle_description)) { vh =>
-    Signal(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
+    Signal.zip(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
   }
 
   private lazy val readReceiptsToggleRow = returning(view[View](R.id.read_receipts_toggle_row)) { vh =>
-    Signal(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
+    Signal.zip(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
   }
 
   private lazy val readReceiptsToggleDesc = returning(view[View](R.id.read_receipts_toggle_description)) { vh =>
-    Signal(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
+    Signal.zip(optionsVisible, userAccountsController.isTeam).onUi { case (opt, vis) => vh.foreach(_.setVisible(opt && vis)) }
   }
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View =

--- a/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
@@ -172,11 +172,11 @@ class AudioMessageRecordingView (val context: Context, val attrs: AttributeSet, 
     case _         => None
   }.map(_.map(getString)).onUi(_.foreach(hintTextView.setText))
 
-  Signal(slideControlState, playbackControls.flatMap(_.isPlaying).orElse(Signal.const(false))).map {
-    case (Recording, _) => Some(R.string.glyph__microphone_on)
-    case (Preview, false)   => Some(R.string.glyph__play)
-    case (Preview, true)   => Some(R.string.glyph__pause)
-    case _         => None
+  Signal.zip(slideControlState, playbackControls.flatMap(_.isPlaying).orElse(Signal.const(false))).map {
+    case (Recording, _)   => Some(R.string.glyph__microphone_on)
+    case (Preview, false) => Some(R.string.glyph__play)
+    case (Preview, true)  => Some(R.string.glyph__pause)
+    case _                => None
   }.map(_.map(getString)).onUi(_.foreach(bottomButtonTextView.setText))
 
   slideControlState.map {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -210,7 +210,7 @@ class NormalConversationFragment extends ConversationListFragment {
 
   override lazy val topToolbar = returning(view[NormalTopToolbar](R.id.conversation_list_top_toolbar)) { vh =>
     subs += accentColor.map(_.color).onUi(color => vh.foreach(_.setIndicatorColor(color)))
-    subs += Signal(unreadCount, incomingClients, readReceiptsChanged).onUi {
+    subs += Signal.zip(unreadCount, incomingClients, readReceiptsChanged).onUi {
       case (count, clients, rrChanged) => vh.foreach(_.setIndicatorVisible(clients.nonEmpty || count > 0 || rrChanged))
     }
   }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -99,9 +99,9 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
   private val menuIndicatorView = ViewUtils.getView(this, R.id.conversation_menu_indicator).asInstanceOf[MenuIndicatorView]
 
   private val userTyping = for {
-    z <- zms
-    convId <- conversation.map(_.id)
-    typing <- Signal.wrap(z.typing.onTypingChanged.filter(_._1 == convId).map(_._2.headOption)).orElse(Signal.const(None))
+    z          <- zms
+    convId     <- conversation.map(_.id)
+    typing     <- Signal.from(z.typing.onTypingChanged.filter(_._1 == convId).map(_._2.headOption)).orElse(Signal.const(None))
     typingUser <- userData(typing.map(_.id))
   } yield typingUser
 
@@ -151,7 +151,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
     conv <- conversation
     memberIds <- members
     memberSeq <- Signal.sequence(memberIds.map(uid => UserSignal(uid)):_*)
-    isGroup <- Signal.future(z.conversations.isGroupConversation(conv.id))
+    isGroup <- Signal.from(z.conversations.isGroupConversation(conv.id))
   } yield {
     val opacity =
       if ((memberIds.isEmpty && isGroup) || conv.convType == ConversationType.WaitForConnection || !conv.isActive)

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -125,10 +125,10 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
     }
 
   val enteredTextEmpty = enteredText.map(_._1.isEmpty).orElse(Signal const true)
-  val sendButtonVisible = Signal(emojiKeyboardVisible, enteredTextEmpty, sendButtonEnabled, isEditingMessage) map {
+  val sendButtonVisible = Signal.zip(emojiKeyboardVisible, enteredTextEmpty, sendButtonEnabled, isEditingMessage).map {
     case (emoji, empty, enabled, editing) => enabled && (emoji || !empty) && !editing
   }
-  val ephemeralBtnVisible = Signal(isEditingMessage, convIsActive).flatMap {
+  val ephemeralBtnVisible = Signal.zip(isEditingMessage, convIsActive).flatMap {
     case (false, true) =>
       isEphemeral.flatMap {
         case true => Signal.const(true)

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -112,7 +112,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
 
   val lineCount = Signal(getInt(R.integer.cursor_starting_lines))
 
-  Signal(controller.typingIndicatorVisible, replyController.currentReplyContent)
+  Signal.zip(controller.typingIndicatorVisible, replyController.currentReplyContent)
     .map { case (typing, currentReply) => !typing && currentReply.isEmpty  }
     .onUi(topBorder.setVisible)
 
@@ -120,10 +120,10 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
   private val cursorText: SourceSignal[String] = Signal(cursorEditText.getEditableText.toString)
   private val cursorSelection: SourceSignal[(Int, Int)] = Signal((cursorEditText.getSelectionStart, cursorEditText.getSelectionEnd))
 
-  val mentionQuery = Signal(cursorText, cursorSelection).collect {
+  val mentionQuery = Signal.zip(cursorText, cursorSelection).collect {
     case (text, (_, sEnd)) if sEnd <= text.length => MentionUtils.mentionQuery(text, sEnd)
   }
-  val selectionHasMention = Signal(cursorText, cursorSelection).collect {
+  val selectionHasMention = Signal.zip(cursorText, cursorSelection).collect {
     case (text, (_, sEnd)) if sEnd <= text.length =>
       MentionUtils.mentionMatch(text, sEnd).exists { m =>
         CursorMentionSpan.hasMentionSpan(cursorEditText.getEditableText, m.start, sEnd)

--- a/app/src/main/scala/com/waz/zclient/cursor/EphemeralTimerButton.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/EphemeralTimerButton.scala
@@ -91,7 +91,7 @@ class EphemeralTimerButton(context: Context, attrs: AttributeSet, defStyleAttr: 
     drawable.onUi(setBackgroundDrawable)
     contentDescription.onUi(setContentDescription)
 
-    Signal(color, iconSize).onUi {
+    Signal.zip(color, iconSize).onUi {
       case (c, s) =>
         setTextColor(c)
         this.setWidthAndHeight(Some(s), Some(s))

--- a/app/src/main/scala/com/waz/zclient/cursor/TooltipView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/TooltipView.scala
@@ -49,13 +49,13 @@ class TooltipView(context: Context, attrs: AttributeSet, defStyleAttr: Int)
 
   val controller = inject[CursorController]
 
-  val tooltip = Signal.wrap(controller.onShowTooltip.map { case (msg, anchor) => (msg, anchor, Instant.now) })
+  val tooltip = Signal.from(controller.onShowTooltip.map { case (msg, anchor) => (msg, anchor, Instant.now) })
 
   val visible = tooltip.map(_._3).orElse(Signal const Instant.EPOCH).flatMap {
     case time if time <= Instant.now - TooltipDuration => Signal const false
     case time =>
       val delay = Instant.now.until(time + TooltipDuration).asScala
-      Signal.future(CancellableFuture.delayed(delay) { false }).orElse(Signal const true)
+      Signal.from(CancellableFuture.delayed(delay) { false }).orElse(Signal const true)
   }
 
   val width = Signal[Int]()
@@ -68,9 +68,9 @@ class TooltipView(context: Context, attrs: AttributeSet, defStyleAttr: Int)
 
   val margin = getDimenPx(R.dimen.wire__padding__regular)
 
-  val offset = Signal(anchorPosition, width, controller.cursorWidth) map {
+  val offset = Signal.zip(anchorPosition, width, controller.cursorWidth).map {
     case (anchor, w, cursorWidth) =>
-      math.max(margin, math.min(cursorWidth - margin - w, anchor - w /2))
+      math.max(margin, math.min(cursorWidth - margin - w, anchor - w / 2))
   }
 
   val fadeAnimator = returning(ValueAnimator.ofFloat(0, 1)) { anim =>

--- a/app/src/main/scala/com/waz/zclient/giphy/GiphySharingPreviewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/giphy/GiphySharingPreviewFragment.scala
@@ -78,7 +78,7 @@ class GiphySharingPreviewFragment extends BaseFragment[GiphySharingPreviewFragme
   private lazy val giphySearchResults = for {
     giphyService <- giphyService
     term <- searchTerm
-    searchResults <- Signal.future(
+    searchResults <- Signal.from(
       if (TextUtils.isEmpty(term)) giphyService.trending()
       else giphyService.search(term)
     )
@@ -214,13 +214,13 @@ class GiphySharingPreviewFragment extends BaseFragment[GiphySharingPreviewFragme
       })
     }
 
-    EventStream.union(
+    EventStream.zip(
       searchTerm.onChanged.map(_ => true),
       selectedGif.onChanged.filter(_.isDefined).map(_ => true),
       giphySearchResults.onChanged.map(_ => false),
       isPreviewShown.onChanged.filter(_ == false),
       isGifShowing.onChanged.map(!_)
-    ) onUi {
+    ).onUi {
       case true  => spinnerController.showSpinner(LoadingIndicatorView.InfiniteLoadingBar)
       case false => spinnerController.hideSpinner()
     }

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -208,7 +208,7 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
   private val zms = inject[Signal[ZMessaging]]
   private val userId = Signal[UserId]()
 
-  private val user = Signal(zms, userId).flatMap {
+  private val user = Signal.zip(zms, userId).flatMap {
     case (z, id) => z.usersStorage.signal(id)
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
   val currentConvIndex = for {
     z       <- zms
     convId  <- currentConvId
-    index   <- Signal.future(z.messagesStorage.msgsIndex(convId))
+    index   <- Signal.from(z.messagesStorage.msgsIndex(convId))
   } yield
     index
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
@@ -66,18 +66,18 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
   val integration = for {
     usr <- user
     intService <- integrations
-    integration <- Signal.future((usr.integrationId, usr.providerId) match {
-    case (Some(i), Some(p)) => intService.getIntegration(p, i).map {
-      case Right(integrationData) => Some(integrationData)
-      case Left(_) => None
-    }
-    case _ => Future.successful(None)
+    integration <- Signal.from((usr.integrationId, usr.providerId) match {
+      case (Some(i), Some(p)) => intService.getIntegration(p, i).map {
+        case Right(integrationData) => Some(integrationData)
+        case Left(_)                => None
+      }
+      case _ => Future.successful(None)
   })
   } yield integration
 
-  Signal(integration, user.map(_.id)).onUi {
+  Signal.zip(integration, user.map(_.id)).onUi {
     case (Some(i), _) => chathead.setIntegration(i)
-    case (_, usr) => chathead.loadUser(usr)
+    case (_, usr)     => chathead.loadUser(usr)
   }
 
   user.map(_.id)(userDetails.setUserId)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MissedCallPartView.scala
@@ -48,7 +48,7 @@ class MissedCallPartView(context: Context, attrs: AttributeSet, style: Int) exte
   private val zms = inject[Signal[ZMessaging]]
   private val userId = Signal[UserId]()
 
-  private val user = Signal(zms, userId).flatMap {
+  private val user = Signal.zip(zms, userId).flatMap {
     case (z, id) => z.usersStorage.signal(id)
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/OtrMsgPartView.scala
@@ -107,7 +107,7 @@ class OtrMsgPartView(context: Context, attrs: AttributeSet, style: Int)
     case OTR_MEMBER_ADDED =>
       Signal.const(getString(R.string.content__otr__new_member__message))
     case RESTRICTED_FILE =>
-      Signal(affectedUserName, message.map(_.name)).map {
+      Signal.zip(affectedUserName, message.map(_.name)).map {
         case (Other(name), _)     => getString(R.string.file_restrictions__receiver_error, name)
         case (_, Some(Name(ext))) => getString(R.string.file_restrictions__sender_error, ext)
         case _                    => getString(R.string.file_restrictions__sender_error, "")
@@ -116,7 +116,7 @@ class OtrMsgPartView(context: Context, attrs: AttributeSet, style: Int)
       Signal.const("")
   }
 
-  Signal(message, msgString, accentColor.accentColor, memberIsJustSelf).onUi { case (msg, text, color, isMe) =>
+  Signal.zip(message, msgString, accentColor.accentColor, memberIsJustSelf).onUi { case (msg, text, color, isMe) =>
     setTextWithLink(text, color.color) {
       (msg.msgType, isMe) match {
         case (OTR_UNVERIFIED | OTR_DEVICE_ADDED | OTR_MEMBER_ADDED, true)  =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReadReceiptsPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReadReceiptsPartView.scala
@@ -55,7 +55,7 @@ class ReadReceiptsPartView(context: Context, attrs: AttributeSet, style: Int)
   private lazy val firstMessage = message.map(_.firstMessage)
   private lazy val msgType      = message.map(_.msgType)
 
-  Signal(senderName, msgType, firstMessage).map {
+  Signal.zip(senderName, msgType, firstMessage).map {
     case (_,           READ_RECEIPTS_ON,  true)  => getString(R.string.content__system__read_receipts_on)
     case (_,           READ_RECEIPTS_OFF, true)  => getString(R.string.content__system__read_receipts_off)
     case (Me,          READ_RECEIPTS_ON,  false) => getString(R.string.content__system__read_receipts_you_turned_on)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
@@ -75,7 +75,7 @@ class TextPartView(context: Context, attrs: AttributeSet, style: Int)
       TextPartView.this.getParent.asInstanceOf[View].performLongClick()
   })
 
-  var messagePart = Signal[Option[MessageContent]]()
+  val messagePart = Signal[Option[MessageContent]]()
 
   val searchResultText = for {
     color         <- accentColorController.accentColor

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -77,7 +77,7 @@ trait ActionableAssetPart extends AssetPart {
 
   val isPlaying = Signal(false)
 
-  Signal(assetStatus.map(_._1), isPlaying).onUi { case (s, p) =>
+  Signal.zip(assetStatus.map(_._1), isPlaying).onUi { case (s, p) =>
     assetActionButton.setStatus(s, "", playing = p)
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
@@ -187,7 +187,7 @@ class FooterPartView(context: Context, attrs: AttributeSet, style: Int) extends 
     lastMsgId = msgId
   }
 
-  Signal(controller.expiring, likeButtonVisible).map { case (e, v) => e || !v }.onUi(likeButton.setGone)
+  Signal.zip(controller.expiring, likeButtonVisible).map { case (e, v) => e || !v }.onUi(likeButton.setGone)
 
   override def onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int): Unit = {
     super.onLayout(changed, left, top, right, bottom)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
@@ -82,7 +82,7 @@ class FooterViewController(implicit inj: Injector, context: Context, ec: EventCo
       untilTimeout = Instant.now.until(time.plus(selection.ActivityTimeout)).asScala
       active <-
         if (msgId != activeId || lTime.isAfter(time) || untilTimeout <= Duration.Zero) Signal.const(false)
-        else Signal.future(CancellableFuture.delayed(untilTimeout)(false)).orElse(Signal const true) // signal `true` switching to `false` on timeout
+        else Signal.from(CancellableFuture.delayed(untilTimeout)(false)).orElse(Signal.const(true)) // signal `true` switching to `false` on timeout
     } yield active
 
   val showTimestamp: Signal[Boolean] = for {

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -78,14 +78,14 @@ class CallingNotificationsController(implicit cxt: WireContext, eventContext: Ev
                                   zs.find(_.selfUserId == account)
                                     .fold2(
                                       Signal.const(conv -> Option.empty[Bitmap]),
-                                      z => Signal.const(conv -> Option.empty[Bitmap]) // //TODO: Use new assets engine to fetch the bitmap
+                                      _ => Signal.const(conv -> Option.empty[Bitmap]) // TODO: Use new assets engine to fetch the bitmap
                                     )
                                 }: _*).map(_.toMap)
       notInfo                <- Signal.sequence(allCallsF.map { case (conv, (caller, account)) =>
                                   zs.find(_.selfUserId == account)
                                     .fold2(
                                       Signal.const(None, Name.Empty, None, false, Availability.None),
-                                      z => Signal(
+                                      z => Signal.zip(
                                         z.calling.joinableCallsNotMuted.map(_.get(conv)),
                                         z.usersStorage.optSignal(caller).map(_.map(_.name).getOrElse(Name.Empty)),
                                         z.convsStorage.optSignal(conv),

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -96,7 +96,7 @@ class MessageNotificationsController(applicationId: String = BuildConfig.APPLICA
   with those notifications. This is separate from removing notifications from the storage and may
   sometimes be inconsistent (notifications in the tray may stay longer than in the storage).
    */
-  Signal(selfId, notificationsSourceVisible).onUi {
+  Signal.zip(selfId, notificationsSourceVisible).onUi {
     case (Some(selfUserId), sources) =>
       val notIds = sources.getOrElse(selfUserId, Set.empty).map(toNotificationConvId(selfUserId, _))
       if (notIds.nonEmpty) notificationManager.cancelNotifications(notIds)

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -299,13 +299,13 @@ object NotificationManagerWrapper {
         } (Threading.Ui)
 
       for {
-        msgSound <- Signal.future(getSound(UserPreferences.TextTone, R.raw.new_message_gcm))
-        pingSound <- Signal.future(getSound(UserPreferences.PingTone, R.raw.ping_from_them))
-        vibration <- Signal.future(am.userPrefs.preference(UserPreferences.VibrateEnabled).apply())
-        channel <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.name, Set(
-            ChannelInfo(MessageNotificationsChannelId(am.userId), R.string.message_notifications_channel_name, R.string.message_notifications_channel_description, msgSound, vibration),
-            ChannelInfo(PingNotificationsChannelId(am.userId), R.string.ping_notifications_channel_name, R.string.ping_notifications_channel_description, pingSound, vibration)
-          )))
+        msgSound  <- Signal.from(getSound(UserPreferences.TextTone, R.raw.new_message_gcm))
+        pingSound <- Signal.from(getSound(UserPreferences.PingTone, R.raw.ping_from_them))
+        vibration <- Signal.from(am.userPrefs.preference(UserPreferences.VibrateEnabled).apply())
+        channel   <- am.storage.usersStorage.signal(am.userId).map(user => ChannelGroup(user.id.str, user.name, Set(
+                       ChannelInfo(MessageNotificationsChannelId(am.userId), R.string.message_notifications_channel_name, R.string.message_notifications_channel_description, msgSound, vibration),
+                       ChannelInfo(PingNotificationsChannelId(am.userId), R.string.ping_notifications_channel_name, R.string.ping_notifications_channel_description, pingSound, vibration)
+                     )))
       } yield channel
     }.toSeq:_*))
 

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -103,10 +103,10 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
     teamMember           <- otherUser.map(_.exists(u => u.teamId.nonEmpty && u.teamId == teamId))
     isBot                <- otherUser.map(_.exists(_.isWireBot))
     selfRole             <- convController.selfRoleInConv(convId)
-    isCurrentUserCreator <- Signal.future(convController.isCurrentUserCreator(convId))
+    isCurrentUserCreator <- Signal.from(convController.isCurrentUserCreator(convId))
     selectedParticipant  <- participantsController.selectedParticipant
     favoriteConvIds      <- convListController.favoriteConversations.map(_.map(_.conv.id).toSet)
-    customFolderId       <- Signal.future(convListController.getCustomFolderId(convId))
+    customFolderId       <- Signal.from(convListController.getCustomFolderId(convId))
     customFolderData     <- customFolderId.fold(Signal.const[Option[FolderData]](None))(convListController.folder)
   } yield {
     import com.waz.api.ConnectionStatus._

--- a/app/src/main/scala/com/waz/zclient/participants/OptionsMenu.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/OptionsMenu.scala
@@ -55,8 +55,7 @@ case class OptionsMenu(context: Context, controller: OptionsMenuController) exte
         title.setVisible(false)
     }
 
-    Signal(controller.optionItems, controller.selectedItems).onUi { case (items, selected) =>
-
+    Signal.zip(controller.optionItems, controller.selectedItems).onUi { case (items, selected) =>
       container.removeAllViews()
 
       items.foreach { item =>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsController.scala
@@ -59,7 +59,7 @@ class ParticipantsController(implicit injector: Injector, context: Context, ec: 
   lazy val isGroup: Signal[Boolean]                                 = convController.currentConvIsGroup
   lazy val selfRole: Signal[ConversationRole]                       = convController.selfRole
 
-  lazy val otherParticipantId: Signal[Option[UserId]] = Signal(otherParticipants, selectedParticipant).map {
+  lazy val otherParticipantId: Signal[Option[UserId]] = Signal.zip(otherParticipants, selectedParticipant).map {
     case (others, _) if others.size == 1                               => others.headOption.map(_._1)
     case (others, selected) if selected.exists(others.keySet.contains) => selected
     case _                                                             => None

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
@@ -24,7 +24,6 @@ import androidx.annotation.Nullable
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.api.NetworkMode
-import com.waz.model.{UserData, UserId}
 import com.waz.service.{IntegrationsService, NetworkModeService}
 import com.waz.threading.Threading
 import com.waz.utils._
@@ -76,7 +75,7 @@ class GroupParticipantsFragment extends FragmentHelper {
   }
 
   private lazy val participantsAdapter = returning(new ParticipantsAdapter(participantsController.participants, Some(7))) { adapter =>
-    new FutureEventStream[UserId, Option[UserData]](adapter.onClick, participantsController.getUser).onUi {
+    adapter.onClick.mapAsync(participantsController.getUser).onUi {
       case Some(user) => (user.providerId, user.integrationId) match {
         case (Some(pId), Some(iId)) =>
           for {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -93,7 +93,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
     import com.waz.zclient.messages.UsersController
     val usersController = inject[UsersController]
 
-    val availabilityVisible = Signal(participantsController.otherParticipant.map(_.expiresAt.isDefined), usersController.availabilityVisible).map {
+    val availabilityVisible = Signal.zip(participantsController.otherParticipant.map(_.expiresAt.isDefined), usersController.availabilityVisible).map {
       case (true, _)         => false
       case (_, isTeamMember) => isTeamMember
     }
@@ -103,7 +103,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
       av        <- usersController.availability(uId)
     } yield av
 
-    Signal(availabilityVisible, availabilityStatus).map {
+    Signal.zip(availabilityVisible, availabilityStatus).map {
       case (true, status) => Some(status)
       case (false, _)     => None
     }
@@ -111,7 +111,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
 
   private lazy val confButton = returning(view[TextView](R.id.confirmation_button)) { vh =>
 
-    val confButtonEnabled = Signal(newConvController.users.map(_.size), newConvController.integrations.map(_.size), potentialMemberCount).map {
+    val confButtonEnabled = Signal.zip(newConvController.users.map(_.size), newConvController.integrations.map(_.size), potentialMemberCount).map {
       case (newUsers, newIntegrations, potential) => (newUsers > 0 || newIntegrations > 0) && potential <= ConversationController.MaxParticipants
     }
     confButtonEnabled.onUi(e => vh.foreach(_.setEnabled(e)))
@@ -148,7 +148,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
       case Some(EphemeralOptionsFragment.Tag) =>
         Signal.const(getString(R.string.ephemeral_message__options_header))
       case Some(AddParticipantsFragment.Tag) =>
-        Signal(newConvController.users, newConvController.integrations).map {
+        Signal.zip(newConvController.users, newConvController.integrations).map {
           case (u, i) if u.isEmpty && i.isEmpty => getString(R.string.add_participants_empty_header)
           case (u, i) => getString(R.string.add_participants_count_header, (u.size + i.size).toString)
         }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -89,7 +89,7 @@ class SingleParticipantFragment extends FragmentHelper {
   }
 
   protected lazy val readReceipts: Signal[Option[String]] =
-    Signal(participantsController.isGroup, userAccountsController.isTeam, userAccountsController.readReceiptsEnabled).map {
+    Signal.zip(participantsController.isGroup, userAccountsController.isTeam, userAccountsController.readReceiptsEnabled).map {
       case (false, true, true)  => Some(getString(R.string.read_receipts_info_title_enabled))
       case (false, true, false) => Some(getString(R.string.read_receipts_info_title_disabled))
       case _                    => None
@@ -155,7 +155,7 @@ class SingleParticipantFragment extends FragmentHelper {
           case None        => Seq.empty
         }
 
-        subs += Signal(
+        subs += Signal.zip(
           participantsController.otherParticipant.map(_.fields),
           timerText,
           readReceipts,

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -60,7 +60,7 @@ abstract class UntabbedRequestFragment extends SingleParticipantFragment {
               Signal.const(Option.empty[ConversationRole])
 
           val adapter = new UnconnectedParticipantAdapter(user.id, isGuest, isExternal, isDarkTheme, isGroup, isWireless, user.name, formattedHandle)
-          subs += Signal(timerText, participantRole, selfRole).onUi {
+          subs += Signal.zip(timerText, participantRole, selfRole).onUi {
             case (tt, pRole, sRole) => adapter.set(tt, pRole, sRole)
           }
           subs += adapter.onParticipantRoleChange.on(Threading.Background)(participantsController.setRole(user.id, _))

--- a/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/PreferencesActivity.scala
@@ -82,7 +82,7 @@ class PreferencesActivity extends BaseActivity
         case _                   => backStackNavigator.goTo(ProfileBackStackKey())
       }
 
-      Signal(backStackNavigator.currentState, ZMessaging.currentAccounts.accountsWithManagers.map(_.toSeq.length)).on(Threading.Ui){
+      Signal.zip(backStackNavigator.currentState, ZMessaging.currentAccounts.accountsWithManagers.map(_.toSeq.length)).onUi{
         case (state: ProfileBackStackKey, c) if c > 1 =>
           setTitle(R.string.empty_string)
           accountTabsContainer.setVisibility(View.VISIBLE)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -241,7 +241,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   phone.onUi(view.setPhone)
   email.onUi(view.setEmail)
 
-  Signal(isTeam, accounts.isActiveAccountSSO)
+  Signal.zip(isTeam, accounts.isActiveAccountSSO)
     .map { case (team, sso) => team || sso }
     .onUi(t => view.setDeleteAccountEnabled(!t))
 
@@ -365,7 +365,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   }
 
   view.onBackupClick.onUi { _ =>
-    Signal(accounts.isActiveAccountSSO, email).head.map {
+    Signal.zip(accounts.isActiveAccountSSO, email).head.map {
       case (true, _)        => navigator.goTo(BackupExportKey())
       case (false, Some(_)) => navigator.goTo(BackupExportKey())
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -269,8 +269,8 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
     } yield ()
   }
 
-  private def showRemoveDeviceDialog(error: Option[String] = None): Unit = {
-    Signal(accounts.isActiveAccountSSO, model).head.foreach { case (isSSO, name) =>
+  private def showRemoveDeviceDialog(error: Option[String] = None): Unit =
+    Signal.zip(accounts.isActiveAccountSSO, model).head.foreach { case (isSSO, name) =>
       val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onDelete(removeDevice))
       context.asInstanceOf[BaseActivity]
         .getSupportFragmentManager
@@ -280,5 +280,4 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
         .addToBackStack(RemoveDeviceDialog.FragmentTag)
         .commit
     } (Threading.Ui)
-  }
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
@@ -105,7 +105,7 @@ case class DevicesViewController(view: DevicesView)(implicit inj: Injector, ec: 
   val otherClients = for {
     Some(am)      <- accounts.activeAccountManager
     selfClientId  <- am.clientId
-    clients       <- Signal.future(am.storage.otrClientsStorage.get(am.userId))
+    clients       <- Signal.from(am.storage.otrClientsStorage.get(am.userId))
   } yield clients.fold(Seq[Client]())(_.clients.values.filter(client => !selfClientId.contains(client.id)).toSeq.sortBy(_.regTime).reverse)
 
   val incomingClients = for {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -261,12 +261,12 @@ class OptionsViewController(view: OptionsView)(implicit inj: Injector, ec: Event
   userPrefs.flatMap(_.preference(Sounds).signal).onUi{ view.setSounds }
   userPrefs.flatMap(_.preference(RingTone).signal).onUi{ view.setRingtone }
 
-  Signal(userPrefs.flatMap(_.preference(TextTone).signal), channelTextTone).map {
+  Signal.zip(userPrefs.flatMap(_.preference(TextTone).signal), channelTextTone).map {
     case (_, Some(uri)) if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O => uri.toString
     case (uri, _) => uri
   }.onUi(view.setTextTone)
 
-  Signal(userPrefs.flatMap(_.preference(PingTone).signal), channelPingTone).map {
+  Signal.zip(userPrefs.flatMap(_.preference(PingTone).signal), channelPingTone).map {
     case (_, Some(uri)) if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O => uri.toString
     case (uri, _) => uri
   }.onUi(view.setPingTone)

--- a/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/views/ProfileAccountTab.scala
@@ -107,7 +107,7 @@ class ProfileAccountTab(val context: Context, val attrs: AttributeSet, val defSt
     drawable.setBorderColor(color)
   }
 
-  Signal(initials, drawableCorners, selected).onUi {
+  Signal.zip(initials, drawableCorners, selected).onUi {
     case (i, c, s) => drawable.setInfo(i, c, s)
   }
 

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -63,7 +63,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
         case Tab.Services =>
           servicesService.flatMap { svc =>
             Signal
-              .future(svc.searchIntegrations(Option(filter).filter(_.nonEmpty)))
+              .from(svc.searchIntegrations(Option(filter).filter(_.nonEmpty)))
               .map(_.fold[AddUserListState](Error, ss =>
                 if (ss.isEmpty)
                   if (filter.isEmpty) NoServices else NoServicesFound
@@ -92,7 +92,7 @@ class SearchController(implicit inj: Injector, eventContext: EventContext) exten
         case Tab.Services =>
           servicesService.flatMap { svc =>
             Signal
-              .future(svc.searchIntegrations(Option(filter).filter(_.nonEmpty)))
+              .from(svc.searchIntegrations(Option(filter).filter(_.nonEmpty)))
               .map(_.fold[SearchUserListState](Error, ss =>
                 if (ss.isEmpty)
                   if (filter.isEmpty) NoServices else NoServicesFound

--- a/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
@@ -107,7 +107,7 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
     ZMessaging.currentAccounts.activeAccount.onChanged.onUi(_ => vh.foreach(v => v.getElements.foreach(v.removeElement)))
 
     (for {
-      selected <- Signal.wrap(adapter.conversationSelectEvent)
+      selected <- Signal.from(adapter.conversationSelectEvent)
       name     <- convController.conversationName(selected._1)
     } yield (PickableConversation(selected._1.str, name.str), selected._2)).onUi {
       case (convData, true) if multiPicker  => vh.foreach(_.addElement(convData))

--- a/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultConversationRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultConversationRowView.scala
@@ -54,7 +54,7 @@ class SearchResultConversationRowView(val context: Context, val attrs: Attribute
     conv      <- conversationSignal
     memberIds <- ConversationMembersSignal(conv.id)
     memberSeq <- Signal.sequence(memberIds.map(uid => UserSignal(uid)).toSeq:_*)
-    isGroup   <- Signal.future(z.conversations.isGroupConversation(conv.id))
+    isGroup   <- Signal.from(z.conversations.isGroupConversation(conv.id))
   } yield (conv.id, isGroup, memberSeq.filter(_.id != z.selfUserId), z.teamId)).onUi {
     case (convId, isGroup, members, selfTeamId) =>
       avatar.setMembers(members, convId, isGroup, selfTeamId)

--- a/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/views/SearchResultRowView.scala
@@ -75,7 +75,7 @@ class TextSearchResultRowView(context: Context, attrs: AttributeSet, style: Int)
     color    <- accentColorController.accentColor
     m        <- message
     q        <- searchedQuery if q.toString().nonEmpty
-    nContent <- Signal.future(mis.getNormalizedContentForMessage(m.id))
+    nContent <- Signal.from(mis.getNormalizedContentForMessage(m.id))
   } yield (m, q, color, nContent)).onUi {
     case (msg, query, color, Some(normalizedContent)) =>
       val spannableString = CollectionUtils.getHighlightedSpannableString(msg.contentString, normalizedContent, query.elements, ColorUtils.injectAlpha(0.5f, color.color), StartEllipsisThreshold)

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -416,13 +416,13 @@ class ConversationFragment extends FragmentHelper {
 
     cursorView.foreach { v =>
 
-      subs += Signal(v.mentionSearchResults, accountsController.teamId, inject[ThemeController].currentTheme).onUi {
+      subs += Signal.zip(v.mentionSearchResults, accountsController.teamId, inject[ThemeController].currentTheme).onUi {
         case (data, teamId, theme) =>
           mentionCandidatesAdapter.setData(data, teamId, theme)
           mentionsList.foreach(_.scrollToPosition(data.size - 1))
       }
 
-      val mentionsListShouldShow = Signal(v.mentionQuery.map(_.nonEmpty), v.mentionSearchResults.map(_.nonEmpty), v.selectionHasMention).map {
+      val mentionsListShouldShow = Signal.zip(v.mentionQuery.map(_.nonEmpty), v.mentionSearchResults.map(_.nonEmpty), v.selectionHasMention).map {
         case (true, true, false) => true
         case _ => false
       }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -176,7 +176,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.2"
+    const val WIRE_SIGNALS = "0.2.1"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/PlaybackControls.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/api/impl/PlaybackControls.scala
@@ -29,7 +29,7 @@ class PlaybackControls(key: MediaKey, content: Content, durationSource: ZMessagi
   private var playhead = Duration.ZERO
   private var duration = Duration.ZERO
 
-  addLoader(zms => Signal(zms.global.recordingAndPlayback.isPlaying(key), zms.global.recordingAndPlayback.playhead(key), durationSource(zms))) {
+  addLoader(zms => Signal.zip(zms.global.recordingAndPlayback.isPlaying(key), zms.global.recordingAndPlayback.playhead(key), durationSource(zms))) {
     case (nextPlaying, nextPlayhead, nextDuration) =>
       if (nextPlaying != playing || nextPlayhead != playhead || nextDuration != duration) {
         playing = nextPlaying

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -62,7 +62,7 @@ class MembersStorageImpl(context: Context, storage: ZmsDatabase)
   override def activeMembers(conv: ConvId): Signal[Set[UserId]] = {
     def onConvMemberChanged(conv: ConvId) =
       onAdded.map(_.filter(_.convId == conv).map(_.userId -> true))
-        .union(onDeleted.map(_.filter(_._2 == conv).map(_._1 -> false)))
+        .zip(onDeleted.map(_.filter(_._2 == conv).map(_._1 -> false)))
 
     new AggregatingSignal[Seq[(UserId, Boolean)], Set[UserId]](
       onConvMemberChanged(conv),

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -127,7 +127,7 @@ class MessagesStorageImpl(context:     Context,
     Future.traverse(added.groupBy(_.convId)) { case (convId, msgs) =>
       msgsFilteredIndex(convId).foreach(_.add(msgs))
       msgsIndex(convId).flatMap { index =>
-        index.add(msgs).flatMap(_ => index.firstMessageId) map { first =>
+        index.add(msgs).flatMap(_ => index.firstMessageId).map { first =>
           // XXX: calling update here is a bit ugly
           msgs.map {
             case msg if first.contains(msg.id) =>
@@ -204,9 +204,9 @@ class MessagesStorageImpl(context:     Context,
 
   def getLastSentMessage(conv: ConvId) = msgsIndex(conv).flatMap(_.getLastSentMessage)
 
-  def unreadCount(conv: ConvId): Signal[Int] = Signal.future(msgsIndex(conv)).flatMap(_.signals.unreadCount).map(_.messages)
+  def unreadCount(conv: ConvId): Signal[Int] = Signal.from(msgsIndex(conv)).flatMap(_.signals.unreadCount).map(_.messages)
 
-  def lastRead(conv: ConvId) = Signal.future(msgsIndex(conv)).flatMap(_.signals.lastReadTime)
+  def lastRead(conv: ConvId) = Signal.from(msgsIndex(conv)).flatMap(_.signals.lastReadTime)
 
   //TODO: use local instant?
   override def findLocalFrom(conv: ConvId, time: RemoteInstant) =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -57,7 +57,7 @@ class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: M
     find(_.message == message, ReadReceiptDao.findForMessage(message)(_), identity)
 
   override def receipts(message: MessageId): Signal[Seq[ReadReceipt]] = {
-    val changed = onChanged.map(_.filter(_.message == message).map(_.id)).union(onDeleted.map(_.filter(_._1 == message)))
+    val changed = onChanged.map(_.filter(_.message == message).map(_.id)).zip(onDeleted.map(_.filter(_._1 == message)))
     RefreshingSignal[Seq[ReadReceipt]](getReceipts(message), changed)
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -129,7 +129,7 @@ class AccountManager(val userId:  UserId,
       selfClientId <- clientId
       fingerprint  <-
         if (userId == uId && selfClientId.contains(cId))
-          Signal.future(cryptoBox(Future successful _.getLocalFingerprint))
+          Signal.from(cryptoBox(Future successful _.getLocalFingerprint))
         else
           cryptoBox.sessions.remoteFingerprint(SessionId(uId, cId))
     } yield fingerprint

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -334,20 +334,20 @@ class AccountsServiceImpl(global: GlobalModule, kotlinLogoutEnabled: Boolean = f
   }
 
   override lazy val activeAccount = activeAccountManager.flatMap[Option[AccountData]] {
-    case Some(am) => Signal.future(storage).flatMap(_.optSignal(am.userId))
+    case Some(am) => Signal.from(storage).flatMap(_.optSignal(am.userId))
     case None     => Signal.const(None)
   }
 
   override lazy val activeAccountId = activeAccount.map(_.map(_.id))
 
   override lazy val activeZms = activeAccountManager.flatMap[Option[ZMessaging]] {
-    case Some(am) => Signal.future(am.zmessaging.map(Some(_)))
+    case Some(am) => Signal.from(am.zmessaging.map(Some(_)))
     case None     => Signal.const(None)
   }
 
   override lazy val zmsInstances = (for {
     ams <- accountManagers
-    zs  <- Signal.sequence(ams.map(am => Signal.future(am.zmessaging)).toSeq: _*)
+    zs  <- Signal.sequence(ams.map(am => Signal.from(am.zmessaging)).toSeq: _*)
   } yield
     returning(zs.toSet) { v =>
       verbose(l"Loaded: ${v.size} zms instances for ${ams.size} accounts")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
@@ -74,7 +74,7 @@ class ErrorsServiceImpl(userId:    UserId,
     errors
   }
 
-   private val onChanged = errorsStorage.onChanged.map(_ => System.currentTimeMillis()).union(errorsStorage.onDeleted.map(_ => System.currentTimeMillis()))
+   private val onChanged = errorsStorage.onChanged.map(_ => System.currentTimeMillis()).zip(errorsStorage.onDeleted.map(_ => System.currentTimeMillis()))
 
   def onErrorDismissed(handler: PartialFunction[ErrorData, Future[_]]): CancellableFuture[Unit] = dispatcher {
     dismissHandler = dismissHandler.orElse(handler)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -109,7 +109,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
 
   // a utility method for using `filterForExternal` with signals more easily
   private def filterForExternal(query: SearchQuery, searchResults: Signal[IndexedSeq[UserData]]): Signal[IndexedSeq[UserData]] =
-    searchResults.flatMap(res => Signal.future(filterForExternal(query, res)))
+    searchResults.flatMap(res => Signal.from(filterForExternal(query, res)))
 
   override def usersForNewConversation(query: SearchQuery, teamOnly: Boolean): Signal[SearchResults] =
     for {
@@ -218,7 +218,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
 
     val conversations: Signal[IndexedSeq[ConversationData]] =
       if (!query.isEmpty)
-        Signal.future(convsStorage.findGroupConversations(SearchKey(query.str), selfUserId, Int.MaxValue, handleOnly = query.handleOnly))
+        Signal.from(convsStorage.findGroupConversations(SearchKey(query.str), selfUserId, Int.MaxValue, handleOnly = query.handleOnly))
           .map(_.filter(conv => teamId.forall(conv.team.contains)).distinct.toIndexedSeq)
           .flatMap { convs =>
             val gConvs = convs.map { c =>
@@ -230,7 +230,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
                 case false => None
               }
             }
-            Signal.future(Future.sequence(gConvs).map(_.flatten)) //TODO avoid using Signal.future - will not update...
+            Signal.from(Future.sequence(gConvs).map(_.flatten)) //TODO avoid using Signal.future - will not update...
           }
       else Signal.const(IndexedSeq.empty)
 
@@ -240,7 +240,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       top        <- topUsers
       local      <- filterForExternal(query, searchLocal(query, showBlockedUsers = true))
       convs      <- conversations
-      isExternal <- Signal.future(isExternal)
+      isExternal <- Signal.from(isExternal)
       dir        <- filterForExternal(query, if (isExternal) Signal.const(IndexedSeq.empty[UserData]) else directorySearch)
     } yield SearchResults(top, local, convs, dir)
   }
@@ -268,7 +268,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
           usersInStorage(u.id).name != Name.Empty &&
           usersInStorage(u.id).picture.isDefined
       }
-      val allUsers = (local.map(u => usersInStorage(u.id)) ++ remote.map(UserData.apply)).toIndexedSeq
+      val allUsers = (local.map(u => usersInStorage(u.id)) ++ remote.map(UserData(_))).toIndexedSeq
 
       val handle = Handle(query.str)
       if (!allUsers.exists(_.handle.contains(handle)))
@@ -307,7 +307,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
       counts.filter(_._2 > 0).sortBy(_._2)(Ordering[Long].reverse).take(MaxTopPeople).map(_._1)
     }
 
-    Signal.future(loadTopUsers).map(_.toIndexedSeq)
+    Signal.from(loadTopUsers).map(_.toIndexedSeq)
   }
 
   private val topPeoplePredicate: UserData => Boolean = u => ! u.deleted && u.connection == ConnectionStatus.Accepted

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -136,7 +136,7 @@ class UserServiceImpl(selfUserId:        UserId,
     def initialLoad = usersStorage.list().map(_.map(user => user.id -> user.name).toMap)
 
     new AggregatingSignal[Map[UserId, Name], Map[UserId, Name]](
-      EventStream.union(added, updated),
+      EventStream.zip(added, updated),
       initialLoad,
       { (values, changes) => values ++ changes }
     )

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
@@ -40,7 +40,7 @@ class VersionBlacklistService(metadata: MetaDataService, prefs: GlobalPreference
   val lastCheckedVersion = prefs.preference[Int](LastCheckedVersion)
   val upToDatePref       = prefs.preference[Boolean](VersionUpToDate)
 
-  val upToDate = Signal(lastCheckedVersion.signal, upToDatePref.signal) map {
+  val upToDate = Signal.zip(lastCheckedVersion.signal, upToDatePref.signal) map {
     case (lastVersion, isUpToDate) => lastVersion != metadata.appVersion || isUpToDate
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -184,7 +184,7 @@ class GlobalRecordAndPlayService(cache: CacheService, context: Context, fileCach
   def playhead(key: MediaKey): Signal[bp.Duration] = stateSource flatMap {
     case Playing(_, `key`) =>
       ClockSignal(tickInterval).flatMap { i =>
-        Signal.future(duringIdentityTransition { case Playing(player, `key`) => player.playhead })
+        Signal.from(duringIdentityTransition { case Playing(player, `key`) => player.playhead })
       }
     case Paused(player, `key`, media, _) =>
       Signal.const(media.playhead)
@@ -201,7 +201,7 @@ class GlobalRecordAndPlayService(cache: CacheService, context: Context, fileCach
     stateSource.flatMap {
       case Recording(_, `key`, _, _, _, _) =>
         ClockSignal(tickInterval).flatMap { i =>
-          Signal.future(duringIdentityTransition { case Recording(recorder, `key`, _, _, _, _) => successful((peakLoudness(recorder.maxAmplitudeSinceLastCall), i)) })
+          Signal.from(duringIdentityTransition { case Recording(recorder, `key`, _, _, _, _) => successful((peakLoudness(recorder.maxAmplitudeSinceLastCall), i)) })
         }
       case other => Signal.empty[(Float, Instant)]
     }.onChanged.map { case (level, _) => level }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -273,7 +273,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     val onConvMemberDataChanged =
       membersStorage
         .onChanged.map(_.filter(_.convId == conv).map(m => m.userId -> (Option(m), true)))
-        .union(membersStorage.onDeleted.map(_.filter(_._2 == conv).map(_._1 -> (None, false)))).map(_.toMap)
+        .zip(membersStorage.onDeleted.map(_.filter(_._2 == conv).map(_._1 -> (None, false)))).map(_.toMap)
 
     new AggregatingSignal[Map[UserId, (Option[ConversationMemberData], Boolean)], Seq[ConversationMemberData]](
       onConvMemberDataChanged,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -192,7 +192,7 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
 
   override val foldersWithConvs: Signal[Map[FolderId, Set[ConvId]]] = {
     val changesStream: EventStream[(Set[FolderId], Set[FolderId], Map[FolderId, Set[ConvId]], Map[FolderId, Set[ConvId]])] =
-      EventStream.union(
+      EventStream.zip(
         foldersStorage.onDeleted.map            (cs => (cs.toSet,  Set.empty,          Map.empty,                                     Map.empty                                              )),
         foldersStorage.onAdded.map              (cs => (Set.empty, cs.map(_.id).toSet, Map.empty,                                     Map.empty                                              )),
         conversationFoldersStorage.onDeleted.map(cs => (Set.empty, Set.empty,          cs.groupBy(_._2).mapValues(_.map(_._1).toSet), Map.empty                                              )),

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -482,7 +482,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
 
   override def buttonsForMessage(msgId: MessageId): Signal[Seq[ButtonData]] = RefreshingSignal[Seq[ButtonData]](
     loader       = CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),
-    refreshEvent = EventStream.union(buttonsStorage.onChanged.map(_.map(_.id)), buttonsStorage.onDeleted)
+    refreshEvent = EventStream.zip(buttonsStorage.onChanged.map(_.map(_.id)), buttonsStorage.onDeleted)
   )
 
   override def clickButton(messageId: MessageId, buttonId: ButtonId): Future[Unit] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -97,7 +97,7 @@ class OtrServiceImpl(selfUserId:     UserId,
     // request self clients sync to update prekeys on backend
     // we've just created a session from message, this means that some user had to obtain our prekey from backend (so we can upload it)
     // using signal and sync interval parameter to limit requests to one an hour
-    Signal.wrap(sessions.onCreateFromMessage).throttle(15.seconds) { _ => clients.requestSyncIfNeeded(1.hour) }
+    Signal.from(sessions.onCreateFromMessage).throttle(15.seconds) { _ => clients.requestSyncIfNeeded(1.hour) }
   }
 
   override def parseGenericMessage(otrMsg: OtrMessageEvent, genericMsg: GenericMessage): Option[MessageEvent] = {
@@ -289,7 +289,7 @@ class OtrServiceImpl(selfUserId:     UserId,
   }
 
   def fingerprintSignal(userId: UserId, cId: ClientId): Signal[Option[Array[Byte]]] =
-    if (userId == selfUserId && cId == clientId) Signal.future(cryptoBox { cb => Future successful cb.getLocalFingerprint })
+    if (userId == selfUserId && cId == clientId) Signal.from(cryptoBox(cb => Future.successful(cb.getLocalFingerprint)))
     else cryptoBox.sessions.remoteFingerprint(SessionId(userId, cId))
 
   def encryptAssetDataCBC(key: AESKey, data: LocalData): Future[(Sha256, LocalData, EncryptionAlgorithm)] = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -79,7 +79,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
 
   private val schedulePushNotificationsToUi = Signal(false)
 
-  Signal(schedulePushNotificationsToUi, pushService.processing).onChanged {
+  Signal.zip(schedulePushNotificationsToUi, pushService.processing).onChanged {
     case (true, false) =>
       pushNotificationsToUi().map { _ => schedulePushNotificationsToUi ! false }
     case _ =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -122,13 +122,13 @@ class WSPushServiceImpl(userId:              UserId,
   private def webSocketProcessEngine(initialDelay: FiniteDuration): Subscription = {
     verbose(l"Constructing websocket engine subscription.")
     val events: EventStream[Either[ErrorResponse, SocketEvent]] = for {
-      _                 <- EventStream.wrap(Signal.future(CancellableFuture.delay(initialDelay)))
+      _                 <- EventStream.from(Signal.from(CancellableFuture.delay(initialDelay)))
       _                 =  info(l"Opening WebSocket... ${showString({if (retryCount.get() == 0) "" else s"Retry count: ${retryCount.get()}"})}")
-      accessTokenResult <- EventStream.wrap(Signal.future(accessTokenProvider.currentToken()))
+      accessTokenResult <- EventStream.from(Signal.from(accessTokenProvider.currentToken()))
       event             <- accessTokenResult match {
-        case Right(token)        => webSocketFactory.openWebSocket(requestCreator(token)).map(Right.apply)
-        case Left(errorResponse) => EventStream.wrap(Signal.const(Left(errorResponse)))
-      }
+                             case Right(token)        => webSocketFactory.openWebSocket(requestCreator(token)).map(Right.apply)
+                             case Left(errorResponse) => EventStream.from(Signal.const(Left(errorResponse)))
+                           }
     } yield event
 
     events.on(dispatcher) {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -117,7 +117,7 @@ class TeamsServiceImpl(selfUser:           UserId,
     case None => Signal.empty
     case Some(tId) =>
 
-      val changesStream = EventStream.union[Seq[ContentChange[UserId, UserData]]](
+      val changesStream = EventStream.zip[Seq[ContentChange[UserId, UserData]]](
         userStorage.onAdded.map(_.map(d => Added(d.id, d))),
         userStorage.onUpdated.map(_.map { case (prv, curr) => Updated(prv.id, prv, curr) }),
         userStorage.onDeleted.map(_.map(Removed(_)))
@@ -163,7 +163,7 @@ class TeamsServiceImpl(selfUser:           UserId,
     lazy val allChanges = {
       val ev1 = convMemberStorage.onUpdated.map(_.map(_._2.userId))
       val ev2 = convMemberStorage.onDeleted.map(_.map(_._1))
-      EventStream.union(ev1, ev2)
+      EventStream.zip(ev1, ev2)
     }
 
     teamId match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -101,7 +101,7 @@ class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: Zm
   import TrackingService._
 
   override lazy val isTrackingEnabled: Signal[Boolean] =
-    Signal.future(ZMessaging.globalModule).flatMap(_.prefs(analyticsPrefKey).signal)
+    Signal.from(ZMessaging.globalModule).flatMap(_.prefs(analyticsPrefKey).signal)
 
   val events = EventStream[(Option[ZMessaging], TrackingEvent)]()
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
@@ -69,7 +69,7 @@ class SyncSchedulerImpl(accountId:   UserId,
 
   private val waitEntries  = new mutable.HashMap[SyncId, WaitEntry]
   private val waiting      = Signal(Map.empty[SyncId, Long])
-  private val runningCount = Signal(executionsCount, waiting.map(_.size)) map { case (r, w) => r - w }
+  private val runningCount = Signal.zip(executionsCount, waiting.map(_.size)).map { case (r, w) => r - w }
 
   content.syncStorage { storage =>
     storage.getJobs.toSeq.sortBy(_.timestamp) foreach execute

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -766,7 +766,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(convSignal)
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head.map(_.map(_.userId)) }
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
-      (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.wrap(membersOnChanged))
+      (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.from(membersOnChanged))
       (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
       (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
@@ -840,7 +840,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(convSignal)
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head.map(_.map(_.userId)) }
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
-      (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.wrap(membersOnChanged))
+      (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.from(membersOnChanged))
       (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
       (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -94,7 +94,7 @@ package object testutils {
         override def onUnwire(): Unit = a.removeUpdateListener(this)
       }
 
-      def flatSignal[B](f: A => Signal[B]): Signal[B] = new FlatMapSignal(signal(identity), f)
+      def flatSignal[B](f: A => Signal[B]): Signal[B] = signal(identity).flatMap(f)
     }
 
     implicit class SignalToSink[A](val signal: Signal[A]) extends AnyVal {


### PR DESCRIPTION
This PR is mainly about making names of methods more consistent and about hiding classes which shouldn't be used directly. You can look to https://github.com/wireapp/wire-signals/pull/3 for a bit more details.

If during the code review you notice something you would like me to change in `wire-signals`, please write  it down in a comment too. I will contact you and try to include the proposed changes in the next `wire-signals` release. In other words, I'd like to merge this PR without making new changes to `wire-signals`.

#### APK
[Download build #2752](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2752/artifact/build/artifact/wire-dev-PR3019-2752.apk)