### PR TITLE
wire-signals bump to 0.3.1

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
@@ -27,7 +27,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.MessageContent
 import com.waz.service.messages.MessageAndLikes
 import com.waz.threading.Threading
-import com.wire.signals.{NoAutowiring, Signal, SourceSignal}
+import com.wire.signals.{Signal, SourceSignal}
 import com.waz.zclient.common.controllers.AssetsController
 import com.waz.zclient.glide.WireGlide
 import com.waz.zclient.log.LogUI._
@@ -37,6 +37,7 @@ import com.waz.zclient.messages.{HighlightViewPart, MessageViewPart, MsgPart}
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{R, ViewHelper}
 import com.waz.threading.Threading._
+import com.waz.utils.returning
 
 class ImagePartView(context: Context, attrs: AttributeSet, style: Int)
   extends FrameLayout(context, attrs, style)
@@ -55,7 +56,7 @@ class ImagePartView(context: Context, attrs: AttributeSet, style: Int)
 
   private val imageView = findById[ImageView](R.id.image)
 
-  val noWifi: SourceSignal[Boolean] with NoAutowiring = Signal(false)
+  val noWifi: SourceSignal[Boolean] = returning(Signal(false)){ _.disableAutowiring() }
 
   (for {
     noW  <- noWifi

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ReplyPartView.scala
@@ -46,6 +46,7 @@ import com.waz.zclient.utils.{RichTextView, RichView}
 import com.waz.zclient.{R, ViewHelper}
 import org.threeten.bp.Instant
 import com.waz.threading.Threading._
+import com.waz.utils.returning
 
 abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int)
   extends LinearLayout(context, attrs, style)
@@ -83,7 +84,7 @@ abstract class ReplyPartView(context: Context, attrs: AttributeSet, style: Int)
   container.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
   container.setBackground(new ReplyBackgroundDrawable(getStyledColor(R.attr.replyBorderColor), getStyledColor(R.attr.wireBackgroundCollection)))
 
-  protected val quotedMessage: SourceSignal[MessageData] with NoAutowiring = Signal[MessageData]()
+  protected val quotedMessage: SourceSignal[MessageData] = returning(Signal[MessageData]()){ _.disableAutowiring() }
   protected val quotedAsset: Signal[Option[Asset]] =
     quotedMessage.map(_.assetId).flatMap(assetsController.assetSignal).map {
       case Some(x: Asset) => Some(x)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -191,7 +191,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.3.0"
+    const val WIRE_SIGNALS = "0.3.1"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"


### PR DESCRIPTION
This PR consists of the bumping the version and two very minor changes to the code required by changes in wire-signals. The wire-signals update is mostly about making it work with Scala 2.12 and 2.13 - some code was specific to Scala 2.11 we use in wire-android and had to be changed. In 0.3.1 wire-signals compiles under all three versions.

There is also one new method, onUpdated, in the Signal class. It works like onChanged but returns not only the new changed value, but also the old one, so they can be compared to see what exactly changed from one to another. This is a pattern that comes up regularly in the wire-android code - we not only want to know there was a change but also what was changed - and until now it had to be solved in wire-android. This method should simplify our code in a few places.
(But it's not tested yet - I want to first rewrite unit tests in mUnit).

#### APK
[Download build #2969](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2969/artifact/build/artifact/wire-dev-PR3098-2969.apk)