### PR TITLE
Define legal hold request

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
@@ -17,41 +17,37 @@
  */
 package com.waz.model
 
-import com.waz.model.LegalHoldRequest.Client
-import com.waz.model.otr.PreKeyEncoder
+import com.waz.model.otr.{ClientId, PreKeyEncoder}
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 import com.wire.cryptobox.PreKey
 import org.json.JSONObject
 
-final case class LegalHoldRequest(client: Client, lastPreKey: PreKey)
+final case class LegalHoldRequest(clientId: ClientId, lastPreKey: PreKey)
 
 object LegalHoldRequest {
-
-  final case class Client(id: String)
 
   implicit object Decoder extends JsonDecoder[LegalHoldRequest] {
 
     override def apply(implicit json: JSONObject): LegalHoldRequest =
       LegalHoldRequest(
-        client = decodeClient(json.getJSONObject("client")),
+        clientId = decodeClient(json.getJSONObject("client")),
         lastPreKey = otr.PreKeyDecoder(json.getJSONObject("last_prekey"))
       )
 
-    private def decodeClient(implicit json: JSONObject): Client =
-      Client(json.getString("id"))
-
+    private def decodeClient(implicit json: JSONObject): ClientId =
+      ClientId(json.getString("id"))
   }
 
 
   implicit object Encoder extends JsonEncoder[LegalHoldRequest] {
 
     override def apply(request: LegalHoldRequest): JSONObject = JsonEncoder { json =>
-      json.put("client", encodeClient(request.client))
+      json.put("client", encodeClient(request.clientId))
       json.put("last_prekey", JsonEncoder.encode(request.lastPreKey)(PreKeyEncoder))
     }
 
-    private def encodeClient(client: Client): JSONObject = JsonEncoder { json =>
-      json.put("id", client.id)
+    private def encodeClient(client: ClientId): JSONObject = JsonEncoder { json =>
+      json.put("id", client.str)
     }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
@@ -18,7 +18,7 @@
 package com.waz.model
 
 import com.waz.model.LegalHoldRequest.{Client, Prekey}
-import com.waz.utils.JsonDecoder
+import com.waz.utils.{JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 
 final case class LegalHoldRequest(client: Client, lastPrekey: Prekey)
@@ -30,17 +30,33 @@ object LegalHoldRequest {
 
   implicit object Decoder extends JsonDecoder[LegalHoldRequest] {
 
-    override def apply(implicit js: JSONObject): LegalHoldRequest =
+    override def apply(implicit json: JSONObject): LegalHoldRequest =
       LegalHoldRequest(
-        client = decodeClient(js.getJSONObject("client")),
-        lastPrekey = decodePrekey(js.getJSONObject("last_prekey"))
+        client = decodeClient(json.getJSONObject("client")),
+        lastPrekey = decodePrekey(json.getJSONObject("last_prekey"))
       )
 
-    private def decodeClient(implicit js: JSONObject): Client =
-      Client(js.getString("id"))
+    private def decodeClient(implicit json: JSONObject): Client =
+      Client(json.getString("id"))
 
-    private def decodePrekey(implicit js: JSONObject): Prekey =
-      Prekey(js.getInt("id"), js.getString("key"))
+    private def decodePrekey(implicit json: JSONObject): Prekey =
+      Prekey(json.getInt("id"), json.getString("key"))
   }
 
+  implicit object Encoder extends JsonEncoder[LegalHoldRequest] {
+
+    override def apply(request: LegalHoldRequest): JSONObject = JsonEncoder { json =>
+      json.put("client", encodeClient(request.client))
+      json.put("last_prekey", encodePrekey(request.lastPrekey))
+    }
+
+    private def encodeClient(client: Client): JSONObject = JsonEncoder { json =>
+      json.put("id", client.id)
+    }
+
+    private def encodePrekey(prekey: Prekey): JSONObject = JsonEncoder { json =>
+      json.put("id", prekey.id)
+      json.put("key", prekey.key)
+    }
+  }
 }

--- a/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+import com.waz.model.LegalHoldRequest.{Client, Prekey}
+import com.waz.utils.JsonDecoder
+import org.json.JSONObject
+
+final case class LegalHoldRequest(client: Client, lastPrekey: Prekey)
+
+object LegalHoldRequest {
+
+  final case class Client(id: String)
+  final case class Prekey(id: Int, key: String)
+
+  implicit object Decoder extends JsonDecoder[LegalHoldRequest] {
+
+    override def apply(implicit js: JSONObject): LegalHoldRequest =
+      LegalHoldRequest(
+        client = decodeClient(js.getJSONObject("client")),
+        lastPrekey = decodePrekey(js.getJSONObject("last_prekey"))
+      )
+
+    private def decodeClient(implicit js: JSONObject): Client =
+      Client(js.getString("id"))
+
+    private def decodePrekey(implicit js: JSONObject): Prekey =
+      Prekey(js.getInt("id"), js.getString("key"))
+  }
+
+}

--- a/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/LegalHoldRequest.scala
@@ -17,46 +17,41 @@
  */
 package com.waz.model
 
-import com.waz.model.LegalHoldRequest.{Client, Prekey}
+import com.waz.model.LegalHoldRequest.Client
+import com.waz.model.otr.PreKeyEncoder
 import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.wire.cryptobox.PreKey
 import org.json.JSONObject
 
-final case class LegalHoldRequest(client: Client, lastPrekey: Prekey)
+final case class LegalHoldRequest(client: Client, lastPreKey: PreKey)
 
 object LegalHoldRequest {
 
   final case class Client(id: String)
-  final case class Prekey(id: Int, key: String)
 
   implicit object Decoder extends JsonDecoder[LegalHoldRequest] {
 
     override def apply(implicit json: JSONObject): LegalHoldRequest =
       LegalHoldRequest(
         client = decodeClient(json.getJSONObject("client")),
-        lastPrekey = decodePrekey(json.getJSONObject("last_prekey"))
+        lastPreKey = otr.PreKeyDecoder(json.getJSONObject("last_prekey"))
       )
 
     private def decodeClient(implicit json: JSONObject): Client =
       Client(json.getString("id"))
 
-    private def decodePrekey(implicit json: JSONObject): Prekey =
-      Prekey(json.getInt("id"), json.getString("key"))
   }
+
 
   implicit object Encoder extends JsonEncoder[LegalHoldRequest] {
 
     override def apply(request: LegalHoldRequest): JSONObject = JsonEncoder { json =>
       json.put("client", encodeClient(request.client))
-      json.put("last_prekey", encodePrekey(request.lastPrekey))
+      json.put("last_prekey", JsonEncoder.encode(request.lastPreKey)(PreKeyEncoder))
     }
 
     private def encodeClient(client: Client): JSONObject = JsonEncoder { json =>
       json.put("id", client.id)
-    }
-
-    private def encodePrekey(prekey: Prekey): JSONObject = JsonEncoder { json =>
-      json.put("id", prekey.id)
-      json.put("key", prekey.key)
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
@@ -1,8 +1,10 @@
 package com.waz.model
 
-import com.waz.model.LegalHoldRequest.{Client, Prekey}
+import com.waz.model.LegalHoldRequest._
 import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.crypto.AESUtils
 import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.wire.cryptobox.PreKey
 
 class LegalHoldRequestSpec extends AndroidFreeSpec {
 
@@ -18,7 +20,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
           |  },
           |  "last_prekey": {
           |    "id": 456,
-          |    "key": "abc"
+          |    "key": "oENwaFy74nagzFBlqn9nOQ=="
           |  }
           |}
           |""".stripMargin.replaceAll("\\s", "")
@@ -28,13 +30,16 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
 
       // Then
       legalHoldRequest.client.id shouldEqual "123"
-      legalHoldRequest.lastPrekey.id shouldEqual 456
-      legalHoldRequest.lastPrekey.key shouldEqual "abc"
+      legalHoldRequest.lastPreKey.id shouldEqual 456
+      legalHoldRequest.lastPreKey.data shouldEqual AESUtils.base64("oENwaFy74nagzFBlqn9nOQ==")
     }
 
     scenario("to JSON") {
       // Given
-      val legalHoldRequest = LegalHoldRequest(Client("123"), Prekey(456, "abc"))
+      val legalHoldRequest = LegalHoldRequest(
+        Client("123"),
+        new PreKey(456, AESUtils.base64("oENwaFy74nagzFBlqn9nOQ=="))
+      )
 
       // When
       val json = JsonEncoder.encode[LegalHoldRequest](legalHoldRequest)
@@ -48,7 +53,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
           |  },
           |  "last_prekey": {
           |    "id": 456,
-          |    "key": "abc"
+          |    "key": "oENwaFy74nagzFBlqn9nOQ=="
           |  }
           |}
           |""".stripMargin.replaceAll("\\s", "")

--- a/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
@@ -1,0 +1,34 @@
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.JsonDecoder
+
+class LegalHoldRequestSpec extends AndroidFreeSpec {
+
+  feature("Deserialization") {
+
+    scenario("from JSON") {
+      // Given
+      val json =
+        """
+          |{
+          |  "client": {
+          |    "id": "123"
+          |  },
+          |  "last_prekey": {
+          |    "id": 456,
+          |    "key": "abc"
+          |  }
+          |}
+          |""".stripMargin
+
+      // When
+      val legalHoldRequest: LegalHoldRequest = JsonDecoder.decode[LegalHoldRequest](json)
+
+      // Then
+      legalHoldRequest.client.id shouldEqual "123"
+      legalHoldRequest.lastPrekey.id shouldEqual 456
+      legalHoldRequest.lastPrekey.key shouldEqual "abc"
+    }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
@@ -1,11 +1,12 @@
 package com.waz.model
 
+import com.waz.model.LegalHoldRequest.{Client, Prekey}
 import com.waz.specs.AndroidFreeSpec
-import com.waz.utils.JsonDecoder
+import com.waz.utils.{JsonDecoder, JsonEncoder}
 
 class LegalHoldRequestSpec extends AndroidFreeSpec {
 
-  feature("Deserialization") {
+  feature("Serialization") {
 
     scenario("from JSON") {
       // Given
@@ -29,6 +30,28 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
       legalHoldRequest.client.id shouldEqual "123"
       legalHoldRequest.lastPrekey.id shouldEqual 456
       legalHoldRequest.lastPrekey.key shouldEqual "abc"
+    }
+
+    scenario("to JSON") {
+      // Given
+      val legalHoldRequest = LegalHoldRequest(Client("123"), Prekey(456, "abc"))
+
+      // When
+      val json = JsonEncoder.encode[LegalHoldRequest](legalHoldRequest)
+
+      // Then
+      json.toString shouldEqual
+        """
+          |{
+          |  "client": {
+          |    "id": "123"
+          |  },
+          |  "last_prekey": {
+          |    "id": 456,
+          |    "key": "abc"
+          |  }
+          |}
+          |""".stripMargin
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
@@ -1,6 +1,7 @@
 package com.waz.model
 
 import com.waz.model.LegalHoldRequest._
+import com.waz.model.otr.ClientId
 import com.waz.specs.AndroidFreeSpec
 import com.waz.utils.crypto.AESUtils
 import com.waz.utils.{JsonDecoder, JsonEncoder}
@@ -29,7 +30,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
       val legalHoldRequest: LegalHoldRequest = JsonDecoder.decode[LegalHoldRequest](json)
 
       // Then
-      legalHoldRequest.client.id shouldEqual "123"
+      legalHoldRequest.clientId.str shouldEqual "123"
       legalHoldRequest.lastPreKey.id shouldEqual 456
       legalHoldRequest.lastPreKey.data shouldEqual AESUtils.base64("oENwaFy74nagzFBlqn9nOQ==")
     }
@@ -37,7 +38,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
     scenario("to JSON") {
       // Given
       val legalHoldRequest = LegalHoldRequest(
-        Client("123"),
+        ClientId("123"),
         new PreKey(456, AESUtils.base64("oENwaFy74nagzFBlqn9nOQ=="))
       )
 

--- a/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/LegalHoldRequestSpec.scala
@@ -21,7 +21,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
           |    "key": "abc"
           |  }
           |}
-          |""".stripMargin
+          |""".stripMargin.replaceAll("\\s", "")
 
       // When
       val legalHoldRequest: LegalHoldRequest = JsonDecoder.decode[LegalHoldRequest](json)
@@ -51,7 +51,7 @@ class LegalHoldRequestSpec extends AndroidFreeSpec {
           |    "key": "abc"
           |  }
           |}
-          |""".stripMargin
+          |""".stripMargin.replaceAll("\\s", "")
     }
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

JIRA: [SQSERVICES-348](https://wearezeta.atlassian.net/browse/SQSERVICES-348)

The legal hold request (that will be eventually received from the backend) should be stored locally so it can be processed by the self user at an appropriate time. 

### Solutions

Define request model. Instances of the legal hold request are intended to be stored in the properties table, so we also add encoding and decoding functionality.

### Testing

Added tests for encoding to and decoding from JSON objects.

#### APK
[Download build #3242](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3242/artifact/build/artifact/wire-dev-PR3217-3242.apk)