### PR TITLE
Gradle Android Scala plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}"
-        classpath "com.wire.gradle:gradle-android-scala-plugin:${Versions.SCALA_BUILD_PLUGIN}"
+        classpath "com.wire:gradle-android-scala-plugin:${Versions.SCALA_BUILD_PLUGIN}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
         classpath "org.jetbrains.kotlin:kotlin-serialization:${Versions.KOTLIN}"
         classpath "com.google.gms:google-services:${Versions.GMS}"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 
     //plugins
     const val ANDROID_GRADLE_PLUGIN = "3.2.1"
-    const val SCALA_BUILD_PLUGIN = "1.6"
+    const val SCALA_BUILD_PLUGIN = "2.0.1"
     const val GMS = "3.1.1"
     const val DETEKT = "1.2.2"
     const val JACOCO = "0.8.5"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 
     //plugins
     const val ANDROID_GRADLE_PLUGIN = "3.2.1"
-    const val SCALA_BUILD_PLUGIN = "2.0.1"
+    const val SCALA_BUILD_PLUGIN = "2.0.3"
     const val GMS = "3.1.1"
     const val DETEKT = "1.2.2"
     const val JACOCO = "0.8.5"


### PR DESCRIPTION
A bump to the gradle-android-scala-plugin version. 
The new plugin is now published on Sonatype and its sources are here: https://github.com/wireapp/gradle-android-scala-plugin
#### APK
[Download build #3246](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3246/artifact/build/artifact/wire-dev-PR3219-3246.apk)