### PR TITLE
Add legacy external storage request flag to overcome scoped storage on Android 11 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
         android:required="false"
         />
 
+    <!-- TODO: Remove requestLegacyExternalStorage when you bump to sdk 30 and migrate the legacy data-->
     <application
         android:name=".ZApplication"
         android:allowBackup="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
     <application
         android:name=".ZApplication"
         android:allowBackup="false"
+        android:requestLegacyExternalStorage="true"
         android:hardwareAccelerated="true"
         android:icon="${applicationIcon}"
         android:label="${applicationLabel}"


### PR DESCRIPTION
What's new in this PR?

### Issues

With Android 11 devices they introduced a behavioural change concept called Scoped Storage. 

### Causes

This means that the device has limited permissions on particular areas of storage on the device for privacy related reasons. 

### Solutions

It is recommended for those targeting Android 10 to use `android:requestLegacyExternalStorage` to overcome the scoped storage issue on Android 11 devices. 

> Apps that run on Android 11 but target Android 10 (API level 29) can still request the requestLegacyExternalStorage attribute. This flag allows apps to temporarily opt out of the changes associated with scoped storage, such as granting access to different directories and different types of media files. After you update your app to target Android 11, the system ignores the requestLegacyExternalStorage flag.

### Testing

Coinciding with some [changes to testing-gallery](https://github.com/wireapp/testing-gallery/commit/55d73058d80c74533657e81cd80f527dd8acd1a4) this has resolved automation issues presented in the last few days. 

#### APK
[Download build #2877](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2877/artifact/build/artifact/wire-dev-PR3061-2877.apk)