### PR TITLE
Feature: Legal Hold - Legal hold details screen for conversation

### DIFF
--- a/app/src/main/res/layout/fragment_legal_hold_info.xml
+++ b/app/src/main/res/layout/fragment_legal_hold_info.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?wireBackgroundCollection">
 
     <ImageView
         android:id="@+id/legal_hold_info_image_view"
@@ -64,6 +65,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/wire__padding__8"
+        android:layout_marginBottom="@dimen/wire__padding__16"
+        android:background="?wireBackgroundColor"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/legal_hold_info_list_title_text_view" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1581,8 +1581,8 @@
 
     <!-- Legal Hold -->
     <string name="legal_hold_info_title">Legal Hold</string>
-    <string name="legal_hold_self_user_info_message">Legal Hold has been activated for your account.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.\n\nYour conversation partners will be aware of the recording.
-    </string>
+    <string name="legal_hold_self_user_info_message">Legal Hold has been activated for your account.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.\n\nYour conversation partners will be aware of the recording.</string>
+    <string name="legal_hold_conversation_info_message">Legal Hold has been activated for at least one person in this conversation.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.</string>
     <string name="legal_hold_info_list_title">Legal Hold Subjects</string>
     <string name="legal_hold_request_dialog_title">Legal Hold Requested</string>
     <string name="legal_hold_request_dialog_message_for_sso">All future messages will be recorded by the device with fingerprint:\n%1$s\nThis includes deleted, edited and timed messages in all conversations.</string>

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -16,4 +16,7 @@ class LegalHoldController(implicit injector: Injector)
 
   def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] =
     Signal.const(false)
+
+  def legalHoldUsers(conversationId: ConvId): Signal[Seq[UserId]] =
+    Signal.const(Seq.empty)
 }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.waz.model.UserId
+import com.waz.utils.returning
 import com.waz.zclient.pages.BaseFragment
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.{FragmentHelper, R}
@@ -16,6 +17,7 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
 
   private lazy val infoMessageTextView = view[TypefaceTextView](R.id.legal_hold_info_message_text_view)
   private lazy val subjectsRecyclerView = view[RecyclerView](R.id.legal_hold_info_subjects_recycler_view)
+
   private lazy val adapter = new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)
 
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
@@ -30,7 +32,9 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
   }
 
   private def setMessage(): Unit =
-      infoMessageTextView.foreach(_.setText(getContainer.legalHoldInfoMessage))
+    infoMessageTextView.foreach { textView =>
+      getIntArg(ARG_MESSAGE_RES_ID).foreach(textView.setText)
+    }
 
   private def setUpRecyclerView(): Unit =
     subjectsRecyclerView.foreach { recyclerView =>
@@ -43,10 +47,17 @@ object LegalHoldInfoFragment {
 
   trait Container {
     val legalHoldUsers: Signal[Seq[UserId]]
-    val legalHoldInfoMessage: Int
   }
 
+  val TAG = "LegalHoldInfoFragment"
   private val MAX_PARTICIPANTS = 7
+  val ARG_MESSAGE_RES_ID = "messageResId_Arg"
 
-  def newInstance() = new LegalHoldInfoFragment()
+  def newInstance(messageResId: Int): LegalHoldInfoFragment =
+    returning(new LegalHoldInfoFragment()) { frag =>
+      val args = returning(new Bundle()) {
+        _.putInt(ARG_MESSAGE_RES_ID, messageResId)
+      }
+      frag.setArguments(args)
+    }
 }

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -16,8 +16,6 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragm
   override lazy val legalHoldUsers: Signal[Seq[UserId]] =
     inject[UsersController].selfUser.map(user => Seq(user.id))
 
-  override lazy val legalHoldInfoMessage: Int = R.string.legal_hold_self_user_info_message
-
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_legal_hold_info)
@@ -27,11 +25,11 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragm
 
   private def setUpCloseButton(): Unit = closeButton.onClick { finish() }
 
-  private def showLegalHoldInfo(): Unit = 
+  private def showLegalHoldInfo(): Unit =
     getSupportFragmentManager.beginTransaction()
       .replace(
         R.id.legal_hold_info_fragment_container_layout,
-        LegalHoldInfoFragment.newInstance()
+        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message)
       ).commit()
 
   override def finish(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -19,12 +19,11 @@ package com.waz.zclient.participants.fragments
 
 import android.content.Context
 import android.os.Bundle
-import androidx.appcompat.widget.Toolbar
 import android.view._
 import android.widget.{ImageButton, TextView}
-import com.wire.signals.CancellableFuture
+import androidx.appcompat.widget.Toolbar
 import com.waz.threading.Threading
-import com.wire.signals.Signal
+import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient.ManagerFragment.Page
 import com.waz.zclient.common.controllers.ThemeController
@@ -36,13 +35,12 @@ import com.waz.zclient.legalhold.LegalHoldController
 import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.utils.ContextUtils.{getColor, getDimenPx, getDrawable}
-import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils}
-import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
-import com.waz.zclient.utils._
+import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils, _}
 import com.waz.zclient.views.AvailabilityView
+import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
+import com.wire.signals.{CancellableFuture, EventStream, Signal, SourceStream}
 
 import scala.concurrent.duration._
-import com.waz.threading.Threading._
 
 class ParticipantHeaderFragment extends FragmentHelper {
 
@@ -190,6 +188,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
     }
   }
 
+  val onLegalHoldClick: SourceStream[Unit] = EventStream[Unit]()
   private lazy val legalHoldIndicatorButton = view[ImageButton](R.id.participants_header_toolbar_image_button_legal_hold)
 
   private lazy val legalHoldActive : Signal[Boolean] =
@@ -247,12 +246,11 @@ class ParticipantHeaderFragment extends FragmentHelper {
     super.onPause()
   }
 
-  private def setUpLegalHoldIndicator(): Unit = {
-    legalHoldActive.onUi({ isActive =>
-      legalHoldIndicatorButton.foreach(_.setVisible(isActive))
-    })
-    //TODO: set click event for legal hold info
-  }
+  private def setUpLegalHoldIndicator(): Unit =
+    legalHoldIndicatorButton.foreach { button =>
+      button.onClick { onLegalHoldClick ! Unit}
+      legalHoldActive.onUi(button.setVisible)
+    }
 
   private def fromDeepLink() = getBooleanArg(ARG_FROM_DEEP_LINK)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira: [SQSERVICES-343](https://wearezeta.atlassian.net/browse/SQSERVICES-343), [SQSERVICES-345](https://wearezeta.atlassian.net/browse/SQSERVICES-345)

Given there's a conversation with at least one participant who is subject to legal hold, 
when I click on legal hold indicator on top of conversation details title ( #3206 ), 
then I should see a detail screen which explains what legal hold means, 
and see list of participants who are subject to legal hold.

### Solutions

The UI is same as #3212 

### Testing

Tested manually with mock data.



#### APK
[Download build #3227](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3227/artifact/build/artifact/wire-dev-PR3213-3227.apk)
[Download build #3229](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3229/artifact/build/artifact/wire-dev-PR3213-3229.apk)
[Download build #3238](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3238/artifact/build/artifact/wire-dev-PR3213-3238.apk)
[Download build #3244](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3244/artifact/build/artifact/wire-dev-PR3213-3244.apk)
[Download build #3274](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3274/artifact/build/artifact/wire-dev-PR3213-3274.apk)