### PR TITLE
feat: Feature Flag App Lock

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ android {
         buildConfigField 'boolean', 'KOTLIN_SETTINGS', "$rootProject.ext.kotlinSettings"
         buildConfigField 'boolean', 'KOTLIN_CORE', "$rootProject.ext.kotlinCore"
         buildConfigField 'boolean', 'ACTIVE_SPEAKERS', "$activeSpeakers"
+        buildConfigField 'boolean', 'APP_LOCK_FEATURE_FLAG', "$appLockFeatureFlag"
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -44,7 +44,7 @@ import com.waz.service.assets._
 import com.waz.service.call.GlobalCallingService
 import com.waz.service.conversation._
 import com.waz.service.messages.MessagesService
-import com.waz.service.teams.TeamsService
+import com.waz.service.teams.{FeatureFlagsService, TeamsService}
 import com.waz.service.tracking.TrackingService
 import com.waz.services.fcm.FetchJob
 import com.waz.services.gps.GoogleApiImpl
@@ -192,6 +192,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[ConversationFoldersStorage]]    to inject[Signal[ZMessaging]].map(_.conversationFoldersStorage)
     bind [Signal[FoldersService]]                to inject[Signal[ZMessaging]].map(_.foldersService)
     bind [Signal[TeamsService]]                  to inject[Signal[ZMessaging]].map(_.teams)
+    bind [Signal[FeatureFlagsService]]           to inject[Signal[ZMessaging]].map(_.featureFlags)
     bind [Signal[MessageIndexStorage]]           to inject[Signal[ZMessaging]].map(_.messagesIndexStorage)
     bind [Signal[ConnectionService]]             to inject[Signal[ZMessaging]].map(_.connection)
     bind [Signal[ButtonsStorage]]                to inject[Signal[ZMessaging]].map(_.buttonsStorage)

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -49,19 +49,9 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
 
   private lazy val sodiumHandler = inject[SodiumHandler]
 
+  // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
   if (BuildConfig.APP_LOCK_FEATURE_FLAG) {
-    // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled (let's say, June 2021?)
-    inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated).apply().foreach {
-      case true =>
-      case false =>
-        inject[GlobalPreferences].preference(GlobalPreferences.AppLockEnabled).apply().foreach { globalAppLock =>
-          prefs.map(_.preference(AppLockEnabled)).head.foreach { userAppLockPref =>
-            verbose(l"Migrating the AppLockEnabled preference (set to $globalAppLock) from global to user preferences")
-            userAppLockPref := globalAppLock
-            inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated) := true
-          }
-        }
-    }
+    appLockPrefMigration()
   }
 
   appInBackground.foreach {
@@ -183,4 +173,18 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       case Some(id) =>
         sodiumHandler.hash(password, id.str.replace("-", ""))
     }(Threading.Background)
+
+  // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
+  private def appLockPrefMigration() =
+    inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated).apply().foreach {
+      case true =>
+      case false =>
+        inject[GlobalPreferences].preference(GlobalPreferences.AppLockEnabled).apply().foreach { globalAppLock =>
+          prefs.map(_.preference(AppLockEnabled)).head.foreach { userAppLockPref =>
+            verbose(l"Migrating the AppLockEnabled preference (set to $globalAppLock) from global to user preferences")
+            userAppLockPref := globalAppLock
+            inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated) := true
+          }
+        }
+    }
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -19,19 +19,19 @@ package com.waz.zclient.common.controllers.global
 
 import android.content.Context
 import androidx.fragment.app.FragmentTransaction
-import com.waz.content.GlobalPreferences.AppLockEnabled
+import com.waz.content.UserPreferences.{AppLockEnabled, AppLockForced, AppLockTimeout}
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
+import com.waz.service.teams.FeatureFlagsService
 import com.waz.service.{AccountsService, GlobalModule, UserService}
 import com.waz.threading.Threading
-import com.waz.threading.Threading._
-import com.waz.utils.crypto.AESUtils.{encryptWithAlias, decryptWithAlias, EncryptedBytes}
-import com.waz.zclient.common.controllers.ThemeController
+import com.waz.utils.crypto.AESUtils.{EncryptedBytes, decryptWithAlias, encryptWithAlias}
+import com.waz.zclient.common.controllers.{ThemeController, UserAccountsController}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.preferences.dialogs.NewPasswordDialog
 import com.waz.zclient.security.ActivityLifecycleCallback
-import com.waz.zclient.{BaseActivity, Injectable, Injector}
+import com.waz.zclient.{BaseActivity, BuildConfig, Injectable, Injector}
 import com.wire.signals.{EventStream, Signal, SourceStream}
 
 import scala.concurrent.Future
@@ -41,15 +41,46 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
 
   private val accounts = inject[AccountsService]
   private val prefs = inject[Signal[UserPreferences]]
+  private val userAccountsController = inject[UserAccountsController]
+  private lazy val featureFlags = inject[Signal[FeatureFlagsService]]
+  private val appInBackground = inject[ActivityLifecycleCallback].appInBackground.map(_._1)
   private val ssoPassword = prefs.map(_.preference(UserPreferences.SSOPassword))
   private val ssoPasswordIv = prefs.map(_.preference(UserPreferences.SSOPasswordIv))
 
   private lazy val sodiumHandler = inject[SodiumHandler]
 
-  val ssoEnabled:       Signal[Boolean] = accounts.isActiveAccountSSO
-  val ssoPasswordEmpty: Signal[Boolean] = ssoPassword.flatMap(_.signal.map(_.isEmpty))
-  val appLockEnabled:   Signal[Boolean] = inject[GlobalPreferences].preference(AppLockEnabled).signal
-  lazy val password:    Signal[Option[Password]] = accounts.activeAccount.map(_.flatMap(_.password)).disableAutowiring()
+  // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled (let's say, June 2021?)
+  inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated).apply().foreach {
+    case true =>
+    case false =>
+      inject[GlobalPreferences].preference(GlobalPreferences.AppLockEnabled).apply().foreach { globalAppLock =>
+        prefs.map(_.preference(AppLockEnabled)).head.foreach { userAppLockPref =>
+          verbose(l"Migrating the AppLockEnabled preference (set to $globalAppLock) from global to user preferences")
+          userAppLockPref := globalAppLock
+          inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated) := true
+        }
+      }
+  }
+
+  appInBackground.foreach {
+    case true  =>
+      clearPassword()
+    case false =>
+      userAccountsController.isTeam.head.foreach {
+        case true  => featureFlags.head.foreach(_.updateAppLock())
+        case false =>
+      }
+  }
+
+  val ssoEnabled:       Signal[Boolean]                = accounts.isActiveAccountSSO
+  val ssoPasswordEmpty: Signal[Boolean]                = ssoPassword.flatMap(_.signal.map(_.isEmpty))
+  val appLockEnabled:   Signal[Boolean]                = prefs.flatMap(_.preference(AppLockEnabled).signal)
+  val appLockForced:    Signal[Boolean]                = prefs.flatMap(_.preference(AppLockForced).signal)
+  lazy val password:    Signal[Option[Password]]       = accounts.activeAccount.map(_.flatMap(_.password)).disableAutowiring()
+  val appLockTimeout: Signal[Int] = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
+    case None           => BuildConfig.APP_LOCK_TIMEOUT
+    case Some(duration) => duration.toSeconds.toInt
+  }
 
   val passwordCheckSuccessful: SourceStream[Unit] = EventStream[Unit]()
 
@@ -127,11 +158,6 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       ssoIvPref          <- ssoPasswordIv.head
       _                  <- ssoIvPref := Some(iv)
     } yield ()
-
-  inject[ActivityLifecycleCallback].appInBackground.onUi {
-    case (true, _) => clearPassword()
-    case _ =>
-  }
 
   private def checkSSOPassword(pwdToCheck: Password): Future[Boolean] =
     for {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
-import com.waz.content.GlobalPreferences.AppLockEnabled
+import com.waz.content.UserPreferences.AppLockEnabled
 import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.global.PasswordController
@@ -26,11 +26,16 @@ class AppLockView(context: Context, attrs: AttributeSet, style: Int)
   private val passwordController = inject[PasswordController]
 
   private val appLockSwitch = returning(findById[SwitchPreference](R.id.preferences_app_lock_switch)) { appLock =>
-    appLock.setPreference(AppLockEnabled, global = true)
-    appLock.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
+    appLock.setPreference(AppLockEnabled)
+    passwordController.appLockTimeout.foreach { timeout =>
+      appLock.setSubtitle(getString(R.string.pref_options_app_lock_summary, timeout.toString))
+    }
   }
 
-  appLockSwitch.setDisabled(BuildConfig.FORCE_APP_LOCK)
+  passwordController.appLockForced.map {
+    case true  => true
+    case false => BuildConfig.FORCE_APP_LOCK
+  }.foreach(appLockSwitch.setDisabled)
 
   private val appLockChangeButton = returning(findById[TextButton](R.id.preferences_app_lock_change_button)) { button =>
     button.onClickEvent.foreach { _ => passwordController.changeSSOPassword() }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -44,6 +44,7 @@ import com.waz.zclient.notifications.controllers.NotificationManagerWrapper.Andr
 import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
 import com.waz.threading.Threading._
+import com.waz.zclient.common.controllers.global.PasswordController
 
 trait OptionsView {
   def setSounds(level: IntensityLevel): Unit
@@ -103,7 +104,9 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)
 
-  appLockButton.setSubtitle(getString(R.string.pref_options_app_lock_summary, BuildConfig.APP_LOCK_TIMEOUT.toString))
+  inject[PasswordController].appLockTimeout.foreach { timeout =>
+    appLockButton.setSubtitle(getString(R.string.pref_options_app_lock_summary, timeout.toString))
+  }
 
   override val appLock: EventStream[Unit] = appLockButton.onClickEvent.map(_ => ())
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
 
 ext {
     activeSpeakers = true
+    appLockFeatureFlag = true
     //Update kotlinCore flag as well when adding new kotlin features
     kotlinSettings = false
     kotlinCore = kotlinSettings

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -328,7 +328,7 @@ object GlobalPreferences {
 
   lazy val IncognitoKeyboardEnabled: PrefKey[Boolean] = PrefKey[Boolean]("incognito_keyboard_enabled", customDefault = false)
 
-  //deprecated
+  // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
   lazy val AppLockEnabled: PrefKey[Boolean] = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
   lazy val GlobalAppLockDeprecated: PrefKey[Boolean] = PrefKey[Boolean]("global_app_lock_deprecated", customDefault = false)
 }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -414,8 +414,6 @@ object GlobalPreferences {
 
   lazy val RootDetected: PrefKey[Boolean] = PrefKey[Boolean]("root_detected", customDefault = false)
 
-  lazy val AppLockEnabled: PrefKey[Boolean] = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
-
   lazy val IncognitoKeyboardEnabled: PrefKey[Boolean] = PrefKey[Boolean]("incognito_keyboard_enabled", customDefault = false)
 
   //DEPRECATED!!! Use the UserPreferences instead!!
@@ -423,6 +421,9 @@ object GlobalPreferences {
   lazy val _SoundsPrefKey = PrefKey[String]("PREF_KEY_SOUND")
   lazy val _DownloadImages = PrefKey[String]("zms_pref_image_download")
 
+  //deprecated
+  lazy val AppLockEnabled: PrefKey[Boolean] = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
+  lazy val GlobalAppLockDeprecated: PrefKey[Boolean] = PrefKey[Boolean]("global_app_lock_deprecated", customDefault = false)
 }
 
 object UserPreferences {
@@ -508,4 +509,8 @@ object UserPreferences {
 
   lazy val SSOPassword = PrefKey[Option[String]]("sso_password", customDefault = None)
   lazy val SSOPasswordIv = PrefKey[Option[String]]("sso_password_iv", customDefault = None)
+
+  lazy val AppLockEnabled: PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
+  lazy val AppLockForced:  PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_forced", customDefault = false)
+  lazy val AppLockTimeout: PrefKey[Option[FiniteDuration]] = PrefKey[Option[FiniteDuration]]("app_lock_timeout", customDefault = None)
 }

--- a/zmessaging/src/main/scala/com/waz/model/AppLockFeatureFlag.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AppLockFeatureFlag.scala
@@ -1,0 +1,35 @@
+package com.waz.model
+
+import java.util.concurrent.TimeUnit
+
+import com.waz.utils.JsonDecoder
+import org.json.JSONObject
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class AppLockFeatureFlag(enabled: Boolean, forced: Boolean, timeout: Option[FiniteDuration])
+
+object AppLockFeatureFlag {
+  val Default: AppLockFeatureFlag = AppLockFeatureFlag(enabled = false, forced = false, None)
+
+  import JsonDecoder._
+
+  final case class AppLockConfig(enforceAppLock: Boolean, inactivityTimeoutSecs: Int)
+
+  implicit object Decoder extends JsonDecoder[AppLockFeatureFlag] {
+    private def decodeConfig(implicit js: JSONObject): AppLockConfig = {
+      AppLockConfig('enforceAppLock, 'inactivityTimeoutSecs)
+    }
+
+    override def apply(implicit js: JSONObject): AppLockFeatureFlag =
+      if (js.getString("status") == "enabled") {
+        val config = decodeConfig(js.getJSONObject("config"))
+        AppLockFeatureFlag(
+          enabled = true,
+          forced  = config.enforceAppLock,
+          timeout = Some(FiniteDuration(config.inactivityTimeoutSecs, TimeUnit.SECONDS))
+        )
+      } else
+        Default
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -36,7 +36,7 @@ import com.waz.service.media._
 import com.waz.service.messages._
 import com.waz.service.otr._
 import com.waz.service.push._
-import com.waz.service.teams.{TeamsService, TeamsServiceImpl}
+import com.waz.service.teams.{FeatureFlagsService, FeatureFlagsServiceImpl, TeamsService, TeamsServiceImpl}
 import com.waz.service.tracking.TrackingService
 import com.waz.sync._
 import com.waz.sync.client._
@@ -192,6 +192,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val usersClient        = new UsersClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val convClient         = new ConversationsClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val teamClient         = new TeamsClientImpl()(urlCreator, httpClient, authRequestInterceptor)
+  lazy val featureFlagsClient = new FeatureFlagsClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val pushNotificationsClient: PushNotificationsClient = new PushNotificationsClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val gcmClient          = new PushTokenClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val typingClient       = new TypingClientImpl()(urlCreator, httpClient, authRequestInterceptor)
@@ -224,6 +225,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val convsUi: ConversationsUiService            = wire[ConversationsUiServiceImpl]
   lazy val selectedConv: SelectedConversationService  = wire[SelectedConversationServiceImpl]
   lazy val teams: TeamsService                        = wire[TeamsServiceImpl]
+  lazy val featureFlags: FeatureFlagsService          = wire[FeatureFlagsServiceImpl]
   lazy val integrations: IntegrationsService          = wire[IntegrationsServiceImpl]
   lazy val messages: MessagesServiceImpl              = wire[MessagesServiceImpl]
   lazy val verificationUpdater                        = wire[VerificationStateUpdater]
@@ -251,6 +253,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val usersSync: UsersSyncHandler                = wire[UsersSyncHandlerImpl]
   lazy val conversationSync                           = wire[ConversationsSyncHandler]
   lazy val teamsSync:       TeamsSyncHandler          = wire[TeamsSyncHandlerImpl]
+  lazy val featureFlagsSync: FeatureFlagsSyncHandler  = wire[FeatureFlagsSyncHandlerImpl]
   lazy val connectionsSync                            = wire[ConnectionsSyncHandler]
   lazy val gcmSync                                    = wire[PushTokenSyncHandler]
   lazy val typingSync                                 = wire[TypingSyncHandler]

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
@@ -1,0 +1,31 @@
+package com.waz.service.teams
+
+import com.waz.content.UserPreferences
+import com.waz.content.UserPreferences._
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.sync.handler.FeatureFlagsSyncHandler
+import com.waz.log.LogSE._
+
+import scala.concurrent.Future
+
+trait FeatureFlagsService {
+  def updateAppLock(): Future[Unit]
+}
+
+class FeatureFlagsServiceImpl(syncHandler: FeatureFlagsSyncHandler,
+                              userPrefs: UserPreferences)
+  extends FeatureFlagsService with DerivedLogTag {
+  import com.waz.threading.Threading.Implicits.Background
+
+  override def updateAppLock(): Future[Unit] = syncHandler.fetchAppLock().map {
+    case appLock if appLock.enabled =>
+      verbose(l"AppLock feature flag enabled: $appLock")
+      for {
+        _ <- if (appLock.forced) userPrefs(AppLockEnabled) := true else Future.successful(())
+        _ <- userPrefs(AppLockForced) := appLock.forced
+        _ <- userPrefs(AppLockTimeout) := appLock.timeout
+      } yield ()
+    case _ =>
+      verbose(l"AppLock feature flag disabled")
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/sync/client/FeatureFlagsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/FeatureFlagsClient.scala
@@ -1,0 +1,34 @@
+package com.waz.sync.client
+
+import com.waz.api.impl.ErrorResponse
+import com.waz.model.{AppLockFeatureFlag, TeamId}
+import com.waz.znet2.AuthRequestInterceptor
+import com.waz.znet2.http.Request.UrlCreator
+import com.waz.znet2.http.{HttpClient, RawBodyDeserializer, Request}
+import org.json.JSONObject
+
+trait FeatureFlagsClient {
+  def getAppLock(teamId: TeamId): ErrorOrResponse[AppLockFeatureFlag]
+}
+
+class FeatureFlagsClientImpl(implicit
+                             urlCreator: UrlCreator,
+                             httpClient: HttpClient,
+                             authRequestInterceptor: AuthRequestInterceptor) extends FeatureFlagsClient {
+  import FeatureFlagsClient._
+  import HttpClient.dsl._
+  import HttpClient.AutoDerivationOld._
+
+  private implicit val AppLockFeatureFlagDeserializer: RawBodyDeserializer[AppLockFeatureFlag] =
+    RawBodyDeserializer[JSONObject].map(json => AppLockFeatureFlag.Decoder(json))
+
+  override def getAppLock(teamId: TeamId): ErrorOrResponse[AppLockFeatureFlag] =
+    Request.Get(relativePath = path(teamId))
+      .withResultType[AppLockFeatureFlag]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+}
+
+object FeatureFlagsClient {
+  def path(teamId: TeamId): String = s"/teams/${teamId.str}/features/appLock"
+}

--- a/zmessaging/src/main/scala/com/waz/sync/handler/FeatureFlagsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/FeatureFlagsSyncHandler.scala
@@ -1,0 +1,30 @@
+package com.waz.sync.handler
+
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.log.LogSE._
+import com.waz.model.{AppLockFeatureFlag, TeamId}
+import com.waz.sync.client.FeatureFlagsClient
+
+import scala.concurrent.Future
+
+trait FeatureFlagsSyncHandler {
+  def fetchAppLock(): Future[AppLockFeatureFlag]
+}
+
+class FeatureFlagsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureFlagsClient)
+  extends FeatureFlagsSyncHandler with DerivedLogTag {
+  import com.waz.threading.Threading.Implicits.Background
+
+  override def fetchAppLock(): Future[AppLockFeatureFlag] = teamId match {
+    case None =>
+      Future.successful(AppLockFeatureFlag.Default)
+    case Some(tId) =>
+      client.getAppLock(tId).future.map {
+        case Left(err) =>
+          error(l"Unable to fetch AppLock feature flag: $err")
+          AppLockFeatureFlag.Default
+        case Right(appLock) =>
+          appLock
+      }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/model/AppLockFeatureFlagSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/AppLockFeatureFlagSpec.scala
@@ -1,0 +1,43 @@
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.JsonDecoder
+import scala.concurrent.duration._
+
+class AppLockFeatureFlagSpec extends AndroidFreeSpec {
+
+  feature("Deserialization form JSON") {
+
+    scenario("Deserializing an enabled") {
+      val json =
+        """
+          |{
+          |  "status": "enabled",
+          |  "config": {
+          |    "enforceAppLock": true,
+          |    "inactivityTimeoutSecs": 60
+          |  }
+          |}
+          |""".stripMargin
+
+      val appLockFeatureFlag: AppLockFeatureFlag = JsonDecoder.decode[AppLockFeatureFlag](json)
+
+      appLockFeatureFlag.enabled shouldEqual true
+      appLockFeatureFlag.forced shouldEqual true
+      appLockFeatureFlag.timeout shouldEqual Some(60.seconds)
+    }
+
+    scenario("Deserializing a disabled flag") {
+      val json =
+        """
+          |{
+          |  "status": "disabled"
+          |}
+          |""".stripMargin
+
+      val appLockFeatureFlag: AppLockFeatureFlag = JsonDecoder.decode[AppLockFeatureFlag](json)
+
+      appLockFeatureFlag shouldEqual AppLockFeatureFlag.Default
+    }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureFlagsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureFlagsServiceSpec.scala
@@ -1,0 +1,56 @@
+package com.waz.service.teams
+
+import com.waz.content.UserPreferences._
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.model.AppLockFeatureFlag
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.handler.FeatureFlagsSyncHandler
+import com.waz.testutils.TestUserPreferences
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class FeatureFlagsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
+
+  private val userPrefs = new TestUserPreferences
+  private val syncHandler = mock[FeatureFlagsSyncHandler]
+
+  scenario("Fetch the AppLock feature flag and set properties") {
+    userPrefs.setValue(AppLockEnabled, false)
+    userPrefs.setValue(AppLockForced, false)
+    userPrefs.setValue(AppLockTimeout, Some(30.seconds))
+
+    (syncHandler.fetchAppLock _).expects().anyNumberOfTimes().returning(
+      Future.successful(AppLockFeatureFlag(enabled = true, forced = true, timeout = Some(10.seconds)))
+    )
+
+    val service = createService
+    result(service.updateAppLock())
+
+    result(userPrefs(AppLockEnabled).apply()) shouldEqual true
+    result(userPrefs(AppLockForced).apply()) shouldEqual true
+    result(userPrefs(AppLockTimeout).apply()) shouldEqual Some(10.seconds)
+  }
+
+  scenario("When the AppLock feature flag is disabled, don't change properties") {
+    // The name here is a bit confusing.
+    // "AppLockEnabled" in case of the property tells if the feature is on.
+    // "enabled" in case of the feature flag tells if the feature flag (set in the backend) interferes with the feature settings.
+    userPrefs.setValue(AppLockEnabled, true)
+    userPrefs.setValue(AppLockForced, false)
+    userPrefs.setValue(AppLockTimeout, Some(30.seconds))
+
+    (syncHandler.fetchAppLock _).expects().anyNumberOfTimes().returning(
+      Future.successful(AppLockFeatureFlag.Default)
+    )
+
+    val service = createService
+    result(service.updateAppLock())
+
+    result(userPrefs(AppLockEnabled).apply()) shouldEqual true
+    result(userPrefs(AppLockForced).apply()) shouldEqual false
+    result(userPrefs(AppLockTimeout).apply()) shouldEqual Some(30.seconds)
+  }
+
+  private def createService: FeatureFlagsService = new FeatureFlagsServiceImpl(syncHandler, userPrefs)
+}


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-58

Show App-lock feature setting in Wire account setting based on App-lock feature status.
The feature requires communication with a new endpoint for checking the feature flag status  every time when the app goes to the foreground.
If the flag is enabled, we use the returned config to check if the app lock is enforced and what is the timeout.
Contrary to the "forced" setting in the build config, if the app lock is forced by the feature flag, we don't wipe the data clean if the user fails to validate.
If the flag is disabled, local settings apply, just as until now.
The feature flags work only for team accounts. If the account is personal, we act as if the flag was disabled.
The PR also contains some refactoring - I moved the AppLockEnabled preference from GlobalPreferences to UserPreferences, I created user preferences for the "forced" setting and for the timeout, and I created a temporary flag in GlobalPreferences to migrate AppLockEnabled: If the user had AppLockEnabled set to true until now, that setting should be copied to UserPreferences.

#### APK
[Download build #3060](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3060/artifact/build/artifact/wire-dev-PR3137-3060.apk)
[Download build #3061](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3061/artifact/build/artifact/wire-dev-PR3137-3061.apk)
[Download build #3062](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3062/artifact/build/artifact/wire-dev-PR3137-3062.apk)