### PR TITLE
Refactor: Legal Hold Approval Pop-up - Move popup logic to another class

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -74,7 +74,7 @@ import com.waz.zclient.conversation.{ConversationController, ReplyController}
 import com.waz.zclient.conversationlist.{ConversationListController, FolderStateController}
 import com.waz.zclient.cursor.CursorController
 import com.waz.zclient.deeplinks.DeepLinkService
-import com.waz.zclient.legalhold.LegalHoldController
+import com.waz.zclient.legalhold.{LegalHoldApprovalHandler, LegalHoldController}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.controllers.{MessageActionsController, NavigationController}
 import com.waz.zclient.messages.{LikesController, MessagePagedListController, MessageViewFactory, MessagesController, UsersController}
@@ -281,6 +281,8 @@ object WireApplication extends DerivedLogTag {
     bind[SecurityPolicyChecker] to new SecurityPolicyChecker()
 
     bind[FolderStateController] to new FolderStateController()
+
+    bind[LegalHoldApprovalHandler] to new LegalHoldApprovalHandler()
 
     KotlinServices.INSTANCE.init(ctx)
   }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
@@ -1,0 +1,68 @@
+package com.waz.zclient.legalhold
+
+import androidx.fragment.app.FragmentActivity
+import com.waz.model.AccountData.Password
+import com.waz.sync.handler.LegalHoldError
+import com.waz.threading.Threading.Implicits.Ui
+import com.waz.utils.returning
+import com.waz.zclient.utils.ContextUtils
+import com.waz.zclient.{Injectable, Injector, SpinnerController}
+
+import scala.concurrent.{Future, Promise}
+import scala.ref.WeakReference
+
+class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
+
+  private lazy val legalHoldController = inject[LegalHoldController]
+  private lazy val spinnerController = inject[SpinnerController]
+
+  private lazy val actionTaken = Promise[Unit]
+
+  private var activityRef : WeakReference[FragmentActivity] = _
+
+  def showDialog(activity: FragmentActivity): Future[Unit] = {
+    activityRef = new WeakReference(activity)
+    showLegalHoldRequestDialog()
+    actionTaken.future
+  }
+
+  private def showLegalHoldRequestDialog(showError: Boolean = false): Unit = {
+    //TODO: check isSSO and display proper fingerprint
+    def showDialog(activity: FragmentActivity): Unit =
+      returning(LegalHoldRequestDialog.newInstance(isSso = false, "...", showError = showError)) { dialog =>
+        dialog.onAccept(onLegalHoldAccepted)
+        dialog.onDecline(_ => setFinished())
+      }.show(activity.getSupportFragmentManager, LegalHoldRequestDialog.TAG)
+
+    activityRef.get.foreach { activity =>
+      if (!isShowingLegalHoldRequestDialog(activity)) {
+        legalHoldController.legalHoldRequest.head.foreach {
+          case Some(_) => showDialog(activity)
+          case None    =>
+        }
+      }
+    }
+  }
+
+  private def isShowingLegalHoldRequestDialog(activity: FragmentActivity) =
+    activity.getSupportFragmentManager.findFragmentByTag(LegalHoldRequestDialog.TAG) != null
+
+  private def onLegalHoldAccepted(password: Option[Password]): Unit = {
+    spinnerController.showDimmedSpinner(show = true)
+
+    legalHoldController.approveRequest(password).map { result =>
+      spinnerController.hideSpinner()
+      result
+    }.foreach {
+      case Left(LegalHoldError.InvalidPassword) => showLegalHoldRequestDialog(true)
+      case Left(_)  => showGeneralError()
+      case Right(_) => setFinished()
+    }
+  }
+
+  private def showGeneralError(): Unit = activityRef.get.foreach {
+    ContextUtils.showGenericErrorDialog()(_).foreach(_ => setFinished())
+  }
+
+  private def setFinished(): Unit = actionTaken.trySuccess(())
+}

--- a/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
+++ b/app/src/main/scala/com/waz/zclient/security/actions/ShowLegalHoldApprovalAction.scala
@@ -1,68 +1,18 @@
 package com.waz.zclient.security.actions
 
 import android.content.Context
-import androidx.fragment.app.{FragmentActivity, FragmentManager}
-import com.waz.model.AccountData.Password
-import com.waz.sync.handler.LegalHoldError
-import com.waz.threading.Threading.Implicits.Ui
-import com.waz.utils.returning
-import com.waz.zclient.SpinnerController
-import com.waz.zclient.legalhold.{LegalHoldController, LegalHoldRequestDialog}
+import androidx.fragment.app.FragmentActivity
+import com.waz.zclient.legalhold.LegalHoldApprovalHandler
 import com.waz.zclient.security.SecurityChecklist
-import com.waz.zclient.utils.ContextUtils
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.Future
 import scala.util.Try
 
-class ShowLegalHoldApprovalAction(legalHoldController: LegalHoldController,
-                                  spinnerController: SpinnerController)(implicit context: Context)
+class ShowLegalHoldApprovalAction(legalHoldApprovalHandler: LegalHoldApprovalHandler)(implicit context: Context)
   extends SecurityChecklist.Action {
 
-  private lazy val actionTaken = Promise[Unit]
-
-  override def execute(): Future[Unit] = {
-    showLegalHoldRequestDialog()
-    actionTaken.future
-  }
-
-  private def showLegalHoldRequestDialog(showError: Boolean = false): Unit = {
-    //TODO: check isSSO and display proper fingerprint
-    def showDialog(fragmentManager: FragmentManager): Unit =
-      returning(LegalHoldRequestDialog.newInstance(isSso = false, "...", showError = showError)) { dialog =>
-        dialog.onAccept(onLegalHoldAccepted)
-        dialog.onDecline(_ => setFinished())
-      }.show(fragmentManager, LegalHoldRequestDialog.TAG)
-
-    activity.map(_.getSupportFragmentManager).foreach { fragmentManager =>
-      if (!isShowingLegalHoldRequestDialog(fragmentManager)) {
-        legalHoldController.legalHoldRequest.head.foreach {
-          case Some(_) => showDialog(fragmentManager)
-          case None    =>
-        }
-      }
-    }
-  }
-
-  private def isShowingLegalHoldRequestDialog(fragmentManager: FragmentManager) =
-    fragmentManager.findFragmentByTag(LegalHoldRequestDialog.TAG) != null
-
-  private def onLegalHoldAccepted(password: Option[Password]): Unit = {
-    spinnerController.showDimmedSpinner(show = true)
-
-    legalHoldController.approveRequest(password).map { result =>
-      spinnerController.hideSpinner()
-      result
-    }.foreach {
-      case Left(LegalHoldError.InvalidPassword) => showLegalHoldRequestDialog(true)
-      case Left(_)  => showGeneralError()
-      case Right(_) => setFinished()
-    }
-  }
-
-  private def showGeneralError(): Unit =
-    ContextUtils.showGenericErrorDialog().foreach(_ => setFinished())
-
-  private def setFinished(): Unit = actionTaken.trySuccess(())
-
-  private def activity = Try(context.asInstanceOf[FragmentActivity])
+  override def execute(): Future[Unit] =
+    Try(context.asInstanceOf[FragmentActivity])
+      .toOption
+      .fold(Future.successful(()))(legalHoldApprovalHandler.showDialog)
 }

--- a/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
@@ -1,7 +1,6 @@
 package com.waz.service
 import com.waz.model.{Event, LegalHoldRequest}
 import com.waz.service.EventScheduler.Stage
-import com.waz.sync.SyncResult
 import com.waz.sync.handler.LegalHoldError
 import com.wire.signals.Signal
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Moves all the logic inside `ShowLegalHoldApprovalAction` to a new `LegalHoldApprovalHandler` class. 

### Causes

This code block needs to be called from more than one place, so it needs to be easily accessible from everywhere.

### Solutions

The only difference is that instead of an implicit Context, the showDialog method now accepts an Activity and keeps a weak reference of it.

### Testing

Manually tested.


#### APK
[Download build #3368](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3368/artifact/build/artifact/wire-dev-PR3268-3368.apk)
[Download build #3370](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3370/artifact/build/artifact/wire-dev-PR3268-3370.apk)