### PR TITLE
feat: Shared tracking id

### DIFF
--- a/app/src/main/res/layout/preferences_dev_layout.xml
+++ b/app/src/main/res/layout/preferences_dev_layout.xml
@@ -60,6 +60,15 @@
             />
 
             <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_dev_generate_random_trackingid"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/wire__padding__20"
+                app:title="@string/pref_dev_random_tracking_id_title"
+                app:subtitle="@string/pref_dev_random_tracking_id_summary"
+                />
+
+            <com.waz.zclient.preferences.views.TextButton
                 android:id="@+id/register_another_client"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -158,6 +158,8 @@
     <string translatable="false" name="pref_dev_websocket_ping_interval_title">WebSocket Ping Frequency (ms)</string>
     <string translatable="false" name="pref_dev_random_last_notification_id_title">Generate a random new value for LastStableNotification</string>
     <string translatable="false" name="pref_dev_random_last_notification_id_summary">Generate a new, random value for the LastStableNotification preference. Use it to test history loss.</string>
+    <string translatable="false" name="pref_dev_random_tracking_id_title">Generate a random new value for TrackingId</string>
+    <string translatable="false" name="pref_dev_random_tracking_id_summary">Generate a new, random value for the CountlyTrackingId preference. Use it to test history loss.</string>
     <string translatable="false" name="pref_dev_full_conv_key">>PREF_FULL_CONV</string>
     <string translatable="false" name="pref_dev_full_conv_summary">Instead of an empty conversation, create one populated with all contacts in the list (up to 256)</string>
     <string translatable="false" name="pref_dev_full_conv_title">Create full conversation</string>

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -159,7 +159,7 @@
     <string translatable="false" name="pref_dev_random_last_notification_id_title">Generate a random new value for LastStableNotification</string>
     <string translatable="false" name="pref_dev_random_last_notification_id_summary">Generate a new, random value for the LastStableNotification preference. Use it to test history loss.</string>
     <string translatable="false" name="pref_dev_random_tracking_id_title">Generate a random new value for TrackingId</string>
-    <string translatable="false" name="pref_dev_random_tracking_id_summary">Generate a new, random value for the CountlyTrackingId preference. Use it to test history loss.</string>
+    <string translatable="false" name="pref_dev_random_tracking_id_summary">Generate a new, random value for the CurrentTrackingId preference. Use it to test tracking.</string>
     <string translatable="false" name="pref_dev_full_conv_key">>PREF_FULL_CONV</string>
     <string translatable="false" name="pref_dev_full_conv_summary">Instead of an empty conversation, create one populated with all contacts in the list (up to 256)</string>
     <string translatable="false" name="pref_dev_full_conv_title">Create full conversation</string>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -240,7 +240,7 @@ class MainActivity extends BaseActivity
   private def initTracking: Future[Unit] =
     for {
       prefs            <- userPreferences.head
-      id               <- prefs.preference(CountlyTrackingId).apply()
+      id               <- prefs.preference(CurrentTrackingId).apply()
       shouldShare      <- prefs.preference(ShouldShareTrackingId).apply()
       trackingCtrl     =  inject[GlobalTrackingController]
       _                =  verbose(l"trackingId: $id, shouldShare: $shouldShare")
@@ -249,10 +249,10 @@ class MainActivity extends BaseActivity
       check            <- prefs.preference[Boolean](TrackingEnabledOneTimeCheckPerformed).apply()
       analyticsEnabled <- prefs.preference[Boolean](TrackingEnabled).apply()
       isProUser        <- userAccountsController.isProUser.head
-      _                <- if(!check)
+      _                <- if (!check)
                             (prefs(TrackingEnabled) := isProUser).flatMap(_ => prefs(TrackingEnabledOneTimeCheckPerformed) := true)
                           else Future.successful(())
-      _                <- if(analyticsEnabled && isProUser) trackingCtrl.init() else Future.successful(())
+      _                <- if (analyticsEnabled && isProUser) trackingCtrl.init() else Future.successful(())
     } yield ()
 
   override def onStart(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -241,19 +241,18 @@ class MainActivity extends BaseActivity
     for {
       prefs            <- userPreferences.head
       id               <- prefs.preference(CountlyTrackingId).apply()
-      _                <- if (id.isEmpty) prefs.preference(CountlyTrackingId) := Some(TrackingId()) else Future.successful(())
+      shouldShare      <- prefs.preference(ShouldShareTrackingId).apply()
+      trackingCtrl     =  inject[GlobalTrackingController]
+      _                =  verbose(l"trackingId: $id, shouldShare: $shouldShare")
+      _                <- if (id.isEmpty || shouldShare) trackingCtrl.setAndSendNewTrackingId() else Future.successful(())
+      _                <- if (shouldShare) prefs.preference(ShouldShareTrackingId) := false else Future.successful(())
       check            <- prefs.preference[Boolean](TrackingEnabledOneTimeCheckPerformed).apply()
       analyticsEnabled <- prefs.preference[Boolean](TrackingEnabled).apply()
       isProUser        <- userAccountsController.isProUser.head
-      _                <-
-        if(!check) {
-          (prefs(TrackingEnabled) := isProUser)
-            .flatMap(_ => prefs(TrackingEnabledOneTimeCheckPerformed) := true)
-        } else Future.successful(())
-      _                <-
-        if(analyticsEnabled && isProUser) {
-          inject[GlobalTrackingController].init()
-        } else Future.successful(())
+      _                <- if(!check)
+                            (prefs(TrackingEnabled) := isProUser).flatMap(_ => prefs(TrackingEnabledOneTimeCheckPerformed) := true)
+                          else Future.successful(())
+      _                <- if(analyticsEnabled && isProUser) trackingCtrl.init() else Future.successful(())
     } yield ()
 
   override def onStart(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -41,6 +41,7 @@ import com.waz.zclient.preferences.dialogs.RequestPasswordDialog
 import com.waz.zclient.preferences.dialogs.RequestPasswordDialog.{PasswordAnswer, PasswordCancelled, PromptAnswer}
 import com.waz.zclient.preferences.views.{SwitchPreference, TextButton}
 import com.waz.zclient.security.checks.RootDetectionCheck
+import com.waz.zclient.tracking.GlobalTrackingController
 import com.waz.zclient.utils.ContextUtils.showToast
 import com.waz.zclient.utils.{BackStackKey, ContextUtils}
 import com.wire.signals.Signal
@@ -74,6 +75,8 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
   }
 
   val randomLastIdButton = findById[TextButton](R.id.preferences_dev_generate_random_lastid)
+
+  private val randomTrackingIdButton = findById[TextButton](R.id.preferences_dev_generate_random_trackingid)
 
   val registerAnotherClient = returning(findById[TextButton](R.id.register_another_client)) {
     _.onClickEvent(_ => registerClient().foreach {
@@ -173,6 +176,10 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
         override def onClick(dialog: DialogInterface, which: Int): Unit = {}
       })
       .setIcon(android.R.drawable.ic_dialog_alert).show
+  }
+
+  randomTrackingIdButton.onClickEvent { _ =>
+    inject[GlobalTrackingController].setAndSendNewTrackingId()
   }
 
   newPicturePicButton.onClickEvent { _ =>

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -21,7 +21,7 @@ package com.waz.zclient.tracking
 import java.util
 
 import android.app.Activity
-import com.waz.content.UserPreferences.CountlyTrackingId
+import com.waz.content.UserPreferences.CurrentTrackingId
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogsService
 import com.waz.model.{TeamId, TrackingId}
@@ -59,9 +59,9 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
     for {
       am            <- am.head
       inited        <- initialized.head
-      curTrackingId <- am.storage.userPrefs(CountlyTrackingId).apply()
+      curTrackingId <- am.storage.userPrefs(CurrentTrackingId).apply()
       isNew         =  !curTrackingId.contains(id)
-      _             =  if (isNew) am.storage.userPrefs(CountlyTrackingId) := Some(id)
+      _             =  if (isNew) am.storage.userPrefs(CurrentTrackingId) := Some(id)
       _             =  if (inited && isNew) Countly.sharedInstance().changeDeviceIdWithMerge(id.str)
       _             =  verbose(l"tracking id set to $id (new: $isNew)")
     } yield ()
@@ -80,7 +80,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
       isProUser        <- userAccountsController.isProUser.head if (isProUser)
       ap               <- tracking.isTrackingEnabled.head if (ap)
       inited           <- initialized.head if (!inited)
-      Some(trackingId) <- am.head.flatMap(_.storage.userPrefs(CountlyTrackingId).apply())
+      Some(trackingId) <- am.head.flatMap(_.storage.userPrefs(CurrentTrackingId).apply())
       logsEnabled      <- inject[LogsService].logsEnabled
     } yield {
         verbose(l"Using countly Id: ${trackingId.str}")

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     // should match okhttp3's mockserver version (see test dependencies)
     implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
-    api "com.wire:generic-message-proto:1.24.2"
+    api "com.wire:generic-message-proto:1.27.1"
     implementation "com.wire:backend-api-proto:2.3"
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -78,6 +78,7 @@ public enum SyncCommand {
     PostFolders("post-folders-favorites"),
     SyncFolders("sync-folders"),
     DeleteGroupConv("delete-group-conv"),
+    PostTrackingId("post-tracking-id"),
 
     Unknown("unknown");
 

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -435,7 +435,7 @@ object UserPreferences {
 
   lazy val CrashesAndAnalyticsRequestShown = PrefKey[Boolean]("usage_data_permissions_shown", customDefault = true) //true to avoid harassing existing users
   lazy val AskMarketingConsentAgain = PrefKey[Boolean]("ask_marketing_consent_again") //used if the user views privacy policy instead of giving consent
-  lazy val CountlyTrackingId = PrefKey[Option[TrackingId]]("tracking_id", customDefault = None)
+  lazy val CurrentTrackingId = PrefKey[Option[TrackingId]]("tracking_id", customDefault = None)
   lazy val TrackingEnabled = PrefKey[Boolean]("countly_analytics_enabled", customDefault = false)
   lazy val TrackingEnabledOneTimeCheckPerformed = PrefKey[Boolean]("analytics_enabled_one_time_check", customDefault = false)
   lazy val ShouldShareTrackingId = PrefKey[Boolean]("should_share_tracking_id_1", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -438,6 +438,7 @@ object UserPreferences {
   lazy val CountlyTrackingId = PrefKey[Option[TrackingId]]("tracking_id", customDefault = None)
   lazy val TrackingEnabled = PrefKey[Boolean]("countly_analytics_enabled", customDefault = false)
   lazy val TrackingEnabledOneTimeCheckPerformed = PrefKey[Boolean]("analytics_enabled_one_time_check", customDefault = false)
+  lazy val ShouldShareTrackingId = PrefKey[Boolean]("should_share_tracking_id_1", customDefault = true)
 
   lazy val SelfClient = PrefKey[ClientRegistrationState]("self_client")
   lazy val PrivateMode = PrefKey[Boolean]("private_mode")

--- a/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
@@ -551,15 +551,28 @@ object GenericContent {
   type LastRead = Messages.LastRead
 
   implicit object LastRead extends GenericContent[LastRead] {
-    override def set(msg: GenericMessage) = msg.setLastRead
+    override def set(msg: GenericMessage): LastRead => GenericMessage = msg.setLastRead
 
-    def apply(conv: RConvId, time: RemoteInstant) = returning(new Messages.LastRead) { l =>
+    def apply(conv: RConvId, time: RemoteInstant): Messages.LastRead = returning(new Messages.LastRead) { l =>
       l.conversationId = conv.str
       l.lastReadTimestamp = time.toEpochMilli
     }
 
     def unapply(arg: LastRead): Option[(RConvId, RemoteInstant)] =
       Some((RConvId(arg.conversationId), RemoteInstant.ofEpochMilli(arg.lastReadTimestamp)))
+  }
+
+  type DataTransfer = Messages.DataTransfer
+
+  implicit object DataTransfer extends GenericContent[DataTransfer] {
+    override def set(msg: GenericMessage): DataTransfer => GenericMessage = msg.setDataTransfer
+
+    def apply(trackingId: TrackingId): Messages.DataTransfer = returning(new Messages.DataTransfer) { d =>
+      d.trackingIdentifier = returning(new Messages.TrackingIdentifier){ _.identifier = trackingId.str }
+    }
+
+    def unapply(arg: DataTransfer): Option[TrackingId] =
+      Some(TrackingId(arg.trackingIdentifier.identifier))
   }
 
   type MsgDeleted = Messages.MessageHide

--- a/zmessaging/src/main/scala/com/waz/model/package.scala
+++ b/zmessaging/src/main/scala/com/waz/model/package.scala
@@ -77,7 +77,7 @@ package object model {
 
     def unapply(msg: GenericMessage): Option[(Uid, Any)] = Some((Uid(msg.messageId), content(msg)))
 
-    def toByteArray(msg: GenericMessage) = MessageNano.toByteArray(msg)
+    def toByteArray(msg: GenericMessage): Array[Byte] = MessageNano.toByteArray(msg)
 
     import Messages.{GenericMessage => GM}
 
@@ -86,7 +86,7 @@ package object model {
       case _ => false
     }
 
-    def content(msg: GenericMessage) = msg.getContentCase match {
+    def content(msg: GenericMessage): Any = msg.getContentCase match {
       case GM.ASSET_FIELD_NUMBER                    => msg.getAsset
       case GM.CALLING_FIELD_NUMBER                  => msg.getCalling
       case GM.CLEARED_FIELD_NUMBER                  => msg.getCleared
@@ -107,6 +107,7 @@ package object model {
       case GM.COMPOSITE_FIELD_NUMBER                => msg.getComposite
       case GM.BUTTONACTION_FIELD_NUMBER             => msg.getButtonAction
       case GM.BUTTONACTIONCONFIRMATION_FIELD_NUMBER => msg.getButtonActionConfirmation
+      case GM.DATATRANSFER_FIELD_NUMBER             => msg.getDataTransfer
       case _                                        => Unknown
     }
 

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -193,6 +193,11 @@ object SyncRequest {
     override def merge(req: SyncRequest) = mergeHelper[PostLastRead](req)(Merged(_))
   }
 
+  case class PostTrackingId(trackingId: TrackingId) extends BaseRequest(Cmd.PostTrackingId) {
+    override val mergeKey: Any = trackingId
+    override def merge(req: SyncRequest): MergeResult[PostTrackingId] = mergeHelper[PostTrackingId](req)(Merged(_))
+  }
+
   case class PostCleared(convId: ConvId, time: RemoteInstant) extends RequestForConversation(Cmd.PostCleared) with Serialized {
     override val mergeKey: Any = (cmd, convId)
     override def merge(req: SyncRequest) = mergeHelper[PostCleared](req) { other =>
@@ -366,6 +371,7 @@ object SyncRequest {
       def messageId = decodeId[MessageId]('message)
       def teamId = decodeId[TeamId]('teamId)
       def users = decodeUserIdSeq('users).toSet
+      def trackingId = decodeId[TrackingId]('trackingId)
       val cmd = js.getString("cmd")
 
       try {
@@ -427,6 +433,7 @@ object SyncRequest {
           case Cmd.PostFolders               => PostFolders
           case Cmd.SyncFolders               => SyncFolders
           case Cmd.DeleteGroupConv           => DeleteGroupConversation(teamId, rConvId)
+          case Cmd.PostTrackingId            => PostTrackingId(trackingId)
           case Cmd.Unknown                   => Unknown
         }
       } catch {
@@ -556,6 +563,8 @@ object SyncRequest {
         case DeleteGroupConversation(teamId, rConvId)  =>
           o.put("teamId", teamId.str)
           o.put("rConv", rConvId.str)
+        case PostTrackingId(trackingId) =>
+          o.put("trackingId", trackingId.str)
       }
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -267,6 +267,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val foldersSyncHandler                         = wire[FoldersSyncHandler]
   lazy val propertiesService: PropertiesService       = wire[PropertiesServiceImpl]
   lazy val fcmNotStatsService                         = wire[FCMNotificationStatsServiceImpl]
+  lazy val trackingSync                               = wire[TrackingSyncHandler]
 
   lazy val eventPipeline: EventPipeline = new EventPipelineImpl(Vector(), eventScheduler.enqueue)
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -69,6 +69,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
           case _: MsgDeleted          => false
           case _: Reaction            => false
           case _: Text                => true
+          case _: DataTransfer        => false
           case _                      => false
         }
       case _ => false

--- a/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -28,7 +28,7 @@ import com.waz.service.tracking.TrackingService.ZmsProvider
 import com.waz.service.tracking.TrackingServiceImpl.{CountlyEventProperties, RichHashMap}
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.utils.{MathUtils, RichWireInstant}
-import com.wire.signals.{EventContext, EventStream, Signal}
+import com.wire.signals.{EventStream, Signal, SourceStream}
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -43,6 +43,8 @@ trait TrackingService {
   def appOpen(userId: UserId): Future[Unit]
 
   def isTrackingEnabled: Signal[Boolean]
+
+  def onTrackingIdChange: SourceStream[TrackingId]
 }
 
 class DummyTrackingService extends TrackingService {
@@ -52,6 +54,7 @@ class DummyTrackingService extends TrackingService {
   override def trackCallState(userId: UserId, callInfo: CallInfo): Future[Unit] = Future.successful(())
   override def appOpen(userId: UserId): Future[Unit] = Future.successful(())
   override def isTrackingEnabled: Signal[Boolean] = Signal.const(true)
+  override def onTrackingIdChange: SourceStream[TrackingId] = EventStream()
 }
 
 object TrackingService {
@@ -196,6 +199,8 @@ class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: Zm
       Some(z)  <- zmsProvider(Some(userId))
     } yield events ! Option(z) -> AppOpenEvent(getUniversalSegments())
   }
+
+  override val onTrackingIdChange: SourceStream[TrackingId] = EventStream()
 }
 
 object TrackingServiceImpl extends DerivedLogTag {

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -93,6 +93,7 @@ trait SyncServiceHandle {
   def postProperty(key: PropertyKey, value: String): Future[SyncId]
   def postFolders(): Future[SyncId]
   def postButtonAction(messageId: MessageId, buttonId: ButtonId, senderId: UserId): Future[SyncId]
+  def postTrackingId(trackingId: TrackingId): Future[SyncId]
 
   def registerPush(token: PushToken): Future[SyncId]
   def deletePushToken(token: PushToken): Future[SyncId]
@@ -193,6 +194,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postProperty(key: PropertyKey, value: Int): Future[SyncId] = addRequest(PostIntProperty(key, value), forceRetry = true)
   def postProperty(key: PropertyKey, value: String): Future[SyncId] = addRequest(PostStringProperty(key, value), forceRetry = true)
   def postFolders(): Future[SyncId] = addRequest(PostFolders, forceRetry = true)
+  def postTrackingId(trackingId: TrackingId): Future[SyncId] = addRequest(PostTrackingId(trackingId))
 
   def registerPush(token: PushToken)    = addRequest(RegisterPushToken(token), priority = Priority.High, forceRetry = true)
   def deletePushToken(token: PushToken) = addRequest(DeletePushToken(token), priority = Priority.Low)
@@ -311,6 +313,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case SyncProperties                                  => zms.propertiesSyncHandler.syncProperties()
           case PostFolders                                     => zms.foldersSyncHandler.postFolders()
           case SyncFolders                                     => zms.foldersSyncHandler.syncFolders()
+          case PostTrackingId(trackingId)                      => zms.trackingSync.postNewTrackingId(trackingId)
           case Unknown                                         => Future.successful(Failure("Unknown sync request"))
       }
       case None => Future.successful(Failure(s"Account $accountId is not logged in"))

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TrackingSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TrackingSyncHandler.scala
@@ -1,0 +1,22 @@
+package com.waz.sync.handler
+
+import com.waz.model.GenericContent.DataTransfer
+import com.waz.model.{ConvId, GenericMessage, TrackingId, Uid, UserId}
+import com.waz.sync.SyncResult
+import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
+
+import scala.concurrent.Future
+
+class TrackingSyncHandler(selfUserId: UserId, otrSync: OtrSyncHandler) {
+  import com.waz.threading.Threading.Implicits.Background
+
+  def postNewTrackingId(trackingId: TrackingId): Future[SyncResult] =
+    otrSync
+      .postOtrMessage(
+        ConvId(selfUserId.str),
+        GenericMessage(Uid(), DataTransfer(trackingId)),
+        TargetRecipients.SpecificUsers(Set(selfUserId))
+      )
+      .map(SyncResult(_))
+}


### PR DESCRIPTION
implements https://wearezeta.atlassian.net/browse/SQCORE-121

The tracking ids are already present in the client code, but now every device has its own tracking id and they are not connected. This PR introduces sharing tracking ids among devices belonging to the same user. The general idea is that every time a new device is added to the user, that device generates a new tracking id and sends it to all other devices. This happens also when the device updates for the first time to the version containing this feature. We are aware there is a risk of race condition when two devices send their tracking ids in the same time, but we decided it's small enough and we can ignore it.

The change requires an update in generic-message-proto. The new version is 1.27.1. It contains a new field called DataTransfer and inside it there's a field trackingIdentifier which is the trackingId that should replace the local tracking id. In the future, DataTransfer might contain more fields, but for now it's only this one, so in the Scala code I made a shortcut that let us easier unpack the tracking id from the incoming message.

I also added a new button to the Dev Settings that can be used to generate a new tracking id without the need to remove and re-add a device. This can help in testing.

#### APK
[Download build #2949](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2949/artifact/build/artifact/wire-dev-PR3092-2949.apk)
[Download build #2950](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2950/artifact/build/artifact/wire-dev-PR3092-2950.apk)
[Download build #2952](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2952/artifact/build/artifact/wire-dev-PR3092-2952.apk)