### PR TITLE
[Calling] Bugfix : Active speakers view stability

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -189,7 +189,7 @@ class CallingFragment extends FragmentHelper {
         views.sortWith {
           case (v1, v2) =>
             infoMap(v1.participant.userId).displayName.toLowerCase < infoMap(v2.participant.userId).displayName.toLowerCase
-        }.take(MaxTopSpeakerVideoPreviews)
+        }
       else
         views.filter {
           case _: SelfVideoView if views.size == 2 && participants.size == 2 && isVideoBeingSent => false
@@ -255,6 +255,5 @@ class CallingFragment extends FragmentHelper {
 object CallingFragment {
   val Tag: String = getClass.getSimpleName
   val MaxAllVideoPreviews = 12
-  val MaxTopSpeakerVideoPreviews = 4
   def apply(): CallingFragment = new CallingFragment()
 }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -54,6 +54,8 @@ class CallController(implicit inj: Injector, cxt: WireContext)
   import Threading.Implicits.Background
   import VideoState._
 
+  val MaxTopSpeakerVideoPreviews = 4
+
   val isFullScreenEnabled = Signal(false)
   val showTopSpeakers = Signal(false)
 
@@ -123,7 +125,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
           activeSpeakers.exists { speaker =>
             participant.clientId == speaker.clientId && participant.userId == speaker.userId && speaker.longTermAudioLevel > 0
           }
-        }
+        }.take(MaxTopSpeakerVideoPreviews)
     }
 
   lazy val videoUsers =

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -121,7 +121,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
       case (activeSpeakers, videoUsers) =>
         videoUsers.filter { participant =>
           activeSpeakers.exists { speaker =>
-            participant.clientId == speaker.clientId && participant.userId == speaker.userId
+            participant.clientId == speaker.clientId && participant.userId == speaker.userId && (speaker.longTermAudioLevel > 0 || speaker.instantAudioLevel > 0)
           }
         }
     }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -121,7 +121,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
       case (activeSpeakers, videoUsers) =>
         videoUsers.filter { participant =>
           activeSpeakers.exists { speaker =>
-            participant.clientId == speaker.clientId && participant.userId == speaker.userId && (speaker.longTermAudioLevel > 0 || speaker.instantAudioLevel > 0)
+            participant.clientId == speaker.clientId && participant.userId == speaker.userId && speaker.longTermAudioLevel > 0
           }
         }
     }

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.12"
+String avsPrivateVersion = "6.7.13"
 
 String nexusUrl = ""
 

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -9,7 +9,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "6.7.9"
+String avsPrivateVersion = "6.7.12"
 
 String nexusUrl = ""
 


### PR DESCRIPTION
## What's new in this PR?

- Bump avs version to 6.7.13
- Move the logic for picking the top 4 active speakers to `CallController`
