### PR TITLE
refactor: Simplify SyncExecutor.execute

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
@@ -28,13 +28,12 @@ import com.waz.service.NetworkModeService
 import com.waz.sync.SyncHandler.RequestInfo
 import com.waz.sync.SyncResult._
 import com.waz.sync.{SyncHandler, SyncResult}
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils._
+import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
 import org.threeten.bp.Instant
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{Future, TimeoutException}
-import scala.util.Failure
 
 class SyncExecutor(account:     UserId,
                    scheduler:   SyncScheduler,
@@ -43,7 +42,7 @@ class SyncExecutor(account:     UserId,
                    handler: =>  SyncHandler) extends DerivedLogTag {
 
   import SyncExecutor._
-  private implicit val dispatcher = SerialDispatchQueue(name = "SyncExecutorQueue")
+  private implicit val dispatcher: DispatchQueue = SerialDispatchQueue(name = "SyncExecutorQueue")
 
   def apply(job: SyncJob): Future[SyncResult] = {
     def withJob(f: SyncJob => Future[SyncResult]) =
@@ -63,55 +62,41 @@ class SyncExecutor(account:     UserId,
     }
   }
 
-  private def execute(job: SyncJob): Future[SyncResult] = {
-    verbose(l"executeJob: $job")
-    val future =
-      for {
-        online     <- network.isOnline.head
-        syncJob    <- content.updateSyncJob(job.id)(job => job.copy(attempts = job.attempts + 1, state = SyncState.SYNCING, error = None, offline = !online))
-        syncResult <- syncJob match {
-          case None => Future.successful(SyncResult(ErrorResponse.internalError(s"Could not update job: $job")))
-          case Some(updated) =>
-            handler(account, updated.request)(RequestInfo(updated.attempts, Instant.ofEpochMilli(updated.startTime), network.networkMode.currentValue))
-              .recover {
-                case e: Throwable =>
-                  SyncResult(ErrorResponse.internalError(s"syncHandler($updated) failed with unexpected error: ${e.getMessage}"))
-              }
-              .flatMap(res => processSyncResult(updated, res))
-        }
-      } yield syncResult
+  private def execute(job: SyncJob): Future[SyncResult] =
+    for {
+      online     <- network.isOnline.head
+      syncJob    <- content.updateSyncJob(job.id)(job => job.copy(attempts = job.attempts + 1, state = SyncState.SYNCING, error = None, offline = !online))
+      syncResult <- syncJob match {
+        case None => Future.successful(SyncResult(ErrorResponse.internalError(s"Could not update job: $job")))
+        case Some(updated) =>
+          handler(account, updated.request)(RequestInfo(updated.attempts, Instant.ofEpochMilli(updated.startTime), network.networkMode.currentValue))
+            .recover {
+              case e: Throwable =>
+                SyncResult(ErrorResponse.internalError(s"syncHandler($updated) failed with unexpected error: ${e.getMessage}"))
+            }
+            .flatMap(res => processSyncResult(updated, res))
+      }
+    } yield syncResult
 
-    // this is only to check for any long running sync requests, which could mean very serious problem
-    CancellableFuture.lift(future).withTimeout(10.minutes).onComplete {
-      case Failure(e: TimeoutException) =>
-        // TODO: Think about removing the sync job at this point
-      case _ =>
-    }
-    future
-  }
-
-  private def processSyncResult(job: SyncJob, result: SyncResult): Future[SyncResult] = {
-
-    result match {
-      case Success =>
-        debug(l"SyncRequest: $job completed successfully")
-        content.removeSyncJob(job.id).map(_ => result)
-      case res @ SyncResult.Failure(error) =>
-        warn(l"SyncRequest: $job, failed permanently with error: $error")
-        content.removeSyncJob(job.id).map(_ => res)
-      case Retry(error) =>
-        warn(l"SyncRequest: $job, failed with error: $error")
-        if (job.attempts > MaxSyncAttempts) {
-          content.removeSyncJob(job.id).map(_ => SyncResult.Failure(error))
-        } else {
-          verbose(l"will schedule retry for: $job")
-          val nextTryTime = System.currentTimeMillis() + SyncExecutor.failureDelay(job)
-          for {
-            online  <- network.isOnline.head
-            _       <- content.updateSyncJob(job.id)(job => job.copy(state = SyncState.FAILED, startTime = nextTryTime, error = Some(error), offline = job.offline || !online))
-          } yield result
-        }
-    }
+  private def processSyncResult(job: SyncJob, result: SyncResult): Future[SyncResult] = result match {
+    case Success =>
+      debug(l"SyncRequest: $job completed successfully")
+      content.removeSyncJob(job.id).map(_ => result)
+    case res @ SyncResult.Failure(error) =>
+      warn(l"SyncRequest: $job, failed permanently with error: $error")
+      content.removeSyncJob(job.id).map(_ => res)
+    case Retry(error) =>
+      warn(l"SyncRequest: $job, failed with error: $error")
+      if (job.attempts > MaxSyncAttempts) {
+        content.removeSyncJob(job.id).map(_ => SyncResult.Failure(error))
+      } else {
+        verbose(l"will schedule retry for: $job")
+        val nextTryTime = System.currentTimeMillis() + SyncExecutor.failureDelay(job)
+        for {
+          online  <- network.isOnline.head
+          _       <- content.updateSyncJob(job.id)(job => job.copy(state = SyncState.FAILED, startTime = nextTryTime, error = Some(error), offline = job.offline || !online))
+        } yield result
+      }
   }
 }
 


### PR DESCRIPTION
While working on wire-signals CancellableFuture I realized that the withTimeout method used here in SyncExecutor
in the execute method have never worked and there is no way to make it work. I decided to remove the call it
to avoid confusion.

Other changes are just indentation.
#### APK
[Download build #3324](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3324/artifact/build/artifact/wire-dev-PR3250-3324.apk)