### PR TITLE
fix: Perform full sync on backup restoration and delete conversations missing on the backend

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -210,6 +210,8 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
       _                    =  backupFile.delete()
       registrationState    <- accountManager.getOrRegisterClient()
       _                    <- Future.traverse(List(SelfClient, OtrLastPrekey, LastSelfClientsSyncRequestedTime, LastStableNotification, ShouldSyncInitial))(p => accountManager.userPrefs.remove(p.str))
+      Some(zms)            <- accountsService.getZms(userId)
+      _                    <- zms.sync.performFullSync()
       _                    =  spinnerController.hideSpinner(Some(getString(R.string.back_up_progress_complete)))
       _                    <- CancellableFuture.delay(750.millis).future
     } yield registrationState match {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -72,6 +72,7 @@ trait ConversationsService {
   def deleteConversation(rConvId: RConvId): Future[Unit]
   def conversationName(convId: ConvId): Signal[Name]
   def deleteMembersFromConversations(members: Set[UserId]): Future[Unit]
+  def remoteIds: Future[Set[RConvId]]
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -377,6 +378,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
                        deleteMembers(convId, uIds.map(_.userId).toSet, remover = None, sendSystemMessage = true)
                      })
     } yield ()
+
+  override def remoteIds: Future[Set[RConvId]] = convsStorage.list.map(_.map(_.remoteId).toSet)
 
   private def deleteMembers(convId: ConvId): Future[Unit] =
     for {

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -1,0 +1,71 @@
+package com.waz.sync.handler
+
+import com.waz.content.{ConversationStorage, MembersStorage, MessagesStorage}
+import com.waz.model._
+import com.waz.service.conversation.{ConversationOrderEventsService, ConversationsContentUpdater, ConversationsService}
+import com.waz.service.messages.MessagesService
+import com.waz.service.{ConversationRolesService, ErrorsService, GenericMessageService, UserService}
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.client.ConversationsClient.ConversationResponse
+import com.waz.sync.client.ConversationsClient.ConversationResponse.ConversationsResult
+import com.waz.sync.client.{ConversationsClient, ErrorOr, ErrorOrResponse}
+import com.wire.signals.{CancellableFuture, Signal}
+
+import scala.concurrent.Future
+
+class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
+
+  private val self = UserData("self")
+  private val teamId = TeamId()
+  private val userService      = mock[UserService]
+  private val messagesStorage = mock[MessagesStorage]
+  private val messagesService = mock[MessagesService]
+  private val convService = mock[ConversationsService]
+  private val convs = mock[ConversationsContentUpdater]
+  private val convEvents = mock[ConversationOrderEventsService]
+  private val convStorage = mock[ConversationStorage]
+  private val errorsService = mock[ErrorsService]
+  private val conversationsClient = mock[ConversationsClient]
+  private val genericMessages = mock[GenericMessageService]
+  private val rolesService = mock[ConversationRolesService]
+  private val membersStorage = mock[MembersStorage]
+
+  private def createHandler: ConversationsSyncHandler = new ConversationsSyncHandler(
+    self.id, Some(teamId), userService, messagesStorage, messagesService,
+    convService, convs, convEvents, convStorage, errorsService,
+    conversationsClient, genericMessages, rolesService, membersStorage
+  )
+
+  private def toConversationResponse(conv: ConversationData) =
+    ConversationResponse(
+      conv.remoteId, conv.name, conv.creator, conv.convType, conv.team,
+      conv.muted, conv.muteTime, conv.archived, conv.archiveTime,
+      conv.access, conv.accessRole, conv.link, None, Map.empty, conv.receiptMode
+    )
+
+  scenario("When syncing conversations, given local convs that are absent from the backend, remove the missing local convs") {
+    val conv1 = ConversationData(team = Some(teamId), creator = self.id)
+    val conv2 = ConversationData(team = Some(teamId), creator = self.id)
+    val conv3 = ConversationData(team = Some(teamId), creator = self.id)
+
+    val resp1 = toConversationResponse(conv1)
+    val resp2 = toConversationResponse(conv2)
+
+    val backendResponse: ErrorOrResponse[ConversationsResult] =
+      CancellableFuture.successful { Right(ConversationsResult(Seq(resp1, resp2), hasMore = false)) }
+    val storageResponse =
+      Future.successful(Set(conv1.remoteId, conv2.remoteId, conv3.remoteId))
+
+    (conversationsClient.loadConversations(_: Option[RConvId], _: Int)).expects(*, *).anyNumberOfTimes().returning(backendResponse)
+    (convService.remoteIds _).expects().anyNumberOfTimes().returning(storageResponse)
+
+    (rolesService.defaultRoles _).expects().anyNumberOfTimes().returning(Signal.const(Set.empty[ConversationRole]))
+    (conversationsClient.loadConversationRoles _).expects(*).anyNumberOfTimes().returning(Future.successful(Map.empty[RConvId, Set[ConversationRole]]))
+    (convService.updateConversationsWithDeviceStartMessage _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
+
+    (convService.deleteConversation _).expects(conv3.remoteId).once().returning(Future.successful(()))
+    val handler = createHandler
+    result(handler.syncConversations())
+  }
+
+}


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-127

When the user deletes a conversation between the backup and its restoration, the restoration brings back the deleted conversation. The fix performs a full sync after the restoration and during syncing conversations it compares the results from the backend with what's in the storage (after the restoration). Any conversation that is not present on the backend will be deleted, together with its members, messages, etc.
On top of it, the full sync applies updates on top of the restored backup - that was also missing from the current implementation.

#### APK
[Download build #3117](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3117/artifact/build/artifact/wire-dev-PR3162-3117.apk)