### PR TITLE
New password dialog

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -18,7 +18,6 @@
 package com.waz.zclient.common.controllers.global
 
 import android.content.Context
-import androidx.fragment.app.FragmentTransaction
 import com.waz.content.UserPreferences.{AppLockEnabled, AppLockForced, AppLockTimeout}
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -34,7 +33,7 @@ import com.waz.zclient.security.{ActivityLifecycleCallback, SecurityPolicyChecke
 import com.waz.zclient.{BaseActivity, BuildConfig, Injectable, Injector}
 import com.wire.signals.{EventStream, Signal, SourceStream}
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 
 class PasswordController(implicit inj: Injector) extends Injectable with DerivedLogTag {
   import Threading.Implicits.Background
@@ -43,17 +42,11 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
   private lazy val prefs                  = inject[Signal[UserPreferences]]
   private lazy val userAccountsController = inject[UserAccountsController]
   private lazy val featureFlags           = inject[Signal[FeatureFlagsService]]
-  private lazy val appInBackground        = inject[ActivityLifecycleCallback].appInBackground
   private lazy val customPassword         = prefs.map(_.preference(UserPreferences.CustomPassword))
   private lazy val customPasswordIv       = prefs.map(_.preference(UserPreferences.CustomPasswordIv))
   private lazy val sodiumHandler          = inject[SodiumHandler]
 
-  // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
-  if (BuildConfig.APP_LOCK_FEATURE_FLAG) {
-    appLockPrefMigration()
-  }
-
-  appInBackground.map(_._1).foreach {
+  inject[ActivityLifecycleCallback].appInBackground.map(_._1).foreach {
     case true  =>
       inject[Signal[UserService]].head.foreach(_.clearAccountPassword())
     case false =>
@@ -65,12 +58,11 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       }
   }
 
-  val ssoEnabled:           Signal[Boolean]                = accounts.isActiveAccountSSO
-  val customPasswordEmpty:  Signal[Boolean]                = customPassword.flatMap(_.signal.map(_.isEmpty))
-  val appLockEnabled:       Signal[Boolean]                = prefs.flatMap(_.preference(AppLockEnabled).signal)
-  val appLockForced:        Signal[Boolean]                = prefs.flatMap(_.preference(AppLockForced).signal)
-
-  val appLockTimeout: Signal[Int] = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
+  val ssoEnabled:          Signal[Boolean] = accounts.isActiveAccountSSO
+  val customPasswordEmpty: Signal[Boolean] = customPassword.flatMap(_.signal.map(_.isEmpty))
+  val appLockEnabled:      Signal[Boolean] = prefs.flatMap(_.preference(AppLockEnabled).signal)
+  val appLockForced:       Signal[Boolean] = prefs.flatMap(_.preference(AppLockForced).signal)
+  val appLockTimeout:      Signal[Int]     = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
     case None           => BuildConfig.APP_LOCK_TIMEOUT
     case Some(duration) => duration.toSeconds.toInt
   }
@@ -83,25 +75,35 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       _    <- openNewPasswordDialog(NewPasswordDialog.ChangeMode)
     } yield ()
 
-  def setCustomPasswordIfNeeded(fromSettings: Boolean = false)(implicit ctx: Context): Future[Unit] =
+  def setCustomPasswordIfNeeded()(implicit ctx: Context): Future[Unit] =
     for {
       enabled       <- appLockEnabled.head
-      forced        <- appLockForced.head
       passwordPref  <- customPassword.head
       password      <- passwordPref()
-      _             <- if (enabled && (fromSettings || forced) && password.isEmpty) openNewPasswordDialog(NewPasswordDialog.ChangeInWireMode)
-                       else Future.successful(())
+      _             <- if (enabled && password.isEmpty)
+                         openNewPasswordDialog(NewPasswordDialog.ChangeInWireMode)
+                       else
+                         Future.successful(())
+    } yield ()
+
+  def clearCustomPassword(): Future[Unit] =
+    for {
+      passwordPref   <- customPassword.head
+      _              <- passwordPref := None
+      passwordIvPref <- customPasswordIv.head
+      _              <- passwordIvPref := None
     } yield ()
 
   // TODO: This check is used for the app lock, but some people still use the account password
-  // instead of the custom one as their app lock password. When everyone migrates, it can be simplified.
+  //   instead of the custom one as their app lock password. When everyone migrates, it can be simplified.
   def checkPassword(password: Password): Future[Boolean] =
     for {
       users       <- inject[Signal[UserService]].head
       isEmpty     <- customPasswordEmpty.head
-      pwdCorrect  <- if (!isEmpty) checkCustomPassword(password)
-                     else users.checkAccountPassword(password).map(_.isRight)
-      _ = if (!pwdCorrect) verbose(l"wrong password")
+      pwdCorrect  <- if (!isEmpty)
+                       checkCustomPassword(password)
+                     else
+                       users.checkAccountPassword(password).map(_.isRight)
     } yield pwdCorrect
 
   private def checkCustomPassword(pwdToCheck: Password): Future[Boolean] =
@@ -119,19 +121,27 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
         false
     }
 
-  private def openNewPasswordDialog(mode: NewPasswordDialog.Mode)(implicit ctx: Context): Future[Int] = Future {
-    // The "Change Passcode" version of the dialog is always presented on the dark theme
-    // even if the controller says otherwise
+  private def openNewPasswordDialog(mode: NewPasswordDialog.Mode)(implicit ctx: Context) =  {
+    // The "Change Passcode" version of the dialog is always presented on the dark theme even if the controller says otherwise
     val isDarkTheme = mode == NewPasswordDialog.ChangeMode || inject[ThemeController].isDarkTheme
-    val fragment = NewPasswordDialog.newInstance(mode, isDarkTheme)
-    ctx.asInstanceOf[BaseActivity]
-      .getSupportFragmentManager
-      .beginTransaction
-      .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
-      .add(fragment, NewPasswordDialog.Tag)
-      .addToBackStack(NewPasswordDialog.Tag)
-      .commit
-  }(Threading.Ui)
+    val dialog = NewPasswordDialog.newInstance(mode, isDarkTheme)
+    dialog.show(ctx.asInstanceOf[BaseActivity])
+    val operationFinished = Promise[Unit]()
+    dialog.onAnswer.foreach {
+      case None if mode.cancellable =>
+        dialog.close()
+        customPasswordEmpty.head.foreach {
+          case true => prefs.foreach(_.preference(AppLockEnabled) := false)
+          case false =>
+        }
+        operationFinished.success(())
+      case Some(password) =>
+        dialog.close()
+        setCustomPassword(password).map(_ => operationFinished.success(()))
+      case _ =>
+    }
+    operationFinished.future
+  }
 
   def setCustomPassword(pwd: Password): Future[Unit] =
     for {
@@ -152,7 +162,7 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
     }(Threading.Background)
 
   // TODO: Remove after everyone migrates to UserPreferences.AppLockEnabled
-  private def appLockPrefMigration(): Unit =
+  if (BuildConfig.APP_LOCK_FEATURE_FLAG) {
     inject[GlobalPreferences].preference(GlobalPreferences.GlobalAppLockDeprecated).apply().foreach {
       case true =>
       case false =>
@@ -164,4 +174,5 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
           }
         }
     }
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -18,7 +18,7 @@
 package com.waz.zclient.common.controllers.global
 
 import android.content.Context
-import com.waz.content.UserPreferences.{AppLockEnabled, AppLockForced, AppLockTimeout}
+import com.waz.content.UserPreferences._
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccountData.Password
@@ -58,11 +58,12 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       }
   }
 
-  val ssoEnabled:          Signal[Boolean] = accounts.isActiveAccountSSO
-  val customPasswordEmpty: Signal[Boolean] = customPassword.flatMap(_.signal.map(_.isEmpty))
-  val appLockEnabled:      Signal[Boolean] = prefs.flatMap(_.preference(AppLockEnabled).signal)
-  val appLockForced:       Signal[Boolean] = prefs.flatMap(_.preference(AppLockForced).signal)
-  val appLockTimeout:      Signal[Int]     = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
+  val ssoEnabled:            Signal[Boolean] = accounts.isActiveAccountSSO
+  val customPasswordEmpty:   Signal[Boolean] = customPassword.flatMap(_.signal.map(_.isEmpty))
+  val appLockEnabled:        Signal[Boolean] = prefs.flatMap(_.preference(AppLockEnabled).signal)
+  val appLockFeatureEnabled: Signal[Boolean] = prefs.flatMap(_.preference(AppLockFeatureEnabled).signal)
+  val appLockForced:         Signal[Boolean] = prefs.flatMap(_.preference(AppLockForced).signal)
+  val appLockTimeout:        Signal[Int]     = prefs.flatMap(_.preference(AppLockTimeout).signal).map {
     case None           => BuildConfig.APP_LOCK_TIMEOUT
     case Some(duration) => duration.toSeconds.toInt
   }
@@ -122,7 +123,7 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
     }
 
   private def openNewPasswordDialog(mode: NewPasswordDialog.Mode)(implicit ctx: Context) =  {
-    // The "Change Passcode" version of the dialog is always presented on the dark theme even if the controller says otherwise
+    // The "Change Passcode" version of the dialog is always presented on the dark themeeven if the controller says otherwise
     val isDarkTheme = mode == NewPasswordDialog.ChangeMode || inject[ThemeController].isDarkTheme
     val dialog = NewPasswordDialog.newInstance(mode, isDarkTheme)
     dialog.show(ctx.asInstanceOf[BaseActivity])

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
@@ -1,7 +1,7 @@
 package com.waz.zclient.preferences.dialogs
 
 import android.app.Dialog
-import android.content.DialogInterface.BUTTON_POSITIVE
+import android.content.DialogInterface.{BUTTON_NEGATIVE, BUTTON_POSITIVE, OnClickListener}
 import android.os.Bundle
 import android.text.method.{HideReturnsTransformationMethod, PasswordTransformationMethod}
 import android.view.{LayoutInflater, View, WindowManager}
@@ -10,12 +10,14 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.waz.model.AccountData.Password
 import com.waz.utils.{PasswordValidator, returning}
-import com.waz.zclient.{BuildConfig, FragmentHelper, R}
-import com.waz.zclient.common.controllers.global.{KeyboardController, PasswordController}
+import com.waz.zclient.{BaseActivity, BuildConfig, FragmentHelper, R}
+import com.waz.zclient.common.controllers.global.KeyboardController
 import com.waz.zclient.utils.ContextUtils
 import ContextUtils._
-
-import scala.util.Try
+import android.content.DialogInterface
+import com.waz.zclient.log.LogUI._
+import com.waz.zclient.ui.utils.KeyboardUtils
+import com.wire.signals.EventStream
 
 class NewPasswordDialog extends DialogFragment with FragmentHelper {
   import NewPasswordDialog._
@@ -46,34 +48,63 @@ class NewPasswordDialog extends DialogFragment with FragmentHelper {
   private lazy val isDarkTheme = getBooleanArg(IsDarkTheme)
   private lazy val keyboard = inject[KeyboardController]
 
-  override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
+  private lazy val dialog = {
     val builder = new AlertDialog.Builder(getActivity)
       .setView(root)
       .setTitle(getString(mode.dialogTitleId))
       .setMessage(getString(R.string.new_password_dialog_message))
-      .setPositiveButton(mode.dialogButtonId, null)
+      .setPositiveButton(mode.dialogButtonId, new OnClickListener() {
+        override def onClick(dialog: DialogInterface, which: Int): Unit = checkAndSetPassword()
+      })
 
-    if (mode.cancellable) builder.setNegativeButton(android.R.string.cancel, null)
+    if (mode.cancellable) builder.setNegativeButton(android.R.string.cancel, new OnClickListener {
+      override def onClick(dialog: DialogInterface, which: Int): Unit = onAnswer ! None
+    })
 
     builder.create()
   }
 
+  val onAnswer = EventStream[Option[Password]]()
+
+  def close(): Unit = {
+    KeyboardUtils.closeKeyboardIfShown(getActivity)
+    dismiss()
+  }
+
+  private def checkAndSetPassword(): Unit = {
+    val pass = passwordEditText.getText.toString
+    if (strongPasswordValidator.isValidPassword(pass)) {
+      onAnswer ! Some(Password(pass))
+    } else {
+      newPasswordHint.setTextColor(getColor(R.color.accent_red))
+    }
+  }
+
+  def show(activity: BaseActivity): Unit =
+    activity.getSupportFragmentManager
+      .beginTransaction
+      .add(this, NewPasswordDialog.Tag)
+      .addToBackStack(NewPasswordDialog.Tag)
+      .commit
+
+  override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
+    dialog
+  }
+
+  override def onBackPressed(): Boolean = {
+    if (mode.cancellable) onAnswer ! None
+    true
+  }
+
   override def onStart(): Unit = {
     super.onStart()
-    Try(getDialog.asInstanceOf[AlertDialog]).foreach {
-      _.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-        def onClick(v: View): Unit = {
-          val pass = passwordEditText.getText.toString
-          if (strongPasswordValidator.isValidPassword(pass)) {
-            inject[PasswordController].setCustomPassword(Password(pass))
-            keyboard.hideKeyboardIfVisible()
-            dismiss()
-          } else {
-            newPasswordHint.setTextColor(getColor(R.color.accent_red))
-          }
-        }
-      })
-    }
+    dialog.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+      override def onClick(v: View): Unit = checkAndSetPassword()
+    })
+
+    if (mode.cancellable) dialog.getButton(BUTTON_NEGATIVE).setOnClickListener(new View.OnClickListener {
+      override def onClick(v: View): Unit = onAnswer ! None
+    })
 
     newPasswordHint
     showHideButton
@@ -97,11 +128,12 @@ object NewPasswordDialog {
   val Mode: String = "Mode"
   val IsDarkTheme: String = "IsDarkTheme"
 
-  def newInstance(mode: Mode, isDarkTheme: Boolean): NewPasswordDialog = returning(new NewPasswordDialog){
-    _.setArguments(returning(new Bundle()) { bundle =>
+  def newInstance(mode: Mode, isDarkTheme: Boolean): NewPasswordDialog = returning(new NewPasswordDialog){ dialog =>
+    dialog.setArguments(returning(new Bundle()) { bundle =>
       bundle.putString(Mode, mode.id)
       bundle.putBoolean(IsDarkTheme, isDarkTheme)
     })
+    dialog.setCancelable(mode.cancellable)
   }
 
   sealed trait Mode {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/NewPasswordDialog.scala
@@ -15,7 +15,6 @@ import com.waz.zclient.common.controllers.global.KeyboardController
 import com.waz.zclient.utils.ContextUtils
 import ContextUtils._
 import android.content.DialogInterface
-import com.waz.zclient.log.LogUI._
 import com.waz.zclient.ui.utils.KeyboardUtils
 import com.wire.signals.EventStream
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
@@ -44,9 +44,11 @@ class AppLockView(context: Context, attrs: AttributeSet, style: Int)
 
   passwordController.appLockEnabled.foreach {
     case true =>
+      verbose(l"app lock enabled")
       passwordController.setCustomPasswordIfNeeded()
       appLockChangeButton.setVisible(true)
     case false =>
+      verbose(l"app lock disabled")
       passwordController.clearCustomPassword()
       appLockChangeButton.setVisible(false)
   }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AppLockView.scala
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import com.waz.content.UserPreferences.AppLockEnabled
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.global.PasswordController
@@ -13,9 +14,10 @@ import com.waz.zclient.preferences.views.{SwitchPreference, TextButton}
 import com.waz.zclient.utils.ContextUtils.getString
 import com.waz.zclient.{BuildConfig, R, ViewHelper}
 import com.waz.zclient.utils._
+import com.waz.zclient.log.LogUI._
 
 class AppLockView(context: Context, attrs: AttributeSet, style: Int)
-  extends LinearLayout(context, attrs, style) with ViewHelper {
+  extends LinearLayout(context, attrs, style) with ViewHelper with DerivedLogTag {
   import Threading.Implicits.Ui
 
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
@@ -42,9 +44,10 @@ class AppLockView(context: Context, attrs: AttributeSet, style: Int)
 
   passwordController.appLockEnabled.foreach {
     case true =>
-      passwordController.setCustomPasswordIfNeeded(fromSettings = true)
+      passwordController.setCustomPasswordIfNeeded()
       appLockChangeButton.setVisible(true)
     case false =>
+      passwordController.clearCustomPassword()
       appLockChangeButton.setVisible(false)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -110,7 +110,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     appLockButton.setSubtitle(getString(R.string.pref_options_app_lock_summary, timeout.toString))
   }
 
-  passwordController.appLockEnabled.foreach(appLockButton.setVisible)
+  passwordController.appLockFeatureEnabled.foreach(appLockButton.setVisible)
 
   override val appLock: EventStream[Unit] = appLockButton.onClickEvent.map(_ => ())
 

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -415,6 +415,7 @@ object UserPreferences {
   lazy val CustomPasswordIv = PrefKey[Option[String]]("sso_password_iv", customDefault = None)
 
   lazy val AppLockEnabled: PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
+  lazy val AppLockFeatureEnabled: PrefKey[Boolean]         = PrefKey[Boolean]("app_lock_feature_enabled", customDefault = true)
   lazy val AppLockForced:  PrefKey[Boolean]                = PrefKey[Boolean]("app_lock_forced", customDefault = false)
   lazy val AppLockTimeout: PrefKey[Option[FiniteDuration]] = PrefKey[Option[FiniteDuration]]("app_lock_timeout", customDefault = None)
 }

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureFlagsService.scala
@@ -21,8 +21,11 @@ class FeatureFlagsServiceImpl(syncHandler: FeatureFlagsSyncHandler,
     for {
       appLock <- syncHandler.fetchAppLock()
       _       =  verbose(l"AppLock feature flag : $appLock")
-      _       <- userPrefs(AppLockEnabled) := appLock.enabled
+      _       <- userPrefs(AppLockFeatureEnabled) := appLock.enabled
       _       <- userPrefs(AppLockForced)  := appLock.forced
+      _       <- if (!appLock.enabled) userPrefs(AppLockEnabled) := false
+                 else if (appLock.forced) userPrefs(AppLockEnabled) := true
+                 else Future.successful(())
       _       <- userPrefs(AppLockTimeout) := appLock.timeout
     } yield ()
 }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-255
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-256
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-258
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-259

The bugs made it clear that the old implementation of the "Set Password" dialog doesn't work. I rewrote it and made it more similar to how "Request Password" works. 
The other significant change is that the `enabled` flag in the App Lock feature flag was sometimes used to indicate that the feature itself is available, and sometimes that the app lock is on/off. I created a new flag for the former meaning.
#### APK
[Download build #3138](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3138/artifact/build/artifact/wire-dev-PR3176-3138.apk)