### PR TITLE
Fix/disable concurent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,4 +230,7 @@ docker run --privileged --network build-machine -d -e DEVICE="Nexus 5" --name ${
     }
 
   }
+  options {
+    disableConcurrentBuilds()
+  }
 }


### PR DESCRIPTION
in order to block concurrent builds on multi branch pipelines in jenkins, it is necessary to add the option element to the pipeline file.

this PR adds this option to the pipeline.