### PR TITLE
Feature: Legal hold acceptance - Check whether pop up should be displayed when app comes to foreground

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -226,6 +226,7 @@ object WireApplication extends DerivedLogTag {
     bind [ThemeController]         to new ThemeController
     bind [SpinnerController]       to new SpinnerController()
     bind [SearchController]        to new SearchController()
+    bind [LegalHoldController]     to new LegalHoldController()
 
     bind [UiStorage] to new UiStorage()
 
@@ -325,7 +326,6 @@ object WireApplication extends DerivedLogTag {
     bind [UiTrackingController]    to new UiTrackingController()
 
     bind[MessagePagedListController] to new MessagePagedListController()
-    bind[LegalHoldController] to new LegalHoldController()
   }
 
   def clearOldVideoFiles(context: Context): Unit = {

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -151,6 +151,13 @@ object SecurityPolicyChecker extends DerivedLogTag {
           Future.successful(Some(check, actions))
     } else EmptyCheck
 
+  private def requestLegalHoldAcceptance(implicit context: Context) = {
+      verbose(l"check request legal hold acceptance")
+      val check = RequestLegalHoldCheck()
+      val actions = List(new ShowLegalHoldApprovalAction())
+      Future.successful(Some(check, actions))
+  }
+
   /**
     * Security checklist for foreground activity
     */
@@ -176,7 +183,8 @@ object SecurityPolicyChecker extends DerivedLogTag {
                                    case _            => requestPassword(ctrl, prefs, am, authNeeded)
                                  }
                              }
-      list                =  new SecurityChecklist(List(blockOnJailbreak, wipeOnCookieInvalid, requestPassword).flatten)
+      requestLegalHold    <- requestLegalHoldAcceptance
+      list                =  new SecurityChecklist(List(blockOnJailbreak, wipeOnCookieInvalid, requestPassword, requestLegalHold).flatten)
       allChecksPassed     <- list.run()
     } yield allChecksPassed
   }

--- a/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
+++ b/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
@@ -1,0 +1,15 @@
+package com.waz.zclient.security.actions
+
+import android.content.Context
+import android.widget.Toast
+import com.waz.zclient.security.SecurityChecklist
+import com.waz.threading.Threading.Implicits.Ui
+
+import scala.concurrent.Future
+
+class ShowLegalHoldApprovalAction(implicit context: Context) extends SecurityChecklist.Action {
+
+  override def execute(): Future[Unit] = Future {
+    Toast.makeText(context, "Please accept legal hold", Toast.LENGTH_SHORT).show()
+  }
+}

--- a/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
+++ b/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
@@ -1,15 +1,12 @@
 package com.waz.zclient.security.actions
 
 import android.content.Context
-import android.widget.Toast
 import com.waz.zclient.security.SecurityChecklist
-import com.waz.threading.Threading.Implicits.Ui
 
 import scala.concurrent.Future
 
 class ShowLegalHoldApprovalAction(implicit context: Context) extends SecurityChecklist.Action {
 
-  override def execute(): Future[Unit] = Future {
-    Toast.makeText(context, "Please accept legal hold", Toast.LENGTH_SHORT).show()
-  }
+  //TODO: display a pop up
+  override def execute(): Future[Unit] = Future.successful(())
 }

--- a/app/src/main/scala/com/waz/zclient/security/checks/RequestLegalHoldCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/checks/RequestLegalHoldCheck.scala
@@ -1,0 +1,13 @@
+package com.waz.zclient.security.checks
+
+import com.waz.zclient.security.SecurityChecklist
+
+import scala.concurrent.Future
+
+class RequestLegalHoldCheck extends SecurityChecklist.Check {
+  override def isSatisfied: Future[Boolean] = Future.successful(false)
+}
+
+object RequestLegalHoldCheck {
+  def apply(): RequestLegalHoldCheck = new RequestLegalHoldCheck()
+}

--- a/app/src/main/scala/com/waz/zclient/security/checks/RequestLegalHoldCheck.scala
+++ b/app/src/main/scala/com/waz/zclient/security/checks/RequestLegalHoldCheck.scala
@@ -1,13 +1,18 @@
 package com.waz.zclient.security.checks
 
+import com.waz.zclient.legalhold.LegalHoldController
 import com.waz.zclient.security.SecurityChecklist
+import com.waz.threading.Threading.Implicits.Background
 
 import scala.concurrent.Future
 
-class RequestLegalHoldCheck extends SecurityChecklist.Check {
-  override def isSatisfied: Future[Boolean] = Future.successful(false)
+class RequestLegalHoldCheck(legalHoldController: LegalHoldController) extends SecurityChecklist.Check {
+
+  override def isSatisfied: Future[Boolean] =
+    legalHoldController.legalHoldRequest.head.map(_.isEmpty)
 }
 
 object RequestLegalHoldCheck {
-  def apply(): RequestLegalHoldCheck = new RequestLegalHoldCheck()
+  def apply(legalHoldController: LegalHoldController): RequestLegalHoldCheck =
+    new RequestLegalHoldCheck(legalHoldController)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue : [SQSERVICES-351](https://wearezeta.atlassian.net/browse/SQSERVICES-351)

Given there's a pending legal hold request for the self user,
When app comes to foreground,
Then a pop up (#3225 ) should be displayed prompting the user to accept legal hold.

### Solutions

We already had a structure of such checks for when app comes to foreground. Added legal hold check as a last step of these security checks.

### Testing

Manually tested with and without app lock.



#### APK
[Download build #3301](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3301/artifact/build/artifact/wire-dev-PR3243-3301.apk)