### PR TITLE
Feature: Create Personal Account - Username Input - Navigation Fix

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/RegistrationRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/RegistrationRepository.kt
@@ -5,6 +5,6 @@ import com.wire.android.core.functional.Either
 import com.wire.android.feature.auth.registration.personal.PersonalAccountRegistrationResult
 
 interface RegistrationRepository {
-    suspend fun registerPersonalAccount(name: String, email: String, username: String, password: String, activationCode: String):
+    suspend fun registerPersonalAccount(name: String, email: String, password: String, activationCode: String):
             Either<Failure, PersonalAccountRegistrationResult>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSource.kt
@@ -16,15 +16,9 @@ class RegistrationDataSource(
 ) : RegistrationRepository {
 
     override suspend fun registerPersonalAccount(
-        name: String, email: String, username: String, password: String, activationCode: String
+        name: String, email: String, password: String, activationCode: String
     ): Either<Failure, PersonalAccountRegistrationResult> =
-        remoteDataSource.registerPersonalAccount(
-            name = name,
-            email = email,
-            username = username,
-            password = password,
-            activationCode = activationCode
-        ).map {
+        remoteDataSource.registerPersonalAccount(name = name, email = email, password = password, activationCode = activationCode).map {
             PersonalAccountRegistrationResult(
                 user = it.body()?.let { userMapper.fromRegisteredUserResponse(it) },
                 refreshToken = sessionMapper.extractRefreshToken(it.headers())

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegisterPersonalAccountRequest.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegisterPersonalAccountRequest.kt
@@ -1,4 +1,3 @@
-@file:Suppress("LongParameterList")
 package com.wire.android.feature.auth.registration.datasource.remote
 
 import com.google.gson.annotations.SerializedName
@@ -7,7 +6,6 @@ class RegisterPersonalAccountRequest(
     @SerializedName("email") val email: String,
     @SerializedName("locale") val locale: String,
     @SerializedName("name") val name: String,
-    @SerializedName("handle") val handle: String,
     @SerializedName("password") val password: String, //TODO: prevent this from being logged
     @SerializedName("email_code") val emailCode: String,
     @SerializedName("label") val label: String

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegistrationRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegistrationRemoteDataSource.kt
@@ -18,13 +18,12 @@ class RegistrationRemoteDataSource(
     suspend fun registerPersonalAccount(
         name: String,
         email: String,
-        username: String,
         password: String,
         activationCode: String
     ): Either<Failure, Response<RegisteredUserResponse>> = rawRequest {
         api.registerPersonalAccount(
             RegisterPersonalAccountRequest(
-                name = name, handle = username, email = email, password = password, emailCode = activationCode,
+                name = name, email = email, password = password, emailCode = activationCode,
                 locale = localeConfig.currentLocale().toLanguageTag(),
                 label = labelGenerator.newLabel()
             )

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountNameFragment.kt
@@ -42,7 +42,7 @@ class CreatePersonalAccountNameFragment : Fragment(R.layout.fragment_create_pers
         createPersonalAccountNameTitleTextView.headingForAccessibility()
 
     private fun initConfirmationButton() = createPersonalAccountNameConfirmationButton.setOnClickListener {
-        showUsernameScreen(createPersonalAccountNameEditText.text.toStringOrEmpty())
+        showPasswordScreen(createPersonalAccountNameEditText.text.toStringOrEmpty())
     }
 
     private fun observeButtonStatus() {
@@ -61,8 +61,8 @@ class CreatePersonalAccountNameFragment : Fragment(R.layout.fragment_create_pers
         if (inputFocusViewModel.canFocusWithKeyboard()) showKeyboardWithFocusOn(createPersonalAccountNameEditText)
     }
 
-    private fun showUsernameScreen(name: String) =
-        navigator.createAccount.openPersonalAccountUsernameScreen(requireActivity(), name, email, activationCode)
+    private fun showPasswordScreen(name: String) =
+        navigator.createAccount.openPersonalAccountPasswordScreen(requireActivity(), name, email, activationCode)
 
     companion object {
         private const val KEY_EMAIL = "email"

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordFragment.kt
@@ -36,7 +36,6 @@ class CreatePersonalAccountPasswordFragment : Fragment(R.layout.fragment_create_
     private val name by arg<String>(KEY_NAME)
     private val email by arg<String>(KEY_EMAIL)
     private val activationCode by arg<String>(KEY_ACTIVATION_CODE)
-    private val username by arg<String>(KEY_USERNAME)
     private val password: String get() = createPersonalAccountPasswordEditText.text.toStringOrEmpty()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -64,7 +63,7 @@ class CreatePersonalAccountPasswordFragment : Fragment(R.layout.fragment_create_
     private fun observeRegistrationData() {
         passwordViewModel.registrationStatusLiveData.observe(viewLifecycleOwner) {
             it.onSuccess {
-                showMainScreen()
+                showUsernameScreen()
             }.onFailure(::showErrorDialog)
         }
     }
@@ -88,9 +87,9 @@ class CreatePersonalAccountPasswordFragment : Fragment(R.layout.fragment_create_
     }
 
     private fun registerNewUser() =
-        passwordViewModel.registerUser(name = name, username = username, email = email, code = activationCode, password = password)
+        passwordViewModel.registerUser(name = name, email = email, code = activationCode, password = password)
 
-    private fun showMainScreen() = navigator.main.openMainScreen(requireContext())
+    private fun showUsernameScreen() = navigator.createAccount.openPersonalAccountUsernameScreen(requireActivity())
 
     private fun showErrorDialog(message: ErrorMessage) = dialogBuilder.showErrorDialog(requireContext(), message)
 
@@ -98,12 +97,10 @@ class CreatePersonalAccountPasswordFragment : Fragment(R.layout.fragment_create_
         private const val KEY_NAME = "name"
         private const val KEY_EMAIL = "email"
         private const val KEY_ACTIVATION_CODE = "activationCode"
-        private const val KEY_USERNAME = "username"
 
-        fun newInstance(name: String, username: String, email: String, activationCode: String) =
+        fun newInstance(name: String, email: String, activationCode: String) =
             CreatePersonalAccountPasswordFragment().withArgs(
                 KEY_NAME to name,
-                KEY_USERNAME to username,
                 KEY_EMAIL to email,
                 KEY_ACTIVATION_CODE to activationCode
             )

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModel.kt
@@ -46,10 +46,10 @@ class CreatePersonalAccountPasswordViewModel(
             _confirmationButtonEnabledLiveData.value = it.isRight
         }
 
-    fun registerUser(name: String, username: String, email: String, password: String, code: String) =
+    fun registerUser(name: String, email: String, password: String, code: String) =
         registerUseCase(
             viewModelScope,
-            RegisterPersonalAccountParams(name = name, username = username, email = email, password = password, activationCode = code)
+            RegisterPersonalAccountParams(name = name, email = email, password = password, activationCode = code)
         ) {
             it.onSuccess {
                 _registrationStatusLiveData.success()

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountUsernameFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountUsernameFragment.kt
@@ -9,8 +9,6 @@ import com.wire.android.core.accessibility.InputFocusViewModel
 import com.wire.android.core.extension.headingForAccessibility
 import com.wire.android.core.extension.showKeyboardWithFocusOn
 import com.wire.android.core.extension.toStringOrEmpty
-import com.wire.android.core.extension.withArgs
-import com.wire.android.core.ui.arg
 import com.wire.android.core.ui.navigation.Navigator
 import com.wire.android.feature.auth.registration.ui.CreateAccountUsernameViewModel
 import kotlinx.android.synthetic.main.fragment_create_personal_account_username.createPersonalAccountUsernameConfirmationButton
@@ -27,10 +25,6 @@ class CreatePersonalAccountUsernameFragment : Fragment(R.layout.fragment_create_
 
     private val navigator: Navigator by inject()
 
-    private val name by arg<String>(KEY_NAME)
-    private val email by arg<String>(KEY_EMAIL)
-    private val activationCode by arg<String>(KEY_ACTIVATION_CODE)
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpAccessibilityHeading()
@@ -44,7 +38,7 @@ class CreatePersonalAccountUsernameFragment : Fragment(R.layout.fragment_create_
         createPersonalAccountUsernameTitleTextView.headingForAccessibility()
 
     private fun initConfirmationButton() = createPersonalAccountUsernameConfirmationButton.setOnClickListener {
-        showPasswordScreen(createPersonalAccountUsernameEditText.text.toStringOrEmpty())
+        showMainScreen(createPersonalAccountUsernameEditText.text.toStringOrEmpty())
     }
 
     private fun observeButtonStatus() {
@@ -63,19 +57,11 @@ class CreatePersonalAccountUsernameFragment : Fragment(R.layout.fragment_create_
         if (inputFocusViewModel.canFocusWithKeyboard()) showKeyboardWithFocusOn(createPersonalAccountUsernameEditText)
     }
 
-    private fun showPasswordScreen(username: String) =
-        navigator.createAccount.openPersonalAccountPasswordScreen(requireActivity(), name, username, email, activationCode)
+    private fun showMainScreen(username: String) =
+        navigator.main.openMainScreen(requireActivity())
 
     companion object {
-        private const val KEY_NAME = "name"
-        private const val KEY_EMAIL = "email"
-        private const val KEY_ACTIVATION_CODE = "activationCode"
-
-        fun newInstance(name: String, email: String, activationCode: String) =
-            CreatePersonalAccountUsernameFragment().withArgs(
-                KEY_NAME to name,
-                KEY_EMAIL to email,
-                KEY_ACTIVATION_CODE to activationCode
-            )
+        fun newInstance() =
+            CreatePersonalAccountUsernameFragment()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCase.kt
@@ -21,7 +21,7 @@ class RegisterPersonalAccountUseCase(
 
     override suspend fun run(params: RegisterPersonalAccountParams): Either<Failure, Unit> = with(params) {
         suspending {
-            registrationRepository.registerPersonalAccount(name, email, username, password, activationCode).coFold({
+            registrationRepository.registerPersonalAccount(name, email, password, activationCode).coFold({
                 handleRegistrationFailure(it)
             }) {
                 when {
@@ -51,13 +51,7 @@ class RegisterPersonalAccountUseCase(
     }
 }
 
-data class RegisterPersonalAccountParams(
-    val name: String,
-    val email: String,
-    val username: String,
-    val password: String,
-    val activationCode: String
-)
+data class RegisterPersonalAccountParams(val name: String, val email: String, val password: String, val activationCode: String)
 
 sealed class RegisterPersonalAccountFailure : FeatureFailure()
 

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/ui/navigation/CreateAccountNavigator.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/ui/navigation/CreateAccountNavigator.kt
@@ -36,21 +36,20 @@ class CreateAccountNavigator(
         )
     }
 
-    fun openPersonalAccountUsernameScreen(activity: FragmentActivity, name: String, email: String, activationCode: String) =
+    fun openPersonalAccountUsernameScreen(activity: FragmentActivity) =
         fragmentStackHandler.replaceFragment(
             activity,
-            CreatePersonalAccountUsernameFragment.newInstance(name, email, activationCode)
+            CreatePersonalAccountUsernameFragment.newInstance()
         )
 
     fun openPersonalAccountPasswordScreen(
         activity: FragmentActivity,
         name: String,
-        username: String,
         email: String,
         activationCode: String
     ) = fragmentStackHandler.replaceFragment(
         activity,
-        CreatePersonalAccountPasswordFragment.newInstance(name, username, email, activationCode)
+        CreatePersonalAccountPasswordFragment.newInstance(name, email, activationCode)
     )
 
     fun openProAccountTeamNameScreen(activity: FragmentActivity) {

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/datasource/RegistrationDataSourceTest.kt
@@ -60,31 +60,27 @@ class RegistrationDataSourceTest : UnitTest() {
 
     @Test
     fun `given credentials, when registerPersonalAccount() is called, then calls remote data source with credentials`() {
-        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
+        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
 
         runBlocking {
-            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         coVerify(exactly = 1) {
             remoteDataSource.registerPersonalAccount(
-                name = TEST_NAME,
-                email = TEST_EMAIL,
-                username = TEST_USERNAME,
-                password = TEST_PASSWORD,
-                activationCode = TEST_ACTIVATION_CODE
+                name = TEST_NAME, email = TEST_EMAIL, password = TEST_PASSWORD, activationCode = TEST_ACTIVATION_CODE
             )
         }
     }
 
     @Test
     fun `given registerPersonalAccount() is called, when remoteDS returns a response and mappers map successfully, then returns mapping`() {
-        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
+        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
         every { userMapper.fromRegisteredUserResponse(registeredUserResponseBody) } returns user
         every { sessionMapper.extractRefreshToken(headers) } returns TEST_REFRESH_TOKEN
 
         val result = runBlocking {
-            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldSucceed { it shouldBeEqualTo PersonalAccountRegistrationResult(user, TEST_REFRESH_TOKEN) }
@@ -95,11 +91,11 @@ class RegistrationDataSourceTest : UnitTest() {
     @Test
     fun `given registerPersonalAccount() is called, when remoteDS response has a null body, then returns mapping with null User`() {
         every { registeredUserResponse.body() } returns null
-        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
+        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
         every { sessionMapper.extractRefreshToken(headers) } returns TEST_REFRESH_TOKEN
 
         val result = runBlocking {
-            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldSucceed { it shouldBeEqualTo PersonalAccountRegistrationResult(null, TEST_REFRESH_TOKEN) }
@@ -109,12 +105,12 @@ class RegistrationDataSourceTest : UnitTest() {
 
     @Test
     fun `given registerPersonalAccount() is called, when remoteDS response has invalid header, then returns mapping with null token`() {
-        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
+        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any()) } returns Either.Right(registeredUserResponse)
         every { userMapper.fromRegisteredUserResponse(registeredUserResponseBody) } returns user
         every { sessionMapper.extractRefreshToken(headers) } returns null
 
         val result = runBlocking {
-            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldSucceed { it shouldBeEqualTo PersonalAccountRegistrationResult(user, null) }
@@ -125,10 +121,10 @@ class RegistrationDataSourceTest : UnitTest() {
     @Test
     fun `given registerPersonalAccount() is called, when remote data source returns failure, then returns that failure`() {
         val failure = mockk<Failure>()
-        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any(), any()) } returns Either.Left(failure)
+        coEvery { remoteDataSource.registerPersonalAccount(any(), any(), any(), any()) } returns Either.Left(failure)
 
         val result = runBlocking {
-            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            registrationDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldFail { it shouldBe failure }
@@ -139,7 +135,6 @@ class RegistrationDataSourceTest : UnitTest() {
     companion object {
         private const val TEST_NAME = "name"
         private const val TEST_EMAIL = "test@wire.com"
-        private const val TEST_USERNAME = "username"
         private const val TEST_PASSWORD = "abc123!"
         private const val TEST_ACTIVATION_CODE = "123456"
         private const val TEST_REFRESH_TOKEN = "refresh-token-789"

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegistrationRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/datasource/remote/RegistrationRemoteDataSourceTest.kt
@@ -52,7 +52,7 @@ class RegistrationRemoteDataSourceTest : UnitTest() {
             coEvery { api.registerPersonalAccount(any()) } returns it
         }
 
-        runBlocking { remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE) }
+        runBlocking { remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE) }
 
         coVerify(exactly = 1) { api.registerPersonalAccount(capture(registerPersonalAccountRequestCaptor)) }
         with(registerPersonalAccountRequestCaptor.captured) {
@@ -60,7 +60,6 @@ class RegistrationRemoteDataSourceTest : UnitTest() {
             email shouldBeEqualTo TEST_EMAIL
             password shouldBeEqualTo TEST_PASSWORD
             emailCode shouldBeEqualTo TEST_ACTIVATION_CODE
-            handle shouldBeEqualTo TEST_USERNAME
             locale shouldBeEqualTo TEST_LOCALE
             label shouldBeEqualTo TEST_LABEL
         }
@@ -75,7 +74,7 @@ class RegistrationRemoteDataSourceTest : UnitTest() {
         }
 
         val result = runBlocking {
-            remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldSucceed { it.body() shouldBeEqualTo userResponse }
@@ -88,7 +87,7 @@ class RegistrationRemoteDataSourceTest : UnitTest() {
         coEvery { api.registerPersonalAccount(any()) } returns response
 
         val result = runBlocking {
-            remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+            remoteDataSource.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
         }
 
         result shouldFail {}
@@ -98,7 +97,6 @@ class RegistrationRemoteDataSourceTest : UnitTest() {
         private const val TEST_NAME = "name"
         private const val TEST_EMAIL = "test@wire.com"
         private const val TEST_PASSWORD = "abc123!"
-        private const val TEST_USERNAME = "username"
         private const val TEST_ACTIVATION_CODE = "123456"
         private const val TEST_LOCALE = "en-US"
         private const val TEST_LABEL = "label"

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/ui/CreatePersonalAccountPasswordViewModelTest.kt
@@ -109,18 +109,15 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given params, when registerUser is called, then calls registerUseCase with correct params`() {
         coEvery { registerUseCase.run(any()) } returns Either.Right(Unit)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated {}
 
         coVerify(exactly = 1) {
             registerUseCase.run(
                 RegisterPersonalAccountParams(
-                    name = TEST_NAME,
-                    email = TEST_EMAIL,
-                    username = TEST_USERNAME,
-                    password = TEST_PASSWORD,
-                    activationCode = TEST_ACTIVATION_CODE
+                    name = TEST_NAME, email = TEST_EMAIL,
+                    password = TEST_PASSWORD, activationCode = TEST_ACTIVATION_CODE
                 )
             )
         }
@@ -130,7 +127,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns success, then sets success to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Right(Unit)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldSucceed { it shouldBe Unit }
@@ -141,7 +138,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns SessionCannotBeCreated error, then logs the user out`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(SessionCannotBeCreated)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         //TODO: assertion about logout
         viewModel.registrationStatusLiveData.shouldNotBeUpdated()
@@ -151,7 +148,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns NetworkConnection error, then sets NetworkError to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(NetworkConnection)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldFail { it shouldBe NetworkErrorMessage }
@@ -162,7 +159,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns UnauthorizedEmail error, then sets error message to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(UnauthorizedEmail)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_unauthorized_email_error }
@@ -173,7 +170,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns InvalidEmailActivationCode, then sets error msg to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(InvalidEmailActivationCode)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_invalid_activation_code_error }
@@ -184,7 +181,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns EmailInUse error, then sets error message to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(EmailInUse)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldFail { it.message shouldBeEqualTo R.string.create_personal_account_email_in_use_error }
@@ -195,7 +192,7 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
     fun `given registerUser is called, when use case returns other error, then sets GeneralErrorMessage to registerStatusLiveData`() {
         coEvery { registerUseCase.run(any()) } returns Either.Left(ServerError)
 
-        viewModel.registerUser(TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        viewModel.registerUser(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
 
         viewModel.registrationStatusLiveData shouldBeUpdated { result ->
             result shouldFail { it shouldBe GeneralErrorMessage }
@@ -204,7 +201,6 @@ class CreatePersonalAccountPasswordViewModelTest : UnitTest() {
 
     companion object {
         private const val TEST_PASSWORD = "123ABCdef!*"
-        private const val TEST_USERNAME = "username"
         private const val TEST_EMAIL = "test@wire.com"
         private const val TEST_NAME = "Name Surname"
         private const val TEST_ACTIVATION_CODE = "123456"

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/usecase/RegisterPersonalAccountUseCaseTest.kt
@@ -65,15 +65,7 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
 
         val result = runBlocking { useCase.run(params) }
 
-        coVerify(exactly = 1) {
-            registrationRepository.registerPersonalAccount(
-                name = TEST_NAME,
-                email = TEST_EMAIL,
-                username = TEST_USERNAME,
-                password = TEST_PASSWORD,
-                activationCode = TEST_ACTIVATION_CODE
-            )
-        }
+        coVerify(exactly = 1) { registrationRepository.registerPersonalAccount(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE) }
         coVerify(exactly = 1) { userRepository.save(user) }
         coVerify(exactly = 1) { sessionRepository.newAccessToken(TEST_REFRESH_TOKEN) }
         coVerify(exactly = 1) { sessionRepository.save(session, true) }
@@ -200,17 +192,16 @@ class RegisterPersonalAccountUseCaseTest : UnitTest() {
     }
 
     private fun mockRegistrationResponse(response: Either<Failure, PersonalAccountRegistrationResult>) {
-        coEvery { registrationRepository.registerPersonalAccount(any(), any(), any(), any(), any()) } returns response
+        coEvery { registrationRepository.registerPersonalAccount(any(), any(), any(), any()) } returns response
     }
 
     companion object {
         private const val TEST_NAME = "name"
         private const val TEST_EMAIL = "email"
-        private const val TEST_USERNAME = "username"
         private const val TEST_PASSWORD = "password"
         private const val TEST_ACTIVATION_CODE = "123456"
         private const val TEST_REFRESH_TOKEN = "refresh-token"
 
-        private val params = RegisterPersonalAccountParams(TEST_NAME, TEST_EMAIL, TEST_USERNAME, TEST_PASSWORD, TEST_ACTIVATION_CODE)
+        private val params = RegisterPersonalAccountParams(TEST_NAME, TEST_EMAIL, TEST_PASSWORD, TEST_ACTIVATION_CODE)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/ui/navigation/CreateAccountNavigatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/ui/navigation/CreateAccountNavigatorTest.kt
@@ -112,29 +112,27 @@ class CreateAccountNavigatorTest : AndroidTest() {
 
     @Test
     fun `given openPersonalAccountUsernameScreen is called, then replaces CreatePersonalAccountUsernameFragment on given activity`() {
-        createAccountNavigator.openPersonalAccountUsernameScreen(activity, TEST_NAME, TEST_EMAIL, TEST_ACTIVATION_CODE)
+        createAccountNavigator.openPersonalAccountUsernameScreen(activity)
 
         verify(exactly = 1) { fragmentStackHandler.replaceFragment(activity, capture(fragmentSlot), true) }
         fragmentSlot.captured.let {
             it shouldBeInstanceOf CreatePersonalAccountUsernameFragment::class.java
             it.argumentEquals(
-                CreatePersonalAccountUsernameFragment.newInstance(
-                    name = TEST_NAME, email = TEST_EMAIL, activationCode = TEST_ACTIVATION_CODE
-                )
+                CreatePersonalAccountUsernameFragment.newInstance()
             ) shouldBe true
         }
     }
 
     @Test
     fun `given openPersonalAccountPasswordScreen is called, then replaces CreatePersonalAccountPasswordFragment on given activity`() {
-        createAccountNavigator.openPersonalAccountPasswordScreen(activity, TEST_NAME, TEST_USERNAME, TEST_EMAIL, TEST_ACTIVATION_CODE)
+        createAccountNavigator.openPersonalAccountPasswordScreen(activity, TEST_NAME, TEST_EMAIL, TEST_ACTIVATION_CODE)
 
         verify(exactly = 1) { fragmentStackHandler.replaceFragment(activity, capture(fragmentSlot), true) }
         fragmentSlot.captured.let {
             it shouldBeInstanceOf CreatePersonalAccountPasswordFragment::class.java
             it.argumentEquals(
                 CreatePersonalAccountPasswordFragment.newInstance(
-                    name = TEST_NAME, username = TEST_USERNAME, email = TEST_EMAIL, activationCode = TEST_ACTIVATION_CODE
+                    name = TEST_NAME, email = TEST_EMAIL, activationCode = TEST_ACTIVATION_CODE
                 )
             ) shouldBe true
         }
@@ -183,7 +181,6 @@ class CreateAccountNavigatorTest : AndroidTest() {
         private const val TEST_EMAIL = "test@wire.com"
         private const val TEST_ACTIVATION_CODE = "234902"
         private const val TEST_NAME = "name"
-        private const val TEST_USERNAME = "username"
         private const val CONFIG_URL = "https://wire.com"
         private const val TEAM_ABOUT_URL_SUFFIX = "/products/pro-secure-team-collaboration/"
     }


### PR DESCRIPTION
This fixes the issue represented in the description of: https://github.com/wireapp/wire-android-reloaded/pull/157

This allows for us to preauthenticate with the backend before we allow the username to valid/run any checks