### PR TITLE
Move ConversationDataSource to another package

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
@@ -1,12 +1,11 @@
-package com.wire.android.feature.conversation.data.remote
+package com.wire.android.feature.conversation.data
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.suspending
 import com.wire.android.feature.conversation.Conversation
-import com.wire.android.feature.conversation.data.ConversationMapper
-import com.wire.android.feature.conversation.data.ConversationsRepository
 import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource
+import com.wire.android.feature.conversation.data.remote.ConversationRemoteDataSource
 
 class ConversationDataSource(
     private val conversationMapper: ConversationMapper,

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -2,7 +2,7 @@ package com.wire.android.feature.conversation.di
 
 import com.wire.android.core.network.NetworkClient
 import com.wire.android.core.storage.db.user.UserDatabase
-import com.wire.android.feature.conversation.data.remote.ConversationDataSource
+import com.wire.android.feature.conversation.data.ConversationDataSource
 import com.wire.android.feature.conversation.data.ConversationMapper
 import com.wire.android.feature.conversation.data.ConversationsRepository
 import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
@@ -1,13 +1,13 @@
-package com.wire.android.feature.conversation.data.remote
+package com.wire.android.feature.conversation.data
 
 import com.wire.android.UnitTest
 import com.wire.android.core.exception.DatabaseFailure
 import com.wire.android.core.exception.ServerError
 import com.wire.android.core.functional.Either
 import com.wire.android.feature.conversation.Conversation
-import com.wire.android.feature.conversation.data.ConversationMapper
-import com.wire.android.feature.conversation.data.ConversationsRepository
 import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource
+import com.wire.android.feature.conversation.data.remote.ConversationRemoteDataSource
+import com.wire.android.feature.conversation.data.remote.ConversationsResponse
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed


### PR DESCRIPTION
`ConversationDataSource` is taken out of `data.remote` package as it is related to all data sources, not only the remote one.

Committed separately in order to make reviewing #128 easier