### PR TITLE
Feat: Conversation List - Call remote data source to fetch conversation list

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDaoTest.kt
@@ -33,9 +33,9 @@ class ConversationDaoTest : InstrumentationTest() {
 
     @Test
     fun insertAll_readConversations_containsInsertedItems() = databaseTestRule.runTest {
-        val entity1 = ConversationEntity(id = 1, name = "Conversation #1")
-        val entity2 = ConversationEntity(id = 2, name = "Conversation #2")
-        val entity3 = ConversationEntity(id = 3, name = "Conversation #3")
+        val entity1 = ConversationEntity(id = "id-1", name = "Conversation #1")
+        val entity2 = ConversationEntity(id = "id-2", name = "Conversation #2")
+        val entity3 = ConversationEntity(id = "id-3", name = "Conversation #3")
         val entities = listOf(entity1, entity2, entity3)
 
         conversationDao.insertAll(entities)
@@ -45,6 +45,6 @@ class ConversationDaoTest : InstrumentationTest() {
     }
 
     companion object {
-        private val TEST_CONVERSATION_ENTITY = ConversationEntity(5, "Android Team")
+        private val TEST_CONVERSATION_ENTITY = ConversationEntity("id-5", "Android Team")
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
@@ -45,26 +45,11 @@ class ConversationDataSource(
             conversationMapper.fromEntity(it)
         }
 
-    /*
-    TODO: get real list from conversationRemoteDataSource, update tests
-        conversationRemoteDataSource.conversationsByBatch(start, size, ids).map {
-            conversationMapper.fromConversationsResponse(it)
+    private suspend fun fetchConversations(start: String?, size: Int): Either<Failure, Unit> = suspending {
+        conversationRemoteDataSource.conversationsByBatch(start, size).map {
+            conversationMapper.fromConversationResponseToEntityList(it)
+        }.flatMap {
+            conversationLocalDataSource.saveConversations(it)
         }
-     */
-    private suspend fun fetchConversations(start: String?, size: Int): Either<Failure, Unit> =
-        suspending {
-            getDummyConversations(start, size).map {
-                conversationMapper.toEntityList(it)
-            }.flatMap {
-                conversationLocalDataSource.saveConversations(it)
-            }
-        }
-
-    private fun getDummyConversations(start: String?, size: Int): Either<Failure, List<Conversation>> {
-        val startId = start?.toInt() ?: 1
-        return Either.Right((0..size).map {
-            val convId = "${startId + it}"
-            Conversation(id = convId, name = "Conversation #$convId")
-        })
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
@@ -2,32 +2,18 @@ package com.wire.android.feature.conversation.data
 
 import com.wire.android.core.extension.EMPTY
 import com.wire.android.feature.conversation.Conversation
-import com.wire.android.feature.conversation.data.remote.ConversationResponse
 import com.wire.android.feature.conversation.data.remote.ConversationsResponse
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
 
 class ConversationMapper {
 
-    fun fromConversationsResponse(conversationsResponse: ConversationsResponse): List<Conversation> =
-        conversationsResponse.conversationResponses.map {
-            fromConversationResponse(it)
-        }
-
-    //TODO add more fields as we build up the UI
-    private fun fromConversationResponse(conversationResponse: ConversationResponse): Conversation =
-        Conversation(
-            name = conversationResponse.name,
-            id = conversationResponse.id
-        )
-
-    fun toEntityList(conversations: List<Conversation>) =
-        conversations.map {
-            ConversationEntity(name = it.name ?: String.EMPTY) //TODO consider null name on db
+    fun fromConversationResponseToEntityList(response: ConversationsResponse): List<ConversationEntity> =
+        response.conversations.map {
+            ConversationEntity(id = it.id, name = it.name ?: String.EMPTY) //TODO consider null name on db
         }
 
     fun fromEntity(entity: ConversationEntity) = Conversation(
-        id = entity.id.toString(), //TODO: probably we're gonna differentiate remote id and db primary key
+        id = entity.id,
         name = entity.name
     )
-
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsApi.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsApi.kt
@@ -7,10 +7,14 @@ import retrofit2.http.Query
 interface ConversationsApi {
 
     @GET(CONVERSATIONS_END_POINT)
-    suspend fun conversationsByBatch(@Query(SIZE_QUERY_KEY) size: Int): Response<ConversationsResponse>
+    suspend fun conversationsByBatch(
+        @Query(START_QUERY_KEY) start: String?,
+        @Query(SIZE_QUERY_KEY) size: Int
+    ): Response<ConversationsResponse>
 
     companion object {
         private const val CONVERSATIONS_END_POINT = "/conversations"
         private const val SIZE_QUERY_KEY = "size"
+        private const val START_QUERY_KEY = "start"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsRemoteDataSource.kt
@@ -10,6 +10,6 @@ class ConversationsRemoteDataSource(
     private val conversationsApi: ConversationsApi
 ) : ApiService() {
 
-    suspend fun conversationsByBatch(start: String, size: Int, ids: List<String>): Either<Failure, ConversationsResponse> =
-        request { conversationsApi.conversationsByBatch(size) }
+    suspend fun conversationsByBatch(start: String?, size: Int): Either<Failure, ConversationsResponse> =
+        request { conversationsApi.conversationsByBatch(start, size) }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsResponse.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsResponse.kt
@@ -7,12 +7,8 @@ data class ConversationsResponse(
     val hasMore: Boolean,
 
     @SerializedName("conversations")
-    val conversationResponses: List<ConversationResponse>
-) {
-    companion object {
-        val EMPTY = ConversationsResponse(false, emptyList())
-    }
-}
+    val conversations: List<ConversationResponse>
+)
 
 data class ConversationResponse(
     @SerializedName("creator")

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationEntity.kt
@@ -6,6 +6,6 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "conversation")
 data class ConversationEntity(
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @PrimaryKey @ColumnInfo(name = "id") val id: String,
     @ColumnInfo(name = "name") val name: String
 )

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
@@ -1,14 +1,15 @@
 package com.wire.android.feature.conversation.data
 
 import com.wire.android.UnitTest
+import com.wire.android.core.extension.EMPTY
 import com.wire.android.feature.conversation.Conversation
 import com.wire.android.feature.conversation.data.remote.ConversationResponse
 import com.wire.android.feature.conversation.data.remote.ConversationsResponse
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
-import com.wire.android.framework.collections.second
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
 import org.junit.Before
 import org.junit.Test
 
@@ -22,51 +23,39 @@ class ConversationMapperTest : UnitTest() {
     }
 
     @Test
-    //TODO update this when we have a full mapper
-    fun `given fromConversationsResponse is called with a response model, then returns list of conversations`() {
-        val conversationResponse = mockk<ConversationResponse>()
-        every { conversationResponse.id } returns TEST_CONVERSATION_ID
-        every { conversationResponse.name } returns TEST_CONVERSATION_NAME
+    fun `given a ConversationsResponse, when fromConversationResponseToEntityList is called, then returns a list of entities`() {
+        val conversationsResponse = mockk<ConversationsResponse>()
 
-        val conversationResponses = listOf(conversationResponse)
-        val conversationsResponse = ConversationsResponse(
-            hasMore = true,
-            conversationResponses = conversationResponses
+        val id1 = "$TEST_CONVERSATION_ID-1"
+        val name1 = "$TEST_CONVERSATION_NAME-1"
+        val conversationResponse1 = mockk<ConversationResponse>().also {
+            every { it.id } returns id1
+            every { it.name } returns name1
+        }
+
+        val id2 = "$TEST_CONVERSATION_ID-2"
+        val conversationResponse2 = mockk<ConversationResponse>().also {
+            every { it.id } returns id2
+            every { it.name } returns null
+        }
+
+        every { conversationsResponse.conversations } returns listOf(conversationResponse1, conversationResponse2)
+
+        val entityList = conversationMapper.fromConversationResponseToEntityList(conversationsResponse)
+
+        entityList shouldContainSame listOf(
+            ConversationEntity(id = id1, name = name1),
+            ConversationEntity(id = id2, name = String.EMPTY)
         )
-
-        conversationMapper.fromConversationsResponse(conversationsResponse).also {
-            it.first().id shouldBeEqualTo TEST_CONVERSATION_ID
-            it.first().name shouldBeEqualTo TEST_CONVERSATION_NAME
-        }
-    }
-
-    @Test
-    fun `given a list of conversation domain items, when toEntityList is called, then returns list of conversation entities`() {
-        fun mockConversation(name: String): Conversation = mockk<Conversation>(relaxed = false).also {
-            every { it.name } returns name
-        }
-
-        val name1 = "Conv1"
-        val name2 = "Conv2"
-        val conversation1 = mockConversation(name1)
-        val conversation2 = mockConversation(name2)
-
-        val conversationList = listOf(conversation1, conversation2)
-
-        val entityList = conversationMapper.toEntityList(conversationList)
-
-        entityList.first().name shouldBeEqualTo name1
-        entityList.second().name shouldBeEqualTo name2
     }
 
     @Test
     fun `given a conversation entity, when fromEntity is called, then returns a conversation`() {
-        val id = 123
-        val conversationEntity = ConversationEntity(id = id, name = TEST_CONVERSATION_NAME)
+        val conversationEntity = ConversationEntity(id = TEST_CONVERSATION_ID, name = TEST_CONVERSATION_NAME)
 
         val conversation = conversationMapper.fromEntity(conversationEntity)
 
-        conversation shouldBeEqualTo Conversation(id = id.toString(), name = TEST_CONVERSATION_NAME)
+        conversation shouldBeEqualTo Conversation(id = TEST_CONVERSATION_ID, name = TEST_CONVERSATION_NAME)
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/remote/ConversationRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/remote/ConversationRemoteDataSourceTest.kt
@@ -36,11 +36,11 @@ class ConversationRemoteDataSourceTest : UnitTest() {
     fun `given any size, when conversationsByBatch is requested and response is success, propagate successful ConversationsResponse`() {
         every { response.body() } returns conversationsResponse
         every { response.isSuccessful } returns true
-        coEvery { conversationsApi.conversationsByBatch(any()) } returns response
+        coEvery { conversationsApi.conversationsByBatch(any(), any()) } returns response
 
-        val result = runBlocking { remoteDataSource.conversationsByBatch(any(), any(), any()) }
+        val result = runBlocking { remoteDataSource.conversationsByBatch(any(), any()) }
 
-        coVerify(exactly = 1) { conversationsApi.conversationsByBatch(any()) }
+        coVerify(exactly = 1) { conversationsApi.conversationsByBatch(any(), any()) }
         result shouldSucceed {}
     }
 
@@ -48,11 +48,11 @@ class ConversationRemoteDataSourceTest : UnitTest() {
     fun `given any size, when conversationsByBatch is requested and response fails, propagate failure`() {
         every { response.body() } returns null
         every { response.isSuccessful } returns false
-        coEvery { conversationsApi.conversationsByBatch(any()) } returns response
+        coEvery { conversationsApi.conversationsByBatch(any(), any()) } returns response
 
-        val result = runBlocking { remoteDataSource.conversationsByBatch(any(), any(), any()) }
+        val result = runBlocking { remoteDataSource.conversationsByBatch(any(), any()) }
 
-        coVerify(exactly = 1) { conversationsApi.conversationsByBatch(any()) }
+        coVerify(exactly = 1) { conversationsApi.conversationsByBatch(any(), any()) }
         result shouldFail {}
     }
 }


### PR DESCRIPTION
Removes dummy conversation list response and sends an actual network request to fetch conversation list.

**Changes:**

- `id` column of the `conversation` table has data type `TEXT` now. Its value is filled with what we get from network response. Documentation on Confluence is updated as well.
- Removed `ids` field from network request, since `ids` and `start` parameters are mutually exclusive.