### PR TITLE
[Calling] : Disable mute, video and speaker button till the call gets properly connected

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -78,7 +78,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
 
   // first row
   returning(findById[CallControlButtonView](R.id.mute_call)) { button =>
-    button.setEnabled(true)
+    controller.isCallEstablished.onUi(button.setEnabled)
     controller.isMuted.onUi(button.setActivated)
     Signal.zip(controller.isVideoCall, controller.isMuted, themeController.currentTheme).map {
       case (true, true, _)             => Some(drawMuteDark _)
@@ -101,7 +101,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
   }
 
   returning(findById[CallControlButtonView](R.id.speaker_flip_call)) { button =>
-    button.setEnabled(true)
+    controller.isCallEstablished.onUi(button.setEnabled)
     isVideoBeingSent.onUi {
       case true =>
         button.set(WireStyleKit.drawFlip, R.string.incoming__controls__ongoing__flip, flip)


### PR DESCRIPTION
## What's new in this PR?

To keep consistency with iOS, it was requested to disable mute, video and speaker button till the call gets connected properly.

Please note that video button is already disabled when the call is not yet connected.

https://wearezeta.atlassian.net/browse/SQCALL-1

![device-2020-11-02-140926](https://user-images.githubusercontent.com/43655743/97874151-dd0d7780-1d18-11eb-8236-cda4ae4e1186.png)

#### APK
[Download build #2924](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2924/artifact/build/artifact/wire-dev-PR3079-2924.apk)