### PR TITLE
Bump avs version to 6.6.15

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.6.13"
+String avsPrivateVersion = "6.6.15"
 
 String nexusUrl = ""
 


### PR DESCRIPTION
## What's new in this PR?

Bump AVS version to 6.6.15

#### APK
[Download build #3114](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3114/artifact/build/artifact/wire-dev-PR3160-3114.apk)