### PR TITLE
Feature: Legal hold acceptance - Part 3 - Show approval pop up

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -1,5 +1,6 @@
 package com.waz.zclient.legalhold
 
+import com.waz.model.AccountData.Password
 import com.waz.model.{ConvId, LegalHoldRequest, UserId}
 import com.waz.service.LegalHoldService
 import com.waz.sync.handler.LegalHoldError
@@ -21,19 +22,19 @@ class LegalHoldController(implicit injector: Injector)
 
   def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] =
     Signal.const(false)
-    
+
   def legalHoldUsers(conversationId: ConvId): Signal[Seq[UserId]] =
     Signal.const(Seq.empty)
 
   def legalHoldRequest: Signal[Option[LegalHoldRequest]] =
     legalHoldService.flatMap(_.legalHoldRequest)
 
-  def approveRequest(password: Option[String]): Future[Either[LegalHoldError, Unit]] = for {
+  def approveRequest(password: Option[Password]): Future[Either[LegalHoldError, Unit]] = for {
     service <- legalHoldService.head
     request <- service.legalHoldRequest.head
     result  <- request match {
       case None    => Future.successful(Right({}))
-      case Some(r) => service.approveRequest(r, password)
+      case Some(r) => service.approveRequest(r, password.map(_.str))
     }
   } yield result
 

--- a/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
+++ b/app/src/main/scala/com/waz/zclient/security/SecurityPolicyChecker.scala
@@ -157,7 +157,7 @@ object SecurityPolicyChecker extends DerivedLogTag {
   private def requestLegalHoldAcceptance(legalHoldController: LegalHoldController)(implicit context: Context) = {
       verbose(l"check request legal hold acceptance")
       val check = RequestLegalHoldCheck(legalHoldController)
-      val actions = List(new ShowLegalHoldApprovalAction())
+      val actions = List(new ShowLegalHoldApprovalAction(legalHoldController))
       Future.successful(Some(check, actions))
   }
 

--- a/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
+++ b/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
@@ -46,7 +46,7 @@ class ShowLegalHoldApprovalAction(legalHoldController: LegalHoldController)(impl
 
   //TODO: show loading animation while we're waiting for network response
   private def onLegalHoldAccepted(password: Option[Password]): Unit =
-    legalHoldController.approveRequest(password).map {
+    legalHoldController.approveRequest(password).foreach {
       case Left(LegalHoldError.InvalidPassword) => showLegalHoldRequestDialog(true)
       case Left(_)  => showGeneralError()
       case Right(_) => setFinished()


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-351](https://wearezeta.atlassian.net/browse/SQSERVICES-351)
Given there's a pending legal hold request for the self user,
When app comes to foreground,
Then a pop up should be displayed prompting the user to accept legal hold

[SQSERVICES-340](https://wearezeta.atlassian.net/browse/SQSERVICES-340)
Given LH pop up is displayed,
When I enter a wrong password,
Then I should see an error message saying "Wrong password"

[SQSERVICES-341](https://wearezeta.atlassian.net/browse/SQSERVICES-341)
Given LH pop up is displayed,
And I entered a password
And I click "Accept"
When some error is received,
Then I should see a new pop up with generic error message


### Solutions

Modifies `ShowLegalHoldApprovalAction` for given scenarios

### Testing

Tested manually


#### APK
[Download build #3307](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3307/artifact/build/artifact/wire-dev-PR3246-3307.apk)
[Download build #3320](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3320/artifact/build/artifact/wire-dev-PR3246-3320.apk)
[Download build #3322](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3322/artifact/build/artifact/wire-dev-PR3246-3322.apk)
[Download build #3343](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3343/artifact/build/artifact/wire-dev-PR3246-3343.apk)