### PR TITLE
Tests migration to Mockk and Kluent - Part 02

### DIFF
--- a/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/ActivationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/ActivationDataSourceTest.kt
@@ -35,7 +35,7 @@ class ActivationDataSourceTest : UnitTest() {
         runBlocking {
             val response = activationDataSource.sendEmailActivationCode(TEST_EMAIL)
 
-            coVerify { remoteDataSource.sendEmailActivationCode(TEST_EMAIL) }
+            coVerify(exactly = 1) { remoteDataSource.sendEmailActivationCode(TEST_EMAIL) }
             response shouldFail { it shouldBe ServerError }
         }
     }
@@ -47,7 +47,7 @@ class ActivationDataSourceTest : UnitTest() {
         runBlocking {
             val response = activationDataSource.sendEmailActivationCode(TEST_EMAIL)
 
-            coVerify { remoteDataSource.sendEmailActivationCode(TEST_EMAIL) }
+            coVerify(exactly = 1) { remoteDataSource.sendEmailActivationCode(TEST_EMAIL) }
             response shouldSucceed {}
         }
     }
@@ -59,7 +59,7 @@ class ActivationDataSourceTest : UnitTest() {
         runBlocking {
             val response = activationDataSource.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            coVerify { remoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE) }
+            coVerify(exactly = 1) { remoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE) }
             response shouldFail { it shouldBe ServerError }
         }
     }
@@ -71,7 +71,7 @@ class ActivationDataSourceTest : UnitTest() {
         runBlocking {
             val response = activationDataSource.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            coVerify { remoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE) }
+            coVerify(exactly = 1) { remoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE) }
             response shouldSucceed {}
         }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/remote/ActivationRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/activation/datasource/remote/ActivationRemoteDataSourceTest.kt
@@ -36,8 +36,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
         runBlocking {
             activationRemoteDataSource.sendEmailActivationCode(TEST_EMAIL)
 
-            coVerify { activationApi.sendActivationCode(capture(activationCodeRequestSlot)) }
-
+            coVerify(exactly = 1) { activationApi.sendActivationCode(capture(activationCodeRequestSlot)) }
             activationCodeRequestSlot.captured.email shouldBe TEST_EMAIL
         }
     }
@@ -52,7 +51,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
 
             val result = activationRemoteDataSource.sendEmailActivationCode(TEST_EMAIL)
 
-            coVerify { activationApi.sendActivationCode(any()) }
+            coVerify(exactly = 1) { activationApi.sendActivationCode(any()) }
             result shouldSucceed {}
         }
     }
@@ -66,7 +65,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
 
             val result = activationRemoteDataSource.sendEmailActivationCode(TEST_EMAIL)
 
-            coVerify { activationApi.sendActivationCode(any()) }
+            coVerify(exactly = 1) { activationApi.sendActivationCode(any()) }
             result.isLeft shouldBe true
         }
     }
@@ -78,7 +77,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
         runBlocking {
             activationRemoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            coVerify{ activationApi.activateEmail(capture(activationRequestSlot)) }
+            coVerify(exactly = 1) { activationApi.activateEmail(capture(activationRequestSlot)) }
 
             with(activationRequestSlot.captured) {
                 email shouldBe TEST_EMAIL
@@ -98,7 +97,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
 
             val result = activationRemoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            coVerify { activationApi.activateEmail(any()) }
+            coVerify(exactly = 1) { activationApi.activateEmail(any()) }
             result shouldSucceed {}
         }
     }
@@ -112,7 +111,7 @@ class ActivationRemoteDataSourceTest : UnitTest() {
 
             val result = activationRemoteDataSource.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            coVerify { activationApi.activateEmail(any()) }
+            coVerify(exactly = 1) { activationApi.activateEmail(any()) }
             result.isLeft shouldBe true
         }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/activation/usecase/SendEmailActivationCodeUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/activation/usecase/SendEmailActivationCodeUseCaseTest.kt
@@ -42,10 +42,9 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
 
         runBlocking {
             val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
-
-            coVerify { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
             response shouldFail { it shouldBe EmailBlacklisted }
         }
+        coVerify(exactly = 1) { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
     }
 
     @Test
@@ -55,7 +54,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
         runBlocking {
             val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
 
-            coVerify { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
+            coVerify(exactly = 1) { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
             response shouldFail { it shouldBe EmailInUse }
         }
     }
@@ -68,7 +67,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
         runBlocking {
             val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
 
-            coVerify { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
+            coVerify(exactly = 1) { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
             response shouldFail { it shouldBe mockFailure }
         }
     }
@@ -80,7 +79,7 @@ class SendEmailActivationCodeUseCaseTest : UnitTest() {
         runBlocking {
             val response = sendEmailActivationCodeUseCase.run(sendEmailActivationCodeParams)
 
-            coVerify { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
+            coVerify(exactly = 1) { activationRepository.sendEmailActivationCode(TEST_EMAIL) }
             response shouldSucceed  { it shouldBe Unit }
         }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/datasource/LoginDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/datasource/LoginDataSourceTest.kt
@@ -46,7 +46,7 @@ class LoginDataSourceTest : UnitTest() {
         runBlocking {
             loginDataSource.loginWithEmail(TEST_EMAIL, TEST_PASSWORD)
 
-            coVerify { loginRemoteDataSource.loginWithEmail(email = TEST_EMAIL, password = TEST_PASSWORD) }
+            coVerify(exactly = 1) { loginRemoteDataSource.loginWithEmail(email = TEST_EMAIL, password = TEST_PASSWORD) }
         }
     }
 
@@ -59,7 +59,7 @@ class LoginDataSourceTest : UnitTest() {
         runBlocking {
             loginDataSource.loginWithEmail(TEST_EMAIL, TEST_PASSWORD) shouldSucceed { it shouldBe session }
         }
-        verify { sessionMapper.fromLoginResponse(loginWithEmailResponse) }
+        verify(exactly = 1) { sessionMapper.fromLoginResponse(loginWithEmailResponse) }
     }
 
     @Test
@@ -70,7 +70,7 @@ class LoginDataSourceTest : UnitTest() {
             val result = loginDataSource.loginWithEmail(TEST_EMAIL, TEST_PASSWORD)
 
             result shouldFail { it shouldBe ServerError }
-            verify { sessionMapper wasNot Called }
+            verify(exactly = 1) { sessionMapper wasNot Called }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/datasource/remote/LoginRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/datasource/remote/LoginRemoteDataSourceTest.kt
@@ -38,8 +38,8 @@ class LoginRemoteDataSourceTest : UnitTest() {
         runBlocking {
             loginRemoteDataSource.loginWithEmail(TEST_EMAIL, TEST_PASSWORD)
 
-            verify { labelGenerator.newLabel() }
-            coVerify { loginApi.loginWithEmail(capture(loginWithEmailRequestSlot), eq(true)) }
+            verify(exactly = 1) { labelGenerator.newLabel() }
+            coVerify(exactly = 1) { loginApi.loginWithEmail(capture(loginWithEmailRequestSlot), eq(true)) }
             loginWithEmailRequestSlot.captured.let {
                 it.email shouldBe TEST_EMAIL
                 it.password shouldBe TEST_PASSWORD

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
@@ -61,7 +61,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
         }
-        coVerify { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
+        coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
@@ -75,7 +75,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.validateEmail(TEST_EMAIL)
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
         }
-        coVerify { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
+        coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
@@ -85,7 +85,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
         }
-        verify { validateEmailUseCase wasNot Called }
+        verify(exactly = 1) { validateEmailUseCase wasNot Called }
     }
 
     @Test
@@ -99,7 +99,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
         }
-        coVerify { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
+        coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
@@ -113,7 +113,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
         }
-        coVerify { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
+        coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
@@ -127,7 +127,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
             loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe true
         }
-        coVerify { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
+        coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
@@ -140,7 +140,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
             loginWithEmailViewModel.login(TEST_EMAIL, TEST_VALID_PASSWORD)
             loginWithEmailViewModel.loginResultLiveData.awaitValue() shouldSucceed {}
         }
-        coVerify { loginWithEmailUseCase.run(params) }
+        coVerify(exactly = 1) { loginWithEmailUseCase.run(params) }
     }
 
     @Test
@@ -178,7 +178,7 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
             loginWithEmailViewModel.loginResultLiveData.awaitValue() shouldFail { errorAssertion(it) }
         }
-        coVerify { loginWithEmailUseCase.run(params) }
+        coVerify(exactly = 1) { loginWithEmailUseCase.run(params) }
     }
 
     private suspend fun mockEmailValidation(success: Boolean) =

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCaseTest.kt
@@ -55,9 +55,9 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             result shouldSucceed {}
         }
 
-        coVerify { loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD) }
-        coVerify { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
-        coVerify { sessionRepository.save(eq(session), eq(true)) }
+        coVerify(exactly = 1) { loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD) }
+        coVerify(exactly = 1) { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
+        coVerify(exactly = 1) { sessionRepository.save(eq(session), eq(true)) }
     }
 
     @Test
@@ -68,7 +68,7 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result.shouldFail { it shouldBe LoginAuthenticationFailure }
         }
-        verify { userRepository wasNot Called }
+        verify(exactly = 1) { userRepository wasNot Called }
     }
 
     @Test
@@ -79,7 +79,7 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result shouldFail { it shouldBe LoginTooFrequentFailure }
         }
-        verify { userRepository wasNot Called }
+        verify(exactly = 1) { userRepository wasNot Called }
     }
 
     @Test
@@ -90,7 +90,7 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result shouldFail { it shouldBe ServerError }
         }
-        verify { userRepository wasNot Called }
+        verify(exactly = 1) { userRepository wasNot Called }
     }
 
     @Test
@@ -101,7 +101,7 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result shouldFail { it shouldBe SessionCredentialsMissing }
         }
-        verify { userRepository wasNot Called }
+        verify(exactly = 1) { userRepository wasNot Called }
     }
 
     @Test
@@ -114,8 +114,8 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result shouldFail { it shouldBe failure }
         }
-        coVerify { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
-        coVerify { sessionRepository.save(eq(session), any()) wasNot Called }
+        coVerify(exactly = 1) { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
+        coVerify(inverse = true) { sessionRepository.save(eq(session), any()) }
     }
 
     @Test
@@ -129,8 +129,8 @@ class LoginWithEmailUseCaseTest : UnitTest() {
             val result = loginWithEmailUseCase.run(LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_PASSWORD))
             result shouldFail { it shouldBe failure }
         }
-        coVerify { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
-        coVerify { sessionRepository.save(eq(session), eq(true)) }
+        coVerify(exactly = 1) { userRepository.selfUser(accessToken = TEST_ACCESS_TOKEN, tokenType = TEST_TOKEN_TYPE) }
+        coVerify(exactly = 1) { sessionRepository.save(eq(session), eq(true)) }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigatorTest.kt
@@ -39,7 +39,7 @@ class LoginNavigatorTest : AndroidTest() {
         val intentSlot = slot<Intent>()
         loginNavigator.openLogin(context)
 
-        verify { context.startActivity(capture(intentSlot)) }
+        verify(exactly = 1) { context.startActivity(capture(intentSlot)) }
         intentSlot.captured.let {
             it.component?.className shouldBe LoginActivity::class.java.canonicalName
             it.extras shouldBe null
@@ -53,7 +53,7 @@ class LoginNavigatorTest : AndroidTest() {
 
         loginNavigator.openForgotPassword(context)
 
-        verify { uriNavigationHandler.openUri(eq(context), capture(uriSlot)) }
+        verify(exactly = 1) { uriNavigationHandler.openUri(eq(context), capture(uriSlot)) }
         uriSlot.captured.toString() shouldEqual "$TEST_ACCOUNTS_URL/forgot"
     }
 


### PR DESCRIPTION
After part 1 in #105, this PR aims to continue the tests migration to Mockk and Kluent. 

**What is included here?**

 - Classes from package: ```feature.auth.activation.datasource```.
 - Classes from package: ```feature.auth.activation.usecase```.
 - Classes from package: ```feature.auth.login```.
 - Classes from package: ```feature.auth.login```.