### PR TITLE
[Calling] : Bugfix : speakers toggle is selected after starting a new call

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -88,6 +88,10 @@ class CallingFragment extends FragmentHelper {
 
     videoGrid
 
+    controller.showTopSpeakers.onChanged { _ =>
+      clearVideoGrid()
+    }
+
     Signal.zip(
       controller.showTopSpeakers,
       controller.longTermActiveParticipantsWithVideo().map(_.size > 0),

--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -31,8 +31,8 @@ import com.waz.zclient.calling.views.{CallingHeader, CallingMiddleLayout, Contro
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
-import com.waz.zclient.{FragmentHelper, MainActivity, R}
-import com.wire.signals.{Subscription}
+import com.waz.zclient.{BuildConfig, FragmentHelper, MainActivity, R}
+import com.wire.signals.{Signal, Subscription}
 
 class ControlsFragment extends FragmentHelper {
 
@@ -93,9 +93,7 @@ class ControlsFragment extends FragmentHelper {
       }
     }
 
-    //TODO : The calling squad decided to disable all/speaker toggle to perform some optimizations
-    // in terms of user experience before releasing it to public
-    /*if (BuildConfig.ACTIVE_SPEAKERS) {
+    if (BuildConfig.ACTIVE_SPEAKERS) {
        Signal.zip(
          controller.isCallEstablished,
          controller.isGroupCall,
@@ -106,8 +104,7 @@ class ControlsFragment extends FragmentHelper {
          case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
        }
      }
-     else */
-    speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
+     else speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
   }
 
   override def onStart(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -329,6 +329,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
 
   isCallActive.onChanged.filter(_ == false).on(Threading.Ui) { _ =>
     screenManager.releaseWakeLock()
+    showTopSpeakers ! false
   }
 
   (for {


### PR DESCRIPTION
## What's new in this PR?

This PR fixes a bug for the all/speakers toggle. When we switch the toggle from "All" to "Speakers", hang up and start a new call, speakers is selected. The toggle should be resetted to "All".

https://wearezeta.atlassian.net/browse/SQCALL-181
#### APK
[Download build #3170](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3170/artifact/build/artifact/wire-dev-PR3192-3170.apk)