### PR TITLE
Feature: Legal Hold Request - Detect when legal hold is requested and show pop up immediately

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -74,7 +74,7 @@ import com.waz.zclient.conversation.{ConversationController, ReplyController}
 import com.waz.zclient.conversationlist.{ConversationListController, FolderStateController}
 import com.waz.zclient.cursor.CursorController
 import com.waz.zclient.deeplinks.DeepLinkService
-import com.waz.zclient.legalhold.{LegalHoldApprovalHandler, LegalHoldController}
+import com.waz.zclient.legalhold.{LegalHoldApprovalHandler, LegalHoldController, LegalHoldStatusChangeListener}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.controllers.{MessageActionsController, NavigationController}
 import com.waz.zclient.messages.{LikesController, MessagePagedListController, MessageViewFactory, MessagesController, UsersController}
@@ -283,6 +283,7 @@ object WireApplication extends DerivedLogTag {
     bind[FolderStateController] to new FolderStateController()
 
     bind[LegalHoldApprovalHandler] to new LegalHoldApprovalHandler()
+    bind[LegalHoldStatusChangeListener] to new LegalHoldStatusChangeListener()
 
     KotlinServices.INSTANCE.init(ctx)
   }
@@ -449,6 +450,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     Future(checkForPlayServices(prefs, googleApi))(Threading.Background)
 
     inject[SecurityPolicyChecker]
+    inject[LegalHoldStatusChangeListener]
 
     notificationChannel
   }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
@@ -1,0 +1,19 @@
+package com.waz.zclient.legalhold
+
+import com.waz.zclient.security.ActivityLifecycleCallback
+import com.waz.zclient.{Injectable, Injector}
+
+
+class LegalHoldStatusChangeListener(implicit injector: Injector) extends Injectable {
+
+  private lazy val legalHoldController       = inject[LegalHoldController]
+  private lazy val legalHoldApprovalHandler  = inject[LegalHoldApprovalHandler]
+  private lazy val activityLifecycleCallback = inject[ActivityLifecycleCallback]
+
+  legalHoldController.hasPendingRequest.onChanged {
+    case true  => activityLifecycleCallback.withCurrentActivity(legalHoldApprovalHandler.showDialog)
+    case false =>
+  }
+
+  //TODO: show "LH no longer active" pop up when LH is disabled
+}

--- a/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
+++ b/app/src/main/scala/com/waz/zclient/security/ActivityLifecycleCallback.scala
@@ -24,9 +24,10 @@ import android.os.Bundle
 import android.view.WindowManager.LayoutParams.FLAG_SECURE
 import com.waz.content.UserPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.threading.Threading.Implicits.Ui
 import com.waz.threading.Threading._
 import com.waz.zclient.log.LogUI._
-import com.waz.zclient.{BuildConfig, Injectable, Injector, LaunchActivity}
+import com.waz.zclient.{BaseActivity, BuildConfig, Injectable, Injector, LaunchActivity}
 import com.wire.signals._
 
 import scala.collection.convert.DecorateAsScala
@@ -48,6 +49,12 @@ class ActivityLifecycleCallback(implicit injector: Injector)
   protected lazy val userPreferences = inject[Signal[UserPreferences]]
 
   val appInBackground: Signal[(Boolean, Option[Activity])] = activitiesRunning.map { case (running, lastAct) => (running == 0, lastAct) }
+
+  def withCurrentActivity(action: BaseActivity => Unit): Unit =
+    activitiesRunning.map(_._2).head.foreach {
+      case Some(activity) => Try(activity.asInstanceOf[BaseActivity]).foreach(action)
+      case None =>
+    }
 
   override def onActivityStopped(activity: Activity): Unit = synchronized {
     activity match {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-336](https://wearezeta.atlassian.net/browse/SQSERVICES-336)

When an admin requests legal hold for self user, we should immediately display legal hold acceptance pop up (#3225 ) on the screen.

### Solutions

Created a new class `LegalHoldStatusChangeListener` which is responsible for listening any changes to legal hold request (and later, approval) events. Upon receiving those events, it displays proper messages on the current activity. The listener is registered during app start.

Added a convenience method `withCurrentActivity` to `ActivityLifecycleCallback`, which invokes the given action on the topmost activity, if there's any.

### Testing

Manually tested by toggling legal hold request for a test user.


#### APK
[Download build #3404](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3404/artifact/build/artifact/wire-dev-PR3273-3404.apk)