### PR TITLE
Feat: User Session #4 - Save user data into local storage after login & registration

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/di/AuthenticationModule.kt
@@ -48,7 +48,7 @@ private val authenticationCommonModule = module {
 }
 
 private val createAccountModule = module {
-    single<RegistrationRepository> { RegistrationDataSource(get()) }
+    single<RegistrationRepository> { RegistrationDataSource(get(), get()) }
     factory { get<NetworkClient>().create(RegistrationApi::class.java) }
     factory { RegistrationRemoteDataSource(get(), get(), get(), get()) }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
@@ -27,7 +27,7 @@ class LoginWithEmailUseCase(
             else {
                 //TODO: find a suspendable Either solution
                 runBlocking {
-                    userRepository.save(session.userId).flatMap {
+                    userRepository.selfUser(accessToken = session.accessToken, tokenType = session.tokenType).flatMap {
                         runBlocking {
                             sessionRepository.save(session)
                         }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/RegistrationRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/RegistrationRepository.kt
@@ -2,7 +2,8 @@ package com.wire.android.feature.auth.registration
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
+import com.wire.android.shared.user.User
 
 interface RegistrationRepository {
-    suspend fun registerPersonalAccount(name: String, email: String, password: String, activationCode: String): Either<Failure, String>
+    suspend fun registerPersonalAccount(name: String, email: String, password: String, activationCode: String): Either<Failure, User>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSource.kt
@@ -5,12 +5,17 @@ import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.map
 import com.wire.android.feature.auth.registration.RegistrationRepository
 import com.wire.android.feature.auth.registration.datasource.remote.RegistrationRemoteDataSource
+import com.wire.android.shared.user.User
+import com.wire.android.shared.user.mapper.UserMapper
 
-class RegistrationDataSource(private val remoteDataSource: RegistrationRemoteDataSource) : RegistrationRepository {
+class RegistrationDataSource(
+    private val remoteDataSource: RegistrationRemoteDataSource,
+    private val userMapper: UserMapper
+) : RegistrationRepository {
 
     override suspend fun registerPersonalAccount(
         name: String, email: String, password: String, activationCode: String
-    ): Either<Failure, String> =
+    ): Either<Failure, User> =
         remoteDataSource.registerPersonalAccount(name = name, email = email, password = password, activationCode = activationCode)
-            .map { it.id }
+            .map { userMapper.fromRegisteredUserResponse(it) }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
@@ -28,6 +28,7 @@ class RegisterPersonalAccountUseCase(
             //TODO: find a suspendable Either solution
             runBlocking {
                 userRepository.save(it)
+                //TODO get session data
             }
         }!!
     }

--- a/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
@@ -12,6 +12,7 @@ class SessionDataSource(
     private val mapper: SessionMapper
 ) : SessionRepository {
 
+    //TODO: check isCurrent and if true, update older entities
     override suspend fun save(session: Session): Either<Failure, Unit> =
         localDataSource.save(mapper.toSessionEntity(session, true))
 }

--- a/app/src/main/kotlin/com/wire/android/shared/user/UserRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/UserRepository.kt
@@ -6,5 +6,5 @@ import com.wire.android.core.functional.Either
 interface UserRepository {
     suspend fun selfUser(accessToken: String, tokenType: String): Either<Failure, User>
 
-    suspend fun save(userId: String): Either<Failure, Unit>
+    suspend fun save(user: User): Either<Failure, Unit>
 }

--- a/app/src/main/kotlin/com/wire/android/shared/user/datasources/UserDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/datasources/UserDataSource.kt
@@ -2,12 +2,14 @@ package com.wire.android.shared.user.datasources
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
+import com.wire.android.core.functional.flatMap
 import com.wire.android.core.functional.map
 import com.wire.android.shared.user.User
 import com.wire.android.shared.user.UserRepository
 import com.wire.android.shared.user.datasources.local.UserLocalDataSource
 import com.wire.android.shared.user.datasources.remote.UserRemoteDataSource
 import com.wire.android.shared.user.mapper.UserMapper
+import kotlinx.coroutines.runBlocking
 
 class UserDataSource(
     private val localDataSource: UserLocalDataSource,
@@ -18,7 +20,10 @@ class UserDataSource(
     override suspend fun selfUser(accessToken: String, tokenType: String): Either<Failure, User> =
         remoteDataSource.selfUser(accessToken, tokenType).map {
             mapper.fromSelfUserResponse(it)
+        }.flatMap { user ->
+            runBlocking { save(user) }.map { user }
         }
 
-    override suspend fun save(userId: String): Either<Failure, Unit> = localDataSource.saveUser(userId)
+    override suspend fun save(user: User): Either<Failure, Unit> =
+        localDataSource.save(mapper.toUserEntity(user))
 }

--- a/app/src/main/kotlin/com/wire/android/shared/user/datasources/local/UserEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/datasources/local/UserEntity.kt
@@ -4,4 +4,4 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity(tableName = "user")
-data class UserEntity(@PrimaryKey val id: String) //TODO: add other fields as we need
+data class UserEntity(@PrimaryKey val id: String, val name: String, val email: String? = null)

--- a/app/src/main/kotlin/com/wire/android/shared/user/datasources/local/UserLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/datasources/local/UserLocalDataSource.kt
@@ -6,7 +6,7 @@ import com.wire.android.core.storage.db.DatabaseService
 
 class UserLocalDataSource(private val userDao: UserDao) : DatabaseService {
 
-    suspend fun saveUser(userId: String): Either<Failure, Unit> = request {
-        userDao.insert(UserEntity(userId))
+    suspend fun save(userEntity: UserEntity): Either<Failure, Unit> = request {
+        userDao.insert(userEntity)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/shared/user/mapper/UserMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/mapper/UserMapper.kt
@@ -1,10 +1,17 @@
 package com.wire.android.shared.user.mapper
 
+import com.wire.android.feature.auth.registration.datasource.remote.RegisteredUserResponse
 import com.wire.android.shared.user.User
+import com.wire.android.shared.user.datasources.local.UserEntity
 import com.wire.android.shared.user.datasources.remote.SelfUserResponse
 
 class UserMapper {
 
     fun fromSelfUserResponse(response: SelfUserResponse) =
         User(id = response.id, name = response.name, email = response.email)
+
+    fun fromRegisteredUserResponse(response: RegisteredUserResponse) =
+        User(id = response.id, name = response.name, email = response.email)
+
+    fun toUserEntity(user: User) = UserEntity(id = user.id, name = user.name, email = user.email)
 }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.wire.android.core.functional.Either
 import com.wire.android.feature.auth.registration.RegistrationRepository
 import com.wire.android.framework.functional.assertLeft
 import com.wire.android.framework.functional.assertRight
+import com.wire.android.shared.user.User
 import com.wire.android.shared.user.UserRepository
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -27,6 +28,9 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var user: User
+
     private lateinit var useCase: RegisterPersonalAccountUseCase
 
     @Before
@@ -37,13 +41,13 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
     @Test
     fun `given run is called, when registrationRepository and userRepository return success, then returns success`() {
         runBlocking {
-            mockRepositoryResponse(Either.Right(TEST_USER_ID))
-            `when`(userRepository.save(TEST_USER_ID)).thenReturn(Either.Right(Unit))
+            mockRepositoryResponse(Either.Right(user))
+            `when`(userRepository.save(user)).thenReturn(Either.Right(Unit))
 
             val result = useCase.run(params)
 
             verify(registrationRepository).registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
-            verify(userRepository).save(TEST_USER_ID)
+            verify(userRepository).save(user)
             result.assertRight()
         }
     }
@@ -108,9 +112,9 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
     @Test
     fun `given run is called, when registrationRepository returns success but userRepository fails, then returns that failure`() {
         runBlocking {
-            mockRepositoryResponse(Either.Right(TEST_USER_ID))
+            mockRepositoryResponse(Either.Right(user))
             val failure = DatabaseFailure()
-            `when`(userRepository.save(TEST_USER_ID)).thenReturn(Either.Left(failure))
+            `when`(userRepository.save(user)).thenReturn(Either.Left(failure))
 
             val result = useCase.run(params)
 
@@ -120,10 +124,8 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
         }
     }
 
-    private fun mockRepositoryResponse(response: Either<Failure, String>) {
-        runBlocking {
-            `when`(registrationRepository.registerPersonalAccount(any(), any(), any(), any())).thenReturn(response)
-        }
+    private suspend fun mockRepositoryResponse(response: Either<Failure, User>) {
+        `when`(registrationRepository.registerPersonalAccount(any(), any(), any(), any())).thenReturn(response)
     }
 
     companion object {
@@ -131,7 +133,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
         private const val TEST_EMAIL = "email"
         private const val TEST_PASSWORD = "password"
         private const val TEST_ACTIVATION_CODE = "123456"
-        private const val TEST_USER_ID = "2345-sdlfk-234"
+
         private val params = RegisterPersonalAccountParams(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/shared/user/datasources/local/UserLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/shared/user/datasources/local/UserLocalDataSourceTest.kt
@@ -17,6 +17,9 @@ class UserLocalDataSourceTest : UnitTest() {
     @Mock
     private lateinit var userDao: UserDao
 
+    @Mock
+    private lateinit var userEntity: UserEntity
+
     private lateinit var userLocalDataSource : UserLocalDataSource
 
     @Before
@@ -25,25 +28,20 @@ class UserLocalDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given saveUser is called, when dao insertion is successful, then returns success`() {
+    fun `given save is called, when dao insertion is successful, then returns success`() {
         runBlockingTest {
-            `when`(userDao.insert(USER_ENTITY)).thenReturn(Unit)
+            `when`(userDao.insert(userEntity)).thenReturn(Unit)
 
-            userLocalDataSource.saveUser(TEST_USER_ID).assertRight()
+            userLocalDataSource.save(userEntity).assertRight()
         }
     }
 
     @Test
-    fun `given saveUser is called, when dao insertion fails, then returns failure`() {
+    fun `given save is called, when dao insertion fails, then returns failure`() {
         runBlockingTest {
-            `when`(userDao.insert(USER_ENTITY)).thenThrow(RuntimeException())
+            `when`(userDao.insert(userEntity)).thenThrow(RuntimeException())
 
-            userLocalDataSource.saveUser(TEST_USER_ID).onSuccess { fail("Expected a failure") }
+            userLocalDataSource.save(userEntity).onSuccess { fail("Expected a failure") }
         }
-    }
-
-    companion object {
-        private const val TEST_USER_ID = "3324flkdnvdf"
-        private val USER_ENTITY = UserEntity(TEST_USER_ID)
     }
 }


### PR DESCRIPTION
After login:
- Sends a `/self` request and saves received `user` data
- Saves `session` info from login response

After registration
- Saves `user` info from registration response


#### This PR finalises "User Session" flow for "Login with e-mail" feature.

**TODO:**
- Save session info after registration
- Ensure that there is at most one `session` where `is_current = true`