### PR TITLE
Feat: Conversation Members #2 - Saving/retrieving conversation member IDs

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceInstrumentationTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceInstrumentationTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 @Ignore("WIP")
 @Suppress("EmptyFunctionBlock")
-class ConversationDataSourceTest : InstrumentationTest() {
+class ConversationDataSourceInstrumentationTest : InstrumentationTest() {
 
     @Before
     fun setUp() {

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
@@ -4,12 +4,21 @@ import com.wire.android.core.extension.EMPTY
 import com.wire.android.feature.conversation.Conversation
 import com.wire.android.feature.conversation.data.remote.ConversationsResponse
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
 
 class ConversationMapper {
 
     fun fromConversationResponseToEntityList(response: ConversationsResponse): List<ConversationEntity> =
         response.conversations.map {
             ConversationEntity(id = it.id, name = it.name ?: String.EMPTY) //TODO consider null name on db
+        }
+
+    fun fromConversationResponseToConversationMembers(response: ConversationsResponse): List<ConversationMemberEntity> =
+        response.conversations.flatMap { conversation ->
+            val memberIds = conversation.members.otherMembers.map { it.userId }.filter { it.isNotEmpty() }
+            memberIds.map {
+                ConversationMemberEntity(conversationId = conversation.id, contactId = it)
+            }
         }
 
     fun fromEntity(entity: ConversationEntity) = Conversation(

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationsRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationsRepository.kt
@@ -10,4 +10,6 @@ interface ConversationsRepository {
     fun conversationsByBatch(
         pagingDelegate: ConversationsPagingDelegate
     ): Flow<Either<Failure, PagedList<Conversation>>>
+
+    suspend fun conversationMemberIds(conversation: Conversation): Either<Failure, List<String>>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
@@ -6,12 +6,25 @@ import com.wire.android.core.functional.Either
 import com.wire.android.core.storage.db.DatabaseService
 import com.wire.android.feature.conversation.list.datasources.local.ConversationDao
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMembersDao
 
-class ConversationLocalDataSource(private val conversationDao: ConversationDao) : DatabaseService {
+class ConversationLocalDataSource(
+    private val conversationDao: ConversationDao,
+    private val conversationMembersDao: ConversationMembersDao
+) : DatabaseService {
 
-    fun conversationsDataFactory() : DataSource.Factory<Int, ConversationEntity> = conversationDao.conversationsInBatch()
+    fun conversationsDataFactory(): DataSource.Factory<Int, ConversationEntity> = conversationDao.conversationsInBatch()
 
     suspend fun saveConversations(conversations: List<ConversationEntity>): Either<Failure, Unit> = request {
         conversationDao.insertAll(conversations)
+    }
+
+    suspend fun saveMemberIdsForConversations(conversationMemberEntityList: List<ConversationMemberEntity>) = request {
+        conversationMembersDao.insertAll(conversationMemberEntityList)
+    }
+
+    suspend fun conversationMemberIds(conversationId: String): Either<Failure, List<String>> = request {
+        conversationMembersDao.conversationMembers(conversationId)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -32,6 +32,6 @@ val conversationsModule = module {
 
     factory { get<UserDatabase>().conversationDao() }
     factory { get<UserDatabase>().conversationMembersDao() }
-    factory { ConversationLocalDataSource(get()) }
+    factory { ConversationLocalDataSource(get(), get()) }
 }
 

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
@@ -1,0 +1,65 @@
+package com.wire.android.feature.conversation.data
+
+import com.wire.android.UnitTest
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+import com.wire.android.feature.conversation.Conversation
+import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource
+import com.wire.android.feature.conversation.data.remote.ConversationsRemoteDataSource
+import com.wire.android.framework.functional.shouldFail
+import com.wire.android.framework.functional.shouldSucceed
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Before
+import org.junit.Test
+
+class ConversationDataSourceTest : UnitTest() {
+
+    @MockK
+    private lateinit var conversationMapper: ConversationMapper
+
+    @MockK
+    private lateinit var conversationRemoteDataSource: ConversationsRemoteDataSource
+
+    @MockK
+    private lateinit var conversationLocalDataSource: ConversationLocalDataSource
+
+    private lateinit var conversationDataSource: ConversationDataSource
+
+    @Before
+    fun setUp() {
+        conversationDataSource = ConversationDataSource(conversationMapper, conversationRemoteDataSource, conversationLocalDataSource)
+    }
+
+    @Test
+    fun `given conversationMemberIds is called, when localDataSource returns success with member ids, then propagates result`() {
+        val conversation = mockk<Conversation>()
+        every { conversation.id } returns TEST_CONVERSATION_ID
+        val memberIds = mockk<List<String>>()
+        coEvery { conversationLocalDataSource.conversationMemberIds(TEST_CONVERSATION_ID) } returns Either.Right(memberIds)
+
+        val result = runBlocking { conversationDataSource.conversationMemberIds(conversation) }
+
+        result shouldSucceed { it shouldBeEqualTo memberIds }
+    }
+
+    @Test
+    fun `given conversationMemberIds is called, when localDataSource fails to get member ids, then propagates failure`() {
+        val conversation = mockk<Conversation>()
+        every { conversation.id } returns TEST_CONVERSATION_ID
+        val failure = mockk<Failure>()
+        coEvery { conversationLocalDataSource.conversationMemberIds(TEST_CONVERSATION_ID) } returns Either.Left(failure)
+
+        val result = runBlocking { conversationDataSource.conversationMemberIds(conversation) }
+
+        result shouldFail { it shouldBeEqualTo failure }
+    }
+
+    companion object {
+        private const val TEST_CONVERSATION_ID = "conv-id"
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
@@ -3,9 +3,12 @@ package com.wire.android.feature.conversation.data
 import com.wire.android.UnitTest
 import com.wire.android.core.extension.EMPTY
 import com.wire.android.feature.conversation.Conversation
+import com.wire.android.feature.conversation.data.remote.ConversationMembersResponse
+import com.wire.android.feature.conversation.data.remote.ConversationOtherMembersResponse
 import com.wire.android.feature.conversation.data.remote.ConversationResponse
 import com.wire.android.feature.conversation.data.remote.ConversationsResponse
 import com.wire.android.feature.conversation.list.datasources.local.ConversationEntity
+import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
@@ -50,6 +53,30 @@ class ConversationMapperTest : UnitTest() {
     }
 
     @Test
+    fun `given a ConvResponse, when fromConversationResponseToConversationMembers is called, then returns list of entities & member ids`() {
+
+        val conversation1 = mockConversationResponseWithMembers("conv-1", "member-1-1", "member-1-2", "member-1-3")
+        val conversation2 = mockConversationResponseWithMembers("conv-2", "member-2-1", "")
+        val conversation3 = mockConversationResponseWithMembers("conv-3")
+        val conversation4 = mockConversationResponseWithMembers("conv-4", "member-4-1")
+
+        val conversationsResponse = mockk<ConversationsResponse>().also {
+            every { it.conversations } returns listOf(conversation1, conversation2, conversation3, conversation4)
+        }
+
+        val conversationMemberEntities =
+            conversationMapper.fromConversationResponseToConversationMembers(conversationsResponse)
+
+        conversationMemberEntities shouldContainSame listOf(
+            ConversationMemberEntity("conv-1", "member-1-1"),
+            ConversationMemberEntity("conv-1", "member-1-2"),
+            ConversationMemberEntity("conv-1", "member-1-3"),
+            ConversationMemberEntity("conv-2", "member-2-1"),
+            ConversationMemberEntity("conv-4", "member-4-1")
+        )
+    }
+
+    @Test
     fun `given a conversation entity, when fromEntity is called, then returns a conversation`() {
         val conversationEntity = ConversationEntity(id = TEST_CONVERSATION_ID, name = TEST_CONVERSATION_NAME)
 
@@ -61,5 +88,18 @@ class ConversationMapperTest : UnitTest() {
     companion object {
         private const val TEST_CONVERSATION_ID = "test-id-123"
         private const val TEST_CONVERSATION_NAME = "test-name"
+
+        private fun mockConversationResponseWithMembers(conversationId: String, vararg memberIds: String): ConversationResponse =
+            mockk<ConversationResponse>().also {
+                every { it.id } returns conversationId
+
+                val membersResponse = mockk<ConversationMembersResponse>()
+                every { it.members } returns membersResponse
+
+                val otherMembers = memberIds.map { memberId ->
+                    mockk<ConversationOtherMembersResponse>().also { every { it.userId } returns memberId }
+                }
+                every { membersResponse.otherMembers } returns otherMembers
+            }
     }
 }


### PR DESCRIPTION
- When a remote request is made to get the next batch of `Conversation`s, we get the ids of the members of the conversation in the response. This PR saves that member information to database.
- Adds `conversationMemberIds(Conversation)` method to `ConversationsRepository`: Retrieves a list of ids of `Contact`s which are members of the given conversation.

Documentation and a diagram of the flow can be found [here](https://wearezeta.atlassian.net/wiki/spaces/AR/pages/159646151/Conversation+List)