### PR TITLE
fix: NullPointerException in markdown

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
@@ -94,19 +94,26 @@ class TextPartView(context: Context, attrs: AttributeSet, style: Int)
     try {
       textView.setTransformedText(text)
     } catch {
-      case ex: ArrayIndexOutOfBoundsException =>
-        info(l"Error while transforming text link. text: ${redactedString(text)}")
+      case ex: Exception =>
+        warn(l"""
+          Error while transforming text link,
+          exception type: ${ex.getClass.getCanonicalName},
+          text: ${redactedString(text)},
+          stacktrace: ${WhereAmI.whereAmI(ex)}
+        """)
         if (BuildConfig.FLAVOR == "internal") throw ex
     }
 
     try {
       textView.markdown()
     } catch {
-      case ex: ArrayIndexOutOfBoundsException =>
-        warn(l"ArrayIndexOutOfBoundsException on markdown. text: ${redactedString(text)}, stacktrace: ${WhereAmI.whereAmI(ex)}")
-        if (BuildConfig.FLAVOR == "internal") throw ex
-      case ex: NullPointerException =>
-        warn(l"NullPointerException on markdown. text: ${redactedString(text)}, stacktrace: ${WhereAmI.whereAmI(ex)}")
+      case ex: Exception =>
+        warn(l"""
+          Error on markdown,
+          exception type: ${ex.getClass.getCanonicalName},
+          text: ${redactedString(text)},
+          stacktrace: ${WhereAmI.whereAmI(ex)}
+        """)
         if (BuildConfig.FLAVOR == "internal") throw ex
     }
   }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/TextPartView.scala
@@ -40,6 +40,7 @@ import com.waz.zclient.ui.utils.ColorUtils
 import com.waz.zclient.ui.views.OnDoubleClickListener
 import com.waz.zclient.{BuildConfig, R, ViewHelper}
 import com.waz.threading.Threading._
+import com.waz.utils.WhereAmI
 
 class TextPartView(context: Context, attrs: AttributeSet, style: Int)
   extends LinearLayout(context, attrs, style)
@@ -102,7 +103,10 @@ class TextPartView(context: Context, attrs: AttributeSet, style: Int)
       textView.markdown()
     } catch {
       case ex: ArrayIndexOutOfBoundsException =>
-        info(l"Error on markdown. text: ${redactedString(text)}")
+        warn(l"ArrayIndexOutOfBoundsException on markdown. text: ${redactedString(text)}, stacktrace: ${WhereAmI.whereAmI(ex)}")
+        if (BuildConfig.FLAVOR == "internal") throw ex
+      case ex: NullPointerException =>
+        warn(l"NullPointerException on markdown. text: ${redactedString(text)}, stacktrace: ${WhereAmI.whereAmI(ex)}")
         if (BuildConfig.FLAVOR == "internal") throw ex
     }
   }

--- a/zmessaging/src/main/scala/com/waz/utils/WhereAmI.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/WhereAmI.scala
@@ -23,11 +23,18 @@ object WhereAmI {
 
   class WhereAmI() extends Exception("Where am I?")
 
-  def whereAmI = {
+  def whereAmI: String = {
     val where = new WhereAmI()
     val result = new StringWriter()
     val printWriter = new PrintWriter(result)
     where.printStackTrace(printWriter)
+    result.toString
+  }
+
+  def whereAmI(throwable: Throwable): String = {
+    val result = new StringWriter()
+    val printWriter = new PrintWriter(result)
+    throwable.printStackTrace(printWriter)
     result.toString
   }
 }


### PR DESCRIPTION
Google Play Console reports crashes because of an NPE in rendering markdown, but I can't reproduce it and the stacktrace is not very helpful. I decided to use the same solution as with an earlier occurences of ArrayIndexOutOfBoundsException - that is, let's catch the exception, log it, and if we're on production, simply allow the markdown to fail, but don't crash the app.

Hopefully, this way we will eventually get more information from an Internal build which will reproduce the bug.

#### APK
[Download build #3124](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3124/artifact/build/artifact/wire-dev-PR3169-3124.apk)
[Download build #3125](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3125/artifact/build/artifact/wire-dev-PR3169-3125.apk)
[Download build #3129](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3129/artifact/build/artifact/wire-dev-PR3169-3129.apk)