### PR TITLE
Feature : Legal Hold - Indicate legal hold in Conversation title

### DIFF
--- a/app/src/main/res/drawable/ic_legal_hold_active.xml
+++ b/app/src/main/res/drawable/ic_legal_hold_active.xml
@@ -1,0 +1,9 @@
+<vector android:height="16dp" android:viewportHeight="64"
+    android:viewportWidth="64" android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="0.24" android:fillColor="#FF2600"
+        android:fillType="evenOdd"
+        android:pathData="M32,64C49.67,64 64,49.67 64,32 64,14.33 49.67,-0 32,-0 14.33,-0 0,14.33 0,32 0,49.67 14.33,64 32,64ZM32,64"
+        android:strokeAlpha="0.24" android:strokeColor="#FF2600"/>
+    <path android:fillColor="#FF2600" android:fillType="evenOdd"
+        android:pathData="M32,16C40.84,16 48,23.16 48,32 48,40.84 40.84,48 32,48 23.16,48 16,40.84 16,32 16,23.16 23.16,16 32,16ZM32,16" android:strokeColor="#FF2600"/>
+</vector>

--- a/app/src/main/res/drawable/ic_legal_hold_pending.xml
+++ b/app/src/main/res/drawable/ic_legal_hold_pending.xml
@@ -1,0 +1,9 @@
+<vector android:height="16dp" android:viewportHeight="64"
+    android:viewportWidth="64" android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="0.24" android:fillColor="#FF2600"
+        android:fillType="evenOdd"
+        android:pathData="M32,64C49.67,64 64,49.67 64,32 64,14.33 49.67,-0 32,-0 14.33,-0 0,14.33 0,32 0,49.67 14.33,64 32,64ZM32,64"
+        android:strokeAlpha="0.24" android:strokeColor="#00000000"/>
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M32,44L32,44C38.63,44 44,38.63 44,32 44,25.37 38.63,20 32,20 25.37,20 20,25.37 20,32 20,38.63 25.37,44 32,44L32,44 32,44ZM32,48L32,48C23.16,48 16,40.84 16,32 16,23.16 23.16,16 32,16 40.84,16 48,23.16 48,32 48,40.84 40.84,48 32,48L32,48 32,48ZM34,22C34,22 34,26.51 34,30L40,30 40,34 30,34 30,30C30,26.51 30,22 30,22L34,22 34,22ZM34,22" android:strokeColor="#00000000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_conversation.xml
+++ b/app/src/main/res/layout/fragment_conversation.xml
@@ -54,6 +54,14 @@
                 android:orientation="horizontal"
                 >
 
+                <ImageView
+                    android:id="@+id/conversation_toolbar_image_view_legal_hold"
+                    android:layout_width="@dimen/legal_hold_indicator_size"
+                    android:layout_height="@dimen/legal_hold_indicator_size"
+                    android:layout_marginEnd="@dimen/wire__padding__8"
+                    android:src="@drawable/ic_legal_hold_active"
+                    android:visibility="gone"/>
+
                 <com.waz.zclient.views.e2ee.ShieldView
                     android:id="@+id/sv__conversation_toolbar__verified_shield"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -120,6 +120,7 @@
     <dimen name="wire__stroke">0.5dp</dimen>
     <dimen name="wire__button__height_small">28dp</dimen>
     <dimen name="wire__otr__shield__small_width">16dp</dimen>
+    <dimen name="legal_hold_indicator_size">16dp</dimen>
 
     <dimen name="wire__otr__switch_height">20dp</dimen>
     <dimen name="wire__dialog__min_width">104dp</dimen>

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -43,6 +43,7 @@ import com.waz.service._
 import com.waz.service.assets._
 import com.waz.service.call.GlobalCallingService
 import com.waz.service.conversation._
+import com.waz.service.legalhold.LegalHoldController
 import com.waz.service.messages.MessagesService
 import com.waz.service.teams.{FeatureFlagsService, TeamsService}
 import com.waz.service.tracking.TrackingService
@@ -323,6 +324,7 @@ object WireApplication extends DerivedLogTag {
     bind [UiTrackingController]    to new UiTrackingController()
 
     bind[MessagePagedListController] to new MessagePagedListController()
+    bind[LegalHoldController] to new LegalHoldController()
   }
 
   def clearOldVideoFiles(context: Context): Unit = {

--- a/zmessaging/src/main/scala/com/waz/service/legalhold/LegalHoldController.scala
+++ b/zmessaging/src/main/scala/com/waz/service/legalhold/LegalHoldController.scala
@@ -1,0 +1,15 @@
+package com.waz.service.legalhold
+
+import com.waz.model.{ConvId, UserId}
+import com.waz.service.legalhold.LegalHoldStatus.Disabled
+import com.wire.signals.Signal
+
+//TODO: implement status calculation
+class LegalHoldController {
+
+  def legalHoldStatus(userId: UserId): Signal[LegalHoldStatus] =
+    Signal.const(Disabled)
+
+  def legalHoldStatus(conversationId: ConvId): Signal[LegalHoldStatus] =
+    Signal.const(Disabled)
+}

--- a/zmessaging/src/main/scala/com/waz/service/legalhold/LegalHoldStatus.scala
+++ b/zmessaging/src/main/scala/com/waz/service/legalhold/LegalHoldStatus.scala
@@ -1,0 +1,9 @@
+package com.waz.service.legalhold
+
+sealed trait LegalHoldStatus
+
+object LegalHoldStatus {
+  case object Degraded extends LegalHoldStatus
+  case object Enabled extends LegalHoldStatus
+  case object Disabled extends LegalHoldStatus
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-339](https://wearezeta.atlassian.net/browse/SQSERVICES-339)

When at least one of the users are subject to legal hold, we want to display a red "recording" indicator in conversation title, so that all participants are aware of the situation.

This PR only implements the UI part as sync-engine part is subject to change.

### Testing

Manually tested by changing hard coded values on `LegalHoldController`

| 1-1 Conversation | Group Conversation |
|------------------|---------------------|
| <img src="https://user-images.githubusercontent.com/2143283/111500505-5b0c7100-8744-11eb-8749-bcd518904c9f.png" width="300px"/> | <img src="https://user-images.githubusercontent.com/2143283/111500550-69f32380-8744-11eb-8503-36681ca283ca.png" width="300px"/>


#### APK
[Download build #3199](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3199/artifact/build/artifact/wire-dev-PR3205-3199.apk)