### PR TITLE
Feature: Legal Hold - Display participant's legal hold device

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -536,6 +536,7 @@
     <string name="pref_devices_device_id">ID: %1$s</string>
     <string name="pref_devices_device_verified">Verified</string>
     <string name="pref_devices_device_not_verified">Not verified</string>
+    <string name="pref_devices_device_legal_hold">Legal Hold device</string>
     <string name="pref_devices_warning_summary">If you don\'t recognize a device above, remove it and reset your passcode.</string>
     <string name="pref_devices_device_screen_title">Device details</string>
     <string name="pref_devices_device_fingerprint_category_title">Key Fingerprint</string>
@@ -870,6 +871,7 @@
     <string name="otr__participant__device_class__phone">Phone</string>
     <string name="otr__participant__device_class__tablet">Tablet</string>
     <string name="otr__participant__device_class__desktop">Desktop computer</string>
+    <string name="otr__participant__device_class__legal_hold">Legal Hold</string>
     <string name="otr__participant__tab_details">DETAILS</string>
     <string name="otr__participant__tab_devices">DEVICES</string>
     <string name="otr__participant__information">INFORMATION</string>


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-344](https://wearezeta.atlassian.net/browse/SQSERVICES-344)

In conversation participant screen, display participant's legal hold device under Devices tab. Legal Hold device should be shown at the top of the list.

### Testing

Manually tested with existing LH users.

<img src="https://user-images.githubusercontent.com/2143283/116569552-c92e8100-a909-11eb-9470-0763f0e727dc.png" width="400px"/>


#### APK
[Download build #3421](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3421/artifact/build/artifact/wire-dev-PR3282-3421.apk)