### PR TITLE
patch version implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,8 @@ android {
     defaultConfig {
         minSdkVersion Versions.MIN_SDK_VERSION
         targetSdkVersion Versions.TARGET_SDK_VERSION
-        versionCode System.getenv("BUILD_NUMBER") as Integer ?: 99999
+        //BUILD_NUMBER is required by the old jenkins builder, PATCH_VERSION will be used for the new builder to remove the dependency of the pipeline build_number
+        versionCode System.getenv("PATCH_VERSION") as Integer?: System.getenv("BUILD_NUMBER") as Integer ?: 99999
         versionName = (System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION) + android.defaultConfig.versionCode
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"


### PR DESCRIPTION
- implemented the system env PATCH_VERSION for the versionCode as a hybrid mode until BUILD_NUMBER is removed

## What's new in this PR?

this pr is adding a second level system environment variable called PATCH_VERSION into the build.gradle file.
This variable is the first step to remove the dependency for the build.gradle file to the build number of the jenkins builder.

the second step will then be to hook the PATCH_VERSION to a calculation matrix which is incrementing the code based on an algorithm so the patch version becomes a repo variable and not a builder system variable

#### APK
[Download build #3287](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3287/artifact/build/artifact/wire-dev-PR3237-3287.apk)