### PR TITLE
Bump AVS version to 6.4.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.3.4@aar'
+    customAvsVersion = '6.4.1@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'


### PR DESCRIPTION
## What's new in this PR?

Bump AVS version to 6.4.1

#### APK
[Download build #2784](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2784/artifact/build/artifact/wire-dev-PR3031-2784.apk)