### PR TITLE
Refactor: ObservableUseCase - Change return type

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/usecase/UseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/core/usecase/UseCase.kt
@@ -9,5 +9,5 @@ interface UseCase<out Type, in Params> {
 }
 
 interface ObservableUseCase<out Type, in Params> {
-    suspend fun run(params: Params): Flow<Either<Failure, Type>>
+    suspend fun run(params: Params): Flow<Type>
 }

--- a/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
@@ -23,7 +23,7 @@ interface UseCaseExecutor {
         scope: CoroutineScope,
         params: P,
         dispatcher: CoroutineDispatcher = dispatcherProvider.io(),
-        onResult: (Either<Failure, T>) -> Unit = {}
+        onResult: (T) -> Unit = {}
     )
 }
 
@@ -45,7 +45,7 @@ class DefaultUseCaseExecutor(override val dispatcherProvider: DispatcherProvider
         scope: CoroutineScope,
         params: P,
         dispatcher: CoroutineDispatcher,
-        onResult: (Either<Failure, T>) -> Unit
+        onResult: (T) -> Unit
     ) {
         val backgroundJob = scope.async(dispatcher) { run(params) }
         scope.launch {

--- a/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
@@ -5,10 +5,9 @@ import com.wire.android.core.async.DispatcherProvider
 import com.wire.android.core.functional.Either
 import com.wire.android.framework.coroutines.TestDispatcherProvider
 import io.mockk.coEvery
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.flowOf
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBe
 import org.junit.Before
@@ -47,7 +46,7 @@ class DefaultUseCaseExecutorTest : UnitTest() {
     fun `given a scope and an observable use case, when invoke is called on use case, then applies onResult to returned value`() {
         val observableUseCase = mockk<ObservableUseCase<String, Int>>()
         val param = 3
-        val result = Either.Right("3")
+        val result = "abc"
         coEvery { observableUseCase.run(param) } returns flowOf(result)
 
         runBlocking {


### PR DESCRIPTION
- Changes ObservableUseCase signature to return `Flow<T>` instead of `Flow<Either<Failure, T>>`.
- Use cases that wish to return `Flow<Either<Failure, T>>` can still do so by setting `Either<Failure, T>` for `Type`