### PR TITLE
[Conf Calling]: Prepare for public launch

### DIFF
--- a/app/src/main/res/layout/calling_header.xml
+++ b/app/src/main/res/layout/calling_header.xml
@@ -40,20 +40,6 @@
             android:textSize="@dimen/wire__text_size__regular"
             app:themedColor="Primary" />
 
-        <TextView
-            android:id="@+id/conference_calling_badge"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginEnd="@dimen/wire__margin_huge"
-            android:background="@drawable/rounded_rectangle"
-            android:fontFamily="sans-serif-medium"
-            android:paddingTop="@dimen/wire__padding__1"
-            android:paddingBottom="@dimen/wire__padding__1"
-            android:text="@string/conference_calling_badge_title"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/wire__text_size__small" />
     </LinearLayout>
 
     <com.waz.zclient.ui.text.TypefaceTextView

--- a/app/src/main/res/layout/preferences_options_layout.xml
+++ b/app/src/main/res/layout/preferences_options_layout.xml
@@ -54,23 +54,6 @@
                 android:gravity="center_vertical"
                 android:paddingStart="@dimen/wire__padding__16"
                 android:paddingEnd="@dimen/wire__padding__16"
-                android:text="@string/pref_options_conference_calls_category_title"
-                android:textColor="@color/accent_blue" />
-
-            <com.waz.zclient.preferences.views.SwitchPreference
-                android:id="@+id/preferences_conference_calling"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/pref_options_conference_calls_beta_program_title"
-                app:subtitle="@string/pref_options_conference_calls_beta_program_summary"
-                app:title="@string/pref_options_conference_calls_beta_program_title" />
-
-            <com.waz.zclient.ui.text.TypefaceTextView
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/preference_button_height"
-                android:gravity="center_vertical"
-                android:paddingStart="@dimen/wire__padding__16"
-                android:paddingEnd="@dimen/wire__padding__16"
                 android:text="@string/pref_options_alerts_category_title"
                 android:textColor="@color/accent_blue" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,10 +503,6 @@
     <string name="pref_options_incognito_keyboard">Incognito keyboard</string>
     <string name="pref_options_incognito_keyboard_summary">The keyboard will not show suggestions when typing messages</string>
 
-    <string name="pref_options_conference_calls_category_title">Conference Calls</string>
-    <string name="pref_options_conference_calls_beta_program_title">Beta Program</string>
-    <string name="pref_options_conference_calls_beta_program_summary">When this is on, audio and video conference calling is enabled, which allows a higher number of participants.</string>
-
     <!-- Devices -->
     <string name="pref_devices_screen_title">Devices</string>
     <string name="pref_devices_current_device_category_title">Current Device</string>
@@ -1350,7 +1346,7 @@
     <string name="backup_import_error_wrong_account">You cannot restore history from a different account.</string>
     <string name="video_paused">Video paused</string>
     <string name="calling_degraded_title">New device</string>
-    <string name="call_info_text">Up to %1$s people can join a group conversation. Video calls work with up to %2$s other people and you.</string>
+    <string name="call_info">Up to %1$s people can join a group conversation.</string>
 
     <string name="markdown_link_dialog_title">Visit Link</string>
     <string name="markdown_link_dialog_message">This will take you to\n%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,7 +506,6 @@
     <string name="pref_options_conference_calls_category_title">Conference Calls</string>
     <string name="pref_options_conference_calls_beta_program_title">Beta Program</string>
     <string name="pref_options_conference_calls_beta_program_summary">When this is on, audio and video conference calling is enabled, which allows a higher number of participants.</string>
-    <string name="conference_calling_badge_title">CONFERENCE CALLING</string>
 
     <!-- Devices -->
     <string name="pref_devices_screen_title">Devices</string>

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -19,16 +19,13 @@ package com.waz.zclient.calling.views
 
 
 import android.content.Context
-import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.widget.{LinearLayout, TextView}
 import com.waz.content.UserPreferences
 import com.waz.threading.Threading._
 import com.waz.zclient.calling.controllers.CallController
-import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.common.views.GlyphButton
 import com.waz.zclient.utils.ContextUtils.getString
-import com.waz.zclient.utils.RichView
 import com.waz.zclient.{R, ViewHelper}
 import com.wire.signals.Signal
 
@@ -37,13 +34,11 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
   def this(context: Context) =  this(context, null)
 
   private val controller              = inject[CallController]
-  private lazy val accentColor        = inject[AccentColorController].accentColor
   private lazy val vbrSettingsEnabled = inject[Signal[UserPreferences]].flatMap(_.preference(UserPreferences.VBREnabled).signal)
 
   private lazy val nameView               = findById[TextView](R.id.ttv__calling__header__name)
   private lazy val subtitleView           = findById[TextView](R.id.ttv__calling__header__subtitle)
   private lazy val bitRateModeView        = findById[TextView](R.id.ttv__calling__header__bitrate)
-  private lazy val conferenceCallingBadge = findById[TextView](R.id.conference_calling_badge)
 
   lazy val closeButton: GlyphButton = findById[GlyphButton](R.id.calling_header_close)
 
@@ -51,12 +46,6 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
 
   controller.subtitleText.onUi(subtitleView.setText)
   controller.conversationName.onUi(nameView.setText(_))
-
-  controller.isConferenceCall.onUi(conferenceCallingBadge.setVisible)
-
-  accentColor.map(_.color).onUi { color =>
-    conferenceCallingBadge.getBackground.asInstanceOf[GradientDrawable].setColor(color)
-  }
 
   Signal.zip(controller.isCallEstablished, vbrSettingsEnabled, controller.isGroupCall, controller.cbrEnabled).map {
     case (true, _, false, Some(true)) => getString(R.string.audio_message_constant_bit_rate)

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -52,5 +52,4 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
     case (true, false, false, Some(false)) => getString(R.string.audio_message_variable_bit_rate)
     case _ => ""
   }.onUi(bitRateModeView.setText)
-
 }

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationSettingsFragment.scala
@@ -24,7 +24,6 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.{CompoundButton, ImageView, TextView}
 import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.appcompat.widget.SwitchCompat
-import com.waz.service.call.CallingService
 import com.wire.signals.Signal
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.UserAccountsController
@@ -48,7 +47,7 @@ class CreateConversationSettingsFragment extends Fragment with FragmentHelper {
   private lazy val convOptions = view[View](R.id.create_conv_options)
   private lazy val convOptionsArrow = view[ImageView](R.id.create_conv_options_icon)
   private lazy val callInfo = returning(view[TextView](R.id.call_info)) { vh =>
-    vh.foreach(_.setText(getString(R.string.call_info_text, ConversationController.MaxParticipants.toString, CallingService.videoCallMaxMembersExcludingSelf.toString)))
+    vh.foreach(_.setText(getString(R.string.call_info, ConversationController.MaxParticipants.toString)))
   }
 
   private lazy val readReceiptsToggle  = returning(view[SwitchCompat](R.id.read_receipts_toggle)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -33,7 +33,6 @@ import com.waz.content.UsersStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.SearchQuery
-import com.waz.service.call.CallingService
 import com.wire.signals._
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController
@@ -449,7 +448,7 @@ object ParticipantsAdapter {
         Selection.removeSelection(editText.getText)
       }
 
-      callInfo.setText(if (isTeam) getString(R.string.call_info_text, ConversationController.MaxParticipants.toString, CallingService.videoCallMaxMembersExcludingSelf.toString) else getString(R.string.empty_string))
+      callInfo.setText(if (isTeam) getString(R.string.call_info, ConversationController.MaxParticipants.toString) else getString(R.string.empty_string))
       callInfo.setMarginTop(getDimenPx(if (isTeam) R.dimen.wire__padding__16 else R.dimen.wire__padding__8)(view.getContext))
       callInfo.setMarginBottom(getDimenPx(if (isTeam) R.dimen.wire__padding__16 else R.dimen.wire__padding__8)(view.getContext))
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -70,7 +70,6 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   inflate(R.layout.preferences_options_layout)
 
   val vbrSwitch               = findById[SwitchPreference](R.id.preferences_vbr)
-  val conferenceCallingSwitch = findById[SwitchPreference](R.id.preferences_conference_calling)
   val vibrationSwitch         = findById[SwitchPreference](R.id.preferences_vibration)
   val darkThemeSwitch         = findById[SwitchPreference](R.id.preferences_dark_theme)
   val sendButtonSwitch        = findById[SwitchPreference](R.id.preferences_send_button)
@@ -99,7 +98,6 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   downloadImagesSwitch.setPreference(DownloadImagesAlways)
   hideScreenContentSwitch.setPreference(HideScreenContent)
   vbrSwitch.setPreference(VBREnabled)
-  conferenceCallingSwitch.setPreference(ConferenceCallingEnabled)
   messagePreviewSwitch.setPreference(MessagePreview)
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -37,7 +37,6 @@ import com.waz.model.{AccentColor, MessageContent => _, _}
 import com.waz.permissions.PermissionsService
 import com.waz.service.ZMessaging
 import com.waz.service.assets.{Content, ContentForUpload}
-import com.waz.service.call.CallingService
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.wire.signals.{EventStreamWithAuxSignal, Signal}
@@ -218,15 +217,9 @@ class ConversationFragment extends FragmentHelper {
       call                     <- callController.currentCallOpt
       isCallActive              = call.exists(_.convId == convId) && call.exists(_.selfParticipant.userId == selfUserId)
       isTeam                   <- accountsController.isTeam
-      prefs                    <- userPrefs
-      conferenceCallingEnabled <- prefs(UserPreferences.ConferenceCallingEnabled).signal
     } yield {
-      if (isCallActive || !isConvActive || participantsNumber <= 1)
-        Option.empty[Int]
-      else if (!isGroup || conferenceCallingEnabled || (isTeam && participantsNumber <= CallingService.LegacyVideoCallMaxMembers))
-        Some(R.menu.conversation_header_menu_video)
-      else
-        Some(R.menu.conversation_header_menu_audio)
+      if (isCallActive || !isConvActive || participantsNumber <= 1) Option.empty[Int]
+      else Some(R.menu.conversation_header_menu_video)
     }).onUi { id =>
       toolbar.getMenu.clear()
       id.foreach(toolbar.inflateMenu)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -500,5 +500,4 @@ object UserPreferences {
   lazy val FailedPasswordAttempts = PrefKey[Int]("failed_password_attempts", customDefault = 0)
 
   lazy val ShouldWarnAVSUpgrade = PrefKey[Boolean]("should_warn_avs_upgrade", customDefault = false)
-  lazy val ConferenceCallingEnabled = PrefKey[Boolean]("conference_calling_enabled", customDefault = false)
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -111,9 +111,6 @@ trait CallingService {
 
 object CallingService {
 
-  var LegacyVideoCallMaxMembers: Int = 4
-  def videoCallMaxMembersExcludingSelf: Int = LegacyVideoCallMaxMembers - 1
-
   trait AbstractCallProfile[A] {
 
     val calls: Map[A, CallInfo]
@@ -430,15 +427,12 @@ class CallingServiceImpl(val accountId:       UserId,
         profile                  <- callProfile.head
         isGroup                  <- convsService.isGroupConversation(convId)
         vbr                      <- userPrefs.preference(UserPreferences.VBREnabled).apply()
-        conferenceCallingEnabled <- userPrefs.preference(UserPreferences.ConferenceCallingEnabled).apply()
         convSize                 <- convsService.activeMembersData(conv.id).map(_.size).head
         callType =
-          if (!conferenceCallingEnabled && convSize > LegacyVideoCallMaxMembers) Avs.WCallType.ForcedAudio
-          else if (isVideo) Avs.WCallType.Video
+          if (isVideo) Avs.WCallType.Video
           else Avs.WCallType.Normal
         convType =
-          if (isGroup && conferenceCallingEnabled) Avs.WCallConvType.Conference
-          else if (isGroup && !conferenceCallingEnabled) Avs.WCallConvType.Group
+          if (isGroup) Avs.WCallConvType.Conference
           else Avs.WCallConvType.OneOnOne
         _ <- permissions.ensurePermissions(ListSet(android.Manifest.permission.RECORD_AUDIO) ++ (if(forceOption && isVideo) ListSet(android.Manifest.permission.CAMERA) else ListSet()))
         _ <-


### PR DESCRIPTION
## What's new in this PR?

In order to prepare the conference calling feature for public launch, we need to do the following tasks: 
- Remove conference calling badge https://wearezeta.atlassian.net/browse/AN-7095
- Remove toggle to join calling beta and allow only SFT conference calls for group calls https://wearezeta.atlassian.net/browse/AN-6984
- Update calling info copy by removing video group calling limit indication https://wearezeta.atlassian.net/browse/AN-7039

#### APK
[Download build #2779](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2779/artifact/build/artifact/wire-dev-PR3028-2779.apk)
[Download build #2792](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2792/artifact/build/artifact/wire-dev-PR3028-2792.apk)