### PR TITLE
Fixed crash related to IllegalStateException when buffer limit is exc…

### DIFF
--- a/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
@@ -190,6 +190,7 @@ class AndroidCamera2(cameraData: CameraData,
               val corrected = BitmapUtils.fixOrientation(BitmapFactory.decodeByteArray(data, 0, data.length), photoResult.orientation)
               generateOutputByteArray(corrected)
           }
+          photoResult.close()
           promise.success(result)
         case Failure(exception) => promise.failure(exception)
       }(Threading.Ui)
@@ -211,7 +212,7 @@ class AndroidCamera2(cameraData: CameraData,
     val imageQueue = new ArrayBlockingQueue[Image](ImageBufferSize)
     imageReader.setOnImageAvailableListener(new OnImageAvailableListener {
       override def onImageAvailable(reader: ImageReader): Unit = {
-        val image = reader.acquireLatestImage()
+        val image = reader.acquireNextImage()
         imageQueue.add(image)
       }
     }, imageReaderHandler)


### PR DESCRIPTION
…eeded

## What's new in this PR?

### Issues

`java.lang.IllegalStateException: maxImages (3) has already been acquired, call #close before acquiring more
`
### Causes

When you keep more than 3 images in the buffer at once

### Solutions

When taking a photo after you've collected the data you need to close it. 

### Testing

**Scenario 1:** 
1. Log in
2. Go to any conversation
3. Click camera icon on bottom bar 
4. Go to full screen camera 
5. Take photo 
6. Click cancel 
7. Repeat 5 & 6 4 times 
8. App won't crash 