### PR TITLE
[Calling] : Disable active speakers/all toggle

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -31,8 +31,8 @@ import com.waz.zclient.calling.views.{CallingHeader, CallingMiddleLayout, Contro
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
-import com.waz.zclient.{BuildConfig, FragmentHelper, MainActivity, R}
-import com.wire.signals.{Signal, Subscription}
+import com.waz.zclient.{FragmentHelper, MainActivity, R}
+import com.wire.signals.Subscription
 
 class ControlsFragment extends FragmentHelper {
 

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -95,8 +95,10 @@ class ControlsFragment extends FragmentHelper {
     }
 
 
+    //TODO : The calling squad decided to disable all/speaker toggle to perform some optimizations
+    // in terms of user experience before releasing it to public
 
-     if (BuildConfig.ACTIVE_SPEAKERS) {
+     /*if (BuildConfig.ACTIVE_SPEAKERS) {
        Signal.zip(
          controller.isCallEstablished,
          controller.isGroupCall,
@@ -107,7 +109,7 @@ class ControlsFragment extends FragmentHelper {
          case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
        }
      }
-     else
+     else*/
     speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
   }
 


### PR DESCRIPTION
## What's new in this PR?

The active speakers view is still not working as excepted, so it's postponed again to the next release. A tweaking at AVS lib level is still in progress.
