### PR TITLE
Feature: Legal Hold - Legal hold details screen for self user

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2018 Wire Swiss GmbH
@@ -22,8 +21,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.waz.zclient"
     android:sharedUserId="${sharedUserId}"
-    tools:ignore="MissingRegistered"
-    >
+    tools:ignore="MissingRegistered">
 
     <!-- See if device is connected to a network -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -61,50 +59,49 @@
 
     <uses-feature
         android:name="android.hardware.camera"
-        android:required="false"
-        />
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera.front"
-        android:required="false"
-        />
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera.autofocus"
-        android:required="false"
-        />
+        android:required="false" />
 
     <!-- TODO: Remove requestLegacyExternalStorage when you bump to sdk 30 and migrate the legacy data-->
     <application
         android:name=".ZApplication"
         android:allowBackup="false"
-        android:requestLegacyExternalStorage="true"
         android:hardwareAccelerated="true"
         android:icon="${applicationIcon}"
         android:label="${applicationLabel}"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/Theme.Splash"
         android:vmSafeMode="${applicationVmSafeMode}"
-        tools:replace="android:allowBackup"
-        android:networkSecurityConfig="@xml/network_security_config"
-        >
+        tools:replace="android:allowBackup">
 
         <!--    TODO: not required when using play-services-maps:16.1.0 and above
                    https://developer.android.com/about/versions/pie/android-9.0-changes-28#apache-p
                    https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library
         -->
-        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
 
         <activity
             android:name=".LaunchActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:noHistory="true"
-            android:theme="@style/Theme.Splash"
-            android:launchMode="singleTask">
+            android:theme="@style/Theme.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
             <intent-filter>
-                <data android:host="email-verified"
+                <data
+                    android:host="email-verified"
                     android:scheme="${customURLScheme}" />
 
                 <action android:name="android.intent.action.VIEW" />
@@ -117,8 +114,7 @@
             <intent-filter>
                 <data
                     android:host="connect"
-                    android:scheme="${customURLScheme}"
-                    />
+                    android:scheme="${customURLScheme}" />
 
                 <action android:name="android.intent.action.VIEW" />
 
@@ -136,8 +132,7 @@
             android:hardwareAccelerated="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.Light"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            >
+            android:windowSoftInputMode="stateHidden|adjustResize">
 
             <intent-filter>
                 <data android:scheme="${customURLScheme}" />
@@ -149,8 +144,8 @@
             </intent-filter>
 
             <intent-filter>
-                <action android:name="com.wire.ACTION_CURRENT_USER_CHANGED"/>
-                <category android:name="android.intent.category.DEFAULT"/>
+                <action android:name="com.wire.ACTION_CURRENT_USER_CHANGED" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
         </activity>
@@ -162,37 +157,33 @@
             android:screenOrientation="portrait"
             android:showOnLockScreen="true"
             android:theme="@style/Theme.Calling"
-            android:windowSoftInputMode="stateHidden"
-            />
+            android:windowSoftInputMode="stateHidden" />
 
         <activity
             android:name="com.waz.zclient.preferences.PreferencesActivity"
             android:hardwareAccelerated="true"
-            android:theme="@style/Theme.Dark.Preferences"
-            android:launchMode="singleTask"
             android:label="@string/empty_string"
-            />
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Dark.Preferences" />
         <activity
             android:name=".PopupActivity"
+            android:excludeFromRecents="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"
-            android:taskAffinity=""
-            android:excludeFromRecents="true"
             android:screenOrientation="unspecified"
+            android:taskAffinity=""
             android:theme="@style/Theme.Popup"
-            android:windowSoftInputMode="stateVisible"
-            />
+            android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".ShareActivity"
             android:configChanges="orientation|keyboardHidden"
             android:excludeFromRecents="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTask"
-            android:taskAffinity=""
             android:screenOrientation="portrait"
+            android:taskAffinity=""
             android:theme="@style/Theme.Share"
-            android:windowSoftInputMode="adjustPan"
-            >
+            android:windowSoftInputMode="adjustPan">
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -209,44 +200,48 @@
 
         <activity
             android:name=".appentry.AppEntryActivity"
+            android:exported="false"
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:theme="@style/Theme.Dark"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            android:exported="false">
+            android:windowSoftInputMode="stateHidden|adjustResize">
             <intent-filter>
-                <action android:name="com.wire.ACTION_NO_USER_LEFT"/>
-                <category android:name="android.intent.category.DEFAULT"/>
+                <action android:name="com.wire.ACTION_NO_USER_LEFT" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 
         <activity
             android:name=".ForceUpdateActivity"
+            android:launchMode="singleTask"
             android:noHistory="true"
-            android:theme="@style/Theme.Light"
-            android:launchMode="singleTask">
-        </activity>
+            android:theme="@style/Theme.Light" />
 
         <activity
             android:name=".conversation.folders.moveto.MoveToFolderActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".legalhold.SelfUserLegalHoldInfoActivity"
             android:screenOrientation="portrait" />
 
         <receiver
             android:name=".broadcast.ReferralBroadcastReceiver"
             android:exported="true"
             android:permission="android.permission.INSTALL_PACKAGES"
-            tools:ignore="ExportedReceiver"
-            >
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.waz.services.SecurityPolicyService"
-            android:label="@string/security_policy_title"
+        <receiver
+            android:name="com.waz.services.SecurityPolicyService"
             android:description="@string/security_policy_description"
+            android:label="@string/security_policy_title"
             android:permission="android.permission.BIND_DEVICE_ADMIN">
-            <meta-data android:name="android.app.device_admin"
+            <meta-data
+                android:name="android.app.device_admin"
                 android:resource="@xml/device_admin" />
             <intent-filter>
                 <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
@@ -257,7 +252,7 @@
             android:name="com.waz.content.WireContentProvider"
             android:authorities="${applicationId}"
             android:exported="false"
-            android:grantUriPermissions="true"/>
+            android:grantUriPermissions="true" />
 
         <provider
             android:name="androidx.core.content.FileProvider"
@@ -266,7 +261,7 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths"/>
+                android:resource="@xml/provider_paths" />
         </provider>
 
         <!--
@@ -276,28 +271,32 @@
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"
             android:authorities="${applicationId}.firebaseinitprovider"
-            tools:node="remove"/>
+            tools:node="remove" />
 
         <!--Disable tracking in the FCM core-->
-        <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
-        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_deactivated"
+            android:value="true" />
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
 
-        <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyBA1m9faI3-P4sP6S9B_JH3XTNIxHBz2Qg"/>
+            android:value="AIzaSyBA1m9faI3-P4sP6S9B_JH3XTNIxHBz2Qg" />
 
         <service
             android:name="com.waz.services.fcm.FCMHandlerService"
-            android:exported="false"
-            >
+            android:exported="false">
             <meta-data
                 android:name="com.google.firebase.messaging.default_notification_channel_id"
-                android:value="@string/default_notification_channel_id"
-            />
+                android:value="@string/default_notification_channel_id" />
             <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
 
@@ -309,42 +308,42 @@
             </intent-filter>
         </receiver>
 
-        <service android:name="com.waz.services.websocket.WebSocketService"
-            android:exported="false"
-            />
+        <service
+            android:name="com.waz.services.websocket.WebSocketService"
+            android:exported="false" />
 
         <!--For Evernote Background jobs-->
         <service
             android:name="com.evernote.android.job.gcm.PlatformGcmService"
             android:enabled="true"
-            tools:replace="android:enabled"
             android:exported="true"
-            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE">
+            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE"
+            tools:replace="android:enabled">
             <intent-filter>
-                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY"/>
+                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY" />
             </intent-filter>
         </service>
 
         <service
             android:name="com.evernote.android.job.JobRescheduleService"
-            android:exported="false"/>
+            android:exported="false" />
 
         <service
             android:name="com.evernote.android.job.v21.PlatformJobService"
             android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE"/>
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <service
             android:name="com.evernote.android.job.v14.PlatformAlarmService"
-            android:exported="false"/>
+            android:exported="false" />
 
         <receiver
             android:name="com.evernote.android.job.v14.PlatformAlarmReceiver"
             android:exported="false">
             <intent-filter>
                 <!-- Keep the filter for legacy intents -->
-                <action android:name="com.evernote.android.job.v14.RUN_JOB"/>
-                <action android:name="net.vrallev.android.job.v14.RUN_JOB"/>
+                <action android:name="com.evernote.android.job.v14.RUN_JOB" />
+                <action android:name="net.vrallev.android.job.v14.RUN_JOB" />
             </intent-filter>
         </receiver>
 
@@ -352,29 +351,30 @@
             android:name="com.evernote.android.job.JobBootReceiver"
             android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
-                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 
         <service
             android:name="com.waz.services.calling.CallingNotificationsService"
-            android:exported="false"
-            />
+            android:exported="false" />
         <service
             android:name="com.waz.services.calling.CallWakeService"
-            android:exported="true"
-            />
+            android:exported="true" />
         <service
             android:name="com.waz.services.notifications.NotificationsHandlerService"
-            android:exported="false"
-            />
+            android:exported="false" />
 
         <!-- Here you can put customized HTTP Proxy details -->
-        <meta-data android:name="http_proxy_url" android:value=""/>
-        <meta-data android:name="http_proxy_port" android:value=""/>
+        <meta-data
+            android:name="http_proxy_url"
+            android:value="" />
+        <meta-data
+            android:name="http_proxy_port"
+            android:value="" />
     </application>
 
 </manifest>

--- a/app/src/main/res/layout/activity_legal_hold_info.xml
+++ b/app/src/main/res/layout/activity_legal_hold_info.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?wireBackgroundCollection">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/legal_hold_info_toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?wireBackgroundColor"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.waz.zclient.common.views.GlyphButton
+            android:id="@+id/legal_hold_info_close_button"
+            android:layout_width="@dimen/action_icon__size"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical|end"
+            android:layout_marginEnd="@dimen/wire__padding__small"
+            android:text="@string/glyph__close"
+            android:textColor="?wirePrimaryTextColor"
+            android:textSize="@dimen/wire__icon_button__text_size" />
+
+    </androidx.appcompat.widget.Toolbar>
+
+    <FrameLayout
+        android:id="@+id/legal_hold_info_fragment_container_layout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/legal_hold_info_toolbar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_legal_hold_info.xml
+++ b/app/src/main/res/layout/fragment_legal_hold_info.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/legal_hold_info_image_view"
+        android:layout_width="@dimen/legal_hold_info_image_size"
+        android:layout_height="@dimen/legal_hold_info_image_size"
+        android:layout_marginTop="@dimen/wire__margin_huge"
+        android:src="@drawable/ic_legal_hold_active"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/legal_hold_info_title_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/wire__padding__huge"
+        android:text="@string/legal_hold_info_title"
+        android:textColor="?wirePrimaryTextColor"
+        android:textSize="@dimen/wire__text_size__big"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/legal_hold_info_image_view"
+        app:w_font="@string/wire__typeface__bold" />
+
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/legal_hold_info_message_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/wire__padding__huge"
+        android:gravity="start"
+        android:paddingStart="@dimen/wire__padding__16"
+        android:paddingEnd="@dimen/wire__padding__16"
+        android:paddingBottom="@dimen/wire__padding__20"
+        android:textColor="?wirePrimaryTextColor"
+        android:textSize="@dimen/wire__text_size__regular"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/legal_hold_info_title_text_view"
+        app:w_font="@string/wire__typeface__regular"
+        tools:text="@string/legal_hold_self_user_info_message" />
+
+    <com.waz.zclient.ui.text.TypefaceTextView
+        android:id="@+id/legal_hold_info_list_title_text_view"
+        style="?userChatHeadLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/wire__padding__16"
+        android:layout_marginEnd="@dimen/wire__padding__16"
+        android:paddingTop="@dimen/wire__padding__tiny"
+        android:text="@string/legal_hold_info_list_title"
+        android:textColor="@color/light_graphite"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/legal_hold_info_message_text_view"
+        app:w_font="@string/wire__typeface__medium" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/legal_hold_info_subjects_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/wire__padding__8"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/legal_hold_info_list_title_text_view" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -680,4 +680,6 @@
     <dimen name="rounded_button_text_size">12sp</dimen>
     <dimen name="welcome_title_text_size">32sp</dimen>
     <dimen name="welcome_title_line_spacing_extra">8sp</dimen>
+
+    <dimen name="legal_hold_info_image_size">64dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1578,5 +1578,12 @@
     <string name="start_sso_leaving_wire">Redirecting…</string>
     <string name="start_sso_redirected_to">You are being redirected to your dedicated enterprise service.</string>
     <string name="start_sso_notice">Provide credentials only if you\'re sure this is your organization\'s login.</string>
+
+    <!-- Legal Hold -->
+    <string name="legal_hold_info_title">Legal Hold</string>
+    <string name="legal_hold_self_user_info_message">Legal Hold has been activated for your account.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.\n\nYour conversation partners will be aware of the recording.
+    </string>
+    <string name="legal_hold_info_list_title">Legal Hold Subjects</string>
+
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -52,6 +52,7 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{FragmentHelper, OnBackPressedListener, R, ViewHolder}
 import com.waz.threading.Threading._
+import com.waz.zclient.legalhold.SelfUserLegalHoldInfoActivity
 
 /**
   * Due to how we use the NormalConversationListFragment - it gets replaced by the ArchiveConversationListFragment or
@@ -214,6 +215,9 @@ class NormalConversationFragment extends ConversationListFragment {
     subs += Signal.zip(unreadCount, incomingClients, readReceiptsChanged).onUi {
       case (count, clients, rrChanged) => vh.foreach(_.setIndicatorVisible(clients.nonEmpty || count > 0 || rrChanged))
     }
+    vh.foreach({ toolbar =>
+      subs += toolbar.legalHoldIndicatorClick.onUi(_ => showLegalHoldInfo())
+    })
   }
 
   lazy val loadingListView = view[View](R.id.conversation_list_loading_indicator)
@@ -306,6 +310,11 @@ class NormalConversationFragment extends ConversationListFragment {
       showLoading()
       waitingAccount ! Some(UserId(data.getStringExtra(PreferencesActivity.SwitchAccountExtra)))
     }
+  }
+
+  private def showLegalHoldInfo(): Unit = {
+    startActivity(SelfUserLegalHoldInfoActivity.newIntent(getActivity))
+    getActivity.overridePendingTransition(R.anim.in_from_bottom_pop_enter, R.anim.fade_out)
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -105,11 +105,7 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
   private val settingsIndicator = findById[CircleView](R.id.conversation_list_settings_indicator)
 
   private val legalHoldIndicatorButton = returning(findById[ImageButton](R.id.conversation_list_toolbar_image_button_legal_hold)) { button =>
-    button.setOnClickListener(new OnClickListener {
-      override def onClick(v: View): Unit = {
-        legalHoldIndicatorClick ! Unit
-      }
-    })
+    button.onClick { legalHoldIndicatorClick ! (()) }
   }
 
   val legalHoldIndicatorClick: SourceStream[Unit] = EventStream[Unit]()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -25,7 +25,7 @@ import android.widget.{FrameLayout, ImageButton, ImageView}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Availability, UserData}
 import com.waz.service.teams.TeamsService
-import com.wire.signals.{EventStream, Signal}
+import com.wire.signals.{EventStream, Signal, SourceStream}
 import com.waz.utils.{NameParts, returning}
 import com.waz.zclient.common.drawables.TeamIconDrawable
 import com.waz.zclient.common.views.GlyphButton
@@ -104,7 +104,15 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
 
   private val settingsIndicator = findById[CircleView](R.id.conversation_list_settings_indicator)
 
-  private val legalHoldIndicatorButton = findById[ImageButton](R.id.conversation_list_toolbar_image_button_legal_hold)
+  private val legalHoldIndicatorButton = returning(findById[ImageButton](R.id.conversation_list_toolbar_image_button_legal_hold)) { button =>
+    button.setOnClickListener(new OnClickListener {
+      override def onClick(v: View): Unit = {
+        legalHoldIndicatorClick ! Unit
+      }
+    })
+  }
+
+  val legalHoldIndicatorClick: SourceStream[Unit] = EventStream[Unit]()
 
   separatorDrawable.setDuration(0)
   separatorDrawable.setMinMax(0.0f, 1.0f)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -134,10 +134,9 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
   (for {
     selfUser        <- usersController.selfUser
     legalHoldActive <- inject[LegalHoldController].isLegalHoldActive(selfUser.id)
-  } yield (legalHoldActive)).onUi({ isActive =>
-    if (isActive) legalHoldIndicatorButton.setVisibility(View.VISIBLE)
-    else legalHoldIndicatorButton.setVisibility(View.INVISIBLE)
-  })
+  } yield legalHoldActive)
+    .map(if(_) View.VISIBLE else View.INVISIBLE)
+    .onUi(legalHoldIndicatorButton.setVisibility)
 
   def setIndicatorVisible(visible: Boolean): Unit = settingsIndicator.setVisible(visible)
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -2,14 +2,11 @@ package com.waz.zclient.legalhold
 
 import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
-import androidx.annotation.StringRes
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.waz.model.UserId
-import com.waz.utils.returning
-import com.waz.zclient.FragmentHelper
 import com.waz.zclient.pages.BaseFragment
-import com.waz.zclient.R
 import com.waz.zclient.ui.text.TypefaceTextView
+import com.waz.zclient.{FragmentHelper, R}
 import com.wire.signals.Signal
 
 class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container]()
@@ -32,11 +29,8 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
     setUpRecyclerView()
   }
 
-  private def setMessage(): Unit = {
-    getIntArg(ARG_MESSAGE_RES).foreach { messageResId =>
-      infoMessageTextView.foreach(_.setText(messageResId))
-    }
-  }
+  private def setMessage(): Unit =
+      infoMessageTextView.foreach(_.setText(getContainer.legalHoldInfoMessage))
 
   private def setUpRecyclerView(): Unit = {
     subjectsRecyclerView.foreach { recyclerView =>
@@ -50,15 +44,10 @@ object LegalHoldInfoFragment {
 
   trait Container {
     val legalHoldUsers: Signal[Seq[UserId]]
+    val legalHoldInfoMessage: Int
   }
 
   private val MAX_PARTICIPANTS = 7
-  private val ARG_MESSAGE_RES = "LegalHoldInfoFragment_messageResId"
 
-  def newInstance(@StringRes messageResId: Int): LegalHoldInfoFragment =
-    returning(new LegalHoldInfoFragment()) { frag =>
-      val bundle = new Bundle()
-      bundle.putInt(ARG_MESSAGE_RES, messageResId)
-      frag.setArguments(bundle)
-    }
+  def newInstance() = new LegalHoldInfoFragment()
 }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -32,12 +32,11 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
   private def setMessage(): Unit =
       infoMessageTextView.foreach(_.setText(getContainer.legalHoldInfoMessage))
 
-  private def setUpRecyclerView(): Unit = {
+  private def setUpRecyclerView(): Unit =
     subjectsRecyclerView.foreach { recyclerView =>
       recyclerView.setLayoutManager(new LinearLayoutManager(getContext))
       recyclerView.setAdapter(adapter)
     }
-  }
 }
 
 object LegalHoldInfoFragment {

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -1,0 +1,64 @@
+package com.waz.zclient.legalhold
+
+import android.os.Bundle
+import android.view.{LayoutInflater, View, ViewGroup}
+import androidx.annotation.StringRes
+import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
+import com.waz.model.UserId
+import com.waz.utils.returning
+import com.waz.zclient.FragmentHelper
+import com.waz.zclient.pages.BaseFragment
+import com.waz.zclient.R
+import com.waz.zclient.ui.text.TypefaceTextView
+import com.wire.signals.Signal
+
+class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container]()
+  with FragmentHelper {
+
+  import LegalHoldInfoFragment._
+
+  private lazy val infoMessageTextView = view[TypefaceTextView](R.id.legal_hold_info_message_text_view)
+  private lazy val subjectsRecyclerView = view[RecyclerView](R.id.legal_hold_info_subjects_recycler_view)
+  private lazy val adapter = new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)
+
+  private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
+
+  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View =
+    inflater.inflate(R.layout.fragment_legal_hold_info, container, false)
+
+  override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
+    super.onViewCreated(view, savedInstanceState)
+    setMessage()
+    setUpRecyclerView()
+  }
+
+  private def setMessage(): Unit = {
+    getIntArg(ARG_MESSAGE_RES).foreach { messageResId =>
+      infoMessageTextView.foreach(_.setText(messageResId))
+    }
+  }
+
+  private def setUpRecyclerView(): Unit = {
+    subjectsRecyclerView.foreach { recyclerView =>
+      recyclerView.setLayoutManager(new LinearLayoutManager(getContext))
+      recyclerView.setAdapter(adapter)
+    }
+  }
+}
+
+object LegalHoldInfoFragment {
+
+  trait Container {
+    val legalHoldUsers: Signal[Seq[UserId]]
+  }
+
+  private val MAX_PARTICIPANTS = 7
+  private val ARG_MESSAGE_RES = "LegalHoldInfoFragment_messageResId"
+
+  def newInstance(@StringRes messageResId: Int): LegalHoldInfoFragment =
+    returning(new LegalHoldInfoFragment()) { frag =>
+      val bundle = new Bundle()
+      bundle.putInt(ARG_MESSAGE_RES, messageResId)
+      frag.setArguments(bundle)
+    }
+}

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
@@ -1,0 +1,40 @@
+package com.waz.zclient.legalhold
+
+import android.content.Context
+import com.waz.model.UserId
+import com.waz.zclient.Injector
+import com.waz.zclient.participants.ParticipantsAdapter
+import com.waz.zclient.participants.ParticipantsAdapter.{AllParticipants, NoResultsInfo, ParticipantData}
+import com.wire.signals.{EventContext, Signal}
+
+class LegalHoldUsersAdapter(userIds: Signal[Set[UserId]], maxParticipants: Int)
+                           (implicit context: Context, injector: Injector, eventContext: EventContext)
+  extends ParticipantsAdapter(Signal.empty, Some(maxParticipants), true, true, None) {
+
+  override protected lazy val users = for {
+    selfId       <- selfId
+    usersStorage <- usersStorage
+    teamId       <- team
+    userIds      <- userIds
+    users        <- usersStorage.listSignal(userIds.toList)
+  } yield
+    users.map(user => ParticipantData(
+      user,
+      isGuest = user.isGuest(teamId),
+      isAdmin = false, // unused
+      isSelf = user.id == selfId
+    )).sortBy(_.userData.name.str)
+
+  override protected lazy val positions =
+    for {
+      users   <- users
+      toShow   = users.toList.take(maxParticipants)
+      hasMore  = users.size > maxParticipants
+    } yield {
+      if (users.isEmpty) List(Right(NoResultsInfo))
+      else {
+        val moreUsersRow = if (hasMore) List(Right(AllParticipants)) else Nil
+        toShow.map(data => Left(data)) ::: moreUsersRow
+      }
+    }
+}

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -2,12 +2,11 @@ package com.waz.zclient.legalhold
 
 import android.content.{Context, Intent}
 import android.os.Bundle
-import android.view.View
 import com.waz.model.UserId
-import com.waz.zclient.BaseActivity
-import com.waz.zclient.messages.UsersController
-import com.waz.zclient.R
+import com.waz.zclient.{BaseActivity, R}
 import com.waz.zclient.common.views.GlyphButton
+import com.waz.zclient.messages.UsersController
+import com.waz.zclient.utils.RichView
 import com.wire.signals.Signal
 
 class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragment.Container {
@@ -17,6 +16,8 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragm
   override lazy val legalHoldUsers: Signal[Seq[UserId]] =
     inject[UsersController].selfUser.map(user => Seq(user.id))
 
+  override lazy val legalHoldInfoMessage: Int = R.string.legal_hold_self_user_info_message
+
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_legal_hold_info)
@@ -24,17 +25,13 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragm
     showLegalHoldInfo()
   }
 
-  private def setUpCloseButton(): Unit = {
-    closeButton.setOnClickListener(new View.OnClickListener {
-      override def onClick(v: View): Unit = finish()
-    })
-  }
+  private def setUpCloseButton(): Unit = closeButton.onClick { finish() }
 
   private def showLegalHoldInfo(): Unit = {
     getSupportFragmentManager.beginTransaction()
       .replace(
         R.id.legal_hold_info_fragment_container_layout,
-        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message)
+        LegalHoldInfoFragment.newInstance()
       ).commit()
   }
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -1,0 +1,49 @@
+package com.waz.zclient.legalhold
+
+import android.content.{Context, Intent}
+import android.os.Bundle
+import android.view.View
+import com.waz.model.UserId
+import com.waz.zclient.BaseActivity
+import com.waz.zclient.messages.UsersController
+import com.waz.zclient.R
+import com.waz.zclient.common.views.GlyphButton
+import com.wire.signals.Signal
+
+class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragment.Container {
+
+  private lazy val closeButton = findById[GlyphButton](R.id.legal_hold_info_close_button)
+
+  override lazy val legalHoldUsers: Signal[Seq[UserId]] =
+    inject[UsersController].selfUser.map(user => Seq(user.id))
+
+  override def onCreate(savedInstanceState: Bundle): Unit = {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_legal_hold_info)
+    setUpCloseButton()
+    showLegalHoldInfo()
+  }
+
+  private def setUpCloseButton(): Unit = {
+    closeButton.setOnClickListener(new View.OnClickListener {
+      override def onClick(v: View): Unit = finish()
+    })
+  }
+
+  private def showLegalHoldInfo(): Unit = {
+    getSupportFragmentManager.beginTransaction()
+      .replace(
+        R.id.legal_hold_info_fragment_container_layout,
+        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message)
+      ).commit()
+  }
+
+  override def finish(): Unit = {
+    super.finish()
+    overridePendingTransition(R.anim.fade_in, R.anim.out_to_bottom_pop_exit)
+  }
+}
+
+object SelfUserLegalHoldInfoActivity {
+  def newIntent(context: Context) = new Intent(context, classOf[SelfUserLegalHoldInfoActivity])
+}

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -27,13 +27,12 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragm
 
   private def setUpCloseButton(): Unit = closeButton.onClick { finish() }
 
-  private def showLegalHoldInfo(): Unit = {
+  private def showLegalHoldInfo(): Unit = 
     getSupportFragmentManager.beginTransaction()
       .replace(
         R.id.legal_hold_info_fragment_container_layout,
         LegalHoldInfoFragment.newInstance()
       ).commit()
-  }
 
   override def finish(): Unit = {
     super.finish()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira: [SQSERVICES-343](https://wearezeta.atlassian.net/browse/SQSERVICES-343), [SQSERVICES-345](https://wearezeta.atlassian.net/browse/SQSERVICES-345)

Given that I'm under legal hold, when I click on legal hold indicator on top of conversation list page ( #3211 ), then I should see a detail screen which explains what legal hold means.

### Solutions

| Light Theme | Dark Theme |
|-------------|--------------|
| <img src="https://user-images.githubusercontent.com/2143283/112174090-6bb26080-8bf6-11eb-8b4e-25b3d7c8e154.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/2143283/112174151-766cf580-8bf6-11eb-97c5-8f328b8406b8.png" width="300px"/> |

### Testing

Tested manually w/ mock data.

## Notes

A similar screen will be implemented for participants of a conversation, so some values are parameterized.

#### APK
[Download build #3218](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3218/artifact/build/artifact/wire-dev-PR3212-3218.apk)
[Download build #3219](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3219/artifact/build/artifact/wire-dev-PR3212-3219.apk)
[Download build #3220](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3220/artifact/build/artifact/wire-dev-PR3212-3220.apk)
[Download build #3221](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3221/artifact/build/artifact/wire-dev-PR3212-3221.apk)
[Download build #3222](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3222/artifact/build/artifact/wire-dev-PR3212-3222.apk)
[Download build #3223](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3223/artifact/build/artifact/wire-dev-PR3212-3223.apk)
[Download build #3231](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3231/artifact/build/artifact/wire-dev-PR3212-3231.apk)