### PR TITLE
A revert of a part of a code changed in "Optimize push notifications (#3180)"

### DIFF
--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -23,6 +23,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InForeground
 import com.waz.service._
+import com.waz.service.push.PushService.{FetchFromIdle, SyncHistory}
 import com.waz.service.push._
 import com.waz.services.ZMessagingService
 import com.waz.services.fcm.FCMHandlerService._
@@ -31,7 +32,7 @@ import com.waz.utils.JsonDecoder
 import com.waz.zclient.WireApplication
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.security._
-import com.wire.signals.{CancellableFuture, Serialized}
+import com.wire.signals.CancellableFuture
 import org.json
 import org.threeten.bp.Instant
 
@@ -155,7 +156,7 @@ object FCMHandlerService {
           * online at once. For that reason, we start a job which can run for as long as we need to avoid the app from being
           * killed mid-processing messages.
           */
-          _ <- Serialized.future("fetch")(Future(FetchJob(userId, nId)))
+          _ <- push.syncNotifications(SyncHistory(FetchFromIdle(nId)))
       } yield {}
   }
 

--- a/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
+++ b/app/src/main/scala/com/waz/services/fcm/FCMHandlerService.scala
@@ -23,7 +23,6 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Uid, UserId}
 import com.waz.service.AccountsService.InForeground
 import com.waz.service._
-import com.waz.service.push.PushService.{FetchFromIdle, SyncHistory}
 import com.waz.service.push._
 import com.waz.services.ZMessagingService
 import com.waz.services.fcm.FCMHandlerService._
@@ -32,7 +31,7 @@ import com.waz.utils.JsonDecoder
 import com.waz.zclient.WireApplication
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.security._
-import com.wire.signals.CancellableFuture
+import com.wire.signals.{CancellableFuture, Serialized}
 import org.json
 import org.threeten.bp.Instant
 
@@ -156,7 +155,7 @@ object FCMHandlerService {
           * online at once. For that reason, we start a job which can run for as long as we need to avoid the app from being
           * killed mid-processing messages.
           */
-          _ <- push.syncNotifications(SyncHistory(FetchFromIdle(nId)))
+          _ <- Serialized.future("fetch")(Future(FetchJob(userId, nId)))
       } yield {}
   }
 


### PR DESCRIPTION
Since 3.65 which introduced #3180 we get reports from Google Play Console about a crash connected to notifications:
https://play.google.com/console/u/3/developers/7098984309886892484/app/4973241010395499500/vitals/crashes/a5a7d5b2/details?installedFrom=PLAY_STORE&days=30

Unfortunately it doesn't say much. From when the crash started happening and from what I found in Google, it seems to be a problem with notification channels and/or with that too much time passes between when the notification comes to the device and when the app is displayed in the foreground. So, that would mean, the crash may happen when the app is in background, when it is killed, or when the device is sleeping.

I reverted two parts of the code that may have caused it. One, in WebSocketService, creates a new notification channel (before I thought we already have all channels created and this is not needed, but maybe it is) and the other, in FCMHandlerService, schedules a fetch from the backend instead of doing it immediately (maybe doing it immediately is too heavy and the app is killed).

Notice both "maybe". This is a guesswork. I simply don't see any other change that could cause this problem.

#### APK
[Download build #3239](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3239/artifact/build/artifact/wire-dev-PR3216-3239.apk)
[Download build #3245](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3245/artifact/build/artifact/wire-dev-PR3216-3245.apk)