### PR TITLE
[Calling] Enable zooming for videos in 1:1 calls

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -37,6 +37,7 @@ import com.waz.zclient.{FragmentHelper, R}
 import com.wire.signals.Signal
 import com.waz.zclient.calling.CallingFragment.MaxAllVideoPreviews
 import com.waz.zclient.calling.CallingFragment.MaxTopSpeakerVideoPreviews
+import com.waz.zclient.calling.CallingFragment.NbParticipantsOneOneCall
 import com.waz.zclient.calling.controllers.CallController.CallParticipantInfo
 import com.waz.zclient.utils.RichView
 import com.xuliwen.zoom.ZoomLayout
@@ -123,7 +124,7 @@ class CallingFragment extends FragmentHelper {
     }
 
     controller.allParticipants.map(_.size).onUi {
-      case 2 =>
+      case NbParticipantsOneOneCall =>
         zoomLayout.foreach(_.setEnabled(true))
         Toast.makeText(getContext, R.string.calling_screenshare_zooming_message, Toast.LENGTH_LONG).show()
       case _ => zoomLayout.foreach(_.setEnabled(false))
@@ -295,5 +296,6 @@ object CallingFragment {
   val Tag: String = getClass.getSimpleName
   val MaxAllVideoPreviews = 12
   val MaxTopSpeakerVideoPreviews = 4
+  val NbParticipantsOneOneCall: Int = 2
   def apply(): CallingFragment = new CallingFragment()
 }

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -122,8 +122,8 @@ class CallingFragment extends FragmentHelper {
       controller.controlsClick(true)
     }
 
-    Signal.zip(controller.screenShares.map(_.size), controller.allParticipants.map(_.size)).onUi {
-      case (1, 2) =>
+    controller.allParticipants.map(_.size).onUi {
+      case 2 =>
         zoomLayout.foreach(_.setEnabled(true))
         Toast.makeText(getContext, R.string.calling_screenshare_zooming_message, Toast.LENGTH_LONG).show()
       case _ => zoomLayout.foreach(_.setEnabled(false))

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -135,8 +135,6 @@ class CallController(implicit inj: Injector, cxt: WireContext)
         }
     }
 
-  val screenShares = participantInfos.map(_.filter(_.isScreenShareEnabled == true))
-
   private val lastCallAccountId: SourceSignal[UserId] = Signal()
   currentCall.map(_.selfParticipant.userId) { selfUserId => lastCallAccountId ! selfUserId }
 


### PR DESCRIPTION
## What's new in this PR?

In #3251 we introduced zooming in 1:1 calls for screen sharing, the calling squad decided to allow zooming for videos in 1:1 calls as well.

#### APK
[Download build #3328](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3328/artifact/build/artifact/wire-dev-PR3253-3328.apk)
[Download build #3330](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3330/artifact/build/artifact/wire-dev-PR3253-3330.apk)