### PR TITLE
Feature(main screen) : show progress bar during slow sync

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/MainActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/MainActivity.kt
@@ -34,9 +34,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
 
     private fun handleLoadingBarVisibility(state: WorkInfo.State) {
         if (state == WorkInfo.State.RUNNING)
-            infiniteLoadingBarView.visibility = View.VISIBLE
+            mainLoadingProgressIndicator.visibility = View.VISIBLE
         else
-            infiniteLoadingBarView.visibility = View.GONE
+            mainLoadingProgressIndicator.visibility = View.GONE
     }
 
     private fun setUpBottomNavigation() = with(mainBottomNavigation) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.progressindicator.LinearProgressIndicator
-        android:id="@+id/infiniteLoadingBarView"
+        android:id="@+id/mainLoadingProgressIndicator"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:indeterminate="true"


### PR DESCRIPTION
| LTR| RTL |
|----|----|
|![Screen_Recording_20210420-122623_Wire Android Reloaded_1](https://user-images.githubusercontent.com/18124919/115393934-26278a00-a1da-11eb-966b-07487f2e4e51.gif) | ![Screen_Recording_20210420-131026_Wire Android Reloaded_1](https://user-images.githubusercontent.com/18124919/115393954-2d4e9800-a1da-11eb-892b-9c7bdea063d9.gif)|

|Landscape|
|----|
![Screen_Recording_20210420-131632_Wire Android Reloaded_1](https://user-images.githubusercontent.com/18124919/115394642-e44b1380-a1da-11eb-9b8c-c630c26943e4.gif)

Show an infinite loading bar at the top of screen when sync is running, otherwise hide it.


