### PR TITLE
[Calling] Bump AVS version to 6.7.9

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.6"
+String avsPrivateVersion = "6.7.7"
 
 String nexusUrl = ""
 

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.7"
+String avsPrivateVersion = "6.7.9"
 
 String nexusUrl = ""
 

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.4"
+String avsPrivateVersion = "6.7.6"
 
 String nexusUrl = ""
 


### PR DESCRIPTION
## What's new in this PR?

The AVS version 6.7.9 includes an important fix for the active speaker feature.
#### APK
[Download build #3135](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3135/artifact/build/artifact/wire-dev-PR3171-3135.apk)
[Download build #3141](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3141/artifact/build/artifact/wire-dev-PR3171-3141.apk)