### PR TITLE
[Feature] Legal hold acceptance

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -1,13 +1,18 @@
 package com.waz.zclient.legalhold
 
-import com.waz.model.{ConvId, UserId}
+import com.waz.model.{ConvId, LegalHoldRequest, UserId}
 import com.waz.service.LegalHoldService
+import com.waz.sync.handler.LegalHoldError
 import com.waz.zclient.{Injectable, Injector}
 import com.wire.signals.Signal
+
+import scala.concurrent.Future
 
 //TODO: implement status calculation
 class LegalHoldController(implicit injector: Injector)
   extends Injectable {
+
+  import com.waz.threading.Threading.Implicits.Background
 
   private lazy val legalHoldService = inject[Signal[LegalHoldService]]
 
@@ -16,4 +21,17 @@ class LegalHoldController(implicit injector: Injector)
 
   def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] =
     Signal.const(false)
+
+  def legalHoldRequest: Signal[Option[LegalHoldRequest]] =
+    legalHoldService.flatMap(_.legalHoldRequest)
+
+  def approveRequest(password: Option[String]): Future[Either[LegalHoldError, Unit]] = for {
+    service <- legalHoldService.head
+    request <- service.legalHoldRequest.head
+    result  <- request match {
+      case None    => Future.successful(Right({}))
+      case Some(r) => service.approveRequest(r, password)
+    }
+  } yield result
+
 }

--- a/zmessaging/src/main/java/com/waz/api/OtrClientType.java
+++ b/zmessaging/src/main/java/com/waz/api/OtrClientType.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum OtrClientType {
-    PHONE("phone"), TABLET("tablet"), DESKTOP("desktop");
+    PHONE("phone"), TABLET("tablet"), DESKTOP("desktop"), LEGALHOLD("legalhold");
 
     public final String deviceClass;
 
@@ -30,6 +30,7 @@ public enum OtrClientType {
         classMap.put(PHONE.deviceClass, PHONE);
         classMap.put(TABLET.deviceClass, TABLET);
         classMap.put(DESKTOP.deviceClass, DESKTOP);
+        classMap.put(LEGALHOLD.deviceClass, LEGALHOLD);
     }
 
     public static OtrClientType fromDeviceClass(String cls) {

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -1,10 +1,14 @@
 package com.waz.service
 
+import com.waz.api.OtrClientType
 import com.waz.content.{PropertiesStorage, PropertyValue}
+import com.waz.model.otr.ClientId
 import com.waz.model.{LegalHoldRequest, LegalHoldRequestEvent, UserId}
 import com.waz.service.EventScheduler.Stage
+import com.waz.service.otr.OtrService.SessionId
+import com.waz.service.otr.{CryptoSessionService, OtrClientsService}
 import com.waz.sync.SyncResult
-import com.waz.sync.handler.LegalHoldSyncHandler
+import com.waz.sync.handler.{LegalHoldError, LegalHoldSyncHandler}
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 
 import scala.concurrent.Future
@@ -13,13 +17,18 @@ trait LegalHoldService {
   def legalHoldRequestEventStage: Stage.Atomic
   def syncLegalHoldRequest(): Future[SyncResult]
   def fetchLegalHoldRequest(): Future[Option[LegalHoldRequest]]
+  def approveRequest(request: LegalHoldRequest,
+                     password: Option[String]): Future[Either[LegalHoldError, Unit]]
 }
 
-class LegalHoldServiceImpl(selfUserId: UserId, storage: PropertiesStorage, syncHandler: LegalHoldSyncHandler)
-  extends LegalHoldService {
+class LegalHoldServiceImpl(selfUserId: UserId,
+                           storage: PropertiesStorage,
+                           syncHandler: LegalHoldSyncHandler,
+                           clientsService: OtrClientsService,
+                           cryptoSessionService: CryptoSessionService) extends LegalHoldService {
 
-  import com.waz.threading.Threading.Implicits.Background
   import LegalHoldService._
+  import com.waz.threading.Threading.Implicits.Background
 
   override def legalHoldRequestEventStage: Stage.Atomic = EventScheduler.Stage[LegalHoldRequestEvent] { (_, events) =>
     Future.sequence {
@@ -40,6 +49,29 @@ class LegalHoldServiceImpl(selfUserId: UserId, storage: PropertiesStorage, syncH
       property.map(_.value).map(JsonDecoder.decode[LegalHoldRequest])
     }
   }
+
+  override def approveRequest(request: LegalHoldRequest, password: Option[String]): Future[Either[LegalHoldError, Unit]] = for {
+    _      <- createLegalHoldClientAndSession(request)
+    result <- syncHandler.approveRequest(password)
+    _      <- if (result.isLeft) {
+                deleteLegalHoldClientAndSession(request.clientId)
+              } else {
+                Future.successful({})
+              }
+  } yield { result }
+
+  private def createLegalHoldClientAndSession(request: LegalHoldRequest): Future[Unit] = for {
+    client          <- clientsService.getOrCreateClient(selfUserId, request.clientId)
+    legalHoldClient = client.copy(devType = OtrClientType.LEGALHOLD)
+    _               <- clientsService.updateUserClients(selfUserId, Seq(legalHoldClient))
+    sessionId       = SessionId(selfUserId, legalHoldClient.id)
+    _               <- cryptoSessionService.getOrCreateSession(sessionId, request.lastPreKey)
+  } yield ()
+
+  private def deleteLegalHoldClientAndSession(clientId: ClientId): Future[Unit] = for {
+    _ <- clientsService.removeClients(selfUserId, Seq(clientId))
+    _ <- cryptoSessionService.deleteSession(SessionId(selfUserId, clientId))
+  } yield ()
 
   private def storeRequest(request: LegalHoldRequest): Future[Unit] = {
     val value = JsonEncoder.encode[LegalHoldRequest](request).toString

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -127,6 +127,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val otrClientsService: OtrClientsService       = wire[OtrClientsServiceImpl]
   lazy val otrClientsSync:    OtrClientsSyncHandler   = wire[OtrClientsSyncHandlerImpl]
   lazy val otrClient:         OtrClientImpl           = account.otrClient
+  lazy val cryptoSessionService: CryptoSessionService = cryptoBox.sessions
   lazy val credentialsClient: CredentialsUpdateClientImpl = account.credentialsClient
   implicit lazy val authRequestInterceptor: AuthRequestInterceptor = account.authRequestInterceptor
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
@@ -49,7 +49,7 @@ class CryptoBoxService(context: Context, userId: UserId, metadata: MetaDataServi
 
   private var _cryptoBox = Option.empty[CryptoBox]
 
-  lazy val sessions = new CryptoSessionService(this)
+  lazy val sessions = new CryptoSessionServiceImpl(this)
 
   def cryptoBox = Future {
     _cryptoBox.orElse {

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -22,7 +22,7 @@ import com.waz.log.LogSE._
 import com.waz.service.otr.OtrService.SessionId
 import com.waz.service.push.PushNotificationEventsStorage.PlainWriter
 import com.waz.threading.Threading
-import com.wire.signals.{AggregatingSignal, DispatchQueue, EventStream, Serialized}
+import com.wire.signals.{AggregatingSignal, DispatchQueue, EventStream, Serialized, Signal}
 import com.waz.utils.returning
 import com.wire.cryptobox.{CryptoBox, CryptoSession, PreKey}
 
@@ -36,7 +36,7 @@ trait CryptoSessionService {
   def getSession(id: SessionId): Future[Option[CryptoSession]]
   def withSession[A](id: SessionId)(f: CryptoSession => A): Future[Option[A]]
   def decryptMessage(sessionId: SessionId, msg: Array[Byte], eventsWriter: PlainWriter): Future[Unit]
-  def remoteFingerprint(sid: SessionId): AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]]
+  def remoteFingerprint(sid: SessionId): Signal[Option[Array[Byte]]]
 }
 
 class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
@@ -109,7 +109,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
     }
   }
 
-  def remoteFingerprint(sid: SessionId): AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]] = {
+  def remoteFingerprint(sid: SessionId): Signal[Option[Array[Byte]]] = {
     def fingerprint = withSession(sid)(_.getRemoteFingerprint)
     val stream = onCreate.filter(_ == sid).mapAsync(_ => fingerprint)
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -29,7 +29,18 @@ import com.wire.cryptobox.{CryptoBox, CryptoSession, PreKey}
 import scala.concurrent.Future
 import scala.util.Try
 
-class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
+trait CryptoSessionService {
+  val onCreateFromMessage: EventStream[SessionId]
+  def getOrCreateSession(id: SessionId, key: PreKey): Future[Option[CryptoSession]]
+  def deleteSession(id: SessionId): Future[Unit]
+  def getSession(id: SessionId): Future[Option[CryptoSession]]
+  def withSession[A](id: SessionId)(f: CryptoSession => A): Future[Option[A]]
+  def decryptMessage(sessionId: SessionId, msg: Array[Byte], eventsWriter: PlainWriter): Future[Unit]
+  def remoteFingerprint(sid: SessionId): AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]]
+}
+
+class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
+  extends CryptoSessionService with DerivedLogTag {
 
   private implicit val dis: DispatchQueue = Threading.Background
 
@@ -58,12 +69,12 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
       None
     }
 
-  def deleteSession(id: SessionId) = dispatch(id) { cb =>
+  def deleteSession(id: SessionId): Future[Unit] = dispatch(id) { cb =>
     verbose(l"FIX deleteSession($id)")
     cb.foreach(_.deleteSession(id.toString))
   }
 
-  def getSession(id: SessionId) = dispatch(id) { cb =>
+  def getSession(id: SessionId): Future[Option[CryptoSession]] = dispatch(id) { cb =>
     verbose(l"getSession($id)")
     cb.flatMap(loadSession(_, id))
   }
@@ -98,7 +109,7 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
     }
   }
 
-  def remoteFingerprint(sid: SessionId) = {
+  def remoteFingerprint(sid: SessionId): AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]] = {
     def fingerprint = withSession(sid)(_.getRemoteFingerprint)
     val stream = onCreate.filter(_ == sid).mapAsync(_ => fingerprint)
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
@@ -19,6 +19,7 @@ package com.waz.sync.client
 
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.{LegalHoldRequest, TeamId, UserId}
+import com.waz.utils.JsonEncoder
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.{HttpClient, RawBodyDeserializer, Request}
 import com.waz.znet2.http.Request.UrlCreator
@@ -27,6 +28,10 @@ import org.json.JSONObject
 trait LegalHoldClient {
   def fetchLegalHoldRequest(teamId: TeamId,
                             userId: UserId): ErrorOrResponse[Option[LegalHoldRequest]]
+
+  def approveRequest(teamId: TeamId,
+                     userId: UserId,
+                     password: Option[String]): ErrorOrResponse[Unit]
 }
 
 class LegalHoldClientImpl(implicit
@@ -52,6 +57,17 @@ class LegalHoldClientImpl(implicit
       .withResultType[Option[LegalHoldRequest]]
       .withErrorType[ErrorResponse]
       .executeSafe
+
+  override def approveRequest(teamId: TeamId,
+                              userId: UserId,
+                              password: Option[String]): ErrorOrResponse[Unit] =
+    Request.Put(
+      relativePath = s"${path(teamId, userId)}/approve",
+      body = JsonEncoder { _.put("password", password) }
+    )
+    .withResultType[Unit]
+    .withErrorType[ErrorResponse]
+    .executeSafe
 }
 
 object LegalHoldClient {

--- a/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
@@ -62,7 +62,7 @@ class LegalHoldClientImpl(implicit
                               userId: UserId,
                               password: Option[String]): ErrorOrResponse[Unit] =
     Request.Put(
-      relativePath = s"${path(teamId, userId)}/approve",
+      relativePath = approvePath(teamId, userId),
       body = JsonEncoder { _.put("password", password) }
     )
     .withResultType[Unit]
@@ -72,4 +72,5 @@ class LegalHoldClientImpl(implicit
 
 object LegalHoldClient {
   def path(teamId: TeamId, userId: UserId): String = s"/teams/${teamId.str}/legalhold/${userId.str}"
+  def approvePath(teamId: TeamId, userId: UserId): String = s"${path(teamId, userId)}/approve"
 }

--- a/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -135,11 +135,17 @@ class OtrClientImpl(implicit
       o.put("lastkey", JsonEncoder.encode(lastKey)(PreKeyEncoder))
       client.signalingKey foreach { sk => o.put("sigkeys", JsonEncoder.encode(sk)) }
       o.put("prekeys", JsonEncoder.arr(keys)(PreKeyEncoder))
-      o.put("type", if (PermanentClient) "permanent" else "temporary")
       o.put("label", client.label)
       o.put("model", client.model)
       o.put("class", client.devType.deviceClass)
       o.put("cookie", userId.str)
+
+      if (client.devType == OtrClientType.LEGALHOLD) {
+        o.put("type", "legalhold")
+      } else {
+        o.put("type", if (PermanentClient) "permanent" else "temporary")
+      }
+
       password.map(_.str).foreach(o.put("password", _))
     }
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
@@ -9,14 +9,39 @@ import scala.concurrent.Future
 
 trait LegalHoldSyncHandler {
   def fetchLegalHoldRequest(): Future[Either[ErrorResponse, Option[LegalHoldRequest]]]
+  def approveRequest(password: Option[String]): Future[Either[LegalHoldError, Unit]]
 }
 
 class LegalHoldSyncHandlerImpl(teamId: Option[TeamId], userId: UserId, client: LegalHoldClient)
   extends LegalHoldSyncHandler with DerivedLogTag {
+
+  import com.waz.threading.Threading.Implicits.Background
 
   override def fetchLegalHoldRequest(): Future[Either[ErrorResponse, Option[LegalHoldRequest]]] = teamId match {
     case None         => Future.successful(Right(None))
     case Some(teamId) => client.fetchLegalHoldRequest(teamId, userId).future
   }
 
+  override def approveRequest(password: Option[String]): Future[Either[LegalHoldError, Unit]] = teamId match {
+    case None =>
+      Future.successful(Left(LegalHoldError.NotInTeam))
+    case Some(teamId) =>
+      client.approveRequest(teamId, userId, password).future.map {
+        case Left(ErrorResponse(_, _, label)) if label == "access-denied" || label == "invalid-payload" =>
+          Left(LegalHoldError.InvalidPassword)
+        case Left(_) =>
+          Left(LegalHoldError.InvalidResponse)
+        case Right(_) =>
+          Right(())
+      }
+  }
+
+}
+
+sealed trait LegalHoldError
+
+object LegalHoldError {
+  case object NotInTeam extends LegalHoldError
+  case object InvalidPassword extends LegalHoldError
+  case object InvalidResponse extends LegalHoldError
 }

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -15,6 +15,7 @@ import com.waz.sync.handler.{LegalHoldError, LegalHoldSyncHandler}
 import com.waz.utils.JsonEncoder
 import com.waz.utils.crypto.AESUtils
 import com.wire.cryptobox.PreKey
+import com.wire.signals.Signal
 
 import scala.concurrent.Future
 
@@ -38,13 +39,13 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val service = createService()
       val value = JsonEncoder.encode[LegalHoldRequest](legalHoldRequest).toString
 
-      (storage.find _)
+      (storage.optSignal _)
         .expects(LegalHoldRequestKey)
         .once()
-        .returning(Future.successful(Some(PropertyValue(LegalHoldRequestKey, value))))
+        .returning(Signal.const(Some(PropertyValue(LegalHoldRequestKey, value))))
 
       // When
-      val fetchedResult = result(service.fetchLegalHoldRequest())
+      val fetchedResult = result(service.legalHoldRequest.head)
 
       // Then
       fetchedResult shouldBe defined
@@ -57,13 +58,13 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       // Given
       val service = createService()
 
-      (storage.find _)
+      (storage.optSignal _)
         .expects(LegalHoldRequestKey)
         .once()
-        .returning(Future.successful(None))
+        .returning(Signal.const(None))
 
       // When
-      val fetchedResult = result(service.fetchLegalHoldRequest())
+      val fetchedResult = result(service.legalHoldRequest.head)
 
       // Then
       fetchedResult shouldEqual None

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -183,6 +183,12 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
         .once()
         .returning(Future.successful(Right({})))
 
+      // Then pending request is deleted.
+      (storage.deleteByKey _)
+        .expects(LegalHoldRequestKey)
+        .once()
+        .returning(Future.successful({}))
+
       // When
       val actualResult = result(service.approveRequest(legalHoldRequest, Some("password")))
 

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -125,7 +125,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val actualResult = result(syncHandler.approveRequest(Some("123")))
 
       // Then
-      actualResult shouldBe Right(LegalHoldError.NotInTeam)
+      actualResult shouldBe Left(LegalHoldError.NotInTeam)
     }
 
   }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -45,7 +45,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       actualResult.right.get.isEmpty shouldBe true
     }
 
-    scenario("It fails the request fails") {
+    scenario("It fails if the request fails") {
       // Given
       val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
       val error = ErrorResponse(400, "", "")

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -14,52 +14,122 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
 
   private val client = mock[LegalHoldClient]
 
-  scenario("It fetches the legal hold request if the user is a team member") {
-    // Given
-    val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
+  feature("Fetching a legal hold request") {
 
-    (client.fetchLegalHoldRequest _)
-      .expects(TeamId("team1"), UserId("user1"))
-      .once()
-      .returning(CancellableFuture.successful(Right(Some(legalHoldRequest))))
+    scenario("It fetches the legal hold request if the user is a team member") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
 
-    // When
-    val actualResult = result(syncHandler.fetchLegalHoldRequest())
+      (client.fetchLegalHoldRequest _)
+        .expects(TeamId("team1"), UserId("user1"))
+        .once()
+        .returning(CancellableFuture.successful(Right(Some(legalHoldRequest))))
 
-    // Then
-    actualResult.isRight shouldBe true
-    actualResult.right.get.isDefined shouldBe true
+      // When
+      val actualResult = result(syncHandler.fetchLegalHoldRequest())
+
+      // Then
+      actualResult.isRight shouldBe true
+      actualResult.right.get.isDefined shouldBe true
+    }
+
+    scenario("It returns none if the user is not a team member") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(None, UserId("user1"), client)
+
+      // When
+      val actualResult = result(syncHandler.fetchLegalHoldRequest())
+
+      // Then
+      actualResult.isRight shouldBe true
+      actualResult.right.get.isEmpty shouldBe true
+    }
+
+    scenario("It fails the request fails") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
+      val error = ErrorResponse(400, "", "")
+
+      (client.fetchLegalHoldRequest _)
+        .expects(TeamId("team1"), UserId("user1"))
+        .once()
+        .returning(CancellableFuture.successful(Left(error)))
+
+      // When
+      val actualResult = result(syncHandler.fetchLegalHoldRequest())
+
+      // Then
+      actualResult.isLeft shouldBe true
+      actualResult.left.get shouldEqual error
+    }
+
   }
 
-  scenario("It returns none if the user is not a team member") {
-    // Given
-    val syncHandler = new LegalHoldSyncHandlerImpl(None, UserId("user1"), client)
+  feature("Approving a legal hold request") {
 
-    // When
-    val actualResult = result(syncHandler.fetchLegalHoldRequest())
+    scenario("It succeeds if the password is correct") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
 
-    // Then
-    actualResult.isRight shouldBe true
-    actualResult.right.get.isEmpty shouldBe true
+      (client.approveRequest _)
+        .expects(TeamId("team1"), UserId("user1"), Some("123"))
+        .once()
+        .returning(CancellableFuture.successful(Right({})))
+
+      // When
+      val actualResult = result(syncHandler.approveRequest(Some("123")))
+
+      // Then
+      actualResult.isRight shouldBe true
+    }
+
+    scenario("It fails if the password is incorrect") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
+      val error = ErrorResponse(400, "", "access-denied")
+
+      (client.approveRequest _)
+        .expects(TeamId("team1"), UserId("user1"), Some("123"))
+        .once()
+        .returning(CancellableFuture.successful(Left(error)))
+
+      // When
+      val actualResult = result(syncHandler.approveRequest(Some("123")))
+
+      // Then
+      actualResult shouldBe Left(LegalHoldError.InvalidPassword)
+    }
+
+    scenario("It fails if the password is invalid") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
+      val error = ErrorResponse(400, "", "invalid-payload")
+
+      (client.approveRequest _)
+        .expects(TeamId("team1"), UserId("user1"), Some("123"))
+        .once()
+        .returning(CancellableFuture.successful(Left(error)))
+
+      // When
+      val actualResult = result(syncHandler.approveRequest(Some("123")))
+
+      // Then
+      actualResult shouldBe Left(LegalHoldError.InvalidPassword)
+    }
+
+    scenario("It fails if the self user is not in a team") {
+      // Given
+      val syncHandler = new LegalHoldSyncHandlerImpl(teamId = None, UserId("user1"), client)
+
+      // When
+      val actualResult = result(syncHandler.approveRequest(Some("123")))
+
+      // Then
+      actualResult shouldBe Right(LegalHoldError.NotInTeam)
+    }
+
   }
 
-  scenario("It fails the request fails") {
-    // Given
-    val syncHandler = new LegalHoldSyncHandlerImpl(Some(TeamId("team1")), UserId("user1"), client)
-    val error = ErrorResponse(400, "", "")
-
-    (client.fetchLegalHoldRequest _)
-      .expects(TeamId("team1"), UserId("user1"))
-      .once()
-      .returning(CancellableFuture.successful(Left(error)))
-
-    // When
-    val actualResult = result(syncHandler.fetchLegalHoldRequest())
-
-    // Then
-    actualResult.isLeft shouldBe true
-    actualResult.left.get shouldEqual error
-  }
 }
 
 object LegalHoldSyncHandlerSpec {


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-354

### Issues

The user needs a to be able to approve a pending legal hold request. 

### Solutions

When the user approves a request, we create a local legal hold device, establish a cryptographic session with it, post the approval to the backend, and delete the pending request if successful, otherwise delete the device and session if failed.

### Testing

Added tests for:

- handling the `/approve` response
- `approveRequest` method in the `LegalHoldService`

### Notes

It was necessary to provide an abstraction around `CryptoBoxSessionService` so that it could be mocked in the `LegalHoldServiceSpec`.
#### APK
[Download build #3280](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3280/artifact/build/artifact/wire-dev-PR3234-3280.apk)
[Download build #3281](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3281/artifact/build/artifact/wire-dev-PR3234-3281.apk)
[Download build #3282](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3282/artifact/build/artifact/wire-dev-PR3234-3282.apk)
[Download build #3288](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3288/artifact/build/artifact/wire-dev-PR3234-3288.apk)