### PR TITLE
Fix error while sharing small files

### DIFF
--- a/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
+++ b/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
@@ -21,11 +21,12 @@ import java.net.UnknownServiceException
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.wire.signals.CancellableFuture
 import com.waz.znet2.http.HttpClient._
 import com.waz.znet2.http.Request.QueryParameter
+import com.wire.signals.CancellableFuture
 
 import scala.concurrent.ExecutionContext
+import scala.math.max
 
 object HttpClient {
 
@@ -40,10 +41,10 @@ object HttpClient {
   object ProgressFilter {
 
     def steps(n: Long, totalBytes: Long): ProgressFilter = new ProgressFilter {
-      private val stepSize: Long = totalBytes / n
+      private val bytesPerStep: Long = max(totalBytes / n, 1)
       @volatile var lastStep: Long = 0
       override def needPublishProgress(progress: Long, total: Option[Long]): Boolean = {
-        val step = progress / stepSize
+        val step = progress / bytesPerStep
         if (step - lastStep >= 1) {
           lastStep = step
           true

--- a/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/ProgressFilterSpec.scala
+++ b/wire-android-sync-engine/zmessaging/src/test/scala/com/waz/znet2/ProgressFilterSpec.scala
@@ -1,0 +1,34 @@
+package com.waz.znet2
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.znet2.http.HttpClient.ProgressFilter
+
+class ProgressFilterSpec extends AndroidFreeSpec {
+
+  feature("ProgressFilter with step count") {
+
+    scenario("given bytes per step is less than 1, when needPublishProgress is called, then accepts increase of at least 1 byte per call") {
+      val numberOfSteps = 10
+      val totalSize = 3L //bytes
+
+      //bytes per step is 3/10 = 0.3 but adjusted to 1.
+      val progressFilter = ProgressFilter.steps(numberOfSteps, totalSize)
+
+      progressFilter.needPublishProgress(1L, total = Some(totalSize)) shouldBe true
+      progressFilter.needPublishProgress(1.2.toLong, total = Some(totalSize)) shouldBe false
+      progressFilter.needPublishProgress(2.2.toLong, total = Some(totalSize)) shouldBe true
+    }
+
+    scenario("given bytes per step is >= 1, when needPublishProgress is called, then accepts increase of at least original size") {
+      val numberOfSteps = 10
+      val totalSize = 300L //bytes
+
+      //should not accept less than 30 bytes per step
+      val progressFilter = ProgressFilter.steps(numberOfSteps, totalSize)
+
+      progressFilter.needPublishProgress(30L, total = Some(totalSize)) shouldBe true
+      progressFilter.needPublishProgress(45L, total = Some(totalSize)) shouldBe false
+      progressFilter.needPublishProgress(80L, total = Some(totalSize)) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/AN-6620

### Issues

When sharing a small file (e.g. a text file with a few lines in it), we always get a failure.

### Causes

During upload we show a loading animation, calculating the progress of the animation via `ProgressFilter`. For small files, 
`private val stepSize: Long = totalBytes / n` were resolving to 0, which leads to a division with 0 throwing an ArithmeticException at line `val step = progress / stepSize`

### Solutions

Make `stepSize` to be at least 1. This also ensures that step count never decreases between subsequent calls.

### Testing

Unit tests are added for `ProgressFilter.step()` implementation.

**Manual testing steps are:**

1. Create a small text file with size smaller than 100 bytes.
2. Try to upload the file to a conversation

Actual result:
We get an error saying upload is failed.

Expected result: 
The file should be uploaded succesfully.

#### APK
[Download build #2893](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2893/artifact/build/artifact/wire-dev-PR3066-2893.apk)