### PR TITLE
fix: Don't ask for the password when initiating the call

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingActivity.scala
@@ -25,7 +25,6 @@ import com.waz.threading.Threading._
 import com.waz.zclient._
 import com.waz.zclient.calling.controllers.CallController
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.security.SecurityPolicyChecker
 import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.DeprecationUtils
 
@@ -80,8 +79,6 @@ class CallingActivity extends BaseActivity {
   override def onResume(): Unit = {
     super.onResume()
     controller.setVideoPause(pause = false)
-
-    inject[SecurityPolicyChecker].run()(this)
   }
 
   override def onPause(): Unit = {


### PR DESCRIPTION
A fix to a problem which came up after the fix to the password dialog security issue. Generally this is a lesson to me
to write myself a small list of possible bugs I can introduce when changing a piece of code so I can make some manual
tests (or write unit tests when possible) before I make a PR.

The problem was that now the password dialog appears also when the user starts a call and when they receive a call but
after they typed in the password already. This should not be the case. This PR fixes that.

Note that it does not fix some cases when a new password dialog is displayed on top of an older one and the user has to
type in the password twice. This will be addressed in a later PR.

Two changes:
1. I moved calling the security checklist when a call is being made from `CallingActivity` to `CallFragment`. This way I was able to check if the call is incoming (only then we should run the checklist).
2. I introduced a new flag to the security checklist which tells us if the background timer should be enabled. The timer is used to decide if the password dialog should appear and the logic is a bit complicated... It should appear when the app is launched and after some time in the background - that second condition causes problems, because when the call is incoming and the app is in the background, it first comes to the foreground, and only then the calling activity is created. Which means from the activity point of view it was always in the foreground, no way to differentiate. The flag timerEnabled solves this problem but makes the logic less readable 😕
I implemented it as a small `Signal[Boolean]` to be consistent with other fields in the security checklist.