### PR TITLE
Changes needed to make wire-android work with wire-signals:0.3.0

### DIFF
--- a/app/src/main/java/com/waz/zclient/ForceUpdateActivity.scala
+++ b/app/src/main/java/com/waz/zclient/ForceUpdateActivity.scala
@@ -40,8 +40,7 @@ class ForceUpdateActivity extends BaseActivity {
 object ForceUpdateActivity {
   def checkBlacklist(activity: Activity)(implicit ecxt: EventContext): Unit =
     ZMessaging.currentGlobal.blacklist.upToDate
-        .ifFalse
-        .filter(_ => BuildConfig.ENABLE_BLACKLIST)
+        .collect { case false if BuildConfig.ENABLE_BLACKLIST => () }
         .onUi { _ =>
           activity.startActivity(
               new Intent(activity.getApplicationContext, classOf[ForceUpdateActivity]))

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallControlButtonView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallControlButtonView.scala
@@ -47,10 +47,10 @@ class CallControlButtonView(val context: Context, val attrs: AttributeSet, val d
   private val otherColor       = Signal(Option.empty[ButtonColor])
 
   private val enabledChanged   = EventStream[Boolean]()
-  private val enabledSignal    = RefreshingSignal(Future{ isEnabled }(Threading.Ui), enabledChanged)
+  private val enabledSignal    = RefreshingSignal.from(Future { isEnabled }(Threading.Ui), enabledChanged)
 
   private val activatedChanged = EventStream[Boolean]()
-  private val activatedSignal  = RefreshingSignal(Future{ isActivated }(Threading.Ui), activatedChanged)
+  private val activatedSignal  = RefreshingSignal.from(Future { isActivated }(Threading.Ui), activatedChanged)
 
   inflate(R.layout.call_button_view)
 
@@ -81,7 +81,7 @@ class CallControlButtonView(val context: Context, val attrs: AttributeSet, val d
         getStyledDrawable(R.attr.callButtonBackground, themeController.getTheme(theme))
           .getOrElse(getDrawable(R.drawable.selector__icon_button__background__calling))
     }
-  ).onUi(buttonBackground.setBackground(_))
+  ).onUi(buttonBackground.setBackground)
 
   (for {
     otherColor <- otherColor

--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -164,7 +164,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
 
   private def speaker(): Unit = {
     onButtonClick ! {}
-    controller.speakerButton.press()
+    controller.speakerButton.click()
   }
 
   private def video(): Future[Unit] = async {

--- a/app/src/main/scala/com/waz/zclient/collection/views/SingleImageViewToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/SingleImageViewToolbar.scala
@@ -80,7 +80,7 @@ class SingleImageViewToolbar(context: Context, attrs: AttributeSet, style: Int)
 
   likedBySelf.map(if (_) R.string.glyph__liked else R.string.glyph__like).on(Threading.Ui)(likeButton.setText)
 
-  messageActionsController.onDeleteConfirmed.on(Threading.Background){
+  messageActionsController.onDeleteConfirmed.on(Threading.Background) {
     _ => collectionController.focusedItem ! None
   }
 

--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -86,9 +86,9 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
     z                       <- zms
     (cId, cTeam, teamOnly)  <- convController.currentConv.map(c => (c.id, c.team, c.isTeamOnly))
     isGroup                 <- Signal.from(z.conversations.isGroupConversation(cId))
-    canHaveLink             = isGroup && cTeam.exists(z.teamId.contains(_)) && !teamOnly
-    cursor                  <- RefreshingSignal(loadCursor(cId), cursorRefreshEvent(z, cId))
-    _ = verbose(l"cursor changed")
+    canHaveLink             =  isGroup && cTeam.exists(z.teamId.contains(_)) && !teamOnly
+    cursor                  <- RefreshingSignal.from(loadCursor(cId), cursorRefreshEvent(z, cId))
+    _                       =  verbose(l"cursor changed")
     list                    =  PagedListWrapper(getPagedList(cursor))
     lastRead                <- convController.currentConv.map(_.lastRead)
     messageToReveal         <- messageActionsController.messageToReveal.map(_.map(_.id))

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -191,7 +191,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.2.4"
+    const val WIRE_SIGNALS = "0.3.0"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/zmessaging/src/main/scala/com/waz/api/impl/RecordingLevels.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/RecordingLevels.scala
@@ -27,8 +27,9 @@ import scala.concurrent.Future
 import scala.math.max
 
 class RecordingLevels(liveLevels: EventStream[Float]) extends DerivedLogTag {
-  private val allLevels = returning(new AggregatingSignal[Float, Vector[Float]](liveLevels,
-    Future.successful(Vector.empty), _ :+ _))(_.disableAutowiring())
+  private val allLevels = returning(
+    new AggregatingSignal[Float, Vector[Float]](Future.successful(Vector.empty), liveLevels, _ :+ _)
+  )(_.disableAutowiring())
 
   def windowed(windowSize: Int): Signal[Array[Float]] = allLevels map { levels =>
     val startIndex = max(levels.size - windowSize, 0)

--- a/zmessaging/src/main/scala/com/waz/content/Database.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Database.scala
@@ -31,7 +31,7 @@ trait Database {
   val dbHelper: BaseDaoDB
 
   protected lazy val readExecutionContext: DispatchQueue =
-    DispatchQueue(DispatchQueue.UNLIMITED, Threading.IO, name = Some("Database_readQueue_" + hashCode().toHexString))
+    DispatchQueue(DispatchQueue.Unlimited, Threading.IO, name = "Database_readQueue_" + hashCode().toHexString)
 
   def apply[A](f: DB => A)(implicit logTag: LogTag = LogTag("")): CancellableFuture[A] = dispatcher {
     implicit val db:DB = dbHelper.getWritableDatabase

--- a/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
+++ b/zmessaging/src/main/scala/com/waz/content/GlobalDatabase.scala
@@ -27,7 +27,7 @@ import com.waz.zclient.storage.di.StorageModule
 
 class GlobalDatabase(context: Context, dbNameSuffix: String = "", tracking: TrackingService) extends Database {
 
-  override implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IOThreadPool, Option("GlobalDatabase"))
+  override implicit val dispatcher = DispatchQueue(DispatchQueue.Serial, Threading.IOThreadPool, "GlobalDatabase")
   override          val dbHelper  : BaseDaoDB           =
     new RoomDaoDB(StorageModule.getGlobalDatabase(
       context,

--- a/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -63,8 +63,8 @@ class MembersStorageImpl(context: Context, storage: ZmsDatabase)
         .zip(onDeleted.map(_.filter(_._2 == conv).map(_._1 -> false)))
 
     new AggregatingSignal[Seq[(UserId, Boolean)], Set[UserId]](
-      onConvMemberChanged(conv),
       getActiveUsers(conv).map(_.toSet),
+      onConvMemberChanged(conv),
       { (current, changes) =>
         val (active, inactive) = changes.partition(_._2)
         current -- inactive.map(_._1) ++ active.map(_._1)

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -148,7 +148,7 @@ class MessagesStorageImpl(context:     Context,
     }
   }
 
-  convs.onUpdated.on(Background) { _.foreach {
+  convs.onUpdated.foreach { _.foreach {
     case (prev, updated) if updated.lastRead != prev.lastRead =>
       msgsIndex(updated.id).map(_.updateLastRead(updated)).recoverWithLog()
     case _ => // ignore

--- a/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -56,7 +56,7 @@ class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: M
 
   override def receipts(message: MessageId): Signal[Seq[ReadReceipt]] = {
     val changed = onChanged.map(_.filter(_.message == message).map(_.id)).zip(onDeleted.map(_.filter(_._1 == message)))
-    RefreshingSignal[Seq[ReadReceipt]](getReceipts(message), changed)
+    RefreshingSignal.from[Seq[ReadReceipt]](getReceipts(message), changed)
   }
 
   override def removeAllForMessages(messages: Set[MessageId]): Future[Unit] =

--- a/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ZmsDatabase.scala
@@ -30,7 +30,7 @@ import com.waz.zclient.storage.di.StorageModule
   */
 class ZmsDatabase(user: UserId, context: Context) extends Database {
   override implicit val dispatcher: DispatchQueue =
-    DispatchQueue(DispatchQueue.SERIAL, Threading.IOThreadPool, name = Option("ZmsDatabase_" + user.str.substring(24)))
+    DispatchQueue(DispatchQueue.Serial, Threading.IOThreadPool, name = "ZmsDatabase_" + user.str.substring(24))
 
   override val dbHelper: BaseDaoDB =
     new RoomDaoDB(StorageModule.getUserDatabase(

--- a/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -40,7 +40,7 @@ class BufferedLogOutput(baseDir: String,
 
   override val id: String = "BufferedLogOutput" + ZSecureRandom.nextInt().toHexString
 
-  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, Some(id))
+  private implicit val dispatcher: DispatchQueue = DispatchQueue(DispatchQueue.Serial, Threading.IO, id)
 
   private val buffer = StringBuilder.newBuilder
   private val pathRegex = s"$baseDir/${BufferedLogOutput.DefFileName}([0-9]+).log".r

--- a/zmessaging/src/main/scala/com/waz/log/LogsService.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogsService.scala
@@ -38,8 +38,9 @@ class LogsServiceImpl(globalPreferences: GlobalPreferences)
   override lazy val logsEnabledGlobally: Signal[Boolean] =
     globalPreferences(GlobalPreferences.LogsEnabled).signal
 
-  logsEnabledGlobally.ifFalse.apply { _ =>
-    InternalLog.clearAll()
+  logsEnabledGlobally.foreach {
+    case false => InternalLog.clearAll()
+    case _ =>
   }
 
   override def logsEnabled: Future[Boolean] =

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -135,8 +135,8 @@ class UserServiceImpl(selfUserId:        UserId,
     def initialLoad = usersStorage.list().map(_.map(user => user.id -> user.name).toMap)
 
     new AggregatingSignal[Map[UserId, Name], Map[UserId, Name]](
-      EventStream.zip(added, updated),
       initialLoad,
+      EventStream.zip(added, updated),
       { (values, changes) => values ++ changes }
     )
   }
@@ -187,7 +187,8 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] =
     new AggregatingSignal[Seq[UserData], Map[UserId, UserData]](
-      usersStorage.onChanged, usersStorage.listUsersByConnectionStatus(AcceptedOrBlocked),
+      usersStorage.listUsersByConnectionStatus(AcceptedOrBlocked),
+      usersStorage.onChanged,
       { (accu, us) =>
         val (toAdd, toRemove) = us.partition(u => AcceptedOrBlocked(u.connection))
         accu -- toRemove.map(_.id) ++ toAdd.map(u => u.id -> u)

--- a/zmessaging/src/main/scala/com/waz/service/assets/MetaDataRetriever.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/MetaDataRetriever.scala
@@ -30,9 +30,9 @@ import scala.concurrent.Future
 
 object MetaDataRetriever {
 
-  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, Option("MetaDataRetriever"))
+  private implicit val dispatcher: DispatchQueue = DispatchQueue(DispatchQueue.Serial, Threading.IO, "MetaDataRetriever")
 
-  implicit lazy val RetrieverCleanup = new Cleanup[MediaMetadataRetriever] {
+  implicit lazy val retrieverCleanup: Cleanup[MediaMetadataRetriever] = new Cleanup[MediaMetadataRetriever] {
     override def apply(a: MediaMetadataRetriever): Unit = a.release()
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 class PCMPlayer private (content: PCMContent, track: AudioTrack, totalSamples: Long, stream: FileInputStream, observer: Player.Observer) extends Player {
   import PCMPlayer._
 
-  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, None)
+  private implicit val dispatcher: DispatchQueue = DispatchQueue(DispatchQueue.Serial, Threading.IO)
   private val buffer = ByteBuffer.allocateDirect(bufferSizeInShorts * SizeOfShort).order(LITTLE_ENDIAN)
   private def channel = stream.getChannel
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -271,8 +271,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         .zip(membersStorage.onDeleted.map(_.filter(_._2 == conv).map(_._1 -> (None, false)))).map(_.toMap)
 
     new AggregatingSignal[Map[UserId, (Option[ConversationMemberData], Boolean)], Seq[ConversationMemberData]](
-      onConvMemberDataChanged,
       membersStorage.getByConv(conv),
+      onConvMemberDataChanged,
       { (current, changes) =>
         val (active, inactive) = changes.partition(_._2._2)
         val inactiveIds = inactive.keySet

--- a/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -63,9 +63,9 @@ class TypingService(userId:        UserId,
   }
 
   def typingUsers(conv: ConvId): Signal[IndexedSeq[UserId]] = new AggregatingSignal[IndexedSeq[TypingUser], IndexedSeq[UserId]] (
-    source  = onTypingChanged.filter(_._1 == conv).map(_._2),
-    loader  = Future { typing(conv).map(_.id) },
-    updater = (_, updated) => updated.map(_.id)
+    loader        = Future { typing(conv).map(_.id) },
+    sourceStream  = onTypingChanged.filter(_._1 == conv).map(_._2),
+    updater       = (_, updated) => updated.map(_.id)
   )
 
   def handleTypingEvent(e: TypingEvent): Future[Unit] = beDriftPref.apply().map { beDrift =>

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -480,8 +480,8 @@ class MessagesServiceImpl(selfUserId:      UserId,
   override def getAssetIds(messageIds: Set[MessageId]): Future[Set[GeneralAssetId]] = storage.getAssetIds(messageIds)
 
   override def buttonsForMessage(msgId: MessageId): Signal[Seq[ButtonData]] = RefreshingSignal[Seq[ButtonData]](
-    loader       = CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),
-    refreshEvent = EventStream.zip(buttonsStorage.onChanged.map(_.map(_.id)), buttonsStorage.onDeleted)
+    loader        = CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),
+    refreshStream = EventStream.zip(buttonsStorage.onChanged.map(_.map(_.id)), buttonsStorage.onDeleted)
   )
 
   override def clickButton(messageId: MessageId, buttonId: ButtonId): Future[Unit] =

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
@@ -20,18 +20,18 @@ package com.waz.service.otr
 import java.io.File
 
 import android.content.Context
-import com.waz.log.LogSE._
 import com.waz.api.Verification
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.OtrLastPrekey
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.log.LogSE._
 import com.waz.model.UserId
 import com.waz.model.otr.{Client, ClientId, SignalingKey}
 import com.waz.service.MetaDataService
-import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.cryptobox.{CryptoBox, PreKey}
+import com.wire.signals.DispatchQueue
 import org.threeten.bp.Instant
 
 import scala.concurrent.Future
@@ -39,7 +39,7 @@ import scala.util.Try
 
 class CryptoBoxService(context: Context, userId: UserId, metadata: MetaDataService, userPrefs: UserPreferences) extends DerivedLogTag {
   import CryptoBoxService._
-  private implicit val dispatcher = DispatchQueue(DispatchQueue.SERIAL, Threading.IO, None)
+  private implicit val dispatcher: DispatchQueue = DispatchQueue(DispatchQueue.Serial, Threading.IO)
 
   private[service] lazy val cryptoBoxDir = returning(new File(new File(context.getFilesDir, metadata.cryptoBoxDirName), userId.str))(_.mkdirs())
 
@@ -82,7 +82,7 @@ class CryptoBoxService(context: Context, userId: UserId, metadata: MetaDataServi
 
   def createClient(id: ClientId = ClientId()) = apply { cb =>
     val (lastKey, keys) = (cb.newLastPreKey(), cb.newPreKeys(0, PreKeysCount))
-    (lastPreKeyId := keys.last.id) map { _ =>
+    (lastPreKeyId := keys.last.id).map { _ =>
       (Client(id, clientLabel, metadata.deviceModel, Some(Instant.now), signalingKey = Some(SignalingKey()), verified = Verification.VERIFIED, devType = metadata.deviceClass), lastKey, keys.toSeq)
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -39,7 +39,6 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.PushNotificationsClient.LoadNotificationsResult
 import com.waz.sync.client.{PushNotificationEncoded, PushNotificationsClient}
-import com.waz.threading.Threading
 import com.wire.signals.CancellableFuture.lift
 import com.wire.signals.{CancellableFuture, EventSource, SerialDispatchQueue, Signal, SourceSignal, Serialized}
 import com.waz.utils.{RichInstant, _}
@@ -62,14 +61,10 @@ import scala.concurrent.{Future, Promise}
   * receive them in the right order.
   */
 
-trait BgEventSource[T] extends EventSource[T] {
-  override val executionContext = Some(Threading.Background)
-}
-
 trait PushService {
   def syncNotifications(syncMode: SyncMode): Future[Unit]
 
-  def onHistoryLost: SourceSignal[Instant] with BgEventSource[Instant]
+  def onHistoryLost: SourceSignal[Instant]
   def processing: Signal[Boolean]
   def waitProcessing: Future[Unit]
 
@@ -105,7 +100,7 @@ class PushServiceImpl(selfUserId:           UserId,
   implicit val logTag: LogTag = accountTag[PushServiceImpl](selfUserId)
   private implicit val dispatcher = SerialDispatchQueue(name = "PushService")
 
-  override val onHistoryLost = new SourceSignal[Instant] with BgEventSource[Instant]
+  override val onHistoryLost = new SourceSignal[Instant]
   override val processing = Signal(false)
 
   override def waitProcessing =

--- a/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -59,12 +59,12 @@ object Threading {
   /**
    * Thread pool for IO tasks.
    */
-  val IOThreadPool: DispatchQueue = DispatchQueue(Cpus, Executors.newCachedThreadPool(), Option("IoThreadPool"))
+  val IOThreadPool: DispatchQueue = DispatchQueue(Cpus, Executors.newCachedThreadPool(), "IoThreadPool")
 
   /**
    * Thread pool for non-blocking background tasks.
    */
-  val Background: DispatchQueue = DispatchQueue(Cpus, Executors.newCachedThreadPool(), Option("CpuThreadPool"))
+  val Background: DispatchQueue = DispatchQueue(Cpus, Executors.newCachedThreadPool(), "CpuThreadPool")
 
   com.wire.signals.Threading.setAsDefault(Background)
 
@@ -73,7 +73,7 @@ object Threading {
   /**
     * Image decoding/encoding dispatch queue. This operations are quite cpu intensive, we don't want them to use all cores (leaving one spare core for other tasks).
     */
-  val ImageDispatcher: DispatchQueue = DispatchQueue(Cpus - 1, Background.asInstanceOf[ExecutionContext], Option("ImageDispatcher"))
+  val ImageDispatcher: DispatchQueue = DispatchQueue(Cpus - 1, Background.asInstanceOf[ExecutionContext], "ImageDispatcher")
 
   // var for tests
   private var _ui: Option[DispatchQueue] = None

--- a/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
@@ -189,7 +189,6 @@ object HttpClient {
 
   }
 
-  @deprecated("After circe integration we should use 'AutoDerivation'", "?")
   object AutoDerivationOld extends AutoDerivationRulesForSerializersOld with AutoDerivationRulesForDeserializersOld
 
   object AutoDerivation extends AutoDerivationRulesForSerializers with AutoDerivationRulesForDeserializers

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -23,7 +23,7 @@ import com.waz.model.{Availability, _}
 import com.waz.service.assets.{AssetService, AssetStorage}
 import com.waz.service.conversation.SelectedConversationService
 import com.waz.service.messages.MessagesService
-import com.waz.service.push.{BgEventSource, PushService}
+import com.waz.service.push.PushService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.{CredentialsUpdateClient, UsersClient}
@@ -62,7 +62,7 @@ class UserServiceSpec extends AndroidFreeSpec {
 
   (usersStorage.optSignal _).expects(*).anyNumberOfTimes().onCall((id: UserId) => Signal.const(users.find(_.id == id)))
   (accountsService.accountsWithManagers _).expects().anyNumberOfTimes().returning(Signal.empty)
-  (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal(Some(Instant.now())) with BgEventSource[Instant])
+  (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal(Some(Instant.now())))
   (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -25,7 +25,7 @@ import com.waz.model.{ConversationData, ConversationRole, _}
 import com.waz.service._
 import com.waz.service.assets.{AssetService, UriHelper}
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
-import com.waz.service.push.{BgEventSource, NotificationService, PushService}
+import com.waz.service.push.{NotificationService, PushService}
 import com.waz.service.teams.{TeamsService, TeamsServiceImpl}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
@@ -123,7 +123,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   (membersStorage.onUpdated _).expects().anyNumberOfTimes().returning(EventStream())
   (membersStorage.onDeleted _).expects().anyNumberOfTimes().returning(EventStream())
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))
-  (push.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal[Instant] with BgEventSource[Instant])
+  (push.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal[Instant])
   (errors.onErrorDismissed _).expects(*).anyNumberOfTimes().returning(CancellableFuture.successful(()))
 
   (sync.syncTeam _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))

--- a/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
@@ -69,7 +69,7 @@ import scala.concurrent.duration._
       Thread.sleep(500)
       fakeWebSocketEvents ! SocketEvent.Opened(webSocket)
 
-      noException shouldBe thrownBy { result(service.connected.ifTrue.head) }
+      noException shouldBe thrownBy { result(service.connected.onTrue) }
       service.deactivate()
 
       Thread.sleep(500)
@@ -88,7 +88,7 @@ import scala.concurrent.duration._
       Thread.sleep(1000)
       fakeWebSocketEvents ! SocketEvent.Opened(webSocket)
 
-      noException shouldBe thrownBy { result(service.connected.ifTrue.head) }
+      noException shouldBe thrownBy { result(service.connected.onTrue) }
     }
 
     scenario("When web socket closed should become unconnected and retry to connect.") {
@@ -104,12 +104,12 @@ import scala.concurrent.duration._
       Thread.sleep(500)
       fakeWebSocketEvents ! SocketEvent.Closed(webSocket, Some(new InterruptedException))
 
-      noException shouldBe thrownBy { await(service.connected.ifFalse.head) }
+      noException shouldBe thrownBy { await(service.connected.onFalse) }
 
       Thread.sleep(500)
       fakeWebSocketEvents ! SocketEvent.Opened(webSocket)
 
-      noException shouldBe thrownBy { await(service.connected.ifTrue.head) }
+      noException shouldBe thrownBy { await(service.connected.onTrue) }
     }
 
     scenario("When web socket is going to be closed by other side should close web socket with normal closure code.") {
@@ -155,7 +155,7 @@ import scala.concurrent.duration._
 
       gotNotification shouldBe true
 
-      noException shouldBe thrownBy { await(service.connected.ifTrue.head) }
+      noException shouldBe thrownBy { await(service.connected.onTrue) }
     }
 
     scenario("When web socket emmit unknown message, should ignore it and stay connected.") {
@@ -179,7 +179,7 @@ import scala.concurrent.duration._
 
       gotNotification shouldBe false
 
-      noException shouldBe thrownBy { await(service.connected.ifTrue.head) }
+      noException shouldBe thrownBy { await(service.connected.onTrue) }
     }
 
     scenario("When connect and disconnect called to often, should stay in the correct state.") {
@@ -193,7 +193,7 @@ import scala.concurrent.duration._
         if (i%2 == 0) service.deactivate() else service.activate()
       }
 
-      noException shouldBe thrownBy { await(service.connected.ifFalse.head) }
+      noException shouldBe thrownBy { await(service.connected.onFalse) }
     }
 
   }

--- a/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -126,11 +126,11 @@ abstract class AndroidFreeSpec extends ZMockSpec { this: Suite =>
     Intent.setUtil(JVMIntentUtil)
 
     Threading.setUi(DispatchQueue(
-      DispatchQueue.SERIAL,
+      DispatchQueue.Serial,
       Executors.newSingleThreadExecutor(new ThreadFactory {
         override def newThread(r: Runnable) = new Thread(r, Threading.testUiThreadName)
       }),
-      Option(Threading.testUiThreadName)
+      Threading.testUiThreadName
     ))
   }
 


### PR DESCRIPTION
All of the changes are cosmetic: names of fields and method, order of arguments, etc.

`Signal.ifFalse` was removed. It was broken from the beginning. It was supposed to create a signal which would update every time the original signal updated to "false", but that's not how signals work. The new signal updated only once and never again.

The order of arguments in `AggregatingSignal` is now: 
1. `loader` - a future which loads the initial data
2. `sourceStream` - the event stream with events which trigger the update method
3. `updater` - the update method
The `loader` and `sourceStream` switch places so now it's a bit more consistent, and also more similar to `RefreshingSignal` where we first have the `loader` and then the `refreshStream`.

`RefreshingSignal.apply` for creating a refreshing signal from a future and an event stream is changed to `RefreshingSignal.from` to make it more similar to `Signal.from` which takes a future. I'm thinking about doing the same for `AggregatingSignal` but it's not in this PR. 

I changed a bit the overloaded `apply` methods for `DisplatchQueue` so now it's possible to create one with an explicit name given to it as a `String`, not `Option[String]`.

Signals and event streams have now a method `foreach` which works like `on(executionContext)` but it uses the implicit execution context or the default context (`Background` in our case) if there is no implicit one. Ideally, in the future, I would like to use `foreach` as the common case, and `on(...)` only when the execution context has to be different from the implicit one.

And I think that's it.
#### APK
[Download build #2925](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2925/artifact/build/artifact/wire-dev-PR3080-2925.apk)