### PR TITLE
fix: File sharing

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -25,7 +25,6 @@ import androidx.appcompat.app.AlertDialog
 import android.widget.Toast
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
-import com.waz.permissions.PermissionsService
 import com.waz.service.ZMessaging
 import com.waz.service.assets.AssetService
 import com.waz.service.assets.Asset.Image
@@ -61,7 +60,6 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   private lazy val keyboardController   = inject[KeyboardController]
   private lazy val userPrefsController  = inject[IUserPreferencesController]
   private lazy val clipboard            = inject[ClipboardUtils]
-  private lazy val permissions          = inject[PermissionsService]
   private lazy val replyController      = inject[ReplyController]
   private lazy val screenController = inject[ScreenController]
   private lazy val externalFileSharing = inject[ExternalFileSharing]

--- a/app/src/main/scala/com/waz/zclient/utils/Time.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/Time.scala
@@ -101,7 +101,6 @@ object Time {
       format(getString(datePatternRes, timePattern), localTime, defaultDateFormatter)
     }
   }
-
   object TimeStamp {
 
     def apply(time: Instant, showWeekday: Boolean = true): TimeStamp = {

--- a/zmessaging/src/main/scala/com/waz/content/WireContentProvider.scala
+++ b/zmessaging/src/main/scala/com/waz/content/WireContentProvider.scala
@@ -119,7 +119,7 @@ class WireContentProvider extends ContentProvider with DerivedLogTag {
   object CacheUriExtractor {
     val extractor = CacheUri.unapply(getContext) _
 
-    def unapply(uri: Uri): Option[CacheKey] = extractor(new AndroidURI(uri))
+    def unapply(uri: Uri): Option[CacheKey] = extractor(AndroidURI(uri))
   }
 }
 

--- a/zmessaging/src/main/scala/com/waz/utils/wrappers/URI.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/wrappers/URI.scala
@@ -66,17 +66,17 @@ trait URIBuilder {
 }
 
 //Default Android dependencies
-class AndroidURI(val uri: Uri) extends URI {
-  override def buildUpon                      = new AndroidURIBuilder(uri.buildUpon())
-  override def getPath                        = uri.getPath
-  override def getScheme                      = uri.getScheme
-  override def getAuthority                   = uri.getAuthority
-  override def getHost                        = uri.getHost
-  override def getPathSegments                = uri.getPathSegments.asScala.toList
-  override def getLastPathSegment             = uri.getLastPathSegment
-  override def normalizeScheme                = new AndroidURI(uri.normalizeScheme())
-  override def getQueryParameter(key: String) = uri.getQueryParameter(key)
-  override def toString                       = uri.toString
+final case class AndroidURI(uri: Uri) extends URI {
+  override def buildUpon: URIBuilder                  = new AndroidURIBuilder(uri.buildUpon())
+  override def getPath: String                        = uri.getPath
+  override def getScheme: String                      = uri.getScheme
+  override def getAuthority: String                   = uri.getAuthority
+  override def getHost: String                        = uri.getHost
+  override def getPathSegments: List[String]          = uri.getPathSegments.asScala.toList
+  override def getLastPathSegment: String             = uri.getLastPathSegment
+  override def normalizeScheme: URI                   = AndroidURI(uri.normalizeScheme())
+  override def getQueryParameter(key: String): String = uri.getQueryParameter(key)
+  override def toString: String                       = uri.toString
 }
 
 class AndroidURIBuilder(var uriBuilder: Uri.Builder) extends URIBuilder {
@@ -84,13 +84,13 @@ class AndroidURIBuilder(var uriBuilder: Uri.Builder) extends URIBuilder {
   override def encodedPath(path: String)                        = new AndroidURIBuilder(uriBuilder.encodedPath(path))
   override def appendEncodedPath(newSegment: String)            = new AndroidURIBuilder(uriBuilder.appendEncodedPath(newSegment))
   override def appendQueryParameter(key: String, value: String) = new AndroidURIBuilder(uriBuilder.appendQueryParameter(key, value))
-  override def build                                            = new AndroidURI(uriBuilder.build())
+  override def build: AndroidURI                                = AndroidURI(uriBuilder.build())
 
 }
 
 object AndroidURIUtil extends URIUtil {
-  override def parse(uri: String) = new AndroidURI(Uri.parse(uri))
-  override def fromFile(file: File) = new AndroidURI(Uri.fromFile(file))
+  override def parse(uri: String): AndroidURI = AndroidURI(Uri.parse(uri))
+  override def fromFile(file: File): AndroidURI = AndroidURI(Uri.fromFile(file))
 }
 
 object URI {

--- a/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
@@ -159,6 +159,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with Auth
 
       (assetStorage.find _).expects(*).once().returns(Future.successful(Some(asset)))
       (uriHelperMock.assetInput _).expects(*).anyNumberOfTimes().onCall { _: URI => AssetStream(inputStream) }
+      (uriHelperMock.extractMime _).expects(*).anyNumberOfTimes().returns(Success(Mime.Default))
       (uriHelperMock.openInputStream _)
         .expects(*)
         .anyNumberOfTimes()
@@ -185,6 +186,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with Auth
 
       (assetStorage.find _).expects(*).anyNumberOfTimes().returns(Future.successful(Some(asset)))
       (uriHelperMock.assetInput _).expects(*).anyNumberOfTimes().onCall { _: URI => AssetFailure(new IllegalArgumentException) }
+      (uriHelperMock.extractMime _).expects(*).anyNumberOfTimes().returns(Success(Mime.Default))
       (assetStorage.save _).expects(asset.copy(localSource = None)).anyNumberOfTimes().returns(Future.successful(()))
       (client.loadAssetContent _)
         .expects(asset, *)
@@ -217,6 +219,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with Auth
         .expects(*)
         .anyNumberOfTimes()
         .returns(Success(new ByteArrayInputStream(testAssetContent :+ 1.toByte)))
+      (uriHelperMock.extractMime _).expects(*).anyNumberOfTimes().returns(Success(Mime.Default))
       (assetStorage.save _).expects(asset.copy(localSource = None)).anyNumberOfTimes().returns(Future.successful(()))
       (client.loadAssetContent _)
         .expects(asset, *)

--- a/zmessaging/src/test/scala/com/waz/testutils/TestContentProvider.scala
+++ b/zmessaging/src/test/scala/com/waz/testutils/TestContentProvider.scala
@@ -78,10 +78,10 @@ class TestResourceContentProvider(val authority: String = "com.waz.testresources
     } getOrElse Empty
   })
 
-  override def getType(uri: Uri): String = getResource(new AndroidURI(uri)).mime.str
+  override def getType(uri: Uri): String = getResource(AndroidURI(uri)).mime.str
 
   override def query(uri: Uri, projection: Array[String], selection: String, selectionArgs: Array[String], sortOrder: String): Cursor =
-    getResource(new AndroidURI(uri)) match {
+    getResource(AndroidURI(uri)) match {
       case `Empty` => null
       case res => cursor(Vector(DISPLAY_NAME, SIZE), Vector(Vector(res.name, res.size.toString)))
     }


### PR DESCRIPTION
I rewrote `ShareActivity` and made some changes to `AssetService`. The rest is some slight refactoring.

I decided that the best way to simplify and make sure that the widest range of devices will work with this code is to copy
files temporarily to our cache directory and then sending that copy. This makes it easier for us to navigate Android
paths and permissions. Unfortunately, doing it for videos would be an overkill. Instead, in accordance to how we handle videos in other places in the assets functionality, we should access them directly. The side-effect of this is that on the sender's side the app may sometimes be forbidden from accessing the file - either at the moment of sharing the file or when the sender wants to play the file which is already displayed in the conversation. I tried to fix that but it was a bit of a trial and error process.
I can't be sure that it works on all devices. It works on the three I've got :)

If you have time, please download this PR, install it on your phones, and experiment a bit.

There's a place in `AssetService` where we validate the file by computing the sha and comparing it with the one we already have. I decided to drop this for videos - it takes too long and I suspect the app may reach a timeout at one of the internal steps. I'm thinking about dropping validation also for other file types if they are too big.

#### APK
[Download build #3046](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3046/artifact/build/artifact/wire-dev-PR3131-3046.apk)