### PR TITLE
fix: App freeze when the backup is being restored on a new device

### DIFF
--- a/app/src/main/scala/com/waz/zclient/Intents.scala
+++ b/app/src/main/scala/com/waz/zclient/Intents.scala
@@ -34,6 +34,7 @@ object Intents {
   private val ConvIdExtra           = "conv_id"
 
   private val OpenPageExtra         = "open_page"
+  private val InitSyncExtra         = "init_sync"
 
   type Page = String
   object Page {
@@ -60,9 +61,10 @@ object Intents {
   def SharingIntent(implicit context: Context) =
     new Intent(context, classOf[MainActivity]).putExtra(FromSharingExtra, true)
 
-  def EnterAppIntent(showSettings: Boolean = false)(implicit context: Context) = {
+  def EnterAppIntent(showSettings: Boolean = false, initSync: Boolean = false)(implicit context: Context) = {
     returning(new Intent(context, classOf[MainActivity])) { i =>
       if (showSettings) i.putExtra(OpenPageExtra, Page.Settings)
+      if (initSync) i.putExtra(InitSyncExtra, true)
     }
   }
 
@@ -97,7 +99,6 @@ object Intents {
     def getExtras: Option[Bundle] = Option(intent).flatMap(i => Option(i.getExtras))
     def getDataString: Option[String] = Option(intent).map(_.getDataString)
 
-
     def fromNotification: Boolean = Option(intent).exists(_.getBooleanExtra(FromNotificationExtra, false))
     def fromSharing: Boolean = Option(intent).exists(_.getBooleanExtra(FromSharingExtra, false))
 
@@ -106,6 +107,7 @@ object Intents {
     def convId: Option[ConvId] = Option(intent).map(_.getStringExtra(ConvIdExtra)).filter(_ != null).map(ConvId)
 
     def page: Option[Page] = Option(intent).map(_.getStringExtra(OpenPageExtra)).filter(_ != null)
+    def initSync: Boolean = Option(intent).exists(_.getBooleanExtra(InitSyncExtra, false))
 
     def clearExtras(): Unit = Option(intent).foreach { i =>
       i.removeExtra(FromNotificationExtra)
@@ -114,6 +116,7 @@ object Intents {
       i.removeExtra(AccountIdExtra)
       i.removeExtra(ConvIdExtra)
       i.removeExtra(OpenPageExtra)
+      i.removeExtra(InitSyncExtra)
     }
 
     def ssoToken: Option[String] = Option(intent.getDataString).flatMap { str =>

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -459,10 +459,13 @@ class MainActivity extends BaseActivity
       _        <- am.auth.onPasswordReset(emailCredentials = None)
     } yield {}
 
-  def handleIntent(intent: Intent): Future[Boolean] = {
+  private def handleIntent(intent: Intent): Future[Boolean] = {
     verbose(l"handleIntent: ${RichIntent(intent)}")
 
-    def clearIntent() = {
+    if (intent.initSync)
+      userPreferences.head.foreach { prefs => prefs(ShouldSyncInitial) := true }
+
+    def clearIntent(): Unit = {
       intent.clearExtras()
       setIntent(intent)
     }

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -137,7 +137,7 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
         }
       }
     })
-    skipButton.onClick(onEnterApplication(false))
+    skipButton.onClick(onEnterApplication(openSettings = false, initSync = false))
 
     spinnerController.spinnerShowing.onUi {
       case Show(animation, forcedTheme) => progressView.show(animation, darkTheme = forcedTheme.getOrElse(true), 300)
@@ -271,11 +271,11 @@ class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
     }
   }
 
-  def abortAddAccount(): Unit = onEnterApplication(openSettings = false)
+  def abortAddAccount(): Unit = onEnterApplication(openSettings = false, initSync = false)
 
-  def onEnterApplication(openSettings: Boolean, clientRegState: Option[ClientRegistrationState] = None): Unit = {
+  def onEnterApplication(openSettings: Boolean, initSync: Boolean, clientRegState: Option[ClientRegistrationState] = None): Unit = {
     getControllerFactory.getVerificationController.finishVerification()
-    val intent = Intents.EnterAppIntent(openSettings)(this)
+    val intent = Intents.EnterAppIntent(openSettings, initSync)(this)
     clientRegState.foreach(state => intent.putExtra(MainActivity.ClientRegStateArg, PrefCodec.SelfClientIdCodec.encode(state)))
     startActivity(intent)
     finish()

--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -69,7 +69,7 @@ class SSOWebViewFragment extends FragmentHelper {
             am      <- accountsService.accountManagers.head.map(_.find(_.userId == userId))
             clState <- am.fold2(Future.successful(None), _.getOrRegisterClient().map(_.fold(_ => None, Some(_))))
             _       <- accountsService.setAccount(Some(userId))
-          } getActivity.asInstanceOf[AppEntryActivity].onEnterApplication(openSettings = false, clState)
+          } getActivity.asInstanceOf[AppEntryActivity].onEnterApplication(openSettings = false, initSync = false, clState)
       }
     case Left(error) =>
       ViewUtils.showAlertDialog(

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/InviteToTeamFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/InviteToTeamFragment.scala
@@ -106,7 +106,7 @@ case class InviteToTeamFragment() extends CreateTeamFragment {
   }
 
   override def onBackPressed(): Boolean = {
-    appEntryActivity().onEnterApplication(false)
+    appEntryActivity().onEnterApplication(openSettings = false, initSync = false)
     true
   }
 }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/PhoneSetNameFragment.scala
@@ -124,7 +124,7 @@ class PhoneSetNameFragment extends FragmentHelper with TextWatcher with View.OnC
         }
       case Right(accountManager) =>
         activity.enableProgress(false)
-        activity.onEnterApplication(false)
+        activity.onEnterApplication(openSettings = false, initSync = false)
         accountManager.foreach { am =>
           am.initZMessaging()
           am.addUnsplashIfProfilePictureMissing()

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyEmailWithCodeFragment.scala
@@ -201,7 +201,7 @@ class VerifyEmailWithCodeFragment extends FragmentHelper with View.OnClickListen
           }
         case _ =>
           activity.enableProgress(false)
-          activity.onEnterApplication(openSettings = false)
+          activity.onEnterApplication(openSettings = false, initSync = false)
       }
     }
   }

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/VerifyPhoneFragment.scala
@@ -192,7 +192,7 @@ class VerifyPhoneFragment extends FragmentHelper with View.OnClickListener with 
                         }
             _        <- accountService.setAccount(Some(userId))
             regState <- am.fold2(Future.successful(Left(ErrorResponse.internalError(""))), _.getOrRegisterClient())
-          } yield activity.onEnterApplication(openSettings = false, regState.fold(_ => None, Some(_)))
+          } yield activity.onEnterApplication(openSettings = false, initSync = false, regState.fold(_ => None, Some(_)))
       }
     } else {
       accountService.verifyPhoneNumber(PhoneNumber(phone), ConfirmationCode(code), dryRun = true).foreach {

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -19,7 +19,7 @@ package com.waz.sync
 
 import com.waz.api.IConversation.{Access, AccessRole}
 import com.waz.api.NetworkMode
-import com.waz.content.UserPreferences.{ShouldSyncConversations, ShouldSyncInitial}
+import com.waz.content.UserPreferences.{SelfClient, ShouldSyncConversations, ShouldSyncInitial}
 import com.waz.content.{UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
@@ -28,10 +28,12 @@ import com.waz.model.otr.ClientId
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.model.sync._
 import com.waz.model.{AccentColor, Availability, _}
+import com.waz.service.AccountManager.ClientRegistrationState.Registered
 import com.waz.service._
 import com.waz.service.assets.UploadAssetStatus
 import com.waz.sync.SyncResult.Failure
 import com.waz.threading.Threading
+import com.wire.signals.Signal
 import org.threeten.bp.Instant
 
 import scala.concurrent.Future
@@ -121,19 +123,20 @@ class AndroidSyncServiceHandle(account:         UserId,
   import Threading.Implicits.Background
   import com.waz.model.sync.SyncRequest._
 
-  val shouldSyncAll           = userPreferences(ShouldSyncInitial)
-  val shouldSyncConversations = userPreferences(ShouldSyncConversations)
+  private val shouldSyncAll           = userPreferences(ShouldSyncInitial)
+  private val shouldSyncConversations = userPreferences(ShouldSyncConversations)
+  private val isRegistered = userPreferences(SelfClient).signal.map {
+    case Registered(_) => true
+    case _ => false
+  }
 
-  for {
-    all   <- shouldSyncAll()
-    convs <- shouldSyncConversations()
-    _     <-
-      if (all) performFullSync()
-      else if (convs) syncConversations()
-      else Future.successful({})
-    _ <- shouldSyncAll := false
-    _ <- shouldSyncConversations := false
-  } yield {}
+  Signal.zip(isRegistered, shouldSyncAll.signal, shouldSyncConversations.signal).foreach {
+    case (true, true, _) =>
+      performFullSync().flatMap(_ => shouldSyncAll := false).flatMap(_ => shouldSyncConversations := false)
+    case (true, false, true) =>
+      syncConversations().flatMap(_ => shouldSyncConversations := false)
+    case _ =>
+  }
 
   private def addRequest(req: SyncRequest, priority: Int = Priority.Normal, dependsOn: Seq[SyncId] = Nil, forceRetry: Boolean = false, delay: FiniteDuration = Duration.Zero): Future[SyncId] =
     service.addRequest(account, req, priority, dependsOn, forceRetry, delay)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-498

It turns out that asking for a zms instance right after backup restoration but before the end of the initialization process does not work if the app was just installed or if the storage was wiped out. The zms does not exist yet at this point.
(Which is worrying because I remember testing this case a few months ago and it worked back then).

I changed the way of accessing zms to one that shouldn't cause trouble - from the account manager we have just created and we know it exists. I also decided to postpone the sync with backend and to sync only conversations instead of all data. Syncing all data during the backup restoration might actually look like a freeze from the user's point of view, esp. if the internet connection is poor. It's better to do it in the background when the conversation list is loading up. (And then instead of a turning circle the user will see the bar at the top).

#### APK
[Download build #3279](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3279/artifact/build/artifact/wire-dev-PR3233-3279.apk)
[Download build #3293](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3293/artifact/build/artifact/wire-dev-PR3233-3293.apk)