### PR TITLE
Qualified ids

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpDataMapper.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpDataMapper.kt
@@ -6,6 +6,7 @@ import com.waz.zclient.storage.db.users.model.UsersEntity
 class UsersBackUpDataMapper : BackUpDataMapper<UsersBackUpModel, UsersEntity> {
     override fun fromEntity(entity: UsersEntity) = UsersBackUpModel(
         id = entity.id,
+        domain = entity.domain,
         teamId = entity.teamId,
         name = entity.name,
         email = entity.email,
@@ -35,6 +36,7 @@ class UsersBackUpDataMapper : BackUpDataMapper<UsersBackUpModel, UsersEntity> {
 
     override fun toEntity(model: UsersBackUpModel) = UsersEntity(
         id = model.id,
+        domain = model.domain,
         teamId = model.teamId,
         name = model.name,
         email = model.email,

--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpModel.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UsersBackUpModel(
     val id: String,
+    val domain: String?,
     val teamId: String? = null,
     val name: String = String.empty(),
     val email: String? = null,

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -463,7 +463,7 @@ class MainActivity extends BaseActivity
     verbose(l"handleIntent: ${RichIntent(intent)}")
 
     if (intent.initSync)
-      userPreferences.head.foreach { prefs => prefs(ShouldSyncInitial) := true }
+      userPreferences.head.foreach { prefs => prefs(shouldSyncAllOnUpdate) := true }
 
     def clearIntent(): Unit = {
       intent.clearExtras()

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpDataMapperTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpDataMapperTest.kt
@@ -21,6 +21,7 @@ class UsersBackUpDataMapperTest : UnitTest() {
         val data = UsersTestDataProvider.provideDummyTestData()
         val entity = UsersEntity(
             id = data.id,
+            domain = data.domain,
             teamId = data.teamId,
             name = data.name,
             email = data.email,
@@ -82,6 +83,7 @@ class UsersBackUpDataMapperTest : UnitTest() {
         val data = UsersTestDataProvider.provideDummyTestData()
         val model = UsersBackUpModel(
             id = data.id,
+            domain = data.domain,
             teamId = data.teamId,
             name = data.name,
             email = data.email,
@@ -112,6 +114,7 @@ class UsersBackUpDataMapperTest : UnitTest() {
         val entity = mapper.toEntity(model)
 
         assertEquals(data.id, entity.id)
+        assertEquals(data.domain, entity.domain)
         assertEquals(data.teamId, entity.teamId)
         assertEquals(data.name, entity.name)
         assertEquals(data.email, entity.email)

--- a/common-test/src/main/kotlin/com/waz/zclient/framework/data/users/UsersTestDataProvider.kt
+++ b/common-test/src/main/kotlin/com/waz/zclient/framework/data/users/UsersTestDataProvider.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 
 data class UsersTestData(
     val id: String,
+    val domain: String,
     val teamId: String,
     val name: String,
     val email: String,
@@ -36,6 +37,7 @@ object UsersTestDataProvider : TestDataProvider<UsersTestData>() {
     override fun provideDummyTestData(): UsersTestData =
         UsersTestData(
             id = UUID.randomUUID().toString(),
+            domain = "staging.zinfra.io",
             teamId = UUID.randomUUID().toString(),
             name = "name",
             email = "email@email.com",

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -55,6 +55,7 @@ import com.waz.zclient.storage.db.userclients.UserClientsEntity
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_128_TO_129
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO_130
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -104,13 +105,14 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 130
+        const val VERSION = 131
 
         @JvmStatic
         val migrations = arrayOf(
             USER_DATABASE_MIGRATION_127_TO_128,
             USER_DATABASE_MIGRATION_128_TO_129,
-            USER_DATABASE_MIGRATION_129_TO_130
+            USER_DATABASE_MIGRATION_129_TO_130,
+            USER_DATABASE_MIGRATION_130_TO_131
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
@@ -5,12 +5,15 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.waz.zclient.storage.db.users.migration.MigrationUtils.addColumn
 
+private const val USER_TABLE_NAME = "Users"
+private const val DOMAIN_COLUMN_NAME = "domain"
+
 val USER_DATABASE_MIGRATION_130_TO_131 = object : Migration(130, 131) {
     override fun migrate(database: SupportSQLiteDatabase) {
         addColumn(
             database = database,
-            tableName = "Users",
-            columnName = "domain",
+            tableName = USER_TABLE_NAME,
+            columnName = DOMAIN_COLUMN_NAME,
             columnType = MigrationUtils.ColumnType.TEXT
         )
     }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
@@ -1,0 +1,18 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.waz.zclient.storage.db.users.migration.MigrationUtils.addColumn
+
+val USER_DATABASE_MIGRATION_130_TO_131 = object : Migration(130, 131) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        addColumn(
+            database = database,
+            tableName = "Users",
+            columnName = "domain",
+            columnType = MigrationUtils.ColumnType.TEXT
+        )
+    }
+}
+

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase130To131Migration.kt
@@ -15,4 +15,3 @@ val USER_DATABASE_MIGRATION_130_TO_131 = object : Migration(130, 131) {
         )
     }
 }
-

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/model/UsersEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/model/UsersEntity.kt
@@ -18,6 +18,9 @@ data class UsersEntity(
     @PrimaryKey
     val id: String,
 
+    @ColumnInfo(name = "domain")
+    val domain: String?,
+
     @ColumnInfo(name = "teamId")
     val teamId: String?,
 

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -385,7 +385,7 @@ object UserPreferences {
 
   //increment number to perform slow sync on particular type
   lazy val ShouldSyncConversations = PrefKey[Boolean]("should_sync_conversations_2", customDefault = true)
-  lazy val ShouldSyncInitial = PrefKey[Boolean]("should_sync_initial_2", customDefault = true)
+  lazy val ShouldSyncInitial = PrefKey[Boolean]("should_sync_initial_3", customDefault = true)
   lazy val ShouldSyncUsers = PrefKey[Boolean]("should_sync_users_1", customDefault = true)
   lazy val ShouldSyncTeam = PrefKey[Boolean]("should_sync_team_1", customDefault = true)
   lazy val ShouldSyncFolders = PrefKey[Boolean]("should_sync_folders", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -385,7 +385,7 @@ object UserPreferences {
 
   //increment number to perform slow sync on particular type
   lazy val ShouldSyncConversations = PrefKey[Boolean]("should_sync_conversations_2", customDefault = true)
-  lazy val ShouldSyncInitial = PrefKey[Boolean]("should_sync_initial_3", customDefault = true)
+  lazy val shouldSyncAllOnUpdate = PrefKey[Boolean]("should_sync_all_on_update", customDefault = true)
   lazy val ShouldSyncUsers = PrefKey[Boolean]("should_sync_users_1", customDefault = true)
   lazy val ShouldSyncTeam = PrefKey[Boolean]("should_sync_team_1", customDefault = true)
   lazy val ShouldSyncFolders = PrefKey[Boolean]("should_sync_folders", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
@@ -1,0 +1,21 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder.opt
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import org.json.JSONObject
+
+final case class QualifiedId(id: UserId, domain: String)
+
+object QualifiedId {
+  implicit val Encoder: JsonEncoder[QualifiedId] = JsonEncoder.build(qId => js => {
+    js.put("id", qId.id.str)
+    js.put("domain", qId.domain)
+  })
+
+  private def decode(js: JSONObject): QualifiedId =
+    QualifiedId(UserId(js.getString("id")), js.getString("domain"))
+
+  implicit val Decoder: JsonDecoder[QualifiedId] = JsonDecoder.lift(implicit js => decode(js))
+
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[QualifiedId] = opt(s, js => decode(js.getJSONObject(s.name)))
+}

--- a/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
@@ -7,15 +7,21 @@ import org.json.JSONObject
 final case class QualifiedId(id: UserId, domain: String)
 
 object QualifiedId {
-  implicit val Encoder: JsonEncoder[QualifiedId] = JsonEncoder.build(qId => js => {
-    js.put("id", qId.id.str)
-    js.put("domain", qId.domain)
-  })
+  private val IdFieldName = "id"
+  private val DomainFieldName  = "domain"
+
+  implicit val Encoder: JsonEncoder[QualifiedId] =
+    JsonEncoder.build(qId => js => {
+      js.put(IdFieldName, qId.id.str)
+      js.put(DomainFieldName, qId.domain)
+    })
 
   private def decode(js: JSONObject): QualifiedId =
-    QualifiedId(UserId(js.getString("id")), js.getString("domain"))
+    QualifiedId(UserId(js.getString(IdFieldName)), js.getString(DomainFieldName))
 
-  implicit val Decoder: JsonDecoder[QualifiedId] = JsonDecoder.lift(implicit js => decode(js))
+  implicit val Decoder: JsonDecoder[QualifiedId] =
+    JsonDecoder.lift(implicit js => decode(js))
 
-  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[QualifiedId] = opt(s, js => decode(js.getJSONObject(s.name)))
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[QualifiedId] =
+    opt(s, js => decode(js.getJSONObject(s.name)))
 }

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -225,12 +225,14 @@ object UserData {
     val CopyPermissions = long('copy_permissions)(_.permissions._2)
     val CreatedBy = opt(id[UserId]('created_by))(_.createdBy)
 
+    private val UsersTableName = "Users"
+
     private def getVerification(name: String): Verification =
       Try(Verification.valueOf(name)).getOrElse(Verification.UNKNOWN)
 
     override val idCol = Id
     override val table = Table(
-      "Users", Id, Domain, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
+      UsersTableName, Id, Domain, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
       Conversation, Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId,
       ExpiresAt, Managed, SelfPermissions, CopyPermissions, CreatedBy // Fields are now lazy-loaded from BE every time the user opens a profile
     )

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -34,32 +34,33 @@ import com.waz.utils.wrappers.{DB, DBCursor}
 import scala.concurrent.duration._
 import scala.util.Try
 
-case class UserData(override val id:       UserId,
-                    teamId:                Option[TeamId]         = None,
-                    name:                  Name,
-                    email:                 Option[EmailAddress]  = None,
-                    phone:                 Option[PhoneNumber]   = None,
-                    trackingId:            Option[TrackingId]    = None,
-                    picture:               Option[Picture] = None,
-                    accent:                Int                   = 0, // accent color id
-                    searchKey:             SearchKey,
-                    connection:            ConnectionStatus       = ConnectionStatus.Unconnected,
-                    connectionLastUpdated: RemoteInstant          = RemoteInstant.Epoch, // server side timestamp of last connection update
-                    connectionMessage:     Option[String]         = None, // incoming connection request message
-                    conversation:          Option[RConvId]        = None, // remote conversation id with this contact (one-to-one)
-                    relation:              Relation               = Relation.Other, //unused - remove in future migration
-                    syncTimestamp:         Option[LocalInstant]   = None,
-                    verified:              Verification           = Verification.UNKNOWN, // user is verified if he has any otr client, and all his clients are verified
-                    deleted:               Boolean                = false,
-                    availability:          Availability           = Availability.None,
-                    handle:                Option[Handle]         = None,
-                    providerId:            Option[ProviderId]     = None,
-                    integrationId:         Option[IntegrationId]  = None,
-                    expiresAt:             Option[RemoteInstant]  = None,
-                    managedBy:             Option[ManagedBy]      = None,
-                    fields:                Seq[UserField]         = Seq.empty,
-                    permissions:           PermissionsMasks       = (0,0),
-                    createdBy:             Option[UserId]         = None) extends Identifiable[UserId] {
+final case class UserData(override val id:       UserId,
+                          domain:                Option[String]         = None,
+                          teamId:                Option[TeamId]         = None,
+                          name:                  Name,
+                          email:                 Option[EmailAddress]   = None,
+                          phone:                 Option[PhoneNumber]    = None,
+                          trackingId:            Option[TrackingId]     = None,
+                          picture:               Option[Picture]        = None,
+                          accent:                Int                    = 0, // accent color id
+                          searchKey:             SearchKey,
+                          connection:            ConnectionStatus       = ConnectionStatus.Unconnected,
+                          connectionLastUpdated: RemoteInstant          = RemoteInstant.Epoch, // server side timestamp of last connection update
+                          connectionMessage:     Option[String]         = None, // incoming connection request message
+                          conversation:          Option[RConvId]        = None, // remote conversation id with this contact (one-to-one)
+                          relation:              Relation               = Relation.Other, //unused - remove in future migration
+                          syncTimestamp:         Option[LocalInstant]   = None,
+                          verified:              Verification           = Verification.UNKNOWN, // user is verified if he has any otr client, and all his clients are verified
+                          deleted:               Boolean                = false,
+                          availability:          Availability           = Availability.None,
+                          handle:                Option[Handle]         = None,
+                          providerId:            Option[ProviderId]     = None,
+                          integrationId:         Option[IntegrationId]  = None,
+                          expiresAt:             Option[RemoteInstant]  = None,
+                          managedBy:             Option[ManagedBy]      = None,
+                          fields:                Seq[UserField]         = Seq.empty,
+                          permissions:           PermissionsMasks       = (0,0),
+                          createdBy:             Option[UserId]         = None) extends Identifiable[UserId] {
 
   lazy val isConnected: Boolean         = ConnectionStatus.isConnected(connection)
   lazy val hasEmailOrPhone: Boolean     = email.isDefined || phone.isDefined
@@ -173,9 +174,9 @@ object UserData {
 
   // used for testing only
   def apply(name: String): UserData = UserData(UserId(name), name = Name(name), searchKey = SearchKey.simple(name))
-  def withName(id: UserId, name: String): UserData = UserData(id, None, Name(name), None, None, searchKey = SearchKey.simple(name), handle = None)
+  def withName(id: UserId, name: String): UserData = UserData(id, None, None, Name(name), None, None, searchKey = SearchKey.simple(name), handle = None)
 
-  def apply(id: UserId, name: String): UserData = UserData(id, None, Name(name), None, None, searchKey = SearchKey(name), handle = None)
+  def apply(id: UserId, name: String): UserData = UserData(id, None, None, Name(name), None, None, searchKey = SearchKey(name), handle = None)
 
   def apply(entry: UserSearchEntry): UserData =
     UserData(
@@ -194,6 +195,7 @@ object UserData {
 
   implicit object UserDataDao extends Dao[UserData, UserId] with StorageCodecs {
     val Id = id[UserId]('_id, "PRIMARY KEY").apply(_.id)
+    val Domain = opt(text('domain))(_.domain)
     val TeamId = opt(id[TeamId]('teamId))(_.teamId)
     val Name = text[model.Name]('name, _.str, model.Name(_))(_.name)
     val Email = opt(emailAddress('email))(_.email)
@@ -225,13 +227,13 @@ object UserData {
 
     override val idCol = Id
     override val table = Table(
-      "Users", Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
+      "Users", Id, Domain, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
       Conversation, Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId,
       ExpiresAt, Managed, SelfPermissions, CopyPermissions, CreatedBy // Fields are now lazy-loaded from BE every time the user opens a profile
     )
 
     override def apply(implicit cursor: DBCursor): UserData = new UserData(
-      Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
+      Id, Domain, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
       Conversation, Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed,
       Seq.empty, (SelfPermissions, CopyPermissions), CreatedBy
     )

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -71,8 +71,11 @@ final case class UserData(override val id:       UserId,
   lazy val isReadOnlyProfile: Boolean   = managedBy.exists(_ != ManagedBy.Wire) //if none or "Wire", then it's not read only.
   lazy val isWireBot: Boolean           = integrationId.nonEmpty
 
+  lazy val qualifiedId: Option[QualifiedId] = domain.map(d => QualifiedId(id, d))
+
   def updated(user: UserInfo): UserData = updated(user, withSearchKey = true, permissions = permissions)
   def updated(user: UserInfo, withSearchKey: Boolean, permissions: PermissionsMasks): UserData = copy(
+    domain        = user.domain,
     name          = user.name.getOrElse(name),
     email         = user.email.orElse(email),
     phone         = user.phone.orElse(phone),

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -69,7 +69,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
   override def handleUserConnectionEvents(events: Seq[UserConnectionEvent]) = {
     def updateOrCreate(event: UserConnectionEvent)(user: Option[UserData]): UserData =
       user.fold {
-        UserData(event.to, None, event.fromUserName.getOrElse(Name.Empty), None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey.Empty, connectionLastUpdated = event.lastUpdated,
+        UserData(event.to, None, None, event.fromUserName.getOrElse(Name.Empty), None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey.Empty, connectionLastUpdated = event.lastUpdated,
           handle = None)
       } {
         _.copy(conversation = Some(event.convId)).updateConnectionStatus(event.status, Some(event.lastUpdated), event.message)

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -199,7 +199,7 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def getOrCreateUser(id: UserId) = usersStorage.getOrCreate(id, {
     sync.syncUsers(Set(id))
-    UserData(id, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None)
+    UserData(id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None)
   })
 
   override def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None) =

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -19,7 +19,7 @@ package com.waz.sync
 
 import com.waz.api.IConversation.{Access, AccessRole}
 import com.waz.api.NetworkMode
-import com.waz.content.UserPreferences.{SelfClient, ShouldSyncConversations, ShouldSyncInitial}
+import com.waz.content.UserPreferences.{SelfClient, ShouldSyncConversations, shouldSyncAllOnUpdate}
 import com.waz.content.{UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
@@ -124,7 +124,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   import Threading.Implicits.Background
   import com.waz.model.sync.SyncRequest._
 
-  private val shouldSyncAll           = userPreferences(ShouldSyncInitial)
+  private val shouldSyncAll           = userPreferences(shouldSyncAllOnUpdate)
   private val shouldSyncConversations = userPreferences(ShouldSyncConversations)
   private val isRegistered = userPreferences(SelfClient).signal.map {
     case Registered(_) => true

--- a/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
@@ -24,6 +24,7 @@ class UserDataSpec extends AndroidFreeSpec {
 
   val referenceInfo = UserInfo(
     UserId(),
+    Some("staging.zinfra.io"),
     Some(Name("Atticus")),
     Some(4),
     Some(EmailAddress("atticus@wire.com")),
@@ -53,6 +54,7 @@ class UserDataSpec extends AndroidFreeSpec {
 
       // THEN
       data.id.shouldEqual(referenceInfo.id)
+      data.domain.shouldEqual(referenceInfo.domain)
       data.name.shouldEqual(referenceInfo.name.get)
       data.accent.shouldEqual(referenceInfo.accentId.get)
       data.email.shouldEqual(referenceInfo.email)
@@ -72,7 +74,7 @@ class UserDataSpec extends AndroidFreeSpec {
 
       // GIVEN
       val oldData = UserData(referenceInfo, false)
-      val info = UserInfo(referenceInfo.id, referenceInfo.name)
+      val info = UserInfo(referenceInfo.id, None, referenceInfo.name)
 
       // WHEN
       val data = oldData.updated(info)

--- a/zmessaging/src/test/scala/com/waz/model/UserInfoSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserInfoSpec.scala
@@ -18,7 +18,7 @@
 package com.waz.model
 
 import com.waz.specs.AndroidFreeSpec
-import com.waz.utils.JsonDecoder
+import com.waz.utils.{JsonDecoder, JsonEncoder}
 import org.threeten.bp.Instant
 
 class UserInfoSpec extends AndroidFreeSpec {
@@ -54,6 +54,56 @@ class UserInfoSpec extends AndroidFreeSpec {
       info.name.shouldEqual(Some(Name("Atticus")))
       info.accentId.shouldEqual(Some(6))
 
+    }
+
+    scenario("JSON with 'qualified_id'") {
+      // GIVEN
+      val document =
+        """
+          |{
+          |  "qualified_id":{"domain":"staging.zinfra.io","id":"e902e865-7564-4bd9-9789-d2395a984922"},
+          |  "id" : "e902e865-7564-4bd9-9789-d2395a984922",
+          |  "picture" : [
+          |
+          |  ],
+          |  "assets" : [
+          |
+          |  ],
+          |  "name" : "Atticus",
+          |  "accent_id" : 6
+          |}
+          """.stripMargin
+
+      // WHEN
+      val info: UserInfo = JsonDecoder.decode[UserInfo](document)
+
+      // THEN
+      info.id.shouldEqual(UserId("e902e865-7564-4bd9-9789-d2395a984922"))
+      info.domain.shouldEqual(Some("staging.zinfra.io"))
+      info.name.shouldEqual(Some(Name("Atticus")))
+      info.accentId.shouldEqual(Some(6))
+    }
+  }
+
+  feature("Deserialize and serialize again") {
+    scenario("Deserialize and serialize again with 'qualified_id'") {
+      // GIVEN
+      val info = UserInfo(
+        id = UserId("e902e865-7564-4bd9-9789-d2395a984922"),
+        domain = Some("staging.zinfra.io"),
+        name = Some("Atticus"),
+        accentId = Some(6)
+      )
+
+      // WHEN
+      val document = JsonEncoder.encode(info)(UserInfo.Encoder).toString
+      val info2: UserInfo = JsonDecoder.decode[UserInfo](document)
+
+      // THEN
+      info.id.shouldEqual(info2.id)
+      info.domain.shouldEqual(info2.domain)
+      info.name.shouldEqual(info2.name)
+      info.accentId.shouldEqual(info2.accentId)
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -46,7 +46,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
     scenario("Create 1:1 conversation within a team with existing 1:1 conversation between the two members should return existing conversation") {
       val otherUserId = UserId("otherUser")
-      val otherUser = UserData(otherUserId, team, Name("other"), searchKey = SearchKey.simple("other"))
+      val otherUser = UserData(otherUserId, None, team, Name("other"), searchKey = SearchKey.simple("other"))
 
       val existingConv = ConversationData(creator = self, convType = Group, team = team)
 
@@ -68,7 +68,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
     scenario("Existing 1:1 conversation between two team members with NAME should not be returned") {
       val otherUserId = UserId("otherUser")
-      val otherUser = UserData(otherUserId, team, Name("other"), searchKey = SearchKey.simple("other"))
+      val otherUser = UserData(otherUserId, None, team, Name("other"), searchKey = SearchKey.simple("other"))
 
       val name = Some(Name("Conv Name"))
       val existingConv = ConversationData(creator = self, name = name, convType = Group, team = team)
@@ -106,7 +106,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
     //TODO under what circumstances is the user connection status "Ignored"? What happens if you're just unconnected with that person?
     scenario("Create 1:1 conversation with a non-team member should create a real 1:1 conversation") {
       val otherUserId = UserId("otherUser")
-      val otherUser = UserData(otherUserId, Some(TeamId("different_team")), Name("other"), searchKey = SearchKey.simple("other"), connection = ConnectionStatus.Ignored)
+      val otherUser = UserData(otherUserId, None, Some(TeamId("different_team")), Name("other"), searchKey = SearchKey.simple("other"), connection = ConnectionStatus.Ignored)
 
       val expectedConv = ConversationData(ConvId("otherUser"), creator = self, convType = OneToOne, team = None)
 

--- a/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -68,11 +68,11 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
     val initialTeamMembers = Set(
-      UserData(UserId(), teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
-      UserData(UserId(), teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
+      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
     )
 
-    val newTeamMember = UserData(UserId(), teamId, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val newTeamMember = UserData(UserId(), None, teamId, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
 
     (userStorage.getByTeam _).expects(Set(teamId).flatten).once().returning(Future.successful(initialTeamMembers))
 
@@ -100,8 +100,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
 
-    val member1 = UserData(UserId(), teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.simple("user1"))
-    val member2 = UserData(UserId(), teamId, Name("rick2"), handle = Some(Handle()), searchKey = SearchKey.simple("rick2"))
+    val member1 = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.simple("user1"))
+    val member2 = UserData(UserId(), None, teamId, Name("rick2"), handle = Some(Handle()), searchKey = SearchKey.simple("rick2"))
     val member2Updated = member2.copy(name = Name("user2"), searchKey = SearchKey.simple("user2"))
 
     (userStorage.searchByTeam _).expects(teamId.get, SearchKey.simple("user"), false).once().returning(Future.successful(Set(member1)))
@@ -130,11 +130,11 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
     val initialTeamMembers = Set(
-      UserData(UserId(), teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
-      UserData(UserId(), teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
+      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
     )
 
-    val newTeamMember = UserData(UserId(), None, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val newTeamMember = UserData(UserId(), None, None, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
 
     (userStorage.getByTeam _).expects(Set(teamId).flatten).once().returning(Future.successful(initialTeamMembers))
 
@@ -161,8 +161,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onUpdated _).expects().once().returning(userStorageOnUpdated)
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
-    val constUser = UserData(UserId(), teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
-    val teamMemberToUpdate = UserData(UserId(), teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val constUser = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val teamMemberToUpdate = UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
     val updatedTeamMember = teamMemberToUpdate.copy(name = Name("user3"))
 
     val initialTeamMembers = Set(constUser, teamMemberToUpdate)
@@ -184,7 +184,7 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     // GIVEN
     val createdBy = id('creator)
     val permissions = TeamsClient.Permissions(123, 890)
-    val userData = UserData(selfUser, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val userData = UserData(selfUser, None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
     val service = createService
     val teamMember = TeamMember(selfUser, Some(permissions), Some(createdBy))
 

--- a/zmessaging/src/test/scala/com/waz/sync/SyncRequestServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/SyncRequestServiceSpec.scala
@@ -48,7 +48,7 @@ class SyncRequestServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val reporting    = mock[ReportingService]
   val usersStorage = mock[UsersStorage]
   lazy val prefs   = new TestUserPreferences {
-    result(this.preference(UserPreferences.ShouldSyncInitial) := false)
+    result(this.preference(UserPreferences.shouldSyncAllOnUpdate) := false)
     result(this.preference(UserPreferences.ShouldSyncConversations) := false)
   }
 


### PR DESCRIPTION
Changes to UserInfo and UserData which ensure that Wire Android will use qualified ids where they are available, but also will work without them. A qualified id is a pair of user id and domain (a string). The backend should return it as a part of each UserInfo, but it will also return id as a separate field in the json.  In case when qualified_id exists, we give it priority, but anyway both should be the same.
    
Additionally, I changed ClientId to a newtype, in accordance to changes of other ids from a recent PR.
#### APK
[Download build #3367](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3367/artifact/build/artifact/wire-dev-PR3264-3367.apk)
[Download build #3381](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3381/artifact/build/artifact/wire-dev-PR3264-3381.apk)
[Download build #3384](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3384/artifact/build/artifact/wire-dev-PR3264-3384.apk)