### PR TITLE
fix: (Analytics) Wrong toggles displayed on Data Usage Permission Page

### DIFF
--- a/app/src/main/res/layout/data_usage_permissions_layout.xml
+++ b/app/src/main/res/layout/data_usage_permissions_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2018 Wire Swiss GmbH
@@ -19,50 +18,44 @@
 
 -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto"
-       android:orientation="vertical"
-       android:layout_width="match_parent"
-       android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-    >
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-        >
+            android:orientation="vertical">
 
             <com.waz.zclient.preferences.views.SwitchPreference
-                android:id="@+id/preferences_send_anonymous_data"
+                android:id="@+id/preferences_send_anonymous_crash_report_data"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:title="@string/pref_advanced_send_anonymous_data_title"
-                app:subtitle="@string/pref_advanced_send_anonymous_data_summary"
-            />
+                app:subtitle="@string/pref_advanced_send_anonymous_crash_reports_summary"
+                app:title="@string/pref_advanced_send_anonymous_crash_reports_title" />
 
             <com.waz.zclient.preferences.views.SwitchPreference
-                android:id="@+id/preferences_send_analytics_data"
+                android:id="@+id/preferences_send_anonymous_usage_data"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/wire__padding__20"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:title="@string/pref_advanced_send_analytics_data_title"
-                app:subtitle="@string/pref_advanced_send_analytics_data_summary"
-                />
+                app:subtitle="@string/pref_advanced_send_anonymous_usage_data_summary"
+                app:title="@string/pref_advanced_send_anonymous_usage_data_title" />
 
             <com.waz.zclient.preferences.views.SwitchPreference
                 android:id="@+id/preferences_receive_news_and_offers"
-                android:layout_marginTop="@dimen/wire__padding__20"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:title="@string/pref_advanced_receive_news_and_offers_title"
+                android:layout_marginTop="@dimen/wire__padding__20"
                 app:subtitle="@string/pref_advanced_receive_news_and_offers_summary"
-            />
+                app:title="@string/pref_advanced_receive_news_and_offers_title" />
 
         </LinearLayout>
-
     </ScrollView>
-
+    ]
 </merge>

--- a/app/src/main/res/layout/data_usage_permissions_layout.xml
+++ b/app/src/main/res/layout/data_usage_permissions_layout.xml
@@ -57,5 +57,4 @@
 
         </LinearLayout>
     </ScrollView>
-    ]
 </merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,11 +462,10 @@
 
 
     <!-- Data Usage Permissions -->
-
-    <string name="pref_advanced_send_anonymous_data_title">Send anonymous crash reports</string>
-    <string name="pref_advanced_send_anonymous_data_summary">Send anonymous crash reports and basic data like version number and operating system to help Wire identify and solve issues in the app.</string>
-    <string name="pref_advanced_send_analytics_data_title">Send anonymous usage data</string>
-    <string name="pref_advanced_send_analytics_data_summary">Usage data allows Wire to understand how the app is being used and how it can be improved. The data is anonymous and does not include the content of your communications (such as messages, files or calls).</string>
+    <string name="pref_advanced_send_anonymous_crash_reports_title">Send anonymous crash reports</string>
+    <string name="pref_advanced_send_anonymous_crash_reports_summary">Send anonymous crash reports and basic data like version number and operating system to help Wire identify and solve issues in the app.</string>
+    <string name="pref_advanced_send_anonymous_usage_data_title">Send anonymous usage data</string>
+    <string name="pref_advanced_send_anonymous_usage_data_summary">Usage data allows Wire to understand how the app is being used and how it can be improved. The data is anonymous and does not include the content of your communications (such as messages, files or calls).</string>
     <string name="pref_advanced_receive_news_and_offers_title">Receive Newsletter</string>
     <string name="pref_advanced_receive_news_and_offers_summary">Receive news and product updates from Wire via email.</string>
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -249,7 +249,7 @@ class MainActivity extends BaseActivity
       _                <- if (id.isEmpty) prefs.preference(CountlyTrackingId) := Some(TrackingId()) else Future.successful(())
       check            <- prefs.preference[Boolean](TrackingEnabledOneTimeCheckPerformed).apply()
       analyticsEnabled <- prefs.preference[Boolean](TrackingEnabled).apply()
-      isProUser        <- userAccountsController.isProUser
+      isProUser        <- userAccountsController.isProUser.head
       _                <-
         if(!check) {
           (prefs(TrackingEnabled) := isProUser)

--- a/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
@@ -91,14 +91,14 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
 
   lazy val isWireless: Future[Boolean] = for {
     z <- zms.head
-    Some(userData) <- z.usersStorage.get(z.selfUserId)
-  } yield userData.expiresAt.isDefined
+    isWireless <- z.usersStorage.get(z.selfUserId).map(_.isDefined)
+  } yield isWireless
 
   lazy val isProUser: Future[Boolean] =
     for {
       isWireless <- isWireless
-      teamId <- zms.head.map(_.teamId)
-    } yield teamId.isDefined || isWireless
+      isTeam     <- zms.head.map(_.teamId).map(_.isDefined)
+    } yield isTeam || isWireless
 
   lazy val hasCreateConvPermission: Signal[Boolean] = teamId.flatMap {
     case Some(_) => selfPermissions.map(_.contains(CreateConversation))

--- a/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
@@ -27,12 +27,12 @@ import com.waz.model._
 import com.waz.service.AccountsService.{ClientDeleted, InvalidCookie, LogoutReason, UserInitiated}
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, EventStream, Signal}
+import com.waz.threading.Threading._
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
-import com.waz.zclient.{BuildConfig, Injectable, Injector}
 import com.waz.zclient.log.LogUI._
-import com.waz.threading.Threading._
+import com.waz.zclient.{BuildConfig, Injectable, Injector}
+import com.wire.signals.{EventContext, EventStream, Signal}
 
 import scala.concurrent.Future
 
@@ -89,16 +89,14 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
       .map(ps => ExternalPermissions.subsetOf(ps) && ExternalPermissions.size == ps.size)
       .orElse(Signal.const(false))
 
-  lazy val isWireless: Future[Boolean] = for {
-    z <- zms.head
-    isWireless <- z.usersStorage.get(z.selfUserId).map(_.isDefined)
-  } yield isWireless
+  lazy val isWireless = zms
+    .flatMap(_.users.selfUser)
+    .map(_.expiresAt.isDefined)
 
-  lazy val isProUser: Future[Boolean] =
-    for {
-      isWireless <- isWireless
-      isTeam     <- zms.head.map(_.teamId).map(_.isDefined)
-    } yield isTeam || isWireless
+  lazy val isProUser = isTeam.flatMap {
+    case true => Signal.const(true)
+    case false => isWireless
+  }
 
   lazy val hasCreateConvPermission: Signal[Boolean] = teamId.flatMap {
     case Some(_) => selfPermissions.map(_.contains(CreateConversation))

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
@@ -50,11 +50,11 @@ class DataUsagePermissionsView(context: Context, attrs: AttributeSet, style: Int
   inflate(R.layout.data_usage_permissions_layout)
 
   private val am       = inject[Signal[AccountManager]]
-  private lazy val uac = inject[UserAccountsController]
+  private lazy val uac      = inject[UserAccountsController]
   private val tracking = inject[GlobalTrackingController]
 
   val sendAnonymousUsageDataButton = returning(findById[SwitchPreference](R.id.preferences_send_anonymous_usage_data)) { v =>
-    uac.isTeam.foreach { isProUser =>
+    uac.isProUser.head.foreach { isProUser =>
       v.setPreference(TrackingEnabled)
       if (isProUser) {
         v.pref.flatMap(_.signal).onUi {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DataUsagePermissionsView.scala
@@ -53,12 +53,11 @@ class DataUsagePermissionsView(context: Context, attrs: AttributeSet, style: Int
   private lazy val uac = inject[UserAccountsController]
   private val tracking = inject[GlobalTrackingController]
 
-  val analyticsSwitch = returning(findById[SwitchPreference](R.id.preferences_send_analytics_data)) { v =>
-
-    uac.isProUser.foreach { isProUser =>
+  val sendAnonymousUsageDataButton = returning(findById[SwitchPreference](R.id.preferences_send_anonymous_usage_data)) { v =>
+    uac.isTeam.foreach { isProUser =>
       v.setPreference(TrackingEnabled)
       if (isProUser) {
-        v.pref.flatMap(_.signal).onChanged {
+        v.pref.flatMap(_.signal).onUi {
           case true  => tracking.optIn()
           case false => tracking.optOut()
         }
@@ -68,8 +67,7 @@ class DataUsagePermissionsView(context: Context, attrs: AttributeSet, style: Int
     }
   }
 
-  val anonymousDataSwitch = returning(findById[SwitchPreference](R.id.preferences_send_anonymous_data)) { v =>
-
+  val submitCrashReportsButton = returning(findById[SwitchPreference](R.id.preferences_send_anonymous_crash_report_data)) { v =>
     if (BuildConfig.SUBMIT_CRASH_REPORTS) {
       v.setPreference(GlobalPreferences.SendAnonymousDataEnabled, global = true)
     } else {


### PR DESCRIPTION
## What's new in this PR?

JIRA: https://wearezeta.atlassian.net/browse/AN-7105

### Issues

**Current state**: 

STR:1)

- Login at Wire App with Team account 
- Add a second Account, which should be a personal account
- Go to Settings Page>Data Usage Permissions Page when in the personal Account-> Toggles for "Send anonymous crash reports" and "send anonymous usage data" are displayed

2)

- Login with a Wire app with personal account
- Add a second account, which should be a team account
- Go to Settings page>Data Usage Permissions Page when in the team Account-> Only Toggle for "Send anonymous crash reports" is displayed

**Expected**:

when logged in with both accounts together, you should see the same in the settings, depending on which account you are in and enter the settings 

### Causes

It's believe that the value was only getting updated once and wasn't getting re-updated when we switch accounts.

### Solutions

- Changing the isProUser to a signal 
- Checking for isTeam first and then isWireless rather than OR
#### APK
[Download build #2809](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2809/artifact/build/artifact/wire-dev-PR3040-2809.apk)
[Download build #2810](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2810/artifact/build/artifact/wire-dev-PR3040-2810.apk)