### PR TITLE
Feature: Load Contact Asset - Part 2 - Remove contact asset downloading logic from ContactLocalDataSource

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceIntegrationTest.kt
@@ -14,8 +14,6 @@ import com.wire.android.feature.conversation.data.local.ConversationEntity
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListDao
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListLocalDataSource
 import com.wire.android.framework.storage.db.DatabaseTestRule
-import io.mockk.MockKAnnotations
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -48,9 +46,8 @@ class ConversationListDataSourceIntegrationTest : InstrumentationTest() {
         val conversationListLocalDataSource = ConversationListLocalDataSource(conversationListDao)
         val conversationListMapper = ConversationListMapper(ConversationMapper(conversationTypeMapper), ContactMapper())
 
-        MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
         conversationListDataSource = ConversationListDataSource(
-            conversationListLocalDataSource, mockk(), conversationListMapper, conversationTypeMapper
+            conversationListLocalDataSource, conversationListMapper, conversationTypeMapper
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/feature/contact/Contact.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/Contact.kt
@@ -1,3 +1,5 @@
 package com.wire.android.feature.contact
 
-class Contact(val id: String, val name: String, val profilePicturePath: String?)
+import com.wire.android.shared.asset.Asset
+
+class Contact(val id: String, val name: String, val profilePicture: Asset?)

--- a/app/src/main/kotlin/com/wire/android/feature/contact/datasources/ContactDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/datasources/ContactDataSource.kt
@@ -1,7 +1,6 @@
 package com.wire.android.feature.contact.datasources
 
 import com.wire.android.core.exception.Failure
-import com.wire.android.core.exception.GeneralIOFailure
 import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.map
 import com.wire.android.core.functional.suspending
@@ -12,8 +11,6 @@ import com.wire.android.feature.contact.datasources.local.ContactLocalDataSource
 import com.wire.android.feature.contact.datasources.mapper.ContactMapper
 import com.wire.android.feature.contact.datasources.remote.ContactRemoteDataSource
 import com.wire.android.feature.contact.datasources.remote.ContactResponse
-import okhttp3.ResponseBody
-import java.io.File
 
 class ContactDataSource(
     private val contactRemoteDataSource: ContactRemoteDataSource,
@@ -21,60 +18,23 @@ class ContactDataSource(
     private val contactMapper: ContactMapper
 ) : ContactRepository {
 
-    override suspend fun fetchContactsById(ids: Set<String>): Either<Failure, Unit> =
-        remoteContacts(ids).map { Unit }
+    override suspend fun fetchContactsById(ids: Set<String>): Either<Failure, Unit> = suspending {
+        remoteContacts(ids)
+            .flatMap { saveRemoteContacts(it) }
+            .map { Unit }
+    }
 
     override suspend fun contactsById(ids: Set<String>): Either<Failure, List<Contact>> =
-        readContacts(ids).map { entities ->
-            entities.map { contactInfo(it) }
-        }
+        localContacts(ids).map { contactMapper.fromContactEntityList(it) }
 
-    private suspend fun remoteContacts(ids: Set<String>): Either<Failure, List<Contact>> = suspending {
-        fetchContacts(ids).flatMap { contactResponseList ->
-            saveRemoteContacts(contactResponseList).map { contactResponseList }
-        }.map { responseList ->
-            responseList.map { contactInfo(it) }
-        }
-    }
-
-    private suspend fun readContacts(ids: Set<String>): Either<Failure, List<ContactEntity>> =
-        contactLocalDataSource.contactsById(ids)
-
-    private suspend fun fetchContacts(ids: Set<String>): Either<Failure, List<ContactResponse>> =
+    private suspend fun remoteContacts(ids: Set<String>): Either<Failure, List<ContactResponse>> =
         contactRemoteDataSource.contactsById(ids)
 
-    private suspend fun saveRemoteContacts(remoteContacts: List<ContactResponse>): Either<Failure, Unit> {
+    private suspend fun localContacts(ids: Set<String>): Either<Failure, List<ContactEntity>> =
+        contactLocalDataSource.contactsById(ids)
+
+    private suspend fun saveRemoteContacts(remoteContacts: List<ContactResponse>): Either<Failure, List<ContactEntity>> {
         val entities = contactMapper.fromContactResponseListToEntityList(remoteContacts)
-        return contactLocalDataSource.saveContacts(entities)
+        return contactLocalDataSource.saveContacts(entities).map { entities }
     }
-
-    private fun contactInfo(contactEntity: ContactEntity): Contact {
-        val profilePicture = localProfilePicture(contactEntity).fold({ null }) { it }
-        return contactMapper.fromContactEntity(contactEntity, profilePicture)
-    }
-
-    private suspend fun contactInfo(contactResponse: ContactResponse): Contact {
-        val profilePicture = remoteProfilePicture(contactResponse).fold({ null }) { it }
-        return contactMapper.fromContactResponse(contactResponse, profilePicture)
-    }
-
-    private fun localProfilePicture(contactEntity: ContactEntity): Either<Failure, File> =
-        contactLocalDataSource.profilePicture(contactEntity)
-
-    private suspend fun remoteProfilePicture(contactResponse: ContactResponse): Either<Failure, File> = suspending {
-        fetchProfilePicture(contactResponse).flatMap {
-            saveProfilePicture(contactResponse.id, it)
-        }
-    }
-
-    private suspend fun fetchProfilePicture(contactResponse: ContactResponse): Either<Failure, ResponseBody> {
-        val key = contactMapper.profilePictureAssetKey(contactResponse)
-
-        return if (key == null) Either.Left(GeneralIOFailure())
-        else contactRemoteDataSource.downloadProfilePicture(key)
-    }
-
-    private fun saveProfilePicture(contactId: String, responseBody: ResponseBody): Either<Failure, File> =
-        contactLocalDataSource.saveProfilePicture(contactId, responseBody.byteStream())
-
 }

--- a/app/src/main/kotlin/com/wire/android/feature/contact/datasources/local/ContactLocalDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/datasources/local/ContactLocalDataSource.kt
@@ -2,16 +2,9 @@ package com.wire.android.feature.contact.datasources.local
 
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
-import com.wire.android.core.functional.flatMap
-import com.wire.android.core.io.FileSystem
 import com.wire.android.core.storage.db.DatabaseService
-import java.io.File
-import java.io.InputStream
 
-class ContactLocalDataSource(
-    private val contactDao: ContactDao,
-    private val fileSystem: FileSystem
-) : DatabaseService {
+class ContactLocalDataSource(private val contactDao: ContactDao) : DatabaseService {
 
     suspend fun contactsById(ids: Set<String>): Either<Failure, List<ContactEntity>> = request {
         contactDao.contactsById(ids)
@@ -19,20 +12,5 @@ class ContactLocalDataSource(
 
     suspend fun saveContacts(contacts: List<ContactEntity>): Either<Failure, Unit> = request {
         contactDao.insertAll(contacts)
-    }
-
-    fun profilePicture(contactEntity: ContactEntity): Either<Failure, File> =
-        fileSystem.internalFile(profilePictureFilePath(contactEntity.id))
-
-    fun saveProfilePicture(contactId: String, inputStream: InputStream): Either<Failure, File> {
-        val path = profilePictureFilePath(contactId)
-
-        return fileSystem.createInternalFile(path).flatMap { file ->
-            fileSystem.writeToFile(file, inputStream)
-        }
-    }
-
-    companion object {
-        fun profilePictureFilePath(contactId: String) = "/contact/${contactId}/profile_picture.jpg"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapper.kt
@@ -3,15 +3,9 @@ package com.wire.android.feature.contact.datasources.mapper
 import com.wire.android.feature.contact.Contact
 import com.wire.android.feature.contact.datasources.local.ContactEntity
 import com.wire.android.feature.contact.datasources.remote.ContactResponse
-import java.io.File
+import com.wire.android.shared.asset.PublicAsset
 
 class ContactMapper {
-
-    fun profilePictureAssetKey(contactResponse: ContactResponse): String? =
-        contactResponse.assets.find { it.size == ASSET_SIZE_PROFILE_PICTURE }?.key
-
-    fun fromContactResponse(contactResponse: ContactResponse, profilePicture: File?): Contact =
-        Contact(id = contactResponse.id, name = contactResponse.name, profilePicturePath = profilePicture?.absolutePath)
 
     fun fromContactResponseListToEntityList(contactResponseList: List<ContactResponse>): List<ContactEntity> =
         contactResponseList.map { fromContactResponseToEntity(it) }
@@ -23,8 +17,18 @@ class ContactMapper {
             assetKey = profilePictureAssetKey(contactResponse)
         )
 
-    fun fromContactEntity(entity: ContactEntity, profilePicture: File?): Contact =
-        Contact(id = entity.id, name = entity.name, profilePicturePath = profilePicture?.absolutePath)
+    private fun profilePictureAssetKey(contactResponse: ContactResponse): String? =
+        contactResponse.assets.find { it.size == ASSET_SIZE_PROFILE_PICTURE }?.key
+
+    fun fromContactEntityList(entityList: List<ContactEntity>): List<Contact> =
+        entityList.map { fromContactEntity(it) }
+
+    private fun fromContactEntity(entity: ContactEntity): Contact =
+        Contact(
+            id = entity.id,
+            name = entity.name,
+            profilePicture = entity.assetKey?.let { PublicAsset(it) }
+        )
 
     companion object {
         private const val ASSET_SIZE_PROFILE_PICTURE = "complete"

--- a/app/src/main/kotlin/com/wire/android/feature/contact/di/ContactModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/di/ContactModule.kt
@@ -9,14 +9,13 @@ import com.wire.android.feature.contact.datasources.mapper.ContactMapper
 import com.wire.android.feature.contact.datasources.remote.ContactRemoteDataSource
 import com.wire.android.feature.contact.datasources.remote.ContactsApi
 import com.wire.android.feature.contact.ui.icon.ContactIconLoader
-import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val contactModule = module {
     factory<ContactRepository> { ContactDataSource(get(), get(), get()) }
     single { ContactRemoteDataSource(get(), get(), get()) }
     single { get<NetworkClient>().create(ContactsApi::class.java) }
-    factory { ContactLocalDataSource(get(), get()) }
+    factory { ContactLocalDataSource(get()) }
     factory { get<UserDatabase>().contactDao() }
     factory { ContactMapper() }
 

--- a/app/src/main/kotlin/com/wire/android/feature/contact/ui/icon/ContactIconLoader.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/contact/ui/icon/ContactIconLoader.kt
@@ -9,7 +9,6 @@ import com.wire.android.core.config.LocaleConfig
 import com.wire.android.core.extension.toStringOrEmpty
 import com.wire.android.core.ui.drawable.TextDrawable
 import com.wire.android.feature.contact.Contact
-import java.io.File
 
 class ContactIconLoader(private val localeConfig: LocaleConfig) {
 
@@ -19,7 +18,8 @@ class ContactIconLoader(private val localeConfig: LocaleConfig) {
         requestOptions: RequestOptions.() -> Unit = {}
     ): RequestBuilder<Drawable> {
         val fallback = createFallbackDrawable(contact)
-        val data = contact.profilePicturePath?.let { File(it) } ?: fallback
+        //TODO load Asset type with Glide
+        val data = /* contact.profilePicturePath?.let { File(it) } ?: */ fallback
 
         return Glide.with(imageView)
             .load(data)

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -6,8 +6,8 @@ import com.wire.android.core.storage.db.user.UserDatabase
 import com.wire.android.core.ui.navigation.FragmentContainerProvider
 import com.wire.android.feature.conversation.data.ConversationDataSource
 import com.wire.android.feature.conversation.data.ConversationMapper
-import com.wire.android.feature.conversation.data.ConversationTypeMapper
 import com.wire.android.feature.conversation.data.ConversationRepository
+import com.wire.android.feature.conversation.data.ConversationTypeMapper
 import com.wire.android.feature.conversation.data.local.ConversationLocalDataSource
 import com.wire.android.feature.conversation.data.remote.ConversationsApi
 import com.wire.android.feature.conversation.data.remote.ConversationsRemoteDataSource
@@ -53,7 +53,7 @@ val conversationsModule = module {
     factory { get<UserDatabase>().conversationListDao() }
     factory { ConversationListLocalDataSource(get()) }
     factory { ConversationListMapper(get(), get()) }
-    factory<ConversationListRepository> { ConversationListDataSource(get(), get(), get(), get()) }
+    factory<ConversationListRepository> { ConversationListDataSource(get(), get(), get()) }
     factory { GetConversationListUseCase(get()) }
 
     factory { GetConversationMembersUseCase(get(), get()) }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
@@ -6,18 +6,15 @@ import androidx.paging.toLiveData
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.map
-import com.wire.android.feature.contact.datasources.local.ContactLocalDataSource
 import com.wire.android.feature.conversation.ConversationType
 import com.wire.android.feature.conversation.data.ConversationTypeMapper
 import com.wire.android.feature.conversation.list.ConversationListRepository
-import com.wire.android.feature.conversation.list.datasources.local.ConversationListItemEntity
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListLocalDataSource
 import com.wire.android.feature.conversation.list.ui.ConversationListItem
 import kotlinx.coroutines.flow.Flow
 
 class ConversationListDataSource(
     private val conversationListLocalDataSource: ConversationListLocalDataSource,
-    private val contactLocalDataSource: ContactLocalDataSource,
     private val conversationListMapper: ConversationListMapper,
     private val conversationTypeMapper: ConversationTypeMapper
 ) : ConversationListRepository {
@@ -25,19 +22,12 @@ class ConversationListDataSource(
     override fun conversationListInBatch(pageSize: Int, excludeType: ConversationType): Flow<PagedList<ConversationListItem>> =
         conversationListLocalDataSource.conversationListInBatch(
             excludeType = conversationTypeMapper.toIntValue(excludeType)
-        ).map { fromListItemEntity(it) }
+        ).map { conversationListMapper.fromEntity(it) }
             .toLiveData(pageSize = pageSize)
             .asFlow()
 
-    private fun fromListItemEntity(entity: ConversationListItemEntity): ConversationListItem {
-        val profilePictures = entity.members.map { contactEntity ->
-            contactLocalDataSource.profilePicture(contactEntity).fold({ null }) { it }
-        }
-        return conversationListMapper.fromEntity(entity, profilePictures)
-    }
-
     override suspend fun conversationListInBatch(start: Int, count: Int): Either<Failure, List<ConversationListItem>> =
-        conversationListLocalDataSource.conversationListInBatch(start = start, count = count).map {
-            it.map { conversationListMapper.fromEntity(it, emptyList()) }
+        conversationListLocalDataSource.conversationListInBatch(start = start, count = count).map { items ->
+            items.map { conversationListMapper.fromEntity(it) }
         }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListMapper.kt
@@ -4,18 +4,15 @@ import com.wire.android.feature.contact.datasources.mapper.ContactMapper
 import com.wire.android.feature.conversation.data.ConversationMapper
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListItemEntity
 import com.wire.android.feature.conversation.list.ui.ConversationListItem
-import java.io.File
 
 class ConversationListMapper(
     private val conversationMapper: ConversationMapper,
     private val contactMapper: ContactMapper
 ) {
 
-    fun fromEntity(listItemEntity: ConversationListItemEntity, profilePictures: List<File?>): ConversationListItem {
+    fun fromEntity(listItemEntity: ConversationListItemEntity): ConversationListItem {
         val conversation = conversationMapper.fromEntity(listItemEntity.conversation)
-        val contacts = listItemEntity.members.mapIndexed { index, contactEntity ->
-            contactMapper.fromContactEntity(contactEntity, profilePictures.getOrNull(index))
-        }
+        val contacts = contactMapper.fromContactEntityList(listItemEntity.members)
 
         return ConversationListItem(conversation = conversation, members = contacts)
     }

--- a/app/src/main/kotlin/com/wire/android/shared/asset/Asset.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/asset/Asset.kt
@@ -1,3 +1,5 @@
 package com.wire.android.shared.asset
 
 abstract class Asset
+
+data class PublicAsset(val key: String) : Asset()

--- a/app/src/test/kotlin/com/wire/android/feature/contact/datasources/ContactDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/contact/datasources/ContactDataSourceTest.kt
@@ -11,7 +11,6 @@ import com.wire.android.feature.contact.datasources.remote.ContactRemoteDataSour
 import com.wire.android.feature.contact.datasources.remote.ContactResponse
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
-import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -19,14 +18,10 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import okhttp3.ResponseBody
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldContainSame
 import org.junit.Before
 import org.junit.Test
-import java.io.File
-import java.io.InputStream
 
 class ContactDataSourceTest : UnitTest() {
 
@@ -55,41 +50,21 @@ class ContactDataSourceTest : UnitTest() {
 
         result shouldFail { it shouldBeEqualTo failure }
         coVerify(exactly = 1) { contactLocalDataSource.contactsById(TEST_CONTACT_IDS) }
-        verify { contactMapper wasNot Called }
-        coVerify(inverse = true) { contactLocalDataSource.saveContacts(any()) }
     }
 
     @Test
-    fun `given contactsById is called and a local contact found, when contact has profile picture, then returns mapping with picture`() {
-        val entity = mockk<ContactEntity>()
-        coEvery { contactLocalDataSource.contactsById(any()) } returns Either.Right(listOf(entity))
+    fun `given contactsById is called, when local data source returns contacts, then maps local contacts and propagates result`() {
+        val entities = mockk<List<ContactEntity>>()
+        coEvery { contactLocalDataSource.contactsById(TEST_CONTACT_IDS) } returns Either.Right(entities)
 
-        val profilePicture = mockk<File>()
-        coEvery { contactLocalDataSource.profilePicture(entity) } returns Either.Right(profilePicture)
+        val contacts = mockk<List<Contact>>()
+        every { contactMapper.fromContactEntityList(any()) } returns contacts
 
-        val contact = mockk<Contact>()
-        every { contactMapper.fromContactEntity(entity, any()) } returns contact
+        val result = runBlocking { contactDataSource.contactsById(TEST_CONTACT_IDS) }
 
-        val result = runBlocking { contactDataSource.contactsById(setOf(TEST_CONTACT_ID_1)) }
-
-        result shouldSucceed { it shouldContainSame listOf(contact) }
-        verify(exactly = 1) { contactMapper.fromContactEntity(entity, profilePicture) }
-    }
-
-    @Test
-    fun `given contactsById is called & a local contact found, when contact doesn't have a picture, then returns mapping w null picture`() {
-        val entity = mockk<ContactEntity>()
-        coEvery { contactLocalDataSource.contactsById(any()) } returns Either.Right(listOf(entity))
-
-        coEvery { contactLocalDataSource.profilePicture(entity) } returns Either.Left(mockk())
-
-        val contact = mockk<Contact>()
-        every { contactMapper.fromContactEntity(entity, null) } returns contact
-
-        val result = runBlocking { contactDataSource.contactsById(setOf(TEST_CONTACT_ID_1)) }
-
-        result shouldSucceed { it shouldContainSame listOf(contact) }
-        verify(exactly = 1) { contactMapper.fromContactEntity(entity, null) }
+        result shouldSucceed { it shouldBeEqualTo contacts }
+        coVerify(exactly = 1) { contactLocalDataSource.contactsById(TEST_CONTACT_IDS) }
+        verify(exactly = 1) { contactMapper.fromContactEntityList(entities) }
     }
 
     @Test
@@ -103,24 +78,7 @@ class ContactDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given fetchContactsById is called, when remote fetch of contacts are successful, then saves them into local storage`() {
-        val response = mockk<List<ContactResponse>>()
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(response)
-
-        val entities = mockk<List<ContactEntity>>()
-        every { contactMapper.fromContactResponseListToEntityList(response) } returns entities
-
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Left(mockk())
-
-        runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        coVerify(exactly = 1) { contactRemoteDataSource.contactsById(any()) }
-        coVerify(exactly = 1) { contactMapper.fromContactResponseListToEntityList(response) }
-        coVerify(exactly = 1) { contactLocalDataSource.saveContacts(entities) }
-    }
-
-    @Test
-    fun `given fetchContactsById is called, when remotely fetched items fail to be saved, then propagates the failure`() {
+    fun `given fetchContactsById is called and remote items are fetched, when items fail to be saved, then propagates the failure`() {
         coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(mockk())
         every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
 
@@ -133,136 +91,23 @@ class ContactDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given fetchContactsById called & remote items saved, when item doesn't have asset key, then propagate contact without picture`() {
+    fun `given fetchContactsById is called and remote items are fetched, when items are saved successfully, then propagates success`() {
         val contactResponse = mockk<ContactResponse>()
         coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
 
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns null
-
-        every { contactMapper.fromContactResponse(contactResponse, any()) } returns mockk()
+        val savedItems = mockk<List<ContactEntity>>()
+        every { contactMapper.fromContactResponseListToEntityList(any()) } returns savedItems
+        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(Unit)
 
         val result = runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
 
         result shouldSucceed { it shouldBe Unit }
-        verify(exactly = 1) { contactMapper.fromContactResponse(contactResponse, null) }
-    }
-
-    @Test
-    fun `given fetchContactsById is called & remote items are saved, when item has an asset key, then downloads profile picture`() {
-        val contactResponse = mockk<ContactResponse>()
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns TEST_ASSET_KEY
-
-        coEvery { contactRemoteDataSource.downloadProfilePicture(any()) } returns Either.Left(mockk())
-
-        every { contactMapper.fromContactResponse(any(), any()) } returns mockk()
-
-        runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        verify(exactly = 1) { contactMapper.profilePictureAssetKey(contactResponse) }
-        coVerify(exactly = 1) { contactRemoteDataSource.downloadProfilePicture(TEST_ASSET_KEY) }
-    }
-
-    @Test
-    fun `given fetchContactsById called & remote item has asset key, when prof pic download fails, then propagates contact with no pic`() {
-        val contactResponse = mockk<ContactResponse>()
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns TEST_ASSET_KEY
-
-        coEvery { contactRemoteDataSource.downloadProfilePicture(any()) } returns Either.Left(mockk())
-
-        every { contactMapper.fromContactResponse(contactResponse, any()) } returns mockk()
-
-        val result = runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        result shouldSucceed { it shouldBe Unit }
-        verify(exactly = 1) { contactMapper.fromContactResponse(contactResponse, null) }
-    }
-
-    @Test
-    fun `given fetchContactsById is called, when profile pic download is successful, then saves picture into local storage`() {
-        val contactResponse = mockk<ContactResponse>()
-        every { contactResponse.id } returns TEST_CONTACT_ID_1
-
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns TEST_ASSET_KEY
-
-        val downloadResponse = mockk<ResponseBody>()
-        val downloadStream = mockk<InputStream>()
-        every { downloadResponse.byteStream() } returns downloadStream
-        coEvery { contactRemoteDataSource.downloadProfilePicture(any()) } returns Either.Right(downloadResponse)
-
-        every { contactLocalDataSource.saveProfilePicture(any(), any()) } returns Either.Left(mockk())
-        every { contactMapper.fromContactResponse(contactResponse, any()) } returns mockk()
-
-        runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        coVerify(exactly = 1) { contactLocalDataSource.saveProfilePicture(TEST_CONTACT_ID_1, downloadStream) }
-    }
-
-    @Test
-    fun `given fetchContactsById is called, when profile pic cannot be saved into local storage, then propagates contact with no pic`() {
-        val contactResponse = mockk<ContactResponse>()
-        every { contactResponse.id } returns TEST_CONTACT_ID_1
-
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns TEST_ASSET_KEY
-        val downloadResponse = mockk<ResponseBody>()
-        every { downloadResponse.byteStream() } returns mockk()
-        coEvery { contactRemoteDataSource.downloadProfilePicture(any()) } returns Either.Right(downloadResponse)
-
-        every { contactLocalDataSource.saveProfilePicture(any(), any()) } returns Either.Left(mockk())
-
-        every { contactMapper.fromContactResponse(contactResponse, null) } returns mockk()
-
-        val result = runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        result shouldSucceed { it shouldBe Unit }
-        verify { contactMapper.fromContactResponse(contactResponse, null) }
-    }
-
-    @Test
-    fun `given fetchContactsById is called, when profile pic is saved into local storage, then propagates contact with saved picture`() {
-        val contactResponse = mockk<ContactResponse>()
-        every { contactResponse.id } returns TEST_CONTACT_ID_1
-
-        coEvery { contactRemoteDataSource.contactsById(any()) } returns Either.Right(listOf(contactResponse))
-        every { contactMapper.fromContactResponseListToEntityList(any()) } returns mockk()
-        coEvery { contactLocalDataSource.saveContacts(any()) } returns Either.Right(mockk())
-        every { contactMapper.profilePictureAssetKey(contactResponse) } returns TEST_ASSET_KEY
-        val downloadResponse = mockk<ResponseBody>()
-        every { downloadResponse.byteStream() } returns mockk()
-        coEvery { contactRemoteDataSource.downloadProfilePicture(any()) } returns Either.Right(downloadResponse)
-
-        val savedPicture = mockk<File>()
-        every { contactLocalDataSource.saveProfilePicture(any(), any()) } returns Either.Right(savedPicture)
-
-        val contact = mockk<Contact>()
-        every { contactMapper.fromContactResponse(contactResponse, savedPicture) } returns contact
-
-        val result = runBlocking { contactDataSource.fetchContactsById(TEST_CONTACT_IDS) }
-
-        result shouldSucceed { it shouldBe Unit }
-        verify { contactMapper.fromContactResponse(contactResponse, savedPicture) }
+        coVerify(exactly = 1) { contactRemoteDataSource.contactsById(TEST_CONTACT_IDS) }
+        verify(exactly = 1) { contactMapper.fromContactResponseListToEntityList(any()) }
+        coVerify(exactly = 1) { contactLocalDataSource.saveContacts(savedItems) }
     }
 
     companion object {
-        private const val TEST_CONTACT_ID_1 = "contact-id-1"
-        private const val TEST_CONTACT_ID_2 = "contact-id-2"
-        private val TEST_CONTACT_IDS = setOf(TEST_CONTACT_ID_1, TEST_CONTACT_ID_2)
-
-        private const val TEST_ASSET_KEY = "asset-key-3459"
+        private val TEST_CONTACT_IDS = setOf("contact-id-1", "contact-id-2")
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/contact/datasources/local/ContactLocalDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/contact/datasources/local/ContactLocalDataSourceTest.kt
@@ -2,36 +2,26 @@ package com.wire.android.feature.contact.datasources.local
 
 import android.database.sqlite.SQLiteException
 import com.wire.android.UnitTest
-import com.wire.android.core.exception.Failure
-import com.wire.android.core.functional.Either
-import com.wire.android.core.io.FileSystem
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
-import java.io.File
-import java.io.InputStream
 
 class ContactLocalDataSourceTest : UnitTest() {
 
     @MockK
     private lateinit var contactDao: ContactDao
 
-    @MockK
-    private lateinit var fileSystem: FileSystem
-
     private lateinit var contactLocalDataSource: ContactLocalDataSource
 
     @Before
     fun setUp() {
-        contactLocalDataSource = ContactLocalDataSource(contactDao, fileSystem)
+        contactLocalDataSource = ContactLocalDataSource(contactDao)
     }
 
     @Test
@@ -73,80 +63,5 @@ class ContactLocalDataSourceTest : UnitTest() {
         val result = runBlocking { contactLocalDataSource.saveContacts(entityList) }
 
         result shouldFail { }
-    }
-
-    @Test
-    fun `given profilePicture is called, when fileSystem successfully finds the file, then propagates the file`() {
-        val file = mockk<File>()
-        every { fileSystem.internalFile(any()) } returns Either.Right(file)
-
-        val entity = mockk<ContactEntity>()
-        every { entity.id } returns TEST_CONTACT_ID
-
-        val result = contactLocalDataSource.profilePicture(entity)
-
-        result shouldSucceed { it shouldBeEqualTo file }
-        verify(exactly = 1) { fileSystem.internalFile(TEST_PROFILE_PICTURE_PATH) }
-    }
-
-    @Test
-    fun `given profilePicture is called, when fileSystem fails to find the file, then propagates the failure`() {
-        val failure = mockk<Failure>()
-        every { fileSystem.internalFile(any()) } returns Either.Left(failure)
-
-        val entity = mockk<ContactEntity>()
-        every { entity.id } returns TEST_CONTACT_ID
-
-        val result = contactLocalDataSource.profilePicture(entity)
-
-        result shouldFail { it shouldBeEqualTo failure }
-        verify(exactly = 1) { fileSystem.internalFile(TEST_PROFILE_PICTURE_PATH) }
-    }
-
-    @Test
-    fun `given saveProfilePicture is called, when fileSystem fails to create the file, then propagates the failure`() {
-        val failure = mockk<Failure>()
-        every { fileSystem.createInternalFile(any()) } returns Either.Left(failure)
-
-        val result = contactLocalDataSource.saveProfilePicture(TEST_CONTACT_ID, mockk())
-
-        result shouldFail { it shouldBeEqualTo failure }
-        verify(exactly = 1) { fileSystem.createInternalFile(TEST_PROFILE_PICTURE_PATH) }
-    }
-
-    @Test
-    fun `given saveProfilePicture is called and file is created, when fileSystem fails to write to file, then propagates the failure`() {
-        val file = mockk<File>()
-        every { fileSystem.createInternalFile(any()) } returns Either.Right(file)
-
-        val failure = mockk<Failure>()
-        every { fileSystem.writeToFile(file, any()) } returns Either.Left(failure)
-
-        val inputStream = mockk<InputStream>()
-
-        val result = contactLocalDataSource.saveProfilePicture(TEST_CONTACT_ID, inputStream)
-
-        result shouldFail { it shouldBeEqualTo failure }
-        verify(exactly = 1) { fileSystem.writeToFile(file, inputStream) }
-    }
-
-    @Test
-    fun `given saveProfilePicture is called and file is created, when fileSystem writes to file, then propagates the written file`() {
-        every { fileSystem.createInternalFile(any()) } returns Either.Right(mockk())
-
-        val file = mockk<File>()
-        every { fileSystem.writeToFile(any(), any()) } returns Either.Right(file)
-
-        val inputStream = mockk<InputStream>()
-
-        val result = contactLocalDataSource.saveProfilePicture(TEST_CONTACT_ID, inputStream)
-
-        result shouldSucceed { it shouldBeEqualTo file }
-        verify(exactly = 1) { fileSystem.writeToFile(any(), inputStream) }
-    }
-
-    companion object {
-        private const val TEST_CONTACT_ID = "contact-id-1"
-        private const val TEST_PROFILE_PICTURE_PATH = "/contact/$TEST_CONTACT_ID/profile_picture.jpg"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/contact/datasources/mapper/ContactMapperTest.kt
@@ -1,10 +1,10 @@
 package com.wire.android.feature.contact.datasources.mapper
 
 import com.wire.android.UnitTest
-import com.wire.android.feature.contact.Contact
 import com.wire.android.feature.contact.datasources.local.ContactEntity
 import com.wire.android.feature.contact.datasources.remote.ContactResponse
 import com.wire.android.framework.collections.second
+import com.wire.android.shared.asset.PublicAsset
 import com.wire.android.shared.asset.datasources.remote.AssetResponse
 import io.mockk.every
 import io.mockk.mockk
@@ -12,7 +12,6 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class ContactMapperTest : UnitTest() {
 
@@ -24,131 +23,73 @@ class ContactMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given profilePictureAssetKey is called, when contactResponse has an asset with size "complete", then returns asset key`() {
-        val contactResponse = mockk<ContactResponse>()
-        val contactAssetResponse = mockk<AssetResponse>()
-        every { contactAssetResponse.size } returns ASSET_SIZE_COMPLETE
-        every { contactAssetResponse.key } returns TEST_ASSET_KEY
-        every { contactResponse.assets } returns listOf(contactAssetResponse)
-
-        val result = contactMapper.profilePictureAssetKey(contactResponse)
-
-        result shouldBeEqualTo TEST_ASSET_KEY
-    }
-
-    @Test
-    fun `given profilePictureAssetKey is called, when contactResponse does not have an asset with size "complete", then returns null`() {
-        val contactResponse = mockk<ContactResponse>()
-        val contactAssetResponse = mockk<AssetResponse>()
-        every { contactAssetResponse.size } returns "preview"
-        every { contactAssetResponse.key } returns TEST_ASSET_KEY
-        every { contactResponse.assets } returns listOf(contactAssetResponse)
-
-        val result = contactMapper.profilePictureAssetKey(contactResponse)
-
-        result shouldBeEqualTo null
-    }
-
-    @Test
-    fun `given fromContactResponse is called, when profile picture is null, then returns a mapping with null picture path`() {
-        val contactResponse = mockk<ContactResponse>()
-        every { contactResponse.id } returns TEST_CONTACT_ID
-        every { contactResponse.name } returns TEST_CONTACT_NAME
-
-        val result = contactMapper.fromContactResponse(contactResponse, null)
-
-        result shouldBeInstanceOf Contact::class
-        result.id shouldBeEqualTo TEST_CONTACT_ID
-        result.name shouldBeEqualTo TEST_CONTACT_NAME
-        result.profilePicturePath shouldBeEqualTo null
-    }
-
-    @Test
-    fun `given fromContactResponse is called, when profile picture is not null, then returns a mapping with picture's path`() {
-        val contactResponse = mockk<ContactResponse>()
-        every { contactResponse.id } returns TEST_CONTACT_ID
-        every { contactResponse.name } returns TEST_CONTACT_NAME
-        val profilePicture = mockk<File>()
-        every { profilePicture.absolutePath } returns TEST_FILE_PATH
-
-        val result = contactMapper.fromContactResponse(contactResponse, profilePicture)
-
-        result shouldBeInstanceOf Contact::class
-        result.id shouldBeEqualTo TEST_CONTACT_ID
-        result.name shouldBeEqualTo TEST_CONTACT_NAME
-        result.profilePicturePath shouldBeEqualTo TEST_FILE_PATH
-    }
-
-    @Test
     fun `given fromContactResponseListToEntityList is called, then returns list of entities with a proper mapping`() {
-        val contactResponse1 = mockk<ContactResponse>()
-        val id1 = "${TEST_CONTACT_ID}_1"
-        val name1 = "${TEST_CONTACT_NAME}_1"
-        every { contactResponse1.id } returns id1
-        every { contactResponse1.name } returns name1
+        val contactResponseWithAsset = mockk<ContactResponse>()
+        every { contactResponseWithAsset.id } returns TEST_CONTACT_ID_1
+        every { contactResponseWithAsset.name } returns TEST_CONTACT_NAME_1
         val contactAssetResponse = mockk<AssetResponse>()
         every { contactAssetResponse.size } returns ASSET_SIZE_COMPLETE
         every { contactAssetResponse.key } returns TEST_ASSET_KEY
-        every { contactResponse1.assets } returns listOf(contactAssetResponse)
+        every { contactResponseWithAsset.assets } returns listOf(contactAssetResponse)
 
-        val contactResponse2 = mockk<ContactResponse>()
-        val id2 = "${TEST_CONTACT_ID}_2"
-        val name2 = "${TEST_CONTACT_NAME}_2"
-        every { contactResponse2.id } returns id2
-        every { contactResponse2.name } returns name2
-        every { contactResponse2.assets } returns emptyList()
+        val contactResponse = mockk<ContactResponse>()
+        every { contactResponse.id } returns TEST_CONTACT_ID_2
+        every { contactResponse.name } returns TEST_CONTACT_NAME_2
+        every { contactResponse.assets } returns emptyList()
 
-        val result = contactMapper.fromContactResponseListToEntityList(listOf(contactResponse1, contactResponse2))
+        val result = contactMapper.fromContactResponseListToEntityList(
+            listOf(contactResponseWithAsset, contactResponse)
+        )
 
         result.first().let {
             it shouldBeInstanceOf ContactEntity::class
-            it.id shouldBeEqualTo id1
-            it.name shouldBeEqualTo name1
+            it.id shouldBeEqualTo TEST_CONTACT_ID_1
+            it.name shouldBeEqualTo TEST_CONTACT_NAME_1
             it.assetKey shouldBeEqualTo TEST_ASSET_KEY
         }
         result.second().let {
             it shouldBeInstanceOf ContactEntity::class
-            it.id shouldBeEqualTo id2
-            it.name shouldBeEqualTo name2
+            it.id shouldBeEqualTo TEST_CONTACT_ID_2
+            it.name shouldBeEqualTo TEST_CONTACT_NAME_2
             it.assetKey shouldBeEqualTo null
         }
     }
 
     @Test
-    fun `given fromContactEntity is called, when profile picture is null, then returns a mapping with null picture path`() {
+    fun `given fromContactEntityList is called, then returns list of contacts with a proper mapping`() {
+        val contactEntityWithAsset = mockk<ContactEntity>()
+        every { contactEntityWithAsset.id } returns TEST_CONTACT_ID_1
+        every { contactEntityWithAsset.name } returns TEST_CONTACT_NAME_1
+        every { contactEntityWithAsset.assetKey } returns TEST_ASSET_KEY
+
         val contactEntity = mockk<ContactEntity>()
-        every { contactEntity.id } returns TEST_CONTACT_ID
-        every { contactEntity.name } returns TEST_CONTACT_NAME
+        every { contactEntity.id } returns TEST_CONTACT_ID_2
+        every { contactEntity.name } returns TEST_CONTACT_NAME_2
+        every { contactEntity.assetKey } returns null
 
-        val result = contactMapper.fromContactEntity(contactEntity, null)
+        val result = contactMapper.fromContactEntityList(
+            listOf(contactEntityWithAsset, contactEntity)
+        )
 
-        result shouldBeInstanceOf Contact::class
-        result.id shouldBeEqualTo TEST_CONTACT_ID
-        result.name shouldBeEqualTo TEST_CONTACT_NAME
-        result.profilePicturePath shouldBeEqualTo null
-    }
-
-    @Test
-    fun `given fromContactEntity is called, when profile picture is not null, then returns a mapping with picture's path`() {
-        val contactEntity = mockk<ContactEntity>()
-        every { contactEntity.id } returns TEST_CONTACT_ID
-        every { contactEntity.name } returns TEST_CONTACT_NAME
-        val profilePicture = mockk<File>()
-        every { profilePicture.absolutePath } returns TEST_FILE_PATH
-
-        val result = contactMapper.fromContactEntity(contactEntity, profilePicture)
-
-        result shouldBeInstanceOf Contact::class
-        result.id shouldBeEqualTo TEST_CONTACT_ID
-        result.name shouldBeEqualTo TEST_CONTACT_NAME
-        result.profilePicturePath shouldBeEqualTo TEST_FILE_PATH
+        result.first().let {
+            it.id shouldBeEqualTo TEST_CONTACT_ID_1
+            it.name shouldBeEqualTo TEST_CONTACT_NAME_1
+            it.profilePicture shouldBeEqualTo PublicAsset(TEST_ASSET_KEY)
+        }
+        result.second().let {
+            it.id shouldBeEqualTo TEST_CONTACT_ID_2
+            it.name shouldBeEqualTo TEST_CONTACT_NAME_2
+            it.profilePicture shouldBeEqualTo null
+        }
     }
 
     companion object {
         private const val ASSET_SIZE_COMPLETE = "complete"
         private const val TEST_ASSET_KEY = "asset_key_356"
-        private const val TEST_CONTACT_ID = "contact_id_8900"
-        private const val TEST_CONTACT_NAME = "Alice Abc"
-        private const val TEST_FILE_PATH = "file://contacts/assets/0-23409-2456.jpg"
+
+        private const val TEST_CONTACT_ID_1 = "contact_id_8900"
+        private const val TEST_CONTACT_NAME_1 = "Alice Abc"
+        private const val TEST_CONTACT_ID_2 = "contact_id_9234"
+        private const val TEST_CONTACT_NAME_2 = "Bob Bcd"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSourceTest.kt
@@ -3,7 +3,6 @@ package com.wire.android.feature.conversation.list.datasources
 import com.wire.android.UnitTest
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
-import com.wire.android.feature.contact.datasources.local.ContactLocalDataSource
 import com.wire.android.feature.conversation.data.ConversationTypeMapper
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListItemEntity
 import com.wire.android.feature.conversation.list.datasources.local.ConversationListLocalDataSource
@@ -28,9 +27,6 @@ class ConversationListDataSourceTest : UnitTest() {
     private lateinit var conversationListLocalDataSource: ConversationListLocalDataSource
 
     @MockK
-    private lateinit var contactLocalDataSource: ContactLocalDataSource
-
-    @MockK
     private lateinit var conversationListMapper: ConversationListMapper
 
     @MockK
@@ -42,7 +38,7 @@ class ConversationListDataSourceTest : UnitTest() {
     @Before
     fun setUp() {
         conversationListDataSource = ConversationListDataSource(
-            conversationListLocalDataSource, contactLocalDataSource,
+            conversationListLocalDataSource,
             conversationListMapper, conversationTypeMapper
         )
     }
@@ -61,12 +57,12 @@ class ConversationListDataSourceTest : UnitTest() {
         val entities = listOf<ConversationListItemEntity>(mockk(), mockk())
         coEvery { conversationListLocalDataSource.conversationListInBatch(any(), any()) } returns Either.Right(entities)
         val conversations = listOf<ConversationListItem>(mockk(), mockk())
-        every { conversationListMapper.fromEntity(any(), any()) } returnsMany conversations
+        every { conversationListMapper.fromEntity(any()) } returnsMany conversations
 
         val result = runBlocking { conversationListDataSource.conversationListInBatch(60, 20) }
 
         result shouldSucceed { it shouldContainSame conversations }
-        verify(exactly = 2) { conversationListMapper.fromEntity(any(), any()) }
+        verify(exactly = 2) { conversationListMapper.fromEntity(any()) }
     }
 
     @Test
@@ -77,7 +73,7 @@ class ConversationListDataSourceTest : UnitTest() {
         val result = runBlocking { conversationListDataSource.conversationListInBatch(60, 20) }
 
         result shouldFail { it shouldBeEqualTo failure }
-        verify(inverse = true) { conversationListMapper.fromEntity(any(), any()) }
+        verify(inverse = true) { conversationListMapper.fromEntity(any()) }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListMapperTest.kt
@@ -15,7 +15,6 @@ import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class ConversationListMapperTest : UnitTest() {
 
@@ -38,26 +37,17 @@ class ConversationListMapperTest : UnitTest() {
         val conversation = mockk<Conversation>()
         every { conversationMapper.fromEntity(conversationEntity) } returns conversation
 
-        val contactEntity1 = mockk<ContactEntity>()
-        val contactEntity2 = mockk<ContactEntity>()
-        val profilePicture1 = mockk<File>()
-        val profilePicture2 = mockk<File>()
-        val contactEntities = listOf(contactEntity1, contactEntity2)
-        val profilePictures = listOf(profilePicture1, profilePicture2)
-
-        val contact1 = mockk<Contact>()
-        val contact2 = mockk<Contact>()
-        every { contactMapper.fromContactEntity(contactEntity1, any()) } returns contact1
-        every { contactMapper.fromContactEntity(contactEntity2, any()) } returns contact2
+        val contactEntities = mockk<List<ContactEntity>>()
+        val contacts = mockk<List<Contact>>()
+        every { contactMapper.fromContactEntityList(contactEntities) } returns contacts
 
         val listItemEntity = ConversationListItemEntity(conversationEntity, contactEntities)
 
-        val result = conversationListMapper.fromEntity(listItemEntity, profilePictures)
+        val result = conversationListMapper.fromEntity(listItemEntity)
 
         result.conversation shouldBeEqualTo conversation
-        result.members shouldBeEqualTo listOf(contact1, contact2)
+        result.members shouldBeEqualTo contacts
         verify(exactly = 1) { conversationMapper.fromEntity(conversationEntity) }
-        verify(exactly = 1) { contactMapper.fromContactEntity(contactEntity1, profilePicture1) }
-        verify(exactly = 1) { contactMapper.fromContactEntity(contactEntity2, profilePicture2) }
+        verify(exactly = 1) { contactMapper.fromContactEntityList(contactEntities) }
     }
 }


### PR DESCRIPTION
We were downloading `ContactAssets` from backend at the same time we're fetching contact info from backend during slow sync. We were also saving all assets into file system manually. 
However, 
1- The device might not have enough storage space for assets of (possibly) hundreds of people. The assets should be downloaded only when we need to display them.
2- Download and saving should be handled by Glide, which has an efficient mechanism to utilize storage space and handles file saving out of the box.

This PR removes asset download/saving logic during slow sync. Glide implementation will be added in future PRs.