### PR TITLE
Feature: Legal Hold - Create pop up for legal hold request

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1584,6 +1584,10 @@
     <string name="legal_hold_self_user_info_message">Legal Hold has been activated for your account.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.\n\nYour conversation partners will be aware of the recording.
     </string>
     <string name="legal_hold_info_list_title">Legal Hold Subjects</string>
-
+    <string name="legal_hold_request_dialog_title">Legal Hold Requested</string>
+    <string name="legal_hold_request_dialog_message_for_sso">All future messages will be recorded by the device with fingerprint:\n%1$s\nThis includes deleted, edited and timed messages in all conversations.</string>
+    <string name="legal_hold_request_dialog_message">All future messages will be recorded by the device with fingerprint:\n%1$s\nThis includes deleted, edited and timed messages in all conversations.\n\nEnter your password to confirm.</string>
+    <string name="legal_hold_request_dialog_positive_button_text">Accept</string>
+    <string name="legal_hold_request_dialog_negative_button_text">Not Now</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
@@ -1,0 +1,42 @@
+package com.waz.zclient.legalhold
+
+import android.os.Bundle
+import com.waz.utils.returning
+import com.waz.zclient.preferences.dialogs.ConfirmationWithPasswordDialog
+import com.waz.zclient.R
+
+class LegalHoldRequestDialog extends ConfirmationWithPasswordDialog {
+  import LegalHoldRequestDialog._
+
+  override def isSSO: Boolean = getArguments.getBoolean(ARG_IS_SSO)
+
+  override def errorMessage: Option[String] = None // TODO
+
+  override def title: String = getString(R.string.legal_hold_request_dialog_title)
+
+  override def message: String = {
+    val stringRes =
+      if (isSSO) R.string.legal_hold_request_dialog_message_for_sso
+      else R.string.legal_hold_request_dialog_message
+    getString(stringRes, getArguments.getString(ARG_CLIENT_FINGERPRINT))
+  }
+
+  override def positiveButtonText: Int = R.string.legal_hold_request_dialog_positive_button_text
+
+  override def negativeButtonText: Int = R.string.legal_hold_request_dialog_negative_button_text
+}
+
+object LegalHoldRequestDialog {
+  val TAG = "LegalHoldRequestDialog"
+
+  private val ARG_IS_SSO = "LegalHold_arg_isSso"
+  private val ARG_CLIENT_FINGERPRINT = "LegalHold_arg_fingerprint"
+
+  def newInstance(isSso: Boolean, fingerprint: String) : LegalHoldRequestDialog =
+    returning(new LegalHoldRequestDialog) {
+      _.setArguments(returning(new Bundle()) { args =>
+        args.putString(ARG_CLIENT_FINGERPRINT, fingerprint)
+        args.putBoolean(ARG_IS_SSO, isSso)
+      })
+    }
+}

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
@@ -8,22 +8,22 @@ import com.waz.zclient.R
 class LegalHoldRequestDialog extends ConfirmationWithPasswordDialog {
   import LegalHoldRequestDialog._
 
-  override def isSSO: Boolean = getArguments.getBoolean(ARG_IS_SSO)
+  override lazy val isSSO: Boolean = getArguments.getBoolean(ARG_IS_SSO)
 
-  override def errorMessage: Option[String] = None // TODO
+  override lazy val errorMessage: Option[String] = None // TODO
 
-  override def title: String = getString(R.string.legal_hold_request_dialog_title)
+  override lazy val title: String = getString(R.string.legal_hold_request_dialog_title)
 
-  override def message: String = {
+  override lazy val message: String = {
     val stringRes =
       if (isSSO) R.string.legal_hold_request_dialog_message_for_sso
       else R.string.legal_hold_request_dialog_message
     getString(stringRes, getArguments.getString(ARG_CLIENT_FINGERPRINT))
   }
 
-  override def positiveButtonText: Int = R.string.legal_hold_request_dialog_positive_button_text
+  override lazy val positiveButtonText: Int = R.string.legal_hold_request_dialog_positive_button_text
 
-  override def negativeButtonText: Int = R.string.legal_hold_request_dialog_negative_button_text
+  override lazy val negativeButtonText: Int = R.string.legal_hold_request_dialog_negative_button_text
 }
 
 object LegalHoldRequestDialog {


### PR DESCRIPTION
## What's new in this PR?

Jira: [SQSERVICES-351](https://wearezeta.atlassian.net/browse/SQSERVICES-351)

### Issues

Given that I am a team user
When a team admin enables legal hold for me
Then I should be informed with a pop up
And the pop up should have a password field for confirmation

Given that I am a team user logged in with SSO
When a team admin enables legal hold for me
Then I should be informed with a pop up
And the pop up should **not** have a password field

### Solutions

LegalHoldRequestDialog is created, based on ConfirmationWithPasswordDialog ( #3224 ) 


|  Non-SSO | SSO |
|-----------|------|
| <img src="https://user-images.githubusercontent.com/2143283/113156551-624e7700-923a-11eb-8133-cab9112b3e83.png" width="300px"/> | <img src="https://user-images.githubusercontent.com/2143283/113156589-6d090c00-923a-11eb-8d37-1f3989397b8d.png" width="300px"/> |

### Testing

Manually tested for sso and non-sso settings.


#### APK
[Download build #3254](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3254/artifact/build/artifact/wire-dev-PR3225-3254.apk)
[Download build #3265](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3265/artifact/build/artifact/wire-dev-PR3225-3265.apk)
[Download build #3270](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3270/artifact/build/artifact/wire-dev-PR3225-3270.apk)