### PR TITLE
fix: Get random profile pictures from Unsplash

### DIFF
--- a/app/src/main/res/layout/preferences_dev_layout.xml
+++ b/app/src/main/res/layout/preferences_dev_layout.xml
@@ -125,6 +125,16 @@
                 app:title="@string/pref_dev_check_check_rooted_device_title"
                 app:subtitle="@string/pref_dev_check_check_rooted_device_summary"
                 />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_dev_new_unsplash_profile_pic"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
+                android:layout_marginBottom="@dimen/wire__padding__20"
+                app:title="@string/pref_dev_new_unsplash_profile_pic_title"
+                app:subtitle="@string/pref_dev_new_unsplash_profile_pic_summary"
+                />
         </LinearLayout>
 
     </ScrollView>

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -169,6 +169,9 @@
     <string translatable="false" name="pref_dev_check_check_rooted_device_title">Check If The Device Is Rooted</string>
     <string translatable="false" name="pref_dev_check_check_rooted_device_summary">Calls a method performing a list of checks in order to figure out if the current device is rooted</string>
 
+    <string translatable="false" name="pref_dev_new_unsplash_profile_pic_title">Change the Profile Picture to a New Unsplash Pic</string>
+    <string translatable="false" name="pref_dev_new_unsplash_profile_pic_summary">Changes your profile picture to a new one, downloaded from Unsplash</string>
+
     <!--Account preferences-->
     <string translatable="false" name="pref_dev_category_sign_in_account_key">PREF_ACCOUNTS_SIGN_IN</string>
     <string translatable="false" name="pref_dev_category_sign_in_account_title">Sign into account</string>

--- a/app/src/main/scala/com/waz/zclient/assets/AndroidUriHelper.scala
+++ b/app/src/main/scala/com/waz/zclient/assets/AndroidUriHelper.scala
@@ -39,7 +39,7 @@ class AndroidUriHelper(context: Context) extends UriHelper with DerivedLogTag {
   private def cursor(uri: URI): Managed[Cursor] =
     Managed.create(
       context.getContentResolver.query(androidUri(uri), null, null, null, null)
-    )(_.close())
+    ) { c => Option(c).foreach(_.close()) }
 
   override def openInputStream(uri: URI): Try[InputStream] = Try {
     context.getContentResolver.openInputStream(androidUri(uri))
@@ -55,8 +55,7 @@ class AndroidUriHelper(context: Context) extends UriHelper with DerivedLogTag {
   }
 
   override def extractSize(uri: URI): Try[Long] = Try {
-    debug(l"Extracting size for $uri")
-
+    debug(l"Extracting size for $uri, scheme: ${uri.getScheme}")
     if (uri.getScheme == ContentResolver.SCHEME_FILE) {
       val file = new File(uri.getPath)
       file.length()

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -32,7 +32,7 @@ import com.waz.model.AccountData.Password
 import com.waz.model.Uid
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
 import com.waz.service.{AccountManager, ZMessaging}
-import com.wire.signals.Signal
+import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient._
 import com.waz.zclient.common.controllers.global.PasswordController
@@ -43,9 +43,9 @@ import com.waz.zclient.preferences.views.{SwitchPreference, TextButton}
 import com.waz.zclient.security.checks.RootDetectionCheck
 import com.waz.zclient.utils.ContextUtils.showToast
 import com.waz.zclient.utils.{BackStackKey, ContextUtils}
+import com.wire.signals.Signal
 
 import scala.concurrent.Future
-import com.waz.threading.Threading._
 
 trait DevSettingsView
 
@@ -93,6 +93,8 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
   val checkDeviceRootedButton = returning(findById[TextButton](R.id.preferences_dev_check_rooted_device)) { v =>
     v.onClickEvent(_ => checkIfDeviceIsRooted())
   }
+
+  val newPicturePicButton = findById[TextButton](R.id.preferences_dev_new_unsplash_profile_pic)
 
   private def checkIfDeviceIsRooted(): Unit = {
     val preferences = inject[GlobalPreferences]
@@ -171,6 +173,12 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
         override def onClick(dialog: DialogInterface, which: Int): Unit = {}
       })
       .setIcon(android.R.drawable.ic_dialog_alert).show
+  }
+
+  newPicturePicButton.onClickEvent { _ =>
+    am.head.flatMap(_.addUnsplashPicture()).foreach { _ =>
+      showToast("The profile picture changed")
+    }
   }
 }
 

--- a/zmessaging/src/main/scala/com/waz/model/AssetData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AssetData.scala
@@ -73,16 +73,12 @@ case class AssetData(override val id: AssetId               = AssetId(),
     case _ => Some(RemoteData(remoteId, token, otrKey, sha, encryption))
   }
 
-  lazy val cacheKey = {
-    val key = (proxyPath, source) match {
-      case (Some(proxy), _)                                                 => CacheKey(proxy)
-      case (_, Some(uri)) if uri.getPath != AssetClient.UnsplashUrl.getPath => CacheKey.fromUri(uri)
-      case _                                                                => CacheKey.fromAssetId(id)
-    }
-    //verbose(s"created cache key: $key for asset: $id")
-    key
+  lazy val cacheKey: CacheKey = (proxyPath, source) match {
+    case (Some(proxy), _)                                          => CacheKey(proxy)
+    case (_, Some(uri)) if uri.getPath != AssetClient.UnsplashPath => CacheKey.fromUri(uri)
+    case _                                                         => CacheKey.fromAssetId(id)
   }
-
+  
   lazy val isDownloadable = this match {
     case WithRemoteData(_)  => true
     case WithExternalUri(_) => true

--- a/zmessaging/src/main/scala/com/waz/model/AssetData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AssetData.scala
@@ -25,7 +25,8 @@ import com.waz.model.AssetMetaData.Image.Tag
 import com.waz.model.AssetStatus.{UploadCancelled, UploadDone}
 import com.waz.model.GenericContent.EncryptionAlgorithm
 import com.waz.model.otr.SignalingKey
-import com.waz.service.{UserService, ZMessaging}
+import com.waz.service.ZMessaging
+import com.waz.sync.client.AssetClient
 import com.waz.utils.JsonDecoder.{apply => _, opt => _}
 import com.waz.utils._
 import com.waz.utils.crypto.AESUtils
@@ -74,9 +75,9 @@ case class AssetData(override val id: AssetId               = AssetId(),
 
   lazy val cacheKey = {
     val key = (proxyPath, source) match {
-      case (Some(proxy), _)                            => CacheKey(proxy)
-      case (_, Some(uri)) if !NonKeyURIs.contains(uri) => CacheKey.fromUri(uri)
-      case _                                           => CacheKey.fromAssetId(id)
+      case (Some(proxy), _)                                                 => CacheKey(proxy)
+      case (_, Some(uri)) if uri.getPath != AssetClient.UnsplashUrl.getPath => CacheKey.fromUri(uri)
+      case _                                                                => CacheKey.fromAssetId(id)
     }
     //verbose(s"created cache key: $key for asset: $id")
     key
@@ -121,11 +122,6 @@ case class AssetData(override val id: AssetId               = AssetId(),
 }
 
 object AssetData {
-
-  /**
-    * Do not use these URIs as cache keys, as they do not provide a unique identifier to the asset downloaded from them
-    */
-  val NonKeyURIs: Set[URI] = Set(UserService.UnsplashUrl)
 
   def decodeData(data64: String): Array[Byte] = AESUtils.base64(data64)
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -348,7 +348,7 @@ class UserServiceImpl(selfUserId:        UserId,
     usersStorage.updateAll2(availabilities.keySet, u => availabilities.get(u.id).fold(u)(av => u.copy(availability = av)))
   }
 
-  override def updateSelfPicture(content: Content) = {
+  override def updateSelfPicture(content: Content): Future[Unit] = {
     val contentForUpload = ContentForUpload("profile-picture", content)
     for {
       asset <- assets.createAndSaveUploadAsset(contentForUpload, NoEncryption, public = true, Retention.Eternal, None)
@@ -366,8 +366,6 @@ class UserServiceImpl(selfUserId:        UserId,
 object UserService {
 
   val SyncIfOlderThan = 24.hours
-
-  val UnsplashUrl = AndroidURIUtil.parse("https://source.unsplash.com/800x800/?landscape")
 
   lazy val AcceptedOrBlocked = Set(ConnectionStatus.Accepted, ConnectionStatus.Blocked)
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, InputStream}
+import java.net.URL
 import java.security.{DigestOutputStream, MessageDigest}
 
 import com.waz.api.impl.ErrorResponse
@@ -49,6 +50,7 @@ trait AssetClient {
     * Usually reserved for profile pictures.
     */
   def loadPublicAssetContent(assetId: AssetId, convId: Option[ConvId], callback: Option[ProgressCallback]): ErrorOrResponse[InputStream]
+  def loadUnsplashProfilePicture(): ErrorOrResponse[InputStream]
 }
 
 class AssetClientImpl(implicit
@@ -105,6 +107,12 @@ class AssetClientImpl(implicit
       .executeSafe
   }
 
+  override def loadUnsplashProfilePicture(): ErrorOrResponse[InputStream] =
+    Request.create(method = Method.Get, url = AssetClient.UnsplashUrl)
+      .withResultType[InputStream]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+
   private implicit def RawAssetRawBodySerializer: RawBodySerializer[AssetContent] =
     RawBodySerializer.create { asset =>
       val data = () => Await.result(asset.data(), Duration.Inf) //TODO RawBody should take () => Future[_] as data
@@ -142,6 +150,7 @@ object AssetClient {
   implicit val DefaultExpiryTime: Expiration = 1.hour
 
   val AssetsV3Path = "/assets/v3"
+  val UnsplashUrl: URL = new URL("https://source.unsplash.com/800x800/?landscape")
 
   sealed trait Retention
   object Retention {

--- a/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
@@ -150,7 +150,8 @@ object AssetClient {
   implicit val DefaultExpiryTime: Expiration = 1.hour
 
   val AssetsV3Path = "/assets/v3"
-  val UnsplashUrl: URL = new URL("https://source.unsplash.com/800x800/?landscape")
+  val UnsplashPath: String = "https://source.unsplash.com/800x800/?landscape"
+  val UnsplashUrl: URL = new URL(UnsplashPath)
 
   sealed trait Retention
   object Retention {


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/AN-7047

I'm not exactly sure how long this functionality was broken but it looks like it was for a long time. The previous code
tried to treat an Unsplash URL as if it was a regular asset that was supposed to be downloaded through our backend.
The backend failed because it didn't understand the request.I rewrote `AccountManager.addUnsplashPicture()` and added
methods to `AssetService` and `AssetClient` which download the picture from Unsplash. Then the picture is set as
the profile one and sent to the backend exactly as if it was a regular profile picture.

I also added a button in Dev Settings to test it. From now on it can be used if we want to test any change in code connected to profile pictures.

#### APK
[Download build #2926](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2926/artifact/build/artifact/wire-dev-PR3081-2926.apk)
[Download build #2927](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2927/artifact/build/artifact/wire-dev-PR3081-2927.apk)