### PR TITLE
version code improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -472,7 +472,10 @@ def getDate() {
 }
 
 def getUnixTimestamp() {
-    return (int)(new Date().getTime()/1000L)
+    def date = new Date()
+    def versionCode = (int)(date.getTime()/1000L)
+    println("VERSIONCODE for ("+date.dateTimeString+"):"+versionCode)
+    return versionCode
 }
 
 def buildSuffixForVersion(String versionString) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,8 @@ task copyCustomResources(type: Copy) {
 }
 
 android {
+    def patchVersion = System.getenv("PATCH_VERSION") as Integer?: System.getenv("BUILD_NUMBER") as Integer ?: 99999
+
     //Trigger the licenseFormat task at least once in any compile phase
     applicationVariants.all { variant ->
         variant.javaCompiler.dependsOn(rootProject.licenseFormat)
@@ -71,9 +73,8 @@ android {
     defaultConfig {
         minSdkVersion Versions.MIN_SDK_VERSION
         targetSdkVersion Versions.TARGET_SDK_VERSION
-        //BUILD_NUMBER is required by the old jenkins builder, PATCH_VERSION will be used for the new builder to remove the dependency of the pipeline build_number
-        versionCode System.getenv("PATCH_VERSION") as Integer?: System.getenv("BUILD_NUMBER") as Integer ?: 99999
-        versionName = (System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION) + android.defaultConfig.versionCode
+        versionCode getUnixTimestamp() as Integer
+        versionName = (System.getenv("CLIENT_VERSION") ?: Versions.ANDROID_CLIENT_MAJOR_VERSION) + patchVersion
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 
@@ -464,13 +465,17 @@ tasks.withType(ScalaCompile) {
         "UTF-8"]
 }
 
-static def getDate() {
+def getDate() {
     def date = new Date()
     def formattedDate = date.format('MM/dd HH:mm:ss')
     return formattedDate
 }
 
-static def buildSuffixForVersion(String versionString) {
+def getUnixTimestamp() {
+    return (int)(new Date().getTime()/1000L)
+}
+
+def buildSuffixForVersion(String versionString) {
     if (versionString.matches("\\d+\\.\\d+\\.\\d+(-[.0-9a-zA-Z]+)")) "" else "-DEV"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -472,8 +472,11 @@ def getDate() {
 }
 
 def getUnixTimestamp() {
+    def dateOffset = new Date("04/21/2021 01:00:00")
     def date = new Date()
-    def versionCode = (int)(date.getTime()/10000L)
+    def dateTime = (date.getTime()/10000L)
+    def dateTimeOffset = (dateOffset.getTime()/10000L)
+    def versionCode = (int)(dateTime-dateTimeOffset)
     println("VERSIONCODE for ("+date.dateTimeString+"):"+versionCode)
     return versionCode
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -473,7 +473,7 @@ def getDate() {
 
 def getUnixTimestamp() {
     def date = new Date()
-    def versionCode = (int)(date.getTime()/1000L)
+    def versionCode = (int)(date.getTime()/10000L)
     println("VERSIONCODE for ("+date.dateTimeString+"):"+versionCode)
     return versionCode
 }


### PR DESCRIPTION
- changed the versionCode to a representive of the unix timestamp div 1000 (possible values until June 2036)
- added a variable called patchVersion to be used for the versionName, which represents the given BUILD_NUMBER, PATCH_VERSION or per default 99999 which was earlier used for the versionCode
- removed the static definitions from the defs getDate, buildSuffixForVersion and getUnixTimestamp

## What's new in this PR?

wire-android is currently bound to the BUILD_NUMBER of the Jenkinsbuilder is is build on, or reflects the usage of a static number on the local machine stated as 99999.
this causes the issue that a client can not be installed over another one on several test scenarios, as the versionCode would be lower or incorrect. 

in order to fix this, this PR is changing the way the versionCode is defined.
instead of using the BUILD_NUMBER from Jenkins, the unix timestamp is used for the calculation.
the logic will work for the next 15 years until the 18th of June 2036.

in addition to not cryptorize the name of the apk file, a seprate "patchVersion" variable has been introduced for using it for the versionName which is also represented in the filename of the generated APK file.
#### APK
[Download build #3319](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3319/artifact/build/artifact/wire-dev-PR3248-3319.apk)
[Download build #3335](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3335/artifact/build/artifact/wire-dev-PR3248-3335.apk)
[Download build #3337](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3337/artifact/build/artifact/wire-dev-PR3248-3337.apk)