### PR TITLE
fix: The password dialog disappears when another person calls

### DIFF
--- a/app/src/main/res/layout/password_dialog.xml
+++ b/app/src/main/res/layout/password_dialog.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Wire
+    Copyright (C) 2018 Wire Swiss GmbH
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/prefs__dialog__padding"
+    android:paddingEnd="@dimen/prefs__dialog__padding"
+    >
+
+    <ScrollView
+        android:id="@+id/password_dialog_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:overScrollMode="ifContentScrolls"
+        >
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_dialog_error_layout"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_dialog_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:inputType="textPassword"
+                />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/scala/com/waz/zclient/BaseActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/BaseActivity.scala
@@ -41,7 +41,6 @@ import com.waz.zclient.Intents.RichIntent
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.IControllerFactory
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.security.ActivityLifecycleCallback
 import com.waz.zclient.utils.{ContextUtils, ViewUtils}
 
 import scala.collection.JavaConverters._
@@ -60,7 +59,6 @@ class BaseActivity extends AppCompatActivity
   protected lazy val themeController = inject[ThemeController]
   protected lazy val userPreferences = inject[Signal[UserPreferences]]
   private lazy val permissions       = inject[PermissionsService]
-  private lazy val activityLifecycle = inject[ActivityLifecycleCallback]
   private lazy val uiLifeCycle       = inject[UiLifeCycle]
   private lazy val secPolicy         = new ComponentName(this, classOf[SecurityPolicyService])
   private lazy val dpm               = getSystemService(Context.DEVICE_POLICY_SERVICE).asInstanceOf[DevicePolicyManager]

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
@@ -54,7 +54,7 @@ class CallStartController(implicit inj: Injector, cxt: WireContext, ec: EventCon
     autoAnswer <- prefs.flatMap(_.preference(AutoAnswerCallPrefKey).signal)
   } if (call.state == CallState.OtherCalling && autoAnswer) startCall(call.selfParticipant.userId, call.convId)
 
-  def startCallInCurrentConv(withVideo: Boolean, forceOption: Boolean = false) = {
+  def startCallInCurrentConv(withVideo: Boolean, forceOption: Boolean = false): Future[Unit] = {
     (for {
       Some(zms)  <- inject[Signal[Option[ZMessaging]]].head
       Some(conv) <- inject[Signal[Option[ConvId]]].head
@@ -64,12 +64,6 @@ class CallStartController(implicit inj: Injector, cxt: WireContext, ec: EventCon
         case NonFatal(e) => warn(l"Failed to start call", e)
       }
   }
-
-  def acceptCall(): Future[Unit] =
-    currentCallOpt.head.flatMap {
-      case Some(call) => startCall(call.selfParticipant.userId, call.convId)
-      case None => Future.successful(warn(l"No active call to accept..."))
-    }
 
   def startCall(account: UserId, conv: ConvId, withVideo: Boolean = false, forceOption: Boolean = false): Future[Unit] = {
     verbose(l"startCall: account: $account, conv: $conv")

--- a/app/src/main/scala/com/waz/zclient/security/SecurityChecklist.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityChecklist.scala
@@ -26,14 +26,13 @@ import scala.concurrent.Future
 
 class SecurityChecklist(list: List[(Check, List[Action])]) extends DerivedLogTag {
 
-  def run(): Future[Boolean] = {
+  def run(): Future[Boolean] =
     if (list.isEmpty) {
       Future.successful(true)
     } else {
       info(l"Running security checks")
       runChecks(list)
     }
-  }
 
   private def runChecks(checks: List[(Check, List[Action])]): Future[Boolean] = checks match {
     case Nil =>


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-46

1. You have the password dialog enabled, either because you're on a custom build, or you enabled it in the options. It appears when you open the app or if it was in the background for more than 10s (or 30s dependent on the build).
2. On new phones there's also a biometric check but that's up to Android.
3. If someone calls, the call screen appears on top of the password dialog. The user can answer the call. That shouldn't be allowed. The user should have to enter the password first.
4. And also, when the call ends, or is dropped by the caller, the user goes back to the conversation list and doesn't see the password dialog anymore.

I fixed that. Now we have another password dialog on the call screen (so the user has to type in the password to answer the call - that also didn't work) and the password dialog on the main screen doesn't go away.

That however created a glitch. The two password dialogs don't communicate with one another. So if the user types in the password on the call screen, after the call ends, they need to type in the password again on the main screen. Some decisions were taken when we implemented the calling long time ago and connecting them now proves quite difficult. I keep running into situations when again the password dialog is gone in some corner cases.
In the end, I decided to leave the glitch. There is a plan to rewrite the calling activity code. Maybe then it will be possible to fix this problem in an easy way.

Additional note:
The password layout was using the same layout file as the dialog requesting the password for removing one of devices. I used this opportunity to introduce a new, simpler layout, especially for the password dialog.
#### APK
[Download build #2938](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2938/artifact/build/artifact/wire-dev-PR3084-2938.apk)