### PR TITLE
fix: App crash when just after the install the app is put to background

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -174,11 +174,12 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
   private lazy val appInForegroundSubscription =
     controller.serviceInForeground.foreach {
       case false =>
+        notificationChannel
         stopForeground(true)
       case true =>
         notificationChannel
         startForeground(getString(controller.notificationTitleId))
-    }
+    }(Threading.Ui)
 
   override def onBind(intent: content.Intent): IBinder = null
 


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-600

Since Android 8.1 we need to create a notification channel for our app. We need to do it lazily, but early enough.
The bug was that if the app was opened for the first time, the notification channel was not created right away,
and then when the app was put to background, we called `stopForeground` in `WebSocketService` - that method crashes
the app if the notification channel is not created. Fixed that. Now we ensure that the notification channel is
created also when going to the background, before `stopForeground` is called.
#### APK
[Download build #3298](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3298/artifact/build/artifact/wire-dev-PR3242-3298.apk)