### PR TITLE
Fix: Flaky test in CreateProAccountTeamEmailFragmentTest

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragmentTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/auth/registration/pro/email/CreateProAccountTeamEmailFragmentTest.kt
@@ -44,8 +44,10 @@ class CreateProAccountTeamEmailFragmentTest : FunctionalTest() {
 
     @Test
     fun inputTextIsNotEmpty_confirmationButtonShouldBeEnabled() {
-        onView(withId(R.id.createProAccountTeamEmailEditText))
-            .perform(replaceText(TEST_TEAM_EMAIL))
+        onView(withId(R.id.createProAccountTeamEmailEditText)).perform(
+            replaceText(TEST_TEAM_EMAIL),
+            closeSoftKeyboard()
+        )
         onView(withId(R.id.createProAccountTeamEmailInputConfirmationButton))
             .check(matches(isEnabled()))
     }


### PR DESCRIPTION
```
com.wire.android.feature.auth.registration.pro.email.CreateProAccountTeamEmailFragmentTest > inputTextIsNotEmpty_confirmationButtonShouldBeEnabled[Android SDK built for x86 - 10] FAILED 

	androidx.test.espresso.base.DefaultFailureHandler$AssertionFailedWithCauseError: 'is enabled' doesn't match the selected view.

	Expected: is enabled
```