### PR TITLE
[Calling] : fix for maximization feature : self user video is not maximized on double click

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -127,10 +127,8 @@ class CallingFragment extends FragmentHelper {
       viewMap = viewMap.updated(participant, userView)
       if (BuildConfig.MAXIMIZE_MINIMIZE_VIDEO) {
 
-        val isMultiParticipant: Signal[Boolean] = controller.otherParticipants.map(_.size > 2)
-
         userView.onDoubleClick.onUi { _ =>
-          isMultiParticipant.head.foreach {
+          controller.otherParticipants.map(_.size > 2).head.foreach {
             case true =>
               showFullScreenVideo(participant)
               clearVideoGrid()

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -119,20 +119,22 @@ class CallingFragment extends FragmentHelper {
 
   private var viewMap = Map[Participant, UserVideoView]()
 
-  private def refreshViews(videoUsers        : Seq[Participant],
-                           selfParticipant   : Participant,
-                           isMultiParticipant: Boolean
-                          ): Seq[UserVideoView] = {
+  private def refreshViews(videoUsers: Seq[Participant], selfParticipant: Participant): Seq[UserVideoView] = {
     def createView(participant: Participant): UserVideoView = returning {
       if (participant == selfParticipant) new SelfVideoView(getContext, participant)
       else new OtherVideoView(getContext, participant)
     } { userView =>
       viewMap = viewMap.updated(participant, userView)
       if (BuildConfig.MAXIMIZE_MINIMIZE_VIDEO) {
+
+        val isMultiParticipant: Signal[Boolean] = controller.otherParticipants.map(_.size > 2)
+
         userView.onDoubleClick.onUi { _ =>
-          if (isMultiParticipant) {
-            showFullScreenVideo(participant)
-            clearVideoGrid()
+          isMultiParticipant.head.foreach {
+            case true =>
+              showFullScreenVideo(participant)
+              clearVideoGrid()
+            case false =>
           }
         }
       }
@@ -148,7 +150,8 @@ class CallingFragment extends FragmentHelper {
                                participants    : Set[Participant],
                                isVideoBeingSent: Boolean
                               ): Unit = {
-    val views = refreshViews(videoUsers, selfParticipant, isMultiParticipant = participants.size > 2)
+
+    val views = refreshViews(videoUsers, selfParticipant)
 
     viewMap.get(selfParticipant).foreach { selfView =>
       previewCardView.foreach { cardView =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

On a video group with 3 enabled videos,  the self user video is not maximized on double click when the call started.

https://wearezeta.atlassian.net/browse/SQCALL-81

### Causes

The number of participants is checked at the moment of the creation of the view, not at the moment of the double click.

### Solutions

Convert `isMultiParticipant` to a `Signal` and observe its value.

#### APK
[Download build #3013](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3013/artifact/build/artifact/wire-dev-PR3115-3013.apk)
[Download build #3014](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3014/artifact/build/artifact/wire-dev-PR3115-3014.apk)