### PR TITLE
feat: Fetch clients for users in batches

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
@@ -28,7 +28,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.waz.api.{OtrClientType, Verification}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.otr.Client
-import com.waz.service.ZMessaging
+import com.waz.service.{UserService, ZMessaging}
 import com.waz.threading.Threading
 import com.wire.signals.{EventContext, EventStream, Signal, SourceStream}
 import com.waz.zclient.common.controllers.global.AccentColorController
@@ -42,11 +42,11 @@ class ParticipantOtrDeviceAdapter(implicit context: Context, injector: Injector,
   extends RecyclerView.Adapter[ParticipantOtrDeviceAdapter.ViewHolder]
     with Injectable
     with DerivedLogTag {
-  
+
   import ParticipantOtrDeviceAdapter._
   import Threading.Implicits.Background
 
-  private lazy val zms = inject[Signal[ZMessaging]]
+  private lazy val userService = inject[Signal[UserService]]
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val accentColorController = inject[AccentColorController]
 
@@ -64,9 +64,9 @@ class ParticipantOtrDeviceAdapter(implicit context: Context, injector: Injector,
   } yield clients.fold(List.empty[Client])(_.clients.values.toList.reverse)
 
   private lazy val syncClientsRequest = for {
-    z             <- zms.head
+    userService   <- userService.head
     Some(userId)  <- participantsController.otherParticipantId.head
-  } yield z.sync.syncClients(userId)
+  } yield userService.syncClients(userId)
 
   (for {
     cs    <- clients

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -62,6 +62,7 @@ public enum SyncCommand {
     SyncSelfClients("sync-clients"),   // sync user clients, register current client and update prekeys when needed
     SyncSelfPermissions("sync-self-permissions"),
     SyncClients("sync-user-clients"),
+    SyncClientsBatch("sync-user-clients-batch"),
     SyncClientLocation("sync-client-location"),
     SyncPreKeys("sync-prekeys"),
     PostAddBot("post-add-bot"),

--- a/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ErrorResponse.scala
@@ -58,6 +58,7 @@ object ErrorResponse {
   val Unverified = ErrorResponse(UnverifiedCode, "Unverified", "")
   val PasswordExists = ErrorResponse(Forbidden, "Forbidden", "password-exists")
   val Unauthorized = ErrorResponse(UnauthorizedCode, "Unauthorized", "account-logged-out")
+  val PageNotFound = ErrorResponse(NotFound, "NotFound", "not-found")
 
   implicit lazy val Decoder: JsonDecoder[ErrorResponse] = new JsonDecoder[ErrorResponse] {
     import JsonDecoder._

--- a/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -72,9 +72,9 @@ class MembersStorageImpl(context: Context, storage: ZmsDatabase)
       })
   }
 
-  override def getActiveUsers(conv: ConvId) = getByConv(conv) map { _.map(_.userId) }
+  override def getActiveUsers(conv: ConvId): Future[Seq[UserId]] = getByConv(conv).map { _.map(_.userId) }
 
-  override def getActiveConvs(user: UserId) = getByUser(user) map { _.map(_.convId) }
+  override def getActiveConvs(user: UserId): Future[Seq[ConvId]] = getByUser(user).map { _.map(_.convId) }
 
   override def getActiveUsers2(convs: Set[ConvId]): Future[Map[ConvId, Set[UserId]]] =
     getByConvs(convs).map(_.groupBy(_.convId).map {

--- a/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
@@ -7,6 +7,8 @@ import org.json.JSONObject
 final case class QualifiedId(id: UserId, domain: String)
 
 object QualifiedId {
+  def apply(userId: UserId): QualifiedId = QualifiedId(userId, "")
+
   private val IdFieldName = "id"
   private val DomainFieldName  = "domain"
 

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -90,6 +90,7 @@ final case class Client(override val id: ClientId,
 
   lazy val isVerified: Boolean = verified == Verification.VERIFIED
 
+
   def updated(c: Client): Client = {
     val location = (regLocation, c.regLocation) match {
       case (Some(loc), Some(l)) if loc.lat == l.lat && loc.lon == l.lon => Some(loc)

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -31,7 +31,6 @@ import org.threeten.bp.Instant
 
 import scala.collection.breakOut
 
-
 final case class ClientId(str: String) extends AnyVal {
   def longId: Long = new BigInteger(str, 16).longValue()
   override def toString: String = str

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -23,6 +23,7 @@ import com.waz.api.{OtrClientType, Verification}
 import com.waz.db.Col._
 import com.waz.db.Dao
 import com.waz.model.{Id, UserId}
+import com.waz.utils.JsonDecoder.{decodeId, decodeOptString, decodeOptUtcDate, opt}
 import com.waz.utils.crypto.ZSecureRandom
 import com.waz.utils.wrappers.{DB, DBCursor}
 import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder}
@@ -129,7 +130,14 @@ object Client {
   implicit lazy val Decoder: JsonDecoder[Client] = new JsonDecoder[Client] {
     import JsonDecoder._
     override def apply(implicit js: JSONObject): Client = {
-      new Client(decodeId[ClientId]('id), 'label, 'model, 'regTime, opt[Location]('regLocation), 'regIpAddress, opt[SignalingKey]('signalingKey),
+      new Client(
+        decodeId[ClientId]('id),
+        'label,
+        'model,
+        'regTime,
+        opt[Location]('regLocation),
+        'regIpAddress,
+        opt[SignalingKey]('signalingKey),
         decodeOptString('verification).fold(Verification.UNKNOWN)(Verification.valueOf),
         decodeOptString('devType).fold(OtrClientType.PHONE)(OtrClientType.fromDeviceClass)
       )

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -31,6 +31,7 @@ import org.threeten.bp.Instant
 
 import scala.collection.breakOut
 
+
 final case class ClientId(str: String) extends AnyVal {
   def longId: Long = new BigInteger(str, 16).longValue()
   override def toString: String = str
@@ -87,6 +88,7 @@ final case class Client(override val id: ClientId,
                         signalingKey:    Option[SignalingKey] = None,
                         verified:        Verification = Verification.UNKNOWN,
                         devType:         OtrClientType = OtrClientType.PHONE) extends Identifiable[ClientId] {
+
   lazy val isVerified: Boolean = verified == Verification.VERIFIED
 
   def updated(c: Client): Client = {
@@ -95,7 +97,7 @@ final case class Client(override val id: ClientId,
       case (_, loc @ Some(_)) => loc
       case (loc, _) => loc
     }
-    copy (
+    copy(
       label        = if (c.label.isEmpty) label else c.label,
       model        = if (c.model.isEmpty) model else c.model,
       regTime      = c.regTime.orElse(regTime),
@@ -154,7 +156,6 @@ object UserClients {
   }
 
   implicit object UserClientsDao extends Dao[UserClients, UserId] {
-
     val Id = id[UserId]('_id, "PRIMARY KEY").apply(_.user)
     val Data = text('data)(JsonEncoder.encodeString(_))
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -56,6 +56,7 @@ trait UserService {
 
   def getSelfUser: Future[Option[UserData]]
   def findUser(id: UserId): Future[Option[UserData]]
+  def qualifiedId(userId: UserId): Future[QualifiedId]
   def getOrCreateUser(id: UserId): Future[UserData]
   def updateUserData(id: UserId, updater: UserData => UserData): Future[Option[(UserData, UserData)]]
   def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]]
@@ -86,6 +87,10 @@ trait UserService {
 
   def storeAvailabilities(availabilities: Map[UserId, Availability]): Future[Seq[(UserData, UserData)]]
   def updateSelfPicture(content: Content): Future[Unit]
+
+  def syncClients(userId: UserId): Future[Unit]
+  def syncClients(userIds: Set[UserId]): Future[Unit]
+  def syncClients(convId: ConvId): Future[Unit]
 }
 
 class UserServiceImpl(selfUserId:        UserId,
@@ -196,6 +201,9 @@ class UserServiceImpl(selfUserId:        UserId,
     )
 
   override def findUser(id: UserId): Future[Option[UserData]] = usersStorage.get(id)
+
+  override def qualifiedId(userId: UserId): Future[QualifiedId] =
+    findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
 
   override def getOrCreateUser(id: UserId) = usersStorage.getOrCreate(id, {
     sync.syncUsers(Set(id))
@@ -358,6 +366,19 @@ class UserServiceImpl(selfUserId:        UserId,
       case Some((p, u)) if p != u => sync(u).map(_ => {})
       case _ => Future.successful({})
     })
+
+  override def syncClients(userId: UserId): Future[Unit] =
+    sync.syncClients(userId).map(_ => ())
+
+  override def syncClients(userIds: Set[UserId]): Future[Unit] =
+    for {
+      users <- usersStorage.listAll(userIds)
+      qIds  =  users.map(user => user.qualifiedId.getOrElse(QualifiedId(user.id))).toSet
+      _     <- sync.syncClients(qIds)
+    } yield ()
+
+  override def syncClients(convId: ConvId): Future[Unit] =
+    membersStorage.getActiveUsers(convId).flatMap(userIds => syncClients(userIds.toSet))
 }
 
 object UserService {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/SelectedConversationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/SelectedConversationService.scala
@@ -33,8 +33,11 @@ trait SelectedConversationService {
 
 /**
  * Keeps track of general conversation list stats needed for display of conversations lists.
+ *
+ * UserService is injected lazily (`users : => UserService` instead of `users: UserService`)
+ * to prevent circular dependency.
  */
-class SelectedConversationServiceImpl(userPrefs: UserPreferences, users: UserService) extends SelectedConversationService {
+class SelectedConversationServiceImpl(userPrefs: UserPreferences, users: => UserService) extends SelectedConversationService {
   import com.waz.threading.Threading.Implicits.Background
 
   val selectedConvIdPref: Preferences.Preference[Option[ConvId]] = userPrefs.preference(SelectedConvId)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/SelectedConversationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/SelectedConversationService.scala
@@ -43,7 +43,8 @@ class SelectedConversationServiceImpl(userPrefs: UserPreferences, users: UserSer
 
   def selectConversation(id: Option[ConvId]): Future[Unit] = selectedConvIdPref := id
 
-  selectedConversationId
-    .collect { case Some(convId) => convId }
-    .foreach(convId => users.syncClients(convId))
+  selectedConversationId.foreach {
+    case Some(convId) => users.syncClients(convId)
+    case _ =>
+  }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -105,6 +105,7 @@ trait SyncServiceHandle {
   def syncSelfPermissions(): Future[SyncId]
   def postClientLabel(id: ClientId, label: String): Future[SyncId]
   def syncClients(user: UserId): Future[SyncId]
+  def syncClients(users: Set[QualifiedId]): Future[SyncId]
   def syncClientsLocation(): Future[SyncId]
   def syncProperties(): Future[SyncId]
 
@@ -208,6 +209,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def syncSelfPermissions() = addRequest(SyncSelfPermissions, priority = Priority.High)
   def postClientLabel(id: ClientId, label: String) = addRequest(PostClientLabel(id, label))
   def syncClients(user: UserId) = addRequest(SyncClients(user))
+  def syncClients(users: Set[QualifiedId]) = addRequest(SyncClientsBatch(users))
   def syncClientsLocation() = addRequest(SyncClientsLocation)
   def syncPreKeys(user: UserId, clients: Set[ClientId]) = addRequest(SyncPreKeys(user, clients))
   def syncProperties(): Future[SyncId] = addRequest(SyncProperties, forceRetry = true)
@@ -263,6 +265,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
         req match {
           case SyncSelfClients                                 => zms.otrClientsSync.syncClients(accountId)
           case SyncClients(user)                               => zms.otrClientsSync.syncClients(user)
+          case SyncClientsBatch(users)                         => zms.otrClientsSync.syncClients(users)
           case SyncClientsLocation                             => zms.otrClientsSync.syncClientsLocation()
           case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(Map(user -> clients.toSeq))
           case PostClientLabel(id, label)                      => zms.otrClientsSync.postLabel(id, label)

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -276,13 +276,13 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
 
 object OtrSyncHandler {
 
-  case object UnverifiedException extends Exception
+  final case object UnverifiedException extends Exception
 
-  case class OtrMessage(sender:         ClientId,
-                        recipients:     EncryptedContent,
-                        external:       Option[Array[Byte]] = None,
-                        nativePush:     Boolean = true,
-                        report_missing: Option[Set[UserId]] = None)
+  final case class OtrMessage(sender:         ClientId,
+                              recipients:     EncryptedContent,
+                              external:       Option[Array[Byte]] = None,
+                              nativePush:     Boolean = true,
+                              report_missing: Option[Set[UserId]] = None)
 
   val MaxInlineSize  = 10 * 1024
   val MaxContentSize = 256 * 1024 // backend accepts 256KB for otr messages, but we would prefer to send less
@@ -292,13 +292,13 @@ object OtrSyncHandler {
 
   object TargetRecipients {
     /// All participants (and all their clients) should receive the message.
-    object ConversationParticipants extends TargetRecipients
+    final object ConversationParticipants extends TargetRecipients
 
     /// All clients of the given users should receive the message.
-    case class SpecificUsers(userIds: Set[UserId]) extends TargetRecipients
+    final case class SpecificUsers(userIds: Set[UserId]) extends TargetRecipients
 
     /// These exact clients should receive the message.
-    case class SpecificClients(clientsByUser: Map[UserId, Set[ClientId]]) extends TargetRecipients
+    final case class SpecificClients(clientsByUser: Map[UserId, Set[ClientId]]) extends TargetRecipients
   }
 
   /// Describes how missing clients should be handled.
@@ -312,7 +312,7 @@ object OtrSyncHandler {
     object IgnoreMissingClients extends MissingClientsStrategy
 
     /// Only fetch missing clients from the given users and resend the message.
-    case class IgnoreMissingClientsExceptFromUsers(userIds: Set[UserId]) extends MissingClientsStrategy
+    final case class IgnoreMissingClientsExceptFromUsers(userIds: Set[UserId]) extends MissingClientsStrategy
   }
 
 }

--- a/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
@@ -223,4 +223,9 @@ object JsonDecoder {
   implicit def decodeConversationRole(s: Symbol)(implicit js: JSONObject): ConversationRole = ConversationRole.getRole(js.getString(s.name))
   implicit def decodeOptConversationRole(s: Symbol)(implicit js: JSONObject): Option[ConversationRole] =
     opt(s, js => ConversationRole.getRole(js.getString(s.name)))
+
+  implicit def decodeQualifiedId(s: Symbol)(implicit js: JSONObject): QualifiedId =
+    QualifiedId.Decoder(js.getJSONObject(s.name))
+  implicit def decodeQualifiedIds(s: Symbol)(implicit js: JSONObject): Seq[QualifiedId] =
+    array[QualifiedId](s)({ (arr, i) => QualifiedId.Decoder(arr.getJSONObject(i)) })
 }

--- a/zmessaging/src/main/scala/com/waz/znet2/http/Models.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/http/Models.scala
@@ -256,6 +256,6 @@ object RequestInterceptor {
 
 }
 
-case class Request[+T](url: URL, httpMethod: Method, headers: Headers, body: T, interceptor: RequestInterceptor)
+final case class Request[+T](url: URL, httpMethod: Method, headers: Headers, body: T, interceptor: RequestInterceptor)
 
-case class Response[T](code: Int, headers: Headers, body: T)
+final case class Response[T](code: Int, headers: Headers, body: T)

--- a/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
@@ -1,0 +1,59 @@
+package com.waz.model
+
+import com.waz.model.otr.{Client, ClientId}
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.client.OtrClient.ListClientsRequest
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.sync.client.OtrClient.ListClientsResponse._
+
+class ClientSpec extends AndroidFreeSpec {
+  private val domain = "domain1.example.com"
+  private val userId = UserId("000600d0-000b-9c1a-000d-a4130002c221")
+  private val client = Client(id = ClientId("d0"), label = "phone")
+
+  private val qualifiedId = QualifiedId(userId, domain)
+
+  scenario("Deserialize a client list response from JSON") {
+    // given
+    val json =
+    s"""
+       |{
+       |  "qualified_user_map": {
+       |    "$domain": {
+       |      "${userId.str}": [
+       |        {
+       |          "id": "${client.id.str}",
+       |          "label": "${client.label}"
+       |        }
+       |      ]
+       |    }
+       |  }
+       |}
+       |""".stripMargin
+
+    // when
+    val response = JsonDecoder.decode(json)
+
+    // then
+    response.values.size shouldEqual 1
+    response.values.keys.head shouldEqual qualifiedId
+    response.values(qualifiedId).size shouldEqual 1
+    response.values(qualifiedId).head shouldEqual client
+  }
+
+  scenario("Serialize a client list request toJSON") {
+    // given
+    val req = ListClientsRequest(Seq(qualifiedId))
+
+    // when
+    val response = JsonEncoder.encode(req)
+
+    // then
+    response.has("qualified_users") shouldEqual true
+    val array = response.getJSONArray("qualified_users")
+    array.length() shouldEqual 1
+    val qUser = array.getJSONObject(0)
+    val qId = QualifiedId.Decoder(qUser)
+    qId shouldEqual qualifiedId
+  }
+}


### PR DESCRIPTION
This is a change to OtrClient and classes connected to it that will make it possible to ask the backend
    for clients of many users at once. Currently we do it for each client separately which brings performance
    issues in large conversations. The new implementation is supposed, in future, to use the new endpoint
    /list-clients to fetch a dictionary of users and their clients.
    
    However, to make it work, I first need to implement qualifiable ids from the federation feature.
    So, even though this PR could be merged as it is, it's really unfinished work. I want to make it into a PR
    to just have it as a point of reference, implement qualifiable ids, and then come back to it.
    
    Please do not merge yet.