### PR TITLE
[Fix] : Sorting bug for video grid

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -216,11 +216,12 @@ class CallingFragment extends FragmentHelper {
         }
 
         val gridViews = views.filter {
-          case _:SelfVideoView if views.size == 2 && isVideoBeingSent => false
-          case _:SelfVideoView if views.size > 1 && !isVideoBeingSent => false
+          case _: SelfVideoView if views.size == 2 && isVideoBeingSent => false
+          case _: SelfVideoView if views.size > 1 && !isVideoBeingSent => false
           case _ => true
         }.sortWith {
-          case (_:SelfVideoView, _) => true
+          case (_: SelfVideoView, _) => true
+          case (_, _: SelfVideoView) => false
           case (v1, v2) => findParticipantNameById(v1.participant.userId).toLowerCase <
             findParticipantNameById(v2.participant.userId).toLowerCase
         }.take(maxVideoPreviews)


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR fixes a bug for conference calling grid video : Myself not always on first Place in Video Grid in a group of 12 video call participants.

https://wearezeta.atlassian.net/browse/AN-7052

### Causes

Missing a sort condition :   `case (_, _: SelfVideoView) => false`

#### APK
[Download build #2767](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2767/artifact/build/artifact/wire-dev-PR3026-2767.apk)