### PR TITLE
[Calling] : feature : active speaker - long term and instant audio activity

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -59,7 +59,7 @@ class CallingFragment extends FragmentHelper {
 
     vh.foreach { grid =>
 
-      Signal.zip(videoGridInfo, controller.isFullScreenEnabled, controller.showTopSpeakers, controller.activeParticipantsWithVideo()).foreach {
+      Signal.zip(videoGridInfo, controller.isFullScreenEnabled, controller.showTopSpeakers, controller.longTermActiveParticipantsWithVideo()).foreach {
         case ((selfParticipant, videoUsers, infos, participants, isVideoBeingSent), false, true, activeParticipantsWithVideo) =>
           refreshVideoGrid(grid, selfParticipant, activeParticipantsWithVideo, infos, participants, isVideoBeingSent, true)
         case ((selfParticipant, videoUsers, infos, participants, isVideoBeingSent), false, false, _) =>
@@ -90,7 +90,7 @@ class CallingFragment extends FragmentHelper {
 
     Signal.zip(
       controller.showTopSpeakers,
-      controller.activeParticipantsWithVideo().map(_.size > 0),
+      controller.longTermActiveParticipantsWithVideo().map(_.size > 0),
       controller.controlsVisible,
       controller.isGroupCall
     ).onUi {

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -31,10 +31,8 @@ import com.waz.zclient.calling.views.{CallingHeader, CallingMiddleLayout, Contro
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
-import com.waz.zclient.{FragmentHelper, MainActivity, R}
-import com.wire.signals.Subscription
-//import com.waz.zclient.BuildConfig
-//import com.wire.signals.Signal
+import com.waz.zclient.{BuildConfig, FragmentHelper, MainActivity, R}
+import com.wire.signals.{Signal, Subscription}
 
 class ControlsFragment extends FragmentHelper {
 
@@ -96,10 +94,9 @@ class ControlsFragment extends FragmentHelper {
       }
     }
 
-    //TODO : The calling squad decided to disable all/speaker toggle to perform some optimizations
-    // in terms of user experience before releasing it to public
 
-    /* if (BuildConfig.ACTIVE_SPEAKERS) {
+
+     if (BuildConfig.ACTIVE_SPEAKERS) {
        Signal.zip(
          controller.isCallEstablished,
          controller.isGroupCall,
@@ -110,7 +107,7 @@ class ControlsFragment extends FragmentHelper {
          case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
        }
      }
-     else */
+     else
     speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
   }
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -115,7 +115,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
   lazy val activeSpeakers             = currentCall.map(_.activeSpeakers)
 
 
-  def activeParticipantsWithVideo(): Signal[Seq[Participant]] =
+  def longTermActiveParticipantsWithVideo(): Signal[Seq[Participant]] =
     Signal.zip(activeSpeakers, videoUsers).map {
       case (activeSpeakers, videoUsers) =>
         videoUsers.filter { participant =>
@@ -172,9 +172,9 @@ class CallController(implicit inj: Injector, cxt: WireContext)
       )
     }
 
-  def isActiveSpeaker(userId: UserId, clientId: ClientId): Signal[Boolean] =
+  def isInstantActiveSpeaker(userId: UserId, clientId: ClientId): Signal[Boolean] =
     activeSpeakers.map(_.exists { activeSpeaker =>
-      activeSpeaker.clientId == clientId && activeSpeaker.userId == userId && activeSpeaker.audioLevel > 0
+      activeSpeaker.clientId == clientId && activeSpeaker.userId == userId && activeSpeaker.instantAudioLevel > 0
     })
 
   val flowManager = callingZms.map(_.flowmanager)

--- a/app/src/main/scala/com/waz/zclient/calling/views/OtherVideoView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/OtherVideoView.scala
@@ -31,7 +31,7 @@ class OtherVideoView(context: Context, participant: Participant) extends UserVid
 
   Signal.zip(
     participantInfo.map(_.map(_.isMuted)),
-    callController.isActiveSpeaker(participant.userId, participant.clientId),
+    callController.isInstantActiveSpeaker(participant.userId, participant.clientId),
     accentColorController.accentColor.map(_.color),
     callController.isFullScreenEnabled,
     callController.showTopSpeakers,

--- a/app/src/main/scala/com/waz/zclient/calling/views/SelfVideoView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/SelfVideoView.scala
@@ -35,7 +35,7 @@ class SelfVideoView(context: Context, participant: Participant)
 
   Signal.zip(
     callController.isMuted,
-    callController.isActiveSpeaker(participant.userId, participant.clientId),
+    callController.isInstantActiveSpeaker(participant.userId, participant.clientId),
     accentColorController.accentColor.map(_.color),
     callController.isFullScreenEnabled,
     callController.showTopSpeakers,

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -105,7 +105,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
   private val activeSpeakerData = Signal(Option.empty[(UserId, ClientId)])
   private val isActiveSpeaker = for {
     Some((userId, clientId)) <- activeSpeakerData
-    isActive                 <- callController.isActiveSpeaker(userId, clientId)
+    isActive                 <- callController.isInstantActiveSpeaker(userId, clientId)
   } yield isActive
 
   audioIndicator.setVisible(true)

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.6.15"
+String avsPrivateVersion = "6.7.2"
 
 String nexusUrl = ""
 

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.2"
+String avsPrivateVersion = "6.7.4"
 
 String nexusUrl = ""
 

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -216,11 +216,15 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
 
       val activeSpeakersHandler = new ActiveSpeakersHandler {
-        override def onActiveSpeakersChanged(inst: Handle, convId: String, data: String, arg: Pointer): Unit =
+        override def onActiveSpeakersChanged(inst: Handle, convId: String, data: String, arg: Pointer): Unit = {
+
+          Log.i("mejdoo",data)
+
           ActiveSpeakerChangeDecoder.decode(data).foreach { activeSpeakersChange =>
-            val activeSpeakers = activeSpeakersChange.audio_levels.map(m => ActiveSpeaker(m.userid, m.clientid, m.audio_level)).toSet
+            val activeSpeakers = activeSpeakersChange.audio_levels.map(m => ActiveSpeaker(m.userid, m.clientid, m.audio_level, m.audio_level_now)).toSet
             cs.onActiveSpeakersChanged(RConvId(convId), activeSpeakers)
-          }
+        }
+        }
       }
 
       Calling.wcall_set_active_speaker_handler(wCall, activeSpeakersHandler)
@@ -445,7 +449,7 @@ object Avs extends DerivedLogTag {
 
     case class ActiveSpeakerChange(audio_levels: Seq[Speaker])
 
-    case class Speaker(userid: UserId, clientid: ClientId, audio_level: Int)
+    case class Speaker(userid: UserId, clientid: ClientId, audio_level: Int, audio_level_now: Int)
 
     private lazy val decoder: Decoder[ActiveSpeakerChange] = Decoder.apply
 

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -216,14 +216,10 @@ class AvsImpl() extends Avs with DerivedLogTag {
       Calling.wcall_set_req_clients_handler(wCall, clientsRequestHandler)
 
       val activeSpeakersHandler = new ActiveSpeakersHandler {
-        override def onActiveSpeakersChanged(inst: Handle, convId: String, data: String, arg: Pointer): Unit = {
-
-          Log.i("mejdoo",data)
-
+        override def onActiveSpeakersChanged(inst: Handle, convId: String, data: String, arg: Pointer): Unit =
           ActiveSpeakerChangeDecoder.decode(data).foreach { activeSpeakersChange =>
             val activeSpeakers = activeSpeakersChange.audio_levels.map(m => ActiveSpeaker(m.userid, m.clientid, m.audio_level, m.audio_level_now)).toSet
             cs.onActiveSpeakersChanged(RConvId(convId), activeSpeakers)
-        }
         }
       }
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -144,7 +144,7 @@ case class CallInfo(convId:             ConvId,
 
 object CallInfo {
 
-  case class ActiveSpeaker(userId: UserId, clientId: ClientId, audioLevel: Int)
+  case class ActiveSpeaker(userId: UserId, clientId: ClientId, longTermAudioLevel: Int, instantAudioLevel: Int)
 
   case class Participant(userId: UserId, clientId: ClientId, muted: Boolean = false)
 


### PR DESCRIPTION
It was found in the first implemented iteration that active speakers jump a lot in and out of the active speaker view depending on the instantaneous speech level reported by the AVS library. Further this resulted in showing the “no active speaker” screen quite often when all speakers had a gap in the activity. 

To make the experience less busy and smooth out the transitions the following was decided:
- Active speakers will receive a seat in the active speaker view when video is turned on.
- Up to n (currently n=4) speakers can have a seat in the active speaker view.
- An active speaker will keep a seat in the active speaker view even when the activity has stopped unless one of the following conditions is met:  
-- Speaker was inactive for a long time. The best time is still to be determined. Initially we assume ~30 seconds.
-- Other speakers are more active and no more seat is available.

