### PR TITLE
[Calling] fix : active speaker bugs

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -102,11 +102,11 @@ class ControlsFragment extends FragmentHelper {
         controller.isFullScreenEnabled
       ).onUi {
         case (true, true, true, false) => speakersLayoutContainer.foreach(_.setVisibility(View.VISIBLE))
-        case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.GONE))
+        case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
       }
     }
     else {
-      speakersLayoutContainer.foreach(_.setVisibility(View.GONE))
+      speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
     }
 
   }

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -26,7 +26,6 @@ import androidx.annotation.Nullable
 import androidx.fragment.app.Fragment
 import com.waz.service.call.Avs.VideoState
 import com.waz.threading.Threading._
-import com.waz.utils.returning
 import com.waz.zclient.calling.controllers.CallController
 import com.waz.zclient.calling.views.{CallingHeader, CallingMiddleLayout, ControlsView}
 import com.waz.zclient.log.LogUI._
@@ -46,22 +45,8 @@ class ControlsFragment extends FragmentHelper {
   private lazy val callingMiddle = view[CallingMiddleLayout](R.id.calling_middle)
   private lazy val callingControls = view[ControlsView](R.id.controls_grid)
   private lazy val speakersLayoutContainer = view[LinearLayout](R.id.all_speakers_layout)
-  private lazy val speakersButton = returning(view[Button](R.id.speakers_button)) { vh =>
-    vh.foreach { button =>
-      button.onClick {
-        updateToggleSelection(true)
-      }
-    }
-  }
-
-  private lazy val allButton = returning(view[Button](R.id.all_button)) { vh =>
-    vh.foreach { button =>
-      button.setSelected(true)
-      button.onClick {
-        updateToggleSelection(false)
-      }
-    }
-  }
+  private lazy val speakersButton = view[Button](R.id.speakers_button)
+  private lazy val allButton = view[Button](R.id.all_button)
 
   private var subs = Set[Subscription]()
 
@@ -78,8 +63,18 @@ class ControlsFragment extends FragmentHelper {
 
   override def onViewCreated(v: View, @Nullable savedInstanceState: Bundle): Unit = {
     super.onViewCreated(v, savedInstanceState)
-    speakersButton
-    allButton
+
+    speakersButton.foreach { button =>
+      button.onClick {
+        updateToggleSelection(true)
+      }
+    }
+    allButton.foreach { button =>
+      button.setSelected(true)
+      button.onClick {
+        updateToggleSelection(false)
+      }
+    }
 
     controller.showTopSpeakers.onUi { shouldShowActiveSpeakers =>
       updateToggleSelection(shouldShowActiveSpeakers)


### PR DESCRIPTION
## What's new in this PR?

This PR include fixes for two active speaker bugs:

- Speakers/All toggle don't work after clicking on show all button and going back to `ControlsFragment`.
- When user double taps on a video tile, call drops

https://wearezeta.atlassian.net/browse/SQCALL-121
https://wearezeta.atlassian.net/browse/SQCALL-120


#### APK
[Download build #3069](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3069/artifact/build/artifact/wire-dev-PR3145-3069.apk)
[Download build #3072](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3072/artifact/build/artifact/wire-dev-PR3145-3072.apk)