### PR TITLE
Changes required to make wire-android work with wire-signals 0.3.2

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -325,7 +325,7 @@ object ConversationListController {
     }
 
     val members = new AggregatingSignal[Map[ConvId, Seq[UserId]], Map[ConvId, Seq[UserId]]](
-      zms.membersStorage.list().map(entries),
+      () => zms.membersStorage.list().map(entries),
       updatedEntries,
       _ ++ _
     )
@@ -378,19 +378,19 @@ object ConversationListController {
             .map(LastMsgs.tupled)
 
     private def lastMessageSignal(conv: ConvId): Signal[Option[MessageData]] = cache.getOrElseUpdate(conv,
-      new AggregatingSignal[MessageData, Option[MessageData]](lastMessage(conv), messageUpdateEvents(conv), {
+      new AggregatingSignal[MessageData, Option[MessageData]](() => lastMessage(conv), messageUpdateEvents(conv), {
         case (res @ Some(last), update) if last.time.isAfter(update.time) => res
         case (_, update) => Some(update)
       }))
 
     private def lastReadSignal(conv: ConvId): Signal[Option[RemoteInstant]] = lastReadCache.getOrElseUpdate(conv,
-      new AggregatingSignal[RemoteInstant, Option[RemoteInstant]](lastRead(conv), lastReadUpdateEvents(conv), {
+      new AggregatingSignal[RemoteInstant, Option[RemoteInstant]](() => lastRead(conv), lastReadUpdateEvents(conv), {
         case (res @ Some(last), update) if last.isAfter(update) => res
         case (_, update) => Some(update)
       }))
 
     private def lastMissedCallSignal(conv: ConvId): Signal[Option[MessageData]] =
-      new AggregatingSignal[MessageData, Option[MessageData]](lastUnreadMissedCall(conv), missedCallUpdateEvents(conv), {
+      new AggregatingSignal[MessageData, Option[MessageData]](() => lastUnreadMissedCall(conv), missedCallUpdateEvents(conv), {
         case (res @ Some(last), update) if last.time.isAfter(update.time) => res
         case (_, update) => Some(update)
       })

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -191,7 +191,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.3.1"
+    const val WIRE_SIGNALS = "0.3.2"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/zmessaging/src/main/scala/com/waz/api/impl/RecordingLevels.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/RecordingLevels.scala
@@ -28,7 +28,7 @@ import scala.math.max
 
 class RecordingLevels(liveLevels: EventStream[Float]) extends DerivedLogTag {
   private val allLevels = returning(
-    new AggregatingSignal[Float, Vector[Float]](Future.successful(Vector.empty), liveLevels, _ :+ _)
+    new AggregatingSignal[Float, Vector[Float]](() => Future.successful(Vector.empty), liveLevels, _ :+ _)
   )(_.disableAutowiring())
 
   def windowed(windowSize: Int): Signal[Array[Float]] = allLevels map { levels =>

--- a/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -72,7 +72,7 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
       unread <- Signal.from(messages.countUnread(convId, time))
     } yield unread
 
-    val messagesCursor: Signal[MessagesCursor] = new RefreshingSignal(loadCursor, indexChanged.filter(_.orderChanged))
+    val messagesCursor: Signal[MessagesCursor] = new RefreshingSignal(() => loadCursor, indexChanged.filter(_.orderChanged))
   }
 
   import sources._

--- a/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -63,7 +63,7 @@ class MembersStorageImpl(context: Context, storage: ZmsDatabase)
         .zip(onDeleted.map(_.filter(_._2 == conv).map(_._1 -> false)))
 
     new AggregatingSignal[Seq[(UserId, Boolean)], Set[UserId]](
-      getActiveUsers(conv).map(_.toSet),
+      () => getActiveUsers(conv).map(_.toSet),
       onConvMemberChanged(conv),
       { (current, changes) =>
         val (active, inactive) = changes.partition(_._2)

--- a/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
@@ -50,7 +50,7 @@ class ReactionsStorageImpl(context: Context, storage: Database)
   private val likesCache = new TrimmingLruCache[MessageId, Map[UserId, RemoteInstant]](context, Fixed(1024))
   private val maxTime = returning(
     new AggregatingSignal[RemoteInstant, RemoteInstant](
-      storage.read(LikingDao.findMaxTime(_)),
+      () => storage.read(LikingDao.findMaxTime(_)),
       onChanged.map(_.maxBy(_.timestamp).timestamp),
       _ max _
     )
@@ -89,7 +89,7 @@ class ReactionsStorageImpl(context: Context, storage: Database)
 
   override def likes(msg: MessageId): Signal[Likes] =
     new RefreshingSignal[Likes](
-      CancellableFuture.lift(getLikes(msg)),
+      () => CancellableFuture.lift(getLikes(msg)),
       onChanged.map(_.filter(_.message == msg))
     )
 

--- a/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -45,11 +45,11 @@ class UsersStorageImpl(context: Context, storage: ZmsDatabase)
     with UsersStorage {
   import com.waz.threading.Threading.Implicits.Background
 
-  override def listAll(ids: Traversable[UserId]) = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))
+  override def listAll(ids: Traversable[UserId]): Future[Vector[UserData]] = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))
 
   override def listSignal(ids: Traversable[UserId]): Signal[Vector[UserData]] = {
     val idSet = ids.toSet
-    new RefreshingSignal(listAll(ids).lift, onChanged.map(_.filter(u => idSet(u.id))).filter(_.nonEmpty))
+    new RefreshingSignal(() => listAll(ids).lift, onChanged.map(_.filter(u => idSet(u.id))).filter(_.nonEmpty))
   }
 
   override def listUsersByConnectionStatus(p: Set[ConnectionStatus]): Future[Map[UserId, UserData]] =

--- a/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
+++ b/zmessaging/src/main/scala/com/waz/permissions/PermissionsService.scala
@@ -49,7 +49,7 @@ class PermissionsService extends DerivedLogTag {
     (for {
       keys       <- knownKeys
       Some(prov) <- providerSignal
-      res        <- RefreshingSignal(Threading.Ui.apply(prov.hasPermissions(keys.map(Permission(_)))), refresh)
+      res        <- RefreshingSignal(() => Threading.Ui.apply(prov.hasPermissions(keys.map(Permission(_)))), refresh)
   } yield res).disableAutowiring()
 
   /**

--- a/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
@@ -79,7 +79,7 @@ class ErrorsServiceImpl(userId:    UserId,
     dismissHandler = dismissHandler.orElse(handler)
   }
 
-  def getErrors: Signal[Vector[ErrorData]] = new RefreshingSignal(CancellableFuture(errors.values.toVector.sortBy(_.time)), onChanged)
+  def getErrors: Signal[Vector[ErrorData]] = new RefreshingSignal(() => CancellableFuture(errors.values.toVector.sortBy(_.time)), onChanged)
 
   def dismissError(id: Uid): Future[Unit] =
     storage { ErrorDataDao.getById(id)(_) }

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -135,7 +135,7 @@ class UserServiceImpl(selfUserId:        UserId,
     def initialLoad = usersStorage.list().map(_.map(user => user.id -> user.name).toMap)
 
     new AggregatingSignal[Map[UserId, Name], Map[UserId, Name]](
-      initialLoad,
+      () => initialLoad,
       EventStream.zip(added, updated),
       { (values, changes) => values ++ changes }
     )
@@ -187,7 +187,7 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] =
     new AggregatingSignal[Seq[UserData], Map[UserId, UserData]](
-      usersStorage.listUsersByConnectionStatus(AcceptedOrBlocked),
+      () => usersStorage.listUsersByConnectionStatus(AcceptedOrBlocked),
       usersStorage.onChanged,
       { (accu, us) =>
         val (toAdd, toRemove) = us.partition(u => AcceptedOrBlocked(u.connection))

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -271,7 +271,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         .zip(membersStorage.onDeleted.map(_.filter(_._2 == conv).map(_._1 -> (None, false)))).map(_.toMap)
 
     new AggregatingSignal[Map[UserId, (Option[ConversationMemberData], Boolean)], Seq[ConversationMemberData]](
-      membersStorage.getByConv(conv),
+      () => membersStorage.getByConv(conv),
       onConvMemberDataChanged,
       { (current, changes) =>
         val (active, inactive) = changes.partition(_._2._2)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/FoldersService.scala
@@ -204,7 +204,7 @@ class FoldersServiceImpl(foldersStorage: FoldersStorage,
     } yield folderConvs.toMap
 
     new AggregatingSignal[(Set[FolderId], Set[FolderId], Map[FolderId, Set[ConvId]], Map[FolderId, Set[ConvId]]), Map[FolderId, Set[ConvId]]](
-      loadAll,
+      () => loadAll,
       changesStream,
       { case (current, (deletedFolderIds, addedFolderIds, removedConvIds, addedConvIds)) =>
         // Step 1: remove deleted folders and add new ones

--- a/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -63,7 +63,7 @@ class TypingService(userId:        UserId,
   }
 
   def typingUsers(conv: ConvId): Signal[IndexedSeq[UserId]] = new AggregatingSignal[IndexedSeq[TypingUser], IndexedSeq[UserId]] (
-    loader        = Future { typing(conv).map(_.id) },
+    loader        = () => Future { typing(conv).map(_.id) },
     sourceStream  = onTypingChanged.filter(_._1 == conv).map(_._2),
     updater       = (_, updated) => updated.map(_.id)
   )

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -480,7 +480,7 @@ class MessagesServiceImpl(selfUserId:      UserId,
   override def getAssetIds(messageIds: Set[MessageId]): Future[Set[GeneralAssetId]] = storage.getAssetIds(messageIds)
 
   override def buttonsForMessage(msgId: MessageId): Signal[Seq[ButtonData]] = RefreshingSignal[Seq[ButtonData]](
-    loader        = CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),
+    loader        = () => CancellableFuture.lift(buttonsStorage.findByMessage(msgId).map(_.sortBy(_.ordinal))),
     refreshStream = EventStream.zip(buttonsStorage.onChanged.map(_.map(_.id)), buttonsStorage.onDeleted)
   )
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -103,7 +103,7 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
     val stream = onCreate.filter(_ == sid).mapAsync(_ => fingerprint)
 
     new AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]](
-      fingerprint,
+      () => fingerprint,
       stream,
       (_, next) => next
     )

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -129,7 +129,7 @@ class TeamsServiceImpl(selfUser:           UserId,
       def userMatches(data: UserData) = data.isInTeam(teamId) && data.matchesQuery(query)
 
       new AggregatingSignal[Seq[ContentChange[UserId, UserData]], Set[UserData]](
-        load,
+        () => load,
         changesStream,
         { (current, changes) =>
           val added = changes.collect {
@@ -153,7 +153,7 @@ class TeamsServiceImpl(selfUser:           UserId,
       Signal.const[Option[TeamData]](None)
     case Some(id) =>
       new RefreshingSignal(
-        CancellableFuture.lift(teamStorage.get(id)),
+        () => CancellableFuture.lift(teamStorage.get(id)),
         teamStorage.onChanged.map(_.filter(_.id == id)).filter(_.nonEmpty)
       )
   }
@@ -171,7 +171,7 @@ class TeamsServiceImpl(selfUser:           UserId,
 
     teamId match {
       case None => Signal.const(Set.empty[UserId])
-      case Some(id) => new RefreshingSignal(CancellableFuture.lift(load(id)), allChanges)
+      case Some(id) => RefreshingSignal(() => CancellableFuture.lift(load(id)), allChanges)
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -102,7 +102,7 @@ class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater with Deriv
     }
 
     new AggregatingSignal[Cmd, Map[SyncId, SyncJob]](
-      listSyncJobs.map(_.toIdMap),
+      () => listSyncJobs.map(_.toIdMap),
       onChange,
       {
         case (jobs, Add(job))    => jobs + (job.id -> job)

--- a/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
@@ -94,7 +94,7 @@ trait ReactiveStorage2[K, V <: Identifiable[K]] extends Storage2[K, V] {
   def optSignal(key: K): Signal[Option[V]] = {
     val changeOrDelete = onChanged(key).map(Option(_)).zip(onRemoved(key).map(_ => Option.empty[V]))
     new AggregatingSignal[Option[V], Option[V]](
-      find(key),
+      () => find(key),
       changeOrDelete,
       { (_, v) => v }
     )
@@ -367,7 +367,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
   def optSignal(key: K): Signal[Option[V]] = {
     val changeOrDelete = onChanged(key).map(Option(_)).zip(onRemoved(key).map(_ => Option.empty[V]))
     new AggregatingSignal[Option[V], Option[V]](
-      get(key),
+      () => get(key),
       changeOrDelete,
       { (_, v) => v }
     )
@@ -538,7 +538,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
       valueMap = values.map { v => v.id -> v }.toMap
     } yield valueMap
 
-    new AggregatingSignal[Seq[ContentChange[K, V]], Map[K, V]](load, changesStream, { (values, changes) =>
+    new AggregatingSignal[Seq[ContentChange[K, V]], Map[K, V]](() => load, changesStream, { (values, changes) =>
       val added = new mutable.HashMap[K, V]
       val removed = new mutable.HashSet[K]
       changes foreach {


### PR DESCRIPTION
To make Wire Signals code compatible across Scala versions (2.11, 2.12, 2.13) I had to change one thing in the API: RefreshingSignal and AggregatingSignal take as an argument a reference to a "loader" - a future which will initially compute the value of the signal. Until now, that reference was given by name, which meant that it could be use many times, lazily. It wasn't called in the moment when it was given to the constructor, but it was saved in the signal and called later, as many times as needed. This is no longer the case. Now, the same functionality is achieved by giving to the constructor, as an argument, a function which will produce the future each time it is called.

It's also more intuitive this way. The old way gave an impression that the future is called once, immediately.

The changes in Wire Signals 0.3.2 include also fixing a bug in EventStream.mapAsync, and some compilation-time optimizations.
#### APK
[Download build #3063](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3063/artifact/build/artifact/wire-dev-PR3142-3063.apk)