### PR TITLE
[Calling] Bugfix : Video calling overlay doesn't appear on the maximised video

### DIFF
--- a/app/src/main/res/layout/fragment_calling.xml
+++ b/app/src/main/res/layout/fragment_calling.xml
@@ -47,7 +47,8 @@
     <FrameLayout
         android:id="@+id/controls_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:elevation="1dp"/>
 
     <FrameLayout
         android:id="@+id/full_screen_video_container"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Video calling controls overlay doesn't appear on the maximised video.

https://wearezeta.atlassian.net/browse/SQCALL-79

### Causes

`ControlsFragment` is hidden behind `FullScreenVideoFragment`

### Solutions

A simple `android:elevation="1dp"` would solve the problem.
#### APK
[Download build #3011](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3011/artifact/build/artifact/wire-dev-PR3113-3011.apk)