### PR TITLE
Feature: Legal Hold - Legal hold details screen for conversation - Show user's device list

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -5,7 +5,7 @@ import com.waz.model.{ConvId, LegalHoldRequest, UserId}
 import com.waz.service.LegalHoldService
 import com.waz.sync.handler.LegalHoldError
 import com.waz.zclient.{Injectable, Injector}
-import com.wire.signals.Signal
+import com.wire.signals.{EventStream, Signal, SourceStream}
 
 import scala.concurrent.Future
 
@@ -16,6 +16,8 @@ class LegalHoldController(implicit injector: Injector)
   import com.waz.threading.Threading.Implicits.Background
 
   private lazy val legalHoldService = inject[Signal[LegalHoldService]]
+
+  val onLegalHoldSubjectClick: SourceStream[UserId] = EventStream[UserId]
 
   def isLegalHoldActive(userId: UserId): Signal[Boolean] =
     Signal.const(false)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -18,8 +18,10 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
   private lazy val infoMessageTextView = view[TypefaceTextView](R.id.legal_hold_info_message_text_view)
   private lazy val subjectsRecyclerView = view[RecyclerView](R.id.legal_hold_info_subjects_recycler_view)
 
+  private lazy val legalHoldController = inject[LegalHoldController]
+
   private lazy val adapter = returning(new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)) {
-    _.onClick(getContainer.onLegalHoldSubjectClick)
+    _.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
   }
 
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
@@ -49,8 +51,6 @@ object LegalHoldInfoFragment {
 
   trait Container {
     val legalHoldUsers: Signal[Seq[UserId]]
-
-    def onLegalHoldSubjectClick(userId: UserId): Unit = {}
   }
 
   val Tag = "LegalHoldInfoFragment"

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -53,7 +53,7 @@ object LegalHoldInfoFragment {
     def onLegalHoldSubjectClick(userId: UserId): Unit = {}
   }
 
-  val TAG = "LegalHoldInfoFragment"
+  val Tag = "LegalHoldInfoFragment"
   private val MAX_PARTICIPANTS = 7
   val ARG_MESSAGE_RES_ID = "messageResId_Arg"
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -18,7 +18,9 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
   private lazy val infoMessageTextView = view[TypefaceTextView](R.id.legal_hold_info_message_text_view)
   private lazy val subjectsRecyclerView = view[RecyclerView](R.id.legal_hold_info_subjects_recycler_view)
 
-  private lazy val adapter = new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)
+  private lazy val adapter = returning(new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)) {
+    _.onClick(getContainer.onLegalHoldSubjectClick)
+  }
 
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
 
@@ -47,6 +49,8 @@ object LegalHoldInfoFragment {
 
   trait Container {
     val legalHoldUsers: Signal[Seq[UserId]]
+
+    def onLegalHoldSubjectClick(userId: UserId): Unit = {}
   }
 
   val TAG = "LegalHoldInfoFragment"

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -246,9 +246,9 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       .replace(
         R.id.fl__participant__container,
         LegalHoldInfoFragment.newInstance(R.string.legal_hold_conversation_info_message),
-        LegalHoldInfoFragment.TAG
+        LegalHoldInfoFragment.Tag
       )
-      .addToBackStack(LegalHoldInfoFragment.TAG)
+      .addToBackStack(LegalHoldInfoFragment.Tag)
       .commit
 
   override def onLegalHoldSubjectClick(userId: UserId): Unit = showUser(userId, forLegalHold = true)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -251,7 +251,9 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       .addToBackStack(LegalHoldInfoFragment.TAG)
       .commit
 
-  private def showUser(userId: UserId): Unit = usersController.syncUserAndCheckIfDeleted(userId).foreach {
+  override def onLegalHoldSubjectClick(userId: UserId): Unit = showUser(userId, forLegalHold = true)
+
+  private def showUser(userId: UserId, forLegalHold: Boolean = false): Unit = usersController.syncUserAndCheckIfDeleted(userId).foreach {
     case (Some(user), None) =>
       ContextUtils.showToast(getString(R.string.participant_was_removed_from_team, user.name.str))
     case (None, None) =>
@@ -267,7 +269,9 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
         isTeamMember <- userAccountsController.isTeamMember(userId).head
       } userOpt match {
         case Some(user) if user.connection == ACCEPTED || user.expiresAt.isDefined || isTeamMember =>
-          openUserProfileFragment(SingleParticipantFragment.newInstance(), SingleParticipantFragment.Tag)
+          import SingleParticipantFragment._
+          val tabToOpen = if (forLegalHold) Some(DevicesTab.str) else None
+          openUserProfileFragment(SingleParticipantFragment.newInstance(tabToOpen), Tag)
 
         case Some(user) if user.connection == PENDING_FROM_USER || user.connection == IGNORED =>
           import PendingConnectRequestFragment._

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -66,13 +66,14 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
   private lazy val singleImageController  = inject[ISingleImageController]
   private lazy val userAccountsController = inject[UserAccountsController]
   private lazy val convScreenController   = inject[IConversationScreenController]
+  private lazy val legalHoldController    = inject[LegalHoldController]
 
   private lazy val headerFragment = ParticipantHeaderFragment.newInstance(fromDeepLink = getBooleanArg(FromDeepLinkArg))
 
   override lazy val legalHoldUsers: Signal[Seq[UserId]] =
     for {
       convId <- inject[ConversationController].currentConvId
-      users  <- inject[LegalHoldController].legalHoldUsers(convId)
+      users  <- legalHoldController.legalHoldUsers(convId)
     } yield users
 
   override def onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation =
@@ -128,6 +129,7 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       case _ =>
     }
     headerFragment.onLegalHoldClick { _ => openLegalHoldInfoScreen() }
+    legalHoldController.onLegalHoldSubjectClick { userId => showUser(userId, forLegalHold = true) }
   }
 
   override def onStart(): Unit = {
@@ -250,8 +252,6 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       )
       .addToBackStack(LegalHoldInfoFragment.Tag)
       .commit
-
-  override def onLegalHoldSubjectClick(userId: UserId): Unit = showUser(userId, forLegalHold = true)
 
   private def showUser(userId: UserId, forLegalHold: Boolean = false): Unit = usersController.syncUserAndCheckIfDeleted(userId).foreach {
     case (Some(user), None) =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira: [SQSERVICES-345](https://wearezeta.atlassian.net/browse/SQSERVICES-345)

Given that I am on legal hold details screen for a conversation, 
when I click one of the users on legal hold subjects list,
then I should see user's device list

### Solutions

Open user details screen using existing checks with devices tab on if possible.


#### APK
[Download build #3225](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3225/artifact/build/artifact/wire-dev-PR3214-3225.apk)
[Download build #3228](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3228/artifact/build/artifact/wire-dev-PR3214-3228.apk)
[Download build #3230](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3230/artifact/build/artifact/wire-dev-PR3214-3230.apk)
[Download build #3232](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3232/artifact/build/artifact/wire-dev-PR3214-3232.apk)
[Download build #3234](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3234/artifact/build/artifact/wire-dev-PR3214-3234.apk)
[Download build #3243](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3243/artifact/build/artifact/wire-dev-PR3214-3243.apk)
[Download build #3273](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3273/artifact/build/artifact/wire-dev-PR3214-3273.apk)
[Download build #3275](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3275/artifact/build/artifact/wire-dev-PR3214-3275.apk)
[Download build #3277](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3277/artifact/build/artifact/wire-dev-PR3214-3277.apk)
[Download build #3350](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3350/artifact/build/artifact/wire-dev-PR3214-3350.apk)