### PR TITLE
Refactoring WSPushService + other changes required to make wire-android work with wire-signals 0.2.2

### DIFF
--- a/app/src/main/scala/com/waz/zclient/camera/views/CameraPreviewTextureView.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/views/CameraPreviewTextureView.scala
@@ -101,7 +101,7 @@ class CameraPreviewTextureView(val cxt: Context, val attrs: AttributeSet, val de
       case Success((previewSize, flashModes)) =>
         updateTextureMatrix((getWidth, getHeight), previewSize)
         observer.foreach(_.onCameraLoaded(flashModes.asJava))
-      case Failure(ex : CancelException) =>
+      case Failure(CancelException) =>
       case Failure(ex) =>
         Logger.warn("CameraPreviewTextureView", "Failed to open camera - camera is likely unavailable", ex)
         observer.foreach(_.onCameraLoadingFailed())

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -176,7 +176,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.2.1"
+    const val WIRE_SIGNALS = "0.2.2"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
@@ -129,8 +129,8 @@ class CacheServiceImpl(context: Context, storage: Database, cacheStorage: CacheS
         case Success((fileId, path, encKey, len)) =>
           verbose(l"added stream to storage: $path, with key: $encKey")
           add(CacheEntryData(key, timeout = timeout.timeout, path = Some(path), fileId = fileId, encKey = encKey, fileName = name, mimeType = mime, length = Some(len)))
-        case Failure(c: CancelException) =>
-          Future.failed(c)
+        case Failure(CancelException) =>
+          Future.failed(CancelException)
         case Failure(e) =>
           tracking.exception(e, s"addStream failed")
           Future.failed(e)
@@ -153,7 +153,7 @@ class CacheServiceImpl(context: Context, storage: Database, cacheStorage: CacheS
       def entry(d: File) = returning(entryFile(d, id))(_.getParentFile.mkdirs())
 
       Try(writer(outputStream(enc, new FileOutputStream(entry(dir))))).recoverWith {
-        case c: CancelException => Failure(c)
+        case CancelException => Failure(CancelException)
         case t: Throwable =>
           if (enc.isDefined) Try(writer(outputStream(None, new FileOutputStream(entry(intCacheDir)))))
           else Failure(t)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -118,7 +118,7 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
     import scala.concurrent.duration._
     for {
       _ <- Cancellable.cancel(UploadTaskKey(id))
-      _ <- CancellableFuture.timeout(3.seconds).future
+      _ <- CancellableFuture.delay(3.seconds).future
       _ <- uploadAssetStorage.update(id, asset => {
         if (asset.status == AssetStatus.Done) asset
         else asset.copy(status = UploadAssetStatus.Cancelled)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
@@ -157,7 +157,7 @@ class SyncSchedulerImpl(accountId:   UserId,
       val d = math.max(0, startJob - t).millis
       val delay = CancellableFuture.delay(d)
       for {
-        _ <- delay.recover { case _: CancelException => () } .future
+        _ <- delay.recover { case CancelException => () } .future
         _ <- Future.traverse(job.dependsOn)(await)
         _ <- queue.acquire(job.priority)
       } yield {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -23,7 +23,7 @@ import android.os.{Handler, HandlerThread, Looper}
 import com.waz.utils.returning
 import com.waz.zms.BuildConfig
 import com.wire.signals.Threading.{Cpus, executionContext}
-import com.wire.signals.{DispatchQueue, DispatchQueueStats, EventContext, EventStream, Events, LimitedDispatchQueue, Signal, Subscription}
+import com.wire.signals.{DispatchQueue, EventContext, EventStream, Events, LimitedDispatchQueue, Signal, Subscription}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
@@ -43,7 +43,7 @@ object Threading {
   final class UiDispatchQueue() extends DispatchQueue {
     private val handler = new Handler(Looper.getMainLooper)
 
-    override def execute(runnable: Runnable): Unit = handler.post(DispatchQueueStats("UiDispatchQueue", runnable))
+    override def execute(runnable: Runnable): Unit = handler.post(runnable)
   }
 
   object Implicits {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/IoUtils.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/IoUtils.scala
@@ -20,11 +20,11 @@ package com.waz.utils
 import java.io._
 import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.zip.{GZIPOutputStream, ZipEntry, ZipInputStream, ZipOutputStream}
+import java.util.zip.{GZIPOutputStream, ZipEntry, ZipOutputStream}
 
-import com.waz.log.BasicLogging.LogTag
 import com.waz.model.errors.FileSystemError
 import com.wire.signals.CancellableFuture
+import com.wire.signals.CancellableFuture.CancelException
 
 import scala.annotation.tailrec
 import scala.collection.Iterator.continually
@@ -208,12 +208,12 @@ object IoUtils {
 
 class CancellableStream(stream: InputStream, cancelled: AtomicBoolean) extends FilterInputStream(stream) {
   override def read(buffer: Array[Byte], byteOffset: Int, byteCount: Int): Int = {
-    if (cancelled.get) throw CancellableFuture.DefaultCancelException
+    if (cancelled.get) throw CancelException
     else super.read(buffer, byteOffset, byteCount)
   }
 
   override def read(): Int = {
-    if (cancelled.get) throw CancellableFuture.DefaultCancelException
+    if (cancelled.get) throw CancelException
     else super.read()
   }
 }


### PR DESCRIPTION
In `wire-signals 0.2.2`, I added methods `EventStream.from(future: Future)` and `EventStream.from(future: CancellableFuture)` which I wanted to use in `WSPushService`, becase until now to make an event stream out of a future this class used `EventStream.from(Signal.from(future: CancellableFuture))` which created an unnecessary signal in the middle. But while I worked on that, I noticed in the logs that WebSocket is opened and closed multiple times when only one operation was sufficient. I rewrote that code. I also experienced a bug when the WebSocket stopped responding after switcihng between two accounts several times, but I can't be sure if it was there before. Now I can't reproduce it anymore.

For information on what's included in `wire-signals 0.2.2`, please check here: https://github.com/wireapp/wire-signals/pull/5

#### APK
[Download build #2777](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2777/artifact/build/artifact/wire-dev-PR3027-2777.apk)