### PR TITLE
Feature: Conversation Name - Part 2 - Add numberOfConversations method to data layer

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/local/ConversationDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/data/local/ConversationDaoTest.kt
@@ -95,6 +95,26 @@ class ConversationDaoTest : InstrumentationTest() {
         remainingConversations shouldContainSame listOf(TEST_CONVERSATION_ENTITY)
     }
 
+    @Test
+    fun count_conversationsExistInDatabase_returnsNumberOfConversations() = databaseTestRule.runTest {
+        val count = 125
+        val conversations = (1..count).map {
+            ConversationEntity(id = "id_$it", name = "Conversation #$it", type = it % 5)
+        }
+        conversationDao.insertAll(conversations)
+
+        val result = conversationDao.count()
+
+        result shouldBeEqualTo count
+    }
+
+    @Test
+    fun count_noConversationsExistInDatabase_returnsZero() = databaseTestRule.runTest {
+        val result = conversationDao.count()
+
+        result shouldBeEqualTo 0
+    }
+
     companion object {
         private val TEST_CONVERSATION_ENTITY = ConversationEntity("id-5", "Android Team", 0)
     }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationDataSource.kt
@@ -57,6 +57,9 @@ class ConversationDataSource(
         return conversationLocalDataSource.updateConversations(entities)
     }
 
+    override suspend fun numberOfConversations(): Either<Failure, Int> =
+        conversationLocalDataSource.numberOfConversations()
+
     companion object {
         private const val CONVERSATION_REQUEST_PAGE_SIZE = 100
     }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationRepository.kt
@@ -12,4 +12,6 @@ interface ConversationRepository {
     suspend fun allConversationMemberIds(): Either<Failure, List<String>>
 
     suspend fun updateConversations(conversations: List<Conversation>): Either<Failure, Unit>
+
+    suspend fun numberOfConversations(): Either<Failure, Int>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationDao.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationDao.kt
@@ -23,4 +23,7 @@ interface ConversationDao {
 
     @Query("SELECT * FROM conversation")
     suspend fun conversations(): List<ConversationEntity>
+
+    @Query("SELECT COUNT(*) FROM conversation")
+    suspend fun count(): Int
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSource.kt
@@ -1,6 +1,5 @@
 package com.wire.android.feature.conversation.data.local
 
-import androidx.paging.DataSource
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import com.wire.android.core.storage.db.DatabaseService
@@ -31,4 +30,6 @@ class ConversationLocalDataSource(
     suspend fun allConversationMemberIds(): Either<Failure, List<String>> = request {
         conversationMembersDao.allConversationMemberIds()
     }
+
+    suspend fun numberOfConversations(): Either<Failure, Int> = request { conversationDao.count() }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationDataSourceTest.kt
@@ -244,6 +244,26 @@ class ConversationDataSourceTest : UnitTest() {
         result shouldFail { it shouldBeEqualTo failure }
     }
 
+    @Test
+    fun `given numberOfConversations is called, when localDataSource returns the count, then propagates the count`() {
+        val count = 250
+        coEvery { conversationLocalDataSource.numberOfConversations() } returns Either.Right(count)
+
+        val result = runBlocking { conversationDataSource.numberOfConversations() }
+
+        result shouldSucceed { it shouldBeEqualTo count }
+    }
+
+    @Test
+    fun `given numberOfConversations is called, when localDataSource fails to return the count, then propagates failure`() {
+        val failure = mockk<Failure>()
+        coEvery { conversationLocalDataSource.numberOfConversations() } returns Either.Left(failure)
+
+        val result = runBlocking { conversationDataSource.numberOfConversations() }
+
+        result shouldFail { it shouldBeEqualTo failure }
+    }
+
     companion object {
         private const val TEST_CONVERSATION_ID = "conv-id"
     }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/local/ConversationLocalDataSourceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
 import java.sql.SQLException
@@ -138,5 +139,26 @@ class ConversationLocalDataSourceTest : UnitTest() {
 
         result shouldFail { }
         coVerify { conversationMembersDao.allConversationMemberIds() }
+    }
+
+    @Test
+    fun `given numberOfConversations is called, when dao operation returns the count, then propagates the count`() {
+        val count = 218
+        coEvery { conversationDao.count() } returns count
+
+        val result = runBlocking { conversationLocalDataSource.numberOfConversations() }
+
+        result shouldSucceed { it shouldBeEqualTo  count }
+        coVerify { conversationDao.count() }
+    }
+
+    @Test
+    fun `given numberOfConversations is called, when dao operation fails, then propagates failure`() {
+        coEvery { conversationDao.count() } throws SQLException()
+
+        val result = runBlocking { conversationLocalDataSource.numberOfConversations() }
+
+        result shouldFail { }
+        coVerify { conversationDao.count() }
     }
 }


### PR DESCRIPTION
- Adds numberOfConversations method to `ConversationRepository` and related data sources & dao.

The result of this method will be used as a threshold while querying `conversation` table page by page.