### PR TITLE
Refactor: More Granular Global Configuration

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/config/GlobalConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/core/config/GlobalConfig.kt
@@ -2,18 +2,21 @@ package com.wire.android.core.config
 
 import com.wire.android.BuildConfig
 
-//TODO this needs to be well adjusted and more dynamic. Futher solution incoming.
-class GlobalConfig {
-
-    //System
-    val osVersion = "Android ${android.os.Build.VERSION.RELEASE}"
-    val userAgent = "HttpLibrary ${okhttp3.internal.userAgent}"
-
-    //Client App
-    val appVersion = "Wire ${BuildConfig.VERSION_NAME}"
-
+/**
+ * Global Wire Android Client Configuration.
+ * Non-instantiability is enforced to encourage the creation of
+ * injectable mini-config components.
+ */
+class GlobalConfig private constructor() {
     companion object {
-        //Urls and Api
+        //OS Config
+        val OS_VERSION = "Android ${android.os.Build.VERSION.RELEASE}"
+
+        //Application Config
+        const val APP_VERSION = "Wire ${BuildConfig.VERSION_NAME}"
+
+        //Network Config
+        const val USER_AGENT = "HttpLibrary ${okhttp3.internal.userAgent}"
         const val API_BASE_URL = BuildConfig.API_BASE_URL
         const val ACCOUNTS_URL = BuildConfig.ACCOUNTS_URL
     }

--- a/app/src/main/kotlin/com/wire/android/core/di/Modules.kt
+++ b/app/src/main/kotlin/com/wire/android/core/di/Modules.kt
@@ -39,7 +39,6 @@ val compatibilityModule: Module = module {
 
 val appConfigModule: Module = module {
     factory { LocaleConfig(androidContext()) }
-    single { GlobalConfig() }
 }
 
 

--- a/app/src/main/kotlin/com/wire/android/core/network/BackendConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/BackendConfig.kt
@@ -1,8 +1,0 @@
-package com.wire.android.core.network
-
-import com.wire.android.core.config.GlobalConfig
-
-data class BackendConfig(
-    val baseUrl: String = GlobalConfig.API_BASE_URL,
-    val accountsUrl: String = GlobalConfig.ACCOUNTS_URL
-)

--- a/app/src/main/kotlin/com/wire/android/core/network/NetworkConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/NetworkConfig.kt
@@ -1,0 +1,15 @@
+package com.wire.android.core.network
+
+import com.wire.android.core.config.GlobalConfig
+
+data class NetworkConfig(
+    val osVersion: String = GlobalConfig.OS_VERSION,
+    val appVersion: String = GlobalConfig.APP_VERSION,
+    val userAgent: String = GlobalConfig.USER_AGENT,
+    val baseUrl: String = GlobalConfig.API_BASE_URL,
+    val accountsUrl: String = GlobalConfig.ACCOUNTS_URL) {
+
+    companion object {
+        const val USER_AGENT_HEADER_KEY = "User-Agent"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/core/network/UserAgentInterceptor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/UserAgentInterceptor.kt
@@ -1,10 +1,10 @@
 package com.wire.android.core.network
 
-import com.wire.android.core.config.GlobalConfig
 import com.wire.android.core.extension.EMPTY
+import com.wire.android.core.network.NetworkConfig.Companion.USER_AGENT_HEADER_KEY
 import okhttp3.Interceptor
 
-class UserAgentInterceptor(private val config: GlobalConfig) : Interceptor {
+class UserAgentInterceptor(private val config: NetworkConfig) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain) =
         if (requestHasUserHeader(chain)) {
@@ -25,9 +25,4 @@ class UserAgentInterceptor(private val config: GlobalConfig) : Interceptor {
 
     private fun buildUserAgentHeader(): String =
         config.osVersion + " / " + config.appVersion + " / " + config.userAgent
-
-
-    companion object {
-        private const val USER_AGENT_HEADER_KEY = "User-Agent"
-    }
 }

--- a/app/src/main/kotlin/com/wire/android/core/network/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/di/NetworkModule.kt
@@ -5,7 +5,7 @@ package com.wire.android.core.network.di
 import android.content.Context
 import android.net.ConnectivityManager
 import com.wire.android.BuildConfig
-import com.wire.android.core.network.BackendConfig
+import com.wire.android.core.network.NetworkConfig
 import com.wire.android.core.network.HttpRequestParams
 import com.wire.android.core.network.NetworkClient
 import com.wire.android.core.network.NetworkHandler
@@ -65,7 +65,7 @@ object NetworkDependencyProvider {
 val networkModule: Module = module {
     single { NetworkHandler(androidContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager) }
     single<NetworkClient> { RetrofitClient(get()) }
-    single { retrofit(get(), get<BackendConfig>().baseUrl) }
+    single { retrofit(get(), get<NetworkConfig>().baseUrl) }
     single { createHttpClientWithAuth(get(), get(), get(), get()) }
     single { HttpRequestParams() }
     single { AccessTokenAuthenticator(get()) }
@@ -74,8 +74,8 @@ val networkModule: Module = module {
 
     val networkClientForNoAuth = "NETWORK_CLIENT_NO_AUTH_REQUEST"
     single<NetworkClient>(named(networkClientForNoAuth)) {
-        RetrofitClient(retrofit(createHttpClientWithoutAuth(get(), get()), get<BackendConfig>().baseUrl))
+        RetrofitClient(retrofit(createHttpClientWithoutAuth(get(), get()), get<NetworkConfig>().baseUrl))
     }
     single { get<NetworkClient>(named(networkClientForNoAuth)).create(SessionApi::class.java) }
-    single { BackendConfig() }
+    single { NetworkConfig() }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigator.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigator.kt
@@ -3,17 +3,17 @@ package com.wire.android.feature.auth.login.ui.navigation
 import android.content.Context
 import android.net.Uri
 import com.wire.android.core.extension.domainAddress
-import com.wire.android.core.network.BackendConfig
+import com.wire.android.core.network.NetworkConfig
 import com.wire.android.core.ui.navigation.UriNavigationHandler
 import com.wire.android.feature.auth.login.LoginActivity
 
 class LoginNavigator(
     private val uriNavigationHandler: UriNavigationHandler,
-    private val backendConfig: BackendConfig
+    private val networkConfig: NetworkConfig
 ) {
 
     private val forgotPasswordUri by lazy {
-        Uri.Builder().domainAddress(backendConfig.accountsUrl).appendPath(FORGOT_PASSWORD_PATH).build()
+        Uri.Builder().domainAddress(networkConfig.accountsUrl).appendPath(FORGOT_PASSWORD_PATH).build()
     }
 
     fun openLogin(context: Context) = context.startActivity(LoginActivity.newIntent(context))

--- a/app/src/test/kotlin/com/wire/android/core/network/UserAgentInterceptorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/network/UserAgentInterceptorTest.kt
@@ -1,7 +1,6 @@
 package com.wire.android.core.network
 
 import com.wire.android.UnitTest
-import com.wire.android.core.config.GlobalConfig
 import com.wire.android.core.extension.EMPTY
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -28,15 +27,15 @@ class UserAgentInterceptorTest : UnitTest() {
     private lateinit var newRequest: Request
 
     @MockK
-    private lateinit var globalConfig: GlobalConfig
+    private lateinit var networkConfig: NetworkConfig
 
     @Before
     fun setup() {
-        every { globalConfig.appVersion } returns WIRE_DETAILS
-        every { globalConfig.osVersion } returns ANDROID_DETAILS
-        every { globalConfig.userAgent } returns HTTP_DETAILS
+        every { networkConfig.appVersion } returns WIRE_DETAILS
+        every { networkConfig.osVersion } returns ANDROID_DETAILS
+        every { networkConfig.userAgent } returns HTTP_DETAILS
 
-        userAgentInterceptor = UserAgentInterceptor(globalConfig)
+        userAgentInterceptor = UserAgentInterceptor(networkConfig)
 
         every { chain.request() } returns originalRequest
         every { originalRequest.newBuilder() } returns requestBuilder

--- a/app/src/test/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/login/ui/navigation/LoginNavigatorTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import com.wire.android.AndroidTest
-import com.wire.android.core.network.BackendConfig
+import com.wire.android.core.network.NetworkConfig
 import com.wire.android.core.ui.navigation.UriNavigationHandler
 import com.wire.android.feature.auth.login.LoginActivity
 import io.mockk.every
@@ -22,7 +22,7 @@ class LoginNavigatorTest : AndroidTest() {
     private lateinit var uriNavigationHandler: UriNavigationHandler
 
     @MockK
-    private lateinit var backendConfig: BackendConfig
+    private lateinit var networkConfig: NetworkConfig
 
     @MockK
     private lateinit var context: Context
@@ -31,7 +31,7 @@ class LoginNavigatorTest : AndroidTest() {
 
     @Before
     fun setUp() {
-        loginNavigator = LoginNavigator(uriNavigationHandler, backendConfig)
+        loginNavigator = LoginNavigator(uriNavigationHandler, networkConfig)
     }
 
     @Test
@@ -49,7 +49,7 @@ class LoginNavigatorTest : AndroidTest() {
     @Test
     fun `given openForgotPassword is called, then calls uriNavigationHandler to open correct uri`() {
         val uriSlot = slot<Uri>()
-        every { backendConfig.accountsUrl } returns TEST_ACCOUNTS_URL
+        every { networkConfig.accountsUrl } returns TEST_ACCOUNTS_URL
 
         loginNavigator.openForgotPassword(context)
 


### PR DESCRIPTION
This PR aims to refactor how our Wire client manages Configuration across the different packages/modules. 

Some of the clean up here includes:
 - Use constant values when possible.
 - Rename ```BackendConfig``` to ```NetworkConfig```
 - Defensive Non-Instantiability ```GlobalConfig``` class enforced to avoid accidentally injecting the global object accross the codebase.  

This is a starting point and is very likely to be evolved over the time as soon as we grow the codebase. 