### PR TITLE
Feature: Legal Hold info modal - Display All legal hold subjects on a separate screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1591,5 +1591,6 @@
     <string name="legal_hold_request_dialog_positive_button_text">Accept</string>
     <string name="legal_hold_request_dialog_negative_button_text">Not Now</string>
     <string name="legal_hold_request_dialog_wrong_password_error">Wrong password</string>
+    <string name="legal_hold_all_subjects_title">LEGAL HOLD SUBJECTS</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
@@ -28,9 +28,17 @@ class AllLegalHoldSubjectsFragment extends BaseFragment[LegalHoldSubjectsContain
 
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
-    val recyclerView = findById[RecyclerView](R.id.recycler_view)
-    recyclerView.setLayoutManager(new LinearLayoutManager(getContext))
-    recyclerView.setAdapter(adapter)
+    setUpRecyclerView()
+    setUpSearchBox()
+  }
+
+  private def setUpRecyclerView(): Unit =
+    returning(findById[RecyclerView](R.id.recycler_view)) { recyclerView =>
+      recyclerView.setLayoutManager(new LinearLayoutManager(getContext))
+      recyclerView.setAdapter(adapter)
+    }
+
+  private def setUpSearchBox(): Unit =
     searchBox.foreach { sb =>
       sb.applyDarkTheme(inject[ThemeController].isDarkTheme)
       sb.setCallback(new PickerSpannableEditText.Callback {
@@ -41,7 +49,6 @@ class AllLegalHoldSubjectsFragment extends BaseFragment[LegalHoldSubjectsContain
         }
       })
     }
-  }
 }
 
 object AllLegalHoldSubjectsFragment {

--- a/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
@@ -1,0 +1,52 @@
+package com.waz.zclient.legalhold
+
+import android.os.Bundle
+import android.view.{LayoutInflater, View, ViewGroup}
+import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
+import com.waz.utils.returning
+import com.waz.zclient.{FragmentHelper, R}
+import com.waz.zclient.common.controllers.ThemeController
+import com.waz.zclient.common.views.PickableElement
+import com.waz.zclient.pages.BaseFragment
+import com.waz.zclient.usersearch.views.{PickerSpannableEditText, SearchEditText}
+
+class AllLegalHoldSubjectsFragment extends BaseFragment[LegalHoldSubjectsContainer]()
+  with FragmentHelper {
+
+  private lazy val legalHoldController = inject[LegalHoldController]
+
+  private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
+
+  private lazy val adapter = returning(new LegalHoldUsersAdapter(users)) {
+    _.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
+  }
+
+  private lazy val searchBox = view[SearchEditText](R.id.search_box)
+
+  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) =
+    inflater.inflate(R.layout.all_participants_fragment, container, false)
+
+
+  override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
+    val recyclerView = findById[RecyclerView](R.id.recycler_view)
+    recyclerView.setLayoutManager(new LinearLayoutManager(getContext))
+    recyclerView.setAdapter(adapter)
+    searchBox.foreach { sb =>
+      sb.applyDarkTheme(inject[ThemeController].isDarkTheme)
+      sb.setCallback(new PickerSpannableEditText.Callback {
+        override def onRemovedTokenSpan(element: PickableElement): Unit = {}
+
+        override def afterTextChanged(s: String): Unit = {
+          adapter.filter ! s
+        }
+      })
+    }
+  }
+}
+
+object AllLegalHoldSubjectsFragment {
+
+  val Tag = "AllLegalHoldSubjectsFragment"
+
+  def newInstance() = new AllLegalHoldSubjectsFragment
+}

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -18,6 +18,7 @@ class LegalHoldController(implicit injector: Injector)
   private lazy val legalHoldService = inject[Signal[LegalHoldService]]
 
   val onLegalHoldSubjectClick: SourceStream[UserId] = EventStream[UserId]
+  val onAllLegalHoldSubjectsClick: SourceStream[Unit] = EventStream[Unit]
 
   def isLegalHoldActive(userId: UserId): Signal[Boolean] =
     Signal.const(false)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -10,7 +10,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.{FragmentHelper, R}
 import com.wire.signals.Signal
 
-class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container]()
+class LegalHoldInfoFragment extends BaseFragment[LegalHoldSubjectsContainer]()
   with FragmentHelper {
 
   import LegalHoldInfoFragment._
@@ -20,8 +20,9 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
 
   private lazy val legalHoldController = inject[LegalHoldController]
 
-  private lazy val adapter = returning(new LegalHoldUsersAdapter(users, MAX_PARTICIPANTS)) {
-    _.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
+  private lazy val adapter = returning(new LegalHoldUsersAdapter(users, Some(MAX_PARTICIPANTS))) { adapter =>
+    adapter.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
+    adapter.onShowAllParticipantsClick(_ => legalHoldController.onAllLegalHoldSubjectsClick ! (()))
   }
 
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
@@ -49,12 +50,8 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldInfoFragment.Container
 
 object LegalHoldInfoFragment {
 
-  trait Container {
-    val legalHoldUsers: Signal[Seq[UserId]]
-  }
-
   val Tag = "LegalHoldInfoFragment"
-  private val MAX_PARTICIPANTS = 7
+  private val MAX_PARTICIPANTS = 4
   val ARG_MESSAGE_RES_ID = "messageResId_Arg"
 
   def newInstance(messageResId: Int): LegalHoldInfoFragment =
@@ -64,4 +61,8 @@ object LegalHoldInfoFragment {
       }
       frag.setArguments(args)
     }
+}
+
+trait LegalHoldSubjectsContainer {
+  val legalHoldUsers: Signal[Seq[UserId]]
 }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
@@ -2,14 +2,17 @@ package com.waz.zclient.legalhold
 
 import android.content.Context
 import com.waz.model.UserId
+import com.waz.service.SearchQuery
 import com.waz.zclient.Injector
 import com.waz.zclient.participants.ParticipantsAdapter
 import com.waz.zclient.participants.ParticipantsAdapter.{AllParticipants, NoResultsInfo, ParticipantData}
 import com.wire.signals.{EventContext, Signal}
 
-class LegalHoldUsersAdapter(userIds: Signal[Set[UserId]], maxParticipants: Int)
+class LegalHoldUsersAdapter(userIds: Signal[Set[UserId]], maxParticipants: Option[Int] = None)
                            (implicit context: Context, injector: Injector, eventContext: EventContext)
-  extends ParticipantsAdapter(Signal.empty, Some(maxParticipants), true, true, None) {
+  extends ParticipantsAdapter(Signal.empty, maxParticipants, showPeopleOnly = false, true, None) {
+
+  private var numUsers = 0
 
   override protected lazy val users = for {
     selfId       <- selfId
@@ -17,24 +20,29 @@ class LegalHoldUsersAdapter(userIds: Signal[Set[UserId]], maxParticipants: Int)
     teamId       <- team
     userIds      <- userIds
     users        <- usersStorage.listSignal(userIds.toList)
+    filter       <- filter
   } yield
-    users.map(user => ParticipantData(
-      user,
-      isGuest = user.isGuest(teamId),
-      isAdmin = false, // unused
-      isSelf = user.id == selfId
-    )).sortBy(_.userData.name.str)
+    users.filter(_.matchesQuery(SearchQuery(filter)))
+      .map(user => ParticipantData(
+        user,
+        isGuest = user.isGuest(teamId),
+        isAdmin = false, // unused
+        isSelf = user.id == selfId
+      )).sortBy(_.userData.name.str)
 
   override protected lazy val positions =
     for {
       users   <- users
-      toShow   = users.toList.take(maxParticipants)
-      hasMore  = users.size > maxParticipants
+      toShow   = maxParticipants.fold(users.toList)(max => users.toList.take(max))
+      hasMore  = maxParticipants.fold(false)(users.size > _)
     } yield {
+      numUsers = users.size
       if (users.isEmpty) List(Right(NoResultsInfo))
       else {
         val moreUsersRow = if (hasMore) List(Right(AllParticipants)) else Nil
         toShow.map(data => Left(data)) ::: moreUsersRow
       }
     }
+
+  override protected def allParticipantsCount: Int = numUsers
 }

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -9,7 +9,7 @@ import com.waz.zclient.messages.UsersController
 import com.waz.zclient.utils.RichView
 import com.wire.signals.Signal
 
-class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldInfoFragment.Container {
+class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldSubjectsContainer {
 
   private lazy val closeButton = findById[GlyphButton](R.id.legal_hold_info_close_button)
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -211,7 +211,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
 
   override def onBindViewHolder(holder: ViewHolder, position: Int): Unit = (items(position), holder) match {
     case (Right(AllParticipants), h: ShowAllParticipantsViewHolder) =>
-      h.bind(membersCount + adminsCount)
+      h.bind(allParticipantsCount)
     case (Left(userData), h: ParticipantRowViewHolder) if userData.isAdmin =>
       val lastRow = maxParticipants.forall(n => if (userData.isAdmin) adminsCount <= n else membersCount <= n) && items.lift(position + 1).forall(_.isRight)
       h.bind(userData, teamId, lastRow, createSubtitle, showArrow)
@@ -252,6 +252,8 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
       if (showPeopleOnly) h.setContentDescription(s"Admins") else h.setContentDescription(s"Admins: $adminsCount")
     case _ =>
   }
+
+  protected def allParticipantsCount: Int = membersCount + adminsCount
 
   override def getItemCount: Int = items.size
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -31,7 +31,7 @@ import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.controllers.navigation.{INavigationController, Page => NavPage}
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.conversation.creation.{AddParticipantsFragment, CreateConversationController}
-import com.waz.zclient.legalhold.LegalHoldController
+import com.waz.zclient.legalhold.{AllLegalHoldSubjectsFragment, LegalHoldController}
 import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.participants.ParticipantsController
 import com.waz.zclient.utils.ContextUtils.{getColor, getDimenPx, getDrawable}
@@ -155,6 +155,8 @@ class ParticipantHeaderFragment extends FragmentHelper {
         }
       case Some(AllGroupParticipantsFragment.Tag) =>
         Signal.const(getString(R.string.participant_search_title))
+      case Some(AllLegalHoldSubjectsFragment.Tag) =>
+        Signal.const(getString(R.string.legal_hold_all_subjects_title))
       case _ =>
         Signal.const(getString(R.string.empty_string))
     }.onUi(t => vh.foreach { view =>


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-345](https://wearezeta.atlassian.net/browse/SQSERVICES-345)

In Legal Hold info modal for a conversation, when the list of all legal hold subjects don't fit into one screen, display a "Show All" button that opens a new screen.

### Solutions

Creates a new screen similar to "All Group Participants" screen

### Testing

Tested manually.

| Info Modal | All Subjects |
|-----------|-------------|
|<img src="https://user-images.githubusercontent.com/2143283/116534495-e3a13400-a8e2-11eb-89b9-03ef7a7e9c1c.png" width="300dp"/> | <img src="https://user-images.githubusercontent.com/2143283/116534536-edc33280-a8e2-11eb-9980-5f96b8c309b1.png" width="300dp"/> |



#### APK
[Download build #3417](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3417/artifact/build/artifact/wire-dev-PR3280-3417.apk)
[Download build #3420](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3420/artifact/build/artifact/wire-dev-PR3280-3420.apk)