### PR TITLE
Fix: Asset selection intent for developer mode

### DIFF
--- a/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
+++ b/app/src/main/java/com/waz/zclient/pages/main/conversation/AssetIntentsManager.java
@@ -85,8 +85,7 @@ public class AssetIntentsManager {
                 intent.setType(INTENT_ALL_TYPES);
                 intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes.toArray());
             }
-            if (!context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_ALL).isEmpty()) {
-                callback.openIntent(intent, tpe);
+            if (callback.openIntent(intent, tpe)) {
                 return;
             }
             Logger.info(TAG, "Did not resolve testing gallery for intent:" + intent.toString());
@@ -284,7 +283,7 @@ public class AssetIntentsManager {
 
         void onFailed(IntentType type);
 
-        void openIntent(Intent intent, AssetIntentsManager.IntentType intentType);
+        boolean openIntent(Intent intent, AssetIntentsManager.IntentType intentType);
     }
 
     public static void grantUriPermissions(Context context, Intent intent, Uri uri) {

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -85,7 +85,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
     }
     override def onCanceled(`type`: AssetIntentsManager.IntentType): Unit = {}
     override def onFailed(`type`: AssetIntentsManager.IntentType): Unit = {}
-    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
+    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Boolean =
       safeStartActivityForResult(intent, intentType.requestCode)
   }
 

--- a/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/CameraFragment.scala
@@ -118,7 +118,7 @@ class CameraFragment extends FragmentHelper
       override def onDataReceived(t: AssetIntentsManager.IntentType, uri: URI): Unit = processGalleryImage(uri)
       override def onCanceled(t: AssetIntentsManager.IntentType): Unit = showCameraFeed()
       override def onFailed(t: AssetIntentsManager.IntentType): Unit = showCameraFeed()
-      override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
+      override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Boolean =
         safeStartActivityForResult(intent, intentType.requestCode)
     })
   }

--- a/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/drawing/DrawingFragment.scala
@@ -360,9 +360,11 @@ class DrawingFragment extends FragmentHelper
 
   override def onFailed(tpe: AssetIntentsManager.IntentType): Unit = {}
 
-  override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit =
-    if (safeStartActivityForResult(intent, intentType.requestCode))
+  override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Boolean =
+    if (safeStartActivityForResult(intent, intentType.requestCode)) {
       getActivity.overridePendingTransition(R.anim.camera_in, R.anim.camera_out)
+      true
+    } else false
 
   override def onColorSelected(color: Int, strokeSize: Int): Unit = {
     onSketchClick() //when user selects color, they expect to be able to sketch

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -544,7 +544,7 @@ class ConversationFragment extends FragmentHelper {
         extendedCursorContainer.foreach(_.close(true))
     }
 
-    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Unit = {
+    override def openIntent(intent: Intent, intentType: AssetIntentsManager.IntentType): Boolean = {
       extendedCursorContainer.foreach { ecc =>
         if (MediaStore.ACTION_VIDEO_CAPTURE.equals(intent.getAction) &&
           ecc.getType == ExtendedCursorContainer.Type.IMAGES &&
@@ -554,8 +554,10 @@ class ConversationFragment extends FragmentHelper {
         }
       }
 
-      if (safeStartActivityForResult(intent, intentType.requestCode))
+      if (safeStartActivityForResult(intent, intentType.requestCode)) {
         getActivity.overridePendingTransition(R.anim.camera_in, R.anim.camera_out)
+        true
+      } else false
     }
 
     override def onFailed(tpe: AssetIntentsManager.IntentType): Unit = {}


### PR DESCRIPTION
## What's new in this PR?

### Issues

If app is in development mode, and Testing Gallery is installed on the phone, Testing Gallery should be opened instead of phone's own file storage.

For Android 10 and later, this functionality is broken and Testing Gallery is never opened.

### Causes

After Android 10, `context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_ALL)` check always returns an empty list. A similar problem was experienced before for Video sharing and fixed similarly on #3111 . Please refer to that PR for detailed explanation.

### Solutions

Return a boolean to denote whether the app is opened via callback.
### Testing

Steps:
1. Open a conversation
2. Select attachment icon in bottom conversation menu

**Scenario 1:**
- Wire Dev or Internal app is installed.
- Testing Gallery is installed

Expected Result:
Testing Gallery should be opened.

**Scenario 2:**
- Wire Dev or Internal app is installed.
- Testing Gallery is not installed

Expected Result:
Phone's Gallery should be opened.

**Scenario 3:**
- Wire Prod app is installed.
- Testing Gallery is installed

Expected Result:
Phone's Gallery should be opened.

**Scenario 4:**
- Wire Prod app is installed.
- Testing Gallery is not installed

Expected Result:
Phone's Gallery should be opened.

## Notes

_Specify here any other facts that you think are important for this issue. (Optional)_

#### APK
[Download build #3074](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3074/artifact/build/artifact/wire-dev-PR3147-3074.apk)