### PR TITLE
Fix build warning

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/login/email/ui/LoginWithEmailFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.extension.toStringOrEmpty
 import com.wire.android.core.functional.onFailure

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountCodeFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountCodeFragment.kt
@@ -3,7 +3,6 @@ package com.wire.android.feature.auth.registration.personal.ui
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.poovam.pinedittextfield.PinField.OnTextCompleteListener
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountEmailFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountEmailFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.core.widget.doAfterTextChanged
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility

--- a/app/src/main/kotlin/com/wire/android/feature/launch/ui/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/launch/ui/LauncherActivity.kt
@@ -2,7 +2,6 @@ package com.wire.android.feature.launch.ui
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.observe
 import com.wire.android.R
 import com.wire.android.core.ui.navigation.Navigator
 import org.koin.android.ext.android.inject


### PR DESCRIPTION
**Problem:**
After we bumped the Kotlin version to 1.4.0 we started seeing this build warning:

```
Candidate resolution will be changed soon, please use fully qualified name to invoke the following closer candidate explicitly '
public open fun observe(p0: LifecycleOwner, p1: Observer<in String!>): Unit defined in androidx.lifecycle.LiveData'
```

**Cause:**
Before Kotlin 1.4.0, we needed extension function from `lifecycle-livedata-core-ktx` to take the lambda out of `observe` function
```
        liveData.observe(lifecycleOwner) { value ->
            ...
        }
```

With Kotlin 1.4.0, `observe` function in `LiveData.java` can be resolved in the same way as well, so there's a conflict in signatures of the two method.

**Solution:**
Do not use extension function anymore and go with `LiveData.java`'s observe function.