### PR TITLE
Define legal hold service

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -197,6 +197,7 @@ object WireApplication extends DerivedLogTag {
     bind [Signal[MessageIndexStorage]]           to inject[Signal[ZMessaging]].map(_.messagesIndexStorage)
     bind [Signal[ConnectionService]]             to inject[Signal[ZMessaging]].map(_.connection)
     bind [Signal[ButtonsStorage]]                to inject[Signal[ZMessaging]].map(_.buttonsStorage)
+    bind [Signal[LegalHoldService]]              to inject[Signal[ZMessaging]].map(_.legalHold)
 
     // old controllers
     // TODO: remove controller factory, reimplement those controllers

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -1,10 +1,15 @@
 package com.waz.zclient.legalhold
 
 import com.waz.model.{ConvId, UserId}
+import com.waz.service.LegalHoldService
+import com.waz.zclient.{Injectable, Injector}
 import com.wire.signals.Signal
 
 //TODO: implement status calculation
-class LegalHoldController {
+class LegalHoldController(implicit injector: Injector)
+  extends Injectable {
+
+  private lazy val legalHoldService = inject[Signal[LegalHoldService]]
 
   def isLegalHoldActive(userId: UserId): Signal[Boolean] =
     Signal.const(false)

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -234,6 +234,7 @@ object Event {
         case "user.client-remove" => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
         case "user.properties-set" => PropertyEvent.Decoder(js)
         case "user.properties-delete" => PropertyEvent.Decoder(js)
+        case "user.client-legal-hold-request" => LegalHoldRequestEvent(LegalHoldRequest.Decoder(js))
         case _ =>
           error(l"unhandled event: $js")
           UnknownEvent(js)
@@ -458,3 +459,6 @@ object PropertyEvent {
     }
   }
 }
+
+sealed trait LegalHoldEvent extends UserEvent
+case class LegalHoldRequestEvent(request: LegalHoldRequest) extends LegalHoldEvent

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -1,0 +1,42 @@
+package com.waz.service
+
+import com.waz.content.{PropertiesStorage, PropertyValue}
+import com.waz.model.{LegalHoldRequest, LegalHoldRequestEvent}
+import com.waz.service.EventScheduler.Stage
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+
+import scala.concurrent.Future
+
+trait LegalHoldService {
+  def legalHoldRequestEventStage: Stage.Atomic
+  def fetchLegalHoldRequest: Future[Option[LegalHoldRequest]]
+}
+
+class LegalHoldServiceImpl(storage: PropertiesStorage)
+  extends LegalHoldService {
+
+  import com.waz.threading.Threading.Implicits.Background
+  import LegalHoldService._
+
+  override def legalHoldRequestEventStage: Stage.Atomic = EventScheduler.Stage[LegalHoldRequestEvent] { (_, events) =>
+    Future.sequence(events.map(event => storeRequest(event.request))).map(_ => ())
+  }
+
+  override def fetchLegalHoldRequest: Future[Option[LegalHoldRequest]] = {
+    storage.find(LegalHoldRequestKey).map { property =>
+      property.map(_.value).map(JsonDecoder.decode[LegalHoldRequest])
+    }
+  }
+
+  private def storeRequest(request: LegalHoldRequest): Future[Unit] = {
+    val value = JsonEncoder.encode[LegalHoldRequest](request).toString
+    storage.save(PropertyValue(LegalHoldRequestKey, value))
+  }
+
+}
+
+object LegalHoldService {
+
+  val LegalHoldRequestKey: PropertyKey = PropertyKey("legal-hold-request")
+
+}

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -269,6 +269,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val propertiesService: PropertiesService       = wire[PropertiesServiceImpl]
   lazy val fcmNotStatsService                         = wire[FCMNotificationStatsServiceImpl]
   lazy val trackingSync                               = wire[TrackingSyncHandler]
+  lazy val legalHold: LegalHoldService                = wire[LegalHoldServiceImpl]
 
   lazy val eventPipeline: EventPipeline = new EventPipelineImpl(Vector(), eventScheduler.enqueue)
 
@@ -319,7 +320,8 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
         notifications.connectionNotificationEventStage,
         genericMsgs.eventProcessingStage,
         foldersService.eventProcessingStage,
-        propertiesService.eventProcessor
+        propertiesService.eventProcessor,
+        legalHold.legalHoldRequestEventStage
       )
     )
   }

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -22,6 +22,7 @@ import com.waz.model.otr.ClientId
 import com.waz.service.PropertyKey
 import com.waz.specs.AndroidFreeSpec
 import com.waz.utils.JsonDecoder
+import com.waz.utils.crypto.AESUtils
 import org.json.JSONObject
 import org.scalatest._
 import org.threeten.bp.Instant
@@ -246,6 +247,31 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
         case e => fail(s"unexpected event: $e")
       }
 
+    }
+
+    scenario("parse LegalHoldRequestEvent") {
+      val jsonStr =
+        """
+          |{
+          |  "client": {
+          |    "id": "123"
+          |  },
+          |  "last_prekey": {
+          |    "id": 456,
+          |    "key": "oENwaFy74nagzFBlqn9nOQ=="
+          |  },
+          |  "type": "user.client-legal-hold-request"
+          |}
+          |""".stripMargin
+
+      val jsonObject = new JSONObject(jsonStr)
+      EventDecoder(jsonObject) match {
+        case ev: LegalHoldRequestEvent =>
+          ev.request.clientId.str shouldEqual "123"
+          ev.request.lastPreKey.id shouldEqual 456
+          ev.request.lastPreKey.data shouldEqual AESUtils.base64("oENwaFy74nagzFBlqn9nOQ==")
+        case e => fail(s"unexpected event: $e")
+      }
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -59,7 +59,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
 
   feature("Legal hold event processing") {
 
-    scenario("if processes the legal hold request event") {
+    scenario("it processes the legal hold request event") {
       // Given
       val service = new LegalHoldServiceImpl(storage)
       val scheduler = new EventScheduler(Stage(Sequential)(service.legalHoldRequestEventStage))

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -1,0 +1,90 @@
+package com.waz.service
+
+import com.waz.content.{PropertiesStorage, PropertyValue}
+import com.waz.specs.AndroidFreeSpec
+import LegalHoldService._
+import com.waz.model.{LegalHoldRequest, LegalHoldRequestEvent}
+import com.waz.model.otr.ClientId
+import com.waz.service.EventScheduler.{Sequential, Stage}
+import com.waz.utils.JsonEncoder
+import com.waz.utils.crypto.AESUtils
+import com.wire.cryptobox.PreKey
+
+import scala.concurrent.Future
+
+class LegalHoldServiceSpec extends AndroidFreeSpec {
+
+  import LegalHoldServiceSpec._
+
+  private val storage = mock[PropertiesStorage]
+
+  feature("Fetch the legal hold request") {
+
+    scenario("legal hold request exists") {
+      // Given
+      val service = new LegalHoldServiceImpl(storage)
+      val value = JsonEncoder.encode[LegalHoldRequest](legalHoldRequest).toString
+
+      (storage.find _)
+        .expects(LegalHoldRequestKey)
+        .once()
+        .returning(Future.successful(Some(PropertyValue(LegalHoldRequestKey, value))))
+
+      // When
+      val fetchedResult = result(service.fetchLegalHoldRequest)
+
+      // Then
+      fetchedResult shouldBe defined
+      fetchedResult.get.clientId.str shouldEqual "abc"
+      fetchedResult.get.lastPreKey.id shouldEqual legalHoldRequest.lastPreKey.id
+      fetchedResult.get.lastPreKey.data shouldEqual legalHoldRequest.lastPreKey.data
+    }
+
+    scenario("legal hold request does not exist") {
+      // Given
+      val service = new LegalHoldServiceImpl(storage)
+
+      (storage.find _)
+        .expects(LegalHoldRequestKey)
+        .once()
+        .returning(Future.successful(None))
+
+      // When
+      val fetchedResult = result(service.fetchLegalHoldRequest)
+
+      // Then
+      fetchedResult shouldEqual None
+    }
+  }
+
+  feature("Legal hold event processing") {
+
+    scenario("if processes the legal hold request event") {
+      // Given
+      val service = new LegalHoldServiceImpl(storage)
+      val scheduler = new EventScheduler(Stage(Sequential)(service.legalHoldRequestEventStage))
+      val pipeline  = new EventPipelineImpl(Vector.empty, scheduler.enqueue)
+      val event = LegalHoldRequestEvent(legalHoldRequest)
+
+      // Then
+      (storage.save _)
+        .expects( PropertyValue(LegalHoldRequestKey, encodedLegalHoldRequest))
+        .once()
+        .returning(Future.successful({}))
+
+      // When
+      result(pipeline.apply(Seq(event)))
+    }
+  }
+}
+
+object LegalHoldServiceSpec {
+
+  val legalHoldRequest: LegalHoldRequest = LegalHoldRequest(
+    ClientId("abc"),
+    new PreKey(123, AESUtils.base64("oENwaFy74nagzFBlqn9nOQ=="))
+  )
+
+  val encodedLegalHoldRequest: String = JsonEncoder.encode[LegalHoldRequest](legalHoldRequest).toString
+
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need to be able to receive and process legal hold request events in order to present the legal hold request alert to the user.

### Solutions

- Define `LegalHoldRequestEvent`, which will contain the `LegalHoldRequest`
- Define `LegalHoldService`, which will process legal hold events and store the request in the properties table.
- Add the legal hold event stage to the pipeline.
- Add the legal hold service to the controller (to be used in the future).

### Testing

- Decoding legal hold request event
- Processing legal hold request event
- Retrieving the legal hold request from storage


#### APK
[Download build #3247](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3247/artifact/build/artifact/wire-dev-PR3220-3247.apk)
[Download build #3248](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3248/artifact/build/artifact/wire-dev-PR3220-3248.apk)