### PR TITLE
Fix: Legal Hold Request Signal update problem

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -46,7 +46,7 @@ class LegalHoldServiceImpl(selfUserId: UserId,
 
   private lazy val legalHoldRequestPref = userPrefs(UserPreferences.LegalHoldRequest)
 
-  override val legalHoldRequest: Signal[Option[LegalHoldRequest]] = legalHoldRequestPref.signal
+  override def legalHoldRequest: Signal[Option[LegalHoldRequest]] = legalHoldRequestPref.signal
 
   override def getFingerprint(request: LegalHoldRequest): Option[String] =
     Try(CryptoBox.getFingerprintFromPrekey(request.lastPreKey)).toOption.map(new String(_))

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -44,8 +44,9 @@ class LegalHoldServiceImpl(selfUserId: UserId,
     }.map(_ => ())
   }
 
-  override def legalHoldRequest: Signal[Option[LegalHoldRequest]] =
-    userPrefs.preference(UserPreferences.LegalHoldRequest).signal
+  private lazy val legalHoldRequestPref = userPrefs(UserPreferences.LegalHoldRequest)
+
+  override val legalHoldRequest: Signal[Option[LegalHoldRequest]] = legalHoldRequestPref.signal
 
   override def getFingerprint(request: LegalHoldRequest): Option[String] =
     Try(CryptoBox.getFingerprintFromPrekey(request.lastPreKey)).toOption.map(new String(_))
@@ -88,10 +89,10 @@ class LegalHoldServiceImpl(selfUserId: UserId,
   } yield ()
 
   def storeLegalHoldRequest(request: LegalHoldRequest): Future[Unit] =
-    userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(request))
+    legalHoldRequestPref := Some(request)
 
   def deleteLegalHoldRequest(): Future[Unit] =
-    userPrefs.setValue(UserPreferences.LegalHoldRequest, None)
+    legalHoldRequestPref := None
 
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the value of the `LegalHoldRequest` preference changes in the database, the `legalHoldRequest` Signal on `LegalHoldServiceImpl` does not emit updated value.

### Causes

In order to update the value, `setValue` method was used. However, this `setValue` does not publish the new value. Instead, `update` (or `:=`) method should be used.

### Solutions

Use `:=` method to update preference value.

### Testing

Manually tested by checking whether "pending" icon is changed in the screen.


#### APK
[Download build #3401](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3401/artifact/build/artifact/wire-dev-PR3271-3401.apk)