### PR TITLE
fix: The visibility of the "eye" icon on the "Change Passcode" dialog

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -93,7 +93,9 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
     }
 
   private def openNewPasswordDialog(mode: NewPasswordDialog.Mode)(implicit ctx: Context): Future[Int] = Future {
-    val isDarkTheme = inject[ThemeController].isDarkTheme
+    // The "Change Passcode" version of the dialog is always presented on the dark theme
+    // even if the controller says otherwise
+    val isDarkTheme = mode == NewPasswordDialog.ChangeMode || inject[ThemeController].isDarkTheme
     val fragment = NewPasswordDialog.newInstance(mode, isDarkTheme)
     ctx.asInstanceOf[BaseActivity]
       .getSupportFragmentManager


### PR DESCRIPTION
The "Change Passcode" dialog is always opened from the Settings. Settings ignore the theme from ThemeController -
it's always dark theme in the settings. It means that if we open the SSO password dialog from the Settings
(i.e. the "Change Passcode" case) we need to always use the dark mode as well or otherwise the "eye" icon will
be displayed black instead of white and it will be hardly visible.

#### APK
[Download build #3010](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3010/artifact/build/artifact/wire-dev-PR3112-3010.apk)