### PR TITLE
Fix: flaky test in CreateProAccountTeamNameFragment test

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameFragmentUiTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/auth/registration/pro/team/CreateProAccountTeamNameFragmentUiTest.kt
@@ -46,7 +46,7 @@ class CreateProAccountTeamNameFragmentUiTest : FunctionalActivityTest(CreateAcco
 
     @Test
     fun inputTextIsNotEmpty_confirmationButtonShouldBeEnabled() {
-        onView(withId(R.id.createProAccountTeamNameEditText)).perform(typeTextIntoFocusedView(TEST_TEAM_NAME))
+        onView(withId(R.id.createProAccountTeamNameEditText)).perform(replaceText(TEST_TEAM_NAME))
         onView(withId(R.id.createProAccountTeamNameInputConfirmationButton)).check(matches(isEnabled()))
     }
 


### PR DESCRIPTION
Potential fix for: 

```
com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailFragmentTest > inputTextIsNotEmpty_confirmationButtonShouldBeEnabled[Android SDK built for x86_64 - 9] [31mFAILED [0m
	androidx.test.espresso.base.DefaultFailureHandler$AssertionFailedWithCauseError: 'is enabled' doesn't match the selected view.
	Expected: is enabled
```