### PR TITLE
Fix: Various fixes for bugs regarding the Camera2 API

### DIFF
--- a/app/src/main/java/com/waz/zclient/camera/FlashMode.java
+++ b/app/src/main/java/com/waz/zclient/camera/FlashMode.java
@@ -17,14 +17,21 @@
  */
 package com.waz.zclient.camera;
 
-import android.hardware.camera2.CaptureRequest;
+class FlashModeConstants {
+    static final int FLASH_OFF = 0;
+    static final int FLASH_ON = 1;
+    static final int FLASH_TORCH = 2;
+    static final int FLASH_AUTO = 3;
+    static final int FLASH_RED_EYE = 4;
+}
 
 public enum FlashMode {
 
-    OFF(CaptureRequest.FLASH_MODE_OFF),
-    AUTO(CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH),
-    ON(CaptureRequest.FLASH_MODE_SINGLE),
-    TORCH(CaptureRequest.FLASH_MODE_TORCH);
+    OFF(FlashModeConstants.FLASH_OFF),
+    ON(FlashModeConstants.FLASH_ON),
+    TORCH(FlashModeConstants.FLASH_TORCH),
+    AUTO(FlashModeConstants.FLASH_AUTO),
+    RED_EYE(FlashModeConstants.FLASH_RED_EYE);
 
     public int mode;
 
@@ -33,7 +40,7 @@ public enum FlashMode {
     }
 
     public static FlashMode get(int mode) {
-        for (FlashMode state: FlashMode.values()) {
+        for (FlashMode state : FlashMode.values()) {
             if (mode == state.mode) {
                 return state;
             }

--- a/app/src/main/java/com/waz/zclient/pages/main/profile/camera/controls/CameraTopControl.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/profile/camera/controls/CameraTopControl.java
@@ -1,17 +1,17 @@
 /**
  * Wire
  * Copyright (C) 2018 Wire Swiss GmbH
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,6 +24,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
+
 import com.waz.zclient.R;
 import com.waz.zclient.camera.FlashMode;
 import com.waz.zclient.utils.SquareOrientation;
@@ -88,6 +89,9 @@ public class CameraTopControl extends FrameLayout {
             case TORCH:
                 cameraFlashButton.setText(getResources().getString(R.string.glyph__plus));
                 break;
+            case RED_EYE:
+                cameraFlashButton.setText(getResources().getString(R.string.glyph__redo));
+                break;
         }
 
         ObjectAnimator.ofFloat(cameraFlashButton, View.ALPHA, 0, 1).setDuration(getResources().getInteger(R.integer.camera__control__ainmation__duration_long)).start();
@@ -129,7 +133,7 @@ public class CameraTopControl extends FrameLayout {
         setFlashModeButton(currentFlashMode);
     }
 
-    public void enableCameraSwitchButtion(boolean enableCameraSwitch) {
+    public void enableCameraSwitchButton(boolean enableCameraSwitch) {
         if (cameraDirectionButton == null) {
             return;
         }
@@ -180,7 +184,9 @@ public class CameraTopControl extends FrameLayout {
 
     public interface CameraTopControlCallback {
         void nextCamera();
+
         void setFlashMode(FlashMode mode);
+
         FlashMode getFlashMode();
     }
 

--- a/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
@@ -164,7 +164,7 @@ class CameraFragment extends FragmentHelper
     cameraPreview.foreach { preview =>
       cameraTopControl.foreach { control =>
         control.setFlashStates(flashModes, preview.getCurrentFlashMode)
-        control.enableCameraSwitchButtion(preview.getNumberOfCameras > 1)
+        control.enableCameraSwitchButton(preview.getNumberOfCameras > 1)
       }
     }
 

--- a/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
@@ -125,7 +125,6 @@ class AndroidCamera2(cameraData: CameraData,
     } catch {
       case ex: SecurityException          => error(l"The app has no permission to access the camera", ex)
       case ex: CameraAccessException      => error(l"Camera access error when opening camera: ", ex)
-      case ex: SecurityException          => error(l"The app has no permission to access the camera", ex)
       case ex: IllegalArgumentException   => error(l"Opening the camera failed", ex)
     }
   }

--- a/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
@@ -41,10 +41,12 @@ class AndroidCamera2(cameraData: CameraData,
                      texture: SurfaceTexture)
   extends WireCamera with DerivedLogTag {
 
+  import AndroidCamera2._
   import ExifInterface._
   import WireCamera._
   import com.waz.zclient.log.LogUI._
-  import AndroidCamera2._
+
+  private var updatedFlash: FlashMode = flashMode
 
   private lazy val cameraThread = returning(new HandlerThread("CameraThread")) {
     _.start()
@@ -78,9 +80,6 @@ class AndroidCamera2(cameraData: CameraData,
   private var camera: Option[CameraDevice] = None
   private var orientation: Orientation = DEFAULT_ORIENTATION
 
-  private def getSupportedFlashMode(mode: FlashMode): Int =
-    if (getSupportedFlashModes(mode)) mode.mode else FlashMode.OFF.mode
-
   def initCamera(): Unit = {
     openCamera(cameraManager, cameraData.cameraId, cameraHandler)
 
@@ -90,12 +89,11 @@ class AndroidCamera2(cameraData: CameraData,
     val targets = List(surface, imageReader.getSurface)
 
     camera.foreach { device: CameraDevice =>
-      cameraRequest = returning(Option(device.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW))) { _.foreach { request =>
-        request.set(requestKey(CaptureRequest.CONTROL_MODE), CameraMetadata.CONTROL_MODE_AUTO)
-        request.set(requestKey(CaptureRequest.CONTROL_AF_MODE), CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
-        request.set(requestKey(CaptureRequest.FLASH_MODE), getSupportedFlashMode(flashMode))
-        request.addTarget(surface)
-      } }
+      cameraRequest = returning(Option(device.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW))) {
+        _.foreach { request =>
+          request.addTarget(surface)
+        }
+      }
       createCameraSession(targets, device)
     }
   }
@@ -125,9 +123,10 @@ class AndroidCamera2(cameraData: CameraData,
         }
       }, cameraHandler)
     } catch {
-      case ex: CameraAccessException    => error(l"Camera access error when opening camera: ", ex)
-      case ex: SecurityException        => error(l"The app has no permission to access the camera", ex)
-      case ex: IllegalArgumentException => error(l"Opening the camera failed", ex)
+      case ex: SecurityException          => error(l"The app has no permission to access the camera", ex)
+      case ex: CameraAccessException      => error(l"Camera access error when opening camera: ", ex)
+      case ex: SecurityException          => error(l"The app has no permission to access the camera", ex)
+      case ex: IllegalArgumentException   => error(l"Opening the camera failed", ex)
     }
   }
 
@@ -136,11 +135,7 @@ class AndroidCamera2(cameraData: CameraData,
       camera.createCaptureSession(targets.asJava, new CameraCaptureSession.StateCallback {
         override def onConfigured(session: CameraCaptureSession): Unit = {
           cameraSession = Some(session)
-          cameraRequest.foreach { request =>
-            request.set(requestKey(CaptureRequest.CONTROL_MODE), CameraMetadata.CONTROL_MODE_AUTO)
-            request.set(requestKey(CaptureRequest.CONTROL_AF_MODE), CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
-            session.setRepeatingRequest(request.build(), null, cameraHandler)
-          }
+          updatePreview()
         }
 
         override def onConfigureFailed(session: CameraCaptureSession): Unit = {
@@ -217,15 +212,16 @@ class AndroidCamera2(cameraData: CameraData,
     val imageQueue = new ArrayBlockingQueue[Image](ImageBufferSize)
     imageReader.setOnImageAvailableListener(new OnImageAvailableListener {
       override def onImageAvailable(reader: ImageReader): Unit = {
-        val image = reader.acquireNextImage()
+        val image = reader.acquireLatestImage()
         imageQueue.add(image)
       }
     }, imageReaderHandler)
 
     cameraSession.foreach { session: CameraCaptureSession =>
-      val captureRequest = returning(session.getDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE)) {
-        _.addTarget(imageReader.getSurface)
+      val captureRequest = returning(session.getDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE)) { request =>
+        request.addTarget(imageReader.getSurface)
       }
+      determineFlash(captureRequest)
       session.capture(captureRequest.build(), new CameraCaptureSession.CaptureCallback {
         private def computeExifOrientation(rotationDegrees: Int, mirrored: Boolean) = (rotationDegrees, mirrored) match {
           case (0, false)    => ORIENTATION_NORMAL
@@ -274,11 +270,23 @@ class AndroidCamera2(cameraData: CameraData,
           val mirrored = getCurrentCameraFacing == CameraMetadata.LENS_FACING_FRONT
           val relativeOrientation = computeRelativeOrientation(orientation.orientation, mirrored)
           val exifOrientation = computeExifOrientation(relativeOrientation, mirrored)
+
+          updatePreview()
+
           promise.success(CombinedCaptureResult(image, result, exifOrientation, imageReader.getImageFormat))
         }
       }, cameraHandler)
     }
     promise.future
+  }
+
+  def updatePreview() = {
+    withSessionAndReqBuilder { (session, request) =>
+      request.set(requestKey(CaptureRequest.CONTROL_MODE), CameraMetadata.CONTROL_MODE_AUTO)
+      request.set(requestKey(CaptureRequest.CONTROL_AF_MODE), CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
+      determineFlash(request)
+      session.setRepeatingRequest(request.build(), null, cameraHandler)
+    }
   }
 
   override def release(): Unit = {
@@ -332,23 +340,39 @@ class AndroidCamera2(cameraData: CameraData,
     promise.future
   }
 
-  override def setFlashMode(fm: FlashMode): Unit = withSessionAndReqBuilder { (session, requestBuilder) =>
-    fm match {
+  def determineFlash(requestBuilder: CaptureRequest.Builder) = {
+    updatedFlash match {
       case FlashMode.AUTO =>
         requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_MODE), CameraMetadata.CONTROL_AE_MODE_ON_AUTO_FLASH)
+        requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_OFF)
       case FlashMode.OFF =>
         requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_MODE), CameraMetadata.CONTROL_AE_MODE_ON)
         requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_OFF)
-      case FlashMode.ON | FlashMode.TORCH =>
+      case FlashMode.ON =>
         requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_MODE), CameraMetadata.CONTROL_AE_MODE_ON)
-        requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_TORCH)
+        requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_SINGLE)
+     case FlashMode.TORCH =>
+       requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_MODE), CameraMetadata.CONTROL_AE_MODE_ON)
+       requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_TORCH)
+      case FlashMode.RED_EYE =>
+        requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_MODE), CameraMetadata.CONTROL_AE_MODE_ON_AUTO_FLASH_REDEYE)
+        requestBuilder.set(requestKey(CaptureRequest.FLASH_MODE), CameraMetadata.FLASH_MODE_OFF)
     }
-    session.setRepeatingRequest(requestBuilder.build(), null, cameraHandler)
+    requestBuilder.set(requestKey(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER),
+      CameraMetadata.CONTROL_AE_PRECAPTURE_TRIGGER_START)
+  }
+
+  override def setFlashMode(fm: FlashMode): Unit = {
+    updatedFlash = fm
   }
 
   override def getSupportedFlashModes: Set[FlashMode] =
-    Option(cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES))
-      .fold(Set.empty[FlashMode])(_.map(FlashMode.get).toSet)
+    if (getCurrentCameraFacing == CameraMetadata.LENS_FACING_BACK && cameraCharacteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE)) {
+      Option(cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES))
+        .fold(Set.empty[FlashMode])(_.map(FlashMode.get).toSet)
+    } else {
+      Set.empty[FlashMode]
+    }
 
   override def setOrientation(o: Orientation): Unit = {
     orientation = o


### PR DESCRIPTION
## What's new in this PR?

1: https://wearezeta.atlassian.net/browse/AN-7126
2: https://wearezeta.atlassian.net/browse/AN-7125

## Issues 
1. Camera crashes when you touch to focus the top left corner of the screen (due to the rect values being negative)
2. Camera flash mode shouldn't be enabled for front facing view 
3. Camera flash mode selected does not represent the flash when the picture is taken
4. If you take more than 3 photos in the same session, it'll crash the app 

**For issue 1:** 
When we touch to focus we set a `MeteringRectangle` with a `Rect` param to let the `Camera2` API know where we touch and where we'd like to have focus, the problem is though that that metering rectangle does not accept any negative values. So, it was throwing an exception: 

`E/AndroidRuntime: java.lang.IllegalArgumentException: rect.left must be nonnegative
`

**For issues 2: and 3:** 

The flash mode doesn't correctly reset itself or co-ordinate with the UI correctly 

The preview requests and capture requests rely on having knowledge of the flash intentions for the device. So when we preview we need to determine the flash and set a rolling request, but, when we capture we need to ensure when that is complete we start the rolling preview again (which explains why the flash stays on after the image is captured). 

**For issue 4:** 

When we capture the image we determine this via an image reader, we use the image readers surface to determine what photos we'd like to take from the buffer (i.e. a session capture). The problem we have is to help performance we set a maximum buffer for the images to be stored in cache of the `ImageReader` to 3, once we take more than this if we're calling `imageReader.aquireNextImage()`, it'll crash the app with the following issue: 

```
  throw new IllegalStateException(
                        String.format(
                                "maxImages (%d) has already been acquired, " +
                                "call #close before acquiring more.", mMaxImages));
```

## Testing

**Scenario 1:** 
1. Log in
2. Go to conversation
3. Click take a photo 
4. Open full screen  
5. Switch to front view 
6. You shouldn't see a flash button 

**Scenario 2:** 
1. Log in
2. Go to conversation
3. Click take a photo 
4. Open full screen  
5. Switch to back view 
6. Click the flash mode to change to whatever mode you need
7. When you take a photo it'll do the particular flash you need 

**Scenario 3:** 
1. Log in
2. Go to conversation
3. Click take a photo 
4. Open full screen  
5. Tap to focus in the top left corner 
6. The app shouldn't crash 

**Scenario 4:** 
1. Log in
2. Go to conversation
3. Click take a photo 
4. Open full screen  
5. Take 3 photos (whilst cancelling the final image) 
6. The app shouldn't crash 

#### APK
[Download build #2907](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2907/artifact/build/artifact/wire-dev-PR3071-2907.apk)