### PR TITLE
fix: Backup restoration freezes the app

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -26,7 +26,6 @@ import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.{Fragment, FragmentTransaction}
-import com.waz.content.UserPreferences.{apply => _, _}
 import com.waz.model.AccountData.Password
 import com.waz.model.UserId
 import com.waz.permissions.PermissionsService
@@ -209,7 +208,6 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
       _                    <- promise.future
       _                    =  backupFile.delete()
       registrationState    <- accountManager.getOrRegisterClient()
-      _                    <- Future.traverse(List(SelfClient, OtrLastPrekey, LastSelfClientsSyncRequestedTime, LastStableNotification, ShouldSyncInitial))(p => accountManager.userPrefs.remove(p.str))
       Some(zms)            <- accountsService.getZms(userId)
       _                    <- zms.sync.performFullSync()
       _                    =  spinnerController.hideSpinner(Some(getString(R.string.back_up_progress_complete)))


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-450

A line of code introduced in September deletes user preferences which are used for user verification on init. While the app is on,everything works fine - that's why it was difficult to track the bug.
I think I copied that line from the previous implementation of backups but in the new one it does not serve any purpose.

#### APK
[Download build #3121](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3121/artifact/build/artifact/wire-dev-PR3166-3121.apk)