### PR TITLE
[Calling] bugfix : On group call when there are 2 participants, self-video turns black for a second each time the user starts speaking

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -165,7 +165,6 @@ class CallingFragment extends FragmentHelper {
         previewCardView.foreach { cardView =>
           if (!showTopSpeakers && views.size == 2 && participants.size == 2 && isVideoBeingSent) {
             verbose(l"Showing card preview")
-            cardView.removeAllViews()
             grid.removeView(selfView)
             selfView.setLayoutParams(
               new FrameLayout.LayoutParams(


### PR DESCRIPTION
This PR includes a fix for a bug related to active speakers feature : On group call when there are 2 participants, self-video turns black for a second each time the user starts speaking.
https://wearezeta.atlassian.net/browse/SQCALL-113
#### APK
[Download build #3076](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3076/artifact/build/artifact/wire-dev-PR3148-3076.apk)