### PR TITLE
Feature: Conversation Name - Part 3- Add manual batch query logic to ConversationListRepository

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceIntegrationTest.kt
@@ -28,7 +28,7 @@ import org.junit.Test
 
 @ExperimentalCoroutinesApi
 @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.O_MR1)
-class ConversationListDataSourceTest : InstrumentationTest() {
+class ConversationListDataSourceIntegrationTest : InstrumentationTest() {
 
     @get:Rule
     val databaseTestRule = DatabaseTestRule.create<UserDatabase>(appContext)

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/ConversationListRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/ConversationListRepository.kt
@@ -1,10 +1,14 @@
 package com.wire.android.feature.conversation.list
 
 import androidx.paging.PagedList
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
 import com.wire.android.feature.conversation.ConversationType
 import com.wire.android.feature.conversation.list.ui.ConversationListItem
 import kotlinx.coroutines.flow.Flow
 
 interface ConversationListRepository {
     fun conversationListInBatch(pageSize: Int, excludeType: ConversationType): Flow<PagedList<ConversationListItem>>
+
+    suspend fun conversationListInBatch(start: Int, count: Int): Either<Failure, List<ConversationListItem>>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
@@ -3,6 +3,9 @@ package com.wire.android.feature.conversation.list.datasources
 import androidx.lifecycle.asFlow
 import androidx.paging.PagedList
 import androidx.paging.toLiveData
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+import com.wire.android.core.functional.map
 import com.wire.android.feature.contact.datasources.local.ContactLocalDataSource
 import com.wire.android.feature.conversation.ConversationType
 import com.wire.android.feature.conversation.data.ConversationTypeMapper
@@ -33,4 +36,8 @@ class ConversationListDataSource(
         return conversationListMapper.fromEntity(entity, profilePictures)
     }
 
+    override suspend fun conversationListInBatch(start: Int, count: Int): Either<Failure, List<ConversationListItem>> =
+        conversationListLocalDataSource.conversationListInBatch(start = start, count = count).map {
+            it.map { conversationListMapper.fromEntity(it, emptyList()) }
+        }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListDao.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListDao.kt
@@ -15,4 +15,8 @@ interface ConversationListDao {
     @Transaction
     @Query("SELECT * FROM conversation WHERE type != :excludeType")
     fun conversationListItemsInBatch(excludeType: Int): DataSource.Factory<Int, ConversationListItemEntity>
+
+    @Transaction
+    @Query("SELECT * FROM conversation ORDER BY id LIMIT :count OFFSET :start ")
+    suspend fun conversationListItemsInBatch(start: Int, count: Int): List<ConversationListItemEntity>
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListLocalDataSource.kt
@@ -1,9 +1,16 @@
 package com.wire.android.feature.conversation.list.datasources.local
 
 import androidx.paging.DataSource
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+import com.wire.android.core.storage.db.DatabaseService
 
-class ConversationListLocalDataSource(private val conversationListDao: ConversationListDao) {
+class ConversationListLocalDataSource(private val conversationListDao: ConversationListDao) : DatabaseService {
 
     fun conversationListInBatch(excludeType: Int): DataSource.Factory<Int, ConversationListItemEntity> =
         conversationListDao.conversationListItemsInBatch(excludeType)
+
+    suspend fun conversationListInBatch(start: Int, count: Int): Either<Failure, List<ConversationListItemEntity>> = request {
+        conversationListDao.conversationListItemsInBatch(start = start, count = count)
+    }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceTest.kt
@@ -1,0 +1,87 @@
+package com.wire.android.feature.conversation.list.datasources
+
+import com.wire.android.UnitTest
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+import com.wire.android.feature.contact.datasources.local.ContactLocalDataSource
+import com.wire.android.feature.conversation.data.ConversationTypeMapper
+import com.wire.android.feature.conversation.list.datasources.local.ConversationListItemEntity
+import com.wire.android.feature.conversation.list.datasources.local.ConversationListLocalDataSource
+import com.wire.android.feature.conversation.list.ui.ConversationListItem
+import com.wire.android.framework.functional.shouldFail
+import com.wire.android.framework.functional.shouldSucceed
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.junit.Before
+import org.junit.Test
+
+class ConversationListDataSourceTest : UnitTest() {
+
+    @MockK
+    private lateinit var conversationListLocalDataSource: ConversationListLocalDataSource
+
+    @MockK
+    private lateinit var contactLocalDataSource: ContactLocalDataSource
+
+    @MockK
+    private lateinit var conversationListMapper: ConversationListMapper
+
+    @MockK
+    private lateinit var conversationTypeMapper: ConversationTypeMapper
+
+
+    private lateinit var conversationListDataSource: ConversationListDataSource
+
+    @Before
+    fun setUp() {
+        conversationListDataSource = ConversationListDataSource(
+            conversationListLocalDataSource, contactLocalDataSource,
+            conversationListMapper, conversationTypeMapper
+        )
+    }
+
+    @Test
+    fun `given conversationListInBatch is called, then calls local data source with given start and count parameters`() {
+        coEvery { conversationListLocalDataSource.conversationListInBatch(any(), any()) } returns Either.Left(mockk())
+
+        runBlocking { conversationListDataSource.conversationListInBatch(TEST_BATCH_START, TEST_BATCH_COUNT) }
+
+        coVerify(exactly = 1) { conversationListLocalDataSource.conversationListInBatch(TEST_BATCH_START, TEST_BATCH_COUNT) }
+    }
+
+    @Test
+    fun `given conversationListInBatch is called, when local data source returns the batch, then maps and propagates items`() {
+        val entities = listOf<ConversationListItemEntity>(mockk(), mockk())
+        coEvery { conversationListLocalDataSource.conversationListInBatch(any(), any()) } returns Either.Right(entities)
+        val conversations = listOf<ConversationListItem>(mockk(), mockk())
+        every { conversationListMapper.fromEntity(any(), any()) } returnsMany conversations
+
+        val result = runBlocking { conversationListDataSource.conversationListInBatch(60, 20) }
+
+        result shouldSucceed { it shouldContainSame conversations }
+        verify(exactly = 2) { conversationListMapper.fromEntity(any(), any()) }
+    }
+
+    @Test
+    fun `given conversationListInBatch is called, when local data source fails to return the batch, then propagates the failure`() {
+        val failure = mockk<Failure>()
+        coEvery { conversationListLocalDataSource.conversationListInBatch(any(), any()) } returns Either.Left(failure)
+
+        val result = runBlocking { conversationListDataSource.conversationListInBatch(60, 20) }
+
+        result shouldFail { it shouldBeEqualTo failure }
+        verify(inverse = true) { conversationListMapper.fromEntity(any(), any()) }
+    }
+
+    companion object {
+        private const val TEST_BATCH_START = 60
+        private const val TEST_BATCH_COUNT = 20
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationListUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/usecase/GetConversationListUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.wire.android.feature.conversation.list.usecase
 
 import androidx.paging.PagedList
 import com.wire.android.UnitTest
+import com.wire.android.feature.conversation.ConversationType
 import com.wire.android.feature.conversation.Self
 import com.wire.android.feature.conversation.list.ConversationListRepository
 import com.wire.android.feature.conversation.list.ui.ConversationListItem
@@ -31,7 +32,7 @@ class GetConversationListUseCaseTest : UnitTest() {
 
     @Test
     fun `given run is called, then calls conversationListRepo to get items except Self conversation`() {
-        coEvery { conversationListRepository.conversationListInBatch(any(), any()) } returns flowOf(mockk())
+        coEvery { conversationListRepository.conversationListInBatch(any(), any<ConversationType>()) } returns flowOf(mockk())
 
         val params = GetConversationListUseCaseParams(pageSize = TEST_PAGE_SIZE)
 
@@ -43,7 +44,7 @@ class GetConversationListUseCaseTest : UnitTest() {
     @Test
     fun `given run is called, when conversationListRepo emits items, then propagates items`() {
         val items = mockk<PagedList<ConversationListItem>>()
-        coEvery { conversationListRepository.conversationListInBatch(any(), any()) } returns flowOf(items)
+        coEvery { conversationListRepository.conversationListInBatch(any(), any<ConversationType>()) } returns flowOf(items)
 
         val params = GetConversationListUseCaseParams(pageSize = TEST_PAGE_SIZE)
 


### PR DESCRIPTION
- Adds a new method to query the database for batches of conversations

This method will be used to update conversation names. We cannot use existing `conversationListInBatch` method for that use case because the `Flow` emits the items all over again every time the contents in the database changes (that's how paging library works). If we were to update a conversation name using that method, the Flow would emit a new list of items with the updated values, hence, there would be an endless loop (or we would have to check whether the current list has already been updated, which is a redundant task). The "manual" solution introduced here does not care whether items are updated after they're returned. It's the caller's responsibility to detect changes and re-query.