### PR TITLE
Changes needed for wire-android to work with wire-signals 0.2.3

### DIFF
--- a/app/src/main/scala/com/waz/background/WorkManagerSyncRequestService.scala
+++ b/app/src/main/scala/com/waz/background/WorkManagerSyncRequestService.scala
@@ -34,7 +34,7 @@ import com.waz.service.NetworkModeService
 import com.waz.sync.SyncHandler.RequestInfo
 import com.waz.sync.{SyncHandler, SyncRequestService, SyncResult}
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.{RichInstant, returning}
 import com.waz.zclient.{Injectable, Injector, WireApplication, WireContext}
 import com.waz.zclient.log.LogUI._
@@ -46,7 +46,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
 
-class WorkManagerSyncRequestService (implicit inj: Injector, cxt: Context, eventContext: EventContext)
+class WorkManagerSyncRequestService (implicit inj: Injector, cxt: Context)
   extends SyncRequestService with Injectable {
 
   import WorkManagerSyncRequestService._

--- a/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
+++ b/app/src/main/scala/com/waz/services/calling/CallWakeService.scala
@@ -22,7 +22,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{ConvId, UserId}
 import com.waz.service.ZMessaging
 import com.waz.services.{FutureService, ZMessagingService}
-import com.wire.signals.EventContext
 import com.waz.utils.returning
 import com.waz.utils.wrappers.Intent
 import com.waz.zclient.log.LogUI._
@@ -36,7 +35,6 @@ class CallWakeService extends FutureService with ZMessagingService with DerivedL
 
   import CallWakeService._
   import com.waz.zclient.Intents.RichIntent
-  implicit val ec: EventContext.Global.type = EventContext.Global
 
   override protected def onIntent(intent: AIntent, id: Int): Future[Any] = onZmsIntent(intent) { implicit zms =>
     debug(l"onIntent ${RichIntent(intent)}")

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -29,7 +29,7 @@ import com.waz.service.push._
 import com.waz.services.ZMessagingService
 import com.waz.services.fcm.FCMHandlerService._
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Serialized}
+import com.wire.signals.Serialized
 import com.waz.utils.{JsonDecoder, RichInstant}
 import com.waz.zclient.WireApplication
 import com.waz.zclient.log.LogUI._
@@ -69,7 +69,6 @@ class FCMHandlerService extends FirebaseMessagingService with ZMessagingService 
     getData(remoteMessage).foreach { data =>
       verbose(l"processing remote message with data: ${redactedString(data.toString())}")
       implicit val context: Context = this
-      implicit val ec: EventContext = EventContext.Global
 
       Option(ZMessaging.currentGlobal) match {
         case None =>

--- a/app/src/main/scala/com/waz/zclient/SpinnerController.scala
+++ b/app/src/main/scala/com/waz/zclient/SpinnerController.scala
@@ -17,11 +17,11 @@
  */
 package com.waz.zclient
 
-import com.wire.signals.{EventContext, Signal, SourceSignal}
+import com.wire.signals.{Signal, SourceSignal}
 import com.waz.zclient.SpinnerController.{Hide, Show, SpinnerParameters}
 import com.waz.zclient.views.LoadingIndicatorView._
 
-class SpinnerController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext) extends Injectable {
+class SpinnerController(implicit inj: Injector, cxt: WireContext) extends Injectable {
 
   val spinnerShowing: SourceSignal[SpinnerParameters] = Signal(Hide())
 

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -115,7 +115,6 @@ object WireApplication extends DerivedLogTag {
 
     implicit lazy val ctx:          WireApplication = WireApplication.APP_INSTANCE
     implicit lazy val wContext:     WireContext     = ctx
-    implicit lazy val eventContext: EventContext    = EventContext.Global
 
     //Android services
     bind [ActivityManager]      to ctx.getSystemService(Context.ACTIVITY_SERVICE).asInstanceOf[ActivityManager]

--- a/app/src/main/scala/com/waz/zclient/appentry/controllers/CreateTeamController.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/controllers/CreateTeamController.scala
@@ -17,10 +17,9 @@
  */
 package com.waz.zclient.appentry.controllers
 
-import com.wire.signals.EventContext
 import com.waz.zclient.{Injectable, Injector}
 
-class CreateTeamController(implicit inj: Injector, eventContext: EventContext) extends Injectable {
+class CreateTeamController(implicit inj: Injector) extends Injectable {
 
   var teamName = ""
   var teamEmail = ""

--- a/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
@@ -23,7 +23,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.EmailAddress
 import com.waz.service.AccountsService
 import com.waz.sync.client.InvitationClient.ConfirmedTeamInvitation
-import com.wire.signals.{CancellableFuture, EventContext, SerialDispatchQueue, Signal}
+import com.wire.signals.{CancellableFuture, SerialDispatchQueue, Signal}
 import com.waz.utils._
 import com.waz.zclient.appentry.controllers.InvitationsController._
 import com.waz.zclient.{Injectable, Injector}
@@ -31,7 +31,7 @@ import com.waz.zclient.{Injectable, Injector}
 import scala.collection.immutable.ListMap
 import scala.concurrent.Future
 
-class InvitationsController(implicit inj: Injector, eventContext: EventContext, context: Context)
+class InvitationsController(implicit inj: Injector, context: Context)
   extends Injectable with DerivedLogTag {
 
   private implicit val dispatcher = SerialDispatchQueue(name = "InvitationsController")

--- a/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
@@ -23,7 +23,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.EmailAddress
 import com.waz.service.AccountsService
 import com.waz.sync.client.InvitationClient.ConfirmedTeamInvitation
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue, Signal}
+import com.wire.signals.{CancellableFuture, Signal}
 import com.waz.utils._
 import com.waz.zclient.appentry.controllers.InvitationsController._
 import com.waz.zclient.{Injectable, Injector}
@@ -33,8 +33,7 @@ import scala.concurrent.Future
 
 class InvitationsController(implicit inj: Injector, context: Context)
   extends Injectable with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "InvitationsController")
+  import com.waz.threading.Threading.Implicits.Background
 
   private lazy val accountsService      = inject[AccountsService]
   private lazy val createTeamController = inject[CreateTeamController]

--- a/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/controllers/InvitationsController.scala
@@ -34,7 +34,7 @@ import scala.concurrent.Future
 class InvitationsController(implicit inj: Injector, eventContext: EventContext, context: Context)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "InvitationsController")
+  private implicit val dispatcher = SerialDispatchQueue(name = "InvitationsController")
 
   private lazy val accountsService      = inject[AccountsService]
   private lazy val createTeamController = inject[CreateTeamController]

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -39,11 +39,10 @@ import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{FragmentHelper, R, ViewHelper}
-import com.wire.signals.{SerialDispatchQueue, Signal}
+import com.wire.signals.Signal
 
 abstract class UserVideoView(context: Context, val participant: Participant) extends FrameLayout(context, null, 0) with ViewHelper {
   protected lazy val controller: CallController = inject[CallController]
-  private implicit val dispatcher = SerialDispatchQueue(name = s"UserVideoView-$participant")
 
   inflate(R.layout.video_call_info_view)
 

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -43,7 +43,7 @@ import com.wire.signals.{SerialDispatchQueue, Signal}
 
 abstract class UserVideoView(context: Context, val participant: Participant) extends FrameLayout(context, null, 0) with ViewHelper {
   protected lazy val controller: CallController = inject[CallController]
-  private implicit val dispatcher = new SerialDispatchQueue(name = s"UserVideoView-$participant")
+  private implicit val dispatcher = SerialDispatchQueue(name = s"UserVideoView-$participant")
 
   inflate(R.layout.video_call_info_view)
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -46,7 +46,7 @@ import org.threeten.bp.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class CallController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext)
+class CallController(implicit inj: Injector, cxt: WireContext)
   extends Injectable with DerivedLogTag {
 
   import Threading.Implicits.Background
@@ -286,7 +286,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
       case true => CallingActivity.start(cxt)
       case false =>
     }
-  }(EventContext.Global)
+  }
 
   (lastCallAccountId zip isCallEstablished).onChanged.filter(_._2 == true) { case (userId, _) =>
     soundController.playCallEstablishedSound(userId)
@@ -298,7 +298,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
 
   isCallActive.onChanged.filter(_ == false).on(Threading.Ui) { _ =>
     screenManager.releaseWakeLock()
-  }(EventContext.Global)
+  }
 
   (for {
     v            <- isVideoCall
@@ -479,7 +479,7 @@ private class ScreenManager(implicit injector: Injector) extends Injectable with
   }
 }
 
-private class GSMManager(callActive: Signal[Boolean])(implicit inject: Injector, ec: EventContext)
+private class GSMManager(callActive: Signal[Boolean])(implicit inject: Injector)
   extends Injectable with DerivedLogTag {
 
   private lazy val telephonyManager = inject[TelephonyManager]

--- a/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/GlobalCameraController.scala
@@ -32,7 +32,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.waz.utils.RichFuture
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.WireContext
 import com.waz.zclient.camera.{CameraFacing, FlashMode}
 import com.waz.zclient.core.logging.Logger
@@ -42,7 +42,7 @@ import com.waz.zclient.utils.{AutoFocusCallbackDeprecation, Callback, CameraPara
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-class GlobalCameraController(cameraFactory: CameraFactory)(implicit cxt: WireContext, eventContext: EventContext)
+class GlobalCameraController(cameraFactory: CameraFactory)(implicit cxt: WireContext)
   extends DerivedLogTag {
   
   implicit val cameraExecutionContext = new ExecutionContext {

--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
@@ -35,7 +35,7 @@ import com.waz.zclient.{Injectable, Injector}
 class CollectionController(implicit injector: Injector)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "CollectionController")
+  private implicit val dispatcher = SerialDispatchQueue(name = "CollectionController")
 
   val zms = inject[Signal[ZMessaging]]
 

--- a/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/controllers/CollectionController.scala
@@ -25,25 +25,17 @@ import com.waz.api.{ContentSearchQuery, Message, TypeFilter}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.ZMessaging
-import com.wire.signals.SerialDispatchQueue
+
 import com.wire.signals.{EventStream, Signal, SourceSignal}
 import com.waz.zclient.collection.controllers.CollectionController.CollectionInfo
 import com.waz.zclient.controllers.collections.CollectionsObserver
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.{Injectable, Injector}
 
-class CollectionController(implicit injector: Injector)
-  extends Injectable with DerivedLogTag {
+class CollectionController(implicit injector: Injector) extends Injectable with DerivedLogTag {
+  private val zms = inject[Signal[ZMessaging]]
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "CollectionController")
-
-  val zms = inject[Signal[ZMessaging]]
-
-  lazy val convController = inject[ConversationController]
-
-  val msgStorage = zms.map(_.messagesStorage)
-
-  val assetStorage = zms.map(_.assetsStorage)
+  private lazy val convController = inject[ConversationController]
 
   private var observers = Set.empty[CollectionsObserver]
 

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -21,7 +21,7 @@ import android.app.Activity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConvId
 import com.wire.signals.SerialDispatchQueue
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.wrappers.{URI => URIWrapper}
 import com.waz.zclient.Intents._
 import com.waz.zclient.conversation.ConversationController
@@ -30,7 +30,7 @@ import com.waz.zclient.{Injectable, Injector, WireContext}
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-class SharingController(implicit injector: Injector, wContext: WireContext, eventContext: EventContext)
+class SharingController(implicit injector: Injector, wContext: WireContext)
   extends Injectable with DerivedLogTag {
 
   import SharingController._

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -35,7 +35,7 @@ class SharingController(implicit injector: Injector, wContext: WireContext, even
 
   import SharingController._
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SharingController")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SharingController")
 
   val sharableContent     = Signal(Option.empty[SharableContent])
   val ephemeralExpiration = Signal(Option.empty[FiniteDuration])

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SharingController.scala
@@ -20,7 +20,6 @@ package com.waz.zclient.common.controllers
 import android.app.Activity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConvId
-import com.wire.signals.SerialDispatchQueue
 import com.wire.signals.Signal
 import com.waz.utils.wrappers.{URI => URIWrapper}
 import com.waz.zclient.Intents._
@@ -35,7 +34,7 @@ class SharingController(implicit injector: Injector, wContext: WireContext)
 
   import SharingController._
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "SharingController")
+  import com.waz.threading.Threading.Implicits.Background
 
   val sharableContent     = Signal(Option.empty[SharableContent])
   val ephemeralExpiration = Signal(Option.empty[FiniteDuration])

--- a/app/src/main/scala/com/waz/zclient/common/controllers/ThemeController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/ThemeController.scala
@@ -26,7 +26,7 @@ import com.waz.content.UserPreferences.DarkTheme
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.AccountManager
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal, SourceSignal}
+import com.wire.signals.{Signal, SourceSignal}
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.ThemeController.Theme
 import com.waz.zclient.ui.theme.{OptionsDarkTheme, OptionsLightTheme, OptionsTheme}
@@ -35,7 +35,7 @@ import com.waz.zclient.{Injectable, Injector, R, ViewHelper}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ThemeController(implicit injector: Injector, context: Context, ec: EventContext)
+class ThemeController(implicit injector: Injector, context: Context)
   extends Injectable with DerivedLogTag {
   
   import Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/UserAccountsController.scala
@@ -32,11 +32,11 @@ import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.core.stores.conversation.ConversationChangeRequester
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{BuildConfig, Injectable, Injector}
-import com.wire.signals.{EventContext, EventStream, Signal}
+import com.wire.signals.{EventStream, Signal}
 
 import scala.concurrent.Future
 
-class UserAccountsController(implicit injector: Injector, context: Context, ec: EventContext)
+class UserAccountsController(implicit injector: Injector, context: Context)
   extends Injectable with DerivedLogTag {
 
   import Threading.Implicits.Ui
@@ -137,7 +137,7 @@ class UserAccountsController(implicit injector: Injector, context: Context, ec: 
     } yield conv.id
 
   def getOrCreateAndOpenConvFor(user: UserId) =
-    getConversationId(user).flatMap(convCtrl.selectConv(_, ConversationChangeRequester.START_CONVERSATION))
+    getConversationId(user).flatMap(convCtrl.selectConv(_, ConversationChangeRequester.START_CONVERSATION))(Threading.Background)
 
   private def observeLogoutEvents(): Unit = {
     accounts.map(_.size).onUi { numberOfAccounts =>

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -21,7 +21,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.service.{AccountsService, GlobalModule, UserService}
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.security.ActivityLifecycleCallback
 import com.waz.zclient.{Injectable, Injector}
 import com.waz.zclient.log.LogUI._
@@ -29,7 +29,7 @@ import com.waz.threading.Threading._
 
 import scala.concurrent.Future
 
-class PasswordController(implicit inj: Injector, ec: EventContext)
+class PasswordController(implicit inj: Injector)
   extends Injectable with DerivedLogTag {
 
   import Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/common/fragments/ConnectivityFragment.scala
@@ -35,16 +35,16 @@ import com.waz.zclient.{FragmentHelper, R}
 
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
+import com.waz.zclient.views.LoadingIndicatorView.InfiniteLoadingBar
 
 class ConnectivityFragment extends Fragment with FragmentHelper with ConnectivityIndicatorView.OnExpandListener {
-
   import ConnectivityFragment._
 
   private lazy val network     = Option(ZMessaging.currentGlobal).map(_.network.networkMode).getOrElse(Signal.const(NetworkMode.UNKNOWN))
   private lazy val accentColor = inject[AccentColorController].accentColor
   private lazy val longProcess = inject[Signal[ZMessaging]].flatMap(_.push.processing).flatMap {
     case true => Signal.from(CancellableFuture.delay(LongProcessingDelay)).map(_ => true).orElse(Signal.const(false))
-    case _ => Signal.const(false)
+    case _    => Signal.const(false)
   }
 
   private var root: View = _
@@ -78,12 +78,9 @@ class ConnectivityFragment extends Fragment with FragmentHelper with Connectivit
       mode       <- network
       processing <- longProcess
     } yield (mode, processing)).onUi {
-      case (NetworkMode.OFFLINE | NetworkMode.UNKNOWN, _) =>
-        loadingIndicatorView.hide()
-      case (_, true) =>
-        loadingIndicatorView.show(LoadingIndicatorView.InfiniteLoadingBar)
-      case _ =>
-        loadingIndicatorView.hide()
+      case (NetworkMode.OFFLINE | NetworkMode.UNKNOWN, _) => loadingIndicatorView.hide()
+      case (_, true)                                      => loadingIndicatorView.show(InfiniteLoadingBar)
+      case _                                              => loadingIndicatorView.hide()
     }
     root
   }

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -32,7 +32,7 @@ import com.waz.model.otr.Client
 import com.waz.service.AccountManager
 import com.waz.service.assets.{AssetInput, Content, ContentForUpload, FileRestrictionList, UriHelper}
 import com.waz.service.conversation.{ConversationsService, ConversationsUiService, SelectedConversationService}
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
 import com.wire.signals.{Serialized, EventStream, Signal, SourceStream}
@@ -56,7 +56,7 @@ import scala.util.{Success, Try}
 class ConversationController(implicit injector: Injector, context: Context)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationController")
+  import com.waz.threading.Threading.Implicits.Background
 
   private lazy val selectedConv          = inject[Signal[SelectedConversationService]]
   private lazy val convsUi               = inject[Signal[ConversationsUiService]]

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -35,7 +35,7 @@ import com.waz.service.conversation.{ConversationsService, ConversationsUiServic
 import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
-import com.wire.signals.{Serialized, EventContext, EventStream, Signal, SourceStream}
+import com.wire.signals.{Serialized, EventStream, Signal, SourceStream}
 import com.waz.utils.{returning, _}
 import com.waz.zclient.calling.controllers.CallStartController
 import com.waz.zclient.common.controllers.global.AccentColorController
@@ -53,7 +53,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
-class ConversationController(implicit injector: Injector, context: Context, ec: EventContext)
+class ConversationController(implicit injector: Injector, context: Context)
   extends Injectable with DerivedLogTag {
 
   private implicit val dispatcher = SerialDispatchQueue(name = "ConversationController")

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -56,7 +56,7 @@ import scala.util.{Success, Try}
 class ConversationController(implicit injector: Injector, context: Context, ec: EventContext)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationController")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationController")
 
   private lazy val selectedConv          = inject[Signal[SelectedConversationService]]
   private lazy val convsUi               = inject[Signal[ConversationsUiService]]
@@ -352,7 +352,7 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
     } yield {}
 
   def leave(convId: ConvId): CancellableFuture[Unit] =
-    returning (Serialized("Conversations", convId)(CancellableFuture.lift(convsUi.head.flatMap(_.leaveConversation(convId))))) { _ =>
+    returning(Serialized(s"Conversations $convId")(CancellableFuture.lift(convsUi.head.flatMap(_.leaveConversation(convId))))) { _ =>
       currentConvId.head.map { id => if (id == convId) setCurrentConversationToNext(ConversationChangeRequester.LEAVE_CONVERSATION) }
     }
 
@@ -382,7 +382,7 @@ class ConversationController(implicit injector: Injector, context: Context, ec: 
     convsUi.head.flatMap(_.setConversationMuted(id, muted)).map(_ => {})
 
   def delete(id: ConvId, alsoLeave: Boolean): CancellableFuture[Option[ConversationData]] = {
-    def clear(id: ConvId) = Serialized("Conversations", id)(CancellableFuture.lift(convsUi.head.flatMap(_.clearConversation(id))))
+    def clear(id: ConvId) = Serialized(s"Conversations $id")(CancellableFuture.lift(convsUi.head.flatMap(_.clearConversation(id))))
     if (alsoLeave) leave(id).flatMap(_ => clear(id)) else clear(id)
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
@@ -23,7 +23,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.tracking.GroupConversationEvent
 import com.waz.service.{IntegrationsService, ZMessaging}
-import com.wire.signals.{EventContext, EventStream, Signal}
+import com.wire.signals.{EventStream, Signal}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.UiStorage
@@ -31,7 +31,7 @@ import com.waz.zclient.{Injectable, Injector}
 
 import scala.concurrent.Future
 
-class CreateConversationController(implicit inj: Injector, ev: EventContext)
+class CreateConversationController(implicit inj: Injector)
   extends Injectable with DerivedLogTag  {
 
   import com.waz.threading.Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -26,7 +26,6 @@ import com.waz.model._
 import com.waz.service.ZMessaging
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService, FoldersService}
 import com.waz.service.teams.TeamsService
-import com.wire.signals.SerialDispatchQueue
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.signals.{AggregatingSignal, EventContext, EventStream, Signal}
@@ -310,7 +309,7 @@ object ConversationListController {
   // Only keeps up to 4 users other than self user, this list is to be used for avatar in conv list.
   // We keep this always in memory to avoid reloading members list for every list row view (caused performance issues)
   class MembersCache(zms: ZMessaging)(implicit inj: Injector, ec: EventContext) extends Injectable {
-    private implicit val dispatcher = SerialDispatchQueue(name = "MembersCache")
+    import com.waz.threading.Threading.Implicits.Background
 
     private def entries(convMembers: Seq[ConversationMemberData]) =
       convMembers.groupBy(_.convId).map { case (convId, ms) =>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -310,7 +310,7 @@ object ConversationListController {
   // Only keeps up to 4 users other than self user, this list is to be used for avatar in conv list.
   // We keep this always in memory to avoid reloading members list for every list row view (caused performance issues)
   class MembersCache(zms: ZMessaging)(implicit inj: Injector, ec: EventContext) extends Injectable {
-    private implicit val dispatcher = new SerialDispatchQueue(name = "MembersCache")
+    private implicit val dispatcher = SerialDispatchQueue(name = "MembersCache")
 
     private def entries(convMembers: Seq[ConversationMemberData]) =
       convMembers.groupBy(_.convId).map { case (convId, ms) =>

--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
@@ -23,8 +23,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.UserId
 import com.waz.service.AccountManager.ClientRegistrationState.Registered
 import com.waz.service.{AccountManager, AccountsService, UserService}
-import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.deeplinks.DeepLink.{Conversation, UserTokenInfo}
 import com.waz.zclient.log.LogUI._
@@ -40,9 +39,9 @@ class DeepLinkService(implicit injector: Injector) extends Injectable with Deriv
 
   val deepLink = Signal(Option.empty[CheckingResult])
 
-  deepLink.on(Threading.Background) { result =>
+  deepLink { result =>
     verbose(l"DeepLink checking result: $result")
-  } (EventContext.Global)
+  }
 
   private lazy val accountsService     = inject[AccountsService]
   private lazy val account             = inject[Signal[Option[AccountManager]]]

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
@@ -22,7 +22,7 @@ import com.waz.api.Message
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.service.ZMessaging
-import com.wire.signals.{EventContext, EventStream, Signal}
+import com.wire.signals.{EventStream, Signal}
 import com.waz.zclient.controllers.navigation._
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.pages.main.conversationpager.controller.{ISlidingPaneController, SlidingPaneObserver}
@@ -32,7 +32,7 @@ import com.waz.utils.RichWireInstant
 
 import scala.concurrent.duration._
 
-class MessagesController()(implicit injector: Injector, cxt: WireContext, ev: EventContext)
+class MessagesController()(implicit injector: Injector, cxt: WireContext)
   extends Injectable with DerivedLogTag {
   
 import com.waz.threading.Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/CallingNotificationsController.scala
@@ -32,7 +32,7 @@ import com.waz.services.calling.CallWakeService._
 import com.waz.services.calling.CallingNotificationsService
 import com.waz.threading.Threading.Implicits.Background
 import com.waz.utils._
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.wrappers.{Context, Intent}
 import com.waz.zclient.Intents.{CallIntent, OpenCallingScreen}
 import com.waz.zclient._
@@ -49,7 +49,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import com.waz.threading.Threading._
 
-class CallingNotificationsController(implicit cxt: WireContext, eventContext: EventContext, inj: Injector) extends Injectable with DerivedLogTag {
+class CallingNotificationsController(implicit cxt: WireContext, inj: Injector) extends Injectable with DerivedLogTag {
 
   import CallingNotificationsController._
 

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
@@ -26,7 +26,7 @@ import com.waz.model.AssetId
 import com.waz.service.ZMessaging
 import com.waz.service.assets.AssetService.BitmapResult
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.wrappers.URI
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.ContextUtils._
@@ -35,7 +35,7 @@ import com.waz.zclient.{Injectable, Injector, R, WireContext}
 
 import scala.util.Try
 
-class ImageNotificationsController(implicit cxt: WireContext, eventContext: EventContext, inj: Injector)
+class ImageNotificationsController(implicit cxt: WireContext, inj: Injector)
   extends Injectable with DerivedLogTag {
 
   import ImageNotificationsController._

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -35,7 +35,7 @@ import com.waz.model._
 import com.waz.service.push.NotificationUiController
 import com.waz.service.{AccountsService, UiLifeCycle}
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.wrappers.Bitmap
 import com.waz.zclient.WireApplication._
 import com.waz.zclient.common.controllers.SoundController
@@ -54,7 +54,7 @@ import scala.concurrent.Future
 import com.waz.threading.Threading._
 
 class MessageNotificationsController(applicationId: String = BuildConfig.APPLICATION_ID)
-                                    (implicit inj: Injector, cxt: Context, eventContext: EventContext)
+                                    (implicit inj: Injector, cxt: Context)
   extends Injectable
     with NotificationUiController
     with DerivedLogTag {

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -45,7 +45,7 @@ import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.{Mes
 import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.zclient.utils.{ResString, RingtoneUtils, format}
 import com.waz.zclient.{Injectable, Injector, Intents, R}
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -287,7 +287,7 @@ object NotificationManagerWrapper {
     def apply(id: String, name: Int, description: Int, sound: Uri, vibration: Boolean)(implicit cxt: Context): ChannelInfo = ChannelInfo(id, getString(name), getString(description), sound, vibration)
   }
 
-  class AndroidNotificationsManager(notificationManager: NotificationManager)(implicit inj: Injector, cxt: Context, eventContext: EventContext)
+  class AndroidNotificationsManager(notificationManager: NotificationManager)(implicit inj: Injector, cxt: Context)
     extends NotificationManagerWrapper with Injectable with DerivedLogTag {
 
     val accountChannels = inject[AccountsService].accountManagers.flatMap(ams => Signal.sequence(ams.map { am =>

--- a/app/src/main/scala/com/waz/zclient/preferences/PreferencesController.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/PreferencesController.scala
@@ -20,13 +20,11 @@ package com.waz.zclient.preferences
 import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.ZMessaging
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.{Injectable, Injector}
 
 //So that java can access the new preferences from the SE
-class PreferencesController(implicit inj: Injector, ec: EventContext)
-  extends Injectable with DerivedLogTag {
-
+class PreferencesController(implicit inj: Injector) extends Injectable with DerivedLogTag {
   private val zms = inject[Signal[ZMessaging]]
   private val userPrefs = zms.map(_.userPrefs)
 

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RequestPasswordDialog.scala
@@ -32,7 +32,7 @@ import com.google.android.material.textfield.{TextInputEditText, TextInputLayout
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, EventStream}
+import com.wire.signals.EventStream
 import com.waz.utils.returning
 import com.waz.zclient.messages.ExecutorWrapper
 import com.waz.zclient.ui.utils.KeyboardUtils
@@ -172,7 +172,7 @@ object RequestPasswordDialog {
             biometricDesc: Option[String] = None,
             isCancellable: Boolean        = true,
             useBiometric:  Boolean        = false
-           )(implicit evContext: EventContext): RequestPasswordDialog =
+           ): RequestPasswordDialog =
     returning(new RequestPasswordDialog) { dialog =>
       dialog.setArguments(returning(new Bundle()) { b =>
         b.putString(TitleArg, title)

--- a/app/src/main/scala/com/waz/zclient/search/SearchController.scala
+++ b/app/src/main/scala/com/waz/zclient/search/SearchController.scala
@@ -21,12 +21,12 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.IntegrationData
 import com.waz.service.{IntegrationsService, SearchQuery, SearchResults, UserSearchService}
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.conversation.creation.CreateConversationController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{Injectable, Injector}
 
-class SearchController(implicit inj: Injector, eventContext: EventContext) extends Injectable with DerivedLogTag {
+class SearchController(implicit inj: Injector) extends Injectable with DerivedLogTag {
 
   import SearchController._
 

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -35,8 +35,6 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     with DerivedLogTag
     with DecorateAsScala {
 
-  import com.wire.signals.EventContext.Implicits.global
-
   private lazy val shouldHideScreenContent = for {
     prefs <- userPreferences
     hideScreenContent <- prefs.preference(UserPreferences.HideScreenContent).signal

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -23,7 +23,7 @@ import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.content.GlobalPreferences.AppLockEnabled
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{AccountManager, ZMessaging}
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient.common.controllers.global.PasswordController
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.security.SecurityChecklist.{Action, Check}
@@ -36,7 +36,7 @@ import org.threeten.bp.temporal.ChronoUnit
 import scala.concurrent.Future
 import com.waz.threading.Threading._
 
-class SecurityPolicyChecker(implicit injector: Injector, ec: EventContext) extends Injectable with DerivedLogTag {
+class SecurityPolicyChecker(implicit injector: Injector) extends Injectable with DerivedLogTag {
   import SecurityPolicyChecker._
   import com.waz.threading.Threading.Implicits.Ui
 
@@ -124,7 +124,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
   private def requestPassword(passwordController: PasswordController,
                               userPreferences: UserPreferences,
                               accountManager: AccountManager,
-                              authNeeded: Boolean)(implicit context: Context, eventContext: EventContext) =
+                              authNeeded: Boolean)(implicit context: Context) =
     if (authNeeded) {
       verbose(l"check request password, force app lock: ${BuildConfig.FORCE_APP_LOCK}")
       val check = RequestPasswordCheck(passwordController, userPreferences)
@@ -141,7 +141,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
                                    accountManager    : Option[AccountManager],
                                    isForeground      : Boolean,
                                    authNeeded        : Boolean
-                                  )(implicit context: Context, eventContext: EventContext): Future[Boolean] = {
+                                  )(implicit context: Context): Future[Boolean] = {
     def unpack[A, B, C](a: Option[A], b: Option[B], c: Option[C]): Option[(A, B, C)] = (a, b, c) match {
       case (Some(aa), Some(bb), Some(cc)) => Some((aa, bb, cc))
       case _ => None
@@ -162,7 +162,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
     * Security checklist for background activities (e.g. receiving notifications). This is
     * static so that it can be accessible from `FCMHandlerService`.
     */
-  def runBackgroundSecurityChecklist()(implicit context: Context, eventContext: EventContext): Future[Boolean] =
+  def runBackgroundSecurityChecklist()(implicit context: Context): Future[Boolean] =
     ZMessaging.currentAccounts.activeAccountManager.head.flatMap(am =>
       runSecurityChecklist(
         passwordController = None,

--- a/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/checks/RequestPasswordCheck.scala
@@ -23,7 +23,6 @@ import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.threading.Threading
-import com.wire.signals.EventContext
 import com.waz.zclient.common.controllers.global.PasswordController
 import com.waz.zclient.preferences.dialogs.RequestPasswordDialog
 import com.waz.zclient.security.SecurityChecklist
@@ -33,7 +32,7 @@ import com.waz.zclient.preferences.dialogs.RequestPasswordDialog.{BiometricCance
 
 import scala.concurrent.{Future, Promise}
 
-class RequestPasswordCheck(pwdCtrl: PasswordController, prefs: UserPreferences)(implicit context: Context, evContext: EventContext)
+class RequestPasswordCheck(pwdCtrl: PasswordController, prefs: UserPreferences)(implicit context: Context)
   extends SecurityChecklist.Check with DerivedLogTag {
   import RequestPasswordCheck._
 
@@ -106,7 +105,7 @@ class RequestPasswordCheck(pwdCtrl: PasswordController, prefs: UserPreferences)(
 }
 
 object RequestPasswordCheck {
-  def apply(pwdCtrl: PasswordController, prefs: UserPreferences)(implicit context: Context, evContext: EventContext): RequestPasswordCheck =
+  def apply(pwdCtrl: PasswordController, prefs: UserPreferences)(implicit context: Context): RequestPasswordCheck =
     new RequestPasswordCheck(pwdCtrl, prefs)
 
   val MaxAttempts = BuildConfig.PASSWORD_MAX_ATTEMPTS

--- a/app/src/main/scala/com/waz/zclient/tracking/CrashController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/CrashController.scala
@@ -18,10 +18,9 @@
 package com.waz.zclient.tracking
 
 import com.waz.log.InternalLog
-import com.wire.signals.EventContext
 import com.waz.zclient.{Injectable, Injector, WireContext}
 
-class CrashController (implicit inj: Injector, cxt: WireContext, eventContext: EventContext) extends Injectable with Thread.UncaughtExceptionHandler {
+class CrashController (implicit inj: Injector, cxt: WireContext) extends Injectable with Thread.UncaughtExceptionHandler {
 
   val defaultHandler = Option(Thread.getDefaultUncaughtExceptionHandler) //reference to previously set handler
   Thread.setDefaultUncaughtExceptionHandler(this) //override with this

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -24,7 +24,7 @@ import android.app.Activity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.service.tracking._
-import com.wire.signals.{EventContext, SerialDispatchQueue, Signal}
+import com.wire.signals.{SerialDispatchQueue, Signal}
 import com.waz.zclient._
 import com.waz.zclient.log.LogUI._
 import com.waz.content.UserPreferences.CountlyTrackingId
@@ -37,10 +37,10 @@ import ly.count.android.sdk.{Countly, CountlyConfig, DeviceId}
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
-class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext)
+class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher =SerialDispatchQueue(name = "Tracking")
+  private implicit val dispatcher = SerialDispatchQueue(name = "Tracking")
 
   private val tracking  = inject[TrackingService]
   private lazy val am = inject[Signal[AccountManager]]

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -40,7 +40,7 @@ import scala.concurrent.Future
 class GlobalTrackingController(implicit inj: Injector, cxt: WireContext, eventContext: EventContext)
   extends Injectable with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "Tracking")
+  private implicit val dispatcher =SerialDispatchQueue(name = "Tracking")
 
   private val tracking  = inject[TrackingService]
   private lazy val am = inject[Signal[AccountManager]]

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -24,7 +24,7 @@ import android.app.Activity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.service.tracking._
-import com.wire.signals.{SerialDispatchQueue, Signal}
+import com.wire.signals.Signal
 import com.waz.zclient._
 import com.waz.zclient.log.LogUI._
 import com.waz.content.UserPreferences.CountlyTrackingId
@@ -39,8 +39,7 @@ import scala.concurrent.Future
 
 class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
   extends Injectable with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "Tracking")
+  import com.waz.threading.Threading.Implicits.Background
 
   private val tracking  = inject[TrackingService]
   private lazy val am = inject[Signal[AccountManager]]
@@ -89,7 +88,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
     } yield ()
   }
 
-  def optOut(): Unit = dispatcher {
+  def optOut(): Unit = {
     verbose(l"optOut")
   }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -178,7 +178,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.2.2"
+    const val WIRE_SIGNALS = "0.2.3"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -43,7 +43,6 @@ class CacheStorageImpl(storage: Database, context: Context)
     with DerivedLogTag {
 
   import com.waz.cache.CacheStorage._
-  import com.wire.signals.EventContext.Implicits.global
 
   private implicit val dispatcher = SerialDispatchQueue(name = "CacheStorage")
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -45,7 +45,7 @@ class CacheStorageImpl(storage: Database, context: Context)
   import com.waz.cache.CacheStorage._
   import com.wire.signals.EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "CacheStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "CacheStorage")
 
   onUpdated { _ foreach {
     case (prev, updated) if prev.fileId != updated.fileId => cleanup(prev)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -44,7 +44,7 @@ class CacheStorageImpl(storage: Database, context: Context)
 
   import com.waz.cache.CacheStorage._
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "CacheStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   onUpdated { _ foreach {
     case (prev, updated) if prev.fileId != updated.fileId => cleanup(prev)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
@@ -22,7 +22,6 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.model.AssetData.AssetDataDao
 import com.waz.model.AssetStatus.UploadDone
 import com.waz.model._
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.{CachedStorageImpl, TrimmingLruCache, _}
 
@@ -40,7 +39,7 @@ class AssetsStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[AssetId, AssetData](new TrimmingLruCache(context, Fixed(100)), storage)(AssetDataDao, LogTag("AssetsStorage"))
     with AssetsStorage {
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "AssetsStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   //allows overwriting of asset data
   override def updateAsset(id: AssetId, updater: AssetData => AssetData): Future[Option[AssetData]] = update(id, updater).mapOpt {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
@@ -40,7 +40,7 @@ class AssetsStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[AssetId, AssetData](new TrimmingLruCache(context, Fixed(100)), storage)(AssetDataDao, LogTag("AssetsStorage"))
     with AssetsStorage {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "AssetsStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "AssetsStorage")
 
   //allows overwriting of asset data
   override def updateAsset(id: AssetId, updater: AssetData => AssetData): Future[Option[AssetData]] = update(id, updater).mapOpt {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
@@ -5,7 +5,6 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ButtonData.{ButtonDataDao, ButtonDataDaoId}
 import com.waz.model.{ButtonData, ButtonId, MessageId}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
@@ -19,7 +18,7 @@ trait ButtonsStorage extends CachedStorage[(MessageId, ButtonId), ButtonData] {
 class ButtonsStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[ButtonDataDaoId, ButtonData](new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(ButtonDataDao, LogTag("ButtonsStorage"))
     with ButtonsStorage with DerivedLogTag {
-  private implicit val dispatcher = SerialDispatchQueue(name = "ButtonsStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   override def findByMessage(messageId: MessageId): Future[Seq[ButtonData]] =
     find(_.messageId == messageId, ButtonDataDao.findForMessage(messageId)(_), identity)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
@@ -19,7 +19,7 @@ trait ButtonsStorage extends CachedStorage[(MessageId, ButtonId), ButtonData] {
 class ButtonsStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[ButtonDataDaoId, ButtonData](new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(ButtonDataDao, LogTag("ButtonsStorage"))
     with ButtonsStorage with DerivedLogTag {
-  private implicit val dispatcher = new SerialDispatchQueue()
+  private implicit val dispatcher = SerialDispatchQueue(name = "ButtonsStorage")
 
   override def findByMessage(messageId: MessageId): Future[Seq[ButtonData]] =
     find(_.messageId == messageId, ButtonDataDao.findForMessage(messageId)(_), identity)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -40,7 +40,7 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
   private implicit val tag: LogTag = LogTag(s"ConvMessagesIndex_$convId")
 
   import com.wire.signals.EventContext.Implicits.global
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConvMessagesIndex")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConvMessagesIndex")
 
   private val indexChanged = EventStream[Change]()
   private var firstMessage = Option.empty[MessageData]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -24,7 +24,7 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.log.LogSE._
 import com.waz.model.MessageData.{MessageDataDao, isUserContent}
 import com.waz.model._
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.CancellableFuture
 import com.waz.utils._
 import com.wire.signals.{EventStream, RefreshingSignal, Signal, SourceSignal}
 
@@ -34,11 +34,9 @@ import scala.concurrent.duration._
 class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserId: UserId,
                         users: UsersStorage, convs: ConversationStorage,
                         msgAndLikes: MessageAndLikesStorage, storage: ZmsDatabase,
-                        filter: Option[MessageFilter] = None) {
-  self =>
-
+                        filter: Option[MessageFilter] = None) { self =>
+  import com.waz.threading.Threading.Implicits.Background
   private implicit val tag: LogTag = LogTag(s"ConvMessagesIndex_$convId")
-  private implicit val dispatcher = SerialDispatchQueue(name = "ConvMessagesIndex")
 
   private val indexChanged = EventStream[Change]()
   private var firstMessage = Option.empty[MessageData]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -38,8 +38,6 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
   self =>
 
   private implicit val tag: LogTag = LogTag(s"ConvMessagesIndex_$convId")
-
-  import com.wire.signals.EventContext.Implicits.global
   private implicit val dispatcher = SerialDispatchQueue(name = "ConvMessagesIndex")
 
   private val indexChanged = EventStream[Change]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
@@ -53,7 +53,7 @@ class ConversationStorageImpl(storage: ZmsDatabase)
     with ConversationStorage with DerivedLogTag {
 
   import EventContext.Implicits.global
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationStorage")
 
   onAdded.on(dispatcher) { cs => updateSearchKey(cs)}
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
@@ -29,7 +29,6 @@ import com.waz.service.SearchKey
 import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.Locales.currentLocaleOrdering
 import com.waz.utils._
-import com.wire.signals._
 
 import scala.collection.GenMap
 import scala.concurrent.Future
@@ -52,7 +51,6 @@ class ConversationStorageImpl(storage: ZmsDatabase)
   extends CachedStorageImpl[ConvId, ConversationData](new UnlimitedLruCache(), storage)(ConversationDataDao, LogTag("ConversationStorage_Cached"))
     with ConversationStorage with DerivedLogTag {
 
-  import EventContext.Implicits.global
   private implicit val dispatcher = SerialDispatchQueue(name = "ConversationStorage")
 
   onAdded.on(dispatcher) { cs => updateSearchKey(cs)}

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Database.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Database.scala
@@ -26,12 +26,12 @@ import com.waz.utils.wrappers.DB
 import scala.concurrent.Future
 
 trait Database {
-  implicit val dispatcher: SerialDispatchQueue
+  protected implicit val dispatcher: DispatchQueue
 
   val dbHelper: BaseDaoDB
 
-  lazy val readExecutionContext: DispatchQueue =
-    new UnlimitedDispatchQueue(Threading.IO, name = "Database_readQueue_" + hashCode().toHexString)
+  protected lazy val readExecutionContext: DispatchQueue =
+    DispatchQueue(DispatchQueue.UNLIMITED, Threading.IO, name = Some("Database_readQueue_" + hashCode().toHexString))
 
   def apply[A](f: DB => A)(implicit logTag: LogTag = LogTag("")): CancellableFuture[A] = dispatcher {
     implicit val db:DB = dbHelper.getWritableDatabase

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
@@ -35,7 +35,7 @@ trait FoldersStorage extends CachedStorage[FolderId, FolderData] {
 class FoldersStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[FolderId, FolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(FolderDataDao, LogTag("FolderStorage_Cached"))
     with FoldersStorage {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "FoldersStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "FoldersStorage")
 
   override def getByType(folderType: Int): Future[Seq[FolderData]] = find(_.folderType == folderType, FolderDataDao.findForType(folderType)(_), identity)
 }
@@ -50,7 +50,7 @@ trait ConversationFoldersStorage extends CachedStorage[(ConvId, FolderId), Conve
 class ConversationFoldersStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[(ConvId, FolderId), ConversationFolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationFolderDataDao, LogTag("ConversationFoldersStorage"))
     with ConversationFoldersStorage {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationFoldersStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationFoldersStorage")
 
   override def findForConv(convId: ConvId): Future[Set[FolderId]] =
     find(_.convId == convId, ConversationFolderDataDao.findForConv(convId)(_), identity).map(_.map(_.folderId).toSet)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
@@ -35,8 +35,6 @@ trait FoldersStorage extends CachedStorage[FolderId, FolderData] {
 class FoldersStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[FolderId, FolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(FolderDataDao, LogTag("FolderStorage_Cached"))
     with FoldersStorage {
-  private implicit val dispatcher = SerialDispatchQueue(name = "FoldersStorage")
-
   override def getByType(folderType: Int): Future[Seq[FolderData]] = find(_.folderType == folderType, FolderDataDao.findForType(folderType)(_), identity)
 }
 
@@ -50,7 +48,7 @@ trait ConversationFoldersStorage extends CachedStorage[(ConvId, FolderId), Conve
 class ConversationFoldersStorageImpl(context: Context, storage: Database)
   extends CachedStorageImpl[(ConvId, FolderId), ConversationFolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationFolderDataDao, LogTag("ConversationFoldersStorage"))
     with ConversationFoldersStorage {
-  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationFoldersStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   override def findForConv(convId: ConvId): Future[Set[FolderId]] =
     find(_.convId == convId, ConversationFolderDataDao.findForConv(convId)(_), identity).map(_.map(_.folderId).toSet)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
@@ -20,14 +20,14 @@ package com.waz.content
 import android.content.Context
 import com.waz.db.{BaseDaoDB, RoomDaoDB, ZGlobalDB}
 import com.waz.service.tracking.TrackingService
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.DispatchQueue
 import com.waz.threading.Threading
 import com.waz.zclient.storage.db.{GlobalDatabase => RoomGlobalDatabase}
 import com.waz.zclient.storage.di.StorageModule
 
 class GlobalDatabase(context: Context, dbNameSuffix: String = "", tracking: TrackingService) extends Database {
 
-  override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "GlobalDatabase")
+  override implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IOThreadPool, Option("GlobalDatabase"))
   override          val dbHelper  : BaseDaoDB           =
     new RoomDaoDB(StorageModule.getGlobalDatabase(
       context,

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -22,7 +22,6 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationMemberData.ConversationMemberDataDao
 import com.waz.model._
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.wire.signals.{AggregatingSignal, Signal}
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
@@ -52,8 +51,7 @@ trait MembersStorage extends CachedStorage[(UserId, ConvId), ConversationMemberD
 class MembersStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[(UserId, ConvId), ConversationMemberData](new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationMemberDataDao, LogTag("MembersStorage_Cached"))
     with MembersStorage with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "MembersStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   def getByConv(conv: ConvId) = find(_.convId == conv, ConversationMemberDataDao.findForConv(conv)(_), identity)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -53,7 +53,7 @@ class MembersStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[(UserId, ConvId), ConversationMemberData](new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationMemberDataDao, LogTag("MembersStorage_Cached"))
     with MembersStorage with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "MembersStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "MembersStorage")
 
   def getByConv(conv: ConvId) = find(_.convId == conv, ConversationMemberDataDao.findForConv(conv)(_), identity)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -25,7 +25,6 @@ import com.waz.db.{CursorIterator, Reader}
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.wrappers.DBCursor
 import com.waz.utils.{CachedStorageImpl, TrimmingLruCache}
@@ -41,7 +40,7 @@ class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorag
   import MessageIndexStorage._
   import MessageContentIndex.TextMessageTypes
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "MessageIndexStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   private def entry(m: MessageData) =
     MessageContentIndexEntry(m.id, m.convId, ContentSearchQuery.transliterated(m.contentString), m.time)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -42,7 +42,7 @@ class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorag
   import MessageContentIndex.TextMessageTypes
   import com.wire.signals.EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "MessageIndexStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "MessageIndexStorage")
 
   private def entry(m: MessageData) =
     MessageContentIndexEntry(m.id, m.convId, ContentSearchQuery.transliterated(m.contentString), m.time)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -40,7 +40,6 @@ class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorag
 
   import MessageIndexStorage._
   import MessageContentIndex.TextMessageTypes
-  import com.wire.signals.EventContext.Implicits.global
 
   private implicit val dispatcher = SerialDispatchQueue(name = "MessageIndexStorage")
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
@@ -24,7 +24,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model._
 import com.waz.service.messages.MessageAndLikes
-import com.wire.signals.{DispatchQueue, EventStream, SerialDispatchQueue}
+import com.wire.signals.{DispatchQueue, EventStream}
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.waz.utils.wrappers.DBCursor
@@ -48,8 +48,7 @@ class MessagesCursor(cursor: DBCursor,
                      loader: MessageAndLikesStorage)(implicit ordering: Ordering[RemoteInstant]) extends MsgCursor with DerivedLogTag { self =>
   import MessagesCursor._
   import scala.concurrent.duration._
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "MessagesCursor")
+  import com.waz.threading.Threading.Implicits.Background
 
   private val messages = new LruCache[MessageId, MessageAndLikes](WindowSize * 2)
   private val quotes = new LruCache[MessageId, Seq[MessageId]](WindowSize * 2)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
@@ -47,8 +47,6 @@ class MessagesCursor(cursor: DBCursor,
                      val lastReadTime: RemoteInstant,
                      loader: MessageAndLikesStorage)(implicit ordering: Ordering[RemoteInstant]) extends MsgCursor with DerivedLogTag { self =>
   import MessagesCursor._
-  import com.wire.signals.EventContext.Implicits.global
-
   import scala.concurrent.duration._
 
   private implicit val dispatcher = SerialDispatchQueue(name = "MessagesCursor")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
@@ -24,10 +24,9 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model._
 import com.waz.service.messages.MessageAndLikes
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.{DispatchQueue, EventStream, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.wire.signals.EventStream
 import com.waz.utils.wrappers.DBCursor
 
 import scala.collection.Searching.{Found, InsertionPoint}
@@ -52,7 +51,7 @@ class MessagesCursor(cursor: DBCursor,
 
   import scala.concurrent.duration._
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "MessagesCursor")
+  private implicit val dispatcher = SerialDispatchQueue(name = "MessagesCursor")
 
   private val messages = new LruCache[MessageId, MessageAndLikes](WindowSize * 2)
   private val quotes = new LruCache[MessageId, Seq[MessageId]](WindowSize * 2)
@@ -260,7 +259,7 @@ object MessagesCursor {
   }
 }
 
-class WindowLoader(cursor: DBCursor)(implicit dispatcher: SerialDispatchQueue) extends DerivedLogTag {
+class WindowLoader(cursor: DBCursor)(implicit dispatcher: DispatchQueue) extends DerivedLogTag {
   import MessagesCursor._
 
   @volatile private[this] var window = IndexWindow.Empty

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -148,7 +148,7 @@ class MessagesStorageImpl(context:     Context,
     }
   }
 
-  convs.onUpdated { _.foreach {
+  convs.onUpdated.on(Background) { _.foreach {
     case (prev, updated) if updated.lastRead != prev.lastRead =>
       msgsIndex(updated.id).map(_.updateLastRead(updated)).recoverWithLog()
     case _ => // ignore

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -31,7 +31,7 @@ import com.waz.model._
 import com.waz.service.Timeouts
 import com.waz.service.messages.MessageAndLikes
 import com.waz.service.tracking.TrackingService
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils._
 import com.wire.signals.{EventStream, Signal, SourceStream}
@@ -93,8 +93,6 @@ class MessagesStorageImpl(context:     Context,
     new TrimmingLruCache[MessageId, Option[MessageData]](context, Fixed(MessagesStorage.cacheSize)),
     storage
   )(MessageDataDao, LogTag("MessagesStorage_Cached")) with MessagesStorage with DerivedLogTag {
-
-  import com.wire.signals.EventContext.Implicits.global
 
   private implicit val dispatcher = SerialDispatchQueue(name = "MessagesStorage")
 
@@ -325,7 +323,6 @@ trait MessageAndLikesStorage {
 
 class MessageAndLikesStorageImpl(selfUserId: UserId, messages: => MessagesStorage, likings: ReactionsStorage) extends MessageAndLikesStorage {
   import com.waz.threading.Threading.Implicits.Background
-  import com.wire.signals.EventContext.Implicits.global
 
   val onUpdate = EventStream[MessageId]() // TODO: use batching, maybe report new message data instead of just id
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -96,7 +96,7 @@ class MessagesStorageImpl(context:     Context,
 
   import com.wire.signals.EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "MessagesStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "MessagesStorage")
 
   //For tracking on UI
   val onMessageSent = EventStream[MessageData]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -31,7 +31,6 @@ import com.waz.model._
 import com.waz.service.Timeouts
 import com.waz.service.messages.MessageAndLikes
 import com.waz.service.tracking.TrackingService
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils._
 import com.wire.signals.{EventStream, Signal, SourceStream}
@@ -94,7 +93,7 @@ class MessagesStorageImpl(context:     Context,
     storage
   )(MessageDataDao, LogTag("MessagesStorage_Cached")) with MessagesStorage with DerivedLogTag {
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "MessagesStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   //For tracking on UI
   val onMessageSent = EventStream[MessageData]()
@@ -149,7 +148,7 @@ class MessagesStorageImpl(context:     Context,
     }
   }
 
-  convs.onUpdated.on(dispatcher) { _.foreach {
+  convs.onUpdated { _.foreach {
     case (prev, updated) if updated.lastRead != prev.lastRead =>
       msgsIndex(updated.id).map(_.updateLastRead(updated)).recoverWithLog()
     case _ => // ignore

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -200,7 +200,7 @@ object Preferences {
   */
 class GlobalPreferences(context: Context, prefs: SharedPreferences) extends Preferences {
 
-  override protected implicit val dispatcher = new SerialDispatchQueue(name = "GlobalPreferencesDispatcher")
+  override protected implicit val dispatcher = SerialDispatchQueue(name = "GlobalPreferencesDispatcher")
   override protected implicit val logTag = LogTag[GlobalPreferences]
 
   def v31AssetsEnabled = false

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
@@ -46,7 +46,7 @@ class ReactionsStorageImpl(context: Context, storage: Database)
   import ReactionsStorageImpl._
   import EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue()
+  private implicit val dispatcher = SerialDispatchQueue(name = "ReactionsStorage")
 
   private val likesCache = new TrimmingLruCache[MessageId, Map[UserId, RemoteInstant]](context, Fixed(1024))
   private val maxTime = returning(new AggregatingSignal[RemoteInstant, RemoteInstant](onChanged.map(_.maxBy(_.timestamp).timestamp), storage.read(LikingDao.findMaxTime(_)), _ max _))(_.disableAutowiring())

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
@@ -44,7 +44,6 @@ class ReactionsStorageImpl(context: Context, storage: Database)
     with DerivedLogTag {
 
   import ReactionsStorageImpl._
-  import EventContext.Implicits.global
 
   private implicit val dispatcher = SerialDispatchQueue(name = "ReactionsStorage")
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
@@ -50,7 +50,7 @@ class ReactionsStorageImpl(context: Context, storage: Database)
   private val likesCache = new TrimmingLruCache[MessageId, Map[UserId, RemoteInstant]](context, Fixed(1024))
   private val maxTime = returning(new AggregatingSignal[RemoteInstant, RemoteInstant](onChanged.map(_.maxBy(_.timestamp).timestamp), storage.read(LikingDao.findMaxTime(_)), _ max _))(_.disableAutowiring())
 
-  onChanged { likes =>
+  onChanged.on(Background) { likes =>
     likes.groupBy(_.message) foreach { case (msg, ls) =>
       Option(likesCache.get(msg)) foreach { current =>
         val (toAdd, toRemove) = ls.partition(_.action == Action.Like)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -26,7 +26,7 @@ import com.waz.utils.TrimmingLruCache.Fixed
 import com.wire.signals.{RefreshingSignal, Signal}
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 trait ReadReceiptsStorage extends CachedStorage[ReadReceipt.Id, ReadReceipt] {
   def getReceipts(message: MessageId): Future[Seq[ReadReceipt]]
@@ -37,7 +37,6 @@ trait ReadReceiptsStorage extends CachedStorage[ReadReceipt.Id, ReadReceipt] {
 class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: MessagesStorage, msgService: MessagesService)
   extends CachedStorageImpl[ReadReceipt.Id, ReadReceipt](new TrimmingLruCache(context, Fixed(ReadReceiptsStorage.cacheSize)), storage)(ReadReceiptDao, LogTag("ReadReceiptsStorage"))
   with ReadReceiptsStorage {
-  import com.wire.signals.EventContext.Implicits.global
   private implicit val dispatcher = SerialDispatchQueue(name = "ReadReceiptsStorage")
 
   msgStorage.onDeleted { ids => removeAllForMessages(ids.toSet) }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -38,7 +38,7 @@ class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: M
   extends CachedStorageImpl[ReadReceipt.Id, ReadReceipt](new TrimmingLruCache(context, Fixed(ReadReceiptsStorage.cacheSize)), storage)(ReadReceiptDao, LogTag("ReadReceiptsStorage"))
   with ReadReceiptsStorage {
   import com.wire.signals.EventContext.Implicits.global
-  private implicit val dispatcher: ExecutionContext = new SerialDispatchQueue()
+  private implicit val dispatcher = SerialDispatchQueue(name = "ReadReceiptsStorage")
 
   msgStorage.onDeleted { ids => removeAllForMessages(ids.toSet) }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -21,7 +21,6 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.model.ReadReceipt.ReadReceiptDao
 import com.waz.model.{MessageId, ReadReceipt}
 import com.waz.service.messages.MessagesService
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.wire.signals.{RefreshingSignal, Signal}
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
@@ -37,7 +36,7 @@ trait ReadReceiptsStorage extends CachedStorage[ReadReceipt.Id, ReadReceipt] {
 class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: MessagesStorage, msgService: MessagesService)
   extends CachedStorageImpl[ReadReceipt.Id, ReadReceipt](new TrimmingLruCache(context, Fixed(ReadReceiptsStorage.cacheSize)), storage)(ReadReceiptDao, LogTag("ReadReceiptsStorage"))
   with ReadReceiptsStorage {
-  private implicit val dispatcher = SerialDispatchQueue(name = "ReadReceiptsStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   msgStorage.onDeleted { ids => removeAllForMessages(ids.toSet) }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -44,7 +44,7 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
 class UsersStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[UserId, UserData](new TrimmingLruCache(context, Fixed(2000)), storage)(UserDataDao, LogTag("UsersStorage_Cached"))
     with UsersStorage {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "UsersStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "UsersStorage")
 
   override def listAll(ids: Traversable[UserId]) = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -22,7 +22,6 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model._
 import com.waz.service.SearchKey
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils._
 import com.wire.signals._
@@ -44,7 +43,7 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
 class UsersStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[UserId, UserData](new TrimmingLruCache(context, Fixed(2000)), storage)(UserDataDao, LogTag("UsersStorage_Cached"))
     with UsersStorage {
-  private implicit val dispatcher = SerialDispatchQueue(name = "UsersStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   override def listAll(ids: Traversable[UserId]) = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
@@ -20,7 +20,7 @@ package com.waz.content
 import android.content.Context
 import com.waz.db.{BaseDaoDB, RoomDaoDB, ZMessagingDB}
 import com.waz.model.UserId
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.DispatchQueue
 import com.waz.threading.Threading
 import com.waz.zclient.storage.db.UserDatabase
 import com.waz.zclient.storage.di.StorageModule
@@ -29,8 +29,10 @@ import com.waz.zclient.storage.di.StorageModule
   * Single user storage. Keeps data specific to used user account.
   */
 class ZmsDatabase(user: UserId, context: Context) extends Database {
-  override implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(executor = Threading.IOThreadPool, name = "ZmsDatabase_" + user.str.substring(24))
-  override          val dbHelper  : BaseDaoDB           =
+  override implicit val dispatcher: DispatchQueue =
+    DispatchQueue(DispatchQueue.SERIAL, Threading.IOThreadPool, name = Option("ZmsDatabase_" + user.str.substring(24)))
+
+  override val dbHelper: BaseDaoDB =
     new RoomDaoDB(StorageModule.getUserDatabase(
       context, user.str,
       ZMessagingDB.migrations.map(_.toRoomMigration).toArray ++ UserDatabase.getMigrations)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -21,7 +21,7 @@ import java.io.{BufferedWriter, File, FileWriter, IOException}
 
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.InternalLog.{LogLevel, dateTag, stackTrace}
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ZSecureRandom
 import com.waz.utils.returning
@@ -40,7 +40,7 @@ class BufferedLogOutput(baseDir: String,
 
   override val id: String = "BufferedLogOutput" + ZSecureRandom.nextInt().toHexString
 
-  private implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(Threading.IO, id)
+  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, Some(id))
 
   private val buffer = StringBuilder.newBuilder
   private val pathRegex = s"$baseDir/${BufferedLogOutput.DefFileName}([0-9]+).log".r

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
@@ -21,7 +21,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogShow.SafeToLog
 import com.waz.log.LogSE._
 import com.waz.model.errors.PermissionDeniedError
-import com.wire.signals.SerialDispatchQueue
 import com.waz.threading.Threading
 import com.wire.signals.{EventStream, RefreshingSignal, Signal}
 
@@ -30,9 +29,8 @@ import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 class PermissionsService extends DerivedLogTag {
-
   import PermissionsService._
-  private implicit val ec = SerialDispatchQueue(name = "PermissionsService")
+  import Threading.Implicits.Background
 
   protected[permissions] val providers      = Signal(Vector.empty[PermissionProvider])
   protected[permissions] val providerSignal = providers.map(_.lastOption)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
@@ -32,7 +32,7 @@ import scala.util.Try
 class PermissionsService extends DerivedLogTag {
 
   import PermissionsService._
-  private implicit val ec = new SerialDispatchQueue(name = "PermissionsService")
+  private implicit val ec = SerialDispatchQueue(name = "PermissionsService")
 
   protected[permissions] val providers      = Signal(Vector.empty[PermissionProvider])
   protected[permissions] val providerSignal = providers.map(_.lastOption)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -22,16 +22,14 @@ import com.waz.log.LogSE._
 import com.waz.model.UserId
 import com.waz.service.AccountsService.LoggedOut
 import com.waz.service.ZMessaging.accountTag
-import com.wire.signals.SerialDispatchQueue
+import com.waz.threading.Threading
 import com.wire.signals.EventContext
 
 class AccountContext(userId: UserId, accounts: AccountsService) extends EventContext {
 
   implicit val logTag: LogTag = accountTag[AccountContext](userId)
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "AccountContext")
-
-  accounts.accountState(userId).on(dispatcher) {
+  accounts.accountState(userId).on(Threading.Background) {
     case LoggedOut =>
       verbose(l"Account context stopped")
       onContextStop()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -29,7 +29,7 @@ class AccountContext(userId: UserId, accounts: AccountsService) extends EventCon
 
   implicit val logTag: LogTag = accountTag[AccountContext](userId)
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "AccountContext")
+  private implicit val dispatcher = SerialDispatchQueue(name = "AccountContext")
 
   accounts.accountState(userId).on(dispatcher) {
     case LoggedOut =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -22,14 +22,14 @@ import com.waz.log.LogSE._
 import com.waz.model.UserId
 import com.waz.service.AccountsService.LoggedOut
 import com.waz.service.ZMessaging.accountTag
-import com.waz.threading.Threading
-import com.wire.signals.EventContext
+import com.wire.signals.{EventContext, SerialDispatchQueue}
 
 class AccountContext(userId: UserId, accounts: AccountsService) extends EventContext {
 
   implicit val logTag: LogTag = accountTag[AccountContext](userId)
+  private implicit val dispatcher = SerialDispatchQueue(name = "AccountContext")
 
-  accounts.accountState(userId).on(Threading.Background) {
+  accounts.accountState(userId).on(dispatcher) {
     case LoggedOut =>
       verbose(l"Account context stopped")
       onContextStop()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -38,5 +38,5 @@ class AccountContext(userId: UserId, accounts: AccountsService) extends EventCon
     case _ =>
       verbose(l"Account context started")
       onContextStart()
-  } (EventContext.Global)
+  }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -54,7 +54,7 @@ class AccountManager(val userId:  UserId,
                      isLogin:     Option[Boolean]) extends DerivedLogTag {
   import AccountManager._
 
-  implicit val dispatcher = new SerialDispatchQueue()
+  private implicit val dispatcher = SerialDispatchQueue(name = "AccountManager")
   implicit val accountContext: AccountContext = new AccountContext(userId, accounts)
   verbose(l"Creating for: $userId, team: $teamId, initialSelf: $initialSelf, isLogin: $isLogin")
 
@@ -144,7 +144,7 @@ class AccountManager(val userId:  UserId,
       } yield resp.fold(err => Left(err), _ => Right({}))
     }
 
-    Serialized.future("register-client", this) {
+    Serialized.future(s"register-client $userId") {
       clientState.head.flatMap {
         case st@Registered(_) =>
           verbose(l"Client already registered, returning")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -34,7 +34,7 @@ import com.waz.service.assets.Content
 import com.waz.service.otr.OtrService.SessionId
 import com.waz.sync.client.InvitationClient.ConfirmedTeamInvitation
 import com.waz.sync.client.{ErrorOr, ErrorOrResponse, InvitationClientImpl, OtrClientImpl}
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.CancellableFuture
 import com.waz.utils._
 import com.wire.signals._
 import com.waz.utils.wrappers.URI
@@ -54,7 +54,7 @@ class AccountManager(val userId:  UserId,
                      isLogin:     Option[Boolean]) extends DerivedLogTag {
   import AccountManager._
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "AccountManager")
+  import com.waz.threading.Threading.Implicits.Background
   implicit val accountContext: AccountContext = new AccountContext(userId, accounts)
   verbose(l"Creating for: $userId, team: $teamId, initialSelf: $initialSelf, isLogin: $isLogin")
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -134,8 +134,6 @@ class AccountsServiceImpl(global: GlobalModule, kotlinLogoutEnabled: Boolean = f
   import AccountsService._
   import Threading.Implicits.Background
 
-  implicit val ec: EventContext = EventContext.Global
-
   //needed immediately for migration, don't make lazy or we risk deadlocks
   val storageOld    = global.accountsStorageOld
   val prefs         = global.prefs

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
@@ -34,7 +34,6 @@ import scala.concurrent.duration._
 class CacheCleaningService(cache: CacheService, prefs: GlobalPreferences) extends DerivedLogTag {
   import CacheCleaningService._
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   CancellableFuture.delayed(1.minute) { requestDeletionOfExpiredCacheEntries() }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -247,7 +247,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
     getOrCreateOneToOneConversations(Seq(OneToOneConvData(toUser, remoteId, convType))).map(_.values.head)
 
   private def getOrCreateOneToOneConversations(convsInfo: Seq[OneToOneConvData]): Future[Map[UserId, ConversationData]] =
-    Serialized.future('getOrCreateOneToOneConversations) {
+    Serialized.future("getOrCreateOneToOneConversations") {
       verbose(l"getOrCreateOneToOneConversations(self: $selfUserId, convs:${convsInfo.size})")
 
       def convIdForUser(userId: UserId) = ConvId(userId.str)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -63,7 +63,6 @@ class ConnectionServiceImpl(selfUserId:      UserId,
                             sync:            SyncServiceHandle) extends ConnectionService with DerivedLogTag {
 
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   override val connectionEventsStage = EventScheduler.Stage[UserConnectionEvent]((c, e) => handleUserConnectionEvents(e))
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
@@ -52,8 +52,6 @@ class ErrorsServiceImpl(userId:    UserId,
                         storage:   ZmsDatabase,
                         accounts:  AccountsService,
                         messages:  MessagesStorage) extends ErrorsService with DerivedLogTag {
-  import com.wire.signals.EventContext.Implicits.global
-
   private implicit val dispatcher = SerialDispatchQueue(name = "ErrorsService")
 
   private var dismissHandler: PartialFunction[ErrorData, Future[_]] = PartialFunction.empty

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
@@ -54,7 +54,7 @@ class ErrorsServiceImpl(userId:    UserId,
                         messages:  MessagesStorage) extends ErrorsService with DerivedLogTag {
   import com.wire.signals.EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ErrorsService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ErrorsService")
 
   private var dismissHandler: PartialFunction[ErrorData, Future[_]] = PartialFunction.empty
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
@@ -26,7 +26,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.media.manager.config.Configuration
 import com.waz.media.manager.context.IntensityLevel
 import com.waz.media.manager.{MediaManager, MediaManagerListener}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils._
 import com.wire.signals._
 import org.json.JSONObject
@@ -46,7 +45,7 @@ trait MediaManagerService {
 class DefaultMediaManagerService(context: Context) extends MediaManagerService with DerivedLogTag { self =>
   import com.waz.service.MediaManagerService._
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "MediaManagerService")
+  import com.waz.threading.Threading.Implicits.Background
 
   private val onPlaybackRouteChanged = EventStream[PlaybackRoute]()
   private val audioConfig = Try(new JSONObject(IoUtils.asString(context.getAssets.open(AudioConfigAsset)))).toOption

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
@@ -46,7 +46,7 @@ trait MediaManagerService {
 class DefaultMediaManagerService(context: Context) extends MediaManagerService with DerivedLogTag { self =>
   import com.waz.service.MediaManagerService._
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "MediaManagerService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "MediaManagerService")
   private implicit val ev = EventContext.Global
 
   private val onPlaybackRouteChanged = EventStream[PlaybackRoute]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
@@ -47,7 +47,6 @@ class DefaultMediaManagerService(context: Context) extends MediaManagerService w
   import com.waz.service.MediaManagerService._
 
   private implicit val dispatcher = SerialDispatchQueue(name = "MediaManagerService")
-  private implicit val ev = EventContext.Global
 
   private val onPlaybackRouteChanged = EventStream[PlaybackRoute]()
   private val audioConfig = Try(new JSONObject(IoUtils.asString(context.getAssets.open(AudioConfigAsset)))).toOption

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
@@ -38,8 +38,6 @@ trait NetworkModeService {
 class DefaultNetworkModeService(context: Context, lifeCycle: UiLifeCycle) extends NetworkModeService with DerivedLogTag {
   import NetworkModeService._
 
-  private implicit val ev = EventContext.Global
-
   private lazy val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE).asInstanceOf[ConnectivityManager]
   private lazy val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE).asInstanceOf[TelephonyManager]
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
@@ -35,7 +35,7 @@ trait PhoneNumberService {
 }
 
 class PhoneNumberServiceImpl(context: Context) extends PhoneNumberService with DerivedLogTag {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "PhoneNumberService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "PhoneNumberService")
 
   private lazy val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE).asInstanceOf[TelephonyManager]
   private lazy val phoneNumberUtil = PhoneNumberUtil.getInstance()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
@@ -24,7 +24,6 @@ import com.google.i18n.phonenumbers.Phonenumber.{PhoneNumber => GooglePhoneNumbe
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.PhoneNumber
-import com.wire.signals.SerialDispatchQueue
 
 import scala.concurrent.Future
 
@@ -35,7 +34,7 @@ trait PhoneNumberService {
 }
 
 class PhoneNumberServiceImpl(context: Context) extends PhoneNumberService with DerivedLogTag {
-  private implicit val dispatcher = SerialDispatchQueue(name = "PhoneNumberService")
+  import com.waz.threading.Threading.Implicits.Background
 
   private lazy val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE).asInstanceOf[TelephonyManager]
   private lazy val phoneNumberUtil = PhoneNumberUtil.getInstance()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
@@ -41,7 +41,7 @@ import scala.concurrent.duration._
 
 trait ReportingService {
   import ReportingService._
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ReportingService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ReportingService")
   private[service] var reporters = Seq.empty[Reporter]
 
   def addStateReporter(report: PrintWriter => Future[Unit])(implicit tag: LogTag): Unit = Future {
@@ -66,7 +66,7 @@ object ReportingService {
 }
 
 class ZmsReportingService(user: UserId, global: ReportingService) extends ReportingService {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ZmsReportingService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ZmsReportingService")
 
   global.addStateReporter(generateStateReport)(LogTag(s"ZMessaging[$user]"))
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
@@ -30,7 +30,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.log.{BufferedLogOutput, InternalLog}
 import com.waz.model.{Mime, UserId}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.threading.Threading
 import com.waz.utils.wrappers.URI
 import com.waz.utils.{IoUtils, RichFuture}
@@ -41,7 +40,7 @@ import scala.concurrent.duration._
 
 trait ReportingService {
   import ReportingService._
-  private implicit val dispatcher = SerialDispatchQueue(name = "ReportingService")
+  import com.waz.threading.Threading.Implicits.Background
   private[service] var reporters = Seq.empty[Reporter]
 
   def addStateReporter(report: PrintWriter => Future[Unit])(implicit tag: LogTag): Unit = Future {
@@ -66,8 +65,6 @@ object ReportingService {
 }
 
 class ZmsReportingService(user: UserId, global: ReportingService) extends ReportingService {
-  private implicit val dispatcher = SerialDispatchQueue(name = "ZmsReportingService")
-
   global.addStateReporter(generateStateReport)(LogTag(s"ZMessaging[$user]"))
 }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UiLifeCycle.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UiLifeCycle.scala
@@ -30,7 +30,7 @@ trait UiLifeCycle {
 
 class UiLifeCycleImpl extends UiLifeCycle {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "LifeCycleDispatcher")
+  private implicit val dispatcher = SerialDispatchQueue(name = "LifeCycleDispatcher")
 
   private val uiCount = Signal(0)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -106,7 +106,6 @@ class UserServiceImpl(selfUserId:        UserId,
                      ) extends UserService with DerivedLogTag {
 
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   private val shouldSyncUsers = userPrefs.preference(UserPreferences.ShouldSyncUsers)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -384,8 +384,7 @@ class ExpiredUsersService(push:         PushService,
                           users:        UserService,
                           usersStorage: UsersStorage,
                           sync:         SyncServiceHandle)(implicit ev: AccountContext) extends DerivedLogTag {
-
-  private implicit val ec = SerialDispatchQueue(name = "ExpiringUsers")
+  import com.waz.threading.Threading.Implicits.Background
 
   private var timers = Map[UserId, CancellableFuture[Unit]]()
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -215,7 +215,7 @@ class UserServiceImpl(selfUserId:        UserId,
     usersStorage.updateOrCreateAll(entries.map(entry => entry.id -> updateOrAdd(entry)).toMap)
   }
 
-  override def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]] = Serialized.future("syncRichInfoNow", id) {
+  override def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]] = Serialized.future(s"syncRichInfoNow $id") {
     usersClient.loadRichInfo(id).future.flatMap {
       case Right(f) =>
           updateUserData(id, u => u.copy(fields = f))
@@ -234,7 +234,7 @@ class UserServiceImpl(selfUserId:        UserId,
         deleteUsers(Set(userId)).map(_ => None)
     }
 
-  def syncSelfNow: Future[Option[UserData]] = Serialized.future("syncSelfNow", selfUserId) {
+  def syncSelfNow: Future[Option[UserData]] = Serialized.future(s"syncSelfNow $selfUserId") {
     usersClient.loadSelf().future.flatMap {
       case Right(info) =>
         updateSyncedUsers(Seq(info)) map { _.headOption }
@@ -386,7 +386,7 @@ class ExpiredUsersService(push:         PushService,
                           usersStorage: UsersStorage,
                           sync:         SyncServiceHandle)(implicit ev: AccountContext) extends DerivedLogTag {
 
-  private implicit val ec = new SerialDispatchQueue(name = "ExpiringUsers")
+  private implicit val ec = SerialDispatchQueue(name = "ExpiringUsers")
 
   private var timers = Map[UserId, CancellableFuture[Unit]]()
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
@@ -24,7 +24,7 @@ import com.waz.log.LogSE._
 import com.waz.model.VersionBlacklist
 import com.waz.sync.client.VersionBlacklistClient
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
+import com.wire.signals.Signal
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -33,7 +33,6 @@ class VersionBlacklistService(metadata: MetaDataService, prefs: GlobalPreference
   extends DerivedLogTag {
 
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
   import metadata._
 
   val lastUpToDateSync   = prefs.preference[Long](LastUpToDateSyncTime)
@@ -53,7 +52,6 @@ class VersionBlacklistService(metadata: MetaDataService, prefs: GlobalPreference
   def shouldSync = for {
     lastSyncTime <- lastUpToDateSync()
     lastVersion <- lastCheckedVersion()
-    isUpToDate <- upToDatePref()
   } yield {
     lastVersion != metadata.appVersion || (System.currentTimeMillis - lastSyncTime).millis > 1.day
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -44,11 +44,9 @@ import com.waz.sync.client._
 import com.waz.sync.handler._
 import com.waz.sync.otr.{OtrClientsSyncHandler, OtrClientsSyncHandlerImpl, OtrSyncHandler, OtrSyncHandlerImpl}
 import com.waz.sync.queue.{SyncContentUpdater, SyncContentUpdaterImpl}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.threading.Threading
 import com.waz.ui.UiModule
 import com.waz.utils.crypto._
-import com.wire.signals.EventContext
 import com.waz.utils.wrappers.{AndroidContext, DB, GoogleApi}
 import com.waz.utils.{IoUtils, Locales}
 import com.waz.znet2.http.HttpClient
@@ -106,8 +104,7 @@ class StorageModule(context: Context, val userId: UserId, globalPreferences: Glo
 }
 
 class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: AccountManager, val storage: StorageModule, val cryptoBox: CryptoBoxService) extends DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "ZMessaging")
+  import com.waz.threading.Threading.Implicits.Background
 
   val httpProxy: Option[Proxy] = ZMessaging.httpProxy
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -295,7 +295,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
         cacheDirectory = lruCacheDirectory,
         directorySizeThreshold = 1024 * 1024 * 200L,
         sizeCheckingInterval = 30.seconds
-      )(Threading.IO, EventContext.Global),
+      )(Threading.IO),
       new UploadAssetContentCacheImpl(rawCacheDirectory)(Threading.IO),
       assetClient,
       sync

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -107,7 +107,7 @@ class StorageModule(context: Context, val userId: UserId, globalPreferences: Glo
 
 class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: AccountManager, val storage: StorageModule, val cryptoBox: CryptoBoxService) extends DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ZMessaging")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ZMessaging")
 
   val httpProxy: Option[Proxy] = ZMessaging.httpProxy
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AssetContentCache.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/AssetContentCache.scala
@@ -33,9 +33,11 @@ import scala.concurrent.duration.FiniteDuration
 trait AssetContentCache extends FileCache[AssetId]
 
 class AssetContentCacheImpl(val cacheDirectory: File, val directorySizeThreshold: Long, val sizeCheckingInterval: FiniteDuration)
-                           (implicit val ec: ExecutionContext, val ev: EventContext) extends LruFileCache[AssetId] with AssetContentCache {
+                           (implicit val ec: ExecutionContext) extends LruFileCache[AssetId] with AssetContentCache {
 
   override protected def createFileName(key: AssetId): String = key.str
+
+  override protected implicit def ev: EventContext = EventContext.Global
 }
 
 /**

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -380,7 +380,7 @@ class GlobalRecordAndPlayService(cache: CacheService, context: Context, fileCach
     transitionF(s => Future(f(s)))(errorMessage, errorType)
 
   private def transitionF(f: State => Future[Transition])(errorMessage: String, errorType: Option[ErrorType] = None): Future[State] =
-    Serialized.future(GlobalRecordAndPlayService)(keepStateOnFailure(stateSource.head.flatMap(f))(errorMessage, errorType).map(applyState))
+    Serialized.future("GlobalRecordAndPlayService")(keepStateOnFailure(stateSource.head.flatMap(f))(errorMessage, errorType).map(applyState))
 
   private def duringIdentityTransition[A](pf: PartialFunction[State, Future[A]]): Future[A] = {
     val p = Promise[A]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -52,14 +52,13 @@ class RecordAndPlayService(userId:        UserId,
                            globalService: GlobalRecordAndPlayService,
                            errors:        ErrorsService,
                            accounts:      AccountsService) {
-  import EventContext.Implicits.global
   import Threading.Implicits.Background
 
   globalService.onError { err =>
     err.tpe.foreach { tpe => errors.addErrorWhenActive(ErrorData(Uid(), tpe, responseMessage = err.message)) }
   }
 
-  accounts.accountState(userId).map(_ == InForeground).onChanged.on(Background) {
+  accounts.accountState(userId).map(_ == InForeground).onChanged {
     case false => globalService.AudioFocusListener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
     case true =>
   }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -62,7 +62,7 @@ class RecordAndPlayService(userId:        UserId,
   accounts.accountState(userId).map(_ == InForeground).onChanged.on(Background) {
     case false => globalService.AudioFocusListener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
     case true =>
-  }(EventContext.Global)
+  }
 }
 
 // invariant: only do side effects and/or access player/recorder during a transition

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/MetaDataRetriever.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/MetaDataRetriever.scala
@@ -22,7 +22,7 @@ import java.io.File
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.utils.{Cleanup, Managed}
 
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 
 object MetaDataRetriever {
 
-  private implicit val dispatcher = new SerialDispatchQueue(Threading.IO, "MetaDataRetriever")
+  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, Option("MetaDataRetriever"))
 
   implicit lazy val RetrieverCleanup = new Cleanup[MediaMetadataRetriever] {
     override def apply(a: MediaMetadataRetriever): Unit = a.release()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
@@ -28,7 +28,7 @@ import android.media.AudioTrack.{MODE_STREAM, OnPlaybackPositionUpdateListener, 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.service.assets.GlobalRecordAndPlayService.{MediaPointer, PCMContent}
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.DispatchQueue
 import com.waz.threading.Threading
 import PCM.SizeOfShort
 import org.threeten.bp
@@ -41,7 +41,7 @@ import scala.util.Try
 class PCMPlayer private (content: PCMContent, track: AudioTrack, totalSamples: Long, stream: FileInputStream, observer: Player.Observer) extends Player {
   import PCMPlayer._
 
-  private implicit val dispatcher = new SerialDispatchQueue(Threading.IO)
+  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, None)
   private val buffer = ByteBuffer.allocateDirect(bufferSizeInShorts * SizeOfShort).order(LITTLE_ENDIAN)
   private def channel = stream.getChannel
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/Player.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/assets/Player.scala
@@ -36,7 +36,7 @@ abstract class Player {
   def repositionPlayhead(pos: bp.Duration): Future[Unit]
 
   private lazy val token = UUID.randomUUID
-  protected def serialized[A](f: => Future[A]): Future[A] = Serialized.future(token)(f)
+  protected def serialized[A](f: => Future[A]): Future[A] = Serialized.future(token.toString)(f)
 }
 
 object Player {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -58,7 +58,7 @@ trait Avs {
   */
 class AvsImpl() extends Avs with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "AvsWrapper")
+  private implicit val dispatcher = SerialDispatchQueue(name = "AvsWrapper")
 
   import Avs._
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -171,7 +171,7 @@ class CallingServiceImpl(val accountId:       UserId,
 
   import CallingService._
 
-  private implicit val dispatcher = SerialDispatchQueue(name = "CallingService")
+  import com.waz.threading.Threading.Implicits.Background
 
   //need to ensure that flow manager and media manager are initialised for v3 (they are lazy values)
   flowManagerService.flowManager

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -205,7 +205,7 @@ class CallingServiceImpl(val accountId:       UserId,
         verbose(l"Account $accountId logged out, unregistering from AVS")
         wCall.map(avs.unregisterAccount)
       case true =>
-    }(EventContext.Global)
+    }
   )
 
   def onSend(ctx: Pointer, msg: String, convId: RConvId, targetRecipients: Option[AvsClientList]): Future[Unit] =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -51,7 +51,7 @@ class DefaultFlowManagerService(context:      Context,
   import FlowManagerService._
 
   private implicit val ev = EventContext.Global
-  private implicit val dispatcher = new SerialDispatchQueue(name = "FlowManagerService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "FlowManagerService")
 
   override val cameraFailedSig = Signal[Boolean](false)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -50,7 +50,6 @@ class DefaultFlowManagerService(context:      Context,
                                 network:      NetworkModeService) extends FlowManagerService with DerivedLogTag {
   import FlowManagerService._
 
-  private implicit val ev = EventContext.Global
   private implicit val dispatcher = SerialDispatchQueue(name = "FlowManagerService")
 
   override val cameraFailedSig = Signal[Boolean](false)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -27,7 +27,6 @@ import com.waz.log.LogSE._
 import com.waz.model._
 import com.waz.service._
 import com.waz.service.call.FlowManagerService.VideoCaptureDevice
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils._
 import com.wire.signals._
 
@@ -49,8 +48,7 @@ class DefaultFlowManagerService(context:      Context,
                                 globalPrefs:  GlobalPreferences,
                                 network:      NetworkModeService) extends FlowManagerService with DerivedLogTag {
   import FlowManagerService._
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "FlowManagerService")
+  import com.waz.threading.Threading.Implicits.Background
 
   override val cameraFailedSig = Signal[Boolean](false)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -40,7 +40,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
                                      sync:       SyncServiceHandle,
                                      pipeline:   EventPipeline) extends DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationEventsDispatcher")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationEventsDispatcher")
 
   private[service] def shouldChangeOrder(event: ConversationEvent): Boolean =
     event match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -26,7 +26,6 @@ import com.waz.service.EventScheduler.Stage
 import com.waz.service.messages.MessagesService
 import com.waz.service.{EventPipeline, EventScheduler, UserService}
 import com.waz.sync.SyncServiceHandle
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils._
 
 import scala.concurrent.Future
@@ -39,8 +38,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
                                      users:      UserService,
                                      sync:       SyncServiceHandle,
                                      pipeline:   EventPipeline) extends DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationEventsDispatcher")
+  import com.waz.threading.Threading.Implicits.Background
 
   private[service] def shouldChangeOrder(event: ConversationEvent): Boolean =
     event match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -74,8 +74,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
                                       membersStorage:  MembersStorage,
                                       messagesStorage: => MessagesStorage,
                                       syncHandler:     SyncServiceHandle) extends ConversationsContentUpdater with DerivedLogTag {
-  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationContentUpdater")
-
+  import com.waz.threading.Threading.Implicits.Background
   val conversationsFuture = Future successful storage
 
   storage.onUpdated(_.foreach {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -74,8 +74,6 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
                                       membersStorage:  MembersStorage,
                                       messagesStorage: => MessagesStorage,
                                       syncHandler:     SyncServiceHandle) extends ConversationsContentUpdater with DerivedLogTag {
-  import com.wire.signals.EventContext.Implicits.global
-
   private implicit val dispatcher = SerialDispatchQueue(name = "ConversationContentUpdater")
 
   val conversationsFuture = Future successful storage

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -76,7 +76,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
                                       syncHandler:     SyncServiceHandle) extends ConversationsContentUpdater with DerivedLogTag {
   import com.wire.signals.EventContext.Implicits.global
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationContentUpdater")
+  private implicit val dispatcher = SerialDispatchQueue(name = "ConversationContentUpdater")
 
   val conversationsFuture = Future successful storage
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -98,7 +98,6 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
                                rolesService:    ConversationRolesService
                               ) extends ConversationsService with DerivedLogTag {
 
-  private implicit val ev = EventContext.Global
   import Threading.Implicits.Background
 
   //On conversation changed, update the state of the access roles as part of migration, then check for a link if necessary

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -64,7 +64,6 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
                          sync: SyncServiceHandle
                         ) extends FoldersService with DerivedLogTag  {
   import Threading.Implicits.Background
-  private implicit val ev: EventContext = EventContext.Global
 
   private val shouldSyncFolders = userPrefs.preference(UserPreferences.ShouldSyncFolders)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -44,7 +44,7 @@ class TypingService(userId:        UserId,
   import timeouts.typing._
 
   private implicit val ev = EventContext.Global
-  private implicit val dispatcher = new SerialDispatchQueue(name = "TypingService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "TypingService")
   private val beDriftPref = prefs.preference(BackendDrift)
 
   private var typing: ConvId Map IndexedSeq[TypingUser] = Map().withDefaultValue(Vector.empty)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -43,7 +43,6 @@ class TypingService(userId:        UserId,
 
   import timeouts.typing._
 
-  private implicit val ev = EventContext.Global
   private implicit val dispatcher = SerialDispatchQueue(name = "TypingService")
   private val beDriftPref = prefs.preference(BackendDrift)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
@@ -40,8 +40,6 @@ class RichMediaService(msgsStorage: MessagesStorage,
   import com.waz.api.Message.Part.Type._
   import Threading.Implicits.Background
 
-  private implicit val ec = EventContext.Global
-
   private def isSyncableMsg(msg: MessageData) = msg.msgType == Message.Type.RICH_MEDIA && msg.content.exists(isSyncable)
 
   private def isSyncable(c: MessageContent) = c.tpe match {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -38,7 +38,6 @@ import com.waz.utils._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-// TODO: obfuscate sent messages when they expire
 class EphemeralMessagesService(selfUserId: UserId,
                                clientId:   ClientId,
                                messages:   MessagesContentUpdater,
@@ -49,7 +48,6 @@ class EphemeralMessagesService(selfUserId: UserId,
                                assets:     AssetService) extends DerivedLogTag {
   import EphemeralMessagesService._
   import com.waz.threading.Threading.Implicits.Background
-  import com.wire.signals.EventContext.Implicits.global
   
   private val nextExpiryTime = Signal[LocalInstant](LocalInstant.Max)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -73,7 +73,7 @@ class EphemeralMessagesService(selfUserId: UserId,
     nextExpiryTime.mutate(_ min time)
   }
 
-  private def removeExpired() = Serialized.future(this, "removeExpired") {
+  private def removeExpired() = Serialized.future(s"removeExpired $selfUserId") {
     verbose(l"removeExpired")
     nextExpiryTime ! LocalInstant.Max
     db.read { implicit db =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -47,7 +47,6 @@ class MessageEventProcessor(selfUserId:           UserId,
                            ) extends DerivedLogTag {
   import MessageEventProcessor._
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   val messageEventProcessingStage = EventScheduler.Stage[MessageEvent] { (convId, events) =>
     convs.processConvWithRemoteId(convId, retryAsync = true) { conv =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -94,7 +94,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
     * @param exp ConvExpiry takes precedence over one-time expiry (exp), which takes precedence over the MessageExpiry
     */
   def addLocalMessage(msg: MessageData, state: Status = Status.PENDING, exp: Option[Option[FiniteDuration]] = None, localTime: LocalInstant = LocalInstant.Now) =
-    Serialized.future("add local message", msg.convId) {
+    Serialized.future(s"add local message ${msg.convId}") {
 
       def expiration =
         if (MessageData.EphemeralMessageTypes(msg.msgType))
@@ -119,7 +119,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
       }
     }
 
-  def addLocalSentMessage(msg: MessageData, time: Option[RemoteInstant] = None) = Serialized.future("add local message", msg.convId) {
+  def addLocalSentMessage(msg: MessageData, time: Option[RemoteInstant] = None) = Serialized.future(s"add local message ${msg.convId}") {
     verbose(l"addLocalSentMessage: $msg")
     time.fold(lastSentEventTime(msg.convId))(Future.successful).flatMap { t =>
       verbose(l"adding local sent message to storage, $t")
@@ -145,7 +145,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
    * Updates last local message or creates new one.
    */
   def updateOrCreateLocalMessage(convId: ConvId, msgType: Message.Type, update: MessageData => MessageData, create: => MessageData) =
-    Serialized.future("update-or-create-local-msg", convId, msgType) {
+    Serialized.future(s"update-or-create-local-msg $convId $msgType") {
       lastSentEventTime(convId).flatMap { time =>
         messagesStorage.getLastSystemMessage(convId, msgType, time).flatMap {
           case Some(msg) if msg.isLocal => // got local message, try updating

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -134,7 +134,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
         Future successful None
     }
 
-  override def applyMessageEdit(convId: ConvId, userId: UserId, time: RemoteInstant, gm: GenericMessage) = Serialized.future("applyMessageEdit", convId) {
+  override def applyMessageEdit(convId: ConvId, userId: UserId, time: RemoteInstant, gm: GenericMessage) = Serialized.future(s"applyMessageEdit $convId") {
 
     def findLatestUpdate(id: MessageId): Future[Option[MessageData]] =
       updater.getMessage(id) flatMap {
@@ -311,7 +311,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
   }
 
   override def addDeviceStartMessages(convs: Seq[ConversationData], selfUserId: UserId): Future[Set[MessageData]] =
-    Serialized.future('addDeviceStartMessages)(traverse(convs filter isGroupOrOneToOne) { conv =>
+    Serialized.future("addDeviceStartMessages")(traverse(convs filter isGroupOrOneToOne) { conv =>
       storage.getLastMessage(conv.id) map {
         case None =>    Some(MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId, time = RemoteInstant.Epoch))
         case Some(_) => None

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -111,7 +111,6 @@ class MessagesServiceImpl(selfUserId:      UserId,
                           buttonsStorage:  ButtonsStorage,
                           sync:            SyncServiceHandle) extends MessagesService with DerivedLogTag {
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   override val msgEdited = EventStream[(MessageId, MessageId)]()
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
@@ -37,7 +37,6 @@ class ReceiptService(messages: MessagesStorage,
                      selfUserId: UserId,
                      convsService: ConversationsService,
                      readReceiptsStorage: ReadReceiptsStorage) extends DerivedLogTag {
-  import EventContext.Implicits.global
   import Threading.Implicits.Background
 
   messages.onAdded { msgs =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
@@ -28,7 +28,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.UserId
 import com.waz.model.otr.{Client, ClientId, SignalingKey}
 import com.waz.service.MetaDataService
-import com.wire.signals.SerialDispatchQueue
+import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.cryptobox.{CryptoBox, PreKey}
@@ -39,7 +39,7 @@ import scala.util.Try
 
 class CryptoBoxService(context: Context, userId: UserId, metadata: MetaDataService, userPrefs: UserPreferences) extends DerivedLogTag {
   import CryptoBoxService._
-  private implicit val dispatcher = new SerialDispatchQueue(Threading.IO)
+  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, None)
 
   private[service] lazy val cryptoBoxDir = returning(new File(new File(context.getFilesDir, metadata.cryptoBoxDirName), userId.str))(_.mkdirs())
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -37,10 +37,10 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
   val onCreateFromMessage = EventStream[SessionId]()
 
   private def dispatch[A](id: SessionId)(f: Option[CryptoBox] => A) =
-    Serialized.future(id){cryptoBox.cryptoBox.map(f)}
+    Serialized.future(id.toString){cryptoBox.cryptoBox.map(f)}
 
   private def dispatchFut[A](id: SessionId)(f: Option[CryptoBox] => Future[A]) =
-    Serialized.future(id){cryptoBox.cryptoBox.flatMap(f)}
+    Serialized.future(id.toString){cryptoBox.cryptoBox.flatMap(f)}
 
   def getOrCreateSession(id: SessionId, key: PreKey) = dispatch(id) {
     case None => None

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
@@ -36,7 +36,6 @@ import scala.collection.immutable.Map
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-
 trait OtrClientsService {
 
   val lastSelfClientsSyncPref: Preferences.Preference[Long]
@@ -65,7 +64,6 @@ class OtrClientsServiceImpl(selfId:    UserId,
                             accounts:  AccountsService) extends OtrClientsService with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Background
-  import com.wire.signals.EventContext.Implicits.global
 
   override lazy val lastSelfClientsSyncPref: Preferences.Preference[Long] = userPrefs.preference(LastSelfClientsSyncRequestedTime)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -45,7 +45,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
 
-
 trait OtrService {
   def sessions: CryptoSessionService // only for tests
 
@@ -89,7 +88,6 @@ class OtrServiceImpl(selfUserId:     UserId,
                      clientsStorage: OtrClientsStorage,
                      prefs:          GlobalPreferences,
                      tracking:       TrackingService) extends OtrService with DerivedLogTag {
-  import EventContext.Implicits.global
   import OtrService._
   import Threading.Implicits.Background
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
@@ -47,7 +47,6 @@ class VerificationStateUpdater(selfUserId:     UserId,
   import Verification._
   import VerificationStateUpdater._
   import com.waz.threading.Threading.Implicits.Background
-  import com.wire.signals.EventContext.Implicits.global
 
   private val SerializationKey = serializationKey(selfUserId)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/otr/VerificationStateUpdater.scala
@@ -72,13 +72,13 @@ class VerificationStateUpdater(selfUserId:     UserId,
   }
 
   membersStorage.onAdded{ members =>
-    Serialized.future(SerializationKey) {
+    Serialized.future(SerializationKey.toString()) {
       updateConversations(members.map(_.convId).distinct, members.map { member => member.userId -> MemberAdded } (breakOut))
     }
   }
 
   membersStorage.onDeleted{ members =>
-    Serialized.future(SerializationKey) {
+    Serialized.future(SerializationKey.toString()) {
       updateConversations(members.map(_._2).distinct, members.map { _._1 -> Other } (breakOut))
     }
   }
@@ -106,7 +106,7 @@ class VerificationStateUpdater(selfUserId:     UserId,
         Future.successful(())
     }
 
-  private[service] def onClientsChanged(changes: Map[UserId, (UserClients, VerificationChange)]) = Serialized.future(SerializationKey) {
+  private[service] def onClientsChanged(changes: Map[UserId, (UserClients, VerificationChange)]) = Serialized.future(SerializationKey.toString()) {
 
     def updateUserVerified(user: UserData) = {
       val clients = changes(user.id)._1.clients.values
@@ -178,7 +178,7 @@ object VerificationStateUpdater extends DerivedLogTag {
 
   // XXX: small hack to synchronize other operations with verification state updating,
   // we sometimes need to make sure that this state is up to date before proceeding
-  def awaitUpdated(userId: UserId) = Serialized.future(serializationKey(userId)) { Future.successful(()) }
+  def awaitUpdated(userId: UserId) = Serialized.future(serializationKey(userId).toString()) { Future.successful(()) }
 
   case class VerificationStateUpdate(convUpdates: Seq[(ConversationData, ConversationData)], convUsers: Map[ConvId, Seq[UserData]], changes: Map[UserId, VerificationChange])
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -71,10 +71,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
                               uiController:    NotificationUiController,
                               userService:     UserService,
                               clock:           Clock) extends NotificationService {
-
   import Threading.Implicits.Background
-  import EventContext.Implicits.global
-
   implicit lazy val logTag: LogTag = accountTag[NotificationService](selfUserId)
 
   private val schedulePushNotificationsToUi = Signal(false)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
@@ -59,7 +59,7 @@ class PushNotificationEventsStorageImpl(context: Context, storage: Database, cli
     with PushNotificationEventsStorage
     with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "PushNotificationEventsStorage")
+  private implicit val dispatcher = SerialDispatchQueue(name = "PushNotificationEventsStorage")
 
   override def setAsDecrypted(index: EventIndex): Future[Unit] = {
     update(index, u => u.copy(decrypted = true)).map {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
@@ -27,14 +27,12 @@ import com.waz.model._
 import com.waz.model.otr.ClientId
 import com.waz.service.push.PushNotificationEventsStorage.{EventHandler, EventIndex, PlainWriter}
 import com.waz.sync.client.PushNotificationEncoded
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.wire.signals.EventContext
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 import org.json.JSONObject
 
 import scala.concurrent.Future
-
 
 object PushNotificationEventsStorage {
   type PlainWriter = Array[Byte] => Future[Unit]
@@ -58,8 +56,7 @@ class PushNotificationEventsStorageImpl(context: Context, storage: Database, cli
   extends CachedStorageImpl[EventIndex, PushNotificationEvent](new TrimmingLruCache(context, Fixed(1024*1024)), storage)(PushNotificationEventsDao, LogTag("PushNotificationEvents_Cached"))
     with PushNotificationEventsStorage
     with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "PushNotificationEventsStorage")
+  import com.waz.threading.Threading.Implicits.Background
 
   override def setAsDecrypted(index: EventIndex): Future[Unit] = {
     update(index, u => u.copy(decrypted = true)).map {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -103,7 +103,7 @@ class PushServiceImpl(selfUserId:           UserId,
   import PushService._
 
   implicit val logTag: LogTag = accountTag[PushServiceImpl](selfUserId)
-  private implicit val dispatcher = new SerialDispatchQueue(name = "PushService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "PushService")
 
   override val onHistoryLost = new SourceSignal[Instant] with BgEventSource[Instant]
   override val processing = Signal(false)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
@@ -52,7 +52,7 @@ class PushTokenService(userId:       UserId,
 
   implicit lazy val logTag: LogTag = accountTag[PushTokenService](userId)
 
-  implicit val dispatcher = new SerialDispatchQueue(name = "PushTokenService")
+  implicit val dispatcher = SerialDispatchQueue(name = "PushTokenService")
 
   private val isLoggedIn = accounts.accountState(userId).map {
     case _: Active => true
@@ -130,7 +130,7 @@ class GlobalTokenServiceImpl(googleApi: GoogleApi,
                              network:   NetworkModeService) extends GlobalTokenService with DerivedLogTag {
   import PushTokenService._
 
-  implicit val dispatcher = new SerialDispatchQueue(name = "GlobalTokenService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "GlobalTokenService")
   implicit val ev = EventContext.Global
 
 //  val pushEnabled  = prefs.preference(PushEnabledKey) //TODO delete the push token if the PushEnabledKey is false

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
@@ -131,7 +131,6 @@ class GlobalTokenServiceImpl(googleApi: GoogleApi,
   import PushTokenService._
 
   private implicit val dispatcher = SerialDispatchQueue(name = "GlobalTokenService")
-  implicit val ev = EventContext.Global
 
 //  val pushEnabled  = prefs.preference(PushEnabledKey) //TODO delete the push token if the PushEnabledKey is false
   val _currentToken = prefs.preference(GlobalPreferences.PushToken)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -95,7 +95,7 @@ class WSPushServiceImpl(userId:              UserId,
                        (implicit ev: EventContext) extends WSPushService {
 
   private implicit val logTag: LogTag = accountTag[WSPushServiceImpl](userId)
-  private implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(name = "WSPushServiceImpl")
+  private implicit val dispatcher = SerialDispatchQueue(name = "WSPushServiceImpl")
 
   override val notifications: SourceStream[Seq[PushNotificationEncoded]] = EventStream()
   override val connected: SourceSignal[Boolean] = Signal(false)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -28,7 +28,7 @@ import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsS
 import com.waz.service.{ConversationRolesService, ErrorsService, EventScheduler, SearchKey, SearchQuery, UserService}
 import com.waz.sync.client.TeamsClient.TeamMember
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.CancellableFuture
 import com.waz.utils.ContentChange.{Added, Removed, Updated}
 import com.wire.signals.{AggregatingSignal, EventStream, RefreshingSignal, Signal}
 import com.waz.utils.{ContentChange, RichFuture, RichInstant}
@@ -77,8 +77,7 @@ class TeamsServiceImpl(selfUser:           UserId,
                        errorsService:      ErrorsService,
                        rolesService:       ConversationRolesService
                       ) extends TeamsService with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "TeamsService")
+  import com.waz.threading.Threading.Implicits.Background
 
   private val shouldSyncTeam = userPrefs.preference(UserPreferences.ShouldSyncTeam)
   private val lastTeamUpdate = userPrefs.preference(UserPreferences.LastTeamUpdate)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -78,7 +78,7 @@ class TeamsServiceImpl(selfUser:           UserId,
                        rolesService:       ConversationRolesService
                       ) extends TeamsService with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "TeamsService")
+  private implicit val dispatcher = SerialDispatchQueue(name = "TeamsService")
 
   private val shouldSyncTeam = userPrefs.preference(UserPreferences.ShouldSyncTeam)
   private val lastTeamUpdate = userPrefs.preference(UserPreferences.LastTeamUpdate)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -56,18 +56,12 @@ class DummyTrackingService extends TrackingService {
 }
 
 object TrackingService {
-
   type ZmsProvider = Option[UserId] => Future[Option[ZMessaging]]
-
-  implicit val dispatcher = new SerialDispatchQueue(name = "TrackingService")
-  private[waz] implicit val ec: EventContext = EventContext.Global
-
 }
 
 class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: ZmsProvider, versionName: String)
   extends TrackingService with DerivedLogTag {
-
-  import TrackingService._
+  private implicit val dispatcher = SerialDispatchQueue(name = "TrackingService")
 
   override lazy val isTrackingEnabled: Signal[Boolean] =
     ZMessaging.currentAccounts.activeZms.flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -27,7 +27,6 @@ import com.waz.service.call.CallInfo.CallState._
 import com.waz.service.tracking.TrackingService.ZmsProvider
 import com.waz.service.tracking.TrackingServiceImpl.{CountlyEventProperties, RichHashMap}
 import com.waz.service.{AccountsService, ZMessaging}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.{MathUtils, RichWireInstant}
 import com.wire.signals.{EventContext, EventStream, Signal}
 
@@ -61,7 +60,7 @@ object TrackingService {
 
 class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: ZmsProvider, versionName: String)
   extends TrackingService with DerivedLogTag {
-  private implicit val dispatcher = SerialDispatchQueue(name = "TrackingService")
+  import com.waz.threading.Threading.Implicits.Background
 
   override lazy val isTrackingEnabled: Signal[Boolean] =
     ZMessaging.currentAccounts.activeZms.flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
@@ -26,13 +26,11 @@ import com.waz.model.{SyncId, UserId}
 import com.waz.service.tracking.TrackingService
 import com.waz.service.{AccountContext, AccountsService, NetworkModeService, ReportingService}
 import com.waz.sync.queue.{SyncContentUpdater, SyncScheduler, SyncSchedulerImpl}
-import com.wire.signals.SerialDispatchQueue
 import com.wire.signals.Signal
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import com.waz.log.LogSE._
-import com.waz.utils.returning
 
 trait SyncRequestService {
 
@@ -57,9 +55,7 @@ class SyncRequestServiceImpl(accountId: UserId,
                              accounts:  AccountsService,
                              tracking:  TrackingService
                             )(implicit accountContext: AccountContext) extends SyncRequestService with DerivedLogTag {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "SyncDispatcher")
-
+  import com.waz.threading.Threading.Implicits.Background
   private val scheduler: SyncScheduler = new SyncSchedulerImpl(accountId, content, network, this, sync, accounts, tracking)
 
   reporting.addStateReporter { pw =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
@@ -58,7 +58,7 @@ class SyncRequestServiceImpl(accountId: UserId,
                              tracking:  TrackingService
                             )(implicit accountContext: AccountContext) extends SyncRequestService with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SyncDispatcher")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SyncDispatcher")
 
   private val scheduler: SyncScheduler = new SyncSchedulerImpl(accountId, content, network, this, sync, accounts, tracking)
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
@@ -60,7 +60,7 @@ class AuthenticationManager(id: UserId,
 
   import AuthenticationManager._
 
-  implicit val dispatcher = new SerialDispatchQueue(name = "AuthenticationManager")
+  private implicit val dispatcher = SerialDispatchQueue(name = "AuthenticationManager")
 
   private def token  = withAccount(_.accessToken)
   private def cookie = withAccount(_.cookie)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/AuthenticationManager.scala
@@ -29,7 +29,6 @@ import com.waz.service.AccountsService.{InvalidCookie, InvalidCredentials, Logou
 import com.waz.service.ZMessaging.{accountTag, clock}
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.sync.client.LoginClient.LoginResult
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.JsonEncoder.encodeInstant
 import com.waz.utils.{JsonDecoder, JsonEncoder, _}
 import com.wire.signals.Serialized
@@ -55,12 +54,9 @@ class AuthenticationManager(id: UserId,
                             accountsService: AccountsService,
                             accountStorage: AccountStorage,
                             client: LoginClient) extends AccessTokenProvider {
-
   implicit val tag: LogTag = accountTag[AuthenticationManager](id)
-
   import AuthenticationManager._
-
-  private implicit val dispatcher = SerialDispatchQueue(name = "AuthenticationManager")
+  import com.waz.threading.Threading.Implicits.Background
 
   private def token  = withAccount(_.accessToken)
   private def cookie = withAccount(_.cookie)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/LoginClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/client/LoginClient.scala
@@ -63,7 +63,7 @@ class LoginClientImpl()
 
   import LoginClient._
 
-  private implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(name = "LoginClient")
+  private implicit val dispatcher = SerialDispatchQueue(name = "LoginClient")
 
   private var lastRequestTime = 0L
   private var failedAttempts = 0

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
@@ -36,7 +36,6 @@ class ConnectionsSyncHandler(usersStorage:      UsersStorage,
                              connectionsClient: ConnectionsClient) extends DerivedLogTag {
 
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   def syncConnections(): Future[SyncResult] = {
     connectionsClient.loadConnections().future flatMap {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -61,7 +61,6 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   import Threading.Implicits.Background
   import com.waz.sync.handler.ConversationsSyncHandler._
-  private implicit val ec = EventContext.Global
 
   // optimization: same team conversations use default roles so we don't have to ask the backend
   private def loadConversationRoles(resps: Seq[ConversationResponse]) = {

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/FoldersSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/FoldersSyncHandler.scala
@@ -30,8 +30,6 @@ import io.circe.generic.auto._
 import scala.concurrent.Future
 
 class FoldersSyncHandler(prefsClient: PropertiesClient, foldersService: FoldersService) {
-  private implicit val ec = EventContext.Global
-
   import Threading.Implicits.Background
   import com.waz.znet2.http.HttpClient.AutoDerivation._
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -57,7 +57,6 @@ class UsersSyncHandlerImpl(userService:      UserService,
   extends UsersSyncHandler with DerivedLogTag {
   import UsersSyncHandler._
   import Threading.Implicits.Background
-  private implicit val ec = EventContext.Global
 
   override def syncUsers(ids: UserId*): Future[SyncResult] = usersClient.loadUsers(ids).future.flatMap {
     case Right(users) =>

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -55,7 +55,7 @@ class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater with Deriv
   import EventContext.Implicits.global
   import SyncContentUpdater._
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SyncContentUpdaterQueue")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SyncContentUpdaterQueue")
 
   private val mergers = new mutable.HashMap[Any, SyncJobMerger]
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -27,12 +27,11 @@ import com.waz.model.sync._
 import com.waz.sync.queue.SyncJobMerger.{Merged, Unchanged, Updated}
 import com.wire.signals.SerialDispatchQueue
 import com.waz.utils._
-import com.wire.signals.{AggregatingSignal, EventContext, EventStream, Signal}
+import com.wire.signals.{AggregatingSignal, EventStream, Signal}
 
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 
 /**
  * Keeps actual SyncJobs in memory, and persists all changes to db.
@@ -52,7 +51,6 @@ trait SyncContentUpdater {
 }
 
 class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater with DerivedLogTag {
-  import EventContext.Implicits.global
   import SyncContentUpdater._
 
   private implicit val dispatcher = SerialDispatchQueue(name = "SyncContentUpdaterQueue")

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
@@ -43,7 +43,7 @@ class SyncExecutor(account:     UserId,
                    handler: =>  SyncHandler) extends DerivedLogTag {
 
   import SyncExecutor._
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SyncExecutorQueue")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SyncExecutorQueue")
 
   def apply(job: SyncJob): Future[SyncResult] = {
     def withJob(f: SyncJob => Future[SyncResult]) =

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
@@ -60,7 +60,7 @@ class SyncSchedulerImpl(accountId:   UserId,
                         tracking:    TrackingService)
                        (implicit accountContext: AccountContext) extends SyncScheduler with DerivedLogTag {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SyncSchedulerQueue")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SyncSchedulerQueue")
 
   private val queue                 = new SyncSerializer
   private[sync] val executor        = new SyncExecutor(accountId, this, content, network, handler)

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{Future, Promise}
 
 class SyncSerializer extends DerivedLogTag {
   import SyncSerializer._
-  private implicit val dispatcher = new SerialDispatchQueue(name = "SyncSerializer")
+  private implicit val dispatcher = SerialDispatchQueue(name = "SyncSerializer")
 
   private var runningJobs = 0
   private val convs = new mutable.HashSet[ConvId]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -31,12 +31,12 @@ import scala.util.control.NonFatal
 object Threading {
 
   implicit class RichSignal[E](val signal: Signal[E]) extends AnyVal {
-    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext): Subscription =
+    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
       signal.on(Threading.Ui)(subscriber)(context)
   }
 
   implicit class RichEventStream[E](val stream: EventStream[E]) extends AnyVal {
-    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext): Subscription =
+    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
       stream.on(Threading.Ui)(subscriber)(context)
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/ui/UiCache.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/ui/UiCache.scala
@@ -37,7 +37,7 @@ class UiCache[Key, A <: AnyRef](lruSize: Int = 0)(implicit ui: UiModule)
   val lru = new LruCache[Key, A](lruSize max 1)
   val items = new mutable.HashMap[Key, WeakReference[A]]
 
-  ui.onReset.onUi(_ => clear())(EventContext.Global)
+  ui.onReset.onUi(_ => clear())
 
   def get(k: Key): Option[A] = {
     Threading.assertUiThread()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/AsyncFileWriter.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/AsyncFileWriter.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 class AsyncFileWriter(file: File) {
-  private val serialDispatcher = new SerialDispatchQueue()
+  private val serialDispatcher = SerialDispatchQueue()
   private val promisedCompletion = Promise[Unit]
   @volatile private var finishCalled = false
   @volatile private var activeStream = Option.empty[FileOutputStream]

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
@@ -261,7 +261,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
                                                  tag: LogTag = LogTag("CachedStorage")
                                                 ) extends CachedStorage[K, V] {
 
-  private implicit val dispatcher = new SerialDispatchQueue(name = tag + "_Dispatcher")
+  private implicit val dispatcher = SerialDispatchQueue(name = tag + "_Dispatcher")
 
   val onAdded = EventStream[Seq[V]]()
   val onUpdated = EventStream[Seq[(V, V)]]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
@@ -24,7 +24,6 @@ import com.waz.content.Database
 import com.waz.db.DaoIdOps
 import com.waz.log.BasicLogging.LogTag
 import com.waz.model.errors.NotFoundLocal
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.ContentChange.{Added, Removed, Updated}
 import com.wire.signals._
 import com.waz.utils.wrappers.DB
@@ -260,8 +259,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
                                                  val dao: StorageDao[K, V],
                                                  tag: LogTag = LogTag("CachedStorage")
                                                 ) extends CachedStorage[K, V] {
-
-  private implicit val dispatcher = SerialDispatchQueue(name = tag + "_Dispatcher")
+  import com.waz.threading.Threading.Implicits.Background
 
   val onAdded = EventStream[Seq[V]]()
   val onUpdated = EventStream[Seq[(V, V)]]()

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/Cancellable.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/Cancellable.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
   * Global registry of cancellable tasks.
   */
 object Cancellable {
-  private implicit val dispatcher: SerialDispatchQueue = new SerialDispatchQueue(name = "Cancellable")
+  private implicit val dispatcher = SerialDispatchQueue(name = "Cancellable")
 
   private val tasks = new mutable.HashMap[Any, CancellableFuture[_]]
 
@@ -49,7 +49,7 @@ object Cancellable {
 }
 
 object AssetProcessing extends DerivedLogTag {
-  private implicit val dispatcher = new SerialDispatchQueue(name = "AssetProcessing")
+  private implicit val dispatcher = SerialDispatchQueue(name = "AssetProcessing")
 
   private val tasks = new mutable.HashMap[ProcessingTaskKey, CancellableFuture[Option[AssetData]]]
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -39,7 +39,6 @@ import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.otr.OtrSyncHandler
 import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
 import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.RichInstant
 import com.wire.signals.Signal
 import com.waz.utils.jna.Uint32_t
@@ -51,8 +50,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
-
-  implicit val executionContext = SerialDispatchQueue(name = "CallingServiceSpec")
+  import com.waz.threading.Threading.Implicits.Background
 
   val context        = mock[Context]
   val avs            = mock[Avs]

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -52,7 +52,7 @@ import scala.util.control.NonFatal
 
 class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
-  implicit val executionContext = new SerialDispatchQueue(name = "CallingServiceSpec")
+  implicit val executionContext = SerialDispatchQueue(name = "CallingServiceSpec")
 
   val context        = mock[Context]
   val avs            = mock[Avs]

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.Future
 
 class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
-  implicit val executionContext = new SerialDispatchQueue(name = "ConnectionServiceAndroidFreeSpec")
+  implicit val executionContext = SerialDispatchQueue(name = "ConnectionServiceAndroidFreeSpec")
 
   val push            = mock[PushService]
   val teamId          = Option.empty[TeamId]

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -29,15 +29,13 @@ import com.waz.service.messages.MessagesService
 import com.waz.service.push.PushService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
-import com.wire.signals.SerialDispatchQueue
 import com.waz.utils.returning
 import org.scalatest.Inside
 
 import scala.concurrent.Future
 
 class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
-
-  implicit val executionContext = SerialDispatchQueue(name = "ConnectionServiceAndroidFreeSpec")
+  import com.waz.threading.Threading.Implicits.Background
 
   val push            = mock[PushService]
   val teamId          = Option.empty[TeamId]

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationOrderEventsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/conversation/ConversationOrderEventsServiceSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
-  implicit val outputDispatcher = new SerialDispatchQueue(name = "OutputWriter")
+  implicit val outputDispatcher = SerialDispatchQueue(name = "OutputWriter")
 
   scenario("All batched conversation events go to the order event service before any other conv-related service") {
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -254,6 +254,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       //WHEN
       result(service.deleteGroupConversation(teamId, rConvId))
+
+      awaitAllTasks
     }
 
     scenario("When delete group conversation request returns error, post error to ui") {
@@ -271,6 +273,7 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val errorResponse = ErrorResponse(404, message = "not found", label = "")
 
       (sync.deleteGroupConversation _).expects(teamId, rConvId).anyNumberOfTimes().onCall { (_, rId) =>
+        println("here")
         service.onGroupConversationDeleteError(errorResponse, rId)
         Future.successful(SyncId())
       }
@@ -282,6 +285,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       //WHEN
       result(service.deleteGroupConversation(teamId, rConvId))
+
+      awaitAllTasks
     }
   }
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -273,7 +273,6 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val errorResponse = ErrorResponse(404, message = "not found", label = "")
 
       (sync.deleteGroupConversation _).expects(teamId, rConvId).anyNumberOfTimes().onCall { (_, rId) =>
-        println("here")
         service.onGroupConversationDeleteError(errorResponse, rId)
         Future.successful(SyncId())
       }

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -29,10 +29,9 @@ import com.waz.service.assets.FileRestrictionList
 import com.waz.service.tracking.TrackingService
 import com.waz.testutils.TestClock
 import com.waz.threading.Threading.{Background, IO, ImageDispatcher, Ui}
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
+import com.wire.signals.{CancellableFuture, DispatchQueue, SerialDispatchQueue, Signal}
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.wire.signals.Signal
 import com.waz.utils.wrappers.{Intent, JVMIntentUtil, JavaURIUtil, URI, _}
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
@@ -126,11 +125,13 @@ abstract class AndroidFreeSpec extends ZMockSpec { this: Suite =>
 
     Intent.setUtil(JVMIntentUtil)
 
-    Threading.setUi(new SerialDispatchQueue({
-      com.wire.signals.Threading.executionContext(Executors.newSingleThreadExecutor(new ThreadFactory {
+    Threading.setUi(DispatchQueue(
+      DispatchQueue.SERIAL,
+      Executors.newSingleThreadExecutor(new ThreadFactory {
         override def newThread(r: Runnable) = new Thread(r, Threading.testUiThreadName)
-      }))
-    }, Threading.testUiThreadName))
+      }),
+      Option(Threading.testUiThreadName)
+    ))
   }
 
   /**

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/Matchers.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/Matchers.scala
@@ -76,8 +76,6 @@ object Matchers {
   }
 
   def withEvent[A, B](p: EventStream[A])(f: PartialFunction[A, Boolean])(body: => B)(implicit timeout: FiniteDuration = 15.seconds): B = {
-    import com.wire.signals.EventContext.Implicits.global
-
     var gotNotification = false
     p {
       f.andThen(if (_) gotNotification = true)

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/TestPreferences.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/TestPreferences.scala
@@ -24,7 +24,7 @@ import com.wire.signals.SerialDispatchQueue
 
 //TODO make Global and User preferences traits so that we don't have to override them both.
 class TestGlobalPreferences extends GlobalPreferences(null, null) {
-  override implicit val dispatcher = new SerialDispatchQueue(name = "TestGlobalPreferenceQueue")
+  override implicit val dispatcher = SerialDispatchQueue(name = "TestGlobalPreferenceQueue")
 
   private var values = Map.empty[String, String]
 
@@ -42,7 +42,7 @@ class TestGlobalPreferences extends GlobalPreferences(null, null) {
 
 class TestUserPreferences extends UserPreferences(null, null) {
 
-  override implicit val dispatcher = new SerialDispatchQueue(name = "TestUserPreferenceQueue")
+  override implicit val dispatcher = SerialDispatchQueue(name = "TestUserPreferenceQueue")
 
   private var values = Map.empty[String, String]
 

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -103,7 +103,7 @@ package object testutils {
 
     class SignalSink[A] {
       @volatile private var sub = Option.empty[Subscription]
-      def subscribe(s: Signal[A])(implicit ctx: EventContext): Unit = sub = Some(s(v => value = Some(v)))
+      def subscribe(s: Signal[A])(implicit ctx: EventContext = EventContext.Global): Unit = sub = Some(s(v => value = Some(v)))
       def unsubscribe: Unit = sub.foreach { s =>
         s.destroy()
         sub = None

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -98,7 +98,7 @@ package object testutils {
     }
 
     implicit class SignalToSink[A](val signal: Signal[A]) extends AnyVal {
-      def sink: SignalSink[A] = returning(new SignalSink[A])(_.subscribe(signal)(EventContext.Global))
+      def sink: SignalSink[A] = returning(new SignalSink[A])(_.subscribe(signal))
     }
 
     class SignalSink[A] {

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
@@ -35,16 +35,12 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Source, Sink, Keep }
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.ws.{ TextMessage, Message, BinaryMessage }
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.Directives
 import scala.concurrent.{ Future, Promise, Await }
 import scala.concurrent.duration._
 
 class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with BeforeAndAfterEach {
-
-  import EventContext.Implicits.global
   import com.waz.BlockingSyntax.toBlocking
 
   private var wsPort: Int = _


### PR DESCRIPTION
Please look to https://github.com/wireapp/wire-signals/pull/6 to see what has changed in the signals.
This PR removes some boilerplate code, but also it removes a lot of serial dispatch queues. We used a separate dispatch queue for virtually every `*Storage` class and often in controllers and services as well. They were all working on the same thread pool. For a long time I suspected they add nothing and in some cases might even slow down the app. I switched many of them to the default `Threading.Background` (not all, I wanted to be on the safe side) and tested main functionalities. So far it looks fine.
#### APK
[Download build #2814](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2814/artifact/build/artifact/wire-dev-PR3041-2814.apk)
[Download build #2825](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2825/artifact/build/artifact/wire-dev-PR3041-2825.apk)