### PR TITLE
Refactor: Session - Make access token and token type nullable

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
@@ -23,8 +23,9 @@ class LoginWithEmailUseCase(
         loginRepository.loginWithEmail(email = params.email, password = params.password).fold({
             handleFailure(it)
         }) { session ->
-            if (session == Session.EMPTY)  Either.Left(SessionCredentialsMissing)
-            else {
+            if (session == Session.EMPTY || session.accessToken == null || session.tokenType == null) {
+                Either.Left(SessionCredentialsMissing)
+            } else {
                 //TODO: find a suspendable Either solution
                 runBlocking {
                     userRepository.selfUser(accessToken = session.accessToken, tokenType = session.tokenType).flatMap {

--- a/app/src/main/kotlin/com/wire/android/shared/session/Session.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/Session.kt
@@ -4,11 +4,11 @@ import com.wire.android.core.extension.EMPTY
 
 data class Session(
     val userId: String,
-    val accessToken: String,
-    val tokenType: String,
+    val accessToken: String? = null,
+    val tokenType: String? = null,
     val refreshToken: String
 ) {
     companion object {
-        val EMPTY = Session(String.EMPTY, String.EMPTY, String.EMPTY, String.EMPTY)
+        val EMPTY = Session(String.EMPTY, null, null, String.EMPTY)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/shared/session/datasources/local/SessionEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/datasources/local/SessionEntity.kt
@@ -17,8 +17,8 @@ import com.wire.android.shared.user.datasources.local.UserEntity
 data class SessionEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     @ColumnInfo(name = "user_id") val userId: String,
-    @ColumnInfo(name = "access_token") val accessToken: String,
-    @ColumnInfo(name = "token_type") val tokenType: String,
+    @ColumnInfo(name = "access_token") val accessToken: String? = null,
+    @ColumnInfo(name = "token_type") val tokenType: String? = null,
     @ColumnInfo(name = "refresh_token") val refreshToken: String,
     @ColumnInfo(name = "is_current") val isCurrent: Boolean
 )

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCaseTest.kt
@@ -118,6 +118,37 @@ class LoginWithEmailUseCaseTest : UnitTest() {
     }
 
     @Test
+    fun `given run is called, when loginRepository returns a session with null access token, then returns SessionCredentialsMissing`() {
+        runBlocking {
+            `when`(loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD)).thenReturn(Either.Right(
+                Session("user-id", null, TEST_TOKEN_TYPE, "refresh-token")
+            ))
+
+            val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
+
+            result.assertLeft {
+                assertThat(it).isEqualTo(SessionCredentialsMissing)
+            }
+            verifyNoInteractions(userRepository)
+        }
+    }
+
+    @Test
+    fun `given run is called, when loginRepository returns a session with null token type, then returns SessionCredentialsMissing`() {
+        runBlocking {
+            `when`(loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD)).thenReturn(Either.Right(
+                Session("user-id", TEST_ACCESS_TOKEN, null, "refresh-token")
+            ))
+            val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
+
+            result.assertLeft {
+                assertThat(it).isEqualTo(SessionCredentialsMissing)
+            }
+            verifyNoInteractions(userRepository)
+        }
+    }
+
+    @Test
     fun `given run is called, when loginRepository returns success but userRepository fails to get self user, then returns failure`() {
         runBlocking {
             val failure = DatabaseFailure()


### PR DESCRIPTION
We don't receive access token and token type from registration response, so it is possible that they can be null in the database until another network call is made to get them.