### PR TITLE
[Fix] Legal hold approval fails with correct password

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/LegalHoldClient.scala
@@ -63,7 +63,7 @@ class LegalHoldClientImpl(implicit
                               password: Option[String]): ErrorOrResponse[Unit] =
     Request.Put(
       relativePath = approvePath(teamId, userId),
-      body = JsonEncoder { _.put("password", password) }
+      body = JsonEncoder { _.put("password", password.getOrElse("")) }
     )
     .withResultType[Unit]
     .withErrorType[ErrorResponse]


### PR DESCRIPTION
## What's new in this PR?

### Issues

When accepting a legal hold request with a valid password, the backend reports that the password is invalid,

### Causes

The password is optional because the user may be an SSO user. However, when putting the password in the body, it was encoded  an optional string, and the backend didn't like this.

### Solutions

Encode the password as a string (or an empty string if not present).

### Testing

We don't have client tests interacting with a mock backend, so I just tested this manually.


#### APK
[Download build #3360](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3360/artifact/build/artifact/wire-dev-PR3267-3360.apk)