### PR TITLE
Remove bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,36 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    repositories {
-        maven {
-            url "https://dl.bintray.com/wire-android/third-party"
+
+    final String NEXUS_URL_ENV_VAR = "NEXUS_URL"
+    final String NEXUS_URL_LOCAL_VAR = "nexus.url"
+    final String LOCAL_PROPERTIES_FILE_NAME = "local.properties"
+
+    String nexusUrl = ""
+    Properties properties = new Properties()
+    def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
+    if (propertiesFile.exists()) {
+        properties.load(propertiesFile.newDataInputStream())
+        nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
+    } else {
+        nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: ""
+    }
+
+    if (!nexusUrl.isEmpty()) {
+        buildscript {
+            repositories {
+                maven { url nexusUrl }
+            }
         }
+        allprojects {
+            repositories {
+                maven { url nexusUrl }
+            }
+        }
+    }
+
+    repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -28,12 +52,8 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         mavenCentral()
-        maven { url "https://dl.bintray.com/wire-android/releases" }
-        maven { url "https://dl.bintray.com/wire-android/snapshots" }
-        maven { url "https://dl.bintray.com/wire-android/third-party" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ buildscript {
                 maven { url nexusUrl }
             }
         }
+
+        ext {
+            nexusUrlExt = nexusUrl
+        }
     }
 
     repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,5 +5,4 @@ plugins {
 repositories {
     mavenCentral()
     google()
-    jcenter()
 }

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -23,18 +23,12 @@ if (propertiesFile.exists()) {
 }
 
 if (!nexusUrl.isEmpty()) {
-    allprojects {
-        repositories {
-            maven { url nexusUrl }
-        }
-    }
     ext {
         avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_PRIVATE_GROUP
         avsName = System.getenv(AVS_NAME_ENV_VAR) ?: AVS_NAME
         avsVersion = System.getenv(AVS_VERSION_ENV_VAR) ?: avsPrivateVersion
         avsDependency = "${avsGroup}:${avsName}:${avsVersion}"
     }
-
 } else {
     ext {
         avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_PUBLIC_GROUP

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -1,9 +1,6 @@
 final String AVS_GROUP_ENV_VAR = "AVS_GROUP"
 final String AVS_NAME_ENV_VAR = "AVS_NAME"
 final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
-final String NEXUS_URL_ENV_VAR = "NEXUS_URL"
-final String NEXUS_URL_LOCAL_VAR = "nexus.url"
-final String LOCAL_PROPERTIES_FILE_NAME = "local.properties"
 final String AVS_PUBLIC_GROUP = "com.wire"
 final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
@@ -11,18 +8,7 @@ final String AVS_NAME = "avs"
 String avsPublicVersion = "6.6.239"
 String avsPrivateVersion = "6.7.16"
 
-String nexusUrl = ""
-
-Properties properties = new Properties()
-def propertiesFile = project.rootProject.file(LOCAL_PROPERTIES_FILE_NAME)
-if (propertiesFile.exists()) {
-    properties.load(propertiesFile.newDataInputStream())
-    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: properties.getProperty(NEXUS_URL_LOCAL_VAR) ?: ""
-} else {
-    nexusUrl = System.getenv(NEXUS_URL_ENV_VAR) ?: ""
-}
-
-if (!nexusUrl.isEmpty()) {
+if (!rootProject.ext.nexusUrlExt.isEmpty()) {
     ext {
         avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_PRIVATE_GROUP
         avsName = System.getenv(AVS_NAME_ENV_VAR) ?: AVS_NAME


### PR DESCRIPTION
## What's new in this PR?
bintray is no longer used or supported, there for we have moved all necessary libs for now to our nexus server. (public sonartype follows)

this PR removes the bintray relation and moved the nexus load to the build.gradle script in order to make it possible to fetch the libraries also for the buildscript section.
#### APK
[Download build #3179](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3179/artifact/build/artifact/wire-dev-PR3194-3179.apk)
[Download build #3193](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3193/artifact/build/artifact/wire-dev-PR3194-3193.apk)