### PR TITLE
Fix : Make sure non-team users never send analytics data even if they turned analytics on

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -251,7 +251,7 @@ class MainActivity extends BaseActivity
             .flatMap(_ => prefs(TrackingEnabledOneTimeCheckPerformed) := true)
         } else Future.successful(())
       _                <-
-        if(analyticsEnabled) {
+        if(analyticsEnabled && isProUser) {
           inject[GlobalTrackingController].init()
         } else Future.successful(())
     } yield ()


### PR DESCRIPTION
## What's new in this PR?

### Issues

In our Countly console, we can see that some devices are sending analytics events. In those events, the team ID is set to n/a. These are probably non-team users that decided to turn analytics on. However, non team users should never send data no matter what. 

https://wearezeta.atlassian.net/browse/AN-7121

### Causes

`GlobalTrackingController].init()` is called without checking whether the user is part of team or not.

### Solutions

Add the missing condition `isProUser` before initializing `GlobalTrackingController`

#### APK
[Download build #2902](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2902/artifact/build/artifact/wire-dev-PR3069-2902.apk)