### PR TITLE
Fix: Acceptance tests for "Create Pro Account - Team Email" screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,10 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".feature.auth.registration.pro.email.CreateProAccountTeamEmailActivity"
+            android:theme="@style/AppTheme.Authentication" />
+
+        <activity
             android:name=".feature.auth.login.LoginActivity"
             android:theme="@style/AppTheme.Authentication" />
 

--- a/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
@@ -23,6 +23,7 @@ import com.wire.android.feature.auth.registration.personal.ui.CreatePersonalAcco
 import com.wire.android.feature.auth.registration.personal.ui.CreatePersonalAccountPasswordViewModel
 import com.wire.android.feature.auth.registration.personal.usecase.ActivateEmailUseCase
 import com.wire.android.feature.auth.registration.personal.usecase.RegisterPersonalAccountUseCase
+import com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailViewModel
 import com.wire.android.feature.auth.registration.pro.team.CreateProAccountTeamNameViewModel
 import com.wire.android.feature.auth.registration.pro.team.data.TeamDataSource
 import com.wire.android.feature.auth.registration.pro.team.data.TeamsRepository
@@ -74,6 +75,8 @@ private val createProAccountModule = module {
     factory { GetTeamNameUseCase(get()) }
     factory { UpdateTeamNameUseCase(get()) }
     single { TeamDataSource() as TeamsRepository }
+
+    viewModel { CreateProAccountTeamEmailViewModel(get()) }
 }
 
 private val loginModule = module {

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragment.kt
@@ -2,14 +2,15 @@ package com.wire.android.feature.auth.registration.pro.email
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility
 import com.wire.android.core.extension.showKeyboardWithFocusOn
+import com.wire.android.core.extension.toStringOrEmpty
 import kotlinx.android.synthetic.main.fragment_create_pro_account_team_email.*
-import kotlinx.android.synthetic.main.fragment_create_pro_account_team_name.*
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class CreateProAccountTeamEmailFragment : Fragment(
@@ -23,7 +24,7 @@ class CreateProAccountTeamEmailFragment : Fragment(
         super.onViewCreated(view, savedInstanceState)
         initTeamEmailHeader()
         initConfirmationButton()
-        observeTeamEmailInput()
+        initTeamEmailInput()
         requestKeyboardFocus()
     }
 
@@ -32,7 +33,7 @@ class CreateProAccountTeamEmailFragment : Fragment(
     }
 
     private fun initConfirmationButton() =
-        with(createProAccountTeamNameInputConfirmationButton) {
+        with(createProAccountTeamEmailInputConfirmationButton) {
             isEnabled = false
             setOnClickListener {
                 //TODO Go to team email verification screen
@@ -42,16 +43,19 @@ class CreateProAccountTeamEmailFragment : Fragment(
             }
         }
 
-    private fun observeTeamEmailInput() =
+    private fun initTeamEmailInput() =
         with(createProAccountTeamEmailViewModel) {
+            createProAccountTeamEmailEditText.doOnTextChanged { text, _, _, _ ->
+                onTeamEmailTextChanged(text.toStringOrEmpty())
+            }
             teamEmailLiveData.observe(viewLifecycleOwner) {
-                createProAccountTeamNameEditText.setText(it)
+                createProAccountTeamEmailEditText.setText(it)
             }
         }
 
     private fun requestKeyboardFocus() {
         if (inputFocusViewModel.canFocusWithKeyboard()) showKeyboardWithFocusOn(
-            createProAccountTeamNameEditText
+            createProAccountTeamEmailEditText
         )
     }
 }

--- a/app/src/main/res/layout/activity_create_pro_account_team_email.xml
+++ b/app/src/main/res/layout/activity_create_pro_account_team_email.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/createProAccountTeamEmailFragmentContainer"
     android:name="com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />


### PR DESCRIPTION
Fixes acceptance tests for the PR #68 

The failures and fixes are:

**1.**
```
java.lang.RuntimeException: Could not launch activity
Caused by: java.lang.RuntimeException: Unable to resolve activity for: Intent { act=android.intent.action.MAIN flg=0x10000000 cmp=com.wire.android.dev.debug/com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailActivity }
```
The activity wasn’t added into `AndroidManifest.xml `


**2.**
```
Caused by: java.lang.IllegalStateException: FragmentContainerView must have an android:id to add Fragment com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailFragment
```
Added an id to `FragmentContainerView`


**3.**
```
 Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.Button.setEnabled(boolean)' on a null object reference
```
The widget name should have been: `createProAccountTeamEmailInputConfirmationButton`


**4.**
```
Caused by: java.lang.IllegalStateException: createProAccountTeamNameEditText must not be null
```
The widget name should have been: `createProAccountTeamEmailEditText`


**5.**
```
Caused by: org.koin.core.error.NoBeanDefFoundException: No definition found for class:'com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailViewModel'. Check your definitions!
```
ViewModel wasn’t added to Koin module 


**6.**
```
inputTextIsNotEmpty_confirmationButtonShouldBeEnabled : FAILED
```
The view wasn’t connected to viewModel method
