### PR TITLE
Fix: Too many calls to /access endpoint

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenAuthenticator.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenAuthenticator.kt
@@ -29,7 +29,7 @@ class AccessTokenAuthenticator(private val repository: SessionRepository) : Auth
         repository.currentSession().map {
             differentRefreshToken(response, it) ?: it.refreshToken
         }.flatMap { refreshToken ->
-            repository.accessToken(refreshToken)
+            repository.newAccessToken(refreshToken)
         }.flatMap { session ->
             repository.save(session).map { session }
         }.fold({ null }) {

--- a/app/src/main/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenInterceptor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenInterceptor.kt
@@ -1,6 +1,5 @@
 package com.wire.android.core.network.auth.accesstoken
 
-import com.wire.android.core.functional.suspending
 import com.wire.android.shared.session.SessionRepository
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -13,15 +12,11 @@ class AccessTokenInterceptor(private val sessionRepository: SessionRepository) :
         chain.proceed(interceptedRequest(chain) ?: chain.request())
     }
 
-    private suspend fun interceptedRequest(chain: Interceptor.Chain): Request? = suspending {
-        sessionRepository.currentSession().flatMap { currentSession ->
-            sessionRepository.accessToken(currentSession.refreshToken)
-        }.fold({ null }) {
-            if (it.accessToken.isNotEmpty()) {
-                addAuthHeader(chain, it.accessToken)
-            } else null
+    private suspend fun interceptedRequest(chain: Interceptor.Chain): Request? =
+        sessionRepository.accessToken().fold({ null }) {
+            if (it.isNotEmpty()) addAuthHeader(chain, it)
+            else null
         }
-    }
 
     private fun addAuthHeader(chain: Interceptor.Chain, token: String) =
         chain.request()

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
@@ -42,7 +42,7 @@ class RegisterPersonalAccountUseCase(
 
     private suspend fun saveDataAndRetrieveSession(user: User, refreshToken: String): Either<Failure, Unit> = suspending {
         userRepository.save(user).flatMap {
-            sessionRepository.accessToken(refreshToken).coFold({
+            sessionRepository.newAccessToken(refreshToken).coFold({
                 Either.Left(SessionCannotBeCreated)
             }) {
                 sessionRepository.save(it)

--- a/app/src/main/kotlin/com/wire/android/shared/session/SessionRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/SessionRepository.kt
@@ -8,8 +8,9 @@ interface SessionRepository {
 
     suspend fun currentSession(): Either<Failure, Session>
 
-    suspend fun accessToken(refreshToken: String): Either<Failure, Session>
+    suspend fun accessToken(): Either<Failure, String>
+
+    suspend fun newAccessToken(refreshToken: String): Either<Failure, Session>
 
     suspend fun doesCurrentSessionExist(): Either<Failure, Boolean>
-
 }

--- a/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/session/datasources/SessionDataSource.kt
@@ -30,7 +30,9 @@ class SessionDataSource(
     private suspend fun saveLocally(session: Session, current: Boolean) =
         localDataSource.save(mapper.toSessionEntity(session, current))
 
-    override suspend fun accessToken(refreshToken: String): Either<Failure, Session> =
+    override suspend fun accessToken(): Either<Failure, String> = currentSession().map { it.accessToken }
+
+    override suspend fun newAccessToken(refreshToken: String): Either<Failure, Session> =
         remoteDataSource.accessToken(refreshToken).map {
             mapper.fromAccessTokenResponse(it, refreshToken)
         }

--- a/app/src/test/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenAuthenticatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/network/auth/accesstoken/AccessTokenAuthenticatorTest.kt
@@ -57,7 +57,7 @@ class AccessTokenAuthenticatorTest : UnitTest() {
 
     @Test
     fun `Given http response, when response cookie header is null, then request access token with the same refresh token as before`() {
-        coEvery { sessionRepository.accessToken(any()) } returns Either.Left(NoEntityFound)
+        coEvery { sessionRepository.newAccessToken(any()) } returns Either.Left(NoEntityFound)
         coEvery { sessionRepository.currentSession() } returns Either.Right(currentSession)
         every { response.headers[TOKEN_HEADER_KEY] } returns null
         every { currentSession.refreshToken } returns CURRENT_REFRESH_TOKEN
@@ -65,13 +65,13 @@ class AccessTokenAuthenticatorTest : UnitTest() {
         accessTokenAuthenticator.authenticate(route, response)
 
         coVerify(exactly = 1) {
-            sessionRepository.accessToken(eq(CURRENT_REFRESH_TOKEN))
+            sessionRepository.newAccessToken(eq(CURRENT_REFRESH_TOKEN))
         }
     }
 
     @Test
     fun `Given cookie header is valid, when refresh token is not current, then build request with new refresh token`() {
-        coEvery { sessionRepository.accessToken(any()) } returns Either.Left(NoEntityFound)
+        coEvery { sessionRepository.newAccessToken(any()) } returns Either.Left(NoEntityFound)
         coEvery { sessionRepository.currentSession() } returns Either.Right(currentSession)
         every { response.headers[TOKEN_HEADER_KEY] } returns NEW_REFRESH_TOKEN
         every { currentSession.refreshToken } returns CURRENT_REFRESH_TOKEN
@@ -79,13 +79,13 @@ class AccessTokenAuthenticatorTest : UnitTest() {
         accessTokenAuthenticator.authenticate(route, response)
 
         coVerify(exactly = 1) {
-            sessionRepository.accessToken(NEW_REFRESH_TOKEN)
+            sessionRepository.newAccessToken(NEW_REFRESH_TOKEN)
         }
     }
 
     @Test
     fun `Given cookie header is valid, when refresh token is same as now, then build request with current refresh token`() {
-        coEvery { sessionRepository.accessToken(any()) } returns Either.Left(NoEntityFound)
+        coEvery { sessionRepository.newAccessToken(any()) } returns Either.Left(NoEntityFound)
         coEvery { sessionRepository.currentSession() } returns Either.Right(currentSession)
         every { response.headers[TOKEN_HEADER_KEY] } returns CURRENT_REFRESH_TOKEN
         every { currentSession.refreshToken } returns CURRENT_REFRESH_TOKEN
@@ -93,13 +93,13 @@ class AccessTokenAuthenticatorTest : UnitTest() {
         accessTokenAuthenticator.authenticate(route, response)
 
         coVerify(exactly = 1) {
-            sessionRepository.accessToken(CURRENT_REFRESH_TOKEN)
+            sessionRepository.newAccessToken(CURRENT_REFRESH_TOKEN)
         }
     }
 
     @Test
     fun `Given http response, when access token request is successful, then save session`() {
-        coEvery { sessionRepository.accessToken(any()) } returns Either.Right(currentSession)
+        coEvery { sessionRepository.newAccessToken(any()) } returns Either.Right(currentSession)
         coEvery { sessionRepository.currentSession() } returns Either.Right(currentSession)
         coEvery { sessionRepository.save(any()) } returns Either.Right(Unit)
         every { response.headers[TOKEN_HEADER_KEY] } returns CURRENT_REFRESH_TOKEN
@@ -108,7 +108,7 @@ class AccessTokenAuthenticatorTest : UnitTest() {
         accessTokenAuthenticator.authenticate(route, response)
 
         coVerify(exactly = 1) {
-            sessionRepository.accessToken(any())
+            sessionRepository.newAccessToken(any())
             sessionRepository.save(currentSession)
         }
     }
@@ -116,7 +116,7 @@ class AccessTokenAuthenticatorTest : UnitTest() {
     @Test
     fun `Given http response, when access token request is successful, then build new authentication request`() {
         every { currentSession.accessToken } returns NEW_ACCESS_TOKEN
-        coEvery { sessionRepository.accessToken(any()) } returns Either.Right(currentSession)
+        coEvery { sessionRepository.newAccessToken(any()) } returns Either.Right(currentSession)
         coEvery { sessionRepository.currentSession() } returns Either.Right(currentSession)
         coEvery { sessionRepository.save(currentSession) } returns Either.Right(Unit)
 
@@ -126,7 +126,7 @@ class AccessTokenAuthenticatorTest : UnitTest() {
 
         accessTokenAuthenticator.authenticate(route, response)
 
-        coVerify(exactly = 1) { sessionRepository.accessToken(any()) }
+        coVerify(exactly = 1) { sessionRepository.newAccessToken(any()) }
         verify(exactly = 1) { requestBuilder.removeHeader(AUTH_HEADER_KEY) }
         verify(exactly = 1) { requestBuilder.addHeader(AUTH_HEADER_KEY, "$AUTH_HEADER_TOKEN_TYPE $NEW_ACCESS_TOKEN") }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
@@ -60,7 +60,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
         every { registrationResult.user } returns user
         every { registrationResult.refreshToken } returns TEST_REFRESH_TOKEN
         coEvery { userRepository.save(user) } returns Either.Right(Unit)
-        coEvery { sessionRepository.accessToken(TEST_REFRESH_TOKEN) } returns Either.Right(session)
+        coEvery { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) } returns Either.Right(session)
         coEvery { sessionRepository.save(session) } returns Either.Right(Unit)
 
         val result = runBlocking { useCase.run(params) }
@@ -75,7 +75,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
             )
         }
         coVerify(exactly = 1) { userRepository.save(user) }
-        coVerify(exactly = 1) { sessionRepository.accessToken(TEST_REFRESH_TOKEN) }
+        coVerify(exactly = 1) { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) }
         coVerify(exactly = 1) { sessionRepository.save(session, true) }
         result shouldSucceed { it shouldBe Unit }
     }
@@ -171,13 +171,13 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
         mockRegistrationResponse(Either.Right(registrationResult))
         coEvery { userRepository.save(user) } returns Either.Right(Unit)
         val failure = mockk<Failure>()
-        coEvery { sessionRepository.accessToken(TEST_REFRESH_TOKEN) } returns Either.Left(failure)
+        coEvery { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) } returns Either.Left(failure)
 
         val result = runBlocking { useCase.run(params) }
 
         result shouldFail { it shouldBe SessionCannotBeCreated }
         coVerify(exactly = 1) { userRepository.save(user) }
-        coVerify(exactly = 1) { sessionRepository.accessToken(TEST_REFRESH_TOKEN) }
+        coVerify(exactly = 1) { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) }
         coVerify(inverse = true) { sessionRepository.save(any(), any()) }
     }
 
@@ -187,7 +187,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
         every { registrationResult.refreshToken } returns TEST_REFRESH_TOKEN
         mockRegistrationResponse(Either.Right(registrationResult))
         coEvery { userRepository.save(user) } returns Either.Right(Unit)
-        coEvery { sessionRepository.accessToken(TEST_REFRESH_TOKEN) } returns Either.Right(session)
+        coEvery { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) } returns Either.Right(session)
         val failure = mockk<Failure>()
         coEvery { sessionRepository.save(session) } returns Either.Left(failure)
 
@@ -195,7 +195,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
 
         result shouldFail { it shouldBe failure }
         coVerify(exactly = 1) { userRepository.save(user) }
-        coVerify(exactly = 1) { sessionRepository.accessToken(TEST_REFRESH_TOKEN) }
+        coVerify(exactly = 1) { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) }
         coVerify(exactly = 1) { sessionRepository.save(session, true) }
     }
 


### PR DESCRIPTION
**Problem:**
With every request, we send an additional `/access` call to backend. This call should only be used to acquire a new access token.

**Cause:**
`AccessTokenInterceptor` intercepts every request and gets `accessToken` via `SessionRepository`. However, the method on `SessionRepository` always calls the remote data source to get the token, instead of using previously fetched data.

**Solution:**
Add another method to re-use locally existing access token