### PR TITLE
Refactor: Tests - Migrate all "awaitValue" usages to "shouldBeUpdated"

### DIFF
--- a/app/src/test/kotlin/com/wire/android/core/ui/SingleLiveEventTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/ui/SingleLiveEventTest.kt
@@ -3,13 +3,11 @@ package com.wire.android.core.ui
 import androidx.lifecycle.Observer
 import com.wire.android.UnitTest
 import com.wire.android.framework.livedata.TestLifecycleOwner
-import com.wire.android.framework.livedata.awaitValue
-import kotlinx.coroutines.runBlocking
+import com.wire.android.framework.livedata.shouldBeUpdated
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeoutException
 
 class SingleLiveEventTest : UnitTest() {
 
@@ -24,19 +22,15 @@ class SingleLiveEventTest : UnitTest() {
     fun `given that value is not consumed yet, when an observer is attached, notifies the observer`() {
         singleLiveEvent.value = TEST_VALUE
 
-        val value = runBlocking { singleLiveEvent.awaitValue()  }
-
-        value shouldBeEqualTo TEST_VALUE
+        singleLiveEvent shouldBeUpdated { it shouldBeEqualTo TEST_VALUE }
     }
 
-    @Test(expected = TimeoutException::class)
+    @Test(expected = AssertionError::class)
     fun `given that value is already consumed, when an observer is attached, does not notify observer`() {
         singleLiveEvent.value = TEST_VALUE
 
-        runBlocking {
-            singleLiveEvent.awaitValue() //consume
-            singleLiveEvent.awaitValue() //wait for 2nd time
-        }
+        singleLiveEvent shouldBeUpdated {} //consume
+        singleLiveEvent shouldBeUpdated {} //wait for 2nd time
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailViewModelTest.kt
@@ -16,7 +16,7 @@ import com.wire.android.feature.auth.login.email.usecase.LoginWithEmailUseCasePa
 import com.wire.android.framework.coroutines.CoroutinesTestRule
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import com.wire.android.shared.user.email.EmailInvalid
 import com.wire.android.shared.user.email.ValidateEmailParams
 import com.wire.android.shared.user.email.ValidateEmailUseCase
@@ -55,78 +55,72 @@ class LoginWithEmailViewModelTest : UnitTest() {
 
     @Test
     fun `given a valid email with no password, then sets continueEnabledLiveData to false`() {
-        coroutinesTestRule.runTest {
-            mockEmailValidation(true)
+        mockEmailValidation(true)
 
-            loginWithEmailViewModel.validateEmail(TEST_EMAIL)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        loginWithEmailViewModel.validateEmail(TEST_EMAIL)
+
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
         coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
     fun `given a valid email but an empty password, then sets continueEnabledLiveData to false`() {
-        coroutinesTestRule.runTest {
-            mockEmailValidation(true)
+        mockEmailValidation(true)
 
-            loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
+        loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
 
-            loginWithEmailViewModel.validateEmail(TEST_EMAIL)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
+
+        loginWithEmailViewModel.validateEmail(TEST_EMAIL)
+
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
         coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
     fun `given a valid password with no email, then sets continueEnabledLiveData to false`() {
-        coroutinesTestRule.runTest {
-            loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
+        loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
 
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
         verify(exactly = 1) { validateEmailUseCase wasNot Called }
     }
 
     @Test
     fun `given a valid password but an invalid email, then sets continueEnabledLiveData to false`() {
-        coroutinesTestRule.runTest {
-            mockEmailValidation(false)
+        mockEmailValidation(false)
 
-            loginWithEmailViewModel.validateEmail(TEST_EMAIL)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
+        loginWithEmailViewModel.validateEmail(TEST_EMAIL)
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
 
-            loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
+
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
         coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
     fun `given an invalid email and an empty password, then sets continueEnabledLiveData to false`() {
-        coroutinesTestRule.runTest {
-            mockEmailValidation(false)
+        mockEmailValidation(false)
 
-            loginWithEmailViewModel.validateEmail(TEST_EMAIL)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
+        loginWithEmailViewModel.validateEmail(TEST_EMAIL)
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
 
-            loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        loginWithEmailViewModel.validatePassword(TEST_EMPTY_PASSWORD)
+
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
         coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
     @Test
     fun `given a valid email and a non-empty password, then sets continueEnabledLiveData to true`() {
-        coroutinesTestRule.runTest {
-            mockEmailValidation(true)
+        mockEmailValidation(true)
 
-            loginWithEmailViewModel.validateEmail(TEST_EMAIL)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe false
+        loginWithEmailViewModel.validateEmail(TEST_EMAIL)
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
 
-            loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
-            loginWithEmailViewModel.continueEnabledLiveData.awaitValue() shouldBe true
-        }
+        loginWithEmailViewModel.validatePassword(TEST_VALID_PASSWORD)
+
+        loginWithEmailViewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe true }
         coVerify(exactly = 1) { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) }
     }
 
@@ -134,12 +128,11 @@ class LoginWithEmailViewModelTest : UnitTest() {
     fun `given login is called, when loginWithEmailUseCase returns success, then sets success to loginResultLiveData`() {
         val params = LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_VALID_PASSWORD)
 
-        coroutinesTestRule.runTest {
-            coEvery { loginWithEmailUseCase.run(params) } returns Either.Right(Unit)
+        coEvery { loginWithEmailUseCase.run(params) } returns Either.Right(Unit)
 
-            loginWithEmailViewModel.login(TEST_EMAIL, TEST_VALID_PASSWORD)
-            loginWithEmailViewModel.loginResultLiveData.awaitValue() shouldSucceed {}
-        }
+        loginWithEmailViewModel.login(TEST_EMAIL, TEST_VALID_PASSWORD)
+
+        loginWithEmailViewModel.loginResultLiveData shouldBeUpdated { it shouldSucceed {} }
         coVerify(exactly = 1) { loginWithEmailUseCase.run(params) }
     }
 
@@ -173,15 +166,13 @@ class LoginWithEmailViewModelTest : UnitTest() {
         val params = LoginWithEmailUseCaseParams(email = TEST_EMAIL, password = TEST_VALID_PASSWORD)
         coEvery { loginWithEmailUseCase.run(params) } returns Either.Left(failure)
 
-        coroutinesTestRule.runTest {
-            loginWithEmailViewModel.login(TEST_EMAIL, TEST_VALID_PASSWORD)
+        loginWithEmailViewModel.login(TEST_EMAIL, TEST_VALID_PASSWORD)
 
-            loginWithEmailViewModel.loginResultLiveData.awaitValue() shouldFail { errorAssertion(it) }
-        }
+        loginWithEmailViewModel.loginResultLiveData shouldBeUpdated { it shouldFail { errorAssertion(it) } }
         coVerify(exactly = 1) { loginWithEmailUseCase.run(params) }
     }
 
-    private suspend fun mockEmailValidation(success: Boolean) =
+    private fun mockEmailValidation(success: Boolean) =
         coEvery { validateEmailUseCase.run(ValidateEmailParams(TEST_EMAIL)) } returns
             if (success) Either.Right(Unit) else Either.Left(EmailInvalid)
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountCodeViewModelTest.kt
@@ -12,7 +12,7 @@ import com.wire.android.feature.auth.registration.personal.usecase.InvalidEmailC
 import com.wire.android.framework.coroutines.CoroutinesTestRule
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,21 +35,16 @@ class CreatePersonalAccountCodeViewModelTest : UnitTest() {
 
     @Before
     fun setUp() {
-        codeViewModel = CreatePersonalAccountCodeViewModel(
-            coroutinesTestRule.dispatcherProvider,
-            activateEmailUseCase
-        )
+        codeViewModel = CreatePersonalAccountCodeViewModel(coroutinesTestRule.dispatcherProvider, activateEmailUseCase)
     }
 
     @Test
     fun `given activateEmail is called, when activateEmailUseCase returns success, then notifies success to activateEmailLiveData`() {
         coEvery { activateEmailUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
+        codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            codeViewModel.activateEmailLiveData.awaitValue() shouldSucceed { it shouldBeEqualTo TEST_CODE }
-        }
+        codeViewModel.activateEmailLiveData shouldBeUpdated { it shouldSucceed { it shouldBeEqualTo TEST_CODE } }
     }
 
     @Test
@@ -57,12 +52,10 @@ class CreatePersonalAccountCodeViewModelTest : UnitTest() {
         //TODO: separate feature failures
         coEvery { activateEmailUseCase.run(any()) } returns Either.Left(InvalidEmailCode)
 
-        coroutinesTestRule.runTest {
-            codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
+        codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            codeViewModel.activateEmailLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo R.string.create_personal_account_code_invalid_code_error
-            }
+        codeViewModel.activateEmailLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_code_invalid_code_error }
         }
     }
 
@@ -70,10 +63,10 @@ class CreatePersonalAccountCodeViewModelTest : UnitTest() {
     fun `given activateEmail is called, when activateEmailUseCase returns NetworkConnection, sets NetworkError to activateEmailLiveData`() {
         coEvery { activateEmailUseCase.run(any()) } returns Either.Left(NetworkConnection)
 
-        coroutinesTestRule.runTest {
-            codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
+        codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            codeViewModel.activateEmailLiveData.awaitValue() shouldFail { it shouldBe NetworkErrorMessage }
+        codeViewModel.activateEmailLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe NetworkErrorMessage }
         }
     }
 
@@ -81,10 +74,10 @@ class CreatePersonalAccountCodeViewModelTest : UnitTest() {
     fun `given activateEmail is called, when activateEmailUseCase returns other error, sets GeneralErrorMsg to activateEmailLiveData`() {
         coEvery { activateEmailUseCase.run(any()) } returns Either.Left(ServerError)
 
-        coroutinesTestRule.runTest {
-            codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
+        codeViewModel.activateEmail(TEST_EMAIL, TEST_CODE)
 
-            codeViewModel.activateEmailLiveData.awaitValue() shouldFail { it shouldBe GeneralErrorMessage }
+        codeViewModel.activateEmailLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe GeneralErrorMessage }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountEmailViewModelTest.kt
@@ -14,7 +14,7 @@ import com.wire.android.feature.auth.activation.usecase.SendEmailActivationCodeU
 import com.wire.android.framework.coroutines.CoroutinesTestRule
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import com.wire.android.shared.user.email.EmailInvalid
 import com.wire.android.shared.user.email.EmailTooShort
 import com.wire.android.shared.user.email.ValidateEmailUseCase
@@ -53,33 +53,27 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given validateEmail is called, when the validation succeeds then isValidEmail should be true`() {
         coEvery { validateEmailUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.validateEmail(TEST_EMAIL)
+        emailViewModel.validateEmail(TEST_EMAIL)
 
-            emailViewModel.isValidEmailLiveData.awaitValue() shouldBe true
-        }
+        emailViewModel.isValidEmailLiveData shouldBeUpdated { it shouldBe true }
     }
 
     @Test
     fun `given validateEmail is called, when the validation fails with EmailTooShort error then isValidEmail should be false`() {
         coEvery { validateEmailUseCase.run(any()) } returns Either.Left(EmailTooShort)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.validateEmail(TEST_EMAIL)
+        emailViewModel.validateEmail(TEST_EMAIL)
 
-            emailViewModel.isValidEmailLiveData.awaitValue() shouldBe false
-        }
+        emailViewModel.isValidEmailLiveData shouldBeUpdated { it shouldBe false }
     }
 
     @Test
     fun `given validateEmail is called, when the validation fails with EmailInvalid error then isValidEmail should be false`() {
         coEvery { validateEmailUseCase.run(any()) } returns Either.Left(EmailInvalid)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.validateEmail(TEST_EMAIL)
+        emailViewModel.validateEmail(TEST_EMAIL)
 
-            emailViewModel.isValidEmailLiveData.awaitValue() shouldBe false
-        }
+        emailViewModel.isValidEmailLiveData shouldBeUpdated { it shouldBe false }
     }
 
     @Test
@@ -87,11 +81,9 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
         val params = SendEmailActivationCodeParams(TEST_EMAIL)
         coEvery { sendActivationCodeUseCase.run(params) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue()
-        }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { }
         coVerify(exactly = 1) { sendActivationCodeUseCase.run(params) }
     }
 
@@ -99,10 +91,10 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given sendActivation is called, when use case is successful, then sets email to sendActivationCodeLiveData`() {
         coEvery { sendActivationCodeUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue() shouldSucceed { it shouldBeEqualTo TEST_EMAIL }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { result ->
+            result shouldSucceed { it shouldBeEqualTo TEST_EMAIL }
         }
     }
 
@@ -110,10 +102,10 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given sendActivation is called, when use case returns NetworkError, then sets NetworkErrorMsg to sendActivationCodeLiveData`() {
         coEvery { sendActivationCodeUseCase.run(any()) } returns Either.Left(NetworkConnection)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue() shouldFail { it shouldBe NetworkErrorMessage }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe NetworkErrorMessage }
         }
     }
 
@@ -121,12 +113,10 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given sendActivation is called, when use case returns EmailBlacklisted, then sets error message to sendActivationCodeLiveData`() {
         coEvery { sendActivationCodeUseCase.run(any()) } returns Either.Left(EmailBlacklisted)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo R.string.create_personal_account_with_email_email_blacklisted_error
-            }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_with_email_email_blacklisted_error }
         }
     }
 
@@ -134,12 +124,10 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given sendActivation is called, when use case returns EmailInUse, then sets error message to sendActivationCodeLiveData`() {
         coEvery { sendActivationCodeUseCase.run(any()) } returns Either.Left(EmailInUse)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo R.string.create_personal_account_with_email_email_in_use_error
-            }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_with_email_email_in_use_error }
         }
     }
 
@@ -147,10 +135,10 @@ class CreatePersonalAccountEmailViewModelTest : UnitTest() {
     fun `given sendActivation is called, when use case returns other error, then sets GeneralErrorMessage to sendActivationCodeLiveData`() {
         coEvery { sendActivationCodeUseCase.run(any()) } returns Either.Left(ServerError)
 
-        coroutinesTestRule.runTest {
-            emailViewModel.sendActivationCode(TEST_EMAIL)
+        emailViewModel.sendActivationCode(TEST_EMAIL)
 
-            emailViewModel.sendActivationCodeLiveData.awaitValue() shouldFail { it shouldBe GeneralErrorMessage }
+        emailViewModel.sendActivationCodeLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe GeneralErrorMessage }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameViewModelTest.kt
@@ -3,7 +3,7 @@ package com.wire.android.feature.auth.registration.personal.ui
 import com.wire.android.UnitTest
 import com.wire.android.core.functional.Either
 import com.wire.android.framework.coroutines.CoroutinesTestRule
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import com.wire.android.shared.user.name.NameTooShort
 import com.wire.android.shared.user.name.ValidateNameParams
 import com.wire.android.shared.user.name.ValidateNameUseCase
@@ -36,24 +36,20 @@ class CreatePersonalAccountNameViewModelTest : UnitTest() {
     fun `given validateName() is called with a name, when use case returns success, then sets continueEnabled to true`() {
         coEvery { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            nameViewModel.validateName(TEST_NAME)
+        nameViewModel.validateName(TEST_NAME)
 
-            nameViewModel.continueEnabled.awaitValue() shouldBe true
-            coVerify(exactly = 1) { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) }
-        }
+        nameViewModel.continueEnabled shouldBeUpdated { it shouldBe true }
+        coVerify(exactly = 1) { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) }
     }
 
     @Test
     fun `given validateName() is called with a name, when use case fails, then sets continueEnabled to false`() {
         coEvery { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) } returns Either.Left(NameTooShort)
 
-        coroutinesTestRule.runTest {
-            nameViewModel.validateName(TEST_NAME)
+        nameViewModel.validateName(TEST_NAME)
 
-            nameViewModel.continueEnabled.awaitValue() shouldBe false
-            coVerify(exactly = 1) { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) }
-        }
+        nameViewModel.continueEnabled shouldBeUpdated { it shouldBe false }
+        coVerify(exactly = 1) { validateNameUseCase.run(ValidateNameParams(TEST_NAME)) }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModelTest.kt
@@ -17,8 +17,8 @@ import com.wire.android.feature.auth.registration.personal.usecase.UnauthorizedE
 import com.wire.android.framework.coroutines.CoroutinesTestRule
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import com.wire.android.framework.livedata.assertNotUpdated
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
+import com.wire.android.framework.livedata.shouldNotBeUpdated
 import com.wire.android.shared.user.password.InvalidPasswordFailure
 import com.wire.android.shared.user.password.ValidatePasswordParams
 import com.wire.android.shared.user.password.ValidatePasswordUseCase
@@ -71,11 +71,9 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given a password, when validatePassword is called, then calls validatePasswordUseCase with correct params`() {
         coEvery { validatePasswordUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            viewModel.validatePassword(TEST_PASSWORD)
+        viewModel.validatePassword(TEST_PASSWORD)
 
-            viewModel.continueEnabledLiveData.awaitValue()
-        }
+        viewModel.continueEnabledLiveData shouldBeUpdated { }
         coVerify(exactly = 1) { validatePasswordUseCase.run(ValidatePasswordParams(TEST_PASSWORD)) }
     }
 
@@ -83,22 +81,18 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given validatePassword is called, when useCase returns success, then sets continueEnabledLiveData to true`() {
         coEvery { validatePasswordUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            viewModel.validatePassword(TEST_PASSWORD)
+        viewModel.validatePassword(TEST_PASSWORD)
 
-            viewModel.continueEnabledLiveData.awaitValue() shouldBe true
-        }
+        viewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe true }
     }
 
     @Test
     fun `given validatePassword is called, when useCase returns InvalidPasswordFailure, then sets continueEnabledLiveData to false`() {
         coEvery { validatePasswordUseCase.run(any()) } returns Either.Left(InvalidPasswordFailure)
 
-        coroutinesTestRule.runTest {
-            viewModel.validatePassword(TEST_PASSWORD)
+        viewModel.validatePassword(TEST_PASSWORD)
 
-            viewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        viewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
     }
 
     @Test
@@ -106,22 +100,18 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
         val failure = mockk<Failure>()
         coEvery { validatePasswordUseCase.run(any()) } returns Either.Left(failure)
 
-        coroutinesTestRule.runTest {
-            viewModel.validatePassword(TEST_PASSWORD)
+        viewModel.validatePassword(TEST_PASSWORD)
 
-            viewModel.continueEnabledLiveData.awaitValue() shouldBe false
-        }
+        viewModel.continueEnabledLiveData shouldBeUpdated { it shouldBe false }
     }
 
     @Test
     fun `given params, when registerUser is called, then calls registerUseCase with correct params`() {
         coEvery { registerUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue()
-        }
+        viewModel.registerStatusLiveData shouldBeUpdated {}
 
         coVerify(exactly = 1) {
             registerUseCase.run(
@@ -137,10 +127,10 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns success, then sets success to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Right(Unit)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldSucceed { it shouldBe Unit }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldSucceed { it shouldBe Unit }
         }
     }
 
@@ -148,22 +138,20 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns SessionCannotBeCreated error, then logs the user out`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(SessionCannotBeCreated)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            //TODO: assertion about logout
-            viewModel.registerStatusLiveData.assertNotUpdated()
-        }
+        //TODO: assertion about logout
+        viewModel.registerStatusLiveData.shouldNotBeUpdated()
     }
 
     @Test
     fun `given registerUser is called, when use case returns NetworkConnection error, then sets NetworkError to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(NetworkConnection)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldFail { it shouldBe NetworkErrorMessage }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe NetworkErrorMessage }
         }
     }
 
@@ -171,12 +159,10 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns UnauthorizedEmail error, then sets error message to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(UnauthorizedEmail)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo  R.string.create_personal_account_unauthorized_email_error
-            }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_unauthorized_email_error }
         }
     }
 
@@ -184,12 +170,10 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns InvalidEmailActivationCode, then sets error msg to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(InvalidEmailActivationCode)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo  R.string.create_personal_account_invalid_activation_code_error
-            }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_invalid_activation_code_error }
         }
     }
 
@@ -197,12 +181,10 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns EmailInUse error, then sets error message to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(EmailInUse)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldFail {
-                it.message shouldBeEqualTo  R.string.create_personal_account_email_in_use_error
-            }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_email_in_use_error }
         }
     }
 
@@ -210,10 +192,10 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns other error, then sets GeneralErrorMessage to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(ServerError)
 
-        coroutinesTestRule.runTest {
-            viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
-            viewModel.registerStatusLiveData.awaitValue() shouldFail { it shouldBe GeneralErrorMessage }
+        viewModel.registerStatusLiveData shouldBeUpdated { result ->
+            result shouldFail { it shouldBe GeneralErrorMessage }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameViewModelTest.kt
@@ -6,7 +6,7 @@ import com.wire.android.core.functional.Either
 import com.wire.android.feature.auth.registration.pro.team.usecase.GetTeamNameUseCase
 import com.wire.android.feature.auth.registration.pro.team.usecase.UpdateTeamNameUseCase
 import com.wire.android.framework.coroutines.CoroutinesTestRule
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,32 +38,24 @@ class CreateProAccountTeamNameViewModelTest : UnitTest() {
 
     @Test
     fun `given viewModel is initialised, when teamName is available, propagate teamName up to the view`() {
-        coroutinesTestRule.runTest {
-            viewModel.teamNameLiveData.awaitValue() shouldBeEqualTo TEST_TEAM_NAME
-        }
+        viewModel.teamNameLiveData shouldBeUpdated { it shouldBeEqualTo TEST_TEAM_NAME }
     }
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be disabled`() {
-        coroutinesTestRule.runTest {
-            viewModel.onTeamNameTextChanged(String.EMPTY)
+        viewModel.onTeamNameTextChanged(String.EMPTY)
 
-            viewModel.confirmationButtonEnabled.awaitValue() shouldBe false
-        }
+        viewModel.confirmationButtonEnabled shouldBeUpdated { it shouldBe false }
     }
 
     @Test
     fun `given empty team name, when on team name text is changed, confirmation button should be enabled`() {
-        coroutinesTestRule.runTest {
-            viewModel.onTeamNameTextChanged(TEST_TEAM_NAME)
+        viewModel.onTeamNameTextChanged(TEST_TEAM_NAME)
 
-            viewModel.confirmationButtonEnabled.awaitValue() shouldBe true
-        }
+        viewModel.confirmationButtonEnabled shouldBeUpdated { it shouldBe true }
     }
 
     companion object {
-        private const val CONFIG_URL = "https://wire.com"
-        private const val TEAM_ABOUT_URL_SUFFIX = "/products/pro-secure-team-collaboration/"
         private const val TEST_TEAM_NAME = "teamName"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/ui/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/ui/ConversationListViewModelTest.kt
@@ -8,8 +8,8 @@ import com.wire.android.feature.conversation.list.usecase.GetConversationsUseCas
 import com.wire.android.framework.coroutines.CoroutinesTestRule
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import com.wire.android.framework.livedata.assertNotUpdated
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
+import com.wire.android.framework.livedata.shouldNotBeUpdated
 import com.wire.android.shared.auth.activeuser.GetActiveUserUseCase
 import com.wire.android.shared.user.User
 import io.mockk.coEvery
@@ -45,32 +45,28 @@ class ConversationListViewModelTest : UnitTest() {
         val user = User(id = TEST_USER_ID, name = TEST_USER_NAME)
         coEvery { getActiveUserUseCase.run(Unit) } returns Either.Right(user)
 
-        coroutinesTestRule.runTest {
-            conversationListViewModel.fetchUserName()
+        conversationListViewModel.fetchUserName()
 
-            conversationListViewModel.userNameLiveData.awaitValue() shouldBeEqualTo TEST_USER_NAME
-        }
+        conversationListViewModel.userNameLiveData shouldBeUpdated { it shouldBeEqualTo TEST_USER_NAME }
     }
 
     @Test
     fun `given fetchUserName is called, when GetActiveUserUseCase is successful, then does not set anything to userNameLiveData`() {
         coEvery { getActiveUserUseCase.run(Unit) } returns Either.Left(ServerError)
 
-        coroutinesTestRule.runTest {
-            conversationListViewModel.fetchUserName()
+        conversationListViewModel.fetchUserName()
 
-            conversationListViewModel.userNameLiveData.assertNotUpdated()
-        }
+        conversationListViewModel.userNameLiveData.shouldNotBeUpdated()
     }
 
     @Test
     fun `given fetchConversations is called, when GetConversationsUseCase is successful, then sets value to conversationsLiveData`() {
         coEvery { getConversationsUseCase.run(Unit) } returns Either.Right(TEST_CONVERSATIONS)
 
-        coroutinesTestRule.runTest {
-            conversationListViewModel.fetchConversations()
+        conversationListViewModel.fetchConversations()
 
-            conversationListViewModel.conversationsLiveData.awaitValue() shouldSucceed { it shouldBeEqualTo TEST_CONVERSATIONS }
+        conversationListViewModel.conversationsLiveData shouldBeUpdated { result ->
+            result shouldSucceed { it shouldBeEqualTo TEST_CONVERSATIONS }
         }
     }
 
@@ -78,11 +74,9 @@ class ConversationListViewModelTest : UnitTest() {
     fun `given fetchConversations is called, when GetConversationsUseCase fails, then sets error to conversationsLiveData`() {
         coEvery { getConversationsUseCase.run(Unit) } returns Either.Left(ServerError)
 
-        coroutinesTestRule.runTest {
-            conversationListViewModel.fetchConversations()
+        conversationListViewModel.fetchConversations()
 
-            conversationListViewModel.conversationsLiveData.awaitValue() shouldFail {}
-        }
+        conversationListViewModel.conversationsLiveData shouldBeUpdated { it shouldFail {} }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/launch/ui/LauncherViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/launch/ui/LauncherViewModelTest.kt
@@ -4,7 +4,7 @@ import com.wire.android.UnitTest
 import com.wire.android.core.exception.SQLiteFailure
 import com.wire.android.core.functional.Either
 import com.wire.android.framework.coroutines.CoroutinesTestRule
-import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.framework.livedata.shouldBeUpdated
 import com.wire.android.shared.session.usecase.CheckCurrentSessionExistsUseCase
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
@@ -34,32 +34,26 @@ class LauncherViewModelTest : UnitTest() {
     fun `given checkIfCurrentSessionExists is called, when use case returns true, then sets true to currentSessionExistsLiveData`() {
         coEvery { checkCurrentSessionExistsUseCase.run(Unit) } returns Either.Right(true)
 
-        coroutinesTestRule.runTest {
-            launcherViewModel.checkIfCurrentSessionExists()
+        launcherViewModel.checkIfCurrentSessionExists()
 
-            launcherViewModel.currentSessionExistsLiveData.awaitValue() shouldBe true
-        }
+        launcherViewModel.currentSessionExistsLiveData shouldBeUpdated { it shouldBe true }
     }
 
     @Test
     fun `given checkIfCurrentSessionExists is called, when use case returns false, then sets false to currentSessionExistsLiveData`() {
         coEvery { checkCurrentSessionExistsUseCase.run(Unit) } returns Either.Right(false)
 
-        coroutinesTestRule.runTest {
-            launcherViewModel.checkIfCurrentSessionExists()
+        launcherViewModel.checkIfCurrentSessionExists()
 
-            launcherViewModel.currentSessionExistsLiveData.awaitValue() shouldBe false
-        }
+        launcherViewModel.currentSessionExistsLiveData shouldBeUpdated { it shouldBe false }
     }
 
     @Test
     fun `given checkIfCurrentSessionExists is called, when use case fails, then sets false to currentSessionExistsLiveData`() {
         coEvery { checkCurrentSessionExistsUseCase.run(Unit) } returns Either.Left(SQLiteFailure())
 
-        coroutinesTestRule.runTest {
-            launcherViewModel.checkIfCurrentSessionExists()
+        launcherViewModel.checkIfCurrentSessionExists()
 
-            launcherViewModel.currentSessionExistsLiveData.awaitValue() shouldBe false
-        }
+        launcherViewModel.currentSessionExistsLiveData shouldBeUpdated { it shouldBe false }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/framework/livedata/LiveDataAssertionsTest.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/livedata/LiveDataAssertionsTest.kt
@@ -1,56 +1,11 @@
 package com.wire.android.framework.livedata
 
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.wire.android.UnitTest
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBe
 import org.junit.Test
-import java.util.concurrent.TimeoutException
 
 class LiveDataAssertionsTest : UnitTest() {
-
-    @Test
-    fun `given awaitValue called on a LiveData, when a value is received, then doesn't disrupt the test`() {
-        runBlocking {
-            val liveData = MutableLiveData<Int>()
-            liveData.value = 5
-
-            liveData.awaitValue()
-        }
-    }
-
-    @Test(expected = TimeoutException::class)
-    fun `given awaitValue called on a LiveData, when the value is not received, then throws a TimeoutException`() {
-        runBlocking {
-            val liveData = MutableLiveData<Int>()
-
-            liveData.awaitValue()
-        }
-    }
-
-    @Test
-    fun `given assertNotUpdated called on a LiveData, when the value is not updated, then doesn't disrupt the test`() {
-        runBlocking {
-            val liveData = MutableLiveData<Int>()
-
-            liveData.assertNotUpdated()
-        }
-    }
-
-    @Test(expected = AssertionError::class)
-    fun `given assertNotUpdated called on a LiveData, when the value is updated, then fails the test`() {
-        runBlocking {
-            val liveData = MutableLiveData<Int>()
-            val lifecycleOwner = TestLifecycleOwner()
-            liveData.value = 5
-
-            liveData.assertNotUpdated()
-
-            liveData.observe(lifecycleOwner, Observer { })
-            lifecycleOwner.destroy()
-        }
-    }
 
     @Test
     fun `given shouldBeUpdated called on a LiveData, when a value is received, then executes the assertion and doesn't disrupt the test`() {

--- a/app/src/test/kotlin/com/wire/android/framework/livedata/Observers.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/livedata/Observers.kt
@@ -4,46 +4,6 @@ import androidx.lifecycle.LiveData
 import io.mockk.Called
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Assert.fail
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
-
-/**
- * A function that suspends the current coroutine until the LiveData's value changes. Then it
- * resumes the coroutine with the new value.
- *
- * @throws TimeoutException if the value of LiveData is not updated within [timeout] seconds.
- */
-@Deprecated("Use shouldBeUpdated instead")
-suspend fun <T> LiveData<T>.awaitValue(timeout: Long = 2L): T = suspendCoroutine { cont ->
-    val latch = CountDownLatch(1)
-
-    this.observeOnce {
-        latch.countDown()
-        cont.resume(it)
-    }
-
-    if (!latch.await(timeout, TimeUnit.SECONDS)) {
-        cont.resumeWithException(TimeoutException("Didn't receive LiveData value after $timeout seconds"))
-    }
-}
-
-@Deprecated("Use shouldNotBeUpdated instead")
-suspend fun <T> LiveData<T>.assertNotUpdated(timeout: Long = 2L) {
-    val value: T?
-
-    try {
-        value = awaitValue(timeout)
-    } catch (ex: TimeoutException) {
-        return
-    }
-
-    value?.let { fail("Didn't expect a value update but got $it") }
-}
 
 infix fun <T> LiveData<T>.shouldBeUpdated(assertion: (T) -> Unit) = this.shouldBeUpdated(2000L, assertion)
 


### PR DESCRIPTION
Gets rid of deprecated `awaitValue` and `assertNotUpdated` usages

See #120 