### PR TITLE
App Lock Feature Flag #2

### DIFF
--- a/app/src/main/res/drawable/selector_alarm_confirmation_button_text_color.xml
+++ b/app/src/main/res/drawable/selector_alarm_confirmation_button_text_color.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:color="@color/white" app:state_confirmed="true" />
+    <item app:state_confirmed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+            <corners android:radius="@dimen/rounded_button_radius" />
+        </shape>
+    </item>
     <item android:color="?attr/alarmButtonTextColor" />
 </selector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="request_password_cancel">Cancel</string>
     <string name="request_password_biometric_description">Unlock using biometric authentication.</string>
     <string name="request_password_biometric_cancel">Cancel</string>
-    <string name="request_password_error">Wrong password</string>
+    <string name="request_password_error">Wrong passcode</string>
 
     <!-- Bots / Integrations / Services -->
     <string name="integrations_picker__section_title">Services</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,14 +478,15 @@
     <string name="pref_options_app_lock">Passcode</string>
     <string name="pref_options_app_lock_change">Change passcode</string>
     <string name="app_lock_locked_title">Wire is locked due to inactivity</string>
-    <string name="app_lock_locked_message">Please enter your account password.</string>
-    <string name="app_lock_setup_dialog_messsage">To unlock Wire, set up a passphrase in your device settings.</string>
+    <string name="app_lock_locked_message">Please enter your account passcode.</string>
+    <string name="app_lock_setup_dialog_messsage">To unlock Wire, set up a passcode in your device settings.</string>
     <string name="new_password_dialog_title">Create a Passcode</string>
     <string name="new_password_dialog_button">Create Passcode</string>
     <string name="new_password_dialog_title_change">Change Passcode</string>
     <string name="new_password_dialog_button_change">Change Passcode</string>
     <string name="new_password_dialog_message">Your organization needs to lock your app when Wire is not in use to keep the Team safe.\nCreate a memorable passcode, as it cannot be recovered.</string>
-    <string name="new_password_dialog_showhide_cd">Show/hide the password</string>
+    <string name="new_password_dialog_showhide_cd">Show/hide the passcode</string>
+    <string name="new_password_dialog_title_change_in_wire">There was a change in Wire</string>
 
     <!-- Options -->
     <string name="pref_options_screen_title">Options</string>
@@ -517,8 +518,8 @@
     <string name="pref_options_cursor_send_button_summary">Disable to send via the keyboard.</string>
     <string name="pref_options_message_previews">Message Previews</string>
     <string name="pref_options_message_previews_summary">Display message content in notifications.</string>
-    <string name="pref_options_app_lock_title">Lock with Passphrase</string>
-    <string name="pref_options_app_lock_summary">Lock Wire after %1$s seconds in the background. Unlock with Pin, Pattern, Password or Biometrics.</string>
+    <string name="pref_options_app_lock_title">Lock with Passcode</string>
+    <string name="pref_options_app_lock_summary">Lock Wire after %1$s seconds in the background. Unlock with Pin, Pattern, Passcode or Biometrics.</string>
     <string name="pref_options_incognito_keyboard">Incognito keyboard</string>
     <string name="pref_options_incognito_keyboard_summary">The keyboard will not show suggestions when typing messages</string>
 
@@ -532,7 +533,7 @@
     <string name="pref_devices_device_id">ID: %1$s</string>
     <string name="pref_devices_device_verified">Verified</string>
     <string name="pref_devices_device_not_verified">Not verified</string>
-    <string name="pref_devices_warning_summary">If you don\'t recognize a device above, remove it and reset your password.</string>
+    <string name="pref_devices_warning_summary">If you don\'t recognize a device above, remove it and reset your passcode.</string>
     <string name="pref_devices_device_screen_title">Device details</string>
     <string name="pref_devices_device_fingerprint_category_title">Key Fingerprint</string>
     <string name="pref_devices_device_fingerprint_summary">Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.</string>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -300,8 +300,8 @@ class MainActivity extends BaseActivity
         am.getOrRegisterClient().map {
           case Right(Registered(_)) =>
             for {
-              _ <- passwordController.clearPassword()
               z <- zms.head
+              _ <- z.users.clearAccountPassword()
               self <- z.users.selfUser.head
               isLogin <- z.userPrefs(IsLogin).apply()
               isNewClient <- z.userPrefs(IsNewClient).apply()

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -83,15 +83,14 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       _    <- openNewPasswordDialog(NewPasswordDialog.ChangeMode)
     } yield ()
 
-  def setCustomPasswordIfNeeded(forced: Boolean = false)(implicit ctx: Context): Future[Unit] =
+  def setCustomPasswordIfNeeded(fromSettings: Boolean = false)(implicit ctx: Context): Future[Unit] =
     for {
       enabled       <- appLockEnabled.head
-      forced        <- if (forced) Future.successful(true) else appLockForced.head
+      forced        <- appLockForced.head
       passwordPref  <- customPassword.head
       password      <- passwordPref()
-      _             <- if (enabled && forced && password.isEmpty) {
-                         openNewPasswordDialog(NewPasswordDialog.ChangeInWireMode)
-                       } else Future.successful(())
+      _             <- if (enabled && (fromSettings || forced) && password.isEmpty) openNewPasswordDialog(NewPasswordDialog.ChangeInWireMode)
+                       else Future.successful(())
     } yield ()
 
   // TODO: This check is used for the app lock, but some people still use the account password

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -30,7 +30,7 @@ import com.waz.utils.crypto.AESUtils.{EncryptedBytes, decryptWithAlias, encryptW
 import com.waz.zclient.common.controllers.{ThemeController, UserAccountsController}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.preferences.dialogs.NewPasswordDialog
-import com.waz.zclient.security.ActivityLifecycleCallback
+import com.waz.zclient.security.{ActivityLifecycleCallback, SecurityPolicyChecker}
 import com.waz.zclient.{BaseActivity, BuildConfig, Injectable, Injector}
 import com.wire.signals.{EventStream, Signal, SourceStream}
 
@@ -142,6 +142,7 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       _                  <- passwordPref := Some(encryptedPwd)
       passwordIvPref     <- customPasswordIv.head
       _                  <- passwordIvPref := Some(iv)
+      _                  =  inject[SecurityPolicyChecker].updateBackgroundEntryTimer()
     } yield ()
 
   private def hash(password: String): Future[Array[Byte]] =

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -24,7 +24,7 @@ import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.service.teams.FeatureFlagsService
-import com.waz.service.{AccountsService, GlobalModule, UserService}
+import com.waz.service.{AccountsService, UserService}
 import com.waz.threading.Threading
 import com.waz.utils.crypto.AESUtils.{EncryptedBytes, decryptWithAlias, encryptWithAlias}
 import com.waz.zclient.common.controllers.{ThemeController, UserAccountsController}
@@ -39,24 +39,23 @@ import scala.concurrent.Future
 class PasswordController(implicit inj: Injector) extends Injectable with DerivedLogTag {
   import Threading.Implicits.Background
 
-  private val accounts = inject[AccountsService]
-  private val prefs = inject[Signal[UserPreferences]]
-  private val userAccountsController = inject[UserAccountsController]
-  private lazy val featureFlags = inject[Signal[FeatureFlagsService]]
-  private val appInBackground = inject[ActivityLifecycleCallback].appInBackground.map(_._1)
-  private val ssoPassword = prefs.map(_.preference(UserPreferences.SSOPassword))
-  private val ssoPasswordIv = prefs.map(_.preference(UserPreferences.SSOPasswordIv))
-
-  private lazy val sodiumHandler = inject[SodiumHandler]
+  private lazy val accounts               = inject[AccountsService]
+  private lazy val prefs                  = inject[Signal[UserPreferences]]
+  private lazy val userAccountsController = inject[UserAccountsController]
+  private lazy val featureFlags           = inject[Signal[FeatureFlagsService]]
+  private lazy val appInBackground        = inject[ActivityLifecycleCallback].appInBackground
+  private lazy val customPassword         = prefs.map(_.preference(UserPreferences.CustomPassword))
+  private lazy val customPasswordIv       = prefs.map(_.preference(UserPreferences.CustomPasswordIv))
+  private lazy val sodiumHandler          = inject[SodiumHandler]
 
   // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
   if (BuildConfig.APP_LOCK_FEATURE_FLAG) {
     appLockPrefMigration()
   }
 
-  appInBackground.foreach {
+  appInBackground.map(_._1).foreach {
     case true  =>
-      clearPassword()
+      inject[Signal[UserService]].head.foreach(_.clearAccountPassword())
     case false =>
       if (BuildConfig.APP_LOCK_FEATURE_FLAG) {
         userAccountsController.isTeam.head.foreach {
@@ -66,11 +65,11 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       }
   }
 
-  val ssoEnabled:       Signal[Boolean]                = accounts.isActiveAccountSSO
-  val ssoPasswordEmpty: Signal[Boolean]                = ssoPassword.flatMap(_.signal.map(_.isEmpty))
-  val appLockEnabled:   Signal[Boolean]                = prefs.flatMap(_.preference(AppLockEnabled).signal)
-  val appLockForced:    Signal[Boolean]                = prefs.flatMap(_.preference(AppLockForced).signal)
-  lazy val password:    Signal[Option[Password]]       = accounts.activeAccount.map(_.flatMap(_.password)).disableAutowiring()
+  val ssoEnabled:           Signal[Boolean]                = accounts.isActiveAccountSSO
+  val customPasswordEmpty:  Signal[Boolean]                = customPassword.flatMap(_.signal.map(_.isEmpty))
+  val appLockEnabled:       Signal[Boolean]                = prefs.flatMap(_.preference(AppLockEnabled).signal)
+  val appLockForced:        Signal[Boolean]                = prefs.flatMap(_.preference(AppLockForced).signal)
+
   val appLockTimeout: Signal[Int] = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
     case None           => BuildConfig.APP_LOCK_TIMEOUT
     case Some(duration) => duration.toSeconds.toInt
@@ -78,42 +77,46 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
 
   val passwordCheckSuccessful: SourceStream[Unit] = EventStream[Unit]()
 
-  def setPassword(p: Password): Future[Unit] = setPassword(Some(p))
-  def clearPassword(): Future[Unit] = setPassword(None)
-
-  def changeSSOPassword()(implicit ctx: Context): Future[Unit] =
+  def changeCustomPassword()(implicit ctx: Context): Future[Unit] =
     for {
       true <- appLockEnabled.head
-      true <- ssoEnabled.head
       _    <- openNewPasswordDialog(NewPasswordDialog.ChangeMode)
     } yield ()
 
-  def setSSOPasswordIfNeeded()(implicit ctx: Context): Future[Unit] =
+  def setCustomPasswordIfNeeded(forced: Boolean = false)(implicit ctx: Context): Future[Unit] =
     for {
-      true        <- appLockEnabled.head
-      true        <- ssoEnabled.head
-      pwd         <- password.head
-      ssoPref     <- ssoPassword.head
-      ssoPassword <- ssoPref()
-      _           <- if (pwd.isEmpty && ssoPassword.isEmpty) openNewPasswordDialog(NewPasswordDialog.SetMode)
-                     else Future.successful(())
+      enabled       <- appLockEnabled.head
+      forced        <- if (forced) Future.successful(true) else appLockForced.head
+      passwordPref  <- customPassword.head
+      password      <- passwordPref()
+      _             <- if (enabled && forced && password.isEmpty) {
+                         openNewPasswordDialog(NewPasswordDialog.ChangeInWireMode)
+                       } else Future.successful(())
     } yield ()
 
+  // TODO: This check is used for the app lock, but some people still use the account password
+  // instead of the custom one as their app lock password. When everyone migrates, it can be simplified.
   def checkPassword(password: Password): Future[Boolean] =
     for {
-      isSSO <- ssoEnabled.head
-      users <- inject[Signal[UserService]].head
-      res   <- if (isSSO)
-                 checkSSOPassword(password).map {
-                   case true  => Right(())
-                   case false => Left("")
-                 }
-               else
-                 users.checkPassword(password)
-    } yield res match {
-      case Right(_)  => true
-      case Left(err) =>
-        verbose(l"Check password error: $err")
+      users       <- inject[Signal[UserService]].head
+      isEmpty     <- customPasswordEmpty.head
+      pwdCorrect  <- if (!isEmpty) checkCustomPassword(password)
+                     else users.checkAccountPassword(password).map(_.isRight)
+      _ = if (!pwdCorrect) verbose(l"wrong password")
+    } yield pwdCorrect
+
+  private def checkCustomPassword(pwdToCheck: Password): Future[Boolean] =
+    for {
+      Some(userId) <- accounts.activeAccountId.head
+      hashToCheck  <- hash(pwdToCheck.str)
+      ssoPref      <- customPassword.head
+      ssoPwd       <- ssoPref()
+      ssoIvPref    <- customPasswordIv.head
+      ssoIv        <- ssoIvPref()
+    } yield (ssoPwd, ssoIv) match {
+      case (Some(encryptedPwd), Some(iv)) =>
+        hashToCheck sameElements decryptWithAlias(EncryptedBytes(encryptedPwd, iv), userId.str)
+      case _ =>
         false
     }
 
@@ -131,42 +134,16 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       .commit
   }(Threading.Ui)
 
-  private def setPassword(pwd: Option[Password]): Future[Unit] =
-    for {
-      Some(accountData) <- accounts.activeAccount.head
-      _                 <- inject[GlobalModule].accountsStorage.update(accountData.id, _.copy(password = pwd))
-      isSSO             <- ssoEnabled.head
-      _                 <- pwd match {
-                             case Some(p) if isSSO => setSSOPassword(p)
-                             case _                => Future.successful(())
-                           }
-    } yield ()
-
-  private def setSSOPassword(pwd: Password): Future[Unit] =
+  def setCustomPassword(pwd: Password): Future[Unit] =
     for {
       Some(userId)       <- accounts.activeAccountId.head
       hashedPwd          <- hash(pwd.str)
       (encryptedPwd, iv) =  encryptWithAlias(hashedPwd, userId.str).asStrings
-      ssoPref            <- ssoPassword.head
-      _                  <- ssoPref := Some(encryptedPwd)
-      ssoIvPref          <- ssoPasswordIv.head
-      _                  <- ssoIvPref := Some(iv)
+      passwordPref       <- customPassword.head
+      _                  <- passwordPref := Some(encryptedPwd)
+      passwordIvPref     <- customPasswordIv.head
+      _                  <- passwordIvPref := Some(iv)
     } yield ()
-
-  private def checkSSOPassword(pwdToCheck: Password): Future[Boolean] =
-    for {
-      Some(userId) <- accounts.activeAccountId.head
-      hashToCheck  <- hash(pwdToCheck.str)
-      ssoPref      <- ssoPassword.head
-      ssoPwd       <- ssoPref()
-      ssoIvPref    <- ssoPasswordIv.head
-      ssoIv        <- ssoIvPref()
-    } yield (ssoPwd, ssoIv) match {
-      case (Some(encryptedPwd), Some(iv)) =>
-        hashToCheck sameElements decryptWithAlias(EncryptedBytes(encryptedPwd, iv), userId.str)
-      case _ =>
-        false
-    }
 
   private def hash(password: String): Future[Array[Byte]] =
     accounts.activeAccountId.head.collect {
@@ -175,7 +152,7 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
     }(Threading.Background)
 
   // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
-  private def appLockPrefMigration() =
+  private def appLockPrefMigration(): Unit =
     inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated).apply().foreach {
       case true =>
       case false =>

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -154,7 +154,7 @@ class MainPhoneFragment extends FragmentHelper
   }
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    inject[PasswordController].setSSOPasswordIfNeeded()
+    inject[PasswordController].setCustomPasswordIfNeeded()
 
     confirmationMenu.foreach(_.setVisibility(View.GONE))
     zms.flatMap(_.errors.getErrors).onUi {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
@@ -53,7 +53,7 @@ class NewPasswordDialog extends DialogFragment with FragmentHelper {
       .setMessage(getString(R.string.new_password_dialog_message))
       .setPositiveButton(mode.dialogButtonId, null)
 
-    if (mode == ChangeMode) builder.setNegativeButton(android.R.string.cancel, null)
+    if (mode.cancellable) builder.setNegativeButton(android.R.string.cancel, null)
 
     builder.create()
   }
@@ -108,24 +108,28 @@ object NewPasswordDialog {
     val id: String
     val dialogTitleId: Int
     val dialogButtonId: Int
+    val cancellable: Boolean
   }
 
   case object SetMode extends Mode {
     override val id: String = "Set"
     override val dialogTitleId: Int = R.string.new_password_dialog_title
     override val dialogButtonId: Int = R.string.new_password_dialog_button
+    override val cancellable: Boolean = false
   }
 
   case object ChangeMode extends Mode {
     override val id: String = "Change"
     override val dialogTitleId: Int = R.string.new_password_dialog_title_change
     override val dialogButtonId: Int = R.string.new_password_dialog_button_change
+    override val cancellable: Boolean = true
   }
 
   case object ChangeInWireMode extends Mode {
     override val id: String = "ChangeInWire"
     override val dialogTitleId: Int = R.string.new_password_dialog_title_change_in_wire
     override val dialogButtonId: Int = R.string.new_password_dialog_button
+    override val cancellable: Boolean = false
   }
 
   def getMode(id: String): Mode = id match {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
@@ -65,7 +65,7 @@ class NewPasswordDialog extends DialogFragment with FragmentHelper {
         def onClick(v: View): Unit = {
           val pass = passwordEditText.getText.toString
           if (strongPasswordValidator.isValidPassword(pass)) {
-            inject[PasswordController].setPassword(Password(pass))
+            inject[PasswordController].setCustomPassword(Password(pass))
             keyboard.hideKeyboardIfVisible()
             dismiss()
           } else {
@@ -122,8 +122,15 @@ object NewPasswordDialog {
     override val dialogButtonId: Int = R.string.new_password_dialog_button_change
   }
 
+  case object ChangeInWireMode extends Mode {
+    override val id: String = "ChangeInWire"
+    override val dialogTitleId: Int = R.string.new_password_dialog_title_change_in_wire
+    override val dialogButtonId: Int = R.string.new_password_dialog_button
+  }
+
   def getMode(id: String): Mode = id match {
-    case SetMode.id    => SetMode
-    case ChangeMode.id => ChangeMode
+    case SetMode.id          => SetMode
+    case ChangeMode.id       => ChangeMode
+    case ChangeInWireMode.id => ChangeInWireMode
   }
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -20,27 +20,23 @@ package com.waz.zclient.preferences.dialogs
 import android.app.Dialog
 import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Bundle
-import com.google.android.material.textfield.TextInputLayout
-import androidx.fragment.app.DialogFragment
-import androidx.appcompat.app.AlertDialog
 import android.view.inputmethod.EditorInfo
 import android.view.{KeyEvent, LayoutInflater, View, WindowManager}
 import android.widget.{EditText, TextView}
-import com.waz.api.EmailCredentials
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.textfield.TextInputLayout
 import com.waz.model.AccountData.Password
-import com.waz.service.ZMessaging
-import com.waz.threading.Threading
-import com.wire.signals.{EventStream, Signal}
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{FragmentHelper, R}
+import com.wire.signals.EventStream
 
 import scala.util.Try
 
 class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
   import RemoveDeviceDialog._
-  import Threading.Implicits.Ui
 
   val onDelete = EventStream[Option[Password]]()
 
@@ -48,16 +44,7 @@ class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
 
   private def providePassword(password: Option[Password]): Unit = {
     onDelete ! password
-    password.foreach { pwd =>
-      for {
-        zms         <- inject[Signal[ZMessaging]].head
-        Some(am)    <- zms.accounts.activeAccountManager.head
-        self        <- am.getSelf
-        Some(email) = self.email
-        _           <- zms.auth.onPasswordReset(Option(EmailCredentials(email, pwd)))
-      } yield ()
-    }
-    dismiss()
+    dismiss() // if the password is wrong a new dialog will appear
   }
 
   private lazy val passwordEditText = returning(findById[EditText](root, R.id.acet__remove_otr__password)) { v =>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
@@ -42,7 +42,7 @@ class AppLockView(context: Context, attrs: AttributeSet, style: Int)
 
   passwordController.appLockEnabled.foreach {
     case true =>
-      passwordController.setCustomPasswordIfNeeded(forced = true)
+      passwordController.setCustomPasswordIfNeeded(fromSettings = true)
       appLockChangeButton.setVisible(true)
     case false =>
       appLockChangeButton.setVisible(false)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
@@ -13,7 +13,6 @@ import com.waz.zclient.preferences.views.{SwitchPreference, TextButton}
 import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.zclient.{BuildConfig, R, ViewHelper}
 import com.waz.zclient.utils._
-import com.wire.signals.Signal
 
 class AppLockView(context: Context, attrs: AttributeSet, style: Int)
   extends LinearLayout(context, attrs, style) with ViewHelper {
@@ -38,14 +37,14 @@ class AppLockView(context: Context, attrs: AttributeSet, style: Int)
   }.foreach(appLockSwitch.setDisabled)
 
   private val appLockChangeButton = returning(findById[TextButton](R.id.preferences_app_lock_change_button)) { button =>
-    button.onClickEvent.foreach { _ => passwordController.changeSSOPassword() }
+    button.onClickEvent.foreach { _ => passwordController.changeCustomPassword() }
   }
 
-  Signal.zip(passwordController.ssoEnabled, passwordController.appLockEnabled).foreach {
-    case (true, true) =>
+  passwordController.appLockEnabled.foreach {
+    case true =>
+      passwordController.setCustomPasswordIfNeeded(forced = true)
       appLockChangeButton.setVisible(true)
-      passwordController.setSSOPasswordIfNeeded()
-    case _ =>
+    case false =>
       appLockChangeButton.setVisible(false)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -31,11 +31,10 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
 import com.waz.model.Uid
 import com.waz.service.AccountManager.ClientRegistrationState.{LimitReached, PasswordMissing, Registered, Unregistered}
-import com.waz.service.{AccountManager, ZMessaging}
+import com.waz.service.{AccountManager, AccountsService, ZMessaging}
 import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient._
-import com.waz.zclient.common.controllers.global.PasswordController
 import com.waz.zclient.preferences.PreferencesActivity
 import com.waz.zclient.preferences.dialogs.RequestPasswordDialog
 import com.waz.zclient.preferences.dialogs.RequestPasswordDialog.{PasswordAnswer, PasswordCancelled, PromptAnswer}
@@ -129,7 +128,7 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
         showToast(s"Registered new client: $id")
         Future.successful(Right(true))
       case Right(PasswordMissing) =>
-        inject[PasswordController].password.head.flatMap {
+        inject[AccountsService].accountPassword.head.flatMap {
           case Some(p) => registerClient(Some(p))
           case _       => Future.successful(Right(false))
         }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
@@ -27,13 +27,12 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.otr.Client
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
-import com.wire.signals.{EventContext, Signal}
-import com.waz.zclient.common.controllers.global.PasswordController
+import com.waz.threading.Threading._
 import com.waz.zclient.preferences.views.DeviceButton
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.{BackStackKey, BackStackNavigator}
 import com.waz.zclient.{Injectable, Injector, R, ViewHelper}
-import com.waz.threading.Threading._
+import com.wire.signals.{EventContext, Signal}
 
 trait DevicesView {
   def setSelfDevice(device: Option[Client]): Unit
@@ -100,7 +99,6 @@ case class DevicesViewController(view: DevicesView)(implicit inj: Injector, ec: 
 
   val zms = inject[Signal[Option[ZMessaging]]]
   val accounts = inject[AccountsService]
-  val passwordController = inject[PasswordController]
 
   val otherClients = for {
     Some(am)      <- accounts.activeAccountManager
@@ -125,8 +123,8 @@ case class DevicesViewController(view: DevicesView)(implicit inj: Injector, ec: 
   def onViewClose(): Unit = {
     implicit val ec = Threading.Background
     for {
-      _         <- passwordController.clearPassword()
       Some(zms) <- zms.head
+      _         <- zms.users.clearAccountPassword()
       _         <- zms.otrClientsService.updateUnknownToUnverified(zms.selfUserId)
     } ()
   }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -110,9 +110,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     appLockButton.setSubtitle(getString(R.string.pref_options_app_lock_summary, timeout.toString))
   }
 
-  Signal.zip(passwordController.appLockEnabled, passwordController.appLockForced).foreach {
-    case (enabled, forced) => appLockButton.setVisible(enabled || !forced)
-  }
+  passwordController.appLockEnabled.foreach(appLockButton.setVisible)
 
   override val appLock: EventStream[Unit] = appLockButton.onClickEvent.map(_ => ())
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -71,6 +71,8 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
 
   inflate(R.layout.preferences_options_layout)
 
+  private lazy val passwordController = inject[PasswordController]
+
   private val vbrSwitch               = findById[SwitchPreference](R.id.preferences_vbr)
   private val vibrationSwitch         = findById[SwitchPreference](R.id.preferences_vibration)
   private val darkThemeSwitch         = findById[SwitchPreference](R.id.preferences_dark_theme)
@@ -104,8 +106,12 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   vibrationSwitch.setPreference(VibrateEnabled)
   sendButtonSwitch.setPreference(SendButtonEnabled)
 
-  inject[PasswordController].appLockTimeout.foreach { timeout =>
+  passwordController.appLockTimeout.foreach { timeout =>
     appLockButton.setSubtitle(getString(R.string.pref_options_app_lock_summary, timeout.toString))
+  }
+
+  Signal.zip(passwordController.appLockEnabled, passwordController.appLockForced).foreach {
+    case (enabled, forced) => appLockButton.setVisible(enabled || !forced)
   }
 
   override val appLock: EventStream[Unit] = appLockButton.onClickEvent.map(_ => ())

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -171,7 +171,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
       wipeOnCookieInvalid <- accountManager.fold(EmptyCheck)(wipeOnCookieInvalid)
       requestPassword     <- unpack(passwordController, userPreferences, accountManager).fold(EmptyCheck) {
                                case (ctrl, prefs, am) =>
-                                 Signal.zip(ctrl.ssoEnabled, ctrl.ssoPasswordEmpty).head.flatMap {
+                                 Signal.zip(ctrl.ssoEnabled, ctrl.customPasswordEmpty).head.flatMap {
                                    case (true, true) => EmptyCheck // the user must set the password first
                                    case _            => requestPassword(ctrl, prefs, am, authNeeded)
                                  }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -415,8 +415,8 @@ object UserPreferences {
 
   lazy val ShouldWarnAVSUpgrade = PrefKey[Boolean]("should_warn_avs_upgrade", customDefault = false)
 
-  lazy val SSOPassword = PrefKey[Option[String]]("sso_password", customDefault = None)
-  lazy val SSOPasswordIv = PrefKey[Option[String]]("sso_password_iv", customDefault = None)
+  lazy val CustomPassword = PrefKey[Option[String]]("sso_password", customDefault = None)
+  lazy val CustomPasswordIv = PrefKey[Option[String]]("sso_password_iv", customDefault = None)
 
   lazy val AppLockEnabled: PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
   lazy val AppLockForced:  PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_forced", customDefault = false)

--- a/zmessaging/src/main/scala/com/waz/model/AppLockFeatureFlag.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AppLockFeatureFlag.scala
@@ -10,7 +10,8 @@ import scala.concurrent.duration.FiniteDuration
 final case class AppLockFeatureFlag(enabled: Boolean, forced: Boolean, timeout: Option[FiniteDuration])
 
 object AppLockFeatureFlag {
-  val Default: AppLockFeatureFlag = AppLockFeatureFlag(enabled = false, forced = false, None)
+  val Default: AppLockFeatureFlag  = AppLockFeatureFlag(enabled = true, forced = false, None)
+  val Disabled: AppLockFeatureFlag = AppLockFeatureFlag(enabled = false, forced = false, None)
 
   import JsonDecoder._
 
@@ -22,14 +23,17 @@ object AppLockFeatureFlag {
     }
 
     override def apply(implicit js: JSONObject): AppLockFeatureFlag =
-      if (js.getString("status") == "enabled") {
+      if (!js.has("status")) {
+        Default
+      } else if (js.getString("status") == "enabled") {
         val config = decodeConfig(js.getJSONObject("config"))
         AppLockFeatureFlag(
           enabled = true,
           forced  = config.enforceAppLock,
           timeout = Some(FiniteDuration(config.inactivityTimeoutSecs, TimeUnit.SECONDS))
         )
-      } else
-        Default
+      } else {
+        Disabled
+      }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -175,7 +175,6 @@ class AccountManager(val userId:  UserId,
     }
   }
 
-  //Note: this method should only be externally called from tests and debug preferences. User `registerClient` for all normal flows.
   def registerNewClient(password: Option[Password] = None): ErrorOr[ClientRegistrationState] = {
     for {
       account <- global.accountsStorage.signal(userId).head

--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -104,6 +104,8 @@ trait AccountsService {
   def loginClient: LoginClient
 
   def wipeDataForAllAccounts(): Future[Unit]
+
+  lazy val accountPassword: Signal[Option[Password]] = activeAccount.map(_.flatMap(_.password)).disableAutowiring()
 }
 
 object AccountsService {

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
@@ -17,12 +17,12 @@ class FeatureFlagsServiceImpl(syncHandler: FeatureFlagsSyncHandler,
   extends FeatureFlagsService with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
-  override def updateAppLock(): Future[Unit] = syncHandler.fetchAppLock().map { appLock =>
-    verbose(l"AppLock feature flag : $appLock")
+  override def updateAppLock(): Future[Unit] =
     for {
-      _ <- userPrefs(AppLockEnabled) := appLock.enabled
-      _ <- userPrefs(AppLockForced) := appLock.forced
-      _ <- userPrefs(AppLockTimeout) := appLock.timeout
+      appLock <- syncHandler.fetchAppLock()
+      _       =  verbose(l"AppLock feature flag : $appLock")
+      _       <- userPrefs(AppLockEnabled) := appLock.enabled
+      _       <- userPrefs(AppLockForced)  := appLock.forced
+      _       <- userPrefs(AppLockTimeout) := appLock.timeout
     } yield ()
-  }
 }

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
@@ -17,15 +17,12 @@ class FeatureFlagsServiceImpl(syncHandler: FeatureFlagsSyncHandler,
   extends FeatureFlagsService with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
-  override def updateAppLock(): Future[Unit] = syncHandler.fetchAppLock().map {
-    case appLock if appLock.enabled =>
-      verbose(l"AppLock feature flag enabled: $appLock")
-      for {
-        _ <- if (appLock.forced) userPrefs(AppLockEnabled) := true else Future.successful(())
-        _ <- userPrefs(AppLockForced) := appLock.forced
-        _ <- userPrefs(AppLockTimeout) := appLock.timeout
-      } yield ()
-    case _ =>
-      verbose(l"AppLock feature flag disabled")
+  override def updateAppLock(): Future[Unit] = syncHandler.fetchAppLock().map { appLock =>
+    verbose(l"AppLock feature flag : $appLock")
+    for {
+      _ <- userPrefs(AppLockEnabled) := appLock.enabled
+      _ <- userPrefs(AppLockForced) := appLock.forced
+      _ <- userPrefs(AppLockTimeout) := appLock.timeout
+    } yield ()
   }
 }

--- a/zmessaging/src/test/scala/com/waz/model/AppLockFeatureFlagSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/AppLockFeatureFlagSpec.scala
@@ -8,7 +8,7 @@ class AppLockFeatureFlagSpec extends AndroidFreeSpec {
 
   feature("Deserialization form JSON") {
 
-    scenario("Deserializing an enabled") {
+    scenario("Deserializing an enabled flag") {
       val json =
         """
           |{
@@ -35,6 +35,13 @@ class AppLockFeatureFlagSpec extends AndroidFreeSpec {
           |}
           |""".stripMargin
 
+      val appLockFeatureFlag: AppLockFeatureFlag = JsonDecoder.decode[AppLockFeatureFlag](json)
+
+      appLockFeatureFlag shouldEqual AppLockFeatureFlag.Disabled
+    }
+
+    scenario("Deserializing an error (empty json object)") {
+      val json = "{}"
       val appLockFeatureFlag: AppLockFeatureFlag = JsonDecoder.decode[AppLockFeatureFlag](json)
 
       appLockFeatureFlag shouldEqual AppLockFeatureFlag.Default

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureFlagsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureFlagsServiceSpec.scala
@@ -32,7 +32,7 @@ class FeatureFlagsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(userPrefs(AppLockTimeout).apply()) shouldEqual Some(10.seconds)
   }
 
-  scenario("When the AppLock feature flag is disabled, don't change properties") {
+  scenario("When the AppLock feature flag is disabled, set the Disabled feature flag") {
     // The name here is a bit confusing.
     // "AppLockEnabled" in case of the property tells if the feature is on.
     // "enabled" in case of the feature flag tells if the feature flag (set in the backend) interferes with the feature settings.
@@ -41,15 +41,15 @@ class FeatureFlagsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     userPrefs.setValue(AppLockTimeout, Some(30.seconds))
 
     (syncHandler.fetchAppLock _).expects().anyNumberOfTimes().returning(
-      Future.successful(AppLockFeatureFlag.Default)
+      Future.successful(AppLockFeatureFlag.Disabled)
     )
 
     val service = createService
     result(service.updateAppLock())
 
-    result(userPrefs(AppLockEnabled).apply()) shouldEqual true
-    result(userPrefs(AppLockForced).apply()) shouldEqual false
-    result(userPrefs(AppLockTimeout).apply()) shouldEqual Some(30.seconds)
+    result(userPrefs(AppLockEnabled).apply()) shouldEqual AppLockFeatureFlag.Disabled.enabled
+    result(userPrefs(AppLockForced).apply()) shouldEqual AppLockFeatureFlag.Disabled.forced
+    result(userPrefs(AppLockTimeout).apply()) shouldEqual AppLockFeatureFlag.Disabled.timeout
   }
 
   private def createService: FeatureFlagsService = new FeatureFlagsServiceImpl(syncHandler, userPrefs)


### PR DESCRIPTION
This is a follow-up of introducing the App Lock Feature Flag. Until now we used the account password for the app lock,
and only if the user was SSO (and so, no password) we used the custom one. Now we will migrate to using the custom
password in the app lock for all users. For some time now, after the user updates to the new Wire Android version,
they will still use the account password for the app lock (nothing changes from the user's perspective) but if they
switch the app lock off and on again, or if it is forced by the feature flag, we will display a dialog asking the user
to create a custom password.

This feature also affected others a bit - removing old devices, and logging in. We need to provide the account password
to log in, as well as to remove a device, but until now the code relied a bit on PasswordController which now is controlling only the custom password. I had to change it, and also I removed a bit of code which I think shouldn't be there -
onPasswordReset was called for apparently no good reason. I want to take a look at it once again, before merging.

I call the custom password "custom", instead of "app lock password", because I suspect in the future it can be used
for other purposes as well. But I left as they were the names of the user preferences used to store the encrypted
custom password: sso_password and sso_password_iv. Renaming them would mean yet one more migration.

Tests:
 * If you turned on the app lock before updating, can you still use the account password for the app lock?
 * If you go to Options -> App Lock and turn the app lock on, does it show the "There was a change in Wire" dialog?
 * If you don't go to Options -> App Lock, but the feature flag on the backend enforces the app lock, is the dialog displayed when you open the app?
 * If you set a new password in the dialog, and it is different from the account password, is it the custom password you use to unlock the app?
 * If you set a new password and turn off and turn on the app lock again, do you still use the same custom password?
 * Is there on Options -> App Lock a button for changing the custom password?
 * Can you change the custom password and is then the new one used to unlock the app?
 * After all the previous tests, do you still use the account password to remove an old device?
 * After all the previous tests, if you log out and log in, do you use the account password to log in?
 * After logging out and in again, is the custom password preserved?
#### APK
[Download build #3085](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3085/artifact/build/artifact/wire-dev-PR3151-3085.apk)
[Download build #3092](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3092/artifact/build/artifact/wire-dev-PR3151-3092.apk)
[Download build #3099](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3099/artifact/build/artifact/wire-dev-PR3151-3099.apk)
[Download build #3100](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3100/artifact/build/artifact/wire-dev-PR3151-3100.apk)
[Download build #3102](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3102/artifact/build/artifact/wire-dev-PR3151-3102.apk)
[Download build #3103](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3103/artifact/build/artifact/wire-dev-PR3151-3103.apk)
[Download build #3104](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3104/artifact/build/artifact/wire-dev-PR3151-3104.apk)
[Download build #3105](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3105/artifact/build/artifact/wire-dev-PR3151-3105.apk)
[Download build #3107](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3107/artifact/build/artifact/wire-dev-PR3151-3107.apk)
[Download build #3110](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3110/artifact/build/artifact/wire-dev-PR3151-3110.apk)