### PR TITLE
[Fix] : crash for missed group calls

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -484,7 +484,7 @@ object ConversationListRow {
             if (conv.unreadCount.total > 1 || conv.isAllMuted || conv.onlyMentionsAllowed)
               getQuantityString(R.plurals.conversation_list__missed_calls_plural, missedCallCount, missedCallCount.toString)
             else
-              getString(R.string.conversation_list__missed_calls_count_group, userName.get)
+              getString(R.string.conversation_list__missed_calls_count_group, userName.getOrElse(Name.Empty))
           } else {
             if (conv.unreadCount.total > 1 || conv.isAllMuted || conv.onlyMentionsAllowed)
               getQuantityString(R.plurals.conversation_list__missed_calls_plural, missedCallCount, missedCallCount.toString)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -484,7 +484,7 @@ object ConversationListRow {
             if (conv.unreadCount.total > 1 || conv.isAllMuted || conv.onlyMentionsAllowed)
               getQuantityString(R.plurals.conversation_list__missed_calls_plural, missedCallCount, missedCallCount.toString)
             else
-              getString(R.string.conversation_list__missed_calls_count_group, userName.getOrElse(Name.Empty))
+              getString(R.string.conversation_list__missed_calls_count_group, userName.getOrElse(Name.Empty).str)
           } else {
             if (conv.unreadCount.total > 1 || conv.isAllMuted || conv.onlyMentionsAllowed)
               getQuantityString(R.plurals.conversation_list__missed_calls_plural, missedCallCount, missedCallCount.toString)


### PR DESCRIPTION
## What's new in this PR?

### Issues

During receiving and starting audio and video calls, the app crashed on Android 10 device.

https://wearezeta.atlassian.net/browse/AN-7094

### Causes

--------- beginning of crash
09-16 12:15:28.057 E/AndroidRuntime(  773): FATAL EXCEPTION: main
09-16 12:15:28.057 E/AndroidRuntime(  773): Process: com.wire.internal, PID: 773
09-16 12:15:28.057 E/AndroidRuntime(  773): **java.util.NoSuchElementException: None.get**
09-16 12:15:28.057 E/AndroidRuntime(  773): 	at scala.None$.get(Option.scala:1347)
09-16 12:15:28.057 E/AndroidRuntime(  773): 	at com.waz.zclient.conversationlist.views.ConversationListRow$.subtitleStringForLastMessages(ConversationListRow.scala:487)

### Solutions

`userName.getOrElse(Name.Empty)`

#### APK
[Download build #2769](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2769/artifact/build/artifact/wire-dev-PR3025-2769.apk)