### PR TITLE
BI spec changes

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -32,7 +32,6 @@ import com.waz.model._
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
 import com.waz.service.AccountsService.UserInitiated
 import com.waz.service.ZMessaging.clock
-import com.waz.service.tracking.TrackingService
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
@@ -275,8 +274,6 @@ class MainActivity extends BaseActivity
     for {
       _      <- initTracking
       _      <- inject[GlobalTrackingController].start(this)
-      userId <- inject[Signal[ZMessaging]].head.map(_.selfUserId)
-      _      <- inject[TrackingService].appOpen(userId)
     } yield ()
 
     val intent = getIntent

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -246,6 +246,9 @@ class MainActivity extends BaseActivity
   private def initTracking: Future[Unit] =
     for {
       prefs            <- userPreferences.head
+      id               <- prefs.preference(CountlyTrackingId).apply()
+      _                <-
+        if(id.isEmpty) prefs.preference(CountlyTrackingId) := Some(TrackingId()) else Future.successful(())
       check            <- prefs.preference[Boolean](TrackingEnabledOneTimeCheckPerformed).apply()
       analyticsEnabled <- prefs.preference[Boolean](TrackingEnabled).apply()
       isProUser        <- userAccountsController.isProUser

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -48,9 +48,9 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
 
   def init(): Future[Unit] = {
     for {
-      ap          <- tracking.isTrackingEnabled.head if(ap)
-      trackingId  <- am.head.flatMap(_.storage.userPrefs(CountlyTrackingId).apply())
-      logsEnabled <- inject[LogsService].logsEnabled
+      ap               <- tracking.isTrackingEnabled.head if(ap)
+      Some(trackingId) <- am.head.flatMap(_.storage.userPrefs(CountlyTrackingId).apply())
+      logsEnabled      <- inject[LogsService].logsEnabled
     } yield {
       verbose(l"Using countly Id: ${trackingId.str}")
 

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -54,7 +54,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
     } yield {
       verbose(l"Using countly Id: ${trackingId.str}")
 
-      val config = new CountlyConfig(cxt, BuildConfig.COUNTLY_APP_KEY, BuildConfig.COUNTLY_SERVER_URL)
+      val config = new CountlyConfig(cxt, GlobalTrackingController.countlyAppKey, BuildConfig.COUNTLY_SERVER_URL)
         .setLoggingEnabled(logsEnabled)
         .setIdMode(DeviceId.Type.DEVELOPER_SUPPLIED)
         .setDeviceId(trackingId.str)
@@ -126,4 +126,16 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventCo
     verbose(l"send countly event: $eventArg")
     Countly.sharedInstance().events().recordEvent(eventArg.name, eventArg.segments.asJava)
   }
+}
+
+object GlobalTrackingController {
+  val internalCountlyAppKey = "18bfffddd3a2a89b6a70bbe6569cc041b17a52d2"
+  val demoCountlyAppKey = "af153753b54e3e8365cd928d30f86b88c164a666"
+
+  val countlyAppKey: String = BuildConfig.FLAVOR match {
+    case "internal" => internalCountlyAppKey
+    case "dev" => demoCountlyAppKey
+    case _ => BuildConfig.COUNTLY_APP_KEY
+  }
+
 }

--- a/default.json
+++ b/default.json
@@ -43,6 +43,6 @@
   "safe_logging": false,
   "file_restriction_enabled": false,
   "file_restriction_list":  "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
-  "countly_server_url": "https://wire.count.ly",
-  "countly_app_key": "9927e629a9302b8c800fc60055723362b0608f19"
+  "countly_server_url": "https://countly.wire.com",
+  "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6"
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -434,7 +434,7 @@ object UserPreferences {
 
   lazy val CrashesAndAnalyticsRequestShown = PrefKey[Boolean]("usage_data_permissions_shown", customDefault = true) //true to avoid harassing existing users
   lazy val AskMarketingConsentAgain = PrefKey[Boolean]("ask_marketing_consent_again") //used if the user views privacy policy instead of giving consent
-  lazy val CountlyTrackingId = PrefKey[TrackingId]("tracking_id", customDefault = TrackingId())
+  lazy val CountlyTrackingId = PrefKey[Option[TrackingId]]("tracking_id", customDefault = None)
   lazy val TrackingEnabled = PrefKey[Boolean]("countly_analytics_enabled", customDefault = false)
   lazy val TrackingEnabledOneTimeCheckPerformed = PrefKey[Boolean]("analytics_enabled_one_time_check", customDefault = false)
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR introduces some fixes that are due to changes in the BI spec, and some bug fixes.

The countly service is now pointed at Wire's hosted instance, using the demo and internal app keys for build where appropriate.

The `app.open` event is now only sent once, and the init is only performed once, per launch.

I also noticed that the old method of setting the `TrackingId` was resulting in new id every launch sometimes. So I switched to a more manual method which should be more reliable.

### Testing

Testing was done manually.
#### APK
[Download build #2791](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2791/artifact/build/artifact/wire-dev-PR3036-2791.apk)