### PR TITLE
Feat: Conversation Members - Add "conversation_members" table to store member id - conversation id pairs

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDaoTest.kt
@@ -4,6 +4,7 @@ import com.wire.android.InstrumentationTest
 import com.wire.android.core.storage.db.user.UserDatabase
 import com.wire.android.framework.storage.db.DatabaseTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContainSame
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +43,26 @@ class ConversationDaoTest : InstrumentationTest() {
         val conversations = conversationDao.conversations()
 
         conversations shouldContainSame listOf(entity1, entity2, entity3)
+    }
+
+    @Test
+    fun deleteConversationById_conversationWithIdExists_deletesConversation() = databaseTestRule.runTest {
+        conversationDao.insert(TEST_CONVERSATION_ENTITY)
+
+        conversationDao.deleteConversationById(TEST_CONVERSATION_ENTITY.id)
+        val remainingConversations = conversationDao.conversations()
+
+        remainingConversations.isEmpty() shouldBeEqualTo true
+    }
+
+    @Test
+    fun deleteConversationById_conversationWithIdDoesNotExist_doesNothing() = databaseTestRule.runTest {
+        conversationDao.insert(TEST_CONVERSATION_ENTITY)
+
+        conversationDao.deleteConversationById("some-other-id")
+        val remainingConversations = conversationDao.conversations()
+
+        remainingConversations shouldContainSame listOf(TEST_CONVERSATION_ENTITY)
     }
 
     companion object {

--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMembersDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMembersDaoTest.kt
@@ -1,0 +1,104 @@
+package com.wire.android.feature.conversation.members.datasources.local
+
+import com.wire.android.InstrumentationTest
+import com.wire.android.core.storage.db.user.UserDatabase
+import com.wire.android.feature.conversation.list.datasources.local.ConversationDao
+import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+import com.wire.android.framework.storage.db.DatabaseTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ConversationMembersDaoTest : InstrumentationTest() {
+
+    @get:Rule
+    val databaseTestRule = DatabaseTestRule.create<UserDatabase>(appContext)
+
+    private lateinit var conversationDao: ConversationDao
+
+    private lateinit var conversationMembersDao: ConversationMembersDao
+
+    @Before
+    fun setUp() {
+        val userDatabase = databaseTestRule.database
+        conversationDao = userDatabase.conversationDao()
+        conversationMembersDao = userDatabase.conversationMembersDao()
+    }
+
+    @Test
+    fun insertEntity_readAll_returnsInsertedItem() = databaseTestRule.runTest {
+        val entity =
+            prepareConversationMemberEntity(conversationId = TEST_CONVERSATION_ID, contactId = TEST_CONTACT_ID)
+        conversationMembersDao.insert(entity)
+
+        val entities = conversationMembersDao.allConversationMembers()
+
+        entities.size shouldBeEqualTo 1
+        entities.first() shouldBeEqualTo entity
+    }
+
+    @Test
+    fun insertAll_readAll_returnsInsertedItems() = databaseTestRule.runTest {
+        val entity1 =
+            prepareConversationMemberEntity(conversationId = "$TEST_CONVERSATION_ID-1", contactId = "$TEST_CONTACT_ID-1")
+        val entity2 =
+            prepareConversationMemberEntity(conversationId = "$TEST_CONVERSATION_ID-2", contactId = "$TEST_CONTACT_ID-2")
+
+        conversationMembersDao.insertAll(listOf(entity1, entity2))
+
+        val entities = conversationMembersDao.allConversationMembers()
+
+        entities shouldContainSame listOf(entity1, entity2)
+    }
+
+    @Test
+    fun entitiesForConversationIdExists_whenConversationRemovedFromDatabase_deletesEntriesWithConversationId() =
+        databaseTestRule.runTest {
+            val entity1 =
+                prepareConversationMemberEntity(conversationId = "$TEST_CONVERSATION_ID-1", contactId = "$TEST_CONTACT_ID-1")
+            val entity2 =
+                prepareConversationMemberEntity(conversationId = "$TEST_CONVERSATION_ID-2", contactId = "$TEST_CONTACT_ID-2")
+            conversationMembersDao.insertAll(listOf(entity1, entity2))
+
+            conversationDao.deleteConversationById(entity1.conversationId)
+            val remainingEntities = conversationMembersDao.allConversationMembers()
+
+            remainingEntities shouldContainSame listOf(entity2)
+        }
+
+    @Test
+    fun conversationMembers_entitiesForConversationIdExists_returnsMemberIds() = databaseTestRule.runTest {
+        conversationDao.insert(ConversationEntity(id = TEST_CONVERSATION_ID, name = "Android Chapter"))
+
+        val entity1 = ConversationMemberEntity(TEST_CONVERSATION_ID, "contact-1")
+        val entity2 = ConversationMemberEntity(TEST_CONVERSATION_ID, "contact-2")
+        val entity3 = ConversationMemberEntity(TEST_CONVERSATION_ID, "contact-3")
+
+        conversationMembersDao.insertAll(listOf(entity1, entity2, entity3))
+
+        val memberIds = conversationMembersDao.conversationMembers(TEST_CONVERSATION_ID)
+
+        memberIds shouldContainSame listOf("contact-1", "contact-2", "contact-3")
+    }
+
+    @Test
+    fun conversationMembers_noEntitiesForConversationIdExists_returnsEmptyList() = databaseTestRule.runTest {
+        val memberIds = conversationMembersDao.conversationMembers(TEST_CONVERSATION_ID)
+
+        memberIds.isEmpty() shouldBeEqualTo true
+    }
+
+    private suspend fun prepareConversationMemberEntity(conversationId: String, contactId: String): ConversationMemberEntity {
+        conversationDao.insert(ConversationEntity(id = conversationId, name = "Conversation $conversationId"))
+        return ConversationMemberEntity(conversationId = conversationId, contactId = contactId)
+    }
+
+    companion object {
+        private const val TEST_CONVERSATION_ID = "conv-id"
+        private const val TEST_CONTACT_ID = "contact-id"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/core/storage/db/user/UserDatabase.kt
+++ b/app/src/main/kotlin/com/wire/android/core/storage/db/user/UserDatabase.kt
@@ -6,13 +6,17 @@ import com.wire.android.feature.contact.datasources.local.ContactDao
 import com.wire.android.feature.contact.datasources.local.ContactEntity
 import com.wire.android.feature.conversation.list.datasources.local.ConversationDao
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMembersDao
 
 private const val VERSION = 1
 
-@Database(entities = [ConversationEntity::class, ContactEntity::class], version = VERSION)
+@Database(entities = [ConversationEntity::class, ContactEntity::class, ConversationMemberEntity::class], version = VERSION)
 abstract class UserDatabase : RoomDatabase() {
 
     abstract fun conversationDao(): ConversationDao
 
     abstract fun contactDao(): ContactDao
+
+    abstract fun conversationMembersDao(): ConversationMembersDao
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -31,6 +31,7 @@ val conversationsModule = module {
     single { get<NetworkClient>().create(ConversationsApi::class.java) }
 
     factory { get<UserDatabase>().conversationDao() }
+    factory { get<UserDatabase>().conversationMembersDao() }
     factory { ConversationLocalDataSource(get()) }
 }
 

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDao.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationDao.kt
@@ -15,6 +15,9 @@ interface ConversationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(conversationList: List<ConversationEntity>)
 
+    @Query("DELETE FROM conversation WHERE id = :id")
+    fun deleteConversationById(id: String)
+
     @Query("SELECT * FROM conversation")
     suspend fun conversations(): List<ConversationEntity>
 

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMemberEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMemberEntity.kt
@@ -1,0 +1,25 @@
+package com.wire.android.feature.conversation.members.datasources.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+
+@Entity(
+    tableName = "conversation_members",
+    primaryKeys = ["contact_id", "conversation_id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ConversationEntity::class,
+            parentColumns = arrayOf("id"), childColumns = arrayOf("conversation_id"), onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(name="conversation_members_conversation_id", value = ["conversation_id"])
+    ]
+)
+data class ConversationMemberEntity(
+    @ColumnInfo(name = "conversation_id") val conversationId: String,
+    @ColumnInfo(name = "contact_id") val contactId: String
+)

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMembersDao.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/members/datasources/local/ConversationMembersDao.kt
@@ -1,0 +1,22 @@
+package com.wire.android.feature.conversation.members.datasources.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ConversationMembersDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(conversationMember: ConversationMemberEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(conversationMemberList: List<ConversationMemberEntity>)
+
+    @Query("SELECT * FROM conversation_members")
+    suspend fun allConversationMembers(): List<ConversationMemberEntity>
+
+    @Query("SELECT contact_id FROM conversation_members WHERE conversation_id = :conversationId")
+    suspend fun conversationMembers(conversationId: String): List<String>
+}


### PR DESCRIPTION
- Adds `conversation_members` table which stores pairs of `conversation id` and `contact id`.
- Adds Dao and tests for the table
- Adds `deleteConversationById` method to `ConversationDao`

**Documentation:**

[Conversation List](https://wearezeta.atlassian.net/wiki/spaces/AR/pages/159646151/Conversation+List)
[User Database](https://wearezeta.atlassian.net/wiki/spaces/AR/pages/122618276/User+Database)

**Table diagram:**

<img width="400" alt="Screenshot 2020-12-03 at 12 06 22" src="https://user-images.githubusercontent.com/2143283/101001889-fdbb2e00-355f-11eb-9d5a-f1a2a360b970.png">
