### PR TITLE
[Calling] fix : hide the active speakers/all toggle for group calls with 2 participants

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/ControlsFragment.scala
@@ -94,17 +94,18 @@ class ControlsFragment extends FragmentHelper {
     }
 
     if (BuildConfig.ACTIVE_SPEAKERS) {
-       Signal.zip(
-         controller.isCallEstablished,
-         controller.isGroupCall,
-         controller.isVideoCall,
-         controller.isFullScreenEnabled
-       ).onUi {
-         case (true, true, true, false) => speakersLayoutContainer.foreach(_.setVisibility(View.VISIBLE))
-         case _                         => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
-       }
-     }
-     else speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
+      Signal.zip(
+        controller.isCallEstablished,
+        controller.isGroupCall,
+        controller.isVideoCall,
+        controller.isFullScreenEnabled,
+        controller.allParticipants.map(_.size > 2)
+      ).onUi {
+        case (true, true, true, false, true) => speakersLayoutContainer.foreach(_.setVisibility(View.VISIBLE))
+        case _                               => speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
+      }
+    }
+    else speakersLayoutContainer.foreach(_.setVisibility(View.INVISIBLE))
   }
 
   override def onStart(): Unit = {


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR include a tiny fix for active speaker toggle : All/speakers shoudn't be visible for group calls with 2 participants.

https://wearezeta.atlassian.net/browse/SQCALL-192

