### PR TITLE
added animationDisabled flag for tests to build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,10 +23,6 @@ android {
         testInstrumentationRunner = AndroidClient.testRunner
     }
 
-    testOptions {
-        animationsDisabled = true
-    }
-
     sourceSets { map { it.java.srcDir("src/${it.name}/kotlin") } }
 }
 

--- a/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
@@ -25,6 +25,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    testOptions {
+        animationsDisabled = true
+    }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }


### PR DESCRIPTION
in order to guarantee that espresso tests do not failed because of animation lags.
it is recommended to set the flag animationDisabled for tests

this PR includes this block into the build.gradle.kts of the app project