### PR TITLE
fix: The camera session may crash when released if it was closed beforehand

### DIFF
--- a/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
+++ b/app/src/main/scala/com/waz/zclient/camera/controllers/AndroidCamera2.scala
@@ -305,8 +305,9 @@ class AndroidCamera2(cameraData: CameraData,
     }
     imageReader.close()
     cameraSession.foreach { session =>
-      session.stopRepeating()
-      session.close()
+      Try(session.close()).recover {
+        case ex => error(l"Unable to close session", ex)
+      }
     }
     camera.foreach(_.close())
     cameraRequest = None


### PR DESCRIPTION
Google Play Console reports that sometimes we get an IllegalStateException: "Session has been closed; further changes are illegal" when we try to release the camera session in AndroidCamera2.release(). This exception is thrown if the session was closed before for whatever reason. In that case, we shouldn't try to close it again.

I wasn't able to reproduce the bug but I think it's safe to fix it by simply wrapping that piece of code in a Try. If the exception is thrown, it means the session is closed, which is exactly what we wanted to achieve. I deleted the direct call to session.stopRepeating() because session.close() do it as well. In fact, that might have been the source of the error.

A link to the Google Play Console report:
https://play.google.com/console/u/3/developers/7098984309886892484/app/4973241010395499500/vitals/crashes/a771bc14/details?installedFrom=PLAY_STORE&days=30

#### APK
[Download build #3094](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3094/artifact/build/artifact/wire-dev-PR3155-3094.apk)