### PR TITLE
fix: Another try at fixing the notification channel crash from Google Play Console

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -199,8 +199,8 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
     notificationChannel
   }
 
-  // this is the same code as in WireApplication.notificationChannel but I don't want to access it
-  // from here and the other way around as well (Maciek)
+  // this is the same code as in WireApplication.notificationChannel
+  // but we don't want to access it from here and the other way around as well
   lazy val notificationChannel: Option[NotificationChannel] =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
       Some(

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -48,7 +48,7 @@ import com.waz.service.teams.{FeatureFlagsService, TeamsService}
 import com.waz.service.tracking.TrackingService
 import com.waz.services.fcm.FetchJob
 import com.waz.services.gps.GoogleApiImpl
-import com.waz.services.websocket.WebSocketController
+import com.waz.services.websocket.{WebSocketController, WebSocketService}
 import com.waz.sync.client.CustomBackendClient
 import com.waz.sync.{SyncHandler, SyncRequestService}
 import com.waz.threading.Threading
@@ -456,7 +456,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
       Some(
         returning(
           new NotificationChannel(
-            getString(R.string.default_notification_channel_id),
+            WebSocketService.ForegroundNotificationChannelId,
             getString(R.string.foreground_service_notification_name),
             NotificationManager.IMPORTANCE_LOW)
         ) { ch =>


### PR DESCRIPTION
I looked through the code of the commit which most probably causes the crashes and through Stack Overflow entries on similar issues. I found this: https://stackoverflow.com/a/51378281/2975925 which says that we shouldn't use localized strings as the notification channel ids, and I followed this advise in WebSocketService, and also I decided to bring back a line that ensures the notification channel is created when the app goes to foreground (just as it was before).

We are still not able to reproduce the crash 100% but I think this PR should help.

#### APK
[Download build #3284](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3284/artifact/build/artifact/wire-dev-PR3235-3284.apk)
[Download build #3286](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3286/artifact/build/artifact/wire-dev-PR3235-3286.apk)