### PR TITLE
Fix: ActivityLifecycleCallback - onStop callback overrides currentActivity set on onStart callback

### DIFF
--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -53,8 +53,11 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     activity match {
       case _: LaunchActivity =>
       case _ =>
+        activitiesRunning.mutate {
+          case (running, Some(currentActivity)) if currentActivity == activity => (running - 1, None)
+          case (running, act) => (running - 1, act)
+        }
         verbose(l"onActivityStopped, activities still active: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
-        activitiesRunning.mutate { case (running, _) => (running - 1, Option(activity)) }
     }
   }
 
@@ -62,9 +65,8 @@ class ActivityLifecycleCallback(implicit injector: Injector)
     activity match {
       case _: LaunchActivity =>
       case _ =>
+        activitiesRunning.mutate { case (running, _) => (running + 1, Some(activity)) }
         verbose(l"onActivityStarted, activities active now: ${activitiesRunning.currentValue}, ${activity.getClass.getName}")
-        activitiesRunning.mutate { case (running, _) => (running + 1, Option(activity)) }
-
     }
   }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

`activitiesRunning` Signal in ActivityLifecycleCallback keeps track of how many activities are running, and the current visible activity. The calculation of current activity was false because the `mutate` call `onActivityStopped` was overriding the `mutate` call on `onActivityStarted`.

### Causes

Suppose we open Activity1, and then we open Activity2 on top of Activity1. The lifecycle callbacks triggered in turn are:

```
onActivityStarted(Activity1)
onActivityStarted(Activity2)
onActivityStopped(Activity1)
```

in the latest call, mutate operation used to set Activity1 as the latest activity, even though Activity2 is the one.

### Solutions

Change operation in `onActivityStopped` so that,

- if currently visible activity is already set to something else, don't change it
- if currently visible activity is equal to activity being stopped, set currently visible activity to `None`, as the app is going to background

### Testing

Manually verified that App Lock feature isn't affected. Got in contact with QA for other test cases.



#### APK
[Download build #3294](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3294/artifact/build/artifact/wire-dev-PR3240-3294.apk)