### PR TITLE
Changes needed for work with wire-signals-0.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -407,6 +407,7 @@ dependencies {
     implementation BuildDependencies.countly
 
     implementation BuildDependencies.wireSignals
+    implementation BuildDependencies.wireSignalsExtensions
 
     implementation BuildDependencies.libSodium
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -42,6 +42,7 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.DeprecationUtils
 import com.waz.zclient.{BuildConfig, Injectable, Injector, R, WireContext}
 import com.wire.signals._
+import com.wire.signals.ext.{ButtonSignal, ClockSignal}
 import org.threeten.bp.Instant
 
 import scala.concurrent.Future

--- a/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/toolbar/AudioMessageRecordingView.scala
@@ -35,7 +35,7 @@ import com.waz.service.ZMessaging
 import com.waz.service.assets.{Content, ContentForUpload}
 import com.waz.service.assets.GlobalRecordAndPlayService.AssetMediaKey
 import com.waz.threading.Threading
-import com.wire.signals.{ClockSignal, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.wrappers.URI
 import com.waz.utils.{RichThreetenBPDuration, returning}
 import com.waz.zclient.common.controllers.AssetsController.PlaybackControls
@@ -54,6 +54,7 @@ import com.waz.zclient.log.LogUI._
 
 import scala.concurrent.Future
 import com.waz.threading.Threading._
+import com.wire.signals.ext.ClockSignal
 
 class AudioMessageRecordingView (val context: Context, val attrs: AttributeSet, val defStyleAttr: Int)
   extends FrameLayout(context, attrs, defStyleAttr)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
@@ -25,7 +25,7 @@ import android.widget.{ImageView, TextView}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.AccentColor
 import com.waz.threading.Threading
-import com.wire.signals.{ClockSignal, Signal}
+import com.wire.signals.Signal
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.messages.MessageViewPart
@@ -33,6 +33,7 @@ import com.waz.zclient.ui.theme.ThemeUtils
 import com.waz.zclient.ui.utils.{ColorUtils, TypefaceUtils}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
+import com.wire.signals.ext.ClockSignal
 
 trait EphemeralPartView extends MessageViewPart { self: ViewHelper =>
 
@@ -100,7 +101,7 @@ trait EphemeralIndicatorPartView
       if (expired) Signal const 360
       else expiryTime.fold(Signal const 0) { time =>
         val interval = ephemeral.get / 360
-        ClockSignal(interval) map { now =>
+        ClockSignal(interval).map { now =>
           val remaining = time.toEpochMilli - now.toEpochMilli
           360 - ((remaining * 360f / ephemeral.get.toMillis).toInt max 0 min 360)
         }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
@@ -25,7 +25,7 @@ import com.waz.service.messages.{MessageAndLikes, MessagesService}
 import com.waz.service.{NetworkModeService, ZMessaging}
 import com.wire.signals.CancellableFuture
 import com.waz.utils._
-import com.wire.signals.{ClockSignal, EventContext, Signal}
+import com.wire.signals.{EventContext, Signal}
 import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.MessageView.MsgBindOptions
@@ -33,6 +33,7 @@ import com.waz.zclient.messages.{LikesController, UsersController}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.Time.SameDayTimeStamp
 import com.waz.zclient.{Injectable, Injector, R}
+import com.wire.signals.ext.ClockSignal
 import org.threeten.bp.Instant
 
 import scala.concurrent.duration._
@@ -42,7 +43,7 @@ import scala.concurrent.duration._
   */
 class FooterViewController(implicit inj: Injector, context: Context, ec: EventContext)
   extends Injectable with DerivedLogTag {
-  
+
   import com.waz.threading.Threading.Implicits.Ui
 
   val accents                = inject[AccentColorController]
@@ -97,7 +98,7 @@ class FooterViewController(implicit inj: Injector, context: Context, ec: EventCo
     case None => Signal const None
     case Some(expiry) if expiry <= LocalInstant.Now => Signal const None
     case Some(expiry) =>
-      ClockSignal(1.second) map { now =>
+      ClockSignal(1.second).map { now =>
         Some(now.until(expiry.instant).asScala).filterNot(_.isNegative)
       }
   }

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -50,6 +50,7 @@ import com.waz.zclient.{Injectable, Injector, R}
 
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
+import com.wire.signals.ext.ClockSignal
 
 class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]],
                           maxParticipants: Option[Int] = None,
@@ -355,7 +356,7 @@ object ParticipantsAdapter {
     private var userId = Option.empty[UserId]
 
     view.onClick(userId.foreach(onClick ! _))
-    
+
     def bind(participant:    ParticipantData,
              teamId:         Option[TeamId],
              lastRow:        Boolean,

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -29,7 +29,7 @@ import com.waz.service.ZMessaging
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.wire.signals.{ClockSignal, Signal, Subscription}
+import com.wire.signals.{Signal, Subscription}
 import com.waz.zclient.common.controllers.{BrowserController, ThemeController, UserAccountsController}
 import com.waz.zclient.controllers.navigation.{INavigationController, Page}
 import com.waz.zclient.conversation.ConversationController
@@ -45,6 +45,7 @@ import org.threeten.bp.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
+import com.wire.signals.ext.ClockSignal
 
 class SingleParticipantFragment extends FragmentHelper {
   import Threading.Implicits.Ui

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -154,6 +154,7 @@ object BuildDependencies {
     val countly = "ly.count.android:sdk:${Versions.COUNTLY}"
 
     val wireSignals = "com.wire:wire-signals_${LegacyDependencies.SCALA_MAJOR_VERSION}:${LegacyDependencies.WIRE_SIGNALS}"
+    val wireSignalsExtensions = "com.wire:wire-signals-extensions_${LegacyDependencies.SCALA_MAJOR_VERSION}:${LegacyDependencies.WIRE_SIGNALS_EXTENSIONS}"
 }
 
 object ModuleDependencies {
@@ -191,7 +192,8 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.3.2"
+    const val WIRE_SIGNALS = "0.4.0"
+    const val WIRE_SIGNALS_EXTENSIONS = "0.4.0"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation "com.wire:icu4j-shrunk:57.1"
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
     implementation BuildDependencies.wireSignals
+    implementation BuildDependencies.wireSignalsExtensions
     implementation BuildDependencies.libSodium
 
     //Provided dependencies

--- a/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -39,6 +39,7 @@ import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.signals._
 import com.waz.utils.wrappers.URI
+import com.wire.signals.ext.ClockSignal
 import org.threeten.bp
 import org.threeten.bp.Instant
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -29,7 +29,8 @@ import com.waz.service.call.CallInfo.{ActiveSpeaker, CallState, OutstandingMessa
 import com.waz.service.call.CallInfo.CallState._
 import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
 import com.waz.utils.returning
-import com.wire.signals.{ClockSignal, Signal}
+import com.wire.signals.Signal
+import com.wire.signals.ext.ClockSignal
 import org.threeten.bp.Duration
 import org.threeten.bp.Duration.between
 


### PR DESCRIPTION
Wire Signals 0.4.0 brings a fix for the throttled signal which before sometimes ignored values sent to it from the original signal (https://github.com/wireapp/wire-signals/pull/48) and it splits the signals project into two: wire-signals and wire-signals-extensions. wire-signals will contain the "core" functionality which depends only on the standard Scala library, and "extensions" will be a small (but growing, hopefully) set of event streams and signals built on top of the core. They can use additional dependencies and can be designed for specific tasks while the ones in the core should be rather generic. 

The reasoning behind this is that the core library is enough to perform the main task of event streams and signals, which is to transport events across the app. For some users this might be all they need and so they will be interested more in lack of additional dependencies, small codebase, and performance.

The "extensions" library contains for now only `ClockSignal` and `ButtonSignal` and depends on ThreeTenBP.

#### APK
[Download build #3147](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3147/artifact/build/artifact/wire-dev-PR3181-3147.apk)