### PR TITLE
Fix: Android 11 UI Distortion + memory leaks along the way 

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -21,6 +21,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
+             android:background="@color/black"
              xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.waz.zclient.common.views.BackgroundImageView

--- a/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/LaunchActivity.scala
@@ -19,7 +19,7 @@
 package com.waz.zclient
 
 import android.app.AlertDialog
-import android.content.{Context, DialogInterface, Intent}
+import android.content.{DialogInterface, Intent}
 import androidx.appcompat.app.AppCompatActivity
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service.{AccountsService, BackendConfig}
@@ -29,8 +29,6 @@ import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.BackendController
 
 class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedLogTag {
-
-  private implicit val context: Context = this
 
   private lazy val backendController = inject[BackendController]
 
@@ -75,7 +73,7 @@ class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedL
     })
 
     builder.setCancelable(false)
-    if (!isFinishing())  builder.create().show()
+    if (!isFinishing)  builder.create().show()
 
     // QA needs to be able to switch backends via intents. Any changes to the backend
     // preference while the dialog is open will be treated as a user selection.
@@ -98,8 +96,4 @@ class LaunchActivity extends AppCompatActivity with ActivityHelper with DerivedL
     startActivity(AppEntryActivity.newIntent(this))
     finish()
   }
-}
-
-object LaunchActivity {
-  val Tag = classOf[LaunchActivity].getName
 }

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -20,8 +20,7 @@ package com.waz.zclient
 import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
-import android.graphics.drawable.ColorDrawable
-import android.graphics.{Color, Paint, PixelFormat}
+import android.graphics.{Paint, PixelFormat}
 import android.os.Bundle
 import androidx.fragment.app.{Fragment, FragmentTransaction}
 import com.waz.content.UserPreferences._
@@ -77,7 +76,7 @@ class MainActivity extends BaseActivity
   with SetHandleFragment.Container
   with DerivedLogTag {
 
-  implicit val cxt: MainActivity = this
+  private implicit val cxt: MainActivity = this
 
   import Threading.Implicits.Ui
 
@@ -101,9 +100,6 @@ class MainActivity extends BaseActivity
   override def onCreate(savedInstanceState: Bundle) = {
     Option(getActionBar).foreach(_.hide())
     super.onCreate(savedInstanceState)
-
-    //Prevent drawing the default background to reduce overdraw
-    getWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT))
     setContentView(R.layout.main)
 
     ViewUtils.lockScreenOrientation(Configuration.ORIENTATION_PORTRAIT, this)
@@ -124,8 +120,7 @@ class MainActivity extends BaseActivity
     themeController.darkThemeSet.onUi {
       case theme if theme != currentlyDarkTheme =>
         info(l"restartActivity")
-        finish()
-        startActivity(getIntent)
+        recreate()
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
       case _ =>
     }

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -399,7 +399,7 @@ trait CallingBannerActivity extends ActivityHelper {
     super.onCreate(savedInstanceState)
 
     callController.isCallActiveDelay.onUi { est =>
-      getWindow.setStatusBarColor(ContextUtils.getColor(if (est) R.color.accent_green else android.R.color.transparent)(this))
+      getWindow.setStatusBarColor(ContextUtils.getColor(if (est) R.color.accent_green else R.color.black)(this))
       callBanner.setVisibility(if (est) View.VISIBLE else View.GONE)
     }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -62,7 +62,7 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
 
   import Threading.Implicits.Ui
 
-  implicit def ctx: Context = this
+  private implicit val ctx: Context = this
 
   private lazy val progressView = ViewUtils.getView(this, R.id.liv__progress).asInstanceOf[LoadingIndicatorView]
   private lazy val countryController: CountryController = new CountryController(this)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -102,6 +102,7 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
   override def onDestroyView() = {
     conversationListView.foreach(_.removeOnScrollListener(conversationsListScrollListener))
+    conversationListView.foreach(_.setAdapter(null))
     super.onDestroyView()
   }
 
@@ -127,7 +128,7 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
   private def configureAdapter(adapter: ConversationListAdapter): Unit = {
     adapter.setMaxAlpha(getResourceFloat(R.dimen.list__swipe_max_alpha))
-    
+
     subs += userAccountsController.currentUser.onUi(user => topToolbar.get.setTitle(adapterMode, user))
 
     subs += adapter.onConversationClick { conv =>

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -30,6 +30,7 @@ import com.waz.zclient.{BuildConfig, Injectable, Injector, LaunchActivity}
 import com.wire.signals._
 
 import scala.collection.convert.DecorateAsScala
+import scala.util.Try
 
 class ActivityLifecycleCallback(implicit injector: Injector)
   extends Application.ActivityLifecycleCallbacks
@@ -76,9 +77,11 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
       Option(activityRef.get()).foreach(_.getWindow.addFlags(FLAG_SECURE))
     } else {
-      shouldHideScreenContent.onUi {
-        case true => Option(activityRef.get()).foreach(_.getWindow.addFlags(FLAG_SECURE))
-        case false => Option(activityRef.get()).foreach(_.getWindow.clearFlags(FLAG_SECURE))
+      shouldHideScreenContent.onUi { hide =>
+        Try(activityRef.get().getWindow).foreach { window =>
+          if (hide) window.addFlags(FLAG_SECURE)
+          else window.clearFlags(FLAG_SECURE)
+        }
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -1,20 +1,20 @@
 /**
-  * Wire
-  * Copyright (C) 2019 Wire Swiss GmbH
-  *
-  * This program is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  */
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.waz.zclient.security
 
 import java.lang.ref.WeakReference
@@ -74,11 +74,11 @@ class ActivityLifecycleCallback(implicit injector: Injector)
   override def onActivityResumed(activity: Activity): Unit = {
     val activityRef = new WeakReference[Activity](activity)
     if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
-      activityRef.get().getWindow.addFlags(FLAG_SECURE)
+      Option(activityRef.get()).foreach(_.getWindow.addFlags(FLAG_SECURE))
     } else {
       shouldHideScreenContent.onUi {
-        case true  => activityRef.get().getWindow.addFlags(FLAG_SECURE)
-        case false => activityRef.get().getWindow.clearFlags(FLAG_SECURE)
+        case true => Option(activityRef.get()).foreach(_.getWindow.addFlags(FLAG_SECURE))
+        case false => Option(activityRef.get()).foreach(_.getWindow.clearFlags(FLAG_SECURE))
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -17,6 +17,8 @@
   */
 package com.waz.zclient.security
 
+import java.lang.ref.WeakReference
+
 import android.app.{Activity, Application}
 import android.os.Bundle
 import android.view.WindowManager.LayoutParams.FLAG_SECURE
@@ -70,12 +72,13 @@ class ActivityLifecycleCallback(implicit injector: Injector)
   override def onActivityCreated(activity: Activity, bundle: Bundle): Unit = {}
 
   override def onActivityResumed(activity: Activity): Unit = {
+    val activityRef = new WeakReference[Activity](activity)
     if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
-      activity.getWindow.addFlags(FLAG_SECURE)
+      activityRef.get().getWindow.addFlags(FLAG_SECURE)
     } else {
       shouldHideScreenContent.onUi {
-        case true  => activity.getWindow.addFlags(FLAG_SECURE)
-        case false => activity.getWindow.clearFlags(FLAG_SECURE)
+        case true  => activityRef.get().getWindow.addFlags(FLAG_SECURE)
+        case false => activityRef.get().getWindow.clearFlags(FLAG_SECURE)
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -18,7 +18,7 @@
 
 package com.waz.zclient.usersearch
 
-import android.content.{Context, Intent}
+import android.content.Intent
 import android.os.Bundle
 import android.view._
 import android.view.animation.Animation
@@ -75,8 +75,6 @@ class SearchUIFragment extends BaseFragment[Container]
   import Threading.Implicits.Ui
 
   private implicit lazy val uiStorage: UiStorage = inject[UiStorage]
-
-  private implicit def context: Context = getContext
 
   private lazy val zms                    = inject[Signal[ZMessaging]]
   private lazy val usersStorage           = inject[Signal[UsersStorage]]


### PR DESCRIPTION
## What's new in this PR?

JIRA ticket (1): https://wearezeta.atlassian.net/browse/AN-7108
JIRA ticket (2): https://wearezeta.atlassian.net/browse/AN-7100
Github: https://github.com/wireapp/wire-android/issues/3002

### Issues

Some Pixel devices are creating an unreadable system UI upon various different actions 

### Causes

It looks like a new reaction to an old problem, when we're setting the `getWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT))` the reaction by the system UI overloads the `MainActivity`. This I believe is because we invalidate and re-create the `PhoneWindow` with the new drawable and opacity.

### Solutions

Remove this call to `getWindow().setBackgroundDrawable(..)` and replace with a color resource rendered when the view has been attached and created. 

### Testing

How to reproduce without this fix: 

- Login as a user without a profile picture
- open a conversation
- come back from the conversation via back arrow or swiping from left to right
-> contact list is broken
- try swiping a conversation to the right
-> contact list gets even worse

You should be able to use the app as normal with this fix. 

## Notes

In order for me to find the problem I spent hours analysing memory dumps, GPU profiles and looking for potential memory leaks. So this PR also includes plugs to some of those leaks. 
#### APK
[Download build #2833](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2833/artifact/build/artifact/wire-dev-PR3051-2833.apk)
[Download build #2835](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2835/artifact/build/artifact/wire-dev-PR3051-2835.apk)
[Download build #2836](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2836/artifact/build/artifact/wire-dev-PR3051-2836.apk)