### PR TITLE
fix: An unrecognized event crashes the decryption process

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -285,11 +285,11 @@ object ConversationEvent extends DerivedLogTag {
         case "conversation.otr-error"            => OtrErrorEvent('convId, time, 'from, decodeOtrError('error))
         case "conversation.session-reset"        => SessionReset('convId, time, 'from, 'sender)
         case _ =>
-          error(l"unhandled event: $js")
+          error(l"unhandled event (1): ${js.toString}")
           UnknownConvEvent(js)
       }
     } .getOrElse {
-      error(l"unhandled event: $js")
+      error(l"unhandled event (2): ${js.toString}")
       UnknownConvEvent(js)
     }
   }


### PR DESCRIPTION
This is a fix to a problem reported on the Internal/staging setup, but the problem might occassionally arise on production as well. If an event can't be deserialized in ConversationEventDecoder, it is wrapped in UnknownConvEvent. But then, in PushService.processEncryptedRows, we assume each event is properly decrypted and we use an unsafe operation to unwrap it. For an unrecognized event this results in a crash of the decryption process, nad since the event is not removed from the queue, when the process restarts, the event is still first in the queue, and crashes the process again. The user experiences it as if no new messages were coming at all.

```
02-01 19:50:20.019 E/PushServiceImpl#21a8e9b8( 7657): Unable to process events: java.lang.ClassCastException: com.waz.model.UnknownConvEvent cannot be cast to com.waz.model.OtrEvent
```

Usually it shouldn't happen - we should be able to recognize all events. But there is no point in using the unsafe operation if it can be easily avoided. I changed that part of the code to the one that doesn't crash on an unrecognized event, and I added log statements, so we can learn what was it that couldn't be deserialized.

#### APK
[Download build #3118](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3118/artifact/build/artifact/wire-dev-PR3163-3118.apk)