### PR TITLE
Bump AVS version to 6.4.9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,13 +9,13 @@ apply plugin: 'kotlinx-serialization'
 //region avs
 //TODO: Migrate this configuration to new dependency system
 ext {
-    avsVersion = '6.4.4@aar'
+    avsVersion = '6.4.9@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
     avsName = 'avs'
     avsGroup = 'com.wire'
 
     // proprietary avs artifact configuration
-    customAvsVersion = '6.4.4@aar'
+    customAvsVersion = '6.4.9@aar'
     customAvsInternalVersion = customAvsVersion
     customAvsName = 'avs'
     customAvsGroup = 'com.wearezeta.avs'

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
     //core
     const val KOTLIN = "1.3.72"
     const val WIRE_TRANSLATIONS = "1.+"
-    val AVS = System.getenv("AVS_VERSION") ?: "6.4.4@aar"
+    val AVS = System.getenv("AVS_VERSION") ?: "6.4.9@aar"
     val WIRE_AUDIO = System.getenv("AUDIO_VERSION") ?: "1.209.0@aar"
 
     //plugins


### PR DESCRIPTION
## What's new in this PR?

Bump AVS version to the latest one 6.4.9

#### APK
[Download build #2830](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2830/artifact/build/artifact/wire-dev-PR3047-2830.apk)