### PR TITLE
Fix AVS open source version number

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'kotlinx-serialization'
 //region avs
 //TODO: Migrate this configuration to new dependency system
 ext {
-    avsVersion = '6.4.12@aar'
+    avsVersion = '6.4.233@aar'
     avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
     avsName = 'avs'
     avsGroup = 'com.wire'


### PR DESCRIPTION
## What's new in this PR?

### Issues

The open source AVS library don't use the same patch version number of the custom one. Github users are not able to build the code using AVS 6.4.12. The correct version numbers for the open source AVS lib are available here : 

https://mvnrepository.com/artifact/com.wire/avs

#### APK
[Download build #2870](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2870/artifact/build/artifact/wire-dev-PR3058-2870.apk)