### PR TITLE
[Fix] Legal hold request event

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -234,7 +234,7 @@ object Event {
         case "user.client-remove" => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
         case "user.properties-set" => PropertyEvent.Decoder(js)
         case "user.properties-delete" => PropertyEvent.Decoder(js)
-        case "user.legalhold-request" => LegalHoldRequestEvent(LegalHoldRequest.Decoder(js))
+        case "user.legalhold-request" => LegalHoldRequestEvent(decodeId[UserId]('id), LegalHoldRequest.Decoder(js))
         case _ =>
           error(l"unhandled event: $js")
           UnknownEvent(js)
@@ -461,4 +461,4 @@ object PropertyEvent {
 }
 
 sealed trait LegalHoldEvent extends UserEvent
-case class LegalHoldRequestEvent(request: LegalHoldRequest) extends LegalHoldEvent
+case class LegalHoldRequestEvent(targetUserId: UserId, request: LegalHoldRequest) extends LegalHoldEvent

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -234,7 +234,7 @@ object Event {
         case "user.client-remove" => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
         case "user.properties-set" => PropertyEvent.Decoder(js)
         case "user.properties-delete" => PropertyEvent.Decoder(js)
-        case "user.client-legal-hold-request" => LegalHoldRequestEvent(LegalHoldRequest.Decoder(js))
+        case "user.legalhold-request" => LegalHoldRequestEvent(LegalHoldRequest.Decoder(js))
         case _ =>
           error(l"unhandled event: $js")
           UnknownEvent(js)

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -1,7 +1,7 @@
 package com.waz.service
 
 import com.waz.content.{PropertiesStorage, PropertyValue}
-import com.waz.model.{LegalHoldRequest, LegalHoldRequestEvent}
+import com.waz.model.{LegalHoldRequest, LegalHoldRequestEvent, UserId}
 import com.waz.service.EventScheduler.Stage
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 
@@ -12,14 +12,18 @@ trait LegalHoldService {
   def fetchLegalHoldRequest: Future[Option[LegalHoldRequest]]
 }
 
-class LegalHoldServiceImpl(storage: PropertiesStorage)
+class LegalHoldServiceImpl(selfUserId: UserId, storage: PropertiesStorage)
   extends LegalHoldService {
 
   import com.waz.threading.Threading.Implicits.Background
   import LegalHoldService._
 
   override def legalHoldRequestEventStage: Stage.Atomic = EventScheduler.Stage[LegalHoldRequestEvent] { (_, events) =>
-    Future.sequence(events.map(event => storeRequest(event.request))).map(_ => ())
+    Future.sequence {
+      events
+        .filter(_.targetUserId == selfUserId)
+        .map(event => storeRequest(event.request))
+    }.map(_ => ())
   }
 
   override def fetchLegalHoldRequest: Future[Option[LegalHoldRequest]] = {

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -260,7 +260,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
           |    "id": 456,
           |    "key": "oENwaFy74nagzFBlqn9nOQ=="
           |  },
-          |  "type": "user.client-legal-hold-request"
+          |  "type": "user.legalhold-request"
           |}
           |""".stripMargin
 

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -260,6 +260,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
           |    "id": 456,
           |    "key": "oENwaFy74nagzFBlqn9nOQ=="
           |  },
+          |  "id": "858db163-c05d-486f-a478-cfe912e9ccde",
           |  "type": "user.legalhold-request"
           |}
           |""".stripMargin


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. The legal hold request event is incorrectly parsed.
2. It's possible to process a legal hold request event for another user

### Causes

1. The tech spec was out of date.
2. We were ignoring the "id" field that specifies the target user.

### Solutions

1. Update the event decoding.
2. Also parse the target user and ignore events that aren't for the self user.

### Testing

Update existing tests and add one more case to check we don't process the legal hold request for another user.


#### APK
[Download build #3259](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3259/artifact/build/artifact/wire-dev-PR3228-3259.apk)