### PR TITLE
Chore : Add bintray-backup repository for Grgit

### DIFF
--- a/scripts/customization.gradle
+++ b/scripts/customization.gradle
@@ -6,6 +6,10 @@ import org.ajoberstar.grgit.Credentials
 buildscript {
     repositories {
         jcenter()
+        maven {
+            name "ajoberstar-backup"
+            url "https://ajoberstar.github.io/bintray-backup/"
+        }
     }
     dependencies {
         classpath "org.ajoberstar.grgit:grgit-core:${Versions.GRGIT}"

--- a/scripts/customization.gradle
+++ b/scripts/customization.gradle
@@ -5,7 +5,7 @@ import org.ajoberstar.grgit.Credentials
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name "ajoberstar-backup"
             url "https://ajoberstar.github.io/bintray-backup/"


### PR DESCRIPTION
## What's new in this PR?

Grgit was previously uploaded to JCenter, which is being retired by JFrog on May 1st 2021. To allow continued access to it, we have to use a Maven repo available in bintray-backup. 

Reference : https://github.com/ajoberstar/grgit
#### APK
[Download build #3148](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3148/artifact/build/artifact/wire-dev-PR3182-3148.apk)
[Download build #3149](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3149/artifact/build/artifact/wire-dev-PR3182-3149.apk)