### PR TITLE
fix: The unsplash picture should be used only if the user didn't provide their own

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -202,7 +202,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
 
     (for {
       Some(accountManager) <- accountsService.createAccountManager(userId, isLogin = Some(true))
-      _                    =  accountManager.addUnsplashPicture()
+      _                    =  accountManager.addUnsplashIfProfilePictureMissing()
       _                    <- accountsService.setAccount(Some(userId))
       _                    <- Future {
                                 KotlinServices.INSTANCE.restoreBackup(backupFile, userId.str, backupPassword.str, onSuccess _, onFailure _)
@@ -232,7 +232,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
     spinnerController.showDimmedSpinner(show = true, "")
     for {
       Some(accountManager) <- accountsService.createAccountManager(userId, isLogin = Some(true))
-      _                    =  accountManager.addUnsplashPicture()
+      _                    =  accountManager.addUnsplashIfProfilePictureMissing()
       _                    <- accountsService.setAccount(Some(userId))
       registrationState    <- accountManager.getOrRegisterClient()
       _                    =  spinnerController.hideSpinner(Some(getString(R.string.back_up_progress_complete)))

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
@@ -127,7 +127,7 @@ class PhoneSetNameFragment extends FragmentHelper with TextWatcher with View.OnC
         activity.onEnterApplication(false)
         accountManager.foreach { am =>
           am.initZMessaging()
-          am.addUnsplashPicture()
+          am.addUnsplashIfProfilePictureMissing()
         }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SetTeamPasswordFragment.scala
@@ -90,7 +90,7 @@ case class SetTeamPasswordFragment() extends CreateTeamFragment {
                   Future.successful(Some(getString(EmailError(error).bodyResource)))
                 case Right(Some(am)) =>
                   am.initZMessaging()
-                  am.addUnsplashPicture()
+                  am.addUnsplashIfProfilePictureMissing()
                   am.setMarketingConsent(createTeamController.receiveNewsAndOffers).map { _ =>
                     showFragment(InviteToTeamFragment(), InviteToTeamFragment.Tag)
                     None

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -175,7 +175,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
       _                   <- resp match {
         case Right(Some(am)) =>
           am.initZMessaging()
-          am.addUnsplashPicture()
+          am.addUnsplashIfProfilePictureMissing()
           (if (!askMarketingConsent) Future.successful(Some(false)) else
             showConfirmationDialog(
               getString(R.string.receive_news_and_offers_request_title),

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
@@ -188,7 +188,7 @@ class VerifyPhoneFragment extends FragmentHelper with View.OnClickListener with 
             am       <- accountService.createAccountManager(userId, isLogin = Some(true))
             _        =  am.foreach { accManager =>
                           accManager.initZMessaging()
-                          accManager.addUnsplashPicture()
+                          accManager.addUnsplashIfProfilePictureMissing()
                         }
             _        <- accountService.setAccount(Some(userId))
             regState <- am.fold2(Future.successful(Left(ErrorResponse.internalError(""))), _.getOrRegisterClient())

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -176,7 +176,7 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
   }
 
   newPicturePicButton.onClickEvent { _ =>
-    am.head.flatMap(_.addUnsplashPicture()).foreach { _ =>
+    am.head.flatMap(_.addUnsplashIfProfilePictureMissing()).foreach { _ =>
       showToast("The profile picture changed")
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -120,8 +120,9 @@ class AccountManager(val userId:  UserId,
     zmessaging
   }
 
-  def addUnsplashPicture(): Future[Unit] = for {
+  def addUnsplashIfProfilePictureMissing(): Future[Unit] = for {
     zms      <- zmessaging
+    true     <- zms.users.selfUser.map(_.picture.isEmpty).head
     unsplash <- zms.assetService.loadUnsplashProfilePicture().future
     content  <- unsplash.toByteArray match {
                   case Success(bytes) => Future.successful(Content.Bytes(Mime.Image.Jpg, bytes))

--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -478,7 +478,7 @@ class AccountsServiceImpl(global: GlobalModule, kotlinLogoutEnabled: Boolean = f
               hadDb =  context.getDatabasePath(userId.str).exists
               am    <- createAccountManager(userId, isLogin = Some(true), initialUser = Some(userInfo))
               r     <- am.fold2(Future.successful(Left(ErrorResponse.internalError(""))), _.otrClient.loadClients().future.mapRight(cs => (cs.nonEmpty, hadDb)))
-              _     =  r.fold(_ => (), res => if (!res._1) am.foreach(_.addUnsplashPicture()))
+              _     =  r.fold(_ => (), res => if (!res._1) am.foreach(_.addUnsplashIfProfilePictureMissing()))
             } yield r
           case Left(error) =>
             verbose(l"login - Get self error: $error")


### PR DESCRIPTION
The recent fix to the unsplash picture revealed another problem: we didn't check if the user already added a profile picture. This small change fixes this problem. First we check if the profile picture is missing and only if yes then we get one from Unsplash.
#### APK
[Download build #2937](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2937/artifact/build/artifact/wire-dev-PR3086-2937.apk)