### PR TITLE
Feature: Load Contact Asset - Part 1 - Save AssetResponse key into database

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/contact/datasources/local/ContactDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/contact/datasources/local/ContactDaoTest.kt
@@ -34,9 +34,9 @@ class ContactDaoTest : InstrumentationTest() {
 
     @Test
     fun insertAll_readContacts_containsInsertedItems() = databaseTestRule.runTest {
-        val entity1 = ContactEntity(id = "id-1", name = "Contact #1")
-        val entity2 = ContactEntity(id = "id-2", name = "Contact #2")
-        val entity3 = ContactEntity(id = "id-3", name = "Contact #3")
+        val entity1 = ContactEntity(id = "id-1", name = "Contact #1", assetKey = "asset-key-1")
+        val entity2 = ContactEntity(id = "id-2", name = "Contact #2", assetKey = "asset-key-2")
+        val entity3 = ContactEntity(id = "id-3", name = "Contact #3", assetKey = null)
         val entities = listOf(entity1, entity2, entity3)
 
         contactDao.insertAll(entities)
@@ -49,9 +49,9 @@ class ContactDaoTest : InstrumentationTest() {
     fun contactsById_contactsWithIdsPresent_returnsEntitiesWithIds() = databaseTestRule.runTest {
         val id1 = "id-1"
         val id2 = "id-2"
-        val entity1 = ContactEntity(id = id1, name = "Contact #1")
-        val entity2 = ContactEntity(id = id2, name = "Contact #2")
-        val entity3 = ContactEntity(id = "id-3", name = "Contact #3")
+        val entity1 = ContactEntity(id = id1, name = "Contact #1", assetKey = "asset-key-1")
+        val entity2 = ContactEntity(id = id2, name = "Contact #2", assetKey = null)
+        val entity3 = ContactEntity(id = "id-3", name = "Contact #3", assetKey = "asset-key-3")
 
         contactDao.insertAll(listOf(entity1, entity2, entity3))
 
@@ -62,9 +62,9 @@ class ContactDaoTest : InstrumentationTest() {
 
     @Test
     fun contactsById_noContactsWithIdsPresent_returnsEmptyList() = databaseTestRule.runTest {
-        val entity1 = ContactEntity(id = "id-1", name = "Contact #1")
-        val entity2 = ContactEntity(id = "id-2", name = "Contact #2")
-        val entity3 = ContactEntity(id = "id-3", name = "Contact #3")
+        val entity1 = ContactEntity(id = "id-1", name = "Contact #1", assetKey = "asset-key-1")
+        val entity2 = ContactEntity(id = "id-2", name = "Contact #2", assetKey = "asset-key-2")
+        val entity3 = ContactEntity(id = "id-3", name = "Contact #3", assetKey = null)
 
         contactDao.insertAll(listOf(entity1, entity2, entity3))
 
@@ -74,6 +74,6 @@ class ContactDaoTest : InstrumentationTest() {
     }
 
     companion object {
-        private val TEST_CONTACT_ENTITY = ContactEntity("id-123", "Edgar Allan Poe")
+        private val TEST_CONTACT_ENTITY = ContactEntity("id-123", "Edgar Allan Poe", "asset-key-5093")
     }
 }

--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/local/ConversationListDaoTest.kt
@@ -85,8 +85,8 @@ class ConversationListDaoTest : InstrumentationTest() {
         databaseTestRule.runTest {
             conversationDao.insert(TEST_CONVERSATION_ENTITY)
 
-            val contact1 = ContactEntity(id = "contact-1", name = "Contact A")
-            val contact2 = ContactEntity(id = "contact-2", name = "Contact B")
+            val contact1 = ContactEntity(id = "contact-1", name = "Contact A", assetKey = "asset-key-A")
+            val contact2 = ContactEntity(id = "contact-2", name = "Contact B", assetKey = null)
             insertMemberForConversation(TEST_CONVERSATION_ENTITY, contact1)
             insertMemberForConversation(TEST_CONVERSATION_ENTITY, contact2)
 
@@ -107,7 +107,7 @@ class ConversationListDaoTest : InstrumentationTest() {
 
             val conversationAndMemberPairs = (1..10).map {
                 val conversation = ConversationEntity(id = "id_$it", name = "Conversation #$it", type = it%5)
-                val member = ContactEntity(id = "contact-$it", name = "Contact $it")
+                val member = ContactEntity(id = "contact-$it", name = "Contact $it", assetKey = "asset-key-$it")
                 conversationDao.insert(conversation)
                 insertMemberForConversation(conversation, member)
                 conversation to member

--- a/app/src/main/kotlin/com/wire/android/feature/contact/datasources/local/ContactEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/datasources/local/ContactEntity.kt
@@ -7,5 +7,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "contact")
 data class ContactEntity(
     @PrimaryKey @ColumnInfo(name = "id") val id: String,
-    @ColumnInfo(name = "name") val name: String
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "asset_key") val assetKey: String?
 )

--- a/app/src/main/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapper.kt
@@ -17,7 +17,11 @@ class ContactMapper {
         contactResponseList.map { fromContactResponseToEntity(it) }
 
     private fun fromContactResponseToEntity(contactResponse: ContactResponse): ContactEntity =
-        ContactEntity(id = contactResponse.id, name = contactResponse.name)
+        ContactEntity(
+            id = contactResponse.id,
+            name = contactResponse.name,
+            assetKey = profilePictureAssetKey(contactResponse)
+        )
 
     fun fromContactEntity(entity: ContactEntity, profilePicture: File?): Contact =
         Contact(id = entity.id, name = entity.name, profilePicturePath = profilePicture?.absolutePath)

--- a/app/src/test/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapperTest.kt
@@ -27,23 +27,21 @@ class ContactMapperTest : UnitTest() {
     fun `given profilePictureAssetKey is called, when contactResponse has an asset with size "complete", then returns asset key`() {
         val contactResponse = mockk<ContactResponse>()
         val contactAssetResponse = mockk<AssetResponse>()
-        val assetKey = "asset_key_356"
-        every { contactAssetResponse.size } returns SIZE_COMPLETE
-        every { contactAssetResponse.key } returns assetKey
+        every { contactAssetResponse.size } returns ASSET_SIZE_COMPLETE
+        every { contactAssetResponse.key } returns TEST_ASSET_KEY
         every { contactResponse.assets } returns listOf(contactAssetResponse)
 
         val result = contactMapper.profilePictureAssetKey(contactResponse)
 
-        result shouldBeEqualTo assetKey
+        result shouldBeEqualTo TEST_ASSET_KEY
     }
 
     @Test
     fun `given profilePictureAssetKey is called, when contactResponse does not have an asset with size "complete", then returns null`() {
         val contactResponse = mockk<ContactResponse>()
         val contactAssetResponse = mockk<AssetResponse>()
-        val assetKey = "asset_key_356"
         every { contactAssetResponse.size } returns "preview"
-        every { contactAssetResponse.key } returns assetKey
+        every { contactAssetResponse.key } returns TEST_ASSET_KEY
         every { contactResponse.assets } returns listOf(contactAssetResponse)
 
         val result = contactMapper.profilePictureAssetKey(contactResponse)
@@ -88,12 +86,17 @@ class ContactMapperTest : UnitTest() {
         val name1 = "${TEST_CONTACT_NAME}_1"
         every { contactResponse1.id } returns id1
         every { contactResponse1.name } returns name1
+        val contactAssetResponse = mockk<AssetResponse>()
+        every { contactAssetResponse.size } returns ASSET_SIZE_COMPLETE
+        every { contactAssetResponse.key } returns TEST_ASSET_KEY
+        every { contactResponse1.assets } returns listOf(contactAssetResponse)
 
         val contactResponse2 = mockk<ContactResponse>()
         val id2 = "${TEST_CONTACT_ID}_2"
         val name2 = "${TEST_CONTACT_NAME}_2"
         every { contactResponse2.id } returns id2
         every { contactResponse2.name } returns name2
+        every { contactResponse2.assets } returns emptyList()
 
         val result = contactMapper.fromContactResponseListToEntityList(listOf(contactResponse1, contactResponse2))
 
@@ -101,11 +104,13 @@ class ContactMapperTest : UnitTest() {
             it shouldBeInstanceOf ContactEntity::class
             it.id shouldBeEqualTo id1
             it.name shouldBeEqualTo name1
+            it.assetKey shouldBeEqualTo TEST_ASSET_KEY
         }
         result.second().let {
             it shouldBeInstanceOf ContactEntity::class
             it.id shouldBeEqualTo id2
             it.name shouldBeEqualTo name2
+            it.assetKey shouldBeEqualTo null
         }
     }
 
@@ -140,7 +145,8 @@ class ContactMapperTest : UnitTest() {
     }
 
     companion object {
-        private const val SIZE_COMPLETE = "complete"
+        private const val ASSET_SIZE_COMPLETE = "complete"
+        private const val TEST_ASSET_KEY = "asset_key_356"
         private const val TEST_CONTACT_ID = "contact_id_8900"
         private const val TEST_CONTACT_NAME = "Alice Abc"
         private const val TEST_FILE_PATH = "file://contacts/assets/0-23409-2456.jpg"


### PR DESCRIPTION
From backend, we get a list of `AssetResponse`s for a `Contact`. Among those assets, only relevant one is the one with the size "complete". We store `key` field of this `AssetResponse` (if exists) into database. This `key` will be used to download the asset via Glide.

The new table structure:

<img width="200px" src="https://user-images.githubusercontent.com/2143283/109785026-f9a8b600-7c0b-11eb-9e29-da72e5d4da34.png">
