### PR TITLE
refactor: Use new protobuf 1.28.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -306,7 +306,6 @@ dependencies {
     implementation BuildDependencies.kotlin.standardLibrary
     implementation BuildDependencies.kotlin.coroutinesAndroid
     implementation BuildDependencies.kotlin.coroutinesCore
-
     implementation avsDependency
 
     implementation BuildDependencies.wire.audioNotifications
@@ -373,6 +372,9 @@ dependencies {
         transitive = true
     }
     annotationProcessor BuildDependencies.glide.compiler
+
+    // protobuf
+    implementation "com.wire:generic-message-proto:1.28.1"
 
     //Retrofit
     implementation BuildDependencies.retrofit.core

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -374,8 +374,11 @@ dependencies {
     annotationProcessor BuildDependencies.glide.compiler
 
     //Retrofit
-    implementation BuildDependencies.retrofit.core
-    implementation BuildDependencies.retrofit.protoBufConverter
+    implementation (BuildDependencies.retrofit.core) {
+        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
+        exclude group: 'com.google.protobuf', module: 'protobuf-lite'
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+    }
     implementation BuildDependencies.retrofit.gsonConverter
 
     //OkHttp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -373,9 +373,6 @@ dependencies {
     }
     annotationProcessor BuildDependencies.glide.compiler
 
-    // protobuf
-    implementation "com.wire:generic-message-proto:1.28.1"
-
     //Retrofit
     implementation BuildDependencies.retrofit.core
     implementation BuildDependencies.retrofit.protoBufConverter

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -140,3 +140,6 @@
 # Coroutines
 -keep class kotlinx.coroutines.experimental.android.AndroidExceptionPreHandler { *; }
 -keep class kotlinx.coroutines.android.** {*;}
+
+# protobuf
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -438,7 +438,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
     } yield (video, state, dur, callerName.filter(_ => group))).map {
       case (true,  SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_video_subtitle)
       case (false, SelfCalling,  _, _)  => cxt.getString(R.string.calling__header__outgoing_subtitle)
-      case (_,     OtherCalling, _, Some(callerName)) => cxt.getString(R.string.calling__header__incoming_subtitle__group, callerName)
+      case (_,     OtherCalling, _, Some(callerName)) => cxt.getString(R.string.calling__header__incoming_subtitle__group, callerName.str)
       case (true,  OtherCalling, _, _)  => cxt.getString(R.string.calling__header__incoming_subtitle__video)
       case (false, OtherCalling, _, _)  => cxt.getString(R.string.calling__header__incoming_subtitle)
       case (_,     SelfJoining,  _, _)  => cxt.getString(R.string.calling__header__joining)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -526,7 +526,7 @@ class ConversationListManagerFragment extends Fragment
           convController.conversationName(cId).head.foreach(convName =>
             showErrorDialog(
               getString(R.string.delete_group_conversation_error_title),
-              getString(R.string.delete_group_conversation_error_message_with_group_name, convName)
+              getString(R.string.delete_group_conversation_error_message_with_group_name, convName.str)
             )
           )
         case _ =>

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesController.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 
 class MessagesController()(implicit injector: Injector, cxt: WireContext)
   extends Injectable with DerivedLogTag {
-  
+
 import com.waz.threading.Threading.Implicits.Background
 
 import scala.concurrent.Future

--- a/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/WebLinkPartView.scala
@@ -35,7 +35,6 @@ import com.wire.signals.Signal
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views.ProgressDotsDrawable
 import com.waz.zclient.glide.WireGlide
-import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.MessageView.MsgBindOptions
 import com.waz.zclient.messages.{ClickableViewPart, MsgPart}
 import com.waz.zclient.utils._
@@ -56,8 +55,7 @@ class WebLinkPartView(context: Context, attrs: AttributeSet, style: Int)
 
   override def set(msg: MessageAndLikes, part: Option[MessageContent], opts: Option[MsgBindOptions]): Unit = {
     super.set(msg, part, opts)
-    verbose(l"set $part")
-    part foreach { content ! _ }
+    part.foreach(content ! _)
   }
 
   private lazy val titleTextView: TextView  = findById(R.id.ttv__row_conversation__link_preview__title)

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -383,7 +383,7 @@ class MainPhoneFragment extends FragmentHelper
             Future.successful(getString(R.string.in_app_notification__sync_error__add_multiple_user__body))
         case CANNOT_CREATE_GROUP_CONVERSATION_WITH_UNCONNECTED_USER =>
           conversationController.conversationName(error.convId.get).head
-            .map(name => getString(R.string.in_app_notification__sync_error__create_group_convo__body, name))
+            .map(name => getString(R.string.in_app_notification__sync_error__create_group_convo__body, name.str))
         case _ =>
           Future.successful(getString(R.string.in_app_notification__sync_error__unknown__body))
       }

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleOtrClientFragment.scala
@@ -93,7 +93,7 @@ class SingleOtrClientFragment extends FragmentHelper {
   private lazy val descriptionText = returning(view[TextView] (R.id.client_description)) { vh =>
     (userId match {
       case Some(uId) =>
-        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.name))
+        usersController.user(uId).map(u => getString(R.string.otr__participant__single_device__description, u.name.str))
       case _ =>
         Signal.const(getString(R.string.otr__participant__my_device__description))
     }).onUi(t => vh.foreach(_.setText(t)))

--- a/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/quickreply/QuickReplyContentAdapter.scala
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model._
+import com.waz.model.Name._
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
 import com.wire.signals.{EventContext, Signal}
@@ -121,7 +122,7 @@ object QuickReplyContentAdapter {
 
     val contentStr = message.zip(userName) map {
       case (msg, name) if isGroupConv =>
-        context.getString(R.string.quick_reply__message_group, name, getMessageBody(msg, name))
+        context.getString(R.string.quick_reply__message_group, name.str, getMessageBody(msg, name.str))
       case (msg, name) =>
         getMessageBody(msg, name)
     }
@@ -133,7 +134,7 @@ object QuickReplyContentAdapter {
       }
     }
 
-    private def getMessageBody(message: MessageData, userName: String): String = {
+    private def getMessageBody(message: MessageData, userName: Name): String = {
       import com.waz.api.Message.Type._
       message.msgType match {
         case TEXT => message.contentString
@@ -151,7 +152,7 @@ object QuickReplyContentAdapter {
         case MEMBER_JOIN =>
           StringUtils.capitalise(context.getString(R.string.notification__message__group__add))
         case CONNECT_ACCEPTED =>
-          context.getString(R.string.notification__message__single__accept_request, userName)
+          context.getString(R.string.notification__message__single__accept_request, userName.str)
         case ANY_ASSET | AUDIO_ASSET | VIDEO_ASSET =>
           context.getString(R.string.notification__message__one_to_one__shared_file)
         case _ => ""

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -85,7 +85,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
     } yield {
         verbose(l"Using countly Id: ${trackingId.str}")
         val config = new CountlyConfig(cxt, GlobalTrackingController.countlyAppKey, BuildConfig.COUNTLY_SERVER_URL)
-          .setLoggingEnabled(logsEnabled)
+          .setLoggingEnabled(false)
           .setIdMode(DeviceId.Type.DEVELOPER_SUPPLIED)
           .setDeviceId(trackingId.str)
           .setRecordAppStartTime(true)

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -85,7 +85,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
     } yield {
         verbose(l"Using countly Id: ${trackingId.str}")
         val config = new CountlyConfig(cxt, GlobalTrackingController.countlyAppKey, BuildConfig.COUNTLY_SERVER_URL)
-          .setLoggingEnabled(false)
+          .setLoggingEnabled(logsEnabled)
           .setIdMode(DeviceId.Type.DEVELOPER_SUPPLIED)
           .setDeviceId(trackingId.str)
           .setRecordAppStartTime(true)

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -414,7 +414,7 @@ class SearchUIFragment extends BaseFragment[Container]
   private def sendGenericInvite(fromSearch: Boolean): Unit =
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
-        getString(R.string.people_picker__invite__share_text__header, self.name),
+        getString(R.string.people_picker__invite__share_text__header, self.name.str),
         getString(R.string.people_picker__invite__share_text__body, StringUtils.formatHandle(self.handle.map(_.string).getOrElse(""))))
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -52,7 +52,7 @@ object Versions {
     const val PLAY_SERVICES_BASE = "17.1.0"
     const val FIREBASE_MESSAGING = "20.1.0"
     const val GLIDE = "4.11.0"
-    const val RETROFIT = "2.6.2"
+    const val RETROFIT = "2.9.0"
     const val OKHTTP = "3.14.9"
     const val KOIN = "2.0.1"
     const val RX_KOTLIN = "2.3.0"
@@ -128,7 +128,6 @@ object BuildDependencies {
     ))
     val retrofit = RetrofitDependencyMap(mapOf(
         "core" to "com.squareup.retrofit2:retrofit:${Versions.RETROFIT}",
-        "protoBufConverter" to "com.squareup.retrofit2:converter-protobuf:${Versions.RETROFIT}",
         "gsonConverter" to "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT}"
     ))
     val okHttpLoggingInterceptor = "com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP}"

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     // should match okhttp3's mockserver version (see test dependencies)
     implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
-    implementation "com.wire:generic-message-proto:1.28.1"
+    implementation "com.wire:generic-message-proto:1.28.2"
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -77,8 +77,7 @@ dependencies {
     // should match okhttp3's mockserver version (see test dependencies)
     implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
-    api "com.wire:generic-message-proto:1.27.1"
-    implementation "com.wire:backend-api-proto:2.3"
+    implementation "com.wire:generic-message-proto:1.28.1"
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"

--- a/zmessaging/src/main/scala/com/waz/db/Col.scala
+++ b/zmessaging/src/main/scala/com/waz/db/Col.scala
@@ -20,8 +20,7 @@ package com.waz.db
 import java.io.File
 import java.util.Date
 
-import com.google.protobuf.nano.MessageNano
-import com.waz.db.Col.{blob, text}
+import com.google.protobuf.MessageLite
 import com.waz.model._
 import com.waz.service.assets.Codec
 import com.waz.utils.wrappers.{DBContentValues, DBCursor, DBProgram}
@@ -74,10 +73,10 @@ object Col {
   })
   def json[A: JsonDecoder : JsonEncoder](name: Symbol) = Col[A](name.name, "TEXT")(DbTranslator.jsonTranslator[A]())
   def jsonArr[A, B[C] <: Traversable[C]](name: Symbol)(implicit enc: JsonEncoder[A], dec: JsonDecoder[A], cbf: CanBuild[A, B[A]]) = Col[B[A]](name.name, "TEXT")(DbTranslator.jsonArrTranslator[A, B]())
-  def jsonArray[A, B[C] <: Traversable[C], D[E] <: B[E]](name: Symbol)(implicit enc: JsonEncoder[A], dec: JsonDecoder[A], cbf: CanBuild[A, D[A]]): Col[B[A]] = jsonArr[A, B](name)(enc, dec, cbf)
+  def jsonArray[A, B[C] <: Traversable[C], D[E] <: B[E]](name: Symbol)(implicit enc: JsonEncoder[A], dec: JsonDecoder[A], cbf: CanBuild[A, B[A]]): Col[B[A]] = jsonArr[A, B](name)(enc, dec, cbf)
 
-  def proto[A <: MessageNano](name: Symbol)(implicit dec: ProtoDecoder[A]) = Col[A](name.name, "BLOB")(DbTranslator.protoTranslator[A]())
-  def protoSeq[A <: MessageNano, B[C] <: Traversable[C], D[E] <: B[E]](name: Symbol)(implicit dec: ProtoDecoder[A], cbf: CanBuild[A, D[A]]): Col[B[A]] = Col[B[A]](name.name, "BLOB")(DbTranslator.protoSeqTranslator[A, B]())
+  def protoSeq(name: Symbol)(implicit dec: ProtoDecoder[Messages.GenericMessage]): Col[Seq[GenericMessage]] =
+    Col[Seq[GenericMessage]](name.name, "BLOB")(DbTranslator.gmSeqTranslator())
 
   def text(name: Symbol) = Col[String](name.name, "TEXT")
   def text(name: Symbol, modifiers: String) = Col[String](name.name, "TEXT", modifiers)

--- a/zmessaging/src/main/scala/com/waz/db/migrate/MessageDataMigration.scala
+++ b/zmessaging/src/main/scala/com/waz/db/migrate/MessageDataMigration.scala
@@ -45,9 +45,9 @@ object MessageDataMigration {
         forEachRow(db.query("Messages", Array("_id", "hot"), "msg_type = 'Knock'", null, null, null, null)) { c =>
           stmt.clearBindings()
           val id = c.getString(0)
-          val protos = Seq(GenericMessage(Uid(id), Knock(false)))
+          val gms = Seq(GenericMessage(Uid(id), Knock(false)))
 
-          dst.Protos.bind(protos, 1, stmt)
+          dst.Protos.bind(gms, 1, stmt)
           stmt.bindString(2, id)
           stmt.execute()
         }
@@ -115,7 +115,7 @@ object MessageDataMigration {
 
     val Type = text[Message.Type]('msg_type, MessageData.MessageTypeCodec.encode, MessageData.MessageTypeCodec.decode)
     val Content = jsonArray[MessageContent, Seq, Vector]('content)
-    val Protos = protoSeq[GenericMessage, Seq, Vector]('protos)
+    val Protos = protoSeq('protos)
 
     val queryString =
       "SELECT _id, conv_id, msg_type, content, protos, time FROM Messages WHERE msg_type IN ('Text', 'TextEmojiOnly', 'RichMedia') AND _id NOT IN (SELECT message_id FROM MessageContentIndex)"
@@ -181,7 +181,7 @@ object MessageDataMigration {
       val Type = text[Message.Type]('msg_type, MessageData.MessageTypeCodec.encode, MessageData.MessageTypeCodec.decode)
       val User = id[UserId]('user_id)
       val Content = jsonArray[MessageContent, Seq, Vector]('content)
-      val Protos = protoSeq[GenericMessage, Seq, Vector]('protos)
+      val Protos = protoSeq('protos)
       val ContentSize = int('content_size)
       val FirstMessage = bool('first_msg)
       val Members = set[UserId]('members, _.mkString(","), _.split(",").filter(!_.isEmpty).map(UserId(_))(breakOut))
@@ -202,7 +202,7 @@ object MessageDataMigration {
       val Type = text[Message.Type]('msg_type, MessageData.MessageTypeCodec.encode, MessageData.MessageTypeCodec.decode)
       val User = id[UserId]('user_id)
       val Content = jsonArray[MessageContent, Seq, Vector]('content)
-      val Protos = protoSeq[GenericMessage, Seq, Vector]('protos)
+      val Protos = protoSeq('protos)
       val ContentSize = int('content_size)
       val FirstMessage = bool('first_msg)
       val Members = set[UserId]('members, _.mkString(","), _.split(",").filter(!_.isEmpty).map(UserId(_))(breakOut))

--- a/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
@@ -339,8 +339,8 @@ trait LogShowInstancesSE {
 
   //Protos
   implicit val GenericMessageLogShow: LogShow[GenericMessage] = LogShow.create { m =>
-    m.getContentCase
-    s"GenericMessage(messageId: ${sha2(m.messageId)} | contentCase: ${m.getContentCase})"
+    m.proto.getContentCase
+    s"GenericMessage(messageId: ${sha2(m.proto.getMessageId)} | contentCase: ${m.proto.getContentCase})"
   }
 
   implicit val ReadReceiptShow: LogShow[ReadReceipt] = LogShow.createFrom { r =>

--- a/zmessaging/src/main/scala/com/waz/model/AssetData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AssetData.scala
@@ -23,7 +23,7 @@ import com.waz.db.Dao
 import com.waz.model.AssetMetaData.Image
 import com.waz.model.AssetMetaData.Image.Tag
 import com.waz.model.AssetStatus.{UploadCancelled, UploadDone}
-import com.waz.model.GenericContent.EncryptionAlgorithm
+import com.waz.model.GenericContent.Asset.EncryptionAlgorithm
 import com.waz.model.otr.SignalingKey
 import com.waz.service.ZMessaging
 import com.waz.sync.client.AssetClient
@@ -61,14 +61,14 @@ case class AssetData(override val id: AssetId               = AssetId(),
 
   import AssetData._
 
-  lazy val size = data.fold(sizeInBytes)(_.length)
+  lazy val size: Long = data.fold(sizeInBytes)(_.length)
 
   //be careful when accessing - can be expensive
   lazy val data64 = data.map(AESUtils.base64)
 
   lazy val fileExtension = mime.extension
 
-  lazy val remoteData = (remoteId, token, otrKey, sha, encryption) match {
+  lazy val remoteData: Option[RemoteData] = (remoteId, token, otrKey, sha, encryption) match {
     case (None, None, None, None, None) => Option.empty[RemoteData]
     case _ => Some(RemoteData(remoteId, token, otrKey, sha, encryption))
   }
@@ -78,7 +78,7 @@ case class AssetData(override val id: AssetId               = AssetId(),
     case (_, Some(uri)) if uri.getPath != AssetClient.UnsplashPath => CacheKey.fromUri(uri)
     case _                                                         => CacheKey.fromAssetId(id)
   }
-  
+
   lazy val isDownloadable = this match {
     case WithRemoteData(_)  => true
     case WithExternalUri(_) => true

--- a/zmessaging/src/main/scala/com/waz/model/CompositeData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/CompositeData.scala
@@ -7,6 +7,6 @@ case class CompositeData(items:                   Seq[CompositeMessageItem],
                          legalHoldStatus:         Option[Int])
 
 sealed trait CompositeMessageItem
-case class TextItem(text: Text)       extends CompositeMessageItem
-case class ButtonItem(button: Button) extends CompositeMessageItem
-case object UnknownItem               extends CompositeMessageItem
+final case class TextItem(text: Text)       extends CompositeMessageItem
+final case class ButtonItem(button: Button) extends CompositeMessageItem
+final case object UnknownItem               extends CompositeMessageItem

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -336,7 +336,7 @@ object MessageEvent {
       event match {
         case GenericMessageEvent(convId, time, from, content) =>
           setFields(json, convId, time, from, "conversation.generic-message")
-            .put("content", AESUtils.base64(GenericMessage.toByteArray(content)))
+            .put("content", AESUtils.base64(content.proto.toByteArray))
         case OtrErrorEvent(convId, time, from, error) =>
           setFields(json, convId, time, from, "conversation.otr-error")
             .put("error", OtrError.OtrErrorEncoder(error))

--- a/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
@@ -463,16 +463,16 @@ object GenericContent {
   }
 
   final case class LinkPreview(override val proto: Messages.LinkPreview) extends GenericContent[Messages.LinkPreview] {
-    def unpackWithAsset: Option[AssetData] = {
-      val image = if (proto.hasImage) Option(proto.getImage) else None
-      image
-        .orElse { if (proto.hasArticle) Option(proto.getArticle.getImage) else None }
-        .map { proto => Asset(proto).unpack._1 }
+    lazy val unpack: (String, String, Option[AssetData]) = {
+      val (title, summary) =
+        if (proto.hasArticle) (proto.getArticle.getTitle, proto.getArticle.getSummary)
+        else (proto.getTitle, proto.getSummary)
+      val image =
+        if (proto.hasImage) Some(proto.getImage)
+        else if (proto.hasArticle && proto.getArticle.hasImage) Some(proto.getArticle.getImage)
+        else None
+      (title, summary, image.map { proto => Asset(proto).unpack._1 })
     }
-
-    def unpackWithDescription: (String, String) =
-      if (proto.hasArticle) (proto.getArticle.getTitle, proto.getArticle.getSummary)
-      else (proto.getTitle, proto.getSummary)
   }
 
   object LinkPreview {

--- a/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GenericContent.scala
@@ -82,9 +82,11 @@ object GenericContent {
 
   object Asset {
 
-    def apply(asset: AssetData, preview: Option[AssetData] = None, expectsReadConfirmation: Boolean): Asset = {
-      val builder = Messages.Asset.newBuilder()
-      builder.setOriginal(Original(asset).proto)
+    def apply(asset: AssetData, preview: Option[AssetData] = None, expectsReadConfirmation: Boolean): Asset = Asset {
+      val builder =
+        Messages.Asset.newBuilder
+          .setOriginal(Original(asset).proto)
+          .setExpectsReadConfirmation(expectsReadConfirmation)
       preview.foreach(p => builder.setPreview(Preview(p).proto))
       (asset.status, asset.remoteData) match {
         case (UploadCancelled, _)         => builder.setNotUploaded(Messages.Asset.NotUploaded.CANCELLED)
@@ -93,35 +95,36 @@ object GenericContent {
         case (DownloadFailed, Some(data)) => builder.setUploaded(RemoteData(data).proto)
         case _ =>
       }
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
-      Asset(builder.build())
+      builder.build
     }
 
-    def apply(asset: UploadAsset, preview: Option[assets.Asset], expectsReadConfirmation: Boolean): Asset = {
-      val builder = Messages.Asset.newBuilder()
-      builder.setOriginal(Original(asset).proto)
+    def apply(asset: UploadAsset, preview: Option[assets.Asset], expectsReadConfirmation: Boolean): Asset = Asset {
+      val builder =
+        Messages.Asset.newBuilder
+          .setOriginal(Original(asset).proto)
+          .setExpectsReadConfirmation(expectsReadConfirmation)
       preview.foreach(p => builder.setPreview(Preview(p).proto))
       asset.status match {
         case UploadAssetStatus.Cancelled => builder.setNotUploaded(Messages.Asset.NotUploaded.CANCELLED)
         case UploadAssetStatus.Failed    => builder.setNotUploaded(Messages.Asset.NotUploaded.FAILED)
         case _ =>
       }
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
-      Asset(builder.build())
+      builder.build
     }
 
-    def apply(asset: assets.Asset, preview: Option[assets.Asset], expectsReadConfirmation: Boolean): Asset = {
-      val builder = Messages.Asset.newBuilder()
-      builder.setOriginal(Original(asset).proto)
+    def apply(asset: assets.Asset, preview: Option[assets.Asset], expectsReadConfirmation: Boolean): Asset = Asset {
+      val builder =
+        Messages.Asset.newBuilder
+          .setOriginal(Original(asset).proto)
+          .setUploaded(RemoteData(asset).proto)
+          .setExpectsReadConfirmation(expectsReadConfirmation)
       preview.foreach(p => builder.setPreview(Preview(p).proto))
-      builder.setUploaded(RemoteData(asset).proto)
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
-      Asset(builder.build())
+      builder.build
     }
 
     final case class Original(override val proto: Messages.Asset.Original) extends GenericContent[Messages.Asset.Original]{
       override def set(builder: Messages.GenericMessage.Builder): Unit = {
-        val ab = Messages.Asset.newBuilder()
+        val ab = Messages.Asset.newBuilder
         ab.setOriginal(proto)
         builder.setAsset(ab)
       }
@@ -141,10 +144,11 @@ object GenericContent {
     }
 
     object Original {
-      def apply(asset: AssetData): Original = {
-        val builder = Messages.Asset.Original.newBuilder()
-        builder.setMimeType(asset.mime.str)
-        builder.setSize(asset.size)
+      def apply(asset: AssetData): Original = Original {
+        val builder =
+          Messages.Asset.Original.newBuilder
+            .setMimeType(asset.mime.str)
+            .setSize(asset.size)
         asset.name.foreach(builder.setName)
         asset.metaData match {
           case Some(video: AssetMetaData.Video) => builder.setVideo(VideoMetaData(video).proto)
@@ -152,35 +156,37 @@ object GenericContent {
           case Some(audio: AssetMetaData.Audio) => builder.setAudio(AudioMetaData(audio).proto)
           case _ =>
         }
-        Original(builder.build())
+        builder.build
       }
 
-      def apply(asset: UploadAsset): Original = {
-        val builder = Messages.Asset.Original.newBuilder()
-        builder.setMimeType(asset.mime.str)
-        builder.setSize(asset.size)
-        builder.setName(asset.name)
+      def apply(asset: UploadAsset): Original = Original {
+        val builder =
+          Messages.Asset.Original.newBuilder
+            .setMimeType(asset.mime.str)
+            .setSize(asset.size)
+            .setName(asset.name)
         asset.details match {
           case image: ImageDetails => builder.setImage(ImageMetaData(image).proto)
           case video: VideoDetails => builder.setVideo(VideoMetaData(video).proto)
           case audio: AudioDetails => builder.setAudio(AudioMetaData(audio).proto)
           case _ =>
         }
-        Original(builder.build())
+        builder.build
       }
 
-      def apply(asset: assets.Asset): Original = {
-        val builder = Messages.Asset.Original.newBuilder()
-        builder.setMimeType(asset.mime.str)
-        builder.setSize(asset.size)
-        builder.setName(asset.name)
+      def apply(asset: assets.Asset): Original = Original {
+        val builder =
+          Messages.Asset.Original.newBuilder
+            .setMimeType(asset.mime.str)
+            .setSize(asset.size)
+            .setName(asset.name)
         asset.details match {
           case image: ImageDetails => builder.setImage(ImageMetaData(image).proto)
           case video: VideoDetails => builder.setVideo(VideoMetaData(video).proto)
           case audio: AudioDetails => builder.setAudio(AudioMetaData(audio).proto)
           case _ =>
         }
-        Original(builder.build())
+        builder.build
       }
     }
 
@@ -190,19 +196,19 @@ object GenericContent {
     }
 
     object ImageMetaData {
-      def apply(image: AssetMetaData.Image): ImageMetaData = {
-        val builder = Messages.Asset.ImageMetaData.newBuilder()
-        builder.setTag(image.tag.toString)
-        builder.setWidth(image.dimensions.width)
-        builder.setHeight(image.dimensions.height)
-        ImageMetaData(builder.build())
+      def apply(image: AssetMetaData.Image): ImageMetaData = ImageMetaData {
+        Messages.Asset.ImageMetaData.newBuilder
+          .setTag(image.tag.toString)
+          .setWidth(image.dimensions.width)
+          .setHeight(image.dimensions.height)
+          .build
       }
 
-      def apply(details: ImageDetails): ImageMetaData = {
-        val builder = Messages.Asset.ImageMetaData.newBuilder()
-        builder.setWidth(details.dimensions.width)
-        builder.setHeight(details.dimensions.height)
-        ImageMetaData(builder.build())
+      def apply(details: ImageDetails): ImageMetaData = ImageMetaData {
+        Messages.Asset.ImageMetaData.newBuilder
+          .setWidth(details.dimensions.width)
+          .setHeight(details.dimensions.height)
+          .build
       }
     }
 
@@ -215,20 +221,20 @@ object GenericContent {
     }
 
     object VideoMetaData {
-      def apply(video: AssetMetaData.Video): VideoMetaData = {
-        val builder = Messages.Asset.VideoMetaData.newBuilder()
-        builder.setWidth(video.dimensions.width)
-        builder.setHeight(video.dimensions.height)
-        builder.setDurationInMillis(video.duration.toMillis)
-        VideoMetaData(builder.build())
+      def apply(video: AssetMetaData.Video): VideoMetaData = VideoMetaData {
+        Messages.Asset.VideoMetaData.newBuilder
+          .setWidth(video.dimensions.width)
+          .setHeight(video.dimensions.height)
+          .setDurationInMillis(video.duration.toMillis)
+          .build
       }
 
-      def apply(details: VideoDetails): VideoMetaData = {
-        val builder = Messages.Asset.VideoMetaData.newBuilder()
-        builder.setWidth(details.dimensions.width)
-        builder.setHeight(details.dimensions.height)
-        builder.setDurationInMillis(details.duration.toMillis)
-        VideoMetaData(builder.build())
+      def apply(details: VideoDetails): VideoMetaData = VideoMetaData {
+        Messages.Asset.VideoMetaData.newBuilder
+          .setWidth(details.dimensions.width)
+          .setHeight(details.dimensions.height)
+          .setDurationInMillis(details.duration.toMillis)
+          .build
       }
     }
 
@@ -241,18 +247,19 @@ object GenericContent {
     }
 
     object AudioMetaData {
-      def apply(audio: AssetMetaData.Audio): AudioMetaData = {
-        val builder = Messages.Asset.AudioMetaData.newBuilder()
-        builder.setDurationInMillis(audio.duration.toMillis)
+      def apply(audio: AssetMetaData.Audio): AudioMetaData = AudioMetaData {
+        val builder =
+          Messages.Asset.AudioMetaData.newBuilder
+            .setDurationInMillis(audio.duration.toMillis)
         audio.loudness.foreach(l => builder.setNormalizedLoudness(bytify(l.levels)))
-        AudioMetaData(builder.build())
+        builder.build
       }
 
-      def apply(details: AudioDetails): AudioMetaData = {
-        val builder = Messages.Asset.AudioMetaData.newBuilder()
-        builder.setDurationInMillis(details.duration.toMillis)
-        builder.setNormalizedLoudness(bytify(details.loudness.levels.map(_.toFloat)))
-        AudioMetaData(builder.build())
+      def apply(details: AudioDetails): AudioMetaData = AudioMetaData {
+        Messages.Asset.AudioMetaData.newBuilder
+          .setDurationInMillis(details.duration.toMillis)
+          .setNormalizedLoudness(bytify(details.loudness.levels.map(_.toFloat)))
+          .build
       }
 
       private def bytify(ls: Iterable[Float]): ByteString = ByteString.copyFrom(ls.map(l => (l * 255f).toByte)(breakOut).toArray)
@@ -262,9 +269,9 @@ object GenericContent {
 
     final case class Preview(override val proto: Messages.Asset.Preview) extends GenericContent[Messages.Asset.Preview] {
       override def set(builder: Messages.GenericMessage.Builder): Unit = {
-        val pb = Messages.Asset.newBuilder()
+        val pb = Messages.Asset.newBuilder
         pb.setPreview(proto)
-        builder.setAsset(pb.build())
+        builder.setAsset(pb.build)
       }
 
       lazy val unpack: Option[AssetData] = Option(proto).map { prev =>
@@ -283,10 +290,11 @@ object GenericContent {
     }
 
     object Preview {
-      def apply(preview: AssetData): Preview = {
-        val builder = Messages.Asset.Preview.newBuilder()
-        builder.setMimeType(preview.mime.str)
-        builder.setSize(preview.size)
+      def apply(preview: AssetData): Preview = Preview {
+        val builder =
+          Messages.Asset.Preview.newBuilder
+            .setMimeType(preview.mime.str)
+            .setSize(preview.size)
 
         // remote
         preview.remoteData.foreach(data => builder.setRemote(RemoteData(data).proto))
@@ -297,14 +305,15 @@ object GenericContent {
           case _ => //other meta data types not supported
         }
 
-        Preview(builder.build())
+        builder.build
       }
 
-      def apply(asset: assets.Asset): Preview = {
-        val builder = Messages.Asset.Preview.newBuilder()
-        builder.setMimeType(asset.mime.str)
-        builder.setSize(asset.size)
-        builder.setRemote(RemoteData(asset).proto)
+      def apply(asset: assets.Asset): Preview = Preview {
+        val builder =
+          Messages.Asset.Preview.newBuilder
+            .setMimeType(asset.mime.str)
+            .setSize(asset.size)
+            .setRemote(RemoteData(asset).proto)
 
         //image meta
         asset.details match {
@@ -312,7 +321,7 @@ object GenericContent {
           case _ =>
         }
 
-        Preview(builder.build())
+        builder.build
       }
     }
 
@@ -339,9 +348,9 @@ object GenericContent {
 
     final case class RemoteData(override val proto: Messages.Asset.RemoteData) extends GenericContent[Messages.Asset.RemoteData] {
       override def set(builder: Messages.GenericMessage.Builder): Unit = {
-        val rdb = Messages.Asset.Preview.newBuilder()
+        val rdb = Messages.Asset.Preview.newBuilder
         rdb.setRemote(proto)
-        Preview(rdb.build()).set(builder)
+        Preview(rdb.build).set(builder)
       }
 
       lazy val unpack: Option[AssetData.RemoteData] = Option(proto).map { rData =>
@@ -356,14 +365,14 @@ object GenericContent {
     }
 
     object RemoteData {
-      def apply(ak: AssetData.RemoteData): RemoteData = {
-        val builder = Messages.Asset.RemoteData.newBuilder()
+      def apply(ak: AssetData.RemoteData): RemoteData = RemoteData {
+        val builder = Messages.Asset.RemoteData.newBuilder
         ak.remoteId.foreach(id => builder.setAssetId(id.str))
         ak.token.foreach(t => builder.setAssetToken(t.str))
         ak.otrKey.foreach(key => builder.setOtrKey(ByteString.copyFrom(key.bytes)))
         ak.sha256.foreach(sha => builder.setSha256(ByteString.copyFrom(sha.bytes)))
         ak.encryption.foreach(enc => builder.setEncryption(toEncryptionAlg(enc)))
-        RemoteData(builder.build())
+        builder.build
       }
 
       private def toEncryptionAlg(enc: EncryptionAlgorithm): Messages.EncryptionAlgorithm = enc match {
@@ -371,18 +380,19 @@ object GenericContent {
         case AES_GCM => Messages.EncryptionAlgorithm.AES_GCM
       }
 
-      def apply(asset: assets.Asset): RemoteData = {
-        val builder = Messages.Asset.RemoteData.newBuilder()
-        builder.setAssetId(asset.id.str)
+      def apply(asset: assets.Asset): RemoteData = RemoteData {
+        val builder =
+          Messages.Asset.RemoteData.newBuilder
+            .setAssetId(asset.id.str)
+            .setSha256(ByteString.copyFrom(asset.sha.bytes))
         asset.token.foreach(token => builder.setAssetToken(token.str))
-        builder.setSha256(ByteString.copyFrom(asset.sha.bytes))
         asset.encryption match {
           case AES_CBC_Encryption(key) =>
             builder.setEncryption(Messages.EncryptionAlgorithm.AES_CBC)
             builder.setOtrKey(ByteString.copyFrom(key.bytes))
           case _ =>
         }
-        RemoteData(builder.build())
+        builder.build
       }
     }
   }
@@ -402,22 +412,25 @@ object GenericContent {
   }
 
   object ImageAsset {
-    def apply(asset: AssetData): ImageAsset = {
-      val builder = Messages.ImageAsset.newBuilder()
-        asset.metaData.foreach {
-          case AssetMetaData.Image(Dim2(w, h), tag) =>
-            builder.setTag(tag.toString)
-            builder.setWidth(w)
-            builder.setHeight(h)
-            builder.setOriginalWidth(w)
-            builder.setOriginalHeight(h)
-          case _ => error(l"Trying to create image proto from non image asset data: $asset")(LogTag("ImageAsset"))
-        }
-      builder.setMimeType(asset.mime.str)
-      builder.setSize(asset.size.toInt)
+    def apply(asset: AssetData): ImageAsset = ImageAsset {
+      val builder =
+        Messages.ImageAsset.newBuilder
+          .setMimeType(asset.mime.str)
+          .setSize(asset.size.toInt)
+      asset.metaData.foreach {
+        case AssetMetaData.Image(Dim2(w, h), tag) =>
+          builder
+            .setTag(tag.toString)
+            .setWidth(w)
+            .setHeight(h)
+            .setOriginalWidth(w)
+            .setOriginalHeight(h)
+        case _ =>
+          error(l"Trying to create image proto from non image asset data: $asset")(LogTag("ImageAsset"))
+      }
       asset.otrKey.foreach(v => builder.setOtrKey(ByteString.copyFrom(v.bytes)))
       asset.sha.foreach(v => builder.setSha256(ByteString.copyFrom(v.bytes)))
-      ImageAsset(builder.build())
+      builder.build
     }
   }
 
@@ -431,12 +444,13 @@ object GenericContent {
   }
 
   object Mention {
-    def apply(userId: Option[UserId], start: Int, length: Int): Mention = {
-      val builder = Messages.Mention.newBuilder()
+    def apply(userId: Option[UserId], start: Int, length: Int): Mention = Mention {
+      val builder =
+        Messages.Mention.newBuilder
+          .setStart(start)
+          .setLength(length)
       userId.map(id => builder.setUserId(id.str))
-      builder.setStart(start)
-      builder.setLength(length)
-      Mention(builder.build())
+      builder.build
     }
 
     def apply(mention: com.waz.model.Mention): Mention =
@@ -454,11 +468,12 @@ object GenericContent {
   }
 
   object Quote {
-    def apply(id: MessageId, sha256: Option[Sha256]): Quote = {
-      val builder = Messages.Quote.newBuilder()
-      builder.setQuotedMessageId(id.str)
+    def apply(id: MessageId, sha256: Option[Sha256]): Quote = Quote {
+      val builder =
+        Messages.Quote.newBuilder
+          .setQuotedMessageId(id.str)
       sha256.foreach(sha => if (sha.bytes.nonEmpty) builder.setQuotedMessageSha256(ByteString.copyFrom(sha.bytes)))
-      Quote(builder.build())
+      builder.build
     }
   }
 
@@ -476,40 +491,38 @@ object GenericContent {
   }
 
   object LinkPreview {
-    def apply(linkPreview: LinkPreview, meta: Messages.Tweet): LinkPreview = {
-      val builder = linkPreview.proto.toBuilder
-      builder.setTweet(meta)
-      LinkPreview(builder.build())
+    def apply(linkPreview: LinkPreview, meta: Messages.Tweet): LinkPreview = LinkPreview {
+      linkPreview.proto.toBuilder.setTweet(meta).build
     }
 
-    def apply(uri: URI, offset: Int): LinkPreview = {
-      val builder = Messages.LinkPreview.newBuilder()
-      builder.setUrl(uri.toString)
-      builder.setUrlOffset(offset)
-      LinkPreview(builder.build())
+    def apply(uri: URI, offset: Int): LinkPreview = LinkPreview {
+      Messages.LinkPreview.newBuilder
+        .setUrl(uri.toString)
+        .setUrlOffset(offset)
+        .build
     }
 
-    def apply(uri: URI, offset: Int, title: String, summary: String, image: Option[Asset], permanentUrl: Option[URI]): LinkPreview = {
-      val builder = Messages.LinkPreview.newBuilder()
-      builder.setUrl(uri.toString)
-      builder.setUrlOffset(offset)
-      builder.setTitle(title)
-      builder.setSummary(summary)
-      permanentUrl.foreach { u => builder.setPermanentUrl(u.toString) }
+    def apply(uri: URI, offset: Int, title: String, summary: String, image: Option[Asset], permanentUrl: Option[URI]): LinkPreview = LinkPreview {
+      val builder =
+        Messages.LinkPreview.newBuilder
+          .setUrl(uri.toString)
+          .setUrlOffset(offset)
+          .setTitle(title)
+          .setSummary(summary)
+          .setArticle(article(title, summary, image, permanentUrl))
+          // set article for backward compatibility, we will stop sending it once all platforms switch to using LinkPreview properties
       image.foreach(im => builder.setImage(im.proto))
-
-      // set article for backward compatibility, we will stop sending it once all platforms switch to using LinkPreview properties
-      builder.setArticle(article(title, summary, image, permanentUrl))
-      LinkPreview(builder.build())
+      permanentUrl.foreach { u => builder.setPermanentUrl(u.toString) }
+      builder.build
     }
 
     private def article(title: String, summary: String, image: Option[Asset], uri: Option[URI]) = {
-      val builder = Messages.Article.newBuilder()
+      val builder = Messages.Article.newBuilder
       builder.setTitle(title)
       builder.setSummary(summary)
       uri.foreach { u => builder.setPermanentUrl(u.toString) }
       image.foreach(im => builder.setImage(im.proto))
-      builder.build()
+      builder.build
     }
 
     implicit object JsDecoder extends JsonDecoder[LinkPreview] {
@@ -538,16 +551,16 @@ object GenericContent {
   object Reaction {
     val HeavyBlackHeart = "\u2764\uFE0F"
 
-    def apply(msg: MessageId, action: Liking.Action): Reaction = {
-      val builder = Messages.Reaction.newBuilder()
-      builder.setEmoji(
-        action match {
-          case Liking.Action.Like => HeavyBlackHeart
-          case Liking.Action.Unlike => ""
-        }
-      )
-      builder.setMessageId(msg.str)
-      Reaction(builder.build())
+    def apply(msg: MessageId, action: Liking.Action): Reaction = Reaction {
+      Messages.Reaction.newBuilder
+        .setMessageId(msg.str)
+        .setEmoji(
+          action match {
+            case Liking.Action.Like => HeavyBlackHeart
+            case Liking.Action.Unlike => ""
+          }
+        )
+        .build
     }
   }
 
@@ -558,11 +571,11 @@ object GenericContent {
   }
 
   object Knock {
-    def apply(expectsReadConfirmation: Boolean): Knock = {
-      val builder = Messages.Knock.newBuilder()
-      builder.setHotKnock(false)
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
-      Knock(builder.build())
+    def apply(expectsReadConfirmation: Boolean): Knock = Knock {
+      Messages.Knock.newBuilder
+        .setHotKnock(false)
+        .setExpectsReadConfirmation(expectsReadConfirmation)
+        .build
     }
   }
 
@@ -590,21 +603,22 @@ object GenericContent {
     def apply(content: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview], expectsReadConfirmation: Boolean): Text =
       apply(content, mentions, links, None, expectsReadConfirmation)
 
-    def apply(content: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview], quote: Option[Quote], expectsReadConfirmation: Boolean): Text = {
-      val builder = Messages.Text.newBuilder()
-      builder.setContent(content)
-      builder.addAllMentions(mentions.map(Mention(_).proto).asJava)
-      builder.addAllLinkPreview(links.map(_.proto).asJava)
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
+    def apply(content: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview], quote: Option[Quote], expectsReadConfirmation: Boolean): Text = Text {
+      val builder =
+        Messages.Text.newBuilder
+          .setContent(content)
+          .addAllMentions(mentions.map(Mention(_).proto).asJava)
+          .addAllLinkPreview(links.map(_.proto).asJava)
+          .setExpectsReadConfirmation(expectsReadConfirmation)
       quote.foreach(q => builder.setQuote(q.proto))
-      Text(builder.build())
+      builder.build
     }
 
-    def newMentions(text: Text, mentions: Seq[com.waz.model.Mention]): Text = {
-      val builder = text.proto.toBuilder
-      builder.clearMentions()
-      builder.addAllMentions(mentions.map(Mention(_).proto).asJava)
-      Text(builder.build())
+    def newMentions(text: Text, mentions: Seq[com.waz.model.Mention]): Text = Text {
+      text.proto.toBuilder
+        .clearMentions()
+        .addAllMentions(mentions.map(Mention(_).proto).asJava)
+        .build
     }
   }
 
@@ -622,11 +636,11 @@ object GenericContent {
   }
 
   object MsgEdit {
-    def apply(ref: MessageId, content: Text): MsgEdit = {
-      val builder = Messages.MessageEdit.newBuilder()
-      builder.setReplacingMessageId(ref.str)
-      builder.setText(content.proto)
-      MsgEdit(builder.build())
+    def apply(ref: MessageId, content: Text): MsgEdit = MsgEdit {
+      Messages.MessageEdit.newBuilder
+        .setReplacingMessageId(ref.str)
+        .setText(content.proto)
+        .build
     }
   }
 
@@ -638,11 +652,11 @@ object GenericContent {
   }
 
   object Cleared {
-    def apply(conv: RConvId, time: RemoteInstant): Cleared  = {
-      val builder = Messages.Cleared.newBuilder()
-      builder.setConversationId(conv.str)
-      builder.setClearedTimestamp(time.toEpochMilli)
-      Cleared(builder.build())
+    def apply(conv: RConvId, time: RemoteInstant): Cleared  = Cleared {
+      Messages.Cleared.newBuilder
+        .setConversationId(conv.str)
+        .setClearedTimestamp(time.toEpochMilli)
+        .build
     }
   }
 
@@ -654,11 +668,11 @@ object GenericContent {
   }
 
   object LastRead {
-    def apply(conv: RConvId, time: RemoteInstant): LastRead  = {
-      val builder = Messages.LastRead.newBuilder()
-      builder.setConversationId(conv.str)
-      builder.setLastReadTimestamp(time.toEpochMilli)
-      LastRead(builder.build())
+    def apply(conv: RConvId, time: RemoteInstant): LastRead  = LastRead {
+      Messages.LastRead.newBuilder
+        .setConversationId(conv.str)
+        .setLastReadTimestamp(time.toEpochMilli)
+        .build
     }
   }
 
@@ -670,11 +684,11 @@ object GenericContent {
   }
 
   object MsgDeleted {
-    def apply(conv: RConvId, msg: MessageId): MsgDeleted  = {
-      val builder = Messages.MessageHide.newBuilder()
-      builder.setConversationId(conv.str)
-      builder.setMessageId(msg.str)
-      MsgDeleted(builder.build())
+    def apply(conv: RConvId, msg: MessageId): MsgDeleted  = MsgDeleted {
+      Messages.MessageHide.newBuilder
+        .setConversationId(conv.str)
+        .setMessageId(msg.str)
+        .build
     }
   }
 
@@ -686,10 +700,10 @@ object GenericContent {
   }
 
   object MsgRecall {
-    def apply(msg: MessageId): MsgRecall  = {
-      val builder = Messages.MessageDelete.newBuilder()
-      builder.setMessageId(msg.str)
-      MsgRecall(builder.build())
+    def apply(msg: MessageId): MsgRecall  = MsgRecall {
+      Messages.MessageDelete.newBuilder
+        .setMessageId(msg.str)
+        .build
     }
   }
 
@@ -707,14 +721,14 @@ object GenericContent {
   }
 
   object Location {
-    def apply(lon: Float, lat: Float, name: String, zoom: Int, expectsReadConfirmation: Boolean): Location = {
-      val builder = Messages.Location.newBuilder()
-      builder.setLongitude(lon)
-      builder.setLatitude(lat)
-      builder.setName(name)
-      builder.setZoom(zoom)
-      builder.setExpectsReadConfirmation(expectsReadConfirmation)
-      Location(builder.build())
+    def apply(lon: Float, lat: Float, name: String, zoom: Int, expectsReadConfirmation: Boolean): Location = Location {
+      Messages.Location.newBuilder
+        .setLongitude(lon)
+        .setLatitude(lat)
+        .setName(name)
+        .setZoom(zoom)
+        .setExpectsReadConfirmation(expectsReadConfirmation)
+        .build
     }
   }
 
@@ -733,19 +747,19 @@ object GenericContent {
   }
 
   object DeliveryReceipt {
-    def apply(msg: MessageId): DeliveryReceipt = {
-      val builder = Messages.Confirmation.newBuilder()
-      builder.setFirstMessageId(msg.str)
-      builder.setType(Messages.Confirmation.Type.DELIVERED)
-      DeliveryReceipt(builder.build())
+    def apply(msg: MessageId): DeliveryReceipt = DeliveryReceipt {
+      Messages.Confirmation.newBuilder
+        .setFirstMessageId(msg.str)
+        .setType(Messages.Confirmation.Type.DELIVERED)
+        .build
     }
 
-    def apply(msgs: Seq[MessageId]): DeliveryReceipt = {
-      val builder = Messages.Confirmation.newBuilder()
-      builder.setFirstMessageId(msgs.head.str)
-      builder.addAllMoreMessageIds(msgs.tail.map(_.str).asJava)
-      builder.setType(Messages.Confirmation.Type.DELIVERED)
-      DeliveryReceipt(builder.build())
+    def apply(msgs: Seq[MessageId]): DeliveryReceipt = DeliveryReceipt {
+      Messages.Confirmation.newBuilder
+        .setFirstMessageId(msgs.head.str)
+        .addAllMoreMessageIds(msgs.tail.map(_.str).asJava)
+        .setType(Messages.Confirmation.Type.DELIVERED)
+        .build
     }
   }
 
@@ -764,19 +778,19 @@ object GenericContent {
   }
 
   object ReadReceipt {
-    def apply(msg: MessageId): ReadReceipt = {
-      val builder = Messages.Confirmation.newBuilder()
-      builder.setFirstMessageId(msg.str)
-      builder.setType(Messages.Confirmation.Type.READ)
-      ReadReceipt(builder.build())
+    def apply(msg: MessageId): ReadReceipt = ReadReceipt {
+      Messages.Confirmation.newBuilder
+        .setFirstMessageId(msg.str)
+        .setType(Messages.Confirmation.Type.READ)
+        .build
     }
 
-    def apply(msgs: Seq[MessageId]): ReadReceipt = {
-      val builder = Messages.Confirmation.newBuilder()
-      builder.setFirstMessageId(msgs.head.str)
-      builder.addAllMoreMessageIds(msgs.tail.map(_.str).asJava)
-      builder.setType(Messages.Confirmation.Type.READ)
-      ReadReceipt(builder.build())
+    def apply(msgs: Seq[MessageId]): ReadReceipt = ReadReceipt {
+      Messages.Confirmation.newBuilder
+        .setFirstMessageId(msgs.head.str)
+        .addAllMoreMessageIds(msgs.tail.map(_.str).asJava)
+        .setType(Messages.Confirmation.Type.READ)
+        .build
     }
   }
 
@@ -788,11 +802,11 @@ object GenericContent {
   }
 
   object External {
-    def apply(key: AESKey, sha: Sha256): External = {
-      val builder = Messages.External.newBuilder()
-      builder.setOtrKey(ByteString.copyFrom(key.bytes))
-      builder.setSha256(ByteString.copyFrom(sha.bytes))
-      External(builder.build())
+    def apply(key: AESKey, sha: Sha256): External = External {
+      Messages.External.newBuilder
+        .setOtrKey(ByteString.copyFrom(key.bytes))
+        .setSha256(ByteString.copyFrom(sha.bytes))
+        .build
     }
   }
 
@@ -804,11 +818,11 @@ object GenericContent {
   }
 
   object EphemeralAsset {
-    def apply(asset: Messages.Asset, expiry: FiniteDuration): EphemeralAsset = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setAsset(asset)
-      builder.setExpireAfterMillis(expiry.toMillis)
-      EphemeralAsset(builder.build())
+    def apply(asset: Messages.Asset, expiry: FiniteDuration): EphemeralAsset = EphemeralAsset {
+      Messages.Ephemeral.newBuilder
+        .setAsset(asset)
+        .setExpireAfterMillis(expiry.toMillis)
+        .build
     }
   }
 
@@ -820,11 +834,11 @@ object GenericContent {
   }
 
   object EphemeralImageAsset {
-    def apply(image: Messages.ImageAsset, expiry: FiniteDuration): EphemeralAsset = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setImage(image)
-      builder.setExpireAfterMillis(expiry.toMillis)
-      EphemeralAsset(builder.build())
+    def apply(image: Messages.ImageAsset, expiry: FiniteDuration): EphemeralAsset = EphemeralAsset {
+      Messages.Ephemeral.newBuilder
+        .setImage(image)
+        .setExpireAfterMillis(expiry.toMillis)
+        .build
     }
   }
 
@@ -836,11 +850,11 @@ object GenericContent {
   }
 
   object EphemeralLocation {
-    def apply(location: Messages.Location, expiry: FiniteDuration): EphemeralLocation = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setLocation(location)
-      builder.setExpireAfterMillis(expiry.toMillis)
-      EphemeralLocation(builder.build())
+    def apply(location: Messages.Location, expiry: FiniteDuration): EphemeralLocation = EphemeralLocation {
+      Messages.Ephemeral.newBuilder
+        .setLocation(location)
+        .setExpireAfterMillis(expiry.toMillis)
+        .build
     }
   }
 
@@ -852,11 +866,11 @@ object GenericContent {
   }
 
   object EphemeralText {
-    def apply(text: Messages.Text, expiry: FiniteDuration): EphemeralText = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setText(text)
-      builder.setExpireAfterMillis(expiry.toMillis)
-      EphemeralText(builder.build())
+    def apply(text: Messages.Text, expiry: FiniteDuration): EphemeralText = EphemeralText {
+      Messages.Ephemeral.newBuilder
+        .setText(text)
+        .setExpireAfterMillis(expiry.toMillis)
+        .build
     }
   }
 
@@ -868,11 +882,11 @@ object GenericContent {
   }
 
   object EphemeralKnock {
-    def apply(knock: Messages.Knock, expiry: FiniteDuration): EphemeralKnock = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setKnock(knock)
-      builder.setExpireAfterMillis(expiry.toMillis)
-      EphemeralKnock(builder.build())
+    def apply(knock: Messages.Knock, expiry: FiniteDuration): EphemeralKnock = EphemeralKnock {
+      Messages.Ephemeral.newBuilder
+        .setKnock(knock)
+        .setExpireAfterMillis(expiry.toMillis)
+        .build
     }
   }
 
@@ -899,11 +913,12 @@ object GenericContent {
   }
 
   object Ephemeral {
-    def apply(expiry: Option[FiniteDuration], content: EphemeralContent): Ephemeral = {
-      val builder = Messages.Ephemeral.newBuilder()
-      builder.setExpireAfterMillis(expiry.getOrElse(Duration.Zero).toMillis)
+    def apply(expiry: Option[FiniteDuration], content: EphemeralContent): Ephemeral = Ephemeral {
+      val builder =
+        Messages.Ephemeral.newBuilder
+          .setExpireAfterMillis(expiry.getOrElse(Duration.Zero).toMillis)
       content.set(builder)
-      Ephemeral(builder.build())
+      builder.build
     }
   }
 
@@ -920,15 +935,15 @@ object GenericContent {
   }
 
   object AvailabilityStatus {
-    def apply(av: Availability): AvailabilityStatus = {
-      val builder = Messages.Availability.newBuilder()
-      builder.setType(av match {
-        case Availability.None      => Messages.Availability.Type.NONE
-        case Availability.Available => Messages.Availability.Type.AVAILABLE
-        case Availability.Away      => Messages.Availability.Type.AWAY
-        case Availability.Busy      => Messages.Availability.Type.BUSY
-      })
-      AvailabilityStatus(builder.build())
+    def apply(av: Availability): AvailabilityStatus = AvailabilityStatus {
+      Messages.Availability.newBuilder
+        .setType(av match {
+          case Availability.None      => Messages.Availability.Type.NONE
+          case Availability.Available => Messages.Availability.Type.AVAILABLE
+          case Availability.Away      => Messages.Availability.Type.AWAY
+          case Availability.Busy      => Messages.Availability.Type.BUSY
+        })
+        .build
     }
   }
 
@@ -962,10 +977,10 @@ object GenericContent {
   }
 
   object Calling {
-    def apply(content: String): Calling = {
-      val builder = Messages.Calling.newBuilder()
-      builder.setContent(content)
-      Calling(builder.build())
+    def apply(content: String): Calling = Calling {
+      Messages.Calling.newBuilder
+        .setContent(content)
+        .build
     }
   }
 
@@ -982,11 +997,11 @@ object GenericContent {
   }
 
   object ButtonAction {
-    def apply(buttonId: String, referenceMsgId: String): ButtonAction = {
-      val builder = Messages.ButtonAction.newBuilder()
-      builder.setButtonId(buttonId)
-      builder.setReferenceMessageId(referenceMsgId)
-      ButtonAction(builder.build())
+    def apply(buttonId: String, referenceMsgId: String): ButtonAction = ButtonAction {
+      Messages.ButtonAction.newBuilder
+        .setButtonId(buttonId)
+        .setReferenceMessageId(referenceMsgId)
+        .build
     }
   }
 
@@ -1013,12 +1028,11 @@ object GenericContent {
   }
 
   object DataTransfer {
-    def apply(trackingId: TrackingId): DataTransfer = {
-      val trackingBuilder = Messages.TrackingIdentifier.newBuilder()
-      trackingBuilder.setIdentifier(trackingId.str)
-      val builder = Messages.DataTransfer.newBuilder()
-      builder.setTrackingIdentifier(trackingBuilder.build())
-      DataTransfer(builder.build())
+    def apply(trackingId: TrackingId): DataTransfer = DataTransfer {
+      val tracking = Messages.TrackingIdentifier.newBuilder.setIdentifier(trackingId.str).build
+      Messages.DataTransfer.newBuilder
+        .setTrackingIdentifier(tracking)
+        .build
     }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -604,7 +604,6 @@ object MessageData extends DerivedLogTag {
   }
 
   def adjustMentions(text: String, mentions: Seq[Mention], forSending: Boolean, offset: Int = 0): Seq[Mention] = {
-    verbose(l"adjustMentions($text, $mentions, $forSending, $offset)")
     lazy val textAsUTF16 = encode(text) // optimization: textAsUTF16 is used only for incoming mentions
 
     mentions.foldLeft(List.empty[Mention]) { case (acc, m) =>
@@ -623,5 +622,5 @@ object MessageData extends DerivedLogTag {
 
   private def decode(array: Array[Byte]) = UTF_16_CHARSET.decode(ByteBuffer.wrap(array)).toString
 
-  def readReceiptMode(enabled: Boolean) = if (enabled) Some(1) else Some(0)
+  def readReceiptMode(enabled: Boolean): Option[Int] = if (enabled) Some(1) else Some(0)
 }

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -82,6 +82,8 @@ case class MessageData(override val id:   MessageId              = MessageId(),
     case _ => Nil
   }
 
+  def unpackLinks: Seq[(String, String, Option[AssetData])] = links.map(_.unpack)
+
   lazy val protoQuote: Option[Quote] = genericMsgs.lastOption match {
     case Some(TextMessage(_, _, _, quote, _)) => quote
     case _ => None

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -29,7 +29,7 @@ import com.waz.db.Dao
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.GenericContent.{Asset, Composite, ImageAsset, Knock, LinkPreview, Location, MsgEdit, Quote, Text}
-import com.waz.model.GenericMessage.{GenericMessageContent, TextMessage}
+import com.waz.model.GenericMessage.TextMessage
 import com.waz.model.MessageData.MessageState
 import com.waz.model.messages.media.{MediaAssetData, MediaAssetDataProtocol}
 import com.waz.model.otr.ClientId
@@ -52,7 +52,7 @@ case class MessageData(override val id:   MessageId              = MessageId(),
                        userId:            UserId                 = UserId(),
                        error:             Option[ErrorContent]   = None,
                        content:           Seq[MessageContent]    = Seq.empty,
-                       protos:            Seq[GenericMessage]    = Seq.empty,
+                       genericMsgs:       Seq[GenericMessage]    = Seq.empty,
                        firstMessage:      Boolean                = false,
                        members:           Set[UserId]            = Set.empty[UserId],
                        recipient:         Option[UserId]         = None,
@@ -70,42 +70,42 @@ case class MessageData(override val id:   MessageId              = MessageId(),
                        quote:             Option[QuoteContent]   = None,
                        forceReadReceipts: Option[Int]            = None
                       ) extends Identifiable[MessageId] with DerivedLogTag {
-  lazy val contentString: String = protos.lastOption match {
+  lazy val contentString: String = genericMsgs.lastOption match {
     case Some(TextMessage(ct, _, _, _, _)) => ct
     case _ if msgType == api.Message.Type.RICH_MEDIA => content.map(_.content).mkString(" ")
     case _ if msgType == api.Message.Type.COMPOSITE => content.map(_.content).mkString("\n")
     case _ => content.headOption.fold("")(_.content)
   }
 
-  lazy val links: Seq[LinkPreview] = protos.lastOption match {
+  lazy val links: Seq[LinkPreview] = genericMsgs.lastOption match {
     case Some(TextMessage(_, _, links, _, _)) => links
     case _ => Nil
   }
 
-  lazy val protoQuote: Option[Quote] = protos.lastOption match {
+  lazy val protoQuote: Option[Quote] = genericMsgs.lastOption match {
     case Some(TextMessage(_, _, _, quote, _)) => quote
     case _ => None
   }
 
-  lazy val protoReadReceipts: Option[Boolean] = protos.lastOption.map {
-    case GenericMessage(_, a @ Text(_, _, _, _))     => a.expectsReadConfirmation
-    case GenericMessage(_, a @ Knock())              => a.expectsReadConfirmation
-    case GenericMessage(_, a @ Location(_, _, _, _)) => a.expectsReadConfirmation
-    case GenericMessage(_, a @ Asset(_, _))          => a.expectsReadConfirmation
-    case GenericMessage(_, a @ Composite(_))         => a.expectsReadConfirmation
+  lazy val protoReadReceipts: Option[Boolean] = genericMsgs.lastOption.map(_.unpackContent match {
+    case t: Text      if t.proto.hasExpectsReadConfirmation => t.proto.getExpectsReadConfirmation
+    case k: Knock     if k.proto.hasExpectsReadConfirmation => k.proto.getExpectsReadConfirmation
+    case l: Location  if l.proto.hasExpectsReadConfirmation => l.proto.getExpectsReadConfirmation
+    case a: Asset     if a.proto.hasExpectsReadConfirmation => a.proto.getExpectsReadConfirmation
+    case c: Composite if c.proto.hasExpectsReadConfirmation => c.proto.getExpectsReadConfirmation
     case _ => false
-  }
+  })
 
   lazy val expectsRead: Option[Boolean] = forceReadReceipts.map(_ > 0).orElse(protoReadReceipts)
 
   // used to create a copy of the message quoting the one that had its msgId changed
   def replaceQuote(quoteId: MessageId): MessageData = {
     // we assume that the reply is already valid, so we don't have to update the hash (the old one is invalid)
-    val newProtos = protos.lastOption match {
+    val newProtos = genericMsgs.lastOption match {
       case Some(TextMessage(text, ms, ls, Some(q), rr)) => Seq(TextMessage(text, ms, ls, Some(Quote(quoteId, None)), rr))
-      case _ => protos
+      case _ => genericMsgs
     }
-    copy(quote = Some(QuoteContent(quoteId, validity = true, None)), protos = newProtos)
+    copy(quote = Some(QuoteContent(quoteId, validity = true, None)), genericMsgs = newProtos)
   }
 
   lazy val isLocal: Boolean = state == Message.Status.DEFAULT || state == Message.Status.PENDING || state == Message.Status.FAILED || state == Message.Status.FAILED_READ
@@ -117,18 +117,31 @@ case class MessageData(override val id:   MessageId              = MessageId(),
 
   def hasMentionOf(userId: UserId): Boolean = mentions.exists(_.userId.forall(_ == userId)) // a mention with userId == None is a "mention" of everyone, so it counts
 
-  lazy val imageDimensions: Option[Dim2] =
-    protos.collectFirst {
-      case GenericMessageContent(Asset(AssetData.WithDimensions(d), _)) => d
-      case GenericMessageContent(ImageAsset(AssetData.WithDimensions(d))) => d
-    } orElse content.headOption.collect {
-      case MessageContent(_, _, _, _, Some(_), w, h, _, _) => Dim2(w, h)
+  object ImageDimensions {
+    def unapply(msg: GenericMessage): Option[Dim2] = msg.unpackContent match {
+      case asset: Asset      => Some(asset.unpack._1.dimensions)
+      case image: ImageAsset => Some(image.unpack.dimensions)
+      case _                 => None
     }
+  }
+
+  lazy val imageDimensions: Option[Dim2] = genericMsgs.collectFirst {
+    case ImageDimensions(dim2) => dim2
+  }.orElse(content.headOption.collect {
+    case MessageContent(_, _, _, _, Some(_), w, h, _, _) => Dim2(w, h)
+  })
+
+  object Location {
+    def unapply(msg: GenericMessage): Option[api.MessageContent.Location] = msg.unpackContent match {
+      case location: Location =>
+        val (lon, lat, name, zoom, _) = location.unpack
+        Some(new api.MessageContent.Location(lon, lat, name.getOrElse(""), zoom.getOrElse(14)))
+      case _ => None
+    }
+  }
 
   lazy val location: Option[api.MessageContent.Location] =
-    protos.collectFirst {
-      case GenericMessageContent(Location(lon, lat, descr, zoom)) => new api.MessageContent.Location(lon, lat, descr.getOrElse(""), zoom.getOrElse(14))
-    }
+    genericMsgs.collectFirst { case Location(loc) => loc }
 
   /**
    * System messages are messages generated by backend in response to user actions.
@@ -155,7 +168,6 @@ case class MessageData(override val id:   MessageId              = MessageId(),
   def adjustMentions(forSending: Boolean): Option[MessageData] =
     if (mentions.isEmpty) None
     else {
-      verbose(l"adjustMentions(forSending = $forSending)")
       val newContent =
         if (content.size == 1)
           content.map(_.copy(mentions = MessageData.adjustMentions(content.head.content, mentions, forSending)))
@@ -173,17 +185,28 @@ case class MessageData(override val id:   MessageId              = MessageId(),
 
       val newMentions = newContent.flatMap(_.mentions)
 
-      val newProto = protos.lastOption match {
-        case Some(GenericMessage(uid, MsgEdit(ref, t @ Text(_, _, links, quote)))) =>
-          GenericMessage(uid, MsgEdit(ref, Text(contentString, newMentions, links, quote, t.expectsReadConfirmation)))
-        case Some(GenericMessage(uid, t @ Text(_, _, links, quote))) =>
-          GenericMessage(uid, ephemeral, Text(contentString, newMentions, links, quote, t.expectsReadConfirmation))
-        case _ =>
-          GenericMessage(id.uid, ephemeral, Text(contentString, newMentions, Nil, protoReadReceipts.getOrElse(false)))
-      }
+      val newProto = (genericMsgs.lastOption.flatMap {
+        _.unpack match {
+            case (uid, edit: MsgEdit) =>
+              edit.unpack.map { case (ref, text) =>
+                val expectsReadConfirmation =
+                  if (text.proto.hasExpectsReadConfirmation) text.proto.getExpectsReadConfirmation
+                  else false
+                GenericMessage(uid, MsgEdit(ref, Text(contentString, newMentions, links, text.unpack._4, expectsReadConfirmation)))
+              }
+            case (uid, text: Text) =>
+              val expectsReadConfirmation =
+                if (text.proto.hasExpectsReadConfirmation) text.proto.getExpectsReadConfirmation
+                else false
+              Some(GenericMessage(uid, ephemeral, Text(contentString, newMentions, links, text.unpack._4, expectsReadConfirmation)))
+            case _ => None
+          }
+      }).getOrElse(
+        GenericMessage(id.uid, ephemeral, Text(contentString, newMentions, Nil, protoReadReceipts.getOrElse(false)))
+      )
 
-      if (content == newContent && protos.lastOption.contains(newProto)) None
-      else Some(copy(content = newContent, protos = Seq(newProto)))
+      if (content == newContent && genericMsgs.lastOption.contains(newProto)) None
+      else Some(copy(content = newContent, genericMsgs = Seq(newProto)))
     }
 }
 
@@ -343,7 +366,7 @@ object MessageData extends DerivedLogTag {
     val Client = opt(id[ClientId]('client_id))(_.error.map(_.clientId))
     val ErrorCode = opt(int('error_code))(_.error.map(_.code))
     val Content = jsonArray[MessageContent, Seq, Vector]('content).apply(_.content)
-    val Protos = protoSeq[GenericMessage, Seq, Vector]('protos).apply(_.protos)
+    val Protos = protoSeq('protos).apply(_.genericMsgs)
     val ContentSize = int('content_size)(_.content.size)
     val FirstMessage = bool('first_msg)(_.firstMessage)
     val Members = set[UserId]('members, _.mkString(","), _.split(",").filter(!_.isEmpty).map(UserId(_))(breakOut))(_.members)
@@ -358,7 +381,7 @@ object MessageData extends DerivedLogTag {
     val ExpiryTime = opt(localTimestamp('expiry_time))(_.expiryTime)
     val Expired = bool('expired)(_.expired)
     val Duration = opt(finiteDuration('duration))(_.duration)
-    val Quote         = opt(id[MessageId]('quote))(_.quote.map(_.message))
+    val Quote = opt(id[MessageId]('quote))(_.quote.map(_.message))
     val QuoteValidity = bool('quote_validity)(_.quote.exists(_.validity))
     val ForceReadReceipts = opt(int('force_read_receipts))(_.forceReadReceipts)
     val AssetId = opt(text('asset_id, GeneralAssetIdCodec.serialize, GeneralAssetIdCodec.deserialize))(_.assetId)
@@ -531,14 +554,20 @@ object MessageData extends DerivedLogTag {
         }
 
         val res = new MessageContentBuilder
-        val end = links.filterNot(l => markdownLinks.contains(l.url)).sortBy(_.urlOffset).foldLeft(0) {
+        val end = links.filterNot { l => markdownLinks.contains(l.proto.getUrl)}.sortBy(_.proto.getUrlOffset).foldLeft(0) {
           case (prevEnd, link) =>
-            if (link.urlOffset > prevEnd) res ++= RichMediaContentParser.splitContent(message.substring(prevEnd, link.urlOffset), mentions, prevEnd)
+            if (link.proto.getUrlOffset > prevEnd)
+              res ++= RichMediaContentParser.splitContent(message.substring(prevEnd, link.proto.getUrlOffset), mentions, prevEnd)
 
-          returning(linkEnd(link.urlOffset)) { end =>
-            if (end > link.urlOffset) {
-              val openGraph = Option(link.getArticle).map { a => OpenGraphData(a.title, a.summary, None, "", Option(a.permanentUrl).filter(_.nonEmpty).map(new URL(_))) }
-              res += MessageContent(Message.Part.Type.WEB_LINK, message.substring(link.urlOffset, end), openGraph)
+          returning(linkEnd(link.proto.getUrlOffset)) { end =>
+            if (end > link.proto.getUrlOffset) {
+              val openGraph =
+                if (link.proto.hasArticle)
+                  Option(link.proto.getArticle).map { a =>
+                    OpenGraphData(a.getTitle, a.getSummary, None, "", Option(a.getPermanentUrl).filter(_.nonEmpty).map(new URL(_)))
+                  }
+                else None
+              res += MessageContent(Message.Part.Type.WEB_LINK, message.substring(link.proto.getUrlOffset, end), openGraph)
             }
           }
         }
@@ -573,6 +602,7 @@ object MessageData extends DerivedLogTag {
   }
 
   def adjustMentions(text: String, mentions: Seq[Mention], forSending: Boolean, offset: Int = 0): Seq[Mention] = {
+    verbose(l"adjustMentions($text, $mentions, $forSending, $offset)")
     lazy val textAsUTF16 = encode(text) // optimization: textAsUTF16 is used only for incoming mentions
 
     mentions.foldLeft(List.empty[Mention]) { case (acc, m) =>

--- a/zmessaging/src/main/scala/com/waz/model/package.scala
+++ b/zmessaging/src/main/scala/com/waz/model/package.scala
@@ -97,16 +97,18 @@ package object model {
   object GenericMessage {
     import GenericContent._
 
-    def apply[Proto](id: Uid, content: GenericContent[Proto]): GenericMessage = {
-      val builder = Messages.GenericMessage.newBuilder()
-      builder.setMessageId(id.str)
+    def apply[Proto](id: Uid, content: GenericContent[Proto]): GenericMessage = GenericMessage {
+      val builder =
+        Messages.GenericMessage.newBuilder
+          .setMessageId(id.str)
       content.set(builder)
-      GenericMessage(builder.build())
+      builder.build()
     }
 
-    def apply[Proto](id: Uid, expiration: Option[FiniteDuration], content: GenericContent[Proto]): GenericMessage = {
-      val builder = Messages.GenericMessage.newBuilder()
-      builder.setMessageId(id.str)
+    def apply[Proto](id: Uid, expiration: Option[FiniteDuration], content: GenericContent[Proto]): GenericMessage = GenericMessage {
+      val builder =
+        Messages.GenericMessage.newBuilder
+          .setMessageId(id.str)
       expiration match {
         case Some(expiry) =>
           val ephemeralContent: Option[EphemeralContent] = content match {
@@ -123,7 +125,7 @@ package object model {
         case None => content.set(builder)
       }
 
-      GenericMessage(builder.build())
+      builder.build
     }
 
     def apply(bytes: Array[Byte]): GenericMessage =

--- a/zmessaging/src/main/scala/com/waz/model/package.scala
+++ b/zmessaging/src/main/scala/com/waz/model/package.scala
@@ -17,10 +17,12 @@
  */
 package com.waz
 
-import com.google.protobuf.nano.{CodedInputByteBufferNano, MessageNano}
-import com.waz.model.nano.Messages
+import com.google.protobuf.{CodedInputStream, MessageLite}
+import com.waz.log.BasicLogging.LogTag
+import com.waz.log.LogSE._
+import com.waz.model.GenericContent.{Ephemeral, Unknown}
 import com.waz.utils.crypto.AESUtils
-import com.waz.utils.{JsonDecoder, JsonEncoder, returning}
+import com.waz.utils.{JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 
 import scala.concurrent.duration.FiniteDuration
@@ -28,125 +30,149 @@ import scala.language.implicitConversions
 
 package object model {
 
-  case class Name(str: String) {
-    def length = str.length
+  final case class Name(str: String) extends AnyVal {
+    def length: Int = str.length
 
     override def toString: String = str
 
     def isEmpty: Boolean = str.isEmpty
     def nonEmpty: Boolean = str.nonEmpty
 
-    def substring(beginIndex: Int, endIndex: Int) =
+    def substring(beginIndex: Int, endIndex: Int): Name =
       Name(str.substring(beginIndex, endIndex))
   }
 
   object Name extends (String => Name) {
     implicit def toNameString(name: Name): String = name.str
     implicit def fromNameString(str: String): Name = Name(str)
-    val Empty = Name("")
+    val Empty: Name = Name("")
   }
 
-  trait ProtoDecoder[A <: MessageNano] {
+  trait ProtoDecoder[A] {
     def apply(data: Array[Byte]): A
-    def apply(in: CodedInputByteBufferNano): A
+    def apply(in: CodedInputStream): A
   }
 
-  val Proto = GenericContent
+  final case class GenericMessage(proto: Messages.GenericMessage) {
+    lazy val unpack: (Uid, GenericContent[_]) = (Uid(proto.getMessageId), content)
 
-  type GenericMessage = Messages.GenericMessage
-  object GenericMessage {
-    import GenericContent._
+    def toByteArray: Array[Byte] = proto.toByteArray
 
-    def apply[A: GenericContent](id: Uid, content: A): GenericMessage =
-      returning(new Messages.GenericMessage()) { msg =>
-        msg.messageId = id.str
-        implicitly[GenericContent[A]].set(msg)(content)
-      }
-
-    def apply[A: EphemeralContent : GenericContent](id: Uid, expiration: Option[FiniteDuration], content: A): GenericMessage =
-      returning(new Messages.GenericMessage()) { msg =>
-        msg.messageId = id.str
-        if (expiration.isEmpty) {
-          implicitly[GenericContent[A]].set(msg)(content)
-        } else {
-          Ephemeral.set(msg)(Ephemeral(expiration, content))
-        }
-      }
-
-    def apply(bytes: Array[Byte]): GenericMessage = Messages.GenericMessage.parseFrom(bytes)
-
-    def unapply(msg: GenericMessage): Option[(Uid, Any)] = Some((Uid(msg.messageId), content(msg)))
-
-    def toByteArray(msg: GenericMessage): Array[Byte] = MessageNano.toByteArray(msg)
-
-    import Messages.{GenericMessage => GM}
-
-    def isBroadcastMessage(msg: GenericMessage): Boolean = msg.getContentCase match {
-      case GM.AVAILABILITY_FIELD_NUMBER => true
+    lazy val isBroadcastMessage: Boolean = proto.getContentCase.getNumber match {
+      case Messages.GenericMessage.AVAILABILITY_FIELD_NUMBER => true
       case _ => false
     }
 
-    def content(msg: GenericMessage): Any = msg.getContentCase match {
-      case GM.ASSET_FIELD_NUMBER                    => msg.getAsset
-      case GM.CALLING_FIELD_NUMBER                  => msg.getCalling
-      case GM.CLEARED_FIELD_NUMBER                  => msg.getCleared
-      case GM.CLIENTACTION_FIELD_NUMBER             => ClientAction(msg.getClientAction)
-      case GM.DELETED_FIELD_NUMBER                  => msg.getDeleted
-      case GM.EDITED_FIELD_NUMBER                   => msg.getEdited
-      case GM.EXTERNAL_FIELD_NUMBER                 => msg.getExternal
-      case GM.HIDDEN_FIELD_NUMBER                   => msg.getHidden
-      case GM.IMAGE_FIELD_NUMBER                    => msg.getImage
-      case GM.KNOCK_FIELD_NUMBER                    => msg.getKnock
-      case GM.LASTREAD_FIELD_NUMBER                 => msg.getLastRead
-      case GM.REACTION_FIELD_NUMBER                 => msg.getReaction
-      case GM.TEXT_FIELD_NUMBER                     => msg.getText
-      case GM.LOCATION_FIELD_NUMBER                 => msg.getLocation
-      case GM.CONFIRMATION_FIELD_NUMBER             => msg.getConfirmation
-      case GM.EPHEMERAL_FIELD_NUMBER                => msg.getEphemeral
-      case GM.AVAILABILITY_FIELD_NUMBER             => msg.getAvailability
-      case GM.COMPOSITE_FIELD_NUMBER                => msg.getComposite
-      case GM.BUTTONACTION_FIELD_NUMBER             => msg.getButtonAction
-      case GM.BUTTONACTIONCONFIRMATION_FIELD_NUMBER => msg.getButtonActionConfirmation
-      case GM.DATATRANSFER_FIELD_NUMBER             => msg.getDataTransfer
-      case _                                        => Unknown
+    def unpackContent: GenericContent[_] = unpack match {
+      case (_, eph: Ephemeral) => eph.unpack._2
+      case (_, content)        => content
     }
+
+    private def content: GenericContent[_] = proto.getContentCase.getNumber match {
+      case Messages.GenericMessage.ASSET_FIELD_NUMBER                    => GenericContent.Asset(proto.getAsset)
+      case Messages.GenericMessage.CALLING_FIELD_NUMBER                  => GenericContent.Calling(proto.getCalling)
+      case Messages.GenericMessage.CLEARED_FIELD_NUMBER                  => GenericContent.Cleared(proto.getCleared)
+      case Messages.GenericMessage.CLIENTACTION_FIELD_NUMBER             => GenericContent.ClientAction(proto.getClientAction.getNumber)
+      case Messages.GenericMessage.DELETED_FIELD_NUMBER                  => GenericContent.MsgRecall(proto.getDeleted)
+      case Messages.GenericMessage.EDITED_FIELD_NUMBER                   => GenericContent.MsgEdit(proto.getEdited)
+      case Messages.GenericMessage.EXTERNAL_FIELD_NUMBER                 => GenericContent.External(proto.getExternal)
+      case Messages.GenericMessage.HIDDEN_FIELD_NUMBER                   => GenericContent.MsgDeleted(proto.getHidden)
+      case Messages.GenericMessage.IMAGE_FIELD_NUMBER                    => GenericContent.ImageAsset(proto.getImage)
+      case Messages.GenericMessage.KNOCK_FIELD_NUMBER                    => GenericContent.Knock(proto.getKnock)
+      case Messages.GenericMessage.LASTREAD_FIELD_NUMBER                 => GenericContent.LastRead(proto.getLastRead)
+      case Messages.GenericMessage.REACTION_FIELD_NUMBER                 => GenericContent.Reaction(proto.getReaction)
+      case Messages.GenericMessage.TEXT_FIELD_NUMBER                     => GenericContent.Text(proto.getText)
+      case Messages.GenericMessage.LOCATION_FIELD_NUMBER                 => GenericContent.Location(proto.getLocation)
+      case Messages.GenericMessage.CONFIRMATION_FIELD_NUMBER             => GenericContent.DeliveryReceipt(proto.getConfirmation)
+      case Messages.GenericMessage.EPHEMERAL_FIELD_NUMBER                => GenericContent.Ephemeral(proto.getEphemeral)
+      case Messages.GenericMessage.AVAILABILITY_FIELD_NUMBER             => GenericContent.AvailabilityStatus(proto.getAvailability)
+      case Messages.GenericMessage.COMPOSITE_FIELD_NUMBER                => GenericContent.Composite(proto.getComposite)
+      case Messages.GenericMessage.BUTTONACTION_FIELD_NUMBER             => GenericContent.ButtonAction(proto.getButtonAction)
+      case Messages.GenericMessage.BUTTONACTIONCONFIRMATION_FIELD_NUMBER => GenericContent.ButtonActionConfirmation(proto.getButtonActionConfirmation)
+      case Messages.GenericMessage.DATATRANSFER_FIELD_NUMBER             => GenericContent.DataTransfer(proto.getDataTransfer)
+      case _ => Unknown
+    }
+  }
+
+  object GenericMessage {
+    import GenericContent._
+
+    def apply[Proto](id: Uid, content: GenericContent[Proto]): GenericMessage = {
+      val builder = Messages.GenericMessage.newBuilder()
+      builder.setMessageId(id.str)
+      content.set(builder)
+      GenericMessage(builder.build())
+    }
+
+    def apply[Proto](id: Uid, expiration: Option[FiniteDuration], content: GenericContent[Proto]): GenericMessage = {
+      val builder = Messages.GenericMessage.newBuilder()
+      builder.setMessageId(id.str)
+      expiration match {
+        case Some(expiry) =>
+          val ephemeralContent: Option[EphemeralContent] = content match {
+            case Asset(proto)      => Some(EphemeralAsset(proto, expiry))
+            case ImageAsset(proto) => Some(EphemeralImageAsset(proto, expiry))
+            case Text(proto)       => Some(EphemeralText(proto, expiry))
+            case Location(proto)   => Some(EphemeralLocation(proto, expiry))
+            case Knock(proto)      => Some(EphemeralKnock(proto, expiry))
+            case _ =>
+              error(l"Unable to create ephemeral content - the generic content cannot be turned into ephemeral: $content")(LogTag("GenericMessage"))
+              None
+          }
+          ephemeralContent.foreach(eph => Ephemeral(expiration, eph).set(builder))
+        case None => content.set(builder)
+      }
+
+      GenericMessage(builder.build())
+    }
+
+    def apply(bytes: Array[Byte]): GenericMessage =
+      GenericMessage(Messages.GenericMessage.parseFrom(bytes))
 
     object TextMessage {
 
+      implicit val log: LogTag = LogTag("TextMessage")
+
       def apply(text: String): GenericMessage = GenericMessage(Uid(), Text(text, Nil, Nil, expectsReadConfirmation = false))
 
-      def apply(text: String, mentions: Seq[com.waz.model.Mention], expectsReadConfirmation: Boolean): GenericMessage = GenericMessage(Uid(), Text(text, mentions, Nil, expectsReadConfirmation))
+      def apply(text: String,
+                mentions: Seq[com.waz.model.Mention],
+                expectsReadConfirmation: Boolean): GenericMessage =
+        GenericMessage(Uid(), Text(text, mentions, Nil, expectsReadConfirmation))
 
-      def apply(text: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview], expectsReadConfirmation: Boolean): GenericMessage = GenericMessage(Uid(), Text(text, mentions, links, expectsReadConfirmation))
+      def apply(text: String,
+                mentions: Seq[com.waz.model.Mention],
+                links: Seq[LinkPreview],
+                expectsReadConfirmation: Boolean): GenericMessage =
+        GenericMessage(Uid(), Text(text, mentions, links, expectsReadConfirmation))
 
-      def apply(text: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview], quote: Option[Quote], expectsReadConfirmation: Boolean): GenericMessage = GenericMessage(Uid(), Text(text, mentions, links, quote, expectsReadConfirmation))
+      def apply(text: String,
+                mentions: Seq[com.waz.model.Mention],
+                links: Seq[LinkPreview],
+                quote: Option[Quote],
+                expectsReadConfirmation: Boolean): GenericMessage =
+        GenericMessage(Uid(), Text(text, mentions, links, quote, expectsReadConfirmation))
 
-      def apply(msg: MessageData): GenericMessage = GenericMessage(msg.id.uid, msg.ephemeral, Text(msg.contentString, msg.content.flatMap(_.mentions), Nil, msg.protoQuote, msg.expectsRead.getOrElse(false)))
+      def apply(msg: MessageData): GenericMessage =
+        GenericMessage(
+          msg.id.uid,
+          msg.ephemeral,
+          Text(msg.contentString, msg.content.flatMap(_.mentions), Nil, msg.protoQuote, msg.expectsRead.getOrElse(false))
+        )
 
-      def unapply(msg: GenericMessage): Option[(String, Seq[com.waz.model.Mention], Seq[LinkPreview], Option[Quote], Boolean)] = msg match {
-        case GenericMessage(_, t @ Text(content, mentions, links, quote)) =>
-          Some((content, mentions, links, quote, t.expectsReadConfirmation))
-        case GenericMessage(_, Ephemeral(_, t @ Text(content, mentions, links, quote))) =>
-          Some((content, mentions, links, quote, t.expectsReadConfirmation))
-        case GenericMessage(_, MsgEdit(_, t @ Text(content, mentions, links, quote))) =>
-          Some((content, mentions, links, quote, t.expectsReadConfirmation))
-        case _ =>
-          None
+      def unapply(msg: GenericMessage): Option[(String, Seq[com.waz.model.Mention], Seq[LinkPreview], Option[Quote], Boolean)] = msg.unpackContent match {
+        case text: Text     => Some(text.unpack)
+        case eph: Ephemeral => eph.unpackContent match {
+          case text: Text => Some(text.unpack)
+          case _          => None
+        }
+        case edit: MsgEdit  => edit.unpack.map(_._2.unpack)
+        case _              => None
       }
 
-      def updateMentions(msg: GenericMessage, newMentions: Seq[com.waz.model.Mention]): GenericMessage = msg match {
-        case GenericMessage(uid, t @ Text(text, mentions, links, quote)) if mentions != newMentions =>
-          GenericMessage(uid, Text(text, newMentions, links, quote, t.expectsReadConfirmation))
-        case _ =>
-          msg
-      }
-    }
-
-    //TODO Dean: this can lead to some very tricky problems - try to get around the Any...
-    object GenericMessageContent {
-      def unapply(msg: GenericMessage): Option[Any] = msg match {
-        case GenericMessage(_, Ephemeral(_, content)) => Some(content)
-        case GenericMessage(_, content)               => Some(content)
+      def updateMentions(msg: GenericMessage, newMentions: Seq[com.waz.model.Mention]): GenericMessage = msg.unpack match {
+        case (uid, t: Text) => GenericMessage(uid, Text.newMentions(t, newMentions))
+        case _ => msg
       }
     }
 
@@ -156,13 +182,18 @@ package object model {
 
     implicit object JsEncoder extends JsonEncoder[GenericMessage] {
       override def apply(v: GenericMessage): JSONObject = JsonEncoder { o =>
-        o.put("proto", AESUtils.base64(MessageNano.toByteArray(v)))
+        o.put("proto", AESUtils.base64(v.proto.toByteArray))
       }
     }
 
     implicit object MessageDecoder extends ProtoDecoder[GenericMessage] {
       override def apply(data: Array[Byte]): GenericMessage = GenericMessage(data)
-      override def apply(in: CodedInputByteBufferNano): GenericMessage = Messages.GenericMessage.parseFrom(in)
+      override def apply(in: CodedInputStream): GenericMessage = GenericMessage(Messages.GenericMessage.parseFrom(in))
+    }
+
+    implicit object GMessageDecoder extends ProtoDecoder[Messages.GenericMessage] {
+      override def apply(data: Array[Byte]): Messages.GenericMessage = Messages.GenericMessage.parseFrom(data)
+      override def apply(in: CodedInputStream): Messages.GenericMessage = Messages.GenericMessage.parseFrom(in)
     }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -233,7 +233,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
         m.copy(
           msgType = tpe,
           content = ct,
-          protos = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(text, ct.flatMap(_.mentions), Nil, m.protoQuote, m.protoReadReceipts.getOrElse(false))))),
+          genericMsgs = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(text, ct.flatMap(_.mentions), Nil, m.protoQuote, m.protoReadReceipts.getOrElse(false))))),
           state = Message.Status.PENDING,
           editTime = (m.time max m.editTime) + 1.millis max LocalInstant.Now.toRemote(currentBeDrift)
         )

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -279,7 +279,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
       val u = prev.copy(
         msgType       = if (msg.msgType != Message.Type.UNKNOWN) msg.msgType else prev.msgType ,
         time          = if (msg.time.isBefore(prev.time) || prev.isLocal) msg.time else prev.time,
-        protos        = prev.protos ++ msg.protos,
+        genericMsgs        = prev.genericMsgs ++ msg.genericMsgs,
         content       = msg.content,
         quote         = msg.quote,
         assetId       = assetId

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -25,7 +25,6 @@ import com.waz.content.{MembersStorage, MessagesStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.AssetData.{ProcessingTaskKey, UploadTaskKey}
-import com.waz.model.{ReadReceipt => MReadReceipt}
 import com.waz.model.GenericContent.{ButtonAction, DeliveryReceipt, Ephemeral, EphemeralLocation, Knock, Location, MsgDeleted, MsgEdit, MsgRecall, Asset => GAsset, ReadReceipt => GReadReceipt}
 import com.waz.model.GenericMessage.TextMessage
 import com.waz.model._
@@ -125,8 +124,7 @@ class MessagesSyncHandler(selfUserId: UserId,
       } yield SyncResult(result)
     }
 
-  def postMessage(convId: ConvId, id: MessageId, editTime: RemoteInstant)(implicit info: RequestInfo): Future[SyncResult] = {
-    verbose(l"postMessage($convId, $id, $editTime)")
+  def postMessage(convId: ConvId, id: MessageId, editTime: RemoteInstant)(implicit info: RequestInfo): Future[SyncResult] =
     storage.getMessage(id).flatMap { message =>
       message
         .fold(successful(None: Option[ConversationData]))(msg => convs.convById(msg.convId))
@@ -178,7 +176,6 @@ class MessagesSyncHandler(selfUserId: UserId,
       case _ =>
         successful(Failure("postMessage failed, couldn't find either message or conversation"))
     }
-  }
 
   /**
     * Sends a message to the given conversation. If the message is an edit, it will also update the message

--- a/zmessaging/src/main/scala/com/waz/utils/crypto/ReplyHashing.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/crypto/ReplyHashing.scala
@@ -56,7 +56,7 @@ class ReplyHashingImpl(storage: AssetStorage) extends ReplyHashing with DerivedL
                     })
       otherShas  <- Future.sequence(otherMsgs.map {
                       case m if ReplyHashing.textTypes.contains(m.msgType) =>
-                        m.protos.last match {
+                        m.genericMsgs.last match {
                           case TextMessage(content, _, _, _, _) => Future.successful(m.id -> hashTextReply(content, m.time))
                           case _                             => Future.successful(m.id -> Sha256.Empty) // should not happen
                         }

--- a/zmessaging/src/test/scala/com/waz/db/ZMessagingDBSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/db/ZMessagingDBSpec.scala
@@ -145,7 +145,7 @@ import org.threeten.bp.Instant
       val msgs = MessageDataDao.list
       msgs should have size 994
       msgs foreach { m =>
-        if (m.msgType == Message.Type.KNOCK) m.protos should have size 1
+        if (m.msgType == Message.Type.KNOCK) m.genericMsgs should have size 1
       }
     }
 
@@ -156,7 +156,7 @@ import org.threeten.bp.Instant
       val msgs = MessageDataDao.list
       msgs should have size 994
       msgs foreach { m =>
-        if (m.msgType == Message.Type.KNOCK) m.protos should have size 1
+        if (m.msgType == Message.Type.KNOCK) m.genericMsgs should have size 1
         m.editTime shouldEqual Instant.EPOCH
       }
     }

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -18,7 +18,6 @@
 package com.waz.model
 
 import com.waz.model.Event.EventDecoder
-import com.waz.model.nano.Messages
 import com.waz.model.otr.ClientId
 import com.waz.service.PropertyKey
 import com.waz.specs.AndroidFreeSpec
@@ -162,7 +161,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode GenericMessageEvent") {
-      val msg = GenericMessageEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), new Messages.GenericMessage)
+      val msg = GenericMessageEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), GenericMessage.TextMessage("content"))
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: GenericMessageEvent =>
           ev.convId shouldEqual msg.convId

--- a/zmessaging/src/test/scala/com/waz/model/MessageDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/MessageDataSpec.scala
@@ -66,7 +66,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val mentions = Seq(Mention(Some(userId1), 4, 5), Mention(Some(userId2), 32, 5))
       val linkPreview = LinkPreview(URI.parse("http://bit.ly"), 15)
 
-      val expected = List(
+      val expected = Vector(
         MessageContent(Message.Part.Type.TEXT, "Aaa @user1 aaa ", mentions = Seq(mentions(0))),
         MessageContent(Message.Part.Type.WEB_LINK, "http://bit.ly", mentions = Nil),
         MessageContent(Message.Part.Type.TEXT, " aaa @user2 aaa", mentions = Seq(mentions(1)))

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -187,24 +187,28 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       val remoteAssetId = AssetId("remoteAssetId")
 
       val originalAsset = GenericContent.Asset {
-        val assetBuilder = Messages.Asset.newBuilder()
-        val origBuilder = Messages.Asset.Original.newBuilder()
-        origBuilder.setName("The Alphabet")
-        origBuilder.setMimeType("text/plain")
-        origBuilder.setSize(26)
+        val orig =
+          Messages.Asset.Original.newBuilder
+            .setName("The Alphabet")
+            .setMimeType("text/plain")
+            .setSize(26)
+            .build
 
-        assetBuilder.setOriginal(origBuilder.build())
-        assetBuilder.build()
+        Messages.Asset.newBuilder
+          .setOriginal(orig)
+          .build
       }
 
       val uploadAsset = GenericContent.Asset {
-        val assetBuilder = Messages.Asset.newBuilder()
-        val remoteDataBuilder = Messages.Asset.RemoteData.newBuilder()
-        remoteDataBuilder.setAssetId(remoteAssetId.str)
-        remoteDataBuilder.setOtrKey(ByteString.copyFromUtf8(""))
-        remoteDataBuilder.setSha256(ByteString.copyFromUtf8(""))
-        assetBuilder.setUploaded(remoteDataBuilder.build())
-        assetBuilder.build()
+        val remoteData =
+          Messages.Asset.RemoteData.newBuilder()
+            .setAssetId(remoteAssetId.str)
+            .setOtrKey(ByteString.copyFromUtf8(""))
+            .setSha256(ByteString.copyFromUtf8(""))
+            .build
+        Messages.Asset.newBuilder
+          .setUploaded(remoteData)
+          .build
       }
 
       clock.advance(5.seconds)
@@ -296,27 +300,20 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
 
   // if we need those utility methods in other specs, we can think of turning them into `apply` methods in GenericContent
   private def button(id: String, text: String) = {
-    val buttonBuilder = Messages.Button.newBuilder()
-    buttonBuilder.setId(id)
-    buttonBuilder.setText(text)
-    val builder = Messages.Composite.Item.newBuilder()
-    builder.setButton(buttonBuilder.build())
-    builder.build()
+    val b = Messages.Button.newBuilder.setId(id).setText(text).build
+    Messages.Composite.Item.newBuilder().setButton(b).build
   }
 
-  private def text(text: String) = {
-    val builder = Messages.Composite.Item.newBuilder()
-    builder.setText(Text(text).proto)
-    builder.build()
-  }
+  private def text(text: String) =
+    Messages.Composite.Item.newBuilder.setText(Text(text).proto).build
 
   private def composite(items: Messages.Composite.Item*) = GenericContent.Composite {
     import scala.collection.JavaConverters._
-    val builder = Messages.Composite.newBuilder()
-    builder.setExpectsReadConfirmation(false)
-    builder.setLegalHoldStatus(Messages.LegalHoldStatus.UNKNOWN)
-    builder.addAllItems(items.toIterable.asJava)
-    builder.build()
+    Messages.Composite.newBuilder
+      .setExpectsReadConfirmation(false)
+      .setLegalHoldStatus(Messages.LegalHoldStatus.UNKNOWN)
+      .addAllItems(items.toIterable.asJava)
+      .build
   }
 
   private def event(convId: RConvId, sender: UserId, uid: String, composite: Composite) =

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -66,19 +66,19 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   private lazy val event = GenericMessageEvent(rConvId, lastEventTime, from, content)
 
   private val msg = MessageData(
-    MessageId(content.messageId),
+    MessageId(content.unpack._1.str),
     conv.id,
     msgType = Message.Type.TEXT,
-    protos  = Seq(content),
+    genericMsgs  = Seq(content),
     userId  = from,
     time    = lastEventTime
   )
 
   private val compositeMsg = MessageData(
-    MessageId(content.messageId),
+    MessageId(content.unpack._1.str),
     conv.id,
     msgType = Message.Type.COMPOSITE,
-    protos  = Seq(content),
+    genericMsgs  = Seq(content),
     userId  = from,
     time    = lastEventTime
   )
@@ -246,15 +246,15 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         MessageId("orig"),
         conv.id,
         msgType = Message.Type.TEXT,
-        protos  = Seq(content),
+        genericMsgs  = Seq(content),
         userId  = self.id,
         time    = lastEventTime
       )
       val reply = MessageData(
-        MessageId(content.messageId),
+        MessageId(content.unpack._1.str),
         conv.id,
         msgType = Message.Type.TEXT,
-        protos  = Seq(content),
+        genericMsgs  = Seq(content),
         userId  = from,
         time    = lastEventTime,
         quote   = Some(QuoteContent(origMsg.id, validity = true, hash = None))
@@ -373,14 +373,14 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       val originalContent = GenericMessage(Uid("messageId"), Text("abc"))
 
-      val editContent1 = GenericMessage(Uid("edit-id-1"), MsgEdit(MessageId(originalContent.messageId), Text("def")))
+      val editContent1 = GenericMessage(Uid("edit-id-1"), MsgEdit(MessageId(originalContent.unpack._1.str), Text("def")))
       val editEvent1 = GenericMessageEvent(rConvId, edit1EventTime, from, editContent1)
 
-      val editContent2 = GenericMessage(Uid("edit-id-2"), MsgEdit(MessageId(editContent1.messageId), Text("ghi")))
+      val editContent2 = GenericMessage(Uid("edit-id-2"), MsgEdit(MessageId(editContent1.unpack._1.str), Text("ghi")))
       val editEvent2 = GenericMessageEvent(rConvId, edit2EventTime, from, editContent2)
 
       val originalNotification = NotificationData(
-        id               = NotId(originalContent.messageId),
+        id               = NotId(originalContent.unpack._1.str),
         msg              = "abc",
         conv             = conv.id,
         user             = from,
@@ -403,7 +403,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (uiController.onNotificationsChanged _).expects(account1Id, *).onCall { (_, nots) =>
         val not = nots.head
-        not.id shouldEqual NotId(editContent2.messageId)
+        not.id shouldEqual NotId(editContent2.unpack._1.str)
         not.msg shouldEqual "ghi"
         Future.successful({})
       }
@@ -436,7 +436,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val deleteContent1 = GenericMessage(Uid(), MsgDeleted(rConvId, MessageId(toBeDeletedNotif.id.str)))
       val deleteEvent1 = GenericMessageEvent(rConvId, RemoteInstant.apply(clock.instant()), from, deleteContent1)
 
-      val deleteContent2 = GenericMessage(Uid(), MsgRecall(MessageId(msgContent.messageId)))
+      val deleteContent2 = GenericMessage(Uid(), MsgRecall(MessageId(msgContent.unpack._1.str)))
       val deleteEvent2 = GenericMessageEvent(rConvId, RemoteInstant.apply(clock.instant()), from, deleteContent2)
 
       setup(

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -34,6 +34,12 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
     userService, usersStorage, assetService, searchService, usersClient, otrSync, Some(teamId), teamsSyncHandler
   )
 
+  private def checkAvailabilityStatus(message: GenericMessage, expectedAvailability: Messages.Availability.Type): Unit = message.unpackContent match {
+    case content: GenericContent.AvailabilityStatus =>
+      content.proto.getType shouldEqual expectedAvailability
+    case _ => fail(s"Availability should be set to $expectedAvailability}")
+  }
+
   feature("Post availability status") {
     scenario("Post only to self and connected users if self is not in a team") {
       // given
@@ -53,11 +59,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.unpackContent match {
-            case content: GenericContent.AvailabilityStatus =>
-              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
-            case _ => fail("Availability should be set to AVAILABLE")
-          }
+          checkAvailabilityStatus(message, Messages.Availability.Type.AVAILABLE)
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -84,11 +86,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.unpackContent match {
-            case content: GenericContent.AvailabilityStatus =>
-              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
-            case _ => fail("Availability should be set to AVAILABLE")
-          }
+          checkAvailabilityStatus(message, Messages.Availability.Type.AVAILABLE)
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id, user4.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -117,11 +115,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.unpackContent match {
-            case content: GenericContent.AvailabilityStatus =>
-              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
-            case _ => fail("Availability should be set to AVAILABLE")
-          }
+          checkAvailabilityStatus(message, Messages.Availability.Type.AVAILABLE)
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id, user4.id, user5.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -148,11 +142,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.unpackContent match {
-            case content: GenericContent.AvailabilityStatus =>
-              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
-            case _ => fail("Availability should be set to AVAILABLE")
-          }
+          checkAvailabilityStatus(message, Messages.Availability.Type.AVAILABLE)
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -180,11 +170,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.unpackContent match {
-            case content: GenericContent.AvailabilityStatus =>
-              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
-            case _ => fail("Availability should be set to AVAILABLE")
-          }
+          checkAvailabilityStatus(message, Messages.Availability.Type.AVAILABLE)
           recipients shouldEqual Some(Set(self.id, user1.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -1,7 +1,6 @@
 package com.waz.sync.handler
 
 import com.waz.content.UsersStorage
-import com.waz.model.nano.Messages
 import com.waz.model._
 import com.waz.service.{UserSearchService, UserService}
 import com.waz.service.assets.AssetService
@@ -54,7 +53,11 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.getAvailability.`type` shouldEqual Messages.Availability.AVAILABLE
+          message.unpackContent match {
+            case content: GenericContent.AvailabilityStatus =>
+              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
+            case _ => fail("Availability should be set to AVAILABLE")
+          }
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -81,7 +84,11 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.getAvailability.`type` shouldEqual Messages.Availability.AVAILABLE
+          message.unpackContent match {
+            case content: GenericContent.AvailabilityStatus =>
+              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
+            case _ => fail("Availability should be set to AVAILABLE")
+          }
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id, user4.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -110,7 +117,11 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.getAvailability.`type` shouldEqual Messages.Availability.AVAILABLE
+          message.unpackContent match {
+            case content: GenericContent.AvailabilityStatus =>
+              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
+            case _ => fail("Availability should be set to AVAILABLE")
+          }
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id, user4.id, user5.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -137,7 +148,11 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.getAvailability.`type` shouldEqual Messages.Availability.AVAILABLE
+          message.unpackContent match {
+            case content: GenericContent.AvailabilityStatus =>
+              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
+            case _ => fail("Availability should be set to AVAILABLE")
+          }
           recipients shouldEqual Some(Set(self.id, user1.id, user2.id, user3.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }
@@ -165,7 +180,11 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       // then
       (otrSync.broadcastMessage _).expects(*, *, *, *).once().onCall {
         (message: GenericMessage, _: Int, _: EncryptedContent, recipients: Option[Set[UserId]]) =>
-          message.getAvailability.`type` shouldEqual Messages.Availability.AVAILABLE
+          message.unpackContent match {
+            case content: GenericContent.AvailabilityStatus =>
+              content.proto.getType shouldEqual Messages.Availability.Type.AVAILABLE
+            case _ => fail("Availability should be set to AVAILABLE")
+          }
           recipients shouldEqual Some(Set(self.id, user1.id))
           Future.successful(Right(RemoteInstant(Instant.now())))
       }

--- a/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -19,7 +19,6 @@ package com.waz
 
 import android.database.Cursor
 import android.os.Parcel
-import com.google.protobuf.nano.MessageNano
 import com.waz.cache.CacheEntryData
 import com.waz.content.MsgCursor
 import com.waz.model.{otr => _, _}
@@ -115,7 +114,7 @@ package object testutils {
     implicit object GenericMessageEquality extends Equality[GenericMessage] {
       override def areEqual(a: GenericMessage, b: Any): Boolean = {
         b match {
-          case m: MessageNano => MessageNano.toByteArray(m).toSeq == MessageNano.toByteArray(a).toSeq
+          case m: GenericMessage => m.proto.toByteArray.sameElements(a.proto.toByteArray)
           case _ => false
         }
       }
@@ -125,8 +124,8 @@ package object testutils {
       override def areEqual(a: MessageData, b: Any): Boolean = {
         b match {
           case m: MessageData =>
-            if (m.copy(protos = Nil) != a.copy(protos = Nil)) println(s"message content differ: \n$a\n$m\n")
-            m.copy(protos = Nil) == a.copy(protos = Nil) && m.protos.size == a.protos.size && m.protos.zip(a.protos).forall { case (p1, p2) => GenericMessageEquality.areEqual(p1, p2) }
+            if (m.copy(genericMsgs = Nil) != a.copy(genericMsgs = Nil)) println(s"message content differ: \n$a\n$m\n")
+            m.copy(genericMsgs = Nil) == a.copy(genericMsgs = Nil) && m.genericMsgs.size == a.genericMsgs.size && m.genericMsgs.zip(a.genericMsgs).forall { case (p1, p2) => GenericMessageEquality.areEqual(p1, p2) }
           case _ => false
         }
       }

--- a/zmessaging/src/test/scala/com/waz/utils/crypto/ReplyHashingSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/crypto/ReplyHashingSpec.scala
@@ -111,8 +111,8 @@ class ReplyHashingSpec extends AndroidFreeSpec {
     scenario("hash locations") {
       val msg1Id = MessageId("msg1")
       val msg2Id = MessageId("msg2")
-      val msg1 = MessageData(id = msg1Id, msgType = Message.Type.LOCATION, time = timestamp1, protos = Seq(GenericMessage(msg1Id.uid, Location(location1._2, location1._1, "", 0, expectsReadConfirmation = false))))
-      val msg2 = MessageData(id = msg2Id, msgType = Message.Type.LOCATION, time = timestamp1, protos = Seq(GenericMessage(msg2Id.uid, Location(location2._2, location2._1, "", 0, expectsReadConfirmation = false))))
+      val msg1 = MessageData(id = msg1Id, msgType = Message.Type.LOCATION, time = timestamp1, genericMsgs = Seq(GenericMessage(msg1Id.uid, Location(location1._2, location1._1, "", 0, expectsReadConfirmation = false))))
+      val msg2 = MessageData(id = msg2Id, msgType = Message.Type.LOCATION, time = timestamp1, genericMsgs = Seq(GenericMessage(msg2Id.uid, Location(location2._2, location2._1, "", 0, expectsReadConfirmation = false))))
 
       (assetStorage.loadAll _).expects(*).once.returning(Future.successful(Nil))
 
@@ -124,8 +124,8 @@ class ReplyHashingSpec extends AndroidFreeSpec {
     scenario("hash text messages") {
       val msg1Id = MessageId("msg1")
       val msg2Id = MessageId("msg2")
-      val msg1 = MessageData(id = msg1Id, msgType = Message.Type.TEXT, time = timestamp2, protos = Seq(GenericMessage(msg1Id.uid, Text("This has **markdown**"))))
-      val msg2 = MessageData(id = msg2Id, msgType = Message.Type.TEXT, time = timestamp2, protos = Seq(GenericMessage(msg2Id.uid, Text("بغداد"))))
+      val msg1 = MessageData(id = msg1Id, msgType = Message.Type.TEXT, time = timestamp2, genericMsgs = Seq(GenericMessage(msg1Id.uid, Text("This has **markdown**"))))
+      val msg2 = MessageData(id = msg2Id, msgType = Message.Type.TEXT, time = timestamp2, genericMsgs = Seq(GenericMessage(msg2Id.uid, Text("بغداد"))))
 
       (assetStorage.loadAll _).expects(*).once.returning(Future.successful(Nil))
 
@@ -133,7 +133,7 @@ class ReplyHashingSpec extends AndroidFreeSpec {
       hexString(shas(msg1Id)) shouldEqual "f25a925d55116800e66872d2a82d8292adf1d4177195703f976bc884d32b5c94"
       hexString(shas(msg2Id)) shouldEqual "5830012f6f14c031bf21aded5b07af6e2d02d01074f137d106d4645e4dc539ca"
     }
-    
+
     scenario("hash mixed messages") {
       val msg1Id = MessageId("msg1")
       val msg2Id = MessageId("msg2")
@@ -141,20 +141,20 @@ class ReplyHashingSpec extends AndroidFreeSpec {
       val msg4Id = MessageId("msg4")
       val msg5Id = MessageId("msg5")
       val msg6Id = MessageId("msg6")
-      
+
       val msg1 = MessageData(id = msg1Id, msgType = Message.Type.IMAGE_ASSET, time = timestamp1, assetId = Some(assetId1))
       val msg2 = MessageData(id = msg2Id, msgType = Message.Type.IMAGE_ASSET, time = timestamp2, assetId = Some(assetId2))
-      val msg3 = MessageData(id = msg3Id, msgType = Message.Type.LOCATION, time = timestamp1, protos = Seq(GenericMessage(msg3Id.uid, Location(location1._2, location1._1, "", 0, expectsReadConfirmation = false))))
-      val msg4 = MessageData(id = msg4Id, msgType = Message.Type.LOCATION, time = timestamp1, protos = Seq(GenericMessage(msg4Id.uid, Location(location2._2, location2._1, "", 0, expectsReadConfirmation = false))))
-      val msg5 = MessageData(id = msg5Id, msgType = Message.Type.TEXT, time = timestamp2, protos = Seq(GenericMessage(msg5Id.uid, Text("This has **markdown**"))))
-      val msg6 = MessageData(id = msg6Id, msgType = Message.Type.TEXT, time = timestamp2, protos = Seq(GenericMessage(msg2Id.uid, Text("بغداد"))))
+      val msg3 = MessageData(id = msg3Id, msgType = Message.Type.LOCATION, time = timestamp1, genericMsgs = Seq(GenericMessage(msg3Id.uid, Location(location1._2, location1._1, "", 0, expectsReadConfirmation = false))))
+      val msg4 = MessageData(id = msg4Id, msgType = Message.Type.LOCATION, time = timestamp1, genericMsgs = Seq(GenericMessage(msg4Id.uid, Location(location2._2, location2._1, "", 0, expectsReadConfirmation = false))))
+      val msg5 = MessageData(id = msg5Id, msgType = Message.Type.TEXT, time = timestamp2, genericMsgs = Seq(GenericMessage(msg5Id.uid, Text("This has **markdown**"))))
+      val msg6 = MessageData(id = msg6Id, msgType = Message.Type.TEXT, time = timestamp2, genericMsgs = Seq(GenericMessage(msg2Id.uid, Text("بغداد"))))
 
       val asset1 = fakeAsset(assetId1)
       val asset2 = fakeAsset(assetId2)
 
 
       (assetStorage.loadAll _).expects(*).anyNumberOfTimes.returning(Future.successful(Seq(asset1, asset2)))
-      
+
       val shas = result(getReplyHashing.hashMessages(Seq(msg3, msg5, msg1, msg4, msg6, msg2)))
 
       hexString(shas(msg1Id)) shouldEqual "bf20de149847ae999775b3cc88e5ff0c0382e9fa67b9d382b1702920b8afa1de"


### PR DESCRIPTION
I know this is huge.

The old protobuf implementation used the now obsolete "nano" mode which created very small Java classes which had to be accessed and modified directly, i.e. every field was public and it was up to us to ensure we use it in the right way. "nano" is no longer used in protobuf, so when I updated protobuf, I hade to change to the more standard "lite" implementation. "lite" uses getters and for modification it has builder classes. That changed a lot how
the protobuf classes need to be handled in our `com.waz.model._` classes, esp. `GenericMessage` and `GenericContent`. On top of that, we recently merged two protobuf libraries: generic-message-proto and backend-api-proto. I had to make so many changes that instead of trying to contain them and change as little as possible (not possible) I decided to refactor also the code which touched those classes, so that it all works better together.

Before, we used a lot of implicit objects with `apply` and `unapply` methods for convertions. In many places it meant that we converted the proto data into logic case classes, used them for checking something, then dismissed them, and then we made convertions again when we needed them again. I removed those implicit objects and introduced "newtypes" - wrapper case classes around proto data. Each of them has a `lazy val unpack`, equivalent to the previous `unapply`, but this time after the first convertion, the converted ("unpacked") version is remembered so we don't get the performance
penalty when we need to mae another convertion. Instead, I guess the app will now need a bit more memory. We need to test it.

Also, I made some performance optimizations in `GenericMessageService`. Until now with every new event we created and then left for garbage collection a lot of intermediate collections. I decided it happens so often that it might make sense to use one mutable cache instead. This too needs to be tested. Fortunately, both `unpack` and this can be easily converted to versions which will be slower but maybe safer, so if we find a bug in this implementation, we may try it.
#### APK
[Download build #3209](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3209/artifact/build/artifact/wire-dev-PR3193-3209.apk)
[Download build #3212](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3212/artifact/build/artifact/wire-dev-PR3193-3212.apk)