### PR TITLE
Changes needed to work with wire-signals 0.2.4

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -28,7 +28,7 @@ import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo.CallState.{SelfJoining, _}
 import com.waz.service.call.CallInfo.Participant
 import com.waz.service.call.{CallInfo, CallingService, GlobalCallingService}
-import com.waz.service.{GlobalModule, ZMessaging}
+import com.waz.service.{GlobalModule, MediaManagerService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
 import com.waz.utils._
@@ -427,7 +427,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
     }
   }
 
-  lazy val speakerButton = ButtonSignal(callingZms.map(_.mediamanager), callingZms.flatMap(_.mediamanager.isSpeakerOn)) {
+  lazy val speakerButton: ButtonSignal[MediaManagerService] = ButtonSignal(callingZms.map(_.mediamanager), callingZms.flatMap(_.mediamanager.isSpeakerOn)) {
     case (mm, isSpeakerSet) => mm.setSpeaker(!isSpeakerSet)
   }.disableAutowiring()
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -178,7 +178,7 @@ case class AccountBackStackKey(args: Bundle = new Bundle()) extends BackStackKey
   private var controller = Option.empty[AccountViewController]
 
   override def onViewAttached(v: View) =
-    controller = Option(v.asInstanceOf[AccountViewImpl]).map(view => new AccountViewController(view)(view.wContext.injector, view, view.getContext))
+    controller = Option(v.asInstanceOf[AccountViewImpl]).map(view => new AccountViewController(view)(view.wContext.injector, view.eventContext, view.getContext))
 
   override def onViewDetached() =
     controller = None

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -163,7 +163,7 @@ case class DeviceDetailsBackStackKey(args: Bundle) extends BackStackKey(args) {
   override def layoutId = R.layout.preferences_device_details
 
   override def onViewAttached(v: View) =
-    controller = Option(v.asInstanceOf[DeviceDetailsViewImpl]).map(view => DeviceDetailsViewController(view, deviceId)(view.injector, view, v.getContext))
+    controller = Option(v.asInstanceOf[DeviceDetailsViewImpl]).map(view => DeviceDetailsViewController(view, deviceId)(view.injector, view.eventContext, v.getContext))
 
   override def onViewDetached() = {
     controller = None

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
@@ -86,7 +86,7 @@ case class DevicesBackStackKey(args: Bundle = new Bundle()) extends BackStackKey
   private var controller = Option.empty[DevicesViewController]
 
   override def onViewAttached(v: View) = {
-    controller = Option(v.asInstanceOf[DevicesViewImpl]).map(view => DevicesViewController(view)(view.injector, view))
+    controller = Option(v.asInstanceOf[DevicesViewImpl]).map(view => DevicesViewController(view)(view.injector, view.eventContext))
   }
 
   override def onViewDetached() = {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -226,7 +226,7 @@ case class OptionsBackStackKey(args: Bundle = new Bundle()) extends BackStackKey
   var controller = Option.empty[OptionsViewController]
 
   override def onViewAttached(v: View) = {
-    controller = Option(v.asInstanceOf[OptionsViewImpl]).map(ov => new OptionsViewController(ov)(ov.injector, ov))
+    controller = Option(v.asInstanceOf[OptionsViewImpl]).map(ov => new OptionsViewController(ov)(ov.injector, ov.eventContext))
   }
 
   override def onViewDetached() = {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfilePictureView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfilePictureView.scala
@@ -64,7 +64,7 @@ case class ProfilePictureBackStackKey(args: Bundle = new Bundle()) extends BackS
   var controller = Option.empty[ProfilePictureViewController]
 
   override def onViewAttached(v: View) = {
-    controller = Option(v.asInstanceOf[ProfilePictureViewImpl]).map(v => new ProfilePictureViewController(v)(v.wContext.injector, v))
+    controller = Option(v.asInstanceOf[ProfilePictureViewImpl]).map(v => new ProfilePictureViewController(v)(v.wContext.injector, v.eventContext))
   }
 
   override def onViewDetached() = {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -226,7 +226,7 @@ case class ProfileBackStackKey(args: Bundle = new Bundle()) extends BackStackKey
   var controller = Option.empty[ProfileViewController]
 
   override def onViewAttached(v: View) = {
-    controller = Option(v.asInstanceOf[ProfileViewImpl]).map(view => new ProfileViewController(view)(view.wContext.injector, view))
+    controller = Option(v.asInstanceOf[ProfileViewImpl]).map(view => new ProfileViewController(view)(view.wContext.injector, view.eventContext))
   }
 
   override def onViewDetached() = {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -112,7 +112,7 @@ case class SettingsBackStackKey(args: Bundle = new Bundle()) extends BackStackKe
   var controller = Option.empty[SettingsViewController]
 
   override def onViewAttached(v: View) = {
-    controller = Option(v.asInstanceOf[SettingsViewImpl]).map(sv => new SettingsViewController(sv)(sv.injector, sv))
+    controller = Option(v.asInstanceOf[SettingsViewImpl]).map(sv => new SettingsViewController(sv)(sv.injector, sv.eventContext))
   }
 
   override def onViewDetached() = {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -178,7 +178,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.2.3"
+    const val WIRE_SIGNALS = "0.2.4"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -22,19 +22,19 @@ import com.waz.log.LogSE._
 import com.waz.model.UserId
 import com.waz.service.AccountsService.LoggedOut
 import com.waz.service.ZMessaging.accountTag
-import com.wire.signals.{EventContext, SerialDispatchQueue}
+import com.wire.signals.{BaseEventContext, SerialDispatchQueue}
 
-class AccountContext(userId: UserId, accounts: AccountsService) extends EventContext {
+class AccountContext(userId: UserId, accounts: AccountsService) extends BaseEventContext {
 
   implicit val logTag: LogTag = accountTag[AccountContext](userId)
   private implicit val dispatcher = SerialDispatchQueue(name = "AccountContext")
 
   accounts.accountState(userId).on(dispatcher) {
     case LoggedOut =>
+      stop()
       verbose(l"Account context stopped")
-      onContextStop()
     case _ =>
+      start()
       verbose(l"Account context started")
-      onContextStart()
   }
 }

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -17,13 +17,14 @@
  */
 package com.waz.threading
 
-import java.util.concurrent.{ExecutorService, Executors}
+import java.util.concurrent.Executors
 
 import android.os.{Handler, HandlerThread, Looper}
 import com.waz.utils.returning
 import com.waz.zms.BuildConfig
+import com.wire.signals.Subscription.Subscriber
 import com.wire.signals.Threading.Cpus
-import com.wire.signals.{DispatchQueue, EventContext, EventStream, Events, Signal, Subscription}
+import com.wire.signals.{DispatchQueue, EventContext, EventStream, Signal, Subscription}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
@@ -31,12 +32,12 @@ import scala.util.control.NonFatal
 object Threading {
 
   implicit class RichSignal[E](val signal: Signal[E]) extends AnyVal {
-    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
+    def onUi(subscriber: Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
       signal.on(Threading.Ui)(subscriber)(context)
   }
 
   implicit class RichEventStream[E](val stream: EventStream[E]) extends AnyVal {
-    def onUi(subscriber: Events.Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
+    def onUi(subscriber: Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
       stream.on(Threading.Ui)(subscriber)(context)
   }
 

--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
@@ -37,7 +37,7 @@ class ZMessagingResolver(ui: UiModule) {
 }
 
 trait UiEventContext {
-  implicit val eventContext = new EventContext() {}
+  implicit lazy val eventContext: EventContext = EventContext()
 
   private[ui] var createCount = 0
   private[ui] var startCount = 0
@@ -50,7 +50,7 @@ trait UiEventContext {
     startCount += 1
 
     if (startCount == 1) {
-      eventContext.onContextStart()
+      eventContext.start()
       onStarted ! true
     }
   }
@@ -62,13 +62,13 @@ trait UiEventContext {
 
     if (startCount == 0) {
       onStarted ! false
-      eventContext.onContextStop()
+      eventContext.stop()
     }
   }
 
   def onDestroy(): Unit = {
     Threading.assertUiThread()
-    eventContext.onContextDestroy()
+    eventContext.destroy()
   }
 }
 
@@ -86,8 +86,6 @@ class UiModule(val global: GlobalModule) extends UiEventContext with ZMessagingR
   currentZms.onChanged { _ => onReset ! true }
 
   def getCurrent: Future[Option[ZMessaging]] = accounts.activeZms.head
-  
-
 }
 
 object UiModule {


### PR DESCRIPTION
For details please look at: https://github.com/wireapp/wire-signals/pull/26

From the wire-android point of view, the main difference is that FragmentHelper, DialogHelper, etc., now do not implement EventContext but contain it as a lazy val.
#### APK
[Download build #2822](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2822/artifact/build/artifact/wire-dev-PR3046-2822.apk)
[Download build #2824](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2824/artifact/build/artifact/wire-dev-PR3046-2824.apk)