### PR TITLE
fix: The login screen fields are moved outside the screen on Android 11

### DIFF
--- a/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
@@ -31,6 +31,7 @@ import android.view.WindowManager;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.view.ViewCompat;
+import android.os.Build;
 
 @SuppressWarnings("Deprecation")
 /*
@@ -89,12 +90,18 @@ public class DeprecationUtils {
 
     public static void setSoftInputMode(Window window, boolean adjustResize, boolean stateAlwaysHidden) {
         int mode = 0;
+
         if (adjustResize) {
             mode |= WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE;
         }
         if (stateAlwaysHidden) {
             mode |= WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN;
         }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(true);
+        }
+
         window.setSoftInputMode(mode);
     }
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/CustomBackendLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/CustomBackendLoginFragment.scala
@@ -1,5 +1,6 @@
 package com.waz.zclient.appentry
-import android.os.{Build, Bundle}
+
+import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup, WindowManager}
 import android.widget.{Button, TextView}
 import com.waz.api.impl.ErrorResponse
@@ -59,8 +60,6 @@ class CustomBackendLoginFragment extends SSOFragment {
 
   override def onPause(): Unit = {
     super.onPause()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-      activity.getWindow.setDecorFitsSystemWindows(false)
     DeprecationUtils.setSoftInputMode(activity.getWindow, true, false)
   }
 

--- a/app/src/main/scala/com/waz/zclient/appentry/WelcomeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/WelcomeFragment.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.appentry
 
-import android.os.{Build, Bundle}
+import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup, WindowManager}
 import android.widget.Button
 import com.waz.utils.returning
@@ -62,8 +62,6 @@ class WelcomeFragment extends SSOFragment {
 
   override def onPause(): Unit = {
     super.onPause()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-      activity.getWindow.setDecorFitsSystemWindows(false)
     DeprecationUtils.setSoftInputMode(activity.getWindow, true, false)
   }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
@@ -19,7 +19,7 @@ package com.waz.zclient.preferences.dialogs
 
 import java.util.Locale
 
-import android.os.{Build, Bundle}
+import android.os.Bundle
 import android.text.{Editable, TextWatcher}
 import android.view.View.OnClickListener
 import android.view.animation.AnimationUtils
@@ -190,15 +190,14 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
     }
   }
 
-  override def onViewCreated(view: View, savedInstanceState: Bundle) = {
-    Try(getDialog.getWindow).foreach { window =>
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) window.setDecorFitsSystemWindows(false)
-      DeprecationUtils.setSoftInputMode(window, true, false)
+  override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
+    Try(getDialog.getWindow).foreach {
+      DeprecationUtils.setSoftInputMode(_, true, false)
     }
     super.onViewCreated(view, savedInstanceState)
   }
 
-  override def onStart() = {
+  override def onStart(): Unit = {
     super.onStart()
     handleEditText.addTextChangedListener(handleTextWatcher)
     backButton.setOnClickListener(backButtonClickListener)

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyEmailPreferencesFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyEmailPreferencesFragment.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.preferences.dialogs
 
-import android.os.{Build, Bundle}
+import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.DialogFragment.STYLE_NO_FRAME
 import android.text.TextUtils
@@ -77,7 +77,6 @@ class VerifyEmailPreferencesFragment extends DialogFragment with FragmentHelper 
     inflater.inflate(R.layout.fragment_preference_email_verification, container, false)
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) getDialog.getWindow.setDecorFitsSystemWindows(false)
     DeprecationUtils.setSoftInputMode(getDialog.getWindow, true, true)
     super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/VerifyPhoneFragment.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.preferences.dialogs
 
-import android.os.{Build, Bundle}
+import android.os.Bundle
 import com.google.android.material.textfield.TextInputLayout
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.DialogFragment.STYLE_NO_FRAME
@@ -50,7 +50,6 @@ class VerifyPhoneFragment extends DialogFragment with FragmentHelper {
   }
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) getDialog.getWindow.setDecorFitsSystemWindows(false)
     DeprecationUtils.setSoftInputMode(getDialog.getWindow, true, true)
     super.onViewCreated(view, savedInstanceState)
   }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-209
fixes https://wearezeta.atlassian.net/browse/SQCORE-210

In order to still use deprecated layout flags, SDK 30 requires that we set `window.setDecorFitsSystemWindows(true)`
or otherwise use a new system of "insets".
#### APK
[Download build #2989](http://10.10.124.11:8080/job/Pull%20Request%20Builder/2989/artifact/build/artifact/wire-dev-PR3105-2989.apk)