### PR TITLE
Fix: Empty layout on ParticipantFragment after opening "Create group" and coming back

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/BlockedUserFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/BlockedUserFragment.scala
@@ -30,7 +30,7 @@ class BlockedUserFragment extends UntabbedRequestFragment {
           inject[IConversationScreenController].showConversationMenu(false, conv.id)
   }
 
-  override protected lazy val footerMenu = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
+  override protected def initFooterMenu(): Unit = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
     vh.foreach { menu =>
       menu.setLeftActionText(getString(R.string.glyph__block))
       menu.setLeftActionLabelText(getString(R.string.connect_request__unblock__button__text))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ConnectRequestFragment.scala
@@ -24,7 +24,7 @@ class ConnectRequestFragment extends UntabbedRequestFragment {
 
   override protected val Tag: String = ConnectRequestFragment.Tag
 
-  private lazy val ignoreButton = returning(view[ZetaButton](R.id.zb__connect_request__ignore_button)) { vh =>
+  private def initIgnoreButton(): Unit = returning(view[ZetaButton](R.id.zb__connect_request__ignore_button)) { vh =>
     vh.foreach { button =>
       button.setIsFilled(false)
       button.onClick(usersController.ignoreConnectionRequest(userToConnectId).map(_ => getActivity.onBackPressed()))
@@ -38,7 +38,7 @@ class ConnectRequestFragment extends UntabbedRequestFragment {
     )
   }
 
-  private lazy val acceptButton = returning(view[ZetaButton](R.id.zb__connect_request__accept_button)) { vh =>
+  private def initAcceptButton(): Unit = returning(view[ZetaButton](R.id.zb__connect_request__accept_button)) { vh =>
     vh.foreach {
       _.onClick(usersController.connectToUser(userToConnectId).map(_ => getActivity.onBackPressed()))
     }
@@ -58,7 +58,7 @@ class ConnectRequestFragment extends UntabbedRequestFragment {
           inject[IConversationScreenController].showConversationMenu(false, conv.id)
   }
 
-  override protected lazy val footerMenu = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
+  override protected def initFooterMenu(): Unit = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
     vh.foreach(_.setCallback(footerCallback))
 
     if (fromParticipants) {
@@ -69,10 +69,10 @@ class ConnectRequestFragment extends UntabbedRequestFragment {
   }
 
   override protected def initViews(savedInstanceState: Bundle): Unit = {
-    detailsView
-    footerMenu
-    ignoreButton
-    acceptButton
+    initDetailsView()
+    initFooterMenu()
+    initIgnoreButton()
+    initAcceptButton()
   }
 }
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/PendingConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/PendingConnectRequestFragment.scala
@@ -50,7 +50,7 @@ class PendingConnectRequestFragment extends UntabbedRequestFragment {
             convScreenController.showConversationMenu(false, conv.id)
   }
 
-  override protected lazy val footerMenu = returning(view[FooterMenu](R.id.not_tabbed_footer)) { vh =>
+  override protected def initFooterMenu(): Unit = returning(view[FooterMenu](R.id.not_tabbed_footer)) { vh =>
     if (fromParticipants) {
       subs += removeMemberPermission.map { remPerm =>
           getString(if (remPerm)  R.string.glyph__more else R.string.empty_string)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
@@ -48,7 +48,7 @@ class SendConnectRequestFragment extends UntabbedRequestFragment {
           convScreenCtrl.showConversationMenu(false, conv.id)
   }
 
-  override protected lazy val footerMenu = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
+  override protected def initFooterMenu(): Unit = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
     vh.foreach { menu =>
       menu.setLeftActionText(getString(R.string.glyph__plus))
       menu.setLeftActionLabelText(getString(R.string.send_connect_request__connect_button__text))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -22,7 +22,7 @@ import com.waz.threading.Threading._
 abstract class UntabbedRequestFragment extends SingleParticipantFragment {
   import Threading.Implicits.Ui
   import UntabbedRequestFragment._
-  
+
   protected val Tag: String
 
   override protected val layoutId: Int = R.layout.fragment_participants_not_tabbed
@@ -34,13 +34,13 @@ abstract class UntabbedRequestFragment extends SingleParticipantFragment {
   protected lazy val removeMemberPermission = participantsController.selfRole.map(_.canRemoveGroupMember)
 
   override protected def initViews(savedInstanceState: Bundle): Unit = {
-    detailsView
-    footerMenu
+    initDetailsView()
+    initFooterMenu()
   }
-  
-  override protected lazy val detailsView = returning( view[RecyclerView](R.id.not_tabbed_recycler_view) ) { vh =>
+
+  override protected def initDetailsView(): Unit = returning(view[RecyclerView](R.id.not_tabbed_recycler_view)) { vh =>
     vh.foreach(_.setLayoutManager(new LinearLayoutManager(ctx)))
-    
+
     (for {
         zms           <- inject[Signal[ZMessaging]].head
         Some(user)    <- participantsController.getUser(userToConnectId)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira: [SQCORE-582](https://wearezeta.atlassian.net/browse/SQCORE-582)

1. Go to a 1-to-1 conversation and open details.
2. You should see participant's info screen with two tabs: details and devices.
3. Click on the "Create group" button.
4. Click the back arrow icon.

Result: Participant info screen (`SingleParticipantFragment`) is visible but it has no content.

### Causes

When we come back to `SingleParticipantFragment`, its `onViewCreated` is called again to re-initialize the views. However, since the views are declared as `lazy val`, they aren't initialized again.

### Solutions

Don't store the views as `lazy`, create methods for initialization instead. I also did the same in all fragments extending from `SingleParticipantFragment`.

### Testing

Manually tested with the steps mentioned above.


#### APK
[Download build #3257](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3257/artifact/build/artifact/wire-dev-PR3227-3257.apk)