### PR TITLE
[Fix] Legal hold request deserialization error

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
@@ -54,7 +54,7 @@ class LegalHoldClientImpl(implicit
   override def fetchLegalHoldRequest(teamId: TeamId,
                                      userId: UserId): ErrorOrResponse[Option[LegalHoldRequest]] =
     Request.Get(relativePath = path(teamId, userId))
-      .withResultType[Option[LegalHoldRequest]]
+      .withResultType[Option[LegalHoldRequest]](responseDeserializerFrom(bodyDeserializerFrom(Deserializer)))
       .withErrorType[ErrorResponse]
       .executeSafe
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The response when fetching the legal hold request cannot be deserialized.

### Causes

The incorrect deserializer is being implicitly used.

### Solutions

Explicitly pass in the correct deserializer.

### Testing

Tested manually.
#### APK
[Download build #3329](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3329/artifact/build/artifact/wire-dev-PR3255-3329.apk)