### PR TITLE
fix: Video recording on Android 11 doesn't work

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -85,12 +85,10 @@ public class AssetIntentsManager {
                 intent.setType(INTENT_ALL_TYPES);
                 intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes.toArray());
             }
-            if (!context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_ALL).isEmpty()) {
-                callback.openIntent(intent, tpe);
-                return;
-            }
-            Logger.info(TAG, "Did not resolve testing gallery for intent:" + intent.toString());
+
+            callback.openIntent(intent, tpe);
         }
+
         final Intent intent = new Intent(openDocumentAction()).addCategory(Intent.CATEGORY_OPENABLE);
         if (mimeTypes.size() == 1) {
             intent.setType(mimeTypes.iterator().next());
@@ -137,9 +135,7 @@ public class AssetIntentsManager {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
-        if (intent.resolveActivity(this.context.getPackageManager()) != null) {
-            callback.openIntent(intent, IntentType.VIDEO);
-        }
+        callback.openIntent(intent, IntentType.VIDEO);
     }
 
     public void openGallery() {

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -20,12 +20,12 @@ package com.waz.zclient
 import android.annotation.SuppressLint
 import android.app.{Dialog, Service}
 import android.content.res.Resources
-import android.content.{Context, ContextWrapper, DialogInterface}
+import android.content.{ActivityNotFoundException, Context, ContextWrapper, DialogInterface, Intent}
 import android.os.Bundle
 import android.view.View.OnClickListener
 import android.view.animation.{AlphaAnimation, Animation, AnimationUtils}
 import android.view.{LayoutInflater, View, ViewGroup, ViewStub}
-import android.widget.TextView
+import android.widget.{TextView, Toast}
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.{Fragment, FragmentActivity, FragmentManager}
@@ -151,6 +151,16 @@ trait FragmentHelper
     else getActivity.findViewById(id).asInstanceOf[V]
   }
 
+  def safeStartActivityForResult(intent: Intent, requestCode: Int): Boolean =
+    try {
+      startActivityForResult(intent, requestCode)
+      true
+    } catch {
+      case ex: ActivityNotFoundException =>
+        error(l"No application found to handle this request", ex)
+        Toast.makeText(getContext, s"No application found to handle this request", Toast.LENGTH_SHORT).show()
+        false
+    }
 
   /*
    * This part (the methods onCreateAnimation and the accompanying util method, getNextAnimationDuration) of the Wire

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -85,9 +85,8 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
     }
     override def onCanceled(`type`: AssetIntentsManager.IntentType): Unit = {}
     override def onFailed(`type`: AssetIntentsManager.IntentType): Unit = {}
-    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit = {
-      startActivityForResult(intent, intentType.requestCode)
-    }
+    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
+      safeStartActivityForResult(intent, intentType.requestCode)
   }
 
   private var assetIntentsManager = Option.empty[AssetIntentsManager]

--- a/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
@@ -48,6 +48,7 @@ import com.waz.threading.Threading._
 
 import scala.concurrent.duration._
 
+
 class CameraFragment extends FragmentHelper
   with CameraPreviewObserver
   with ImagePreviewCallback
@@ -118,7 +119,7 @@ class CameraFragment extends FragmentHelper
       override def onCanceled(t: AssetIntentsManager.IntentType): Unit = showCameraFeed()
       override def onFailed(t: AssetIntentsManager.IntentType): Unit = showCameraFeed()
       override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
-        startActivityForResult(intent, intentType.requestCode)
+        safeStartActivityForResult(intent, intentType.requestCode)
     })
   }
 
@@ -242,7 +243,7 @@ class CameraFragment extends FragmentHelper
   override def onSendPictureFromPreview(image: Content): Unit =
     cameraController.onBitmapSelected(image, cameraContext)
 
-  private def showPreview(setImage: (ImagePreviewLayout) => Unit) = {
+  private def showPreview(setImage: (ImagePreviewLayout) => Unit): Unit = {
     hideCameraFeed()
 
     previewProgressBar.foreach(_.setVisible(false))

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -512,12 +512,11 @@ class ConversationListManagerFragment extends Fragment
       convListType
     }
 
-  override def onMoveToFolder(convId: ConvId): Unit = {
-    startActivityForResult(
+  override def onMoveToFolder(convId: ConvId): Unit =
+    safeStartActivityForResult(
       MoveToFolderActivity.newIntent(requireContext(), convId),
       MoveToFolderActivity.REQUEST_CODE_MOVE_CREATE
     )
-  }
 
   private def handleGroupConvError(errorData: ErrorData) = {
     errorsController.dismissSyncError(errorData.id)

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -27,7 +27,6 @@ import com.google.android.gms.common.{ConnectionResult, GoogleApiAvailability}
 import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
 import com.waz.content.{GlobalPreferences, UserPreferences}
-import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.permissions.PermissionsService
 import com.waz.service.{NetworkModeService, ZMessaging}
@@ -57,9 +56,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
 
-class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
-  extends Injectable with DerivedLogTag {
-
+class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) extends Injectable {
   import CursorController._
   import Threading.Implicits.Ui
 
@@ -294,7 +291,7 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext)
       if (lastExpiration.isDefined && (eph.isEmpty || !eph.get.isInstanceOf[ConvExpiry])) {
         val current = if (eph.isEmpty) lastExpiration else None
         z.convsUi.setEphemeral(c.id, current)
-        if (eph != lastExpiration) onEphemeralExpirationSelected ! current
+        if (eph.map(_.duration) != lastExpiration) onEphemeralExpirationSelected ! current
         keyboard mutate {
           case KeyboardState.ExtendedCursor(_) => KeyboardState.Hidden
           case state => state

--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -360,10 +360,9 @@ class DrawingFragment extends FragmentHelper
 
   override def onFailed(tpe: AssetIntentsManager.IntentType): Unit = {}
 
-  override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit = {
-    startActivityForResult(intent, intentType.requestCode)
-    getActivity.overridePendingTransition(R.anim.camera_in, R.anim.camera_out)
-  }
+  override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
+    if (safeStartActivityForResult(intent, intentType.requestCode))
+      getActivity.overridePendingTransition(R.anim.camera_in, R.anim.camera_out)
 
   override def onColorSelected(color: Int, strokeSize: Int): Unit = {
     onSketchClick() //when user selects color, they expect to be able to sketch

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -264,7 +264,7 @@ class MainPhoneFragment extends FragmentHelper
     inject[PermissionsService].requestAllPermissions(ListSet(android.Manifest.permission.READ_EXTERNAL_STORAGE)).map {
       case true =>
         val galleryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
-        startActivityForResult(galleryIntent, Shortcuts.SHARE_PHOTO_REQUEST_CODE)
+        safeStartActivityForResult(galleryIntent, Shortcuts.SHARE_PHOTO_REQUEST_CODE)
         resetAction()
       case _    =>
     }(Threading.Ui)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-219

Starting Android 11, Android does not allow a third-party app to use `intent.resolveActivity` to easily learn
about other installed apps. One way to solve it is to simply stop using `intent.resolveActivity` and just attempt
to start a new activity and deal with the `ActivityNotFoundException` if it so happens that the app is unable
to find an app for the given intent. In this case, we want to open a video recording app and we can safely
assume that each device we support has it. In a few other places in the coded I decided to use the new code
to guard us from the `ActivityNotFoundException` as well.
#### APK
[Download build #3009](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3009/artifact/build/artifact/wire-dev-PR3111-3009.apk)