### PR TITLE
Fix: Support Java 8 features for API < 26

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,7 @@ object Libraries {
         const val pinEditText = "1.2.3"
         const val viewPager2 = "1.0.0"
         const val room = "2.2.5"
+        const val desugaring = "1.0.10"
     }
 
     const val appCompat        = "androidx.appcompat:appcompat:${Versions.jetpack}"
@@ -48,6 +49,7 @@ object Libraries {
     const val okHttpLogging    = "com.squareup.okhttp3:logging-interceptor:${Versions.okHttpLogging}"
     const val pinEditText      = "com.poovam:pin-edittext-field:${Versions.pinEditText}"
     const val viewPager2       = "androidx.viewpager2:viewpager2:${Versions.viewPager2}"
+    const val desugaring       = "com.android.tools:desugar_jdk_libs:${Versions.desugaring}"
 
     object Koin {
         const val androidCore  = "org.koin:koin-android:${Versions.koin}"

--- a/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
@@ -12,6 +12,10 @@ android {
     }
 
     compileOptions {
+        // support Java 8 features in API < 26
+        // https://developer.android.com/studio/write/java8-support#library-desugaring
+        coreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -19,4 +23,8 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+}
+
+dependencies {
+    coreLibraryDesugaring(Libraries.desugaring)
 }


### PR DESCRIPTION
**Problem:**
During acceptance tests, we noticed that some of the Java 8 features aren't fully supported in API levels < 26 (our minSdk level is 24).

```
com.wire.android.feature.auth.login.LoginViewPagerAdapterTest > createFragment_returnsEmailAndPhoneFragments[7.1.1(AVD) - 7.1.1] FAILED 
        java.lang.RuntimeException: java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/LocalDateTime;
        at androidx.test.runner.MonitoringInstrumentation.runOnMainSync(MonitoringInstrumentation.java:441)

com.wire.android.feature.auth.login.LoginViewPagerAdapterTest > getItemCount_returns2[7.1.1(AVD) - 7.1.1] FAILED 
        java.lang.RuntimeException: java.lang.NoClassDefFoundError: org.assertj.core.configuration.ConfigurationProvider
        at androidx.test.runner.MonitoringInstrumentation.runOnMainSync(MonitoringInstrumentation.java:441)
```

**Reason:** 
The aforementioned classes weren't present in created apk. I couldn't track down assertJ version, but I could find that [java.time package is added in API level 26](https://developer.android.com/reference/java/time/package-summary)

**Solution:**
Use Android's desugaring option to support Java 8+ on API levels < 26.
https://developer.android.com/studio/write/java8-support#library-desugaring