### PR TITLE
fix: TrackingService methods crash if tracking is disabled

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -456,19 +456,18 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
 
   }
 
-  private def checkForPlayServices(prefs: GlobalPreferences, googleApi: GoogleApi): Unit = {
-    val gps = prefs(GlobalPreferences.CheckedForPlayServices)
-    gps.signal.head.collect {
+  private def checkForPlayServices(prefs: GlobalPreferences, googleApi: GoogleApi) =
+    prefs(GlobalPreferences.CheckedForPlayServices).apply().foreach {
       case false =>
         verbose(l"never checked for play services")
         googleApi.isGooglePlayServicesAvailable.head.foreach { gpsAvailable =>
           for {
             _ <- prefs(GlobalPreferences.WsForegroundKey) := !gpsAvailable
-            _ <- gps := true
+            _ <- prefs(GlobalPreferences.CheckedForPlayServices) := true
           } yield ()
         }
+      case true =>
     }
-  }
 
   override def onTerminate(): Unit = {
     controllerFactory.tearDown()

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
@@ -144,8 +144,9 @@ class ImageFragment extends FragmentHelper {
 
         method.foreach { m =>
           getFragmentManager.popBackStack()
-          imageInput.head.collect { case Some(id: AssetId) => id }.foreach {
-            screenController.showSketch ! Sketch.asset(_, m)
+          imageInput.head.foreach {
+            case Some(id: AssetId) => screenController.showSketch ! Sketch.asset(id, m)
+            case _ =>
           }
         }
       case item: MessageActionToolbarItem =>

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -788,10 +788,12 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(convSignal.head)
       (content.updateConversationName _).expects(convId, *).once().onCall { (_: ConvId, name: Name) =>
-        convSignal.head.collect { case Some(conv) =>
-          val newConv = conv.copy(name = Some(name))
-          convSignal ! Some(newConv)
-          Some((conv, newConv))
+        convSignal.head.map {
+          case Some(conv) =>
+            val newConv = conv.copy(name = Some(name))
+            convSignal ! Some(newConv)
+            Some((conv, newConv))
+          case _ => None
         }
       }
       (messages.addMemberLeaveMessage _).expects(convId, *, *).anyNumberOfTimes().returning(Future.successful(()))
@@ -862,10 +864,12 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(convSignal.head)
       (content.updateConversationName _).expects(convId, *).once().onCall { (_: ConvId, name: Name) =>
-        convSignal.head.collect { case Some(conv) =>
-          val newConv = conv.copy(name = Some(name))
-          convSignal ! Some(newConv)
-          Some((conv, newConv))
+        convSignal.head.map {
+          case Some(conv) =>
+            val newConv = conv.copy(name = Some(name))
+            convSignal ! Some(newConv)
+            Some((conv, newConv))
+          case _ => None
         }
       }
       (messages.addMemberLeaveMessage _).expects(convId, *, *).anyNumberOfTimes().returning(Future.successful(()))


### PR DESCRIPTION
Methods of the new TrackingService implementation used `isTrackingEnabled.head.collect { case true => ... }` to check
if the tracking was enabled, and if yes, then to perform some actions. What should supposed to happen if tracking was
disabled was not specified. In such cases, Future.collect failed with `NoSuchElementException` even though in all places
where those methods were used, we expected the successful result (of the type Unit).

This mistake is easy to make because in collections, e.g. `Seq.collect`, if the case for `collect` is not specified,
we will simply get an empty collection. Also, if we use `Future.collect` but expect `Unit` in return, it's ok to allow
`collect` to fail. But if we expect `Future[Unit]` we need to use `Future.map` or `Future.flatMap` and specify what
should happen in all possible cases.

I introduced a special private method `withTracking` which hides these details and requires only the implementation of
what should happen if tracking is enabled. It also prevents the future from failing for other reasons (since this is
TrackingService I assumed that even if something fails in it, it shouldn't crash the app).

I looked through the rest of the code and changed from `Future.collect` to `Future.foreach` and `Future.map` in a few
more cases.

Most of modified lines are only because of indentation.
#### APK
[Download build #2806](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2806/artifact/build/artifact/wire-dev-PR3039-2806.apk)