### PR TITLE
fix: Un-throttling the networkMode signal in WebSocketService.

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/NetworkModeService.scala
@@ -43,12 +43,12 @@ class DefaultNetworkModeService(context: Context, lifeCycle: UiLifeCycle)
   private val currentNetwork = Signal[Option[Network]]()
   private val currentCapabilities = Signal[Option[NetworkCapabilities]]()
 
-  currentNetwork.throttle(500.millis).map {
+  currentNetwork.map {
     case Some(network) => Option(connectivityManager.getNetworkCapabilities(network))
     case None => None
   }.pipeTo(currentCapabilities)
 
-  override val networkMode: Signal[NetworkMode] = currentCapabilities.throttle(500.millis).map {
+  override val networkMode: Signal[NetworkMode] = currentCapabilities.map {
     case Some(capabilities) =>
       returning(computeMode(capabilities)) { mode => info(l"new network mode: $mode") }
     case None =>


### PR DESCRIPTION
* fixes https://wearezeta.atlassian.net/browse/SQCORE-420 (ANR because of WebSocketService)
* fixes https://wearezeta.atlassian.net/browse/SQCORE-359 ("No internet connection" bar constantly displayed)
* connected to https://github.com/wireapp/wire-signals/issues/47

SQRCORE-359 is there because of the bug in wire-signals (linked above), but SQCORE-420 would still be there,
even if that bug was already fixed. SQCORE-420 happens because with the throttled `networkMode` there is too much
delay between `Context.startForegroundService()` and the consecutive `Service.startForeground()`, and Android kills
the service after a timeout. To fix this, I removed the throttling from `networkMode` and made some changes in
`WebSocketService` to ensure that `startForeground` is called a bit quicker.

Previously, I wanted to use throttling to prevent situations, where the network changes rapidly and that causes
innecessary reactions in the app (usually when the connection quality is low). I may think of reintroducing it
when I fix the underlying bug in wire-signals (but then I will not use it for `WebSocketService`).
#### APK
[Download build #3113](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3113/artifact/build/artifact/wire-dev-PR3159-3113.apk)