### PR TITLE
AVS bump to 6.4.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'kotlinx-serialization'
 //region avs
 //TODO: Migrate this configuration to new dependency system
 ext {
-    avsVersion = '5.6.212@aar'
+    avsVersion = '6.4.4@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
     avsName = 'avs'
     avsGroup = 'com.wire'

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
     //core
     const val KOTLIN = "1.3.72"
     const val WIRE_TRANSLATIONS = "1.+"
-    val AVS = System.getenv("AVS_VERSION") ?: "5.3.191@aar"
+    val AVS = System.getenv("AVS_VERSION") ?: "6.4.4@aar"
     val WIRE_AUDIO = System.getenv("AUDIO_VERSION") ?: "1.209.0@aar"
 
     //plugins


### PR DESCRIPTION
The Dev build crashes now if we try to start a call.
This PR fixes it, but you also need to have `user.gradle` in your app folder (contact me if you miss it).

We will still need to make a cleanup of paces where the AVS version can be updated - there's many of them.
#### APK
[Download build #2817](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2817/artifact/build/artifact/wire-dev-PR3043-2817.apk)