### PR TITLE
[Calling] fix : The video of the self user is frozen in the remote side when it not displayed in the screen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -241,7 +241,19 @@ class CallingFragment extends FragmentHelper {
       case (participant, selfView) if participant == selfParticipant => !gridViews.contains(selfView)
       case (participant, _) => !videoUsers.contains(participant)
     }
-    viewsToRemove.foreach { case (_, view) => grid.removeView(view) }
+
+    val isSelfVideoEnabled = videoUsers.contains(selfParticipant)
+
+    viewMap.foreach{case (_,view) => view.setVisibility(View.VISIBLE)}
+
+    viewsToRemove.foreach {
+      case (participant, view) =>
+        if (participant == selfParticipant) {
+          if (showTopSpeakers && !isSelfVideoEnabled) view.setVisibility(View.INVISIBLE)
+          else view.setVisibility(View.VISIBLE)
+        }
+        else grid.removeView(view)
+    }
     viewMap = viewMap.filter { case (participant, _) => videoUsers.contains(participant) }
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR fixes a couple of calling bugs detected after introducing the the active speaker view.

https://wearezeta.atlassian.net/browse/SQCALL-182
https://wearezeta.atlassian.net/browse/SQCALL-183
https://wearezeta.atlassian.net/browse/SQCALL-119

### Causes

The self video stream is no sent remotely  when the self video view is killed. 

### Solutions

The solution is bit hacky, instead of killing the self video view, hide it. I couldn't find another way to solve this issue. 


#### APK
[Download build #3184](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3184/artifact/build/artifact/wire-dev-PR3195-3184.apk)