### PR TITLE
Bump AVS version to 6.4.19

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.4.233"
-String avsPrivateVersion = "6.4.16"
+String avsPrivateVersion = "6.4.19"
 
 String nexusUrl = ""
 


### PR DESCRIPTION
## What's new in this PR?

Bump AVS version to the latest 6.4.19

#### APK
[Download build #2947](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2947/artifact/build/artifact/wire-dev-PR3091-2947.apk)