### PR TITLE
[Calling] - Bugfix : toggling video button multiple times renders white-out/black-out buttons

### DIFF
--- a/app/src/main/res/drawable/selector__icon_button__background__calling.xml
+++ b/app/src/main/res/drawable/selector__icon_button__background__calling.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2018 Wire Swiss GmbH
@@ -19,13 +18,6 @@
 
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:state_pressed="true">
-        <shape android:shape="oval">
-            <solid android:color="@color/white_80" />
-        </shape>
-    </item>
-
     <item android:state_activated="true">
         <shape android:shape="oval">
             <solid android:color="@color/white" />
@@ -34,7 +26,7 @@
 
     <item>
         <shape android:shape="oval">
-            <solid android:color="@color/white_32"/>
+            <solid android:color="@color/white_32" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/selector__icon_button__background__calling_light.xml
+++ b/app/src/main/res/drawable/selector__icon_button__background__calling_light.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2018 Wire Swiss GmbH
@@ -19,13 +18,6 @@
 
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:state_pressed="true">
-        <shape android:shape="oval">
-            <solid android:color="@color/graphite" />
-        </shape>
-    </item>
-
     <item android:state_activated="true">
         <shape android:shape="oval">
             <solid android:color="@color/graphite" />
@@ -34,7 +26,7 @@
 
     <item>
         <shape android:shape="oval">
-            <solid android:color="@color/graphite_8"/>
+            <solid android:color="@color/graphite_8" />
         </shape>
     </item>
 </selector>


### PR DESCRIPTION
## What's new in this PR?

### Issues

The call control buttons "Mute, video and speaker" becomes completely white or completely black when we do a long press.

https://wearezeta.atlassian.net/browse/SQCALL-6

### Causes

`state_pressed` is not relevant for this case, the background color should change only for `state_activated` 

### Solutions

Remove `state_pressed` from the selector.

#### APK
[Download build #2939](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2939/artifact/build/artifact/wire-dev-PR3087-2939.apk)