### PR TITLE
Fix: Camera crash for devices pre-API28

### DIFF
--- a/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
@@ -9,7 +9,7 @@ import android.hardware.camera2._
 import android.hardware.camera2.params.MeteringRectangle
 import android.media.ImageReader.OnImageAvailableListener
 import android.media.{ExifInterface, Image, ImageReader}
-import android.os.{Handler, HandlerThread}
+import android.os.{Build, Handler, HandlerThread}
 import android.view.Surface
 import com.waz.bitmap.BitmapUtils
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -282,7 +282,9 @@ class AndroidCamera2(cameraData: CameraData,
   }
 
   override def release(): Unit = {
-    imageReader.discardFreeBuffers()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      imageReader.discardFreeBuffers()
+    }
     imageReader.close()
     cameraSession.foreach { session =>
       session.stopRepeating()


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/AN-7124

### Issues

For devices running on a version older than Android P, the app crashes when someone tries to open the camera in a conversation .

### Causes

The method `discardFreeBuffers()` is [added in API 28](https://developer.android.com/reference/android/media/ImageReader#discardFreeBuffers())

`java.lang.NoSuchMethodError: No virtualmethod discardFreeBuffers()V in class Landroid/media/ImageReader; or its super classes`

### Solutions

Add dynamic check for version code.

### Testing

Manually tested on devices with API 24 and API 29. Steps are:

1. Install the app on a device with Android O or older
2. Go to any conversation
3. Click on camera icon in bottom row
4. A camera preview should be displayed in bottom corner
5.a. Click on camera icon inside the preview
5.b. Click on rotate camera icon in preview

**Actual result:**
App crashes

**Expected result:**
App shouldn't crash and 
a. we should see full screen camera 
b. the camera should be facing front


#### APK
[Download build #2905](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2905/artifact/build/artifact/wire-dev-PR3070-2905.apk)