### PR TITLE
[Conference Calling] Bugfix: Show VBR/CBR info only once the call is established

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -58,9 +58,9 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
     conferenceCallingBadge.getBackground.asInstanceOf[GradientDrawable].setColor(color)
   }
 
-  Signal.zip(vbrSettingsEnabled, controller.isGroupCall, controller.cbrEnabled).map {
-    case (false, false, true) => getString(R.string.audio_message_constant_bit_rate)
-    case (false, false, false) => getString(R.string.audio_message_variable_bit_rate)
+  Signal.zip(controller.isCallEstablished, vbrSettingsEnabled, controller.isGroupCall, controller.cbrEnabled).map {
+    case (true, false, false, Some(true)) => getString(R.string.audio_message_constant_bit_rate)
+    case (true, false, false, Some(false)) => getString(R.string.audio_message_variable_bit_rate)
     case _ => ""
   }.onUi(bitRateModeView.setText)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -45,7 +45,7 @@ case class CallInfo(convId:             ConvId,
                     otherParticipants:  Set[Participant]             = Set.empty,
                     maxParticipants:    Int                          = 0, //maintains the largest number of users that were ever in the call (for tracking)
                     muted:              Boolean                      = false,
-                    isCbrEnabled:       Boolean                      = false,
+                    isCbrEnabled:       Option[Boolean]              = None,
                     startedAsVideoCall: Boolean                      = false,
                     videoSendState:     VideoState                   = VideoState.Stopped,
                     videoReceiveStates: Map[Participant, VideoState] = Map.empty,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -383,7 +383,7 @@ class CallingServiceImpl(val accountId:       UserId,
   def onBitRateStateChanged(enabled: Boolean): Unit =
     updateActiveCallAsync { (_, _, call) =>
       verbose(l"onBitRateStateChanged enabled=$enabled")
-      call.copy(isCbrEnabled = enabled)
+      call.copy(isCbrEnabled = Some(enabled))
     }("onBitRateStateChanged")
 
   def onVideoStateChanged(userId: String, clientId: String, videoReceiveState: VideoState): Future[Unit] =


### PR DESCRIPTION
## What's new in this PR?

### Issues

A wrong bitrate stat is shown when the call is ringing.

### Causes

Missing the check wether the call is established or not. 

### Solutions

Wait for the call to be established, then show to constant bitrate info.

https://wearezeta.atlassian.net/browse/AN-6970

#### APK
[Download build #2781](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2781/artifact/build/artifact/wire-dev-PR3030-2781.apk)