### PR TITLE
Feature: Legal Hold - Create a general purpose confirmation dialog with password input

### DIFF
--- a/app/src/main/res/layout/confirmation_with_password_dialog.xml
+++ b/app/src/main/res/layout/confirmation_with_password_dialog.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     Wire
     Copyright (C) 2018 Wire Swiss GmbH
@@ -19,48 +18,43 @@
 
 -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingStart="@dimen/prefs__dialog__padding"
-    android:paddingEnd="@dimen/prefs__dialog__padding"
-    >
+    android:paddingEnd="@dimen/prefs__dialog__padding">
 
     <ScrollView
-        android:id="@+id/remove_otr_device_scrollview"
+        android:id="@+id/confirmation_with_password_scrollview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:overScrollMode="ifContentScrolls"
-        >
+        android:overScrollMode="ifContentScrolls">
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/til__remove_otr_device"
-            android:layout_height="wrap_content"
+            android:id="@+id/confirmation_with_password_text_input_layout"
             android:layout_width="match_parent"
-            >
+            android:layout_height="wrap_content">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/acet__remove_otr__password"
+                android:id="@+id/confirmation_with_password_edit_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:maxLines="1"
                 android:inputType="textPassword"
-                />
+                android:maxLines="1" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
     </ScrollView>
 
     <com.waz.zclient.ui.text.TypefaceTextView
-        android:id="@+id/device_forgot_password"
+        android:id="@+id/confirmation_with_password_forgot_password_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/wire__padding__4"
         android:text="@string/new_reg__password__forgot"
         android:textAllCaps="true"
-        android:layout_marginStart="@dimen/wire__padding__4"
         android:textColor="@color/accent_blue"
         android:textSize="@dimen/wire__text_size__small"
         app:w_font="@string/wire__typeface__medium" />

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
@@ -22,14 +22,14 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
 
   val onAccept = EventStream[Option[Password]]()
 
-  private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.remove_otr_device_dialog, null)
+  private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.confirmation_with_password_dialog, null)
 
   private def providePassword(password: Option[Password]): Unit = {
     onAccept ! password
     dismiss() // if the password is wrong a new dialog will appear
   }
 
-  private lazy val passwordEditText = returning(findById[EditText](root, R.id.acet__remove_otr__password)) { v =>
+  private lazy val passwordEditText = returning(findById[EditText](root, R.id.confirmation_with_password_edit_text)) { v =>
     v.setOnEditorActionListener(new TextView.OnEditorActionListener() {
       def onEditorAction(v: TextView, actionId: Int, event: KeyEvent) =
         actionId match {
@@ -41,9 +41,9 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
     })
   }
 
-  private lazy val textInputLayout = findById[TextInputLayout](root, R.id.til__remove_otr_device)
+  private lazy val textInputLayout = findById[TextInputLayout](root, R.id.confirmation_with_password_text_input_layout)
 
-  private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.device_forgot_password)) {
+  private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.confirmation_with_password_forgot_password_button)) {
     _.onClick(inject[BrowserController].openForgotPassword())
   }
 
@@ -56,7 +56,7 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
 
   override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
     if(isSSO){
-      findById[View](root, R.id.remove_otr_device_scrollview).setVisible(false)
+      findById[View](root, R.id.confirmation_with_password_scrollview).setVisible(false)
     }
     passwordEditText.setVisible(!isSSO)
     textInputLayout.setVisible(!isSSO)

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
@@ -1,0 +1,88 @@
+package com.waz.zclient.preferences.dialogs
+
+import android.app.Dialog
+import android.content.DialogInterface.BUTTON_POSITIVE
+import android.os.Bundle
+import android.view.inputmethod.EditorInfo
+import android.view.{KeyEvent, LayoutInflater, View, WindowManager}
+import android.widget.{EditText, TextView}
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.textfield.TextInputLayout
+import com.waz.model.AccountData.Password
+import com.waz.utils.returning
+import com.waz.zclient.common.controllers.BrowserController
+import com.waz.zclient.utils.RichView
+import com.waz.zclient.{FragmentHelper, R}
+import com.wire.signals.EventStream
+
+import scala.util.Try
+
+abstract class ConfirmationWithPasswordDialog extends DialogFragment with FragmentHelper {
+
+  val onAccept = EventStream[Option[Password]]()
+
+  private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.remove_otr_device_dialog, null)
+
+  private def providePassword(password: Option[Password]): Unit = {
+    onAccept ! password
+    dismiss() // if the password is wrong a new dialog will appear
+  }
+
+  private lazy val passwordEditText = returning(findById[EditText](root, R.id.acet__remove_otr__password)) { v =>
+    v.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+      def onEditorAction(v: TextView, actionId: Int, event: KeyEvent) =
+        actionId match {
+          case EditorInfo.IME_ACTION_DONE =>
+            providePassword(Some(Password(v.getText.toString)))
+            true
+          case _ => false
+        }
+    })
+  }
+
+  private lazy val textInputLayout = findById[TextInputLayout](root, R.id.til__remove_otr_device)
+
+  private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.device_forgot_password)) {
+    _.onClick(inject[BrowserController].openForgotPassword())
+  }
+
+  def isSSO : Boolean
+  def errorMessage: Option[String]
+  def title: String
+  def message: String
+  def positiveButtonText: Int
+  def negativeButtonText: Int
+
+  override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
+    if(isSSO){
+      findById[View](root, R.id.remove_otr_device_scrollview).setVisible(false)
+    }
+    passwordEditText.setVisible(!isSSO)
+    textInputLayout.setVisible(!isSSO)
+    forgotPasswordButton.setVisible(!isSSO)
+    errorMessage.foreach(textInputLayout.setError)
+    new AlertDialog.Builder(getActivity)
+      .setView(root)
+      .setTitle(title)
+      .setMessage(message)
+      .setPositiveButton(positiveButtonText, null)
+      .setNegativeButton(negativeButtonText, null)
+      .create
+  }
+
+  override def onStart() = {
+    super.onStart()
+    Try(getDialog.asInstanceOf[AlertDialog]).toOption.foreach { d =>
+      d.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+        def onClick(v: View) =
+          providePassword(if (isSSO) None else Some(Password(passwordEditText.getText.toString)))
+      })
+    }
+  }
+
+  override def onActivityCreated(savedInstanceState: Bundle) = {
+    super.onActivityCreated(savedInstanceState)
+    getDialog.getWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+  }
+}

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -26,21 +26,21 @@ class RemoveDeviceDialog extends ConfirmationWithPasswordDialog {
 
   override lazy val isSSO: Boolean = getArguments.getBoolean(IsSSOARG)
 
-  override def errorMessage: Option[String] = Option(getArguments.getString(ErrorArg))
+  override lazy val errorMessage: Option[String] = Option(getArguments.getString(ErrorArg))
 
-  override def title: String = getString(
+  override lazy val title: String = getString(
     R.string.otr__remove_device__title,
     getArguments.getString(NameArg, getString(R.string.otr__remove_device__default))
   )
 
-  override def message: String = {
+  override lazy val message: String = {
     val resId = if (isSSO) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message
     getString(resId)
   }
 
-  override def positiveButtonText: Int = R.string.otr__remove_device__button_delete
+  override lazy val positiveButtonText: Int = R.string.otr__remove_device__button_delete
 
-  override def negativeButtonText: Int = R.string.otr__remove_device__button_cancel
+  override lazy val negativeButtonText: Int = R.string.otr__remove_device__button_cancel
 }
 
 object RemoveDeviceDialog {

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -17,87 +17,30 @@
  */
 package com.waz.zclient.preferences.dialogs
 
-import android.app.Dialog
-import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Bundle
-import android.view.inputmethod.EditorInfo
-import android.view.{KeyEvent, LayoutInflater, View, WindowManager}
-import android.widget.{EditText, TextView}
-import androidx.appcompat.app.AlertDialog
-import androidx.fragment.app.DialogFragment
-import com.google.android.material.textfield.TextInputLayout
-import com.waz.model.AccountData.Password
 import com.waz.utils.returning
-import com.waz.zclient.common.controllers.BrowserController
-import com.waz.zclient.utils.RichView
-import com.waz.zclient.{FragmentHelper, R}
-import com.wire.signals.EventStream
+import com.waz.zclient.R
 
-import scala.util.Try
-
-class RemoveDeviceDialog extends DialogFragment with FragmentHelper {
+class RemoveDeviceDialog extends ConfirmationWithPasswordDialog {
   import RemoveDeviceDialog._
 
-  val onDelete = EventStream[Option[Password]]()
+  override lazy val isSSO: Boolean = getArguments.getBoolean(IsSSOARG)
 
-  private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.remove_otr_device_dialog, null)
+  override def errorMessage: Option[String] = Option(getArguments.getString(ErrorArg))
 
-  private def providePassword(password: Option[Password]): Unit = {
-    onDelete ! password
-    dismiss() // if the password is wrong a new dialog will appear
+  override def title: String = getString(
+    R.string.otr__remove_device__title,
+    getArguments.getString(NameArg, getString(R.string.otr__remove_device__default))
+  )
+
+  override def message: String = {
+    val resId = if (isSSO) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message
+    getString(resId)
   }
 
-  private lazy val passwordEditText = returning(findById[EditText](root, R.id.acet__remove_otr__password)) { v =>
-    v.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-      def onEditorAction(v: TextView, actionId: Int, event: KeyEvent) =
-        actionId match {
-          case EditorInfo.IME_ACTION_DONE =>
-            providePassword(Some(Password(v.getText.toString)))
-            true
-          case _ => false
-        }
-    })
-  }
+  override def positiveButtonText: Int = R.string.otr__remove_device__button_delete
 
-  private lazy val textInputLayout = findById[TextInputLayout](root, R.id.til__remove_otr_device)
-
-  private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.device_forgot_password)) {
-    _.onClick(inject[BrowserController].openForgotPassword())
-  }
-
-  private lazy val isSSO = getArguments.getBoolean(IsSSOARG)
-
-  override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
-    if(isSSO){
-      findById[View](root, R.id.remove_otr_device_scrollview).setVisible(false)
-    }
-    passwordEditText.setVisible(!isSSO)
-    textInputLayout.setVisible(!isSSO)
-    forgotPasswordButton.setVisible(!isSSO)
-    Option(getArguments.getString(ErrorArg)).foreach(textInputLayout.setError)
-    new AlertDialog.Builder(getActivity)
-      .setView(root)
-      .setTitle(getString(R.string.otr__remove_device__title, getArguments.getString(NameArg, getString(R.string.otr__remove_device__default))))
-      .setMessage(if (isSSO) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message)
-      .setPositiveButton(R.string.otr__remove_device__button_delete, null)
-      .setNegativeButton(R.string.otr__remove_device__button_cancel, null)
-      .create
-  }
-
-  override def onStart() = {
-    super.onStart()
-    Try(getDialog.asInstanceOf[AlertDialog]).toOption.foreach { d =>
-      d.getButton(BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-        def onClick(v: View) =
-          providePassword(if (isSSO) None else Some(Password(passwordEditText.getText.toString)))
-      })
-    }
-  }
-
-  override def onActivityCreated(savedInstanceState: Bundle) = {
-    super.onActivityCreated(savedInstanceState)
-    getDialog.getWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
-  }
+  override def negativeButtonText: Int = R.string.otr__remove_device__button_cancel
 }
 
 object RemoveDeviceDialog {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -265,7 +265,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
 
   private def showRemoveDeviceDialog(error: Option[String] = None): Unit =
     Signal.zip(inject[PasswordController].ssoEnabled, client.map(_.model)).head.foreach { case (isSSO, name) =>
-      val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onDelete(removeDevice))
+      val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onAccept(removeDevice))
       context.asInstanceOf[BaseActivity]
         .getSupportFragmentManager
         .beginTransaction


### PR DESCRIPTION
## What's new in this PR?

Jira: [SQSERVICES-351](https://wearezeta.atlassian.net/browse/SQSERVICES-351)

### Issues

Given that I am a team user
When a team admin enables legal hold for me
Then I should be informed with a pop up

### Solutions

We already have a similar layout with the same UX, called `RemoveDeviceDialog`, only with different texts to be displayed. I extracted main parts to a base class called `ConfirmationWithPasswordDialog` and had `RemoveDeviceDialog` extend it. The base class will later be extended again for legal hold acceptance pop up. UI or logic-wise, nothing has changed.

### Testing

Manually tested by deleting a device from devices list.



#### APK
[Download build #3252](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3252/artifact/build/artifact/wire-dev-PR3224-3252.apk)
[Download build #3261](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3261/artifact/build/artifact/wire-dev-PR3224-3261.apk)