### PR TITLE
Feature: Conversation Name - Part 1 - Add updateConversations method to data layer

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/local/ConversationDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/local/ConversationDaoTest.kt
@@ -46,6 +46,36 @@ class ConversationDaoTest : InstrumentationTest() {
     }
 
     @Test
+    fun updateConversations_conversationExists_updatesItems() = databaseTestRule.runTest {
+        val entity1 = ConversationEntity(id = "id-1", name = "Conversation #1", type = 1)
+        val entity2 = ConversationEntity(id = "id-2", name = "Conversation #2", type = 2)
+        conversationDao.insertAll(listOf(entity1, entity2))
+
+        val newName = "New Conversation Name"
+        val updatedEntity1 = entity1.copy(name = newName)
+        val newType = 3
+        val updatedEntity2 = entity2.copy(type = newType)
+        conversationDao.updateConversations(listOf(updatedEntity1, updatedEntity2))
+
+        val conversations = conversationDao.conversations()
+
+        conversations shouldContainSame listOf(updatedEntity1, updatedEntity2)
+    }
+
+    @Test
+    fun updateConversations_conversationDoesNotExist_doesNothing() = databaseTestRule.runTest {
+        val entity = ConversationEntity(id = "id-1", name = "Conversation #1", type = 1)
+        conversationDao.insert(entity)
+
+        val updatedEntity = ConversationEntity(id = "id-2", name = "Conversation #2", type = 2)
+        conversationDao.updateConversations(listOf(updatedEntity))
+
+        val conversations = conversationDao.conversations()
+
+        conversations shouldContainSame listOf(entity)
+    }
+
+    @Test
     fun deleteConversationById_conversationWithIdExists_deletesConversation() = databaseTestRule.runTest {
         conversationDao.insert(TEST_CONVERSATION_ENTITY)
 

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
@@ -13,7 +13,7 @@ class ConversationDataSource(
     private val conversationMapper: ConversationMapper,
     private val conversationRemoteDataSource: ConversationsRemoteDataSource,
     private val conversationLocalDataSource: ConversationLocalDataSource
-) : ConversationsRepository {
+) : ConversationRepository {
 
     override suspend fun fetchConversations(): Either<Failure, Unit> = fetchRemoteConversations()
 
@@ -51,6 +51,11 @@ class ConversationDataSource(
 
     override suspend fun allConversationMemberIds(): Either<Failure, List<String>> =
         conversationLocalDataSource.allConversationMemberIds()
+
+    override suspend fun updateConversations(conversations: List<Conversation>): Either<Failure, Unit> {
+        val entities = conversationMapper.toEntityList(conversations)
+        return conversationLocalDataSource.updateConversations(entities)
+    }
 
     companion object {
         private const val CONVERSATION_REQUEST_PAGE_SIZE = 100

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
@@ -25,4 +25,13 @@ class ConversationMapper(private val conversationTypeMapper: ConversationTypeMap
         name = entity.name,
         type = conversationTypeMapper.fromIntValue(entity.type)
     )
+
+    fun toEntityList(conversationList: List<Conversation>) : List<ConversationEntity> =
+        conversationList.map { toEntity(it) }
+
+    private fun toEntity(conversation: Conversation) = ConversationEntity(
+        id = conversation.id,
+        name = conversation.name,
+        type = conversationTypeMapper.toIntValue(conversation.type)
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationRepository.kt
@@ -4,10 +4,12 @@ import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import com.wire.android.feature.conversation.Conversation
 
-interface ConversationsRepository {
+interface ConversationRepository {
     suspend fun fetchConversations(): Either<Failure, Unit>
 
     suspend fun conversationMemberIds(conversation: Conversation): Either<Failure, List<String>>
 
     suspend fun allConversationMemberIds(): Either<Failure, List<String>>
+
+    suspend fun updateConversations(conversations: List<Conversation>): Either<Failure, Unit>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationDao.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationDao.kt
@@ -1,10 +1,10 @@
 package com.wire.android.feature.conversation.data.local
 
-import androidx.paging.DataSource
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 
 @Dao
 interface ConversationDao {
@@ -15,12 +15,12 @@ interface ConversationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(conversationList: List<ConversationEntity>)
 
+    @Update
+    suspend fun updateConversations(conversationList: List<ConversationEntity>)
+
     @Query("DELETE FROM conversation WHERE id = :id")
     fun deleteConversationById(id: String)
 
     @Query("SELECT * FROM conversation")
     suspend fun conversations(): List<ConversationEntity>
-
-    @Query("SELECT * FROM conversation")
-    fun conversationsInBatch(): DataSource.Factory<Int, ConversationEntity>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
@@ -12,10 +12,12 @@ class ConversationLocalDataSource(
     private val conversationMembersDao: ConversationMembersDao
 ) : DatabaseService {
 
-    fun conversationsDataFactory(): DataSource.Factory<Int, ConversationEntity> = conversationDao.conversationsInBatch()
-
     suspend fun saveConversations(conversations: List<ConversationEntity>): Either<Failure, Unit> = request {
         conversationDao.insertAll(conversations)
+    }
+
+    suspend fun updateConversations(conversations: List<ConversationEntity>): Either<Failure, Unit> = request {
+        conversationDao.updateConversations(conversations)
     }
 
     suspend fun saveMemberIdsForConversations(conversationMemberEntityList: List<ConversationMemberEntity>) = request {

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -7,7 +7,7 @@ import com.wire.android.core.ui.navigation.FragmentContainerProvider
 import com.wire.android.feature.conversation.data.ConversationDataSource
 import com.wire.android.feature.conversation.data.ConversationMapper
 import com.wire.android.feature.conversation.data.ConversationTypeMapper
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource
 import com.wire.android.feature.conversation.data.remote.ConversationsApi
 import com.wire.android.feature.conversation.data.remote.ConversationsRemoteDataSource
@@ -39,7 +39,7 @@ val conversationsModule = module {
 
     factory { ConversationIconProvider(get()) }
 
-    single<ConversationsRepository> { ConversationDataSource(get(), get(), get()) }
+    single<ConversationRepository> { ConversationDataSource(get(), get(), get()) }
     factory { ConversationMapper(get()) }
     factory { ConversationTypeMapper() }
 

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationMembersUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationMembersUseCase.kt
@@ -7,15 +7,15 @@ import com.wire.android.core.usecase.UseCase
 import com.wire.android.feature.contact.Contact
 import com.wire.android.feature.contact.ContactRepository
 import com.wire.android.feature.conversation.Conversation
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 
 class GetConversationMembersUseCase(
-    private val conversationsRepository: ConversationsRepository,
+    private val conversationRepository: ConversationRepository,
     private val contactRepository: ContactRepository
 ) : UseCase<List<Contact>, GetConversationMembersParams> {
 
     override suspend fun run(params: GetConversationMembersParams): Either<Failure, List<Contact>> = suspending {
-        conversationsRepository.conversationMemberIds(params.conversation).flatMap { memberIds ->
+        conversationRepository.conversationMemberIds(params.conversation).flatMap { memberIds ->
             contactRepository.contactsById(memberIds.toSet())
         }
     }

--- a/app/src/main/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncAllConversationMembersUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncAllConversationMembersUseCase.kt
@@ -5,15 +5,15 @@ import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.suspending
 import com.wire.android.core.usecase.UseCase
 import com.wire.android.feature.contact.ContactRepository
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 
 class SyncAllConversationMembersUseCase(
-    private val conversationsRepository: ConversationsRepository,
+    private val conversationRepository: ConversationRepository,
     private val  contactRepository: ContactRepository
 ) : UseCase<Unit, Unit> {
 
     override suspend fun run(params: Unit): Either<Failure, Unit> = suspending {
-        conversationsRepository.allConversationMemberIds().flatMap {
+        conversationRepository.allConversationMemberIds().flatMap {
             contactRepository.fetchContactsById(it.toSet())
         }
     }

--- a/app/src/main/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncConversationsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncConversationsUseCase.kt
@@ -3,11 +3,11 @@ package com.wire.android.feature.sync.conversation.usecase
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import com.wire.android.core.usecase.UseCase
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 
-class SyncConversationsUseCase(private val conversationsRepository: ConversationsRepository) : UseCase<Unit, Unit> {
+class SyncConversationsUseCase(private val conversationRepository: ConversationRepository) : UseCase<Unit, Unit> {
 
     //TODO: load conversation roles as well
     override suspend fun run(params: Unit): Either<Failure, Unit> =
-        conversationsRepository.fetchConversations()
+        conversationRepository.fetchConversations()
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
@@ -171,8 +171,8 @@ class ConversationDataSourceTest : UnitTest() {
 
         runBlocking { conversationDataSource.fetchConversations() }
 
-        coVerify(exactly = 1) { conversationRemoteDataSource.conversationsByBatch(null, any())  }
-        coVerify(exactly = 1) { conversationRemoteDataSource.conversationsByBatch(TEST_CONVERSATION_ID, any())  }
+        coVerify(exactly = 1) { conversationRemoteDataSource.conversationsByBatch(null, any()) }
+        coVerify(exactly = 1) { conversationRemoteDataSource.conversationsByBatch(TEST_CONVERSATION_ID, any()) }
     }
 
 
@@ -216,6 +216,30 @@ class ConversationDataSourceTest : UnitTest() {
         coEvery { conversationLocalDataSource.allConversationMemberIds() } returns Either.Left(failure)
 
         val result = runBlocking { conversationDataSource.allConversationMemberIds() }
+
+        result shouldFail { it shouldBeEqualTo failure }
+    }
+
+    @Test
+    fun `given updateConversations is called, when localDataSource updates successfully, then propagates success`() {
+        val conversations = mockk<List<Conversation>>()
+        every { conversationMapper.toEntityList(conversations) } returns mockk()
+        coEvery { conversationLocalDataSource.updateConversations(any()) } returns Either.Right(Unit)
+
+        val result = runBlocking { conversationDataSource.updateConversations(conversations) }
+
+        result shouldSucceed { }
+    }
+
+    @Test
+    fun `given updateConversations is called, when localDataSource fails to update, then propagates failure`() {
+        val conversations = mockk<List<Conversation>>()
+        every { conversationMapper.toEntityList(conversations) } returns mockk()
+
+        val failure = mockk<Failure>()
+        coEvery { conversationLocalDataSource.updateConversations(any()) } returns Either.Left(failure)
+
+        val result = runBlocking { conversationDataSource.updateConversations(conversations) }
 
         result shouldFail { it shouldBeEqualTo failure }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
@@ -3,6 +3,8 @@ package com.wire.android.feature.conversation.data
 import com.wire.android.UnitTest
 import com.wire.android.feature.conversation.Conversation
 import com.wire.android.feature.conversation.ConversationType
+import com.wire.android.feature.conversation.Group
+import com.wire.android.feature.conversation.OneToOne
 import com.wire.android.feature.conversation.data.local.ConversationEntity
 import com.wire.android.feature.conversation.data.remote.ConversationMembersResponse
 import com.wire.android.feature.conversation.data.remote.ConversationOtherMembersResponse
@@ -88,6 +90,37 @@ class ConversationMapperTest : UnitTest() {
         val conversation = conversationMapper.fromEntity(conversationEntity)
 
         conversation shouldBeEqualTo Conversation(id = TEST_CONVERSATION_ID, name = TEST_CONVERSATION_NAME, type = type)
+    }
+
+    @Test
+    fun `given a list of conversations, when ToEntityList is called, then returns a list of entities`() {
+        val id1 = "$TEST_CONVERSATION_ID-1"
+        val name1 = "$TEST_CONVERSATION_NAME-1"
+        val groupTypeInt = 0
+        val conversation1 = mockk<Conversation>().also {
+            every { it.id } returns id1
+            every { it.name } returns name1
+            every { it.type } returns Group
+        }
+        every { conversationTypeMapper.toIntValue(Group) } returns groupTypeInt
+
+        val id2 = "$TEST_CONVERSATION_ID-2"
+        val oneToOneTypeInt = 2
+        val conversation2 = mockk<Conversation>().also {
+            every { it.id } returns id2
+            every { it.name } returns null
+            every { it.type } returns OneToOne
+        }
+        every { conversationTypeMapper.toIntValue(OneToOne) } returns oneToOneTypeInt
+
+        val conversationList = listOf(conversation1, conversation2)
+
+        val entityList = conversationMapper.toEntityList(conversationList)
+
+        entityList shouldContainSame listOf(
+            ConversationEntity(id = id1, name = name1, type = groupTypeInt),
+            ConversationEntity(id = id2, name = null, type = oneToOneTypeInt)
+        )
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSourceTest.kt
@@ -1,6 +1,5 @@
 package com.wire.android.feature.conversation.data.local
 
-import androidx.paging.DataSource
 import com.wire.android.UnitTest
 import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
 import com.wire.android.feature.conversation.members.datasources.local.ConversationMembersDao
@@ -8,13 +7,10 @@ import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBe
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
 import java.sql.SQLException
@@ -32,17 +28,6 @@ class ConversationLocalDataSourceTest : UnitTest() {
     @Before
     fun setUp() {
         conversationLocalDataSource = ConversationLocalDataSource(conversationDao, conversationMembersDao)
-    }
-
-    @Test
-    fun `given conversationsDataFactory is called, then calls conversationsDao for factory`() {
-        val daoFactory = mockk<DataSource.Factory<Int, ConversationEntity>>()
-        every { conversationDao.conversationsInBatch() } returns daoFactory
-
-        val dataSourceFactory = conversationLocalDataSource.conversationsDataFactory()
-
-        dataSourceFactory shouldBeEqualTo daoFactory
-        verify(exactly = 1) { conversationDao.conversationsInBatch() }
     }
 
     @Test
@@ -65,6 +50,28 @@ class ConversationLocalDataSourceTest : UnitTest() {
 
         result shouldFail { }
         coVerify { conversationDao.insertAll(conversationEntities) }
+    }
+
+    @Test
+    fun `given updateConversations is called, when dao update is successful, then returns success`() {
+        val conversationEntities = mockk<List<ConversationEntity>>()
+        coEvery { conversationDao.updateConversations(conversationEntities) } returns Unit
+
+        val result = runBlocking { conversationLocalDataSource.updateConversations(conversationEntities) }
+
+        result shouldSucceed { it shouldBe Unit }
+        coVerify { conversationDao.updateConversations(conversationEntities) }
+    }
+
+    @Test
+    fun `given updateConversations is called, when dao update fails, then propagates failure`() {
+        val conversationEntities = mockk<List<ConversationEntity>>()
+        coEvery { conversationDao.updateConversations(conversationEntities) } throws SQLException()
+
+        val result = runBlocking { conversationLocalDataSource.updateConversations(conversationEntities) }
+
+        result shouldFail { }
+        coVerify { conversationDao.updateConversations(conversationEntities) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationMembersUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationMembersUseCaseTest.kt
@@ -6,7 +6,7 @@ import com.wire.android.core.functional.Either
 import com.wire.android.feature.contact.Contact
 import com.wire.android.feature.contact.ContactRepository
 import com.wire.android.feature.conversation.Conversation
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
 import io.mockk.coEvery
@@ -24,7 +24,7 @@ import org.junit.Test
 class GetConversationMembersUseCaseTest : UnitTest() {
 
     @MockK
-    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var conversationRepository: ConversationRepository
 
     @MockK
     private lateinit var contactRepository: ContactRepository
@@ -33,7 +33,7 @@ class GetConversationMembersUseCaseTest : UnitTest() {
 
     @Before
     fun setUp() {
-        getConversationMembersUseCase = GetConversationMembersUseCase(conversationsRepository, contactRepository)
+        getConversationMembersUseCase = GetConversationMembersUseCase(conversationRepository, contactRepository)
     }
 
     @Test
@@ -43,13 +43,13 @@ class GetConversationMembersUseCaseTest : UnitTest() {
         every { params.conversation } returns conversation
 
         val failure = mockk<Failure>()
-        coEvery { conversationsRepository.conversationMemberIds(conversation) } returns Either.Left(failure)
+        coEvery { conversationRepository.conversationMemberIds(conversation) } returns Either.Left(failure)
 
 
         val result = runBlocking { getConversationMembersUseCase.run(params) }
 
         result shouldFail { it shouldBeEqualTo failure }
-        coVerify { conversationsRepository.conversationMemberIds(conversation) }
+        coVerify { conversationRepository.conversationMemberIds(conversation) }
     }
 
     @Test
@@ -57,12 +57,12 @@ class GetConversationMembersUseCaseTest : UnitTest() {
         val conversation = mockk<Conversation>()
         val params = GetConversationMembersParams(conversation)
 
-        coEvery { conversationsRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
+        coEvery { conversationRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
         coEvery { contactRepository.contactsById(any()) } returns Either.Right(mockk())
 
         val result = runBlocking { getConversationMembersUseCase.run(params) }
 
-        coVerify(exactly = 1) { conversationsRepository.conversationMemberIds(conversation) }
+        coVerify(exactly = 1) { conversationRepository.conversationMemberIds(conversation) }
         val contactIdsSlot = slot<Set<String>>()
         coVerify(exactly = 1) { contactRepository.contactsById(capture(contactIdsSlot)) }
         contactIdsSlot.captured shouldContainSame TEST_MEMBER_IDS
@@ -73,14 +73,14 @@ class GetConversationMembersUseCaseTest : UnitTest() {
         val conversation = mockk<Conversation>()
         val params = GetConversationMembersParams(conversation)
 
-        coEvery { conversationsRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
+        coEvery { conversationRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
         val contactList = mockk<List<Contact>>()
         coEvery { contactRepository.contactsById(any()) } returns Either.Right(contactList)
 
         val result = runBlocking { getConversationMembersUseCase.run(params) }
 
         result shouldSucceed { it shouldBeEqualTo contactList }
-        coVerify(exactly = 1) { conversationsRepository.conversationMemberIds(conversation) }
+        coVerify(exactly = 1) { conversationRepository.conversationMemberIds(conversation) }
         coVerify(exactly = 1) { contactRepository.contactsById(any()) }
     }
 
@@ -89,14 +89,14 @@ class GetConversationMembersUseCaseTest : UnitTest() {
         val conversation = mockk<Conversation>()
         val params = GetConversationMembersParams(conversation)
 
-        coEvery { conversationsRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
+        coEvery { conversationRepository.conversationMemberIds(conversation) } returns Either.Right(TEST_MEMBER_IDS)
         val failure = mockk<Failure>()
         coEvery { contactRepository.contactsById(any()) } returns Either.Left(failure)
 
         val result = runBlocking { getConversationMembersUseCase.run(params) }
 
         result shouldFail { it shouldBeEqualTo failure }
-        coVerify(exactly = 1) { conversationsRepository.conversationMemberIds(conversation) }
+        coVerify(exactly = 1) { conversationRepository.conversationMemberIds(conversation) }
         coVerify(exactly = 1) { contactRepository.contactsById(any()) }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncConversationsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncConversationsUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.wire.android.feature.sync.conversation.usecase
 import com.wire.android.UnitTest
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
-import com.wire.android.feature.conversation.data.ConversationsRepository
+import com.wire.android.feature.conversation.data.ConversationRepository
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
 import io.mockk.coEvery
@@ -18,19 +18,19 @@ import org.junit.Test
 class SyncConversationsUseCaseTest : UnitTest() {
 
     @MockK
-    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var conversationRepository: ConversationRepository
 
     private lateinit var syncConversationsUseCase: SyncConversationsUseCase
 
     @Before
     fun setUp() {
-        syncConversationsUseCase = SyncConversationsUseCase(conversationsRepository)
+        syncConversationsUseCase = SyncConversationsUseCase(conversationRepository)
     }
 
     @Test
     fun `given run is called, when conversationRepo fails to fetch conversations, then propagates the failure`() {
         val failure = mockk<Failure>()
-        coEvery { conversationsRepository.fetchConversations() } returns Either.Left(failure)
+        coEvery { conversationRepository.fetchConversations() } returns Either.Left(failure)
 
         val result = runBlocking { syncConversationsUseCase.run(Unit) }
 
@@ -39,7 +39,7 @@ class SyncConversationsUseCaseTest : UnitTest() {
 
     @Test
     fun `given run is called, when conversationRepo fetches conversations, then propagates success`() {
-        coEvery { conversationsRepository.fetchConversations() } returns Either.Right(Unit)
+        coEvery { conversationRepository.fetchConversations() } returns Either.Right(Unit)
 
         val result = runBlocking { syncConversationsUseCase.run(Unit) }
 


### PR DESCRIPTION
- Renames `ConversationsRepository` to `ConversationRepository`
- Adds `updateConversations` method to `ConversationRepository` and related data sources
- Deletes duplicate `conversationsInBatch` methods from `ConversationLocalDataSource` & Dao (duplicated in ConversationListLocalDataSource & Dao)