### PR TITLE
Feature: Either - Extend Either class for suspend fun support

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/functional/SuspendableEitherScope.kt
+++ b/app/src/main/kotlin/com/wire/android/core/functional/SuspendableEitherScope.kt
@@ -1,0 +1,63 @@
+package com.wire.android.core.functional
+
+import com.wire.android.core.functional.Either.Left
+import com.wire.android.core.functional.Either.Right
+
+/**
+ * Helper class that extends [Either] to be compatible with suspend functions. The extension methods created in this class
+ * are only visible inside a scope that belongs to this class. The scope can be created by [suspending] method.
+ *
+ * ```
+ * suspend fun save() {
+ *    ...
+ * }
+ *
+ * suspend fun saveResult() {
+ *     either.flatMap {
+ *        save()        // compile time error: cannot call suspend function here
+ *     }
+ * }
+ *
+ *
+ * suspend fun saveResult() {
+ *     suspending {             // this: SuspendableEitherScope
+ *         either.flatMap {     // resolves "flatMap" in SuspendableEitherScope
+ *             save()           // we can now call a suspend function here
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @see Either
+ */
+class SuspendableEitherScope {
+
+    /**
+     * @see [Either.fold]
+     */
+    suspend fun <L, R, T> Either<L, R>.coFold(fnL: suspend (L) -> T?, fnR: suspend (R) -> T?): T? =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+
+    suspend fun <L, R, T> Either<L, R>.flatMap(fn: suspend (R) -> Either<L, T>): Either<L, T> =
+        when (this) {
+            is Left -> Left(a)
+            is Right -> fn(b)
+        }
+
+    suspend fun <L, R> Either<L, R>.onFailure(fn: suspend (failure: L) -> Unit): Either<L, R> =
+        this.apply { if (this is Left) fn(a) }
+
+    suspend fun <L, R> Either<L, R>.onSuccess(fn: suspend (success: R) -> Unit): Either<L, R> =
+        this.apply { if (this is Right) fn(b) }
+
+    suspend fun <L, R, T> Either<L, R>.map(fn: suspend (R) -> (T)): Either<L, T> =
+        when (this) {
+            is Left -> Left(a)
+            is Right -> Right(fn(b))
+        }
+}
+
+suspend fun <T> suspending(block: suspend SuspendableEitherScope.() -> T): T = SuspendableEitherScope().block()

--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/email/usecase/LoginWithEmailUseCase.kt
@@ -5,13 +5,12 @@ import com.wire.android.core.exception.FeatureFailure
 import com.wire.android.core.exception.Forbidden
 import com.wire.android.core.exception.TooManyRequests
 import com.wire.android.core.functional.Either
-import com.wire.android.core.functional.flatMap
+import com.wire.android.core.functional.suspending
 import com.wire.android.core.usecase.UseCase
 import com.wire.android.feature.auth.login.email.LoginRepository
 import com.wire.android.shared.session.Session
 import com.wire.android.shared.session.SessionRepository
 import com.wire.android.shared.user.UserRepository
-import kotlinx.coroutines.runBlocking
 
 class LoginWithEmailUseCase(
     private val loginRepository: LoginRepository,
@@ -19,22 +18,18 @@ class LoginWithEmailUseCase(
     private val sessionRepository: SessionRepository
 ) : UseCase<Unit, LoginWithEmailUseCaseParams> {
 
-    override suspend fun run(params: LoginWithEmailUseCaseParams): Either<Failure, Unit> =
-        loginRepository.loginWithEmail(email = params.email, password = params.password).fold({
+    override suspend fun run(params: LoginWithEmailUseCaseParams): Either<Failure, Unit> = suspending {
+        loginRepository.loginWithEmail(email = params.email, password = params.password).coFold({
             handleFailure(it)
         }) { session ->
             if (session == Session.EMPTY) Either.Left(SessionCredentialsMissing)
             else {
-                //TODO: find a suspendable Either solution
-                runBlocking {
-                    userRepository.selfUser(accessToken = session.accessToken, tokenType = session.tokenType).flatMap {
-                        runBlocking {
-                            sessionRepository.save(session)
-                        }
-                    }
+                userRepository.selfUser(accessToken = session.accessToken, tokenType = session.tokenType).flatMap {
+                    sessionRepository.save(session)
                 }
             }
         }!!
+    }
 
     private fun handleFailure(failure: Failure) = when (failure) {
         //TODO: should we take "label" in backend response into account?

--- a/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
@@ -2,14 +2,13 @@ package com.wire.android.shared.session.datasources
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
-import com.wire.android.core.functional.flatMap
 import com.wire.android.core.functional.map
+import com.wire.android.core.functional.suspending
 import com.wire.android.shared.session.Session
 import com.wire.android.shared.session.SessionRepository
 import com.wire.android.shared.session.datasources.local.SessionLocalDataSource
 import com.wire.android.shared.session.datasources.remote.SessionRemoteDataSource
 import com.wire.android.shared.session.mapper.SessionMapper
-import kotlinx.coroutines.runBlocking
 
 class SessionDataSource(
     private val remoteDataSource: SessionRemoteDataSource,
@@ -17,12 +16,13 @@ class SessionDataSource(
     private val mapper: SessionMapper
 ) : SessionRepository {
 
-    override suspend fun save(session: Session, current: Boolean): Either<Failure, Unit> =
+    override suspend fun save(session: Session, current: Boolean): Either<Failure, Unit> = suspending {
         if (current) {
             localDataSource.setCurrentSessionToDormant().flatMap {
-                runBlocking { saveLocally(session, true) }
+                saveLocally(session, true)
             }
         } else saveLocally(session, current)
+    }
 
     override suspend fun currentSession(): Either<Failure, Session> = localDataSource.currentSession().map {
         mapper.fromSessionEntity(it)

--- a/app/src/main/kotlin/com/wire/android/shared/user/datasources/UserDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/datasources/UserDataSource.kt
@@ -2,14 +2,12 @@ package com.wire.android.shared.user.datasources
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
-import com.wire.android.core.functional.flatMap
-import com.wire.android.core.functional.map
+import com.wire.android.core.functional.suspending
 import com.wire.android.shared.user.User
 import com.wire.android.shared.user.UserRepository
 import com.wire.android.shared.user.datasources.local.UserLocalDataSource
 import com.wire.android.shared.user.datasources.remote.UserRemoteDataSource
 import com.wire.android.shared.user.mapper.UserMapper
-import kotlinx.coroutines.runBlocking
 
 class UserDataSource(
     private val localDataSource: UserLocalDataSource,
@@ -17,12 +15,13 @@ class UserDataSource(
     private val mapper: UserMapper
 ) : UserRepository {
 
-    override suspend fun selfUser(accessToken: String, tokenType: String): Either<Failure, User> =
+    override suspend fun selfUser(accessToken: String, tokenType: String): Either<Failure, User> = suspending {
         remoteDataSource.selfUser(accessToken, tokenType).map {
             mapper.fromSelfUserResponse(it)
         }.flatMap { user ->
-            runBlocking { save(user) }.map { user }
+            save(user).map { user }
         }
+    }
 
     override suspend fun save(user: User): Either<Failure, Unit> =
         localDataSource.save(mapper.toUserEntity(user))

--- a/app/src/test/kotlin/com/wire/android/core/functional/EitherTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/functional/EitherTest.kt
@@ -45,7 +45,9 @@ class EitherTest : UnitTest() {
     fun `given flatMap is called, when either is Left, doesn't invoke function and returns original Either`() {
         either = Either.Left(12)
 
-        val result = either.flatMap { Either.Right(20) }
+        val result: Either<Int, Int> = either.flatMap {
+            fail("Shouldn't be executed")
+        }
 
         result.isLeft shouldBe true
         result shouldBeEqualTo either
@@ -120,7 +122,9 @@ class EitherTest : UnitTest() {
     fun `given map is called, when either is Left, doesn't invoke function and returns original Either`() {
         either = Either.Left(12)
 
-        val result = either.map { Either.Right(20) }
+        val result = either.map {
+            fail("Shouldn't be executed")
+        }
 
         result.isLeft shouldBe true
         result shouldBeEqualTo either

--- a/app/src/test/kotlin/com/wire/android/core/functional/SuspendableEitherScopeTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/functional/SuspendableEitherScopeTest.kt
@@ -1,0 +1,196 @@
+package com.wire.android.core.functional
+
+import com.wire.android.UnitTest
+import com.wire.android.core.exception.ServerError
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.Before
+import org.junit.Test
+
+class SuspendableEitherScopeTest : UnitTest() {
+
+    private lateinit var either: Either<Int, String>
+
+    private lateinit var suspendableEitherScope: SuspendableEitherScope
+
+    @Before
+    fun setUp() {
+        suspendableEitherScope = SuspendableEitherScope()
+    }
+
+    @Test
+    fun `given coFold is called on an Either, when either is Right, applies fnR and returns its result`() {
+        either = Either.Right("Success")
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+                either.coFold({ fail("Shouldn't be executed") }) { 5 }
+            }
+        }
+
+        result shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `given coFold is called on an Either, when either is Left, applies fnL and returns its result`() {
+        either = Either.Left(12)
+        val foldResult = "Fold Result"
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+                either.coFold({ foldResult }) { fail("Shouldn't be executed") }
+            }
+        }
+
+        result shouldBe foldResult
+    }
+
+    @Test
+    fun `given flatMap is called on an Either, when either is Right, applies function and returns new Either`() {
+        either = Either.Right("Success")
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+
+                either.flatMap {
+                    it shouldBe "Success"
+                    Either.Left(ServerError)
+                }
+            }
+        }
+
+        result shouldBeEqualTo Either.Left(ServerError)
+        result.isLeft shouldBe true
+    }
+
+    @Test
+    fun `given flatMap is called on an Either, when either is Left, doesn't invoke function and returns original Either`() {
+        either = Either.Left(12)
+
+        val result: Either<Int, Int> = runBlocking {
+            with(suspendableEitherScope) {
+                either.flatMap { fail("Shouldn't be executed") }
+            }
+        }
+        result.isLeft shouldBe true
+        result shouldBeEqualTo either
+    }
+
+    @Test
+    fun `given onFailure is called on an Either, when either is Right, doesn't invoke function and returns original Either`() {
+        val success = "Success"
+        either = Either.Right(success)
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+                either.onFailure { fail("Shouldn't be executed") }
+            }
+        }
+
+        result shouldBe either
+        either.getOrElse("Failure") shouldBe success
+    }
+
+    @Test
+    fun `given onFailure is called on an Either, when either is Left, invokes function with left value and returns original Either`() {
+        either = Either.Left(12)
+        var methodCalled = false
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+
+                either.onFailure {
+                    it shouldBeEqualTo 12
+                    methodCalled = true
+                }
+            }
+        }
+
+        result shouldBe either
+        methodCalled shouldBe true
+    }
+
+    @Test
+    fun `given onSuccess is called on an Either, when either is Right, invokes function with right value and returns original Either`() {
+        val success = "Success"
+        either = Either.Right(success)
+        var methodCalled = false
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+
+                either.onSuccess {
+                    it shouldBeEqualTo success
+                    methodCalled = true
+                }
+            }
+        }
+
+        result shouldBe either
+        methodCalled shouldBe true
+    }
+
+    @Test
+    fun `given onSuccess is called on an Either, when either is Left, doesn't invoke function and returns original Either`() {
+        either = Either.Left(12)
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+                either.onSuccess { fail("Shouldn't be executed") }
+            }
+        }
+
+        result shouldBe either
+    }
+
+    @Test
+    fun `given map is called on an Either, when either is Right, invokes function with right value and returns a new Either`() {
+        val success = "Success"
+        val resultValue = "Result"
+        either = Either.Right(success)
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+
+                 either.map {
+                    it shouldBe success
+                    resultValue
+                }
+            }
+        }
+
+        result shouldBeEqualTo Either.Right(resultValue)
+    }
+
+    @Test
+    fun `given map is called on an Either, when either is Left, doesn't invoke function and returns original Either`() {
+        either = Either.Left(12)
+
+        val result = runBlocking {
+            with(suspendableEitherScope) {
+                 either.map { fail("Shouldn't be executed") }
+            }
+        }
+
+        result.isLeft shouldBe true
+        result shouldBeEqualTo either
+    }
+
+    @Test
+    fun `given a block, when suspending is called, then creates a new SuspendableEitherScope and executes block on it`() {
+        val block: SuspendableEitherScope.() -> Unit = mockk(relaxed = true)
+
+        runBlocking {
+            suspending {
+                this shouldBeInstanceOf SuspendableEitherScope::class
+                block()
+            }
+        }
+
+        verify(exactly = 1) { block.invoke(any()) }
+    }
+}


### PR DESCRIPTION
**Problem:**

The "functional" nature of `Either` does not inherently support `suspend` functions. Hence, when invoking a suspend function inside an `Either` operation, we are forced to create a new Coroutine Scope with `runBlocking`, even when we were inside a `suspend fun` in the first place:

```
    override suspend fun save(session: Session, current: Boolean) =	    
        localDataSource.setCurrentSessionToDormant().flatMap {
           runBlocking { 
               saveLocally(session, true) 
           }
        }
```

Even though, `save` is a `suspend fun`, an extra step of `runBlocking` is required inside `flatMap`, as we lost access to the scope of suspend function. There are 2 main problems here:

1.  runBlocking ["should not be used from a coroutine"](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/run-blocking.html)

2.  Chaining calls quickly create a "runBlocking hell" (such an example can be seen in `LoginWithEmailUseCase`)

**Solution:**

A naive solution to this problem was to create "suspendable" equivalents of each operation as seen in [wire-android](https://github.com/wireapp/wire-android/pull/2563#discussion_r368944764) project. However, on various occasions it was stressed that this is far from being an ideal usage because of reasons like "Either shouldn't know about coroutines", "API is being polluted" and so on.

`SuspendableEitherScope` class is created to isolate this behaviour from `Either` class itself. This class adds `Either` class some new behaviour in order to support suspend functions, but this behaviour is only accessible inside a scope which has `SuspendableEitherScope` as receiver.

Now, the example above can be converted to:

```
    override suspend fun save(session: Session, current: Boolean) = suspending {    
        localDataSource.setCurrentSessionToDormant().flatMap {
           saveLocally(session, true) 
        }
    }
```

Note that this scales much better than `runBlocking`, as it allows chaining calls.

**Note:**
The "context-oriented" approach is mainly inspired by [this blog post](https://proandroiddev.com/an-introduction-context-oriented-programming-in-kotlin-2e79d316b0a2). The post itself is quite long, but most relevant part can be summarized here:

```
class B
class A {
    fun B.doBSomething() {}
}
fun main(){
    val a = A()
    val b = B()
    with(a) {
        b.doBSomething() // this will work
    }
    b.doBSomething() // won't compile
}
```
where A and B classes correspond to SuspendableEitherScope and Either respectively.


 


