### PR TITLE
Bugfix : AVS versionning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -319,6 +319,7 @@ dependencies {
     api project(ModuleDependencies.storage)
     api(project(ModuleDependencies.syncEngine)) {
         exclude group: 'com.wire', module: 'avs'
+        exclude group: 'com.wearezeta.avs', module: 'avs'
     }
 
     //Android

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -306,7 +306,7 @@ dependencies {
     implementation BuildDependencies.kotlin.coroutinesAndroid
     implementation BuildDependencies.kotlin.coroutinesCore
 
-    implementation "${rootProject.ext.avsDependency}"
+    implementation avsDependency
 
     implementation BuildDependencies.wire.audioNotifications
     //don't include wire translations for custom builds
@@ -318,8 +318,7 @@ dependencies {
 
     api project(ModuleDependencies.storage)
     api(project(ModuleDependencies.syncEngine)) {
-        exclude group: 'com.wire', module: 'avs'
-        exclude group: 'com.wearezeta.avs', module: 'avs'
+        exclude group: avsGroup, module: avsName
     }
 
     //Android

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,26 +6,6 @@ apply plugin: 'com.mutualmobile.gradle.plugins.dexinfo'
 apply from: 'config/quality.gradle'
 apply plugin: 'kotlinx-serialization'
 
-//region avs
-//TODO: Migrate this configuration to new dependency system
-ext {
-    avsVersion = '6.4.233@aar'
-    avsInternalVersion = avsVersion //leave this here in case we want to test specific AVS versions on internal
-    avsName = 'avs'
-    avsGroup = 'com.wire'
-
-    // proprietary avs artifact configuration
-    customAvsVersion = '6.4.12@aar'
-    customAvsInternalVersion = customAvsVersion
-    customAvsName = 'avs'
-    customAvsGroup = 'com.wearezeta.avs'
-}
-
-if (project.file('user.gradle').exists()) {
-    apply from: "user.gradle"
-}
-//endregion avs
-
 task copyCustomResources(type: Copy) {
     if (buildtimeConfiguration.customResourcesPath == null) {
         return
@@ -317,24 +297,6 @@ dexinfo {
 
 dependencies {
 
-    //region avs
-    // TODO Migrate this configuration to new dependency system
-    boolean internal = true
-    for (String taskName : gradle.startParameter.taskNames) {
-        if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
-            internal = false
-            break
-        }
-    }
-
-    // For using local files in app/libs
-    //implementation (name:'avs', ext:'aar')
-    //implementation (name:'audio-notifications', ext:'aar')
-    //implementation (name:'zmessaging-android', ext:'aar')
-
-    implementation "$avsGroup:$avsName:${internal ? avsInternalVersion : avsVersion}"
-    //endregion avs
-
     implementation LegacyDependencies.scalaLibrary
     implementation LegacyDependencies.scalaReflect
     implementation LegacyDependencies.scalaShapeless
@@ -344,8 +306,8 @@ dependencies {
     implementation BuildDependencies.kotlin.coroutinesAndroid
     implementation BuildDependencies.kotlin.coroutinesCore
 
-    // TODO uncomment when new dependency system supports avs
-//    implementation BuildDependencies.wire.avs
+    implementation "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
+
     implementation BuildDependencies.wire.audioNotifications
     //don't include wire translations for custom builds
     if (buildtimeConfiguration.customResourcesPath == null) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -306,7 +306,7 @@ dependencies {
     implementation BuildDependencies.kotlin.coroutinesAndroid
     implementation BuildDependencies.kotlin.coroutinesCore
 
-    implementation "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
+    implementation "${rootProject.ext.avsDependency}"
 
     implementation BuildDependencies.wire.audioNotifications
     //don't include wire translations for custom builds

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -1,0 +1,25 @@
+String avsPublicVersion = "6.4.228@aar"
+String avsCustomVersion = "6.4.9@aar"
+String avsPublicGroup = "com.wire"
+String avsCustomGroup = "com.wearezeta.avs"
+
+// Set shouldUseCustomAvs value to true if want to test with an AVS custom version in dev, internal or experimental builds
+boolean shouldUseCustomAvs = false
+
+for (String taskName : gradle.startParameter.taskNames) {
+    if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
+        shouldUseCustomAvs = true
+        break
+    }
+}
+
+ext {
+    avsName = System.getenv("AVS_NAME") ?: "avs"
+    if (shouldUseCustomAvs) {
+        avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion
+        avsGroup = System.getenv("AVS_GROUP") ?: avsCustomGroup
+    } else {
+        avsVersion = System.getenv("AVS_VERSION") ?: avsPublicVersion
+        avsGroup = System.getenv("AVS_GROUP") ?: avsPublicGroup
+    }
+}

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -1,40 +1,49 @@
+final String AVS_GROUP_ENV_VAR = "AVS_GROUP"
+final String AVS_NAME_ENV_VAR = "AVS_NAME"
+final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
+final String NEXUS_URL_ENV_VAR = "NEXUS_URL"
+final String NEXUS_URL_LOCAL_VAR = "nexus.url"
+final String LOCAL_PROPERTIES_FILE_NAME = "local.properties"
+final String AVS_PUBLIC_GROUP = "com.wire"
+final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
+final String AVS_NAME = "avs"
+
 String avsPublicVersion = "6.4.233"
-String avsCustomVersion = "6.4.12"
-String avsPublicGroup = "com.wire"
-String avsCustomGroup = "com.wearezeta.avs"
-String nexusUrl = "http://10.10.124.11:8081/nexus/content/groups/public"
+String avsPrivateVersion = "6.4.12"
+String nexusUrl = ""
 
-// Set shouldUseCustomAvs value to true if want to test with a custom AVS version in dev, internal or experimental builds
-boolean shouldUseCustomAvs = false
-
-def isConnected = !"curl -i -m 3 $nexusUrl".execute().err.text.contains("timed out")
-
-if (isConnected) {
-    for (String taskName : gradle.startParameter.taskNames) {
-        if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
-            shouldUseCustomAvs = true
-            break
-        }
+if (System.hasProperty(NEXUS_URL_ENV_VAR)) {
+    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR)
+} else {
+    Properties properties = new Properties()
+    def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
+    if (propertiesFile.exists()) {
+        properties.load(propertiesFile.newDataInputStream())
+        nexusUrl = properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
     }
 }
 
-String avsGroup
-String avsName = System.getenv("AVS_NAME") ?: "avs"
-String avsVersion
+println("nexus " + nexusUrl)
 
-if (shouldUseCustomAvs) {
-    avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion
-    avsGroup = System.getenv("AVS_GROUP") ?: avsCustomGroup
+if (!nexusUrl.isEmpty()) {
     allprojects {
         repositories {
             maven { url nexusUrl }
         }
     }
+    ext {
+        avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_PRIVATE_GROUP
+        avsName = System.getenv(AVS_NAME_ENV_VAR) ?: AVS_NAME
+        avsVersion = System.getenv(AVS_VERSION_ENV_VAR) ?: avsPrivateVersion
+        avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
+    }
+
 } else {
-    avsVersion = System.getenv("AVS_VERSION") ?: avsPublicVersion
-    avsGroup = System.getenv("AVS_GROUP") ?: avsPublicGroup
+    ext {
+        avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_PUBLIC_GROUP
+        avsName = System.getenv(AVS_NAME_ENV_VAR) ?: AVS_NAME
+        avsVersion = System.getenv(AVS_VERSION_ENV_VAR) ?: avsPublicVersion
+        avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
+    }
 }
 
-ext {
-    avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
-}

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -23,8 +23,6 @@ if (System.hasProperty(NEXUS_URL_ENV_VAR)) {
     }
 }
 
-println("nexus " + nexusUrl)
-
 if (!nexusUrl.isEmpty()) {
     allprojects {
         repositories {

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -1,5 +1,5 @@
-String avsPublicVersion = "6.4.228@aar"
-String avsCustomVersion = "6.4.9@aar"
+String avsPublicVersion = "6.4.233@aar"
+String avsCustomVersion = "6.4.12@aar"
 String avsPublicGroup = "com.wire"
 String avsCustomGroup = "com.wearezeta.avs"
 
@@ -13,13 +13,18 @@ for (String taskName : gradle.startParameter.taskNames) {
     }
 }
 
+String avsName = System.getenv("AVS_NAME") ?: "avs"
+String avsVersion
+String avsGroup
+
+if (shouldUseCustomAvs) {
+    avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion
+    avsGroup = System.getenv("AVS_GROUP") ?: avsCustomGroup
+} else {
+    avsVersion = System.getenv("AVS_VERSION") ?: avsPublicVersion
+    avsGroup = System.getenv("AVS_GROUP") ?: avsPublicGroup
+}
+
 ext {
-    avsName = System.getenv("AVS_NAME") ?: "avs"
-    if (shouldUseCustomAvs) {
-        avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion
-        avsGroup = System.getenv("AVS_GROUP") ?: avsCustomGroup
-    } else {
-        avsVersion = System.getenv("AVS_VERSION") ?: avsPublicVersion
-        avsGroup = System.getenv("AVS_GROUP") ?: avsPublicGroup
-    }
+    avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
 }

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -10,18 +10,12 @@ final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.4.233"
 String avsPrivateVersion = "6.4.12"
-String nexusUrl = ""
 
-if (System.hasProperty(NEXUS_URL_ENV_VAR)) {
-    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR)
-} else {
-    Properties properties = new Properties()
-    def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
-    if (propertiesFile.exists()) {
-        properties.load(propertiesFile.newDataInputStream())
-        nexusUrl = properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
-    }
-}
+Properties properties = new Properties()
+def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
+properties.load(propertiesFile.newDataInputStream())
+
+String nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
 
 if (!nexusUrl.isEmpty()) {
     allprojects {

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -7,8 +7,9 @@ String nexusUrl = "http://10.10.124.11:8081/nexus/content/groups/public"
 // Set shouldUseCustomAvs value to true if want to test with a custom AVS version in dev, internal or experimental builds
 boolean shouldUseCustomAvs = false
 
-def proc = "curl -i -m 3 $nexusUrl".execute()
-if (!proc.err.text.contains("timed out")) {
+def isConnected = !"curl -i -m 3 $nexusUrl".execute().err.text.contains("timed out")
+
+if (isConnected) {
     for (String taskName : gradle.startParameter.taskNames) {
         if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
             shouldUseCustomAvs = true

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -1,21 +1,27 @@
-String avsPublicVersion = "6.4.233@aar"
-String avsCustomVersion = "6.4.12@aar"
+String avsPublicVersion = "6.4.233"
+String avsCustomVersion = "6.4.12"
 String avsPublicGroup = "com.wire"
 String avsCustomGroup = "com.wearezeta.avs"
 
-// Set shouldUseCustomAvs value to true if want to test with an AVS custom version in dev, internal or experimental builds
-boolean shouldUseCustomAvs = false
+boolean shouldUseCustomAvs
 
-for (String taskName : gradle.startParameter.taskNames) {
-    if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
-        shouldUseCustomAvs = true
-        break
+def proc = "curl -i -m 3 http://10.10.124.11:8081/nexus/content/groups/public".execute()
+if (proc.err.text.contains("timed out")) shouldUseCustomAvs = false
+else {
+    // Set shouldUseCustomAvs value to true if want to test with an AVS custom version in dev, internal or experimental builds
+    shouldUseCustomAvs = false
+    for (String taskName : gradle.startParameter.taskNames) {
+        if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
+            shouldUseCustomAvs = true
+            break
+        }
     }
 }
 
+
+String avsGroup
 String avsName = System.getenv("AVS_NAME") ?: "avs"
 String avsVersion
-String avsGroup
 
 if (shouldUseCustomAvs) {
     avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -2,14 +2,13 @@ String avsPublicVersion = "6.4.233"
 String avsCustomVersion = "6.4.12"
 String avsPublicGroup = "com.wire"
 String avsCustomGroup = "com.wearezeta.avs"
+String nexusUrl = "http://10.10.124.11:8081/nexus/content/groups/public"
 
-boolean shouldUseCustomAvs
+// Set shouldUseCustomAvs value to true if want to test with a custom AVS version in dev, internal or experimental builds
+boolean shouldUseCustomAvs = false
 
-def proc = "curl -i -m 3 http://10.10.124.11:8081/nexus/content/groups/public".execute()
-if (proc.err.text.contains("timed out")) shouldUseCustomAvs = false
-else {
-    // Set shouldUseCustomAvs value to true if want to test with an AVS custom version in dev, internal or experimental builds
-    shouldUseCustomAvs = false
+def proc = "curl -i -m 3 $nexusUrl".execute()
+if (!proc.err.text.contains("timed out")) {
     for (String taskName : gradle.startParameter.taskNames) {
         if (taskName.contains("Prod") || taskName.contains("Candidate") || taskName == "aPR") {
             shouldUseCustomAvs = true
@@ -18,7 +17,6 @@ else {
     }
 }
 
-
 String avsGroup
 String avsName = System.getenv("AVS_NAME") ?: "avs"
 String avsVersion
@@ -26,6 +24,11 @@ String avsVersion
 if (shouldUseCustomAvs) {
     avsVersion = System.getenv("AVS_VERSION") ?: avsCustomVersion
     avsGroup = System.getenv("AVS_GROUP") ?: avsCustomGroup
+    allprojects {
+        repositories {
+            maven { url nexusUrl }
+        }
+    }
 } else {
     avsVersion = System.getenv("AVS_VERSION") ?: avsPublicVersion
     avsGroup = System.getenv("AVS_GROUP") ?: avsPublicGroup

--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,13 @@ allprojects {
         maven { url "https://dl.bintray.com/wire-android/third-party" }
         maven { url 'https://maven.google.com' }
         mavenCentral()
+        maven { url "http://10.10.124.11:8081/nexus/content/groups/public" }
     }
 }
 
 apply from: "./detekt/setup.gradle"
 apply from: "./jacoco/coverage.gradle"
+apply from: "./avs/avs.gradle"
 
 // FIXME: License header is disabled because it breaks compilation
 //task licenseFormatAndroid(type: nl.javadude.gradle.plugins.license.License) {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ allprojects {
         maven { url "https://dl.bintray.com/wire-android/third-party" }
         maven { url 'https://maven.google.com' }
         mavenCentral()
-        maven { url "http://10.10.124.11:8081/nexus/content/groups/public" }
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,6 @@ object Versions {
     //core
     const val KOTLIN = "1.3.72"
     const val WIRE_TRANSLATIONS = "1.+"
-    val AVS = System.getenv("AVS_VERSION") ?: "6.4.12@aar"
     val WIRE_AUDIO = System.getenv("AUDIO_VERSION") ?: "1.209.0@aar"
 
     //plugins
@@ -75,8 +74,7 @@ object BuildDependencies {
     ))
     val wire = WireDependencyMap(mapOf(
         "audioNotifications" to "com.wire:audio-notifications:${Versions.WIRE_AUDIO}",
-        "translations" to "com.wire:wiretranslations:${Versions.WIRE_TRANSLATIONS}",
-        "avs" to "com.wire:${System.getenv("AVS_NAME") ?: "avs"}:${Versions.AVS}"
+        "translations" to "com.wire:wiretranslations:${Versions.WIRE_TRANSLATIONS}"
     ))
     val androidX = AndroidXDependencyMap(mapOf(
         "material" to "com.google.android.material:material:${Versions.ANDROIDX_MATERIAL}",

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -96,13 +96,14 @@ dependencies {
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
     implementation BuildDependencies.wireSignals
     implementation BuildDependencies.libSodium
+    implementation "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
 
     //Provided dependencies
     compileOnly "com.softwaremill.macwire:macros_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:macrosakka_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:util_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:proxy_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
-    compileOnly "com.wire:avs:3.4.100"
+
     compileOnly "androidx.legacy:legacy-support-v4:1.0.0"
     compileOnly BuildDependencies.threetenbpJava
     compileOnly "net.java.dev.jna:jna:4.4.0@aar"
@@ -127,7 +128,7 @@ dependencies {
     testImplementation "com.typesafe.akka:akka-http_${LegacyDependencies.SCALA_MAJOR_VERSION}:10.1.8"
     testImplementation "com.typesafe.akka:akka-actor_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
     testImplementation "com.typesafe.akka:akka-stream_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
-    testImplementation "com.wire:avs:3.4.100"
+    testImplementation  "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
     testImplementation "androidx.legacy:legacy-support-v4:1.0.0"
     testImplementation BuildDependencies.threetenbpJava
     testImplementation "net.java.dev.jna:jna:4.4.0@aar"

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     compileOnly "com.softwaremill.macwire:macrosakka_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:util_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:proxy_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
-    compileOnly "${rootProject.ext.avsDependency}"
+    compileOnly avsDependency
     compileOnly "androidx.legacy:legacy-support-v4:1.0.0"
     compileOnly BuildDependencies.threetenbpJava
     compileOnly "net.java.dev.jna:jna:4.4.0@aar"
@@ -127,7 +127,7 @@ dependencies {
     testImplementation "com.typesafe.akka:akka-http_${LegacyDependencies.SCALA_MAJOR_VERSION}:10.1.8"
     testImplementation "com.typesafe.akka:akka-actor_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
     testImplementation "com.typesafe.akka:akka-stream_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
-    testImplementation  "${rootProject.ext.avsDependency}"
+    testImplementation  avsDependency
     testImplementation "androidx.legacy:legacy-support-v4:1.0.0"
     testImplementation BuildDependencies.threetenbpJava
     testImplementation "net.java.dev.jna:jna:4.4.0@aar"

--- a/wire-android-sync-engine/zmessaging/build.gradle
+++ b/wire-android-sync-engine/zmessaging/build.gradle
@@ -96,14 +96,13 @@ dependencies {
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
     implementation BuildDependencies.wireSignals
     implementation BuildDependencies.libSodium
-    implementation "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
 
     //Provided dependencies
     compileOnly "com.softwaremill.macwire:macros_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:macrosakka_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:util_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
     compileOnly "com.softwaremill.macwire:proxy_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.3.3"
-
+    compileOnly "${rootProject.ext.avsDependency}"
     compileOnly "androidx.legacy:legacy-support-v4:1.0.0"
     compileOnly BuildDependencies.threetenbpJava
     compileOnly "net.java.dev.jna:jna:4.4.0@aar"
@@ -128,7 +127,7 @@ dependencies {
     testImplementation "com.typesafe.akka:akka-http_${LegacyDependencies.SCALA_MAJOR_VERSION}:10.1.8"
     testImplementation "com.typesafe.akka:akka-actor_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
     testImplementation "com.typesafe.akka:akka-stream_${LegacyDependencies.SCALA_MAJOR_VERSION}:2.5.22"
-    testImplementation  "${rootProject.ext.avsGroup}:${rootProject.ext.avsName}:${rootProject.ext.avsVersion}"
+    testImplementation  "${rootProject.ext.avsDependency}"
     testImplementation "androidx.legacy:legacy-support-v4:1.0.0"
     testImplementation BuildDependencies.threetenbpJava
     testImplementation "net.java.dev.jna:jna:4.4.0@aar"


### PR DESCRIPTION
## What's new in this PR?

### Issues

After merging #3055  Jenkins jobs are using the AVS open source version 6.4.233

### Causes

`if (System.hasProperty(NEXUS_URL_ENV_VAR))`  is checking gradle properties file instead of the environment variable 

### Solutions

Remove unnecessary checks for the env variable and for` local.properties` file existence.
