### PR TITLE
Bugfix : AVS versioning

### DIFF
--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -10,18 +10,12 @@ final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.4.233"
 String avsPrivateVersion = "6.4.12"
-String nexusUrl = ""
 
-if (System.hasProperty(NEXUS_URL_ENV_VAR)) {
-    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR)
-} else {
-    Properties properties = new Properties()
-    def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
-    if (propertiesFile.exists()) {
-        properties.load(propertiesFile.newDataInputStream())
-        nexusUrl = properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
-    }
-}
+Properties properties = new Properties()
+def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
+properties.load(propertiesFile.newDataInputStream())
+
+String nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
 
 if (!nexusUrl.isEmpty()) {
     allprojects {
@@ -44,4 +38,3 @@ if (!nexusUrl.isEmpty()) {
         avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
     }
 }
-

--- a/avs/avs.gradle
+++ b/avs/avs.gradle
@@ -11,11 +11,16 @@ final String AVS_NAME = "avs"
 String avsPublicVersion = "6.4.233"
 String avsPrivateVersion = "6.4.12"
 
+String nexusUrl = ""
+
 Properties properties = new Properties()
 def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
-properties.load(propertiesFile.newDataInputStream())
-
-String nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
+if (propertiesFile.exists()) {
+    properties.load(propertiesFile.newDataInputStream())
+    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
+} else {
+    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: ""
+}
 
 if (!nexusUrl.isEmpty()) {
     allprojects {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After merging #3055  Jenkins jobs are using the AVS open source version 6.4.233

### Causes

`if (System.hasProperty(NEXUS_URL_ENV_VAR))`  is checking gradle properties instead of the environment variable 

### Solutions

Remove wrong check for the env variable.

#### APK
[Download build #2886](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2886/artifact/build/artifact/wire-dev-PR3063-2886.apk)