### PR TITLE
[Conference Calling] Bugfix: VBR/CBR label visibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ ext {
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.3.4@aar'
+    customAvsVersion = '6.4.1@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -59,7 +59,7 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
   }
 
   Signal.zip(controller.isCallEstablished, vbrSettingsEnabled, controller.isGroupCall, controller.cbrEnabled).map {
-    case (true, false, false, Some(true)) => getString(R.string.audio_message_constant_bit_rate)
+    case (true, _, false, Some(true)) => getString(R.string.audio_message_constant_bit_rate)
     case (true, false, false, Some(false)) => getString(R.string.audio_message_variable_bit_rate)
     case _ => ""
   }.onUi(bitRateModeView.setText)


### PR DESCRIPTION
## What's new in this PR?

Another fix for variable bitrate/constant bitrate label. The only time the CBR label is not displayed is when both clients do NOT have CBR enabled. Otherwise, both clients should show it.

https://wearezeta.atlassian.net/browse/AN-6970
#### APK
[Download build #2785](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2785/artifact/build/artifact/wire-dev-PR3032-2785.apk)