### PR TITLE
fix: NetworkModeService crashes on Android 11

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,8 +59,6 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,8 +286,6 @@
     <!-- Conversation: Profile Popover -->
 
     <!-- Calling/voice -->
-    <string name="calling__slow_connection__title">Slow Internet</string>
-    <string name="calling__slow_connection__message">Your Internet connection is too slow to call right now. Please try again later.</string>
     <string name="calling__cannot_start__title">Microphone required</string>
     <string name="calling__cannot_start__message">To call, hang up your current call.</string>
     <string name="calling__cannot_start__no_permission__message">Go to Settings and allow Wire to access the microphone.</string>

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
@@ -101,13 +101,6 @@ class CallStartController(implicit inj: Injector, cxt: WireContext, ec: EventCon
         true              <-
           inject[NetworkModeService].networkMode.head.flatMap {        //check network state, proceed if okay
             case NetworkMode.OFFLINE              => showErrorDialog(R.string.alert_dialog__no_network__header, R.string.calling__call_drop__message).map(_ => false)
-            case NetworkMode._2G                  => showErrorDialog(R.string.calling__slow_connection__title, R.string.calling__slow_connection__message).map(_ => false)
-            case NetworkMode.EDGE if curWithVideo =>
-              showConfirmationDialog(
-                getString(R.string.calling__slow_connection__title),
-                getString(R.string.calling__video_call__slow_connection__message),
-                color = color
-              )
             case _                                => Future.successful(true)
           }
         members           <- newCallZms.conversations.convMembers(newCallConv.id).head

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -288,7 +288,8 @@ class MainPhoneFragment extends FragmentHelper
     confirmationController.addConfirmationObserver(this)
     collectionController.addObserver(this)
     initShortcutDestinations()
-    inject[NetworkModeService].registerNetworkCallback().foreach(_ => consentDialog)
+    inject[NetworkModeService].registerNetworkCallback()
+    consentDialog
   }
 
   override def onResume(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.zclient.pages.main
 
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ShortcutManager
@@ -29,7 +30,7 @@ import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.model.{ErrorData, Uid}
 import com.waz.permissions.PermissionsService
 import com.waz.service.tracking.GroupConversationEvent
-import com.waz.service.{AccountManager, GlobalModule, ZMessaging}
+import com.waz.service.{AccountManager, GlobalModule, NetworkModeService, ZMessaging}
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.wire.signals.Signal
@@ -261,7 +262,7 @@ class MainPhoneFragment extends FragmentHelper
   }
 
   private def openGalleryPicker() =
-    inject[PermissionsService].requestAllPermissions(ListSet(android.Manifest.permission.READ_EXTERNAL_STORAGE)).map {
+    inject[PermissionsService].requestAllPermissions(ListSet(READ_EXTERNAL_STORAGE)).map {
       case true =>
         val galleryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
         safeStartActivityForResult(galleryIntent, Shortcuts.SHARE_PHOTO_REQUEST_CODE)
@@ -287,7 +288,7 @@ class MainPhoneFragment extends FragmentHelper
     confirmationController.addConfirmationObserver(this)
     collectionController.addObserver(this)
     initShortcutDestinations()
-    consentDialog
+    inject[NetworkModeService].registerNetworkCallback().foreach(_ => consentDialog)
   }
 
   override def onResume(): Unit = {

--- a/zmessaging/src/main/java/com/waz/api/NetworkMode.java
+++ b/zmessaging/src/main/java/com/waz/api/NetworkMode.java
@@ -18,11 +18,8 @@
 package com.waz.api;
 
 public enum NetworkMode {
-    _2G,
-    EDGE, //A.K.A 2.5G
-    _3G,
-    _4G,
     WIFI,
+    CELLULAR,
     OFFLINE,
     UNKNOWN
 }

--- a/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
@@ -48,6 +48,10 @@ class DefaultNetworkModeService(context: Context, lifeCycle: UiLifeCycle)
           networkMode ! mode
         }
 
+        /** FIXME: Trying to figure out if we are offline inside `onLost` may suffer from a race condition
+         *    and the app may end up thinking it's offline when it's not or vice versa. Try to find
+         *    a better solution.
+        */
         override def onLost(network: Network): Unit =
           if (Settings.Global.getInt(context.getContentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0) {
             info(l"new network mode: OFFLINE (the airplane mode is on)")

--- a/zmessaging/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
@@ -100,7 +100,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       awaitAllTasks
       calls shouldEqual 1
-      networkMode ! NetworkMode._4G
+      networkMode ! NetworkMode.CELLULAR
       result(currentToken.signal.filter(_.contains(newToken)).head)
 
     }


### PR DESCRIPTION
This fix uses a network callback to listen to changes in the network type. It avoids using NetworkInfo, TelephonyManager, and ConnectivityManager.getActiveNetwork.The only permission we need is ACCESS_NETWORK_STATE. We ask for it when the user opens the app for the first time after the update or installation, just before we register the network callback.

Instead of many types of cellular network we now have only one mode: CELLULAR. Because of this I removed code which warned the user that the network is slow. It checked if we are on 2G and EDGE networks. Anyway, it was only a partial solution - it was still possible for the user to be on 3G or 4G and have poor bandwidth.

There is an old method in NetworkModeService: `override def isDeviceIdleMode: Boolean = false`. I removed comments around it, but left it as it is for this fix. I want to change it to something more meaningful in another PR.

#### APK
[Download build #3020](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3020/artifact/build/artifact/wire-dev-PR3121-3020.apk)
[Download build #3021](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3021/artifact/build/artifact/wire-dev-PR3121-3021.apk)
[Download build #3022](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3022/artifact/build/artifact/wire-dev-PR3121-3022.apk)
[Download build #3023](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3023/artifact/build/artifact/wire-dev-PR3121-3023.apk)