### PR TITLE
Trying to overcome file sharing ban with Intent.FLAG_GRANT_READ_URI_PERMISSION

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -496,7 +496,7 @@ class MainActivity extends BaseActivity
 
       case SharingIntent() =>
         for {
-          convs <- sharingController.sendContent(this)
+          convs <- sharingController.sendContent(intent, this)
           _     <- if (convs.size == 1) conversationController.switchConversation(convs.head) else Future.successful({})
           _     =  clearIntent()
         } yield true

--- a/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
@@ -263,7 +263,7 @@ class AudioMessageRecordingView (val context: Context, val attrs: AttributeSet, 
   }
 
   private def sendAudioAsset(content: ContentForUpload): Future[Unit] =
-    convController.sendAssetMessage(content, getContext.asInstanceOf[Activity], None).map(_ => hide())(Threading.Ui)
+    convController.sendAssetMessage(content, None).map(_ => hide())(Threading.Ui)
 
   def onMotionEventFromAudioMessageButton(motionEvent: MotionEvent): Unit = {
     def stopRecording(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/giphy/GiphySharingPreviewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/giphy/GiphySharingPreviewFragment.scala
@@ -258,7 +258,7 @@ class GiphySharingPreviewFragment extends BaseFragment[GiphySharingPreviewFragme
       gifContent <- Future { WireGlide(getContext).as(classOf[Array[Byte]]).load(gif.get.original.source.toString).submit().get() }(Threading.Background)
       contentForUpload = ContentForUpload(s"${gif.get.id}.${Mime.extensionsMap(Mime.Image.Gif)}", Content.Bytes(Mime.Image.Gif, gifContent))
       _  <- conversationController.sendMessage(msg)
-      _  <- conversationController.sendAssetMessage(contentForUpload, getActivity, None)
+      _  <- conversationController.sendAssetMessage(contentForUpload, None)
     } yield ()
     screenController.hideGiphy ! true
   }

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -525,7 +525,7 @@ class ConversationFragment extends FragmentHelper {
       case AssetIntentsManager.IntentType.FILE_SHARING =>
         permissions.requestAllPermissions(ListSet(READ_EXTERNAL_STORAGE)).map {
           case true =>
-            convController.sendAssetMessage(URIWrapper.toJava(uri), getActivity, None)
+            convController.sendAssetMessage(URIWrapper.toJava(uri), None)
           case _ =>
             ViewUtils.showAlertDialog(
               getActivity,
@@ -539,7 +539,7 @@ class ConversationFragment extends FragmentHelper {
       case AssetIntentsManager.IntentType.GALLERY =>
         showImagePreview { _.setImage(uri) }
       case _ =>
-        convController.sendAssetMessage(URIWrapper.toJava(uri), getActivity, None)
+        convController.sendAssetMessage(URIWrapper.toJava(uri), None)
         navigationController.setRightPage(Page.MESSAGE_STREAM, TAG)
         extendedCursorContainer.foreach(_.close(true))
     }
@@ -613,7 +613,7 @@ class ConversationFragment extends FragmentHelper {
 
           override def sendRecording(mime: String, audioFile: File): Unit = {
             val content = ContentForUpload(s"audio_record_${System.currentTimeMillis()}.m4a", Content.File(Mime.Audio.M4A, audioFile))
-            convController.sendAssetMessage(content, getActivity, None)
+            convController.sendAssetMessage(content, None)
             extendedCursorContainer.foreach(_.close(true))
           }
         }))


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-7114

I have found this possible fix for sharing files on new Androids: https://github.com/lubritto/flutter_share/pull/20.
I tweaked the sharing file functionality a bit so that I was able to put the copied code in one place, `AssetIntentsManager`,
and access it from all places where we attempt to send files from the external storage to a conversation.

Please review and test, especially on Android 11 and Android 10 on new Pixel phones. Please also test sharing files from outside the app. It didn't work before in some cases, so if it doesn't work now, it doesn't mean it's a regression. But it shouldn't get worse.
#### APK
[Download build #2865](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2865/artifact/build/artifact/wire-dev-PR3057-2865.apk)