### PR TITLE
[Bugfix : Call Degradation] : Call degradation popup should be displayed when Self User adds a new device

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -332,7 +332,7 @@ class CallController(implicit inj: Injector, cxt: WireContext, eventContext: Eve
     zms     <- callingZms
     convId  <- callConvId
     members <- zms.membersStorage.activeMembers(convId)
-    users   <- zms.usersStorage.listSignal(members.filterNot(_ == zms.selfUserId))
+    users   <- zms.usersStorage.listSignal(members)
   } yield users.map(u => u.id -> u.isVerified).toMap
 
   usersVerifications { newUV =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

A last minute fix for call degradation feature : call degradation popup should be displayed when a verified self user (having all devices verified), adds a new device during the call.

https://wearezeta.atlassian.net/browse/AN-7110
#### APK
[Download build #2812](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2812/artifact/build/artifact/wire-dev-PR3042-2812.apk)