### PR TITLE
Fix invalid ignore paths on codecov config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,11 +14,11 @@ coverage:
 # --------------
 # which folders/files to ignore
 ignore:
-  - */tests/.*
-  - */androidTest/.*
-  - */_version.py
-  - setup.py
-  - versioneer.py
+  - ".*/test/.*"
+  - ".*/androidTest/.*"
+  - ".*/_version.py"
+  - "setup.py"
+  - "versioneer.py"
 
 # Pull request comments:
 # ----------------------


### PR DESCRIPTION
```
$ cat codecov.yml | curl --data-binary @- https://codecov.io/validate
Valid!

{
  "ignore": [
    ".*/test/.*",
    ".*/androidTest/.*",
    ".*/_version.py",
    "^setup.py.*",
    "^versioneer.py.*"
  ],
  "coverage": {
    "status": {
      "patch": false,
      "project": {
        "default": {
          "target": "auto",
          "threshold": 5.0,
          "base": "auto"
        }
      }
    }
  },
  "comment": {
    "layout": "diff, files"
  }
}

```