### PR TITLE
[Calling] Feature :  Show similar calling experience for 1:1 calls and group calls with 2 participants

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -85,9 +85,12 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     }
   }
 
-  Signal.zip(controller.isGroupCall, controller.controlsVisible).map {
-    case (true, false) => View.VISIBLE
-    case _             => View.GONE
+  Signal.zip(controller.isGroupCall, controller.controlsVisible,
+    controller.otherParticipants.map(_.size)
+  ).map {
+    case (true, false, 0 | 1 | 2) => View.GONE
+    case (true, false, _)     => View.VISIBLE
+    case _                    => View.GONE
   }.onUi(participantInfoCardView.setVisibility)
 
   protected def registerHandler(view: View) = {
@@ -171,8 +174,9 @@ class CallingFragment extends FragmentHelper {
       controller.callingZms.map(zms => Participant(zms.selfUserId, zms.clientId)),
       controller.isVideoCall,
       controller.isCallIncoming,
-      controller.participantInfos()
-    ).onUi { case (vrs, selfParticipant, videoCall, incoming, infos) =>
+      controller.participantInfos(),
+      controller.otherParticipants
+    ).onUi { case (vrs, selfParticipant, videoCall, incoming, infos, participants) =>
 
         def createView(participant: Participant): UserVideoView = returning {
           if (participant == selfParticipant) new SelfVideoView(getContext, participant)
@@ -194,7 +198,7 @@ class CallingFragment extends FragmentHelper {
 
         viewMap.get(selfParticipant).foreach { selfView =>
           previewCardView.foreach { cardView =>
-            if (views.size == 2 && isVideoBeingSent) {
+            if (views.size == 2 && participants.size == 2 && isVideoBeingSent) {
               verbose(l"Showing card preview")
               cardView.removeAllViews()
               v.removeView(selfView)
@@ -215,7 +219,7 @@ class CallingFragment extends FragmentHelper {
         }
 
         val gridViews = views.filter {
-          case _: SelfVideoView if views.size == 2 && isVideoBeingSent => false
+          case _: SelfVideoView if views.size == 2 && participants.size == 2 && isVideoBeingSent => false
           case _: SelfVideoView if views.size > 1 && !isVideoBeingSent => false
           case _ => true
         }.sortWith {
@@ -227,9 +231,9 @@ class CallingFragment extends FragmentHelper {
 
         gridViews.zipWithIndex.foreach { case (r, index) =>
           val (row, col, span, width) = index match {
-            case 0 if !isVideoBeingSent && gridViews.size == 2 => (0, 0, 2, 0)
+            case 0 if gridViews.size == 2 => (0, 0, 2, 0)
             case 0 => (0, 0, 1, 0)
-            case 1 if !isVideoBeingSent && gridViews.size == 2 => (1, 0, 2, 0)
+            case 1 if gridViews.size == 2 => (1, 0, 2, 0)
             case 1 => (0, 1, 1, 0)
             // The max number of columns is 2 and the max number of rows is undefined
             // if the index of the video preview is even, display it in row n/2, column 1 , span 1 , width match_parent(0)


### PR DESCRIPTION
## What's new in this PR?

This PR is part of video management view improvements. We have a new feature request which is to display the video calling experience of 1:1 calls for conference calls with 2 participants: 
- Showing the floating cardView instead of the gridView
- Hiding the name and mute status in the videoView.

https://wearezeta.atlassian.net/browse/SQCALL-8
#### APK
[Download build #2943](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2943/artifact/build/artifact/wire-dev-PR3090-2943.apk)