### PR TITLE
testfix: Removes and renames code with mentions of the migration 126 to 127

### DIFF
--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetTables127to128MigrationTests.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetTables127to128MigrationTests.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.storage.userdatabase.assets
 
 import com.waz.zclient.framework.data.assets.AssetsTestDataProvider
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.runBlocking
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
+class AssetTables127to128MigrationTests : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenV1AssetInsertedIntoAssetsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenV1AssetInsertedIntoAssetsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val assetId = "i747749kk-77"
         val assetType = "IMAGE"
         val assetData = "data"
@@ -24,7 +23,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(getV1Assets()[0]) {
@@ -36,7 +35,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
     }
 
     @Test
-    fun givenV2AssetInsertedIntoAssetsV2TableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenV2AssetInsertedIntoAssetsV2TableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val data = AssetsTestDataProvider.provideDummyTestData()
         AssetsV2TableTestHelper.insertV2Asset(
             data.id,
@@ -53,7 +52,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(getV2Assets()[0]) {
@@ -73,7 +72,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
     }
 
     @Test
-    fun givenDownloadAssetInsertedIntoDownloadAssetsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenDownloadAssetInsertedIntoDownloadAssetsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val assetId = "i747749kk-77"
         val mime = "png"
         val name = "Test image"
@@ -95,7 +94,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(getDownloadAssets()[0]) {
@@ -112,7 +111,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
     }
 
     @Test
-    fun givenUploadAssetInsertedIntoUploadAssetsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenUploadAssetInsertedIntoUploadAssetsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val uploadAssetId = "1100"
         val assetId = "i747749kk-77"
         val assetName = "IMAGE"
@@ -149,7 +148,7 @@ class AssetTables126to128MigrationTests : UserDatabaseMigrationTest(126, 128) {
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(getUploadAssets()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/clients/ClientsTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/clients/ClientsTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
-package com.waz.zclient.storage.userdatabase.sync
+package com.waz.zclient.storage.userdatabase.clients
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,30 +8,30 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class SyncJobsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class ClientsTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenSyncJobInsertedIntoSyncJobsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenClientIntoClientsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val id = "testId"
         val data = "testData"
 
-        SyncJobsTableTestHelper.insertSyncJob(
+        ClientsTableTestHelper.insertClient(
             id = id,
             data = data,
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
-            with(allSyncJobs()[0]) {
+            with(allClients()[0]) {
                 assertEquals(this.id, id)
                 assertEquals(this.data, data)
             }
         }
     }
 
-    private suspend fun allSyncJobs() =
-        getDatabase().syncJobsDao().allSyncJobs()
+    private suspend fun allClients() =
+        getDatabase().userClientDao().allClients()
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationTables127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationTables127to128MigrationTest.kt
@@ -1,17 +1,16 @@
 package com.waz.zclient.storage.userdatabase.conversations
 
 import com.waz.zclient.framework.data.conversations.ConversationRolesTestDataProvider
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class ConversationTables127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenFolderInsertedIntoConversationFoldersTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenFolderInsertedIntoConversationFoldersTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val conversationId = "7577489"
         val folderId = "377474"
 
@@ -21,7 +20,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allConversationFolders()[0]) {
@@ -32,7 +31,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
     }
 
     @Test
-    fun givenMemberInsertedIntoConversationMembersTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenMemberInsertedIntoConversationMembersTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val userId = "h477474849jfnj777478-"
         val convId = "7577489"
         val roleId = "1100"
@@ -44,7 +43,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allConversationMembers()[0]) {
@@ -56,7 +55,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
     }
 
     @Test
-    fun givenRoleActionInsertedIntoConversationRoleActionTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenRoleActionInsertedIntoConversationRoleActionTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val data = ConversationRolesTestDataProvider.provideDummyTestData()
         ConversationsRoleActionTableTestHelper.insertConversationRoleAction(
             data.convId,
@@ -65,7 +64,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allConversationRoleActions()[0]) {
@@ -77,7 +76,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
     }
 
     @Test
-    fun givenRoleActionInsertedIntoConversationsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenRoleActionInsertedIntoConversationsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val convId = "7577489"
         val remoteId = "888"
         val name = "Test Conversation Name"
@@ -148,7 +147,7 @@ class ConversationTables126to128MigrationTest : UserDatabaseMigrationTest(126, 1
             testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allConversations()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/errors/ErrorsTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/errors/ErrorsTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.errors
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class ErrorsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class ErrorsTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenErrorInsertedIntoErrorsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenErrorInsertedIntoErrorsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val id = "id"
         val type = "type"
@@ -37,7 +36,7 @@ class ErrorsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             val syncJob = allErrors()[0]

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/folders/FoldersTable127to128MigrationTest.kt
@@ -1,7 +1,6 @@
 package com.waz.zclient.storage.userdatabase.folders
 
 import com.waz.zclient.framework.data.folders.FoldersTestDataProvider
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,10 +9,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class FoldersTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class FoldersTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenFolderInsertedIntoFoldersTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenFolderInsertedIntoFoldersTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
         val data = FoldersTestDataProvider.provideDummyTestData()
         FoldersTableTestHelper.insertFolder(
             id = data.id,
@@ -22,7 +21,7 @@ class FoldersTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allFolders()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/history/EditHistoryTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.history
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class EditHistoryTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class EditHistoryTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenHistoryInsertedIntoEditHistoryTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenHistoryInsertedIntoEditHistoryTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val originalId = "testOriginalID"
         val updatedId = "testUpdatedID"
@@ -25,7 +24,7 @@ class EditHistoryTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allHistory()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/notifications/NotificationsTables127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/notifications/NotificationsTables127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.notifications
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,10 +9,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class NotificationsTables127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenCloudNotificationsStatInsertedIntoCloudNotificationsStatsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenCloudNotificationsStatInsertedIntoCloudNotificationsStatsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val stage = "testStage"
         val firstBucket = 1
@@ -23,7 +22,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
         CloudNotificationsStatsTableTestHelper.insertCloudNotificationStat(stage, firstBucket,
             secondBucket, thirdBucket, openHelper = testOpenHelper)
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allCloudNotificationStats()[0]) {
@@ -36,7 +35,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
     }
 
     @Test
-    fun givenCloudNotificationInsertedIntoCloudNotificationsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenCloudNotificationInsertedIntoCloudNotificationsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val id = "testId"
         val stage = "testStage"
@@ -46,7 +45,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allCloudNotifications()[0]) {
@@ -58,7 +57,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
     }
 
     @Test
-    fun givenNotificationDataInsertedIntoNotificationDataTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenNotificationDataInsertedIntoNotificationDataTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val id = "testId"
         val data = "testData"
@@ -69,7 +68,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allNotificationsData()[0]) {
@@ -80,7 +79,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
     }
 
     @Test
-    fun givenPushNotificationEventInsertedIntoPushNotificationEventsDataTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenPushNotificationEventInsertedIntoPushNotificationEventsDataTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
 
         val eventIndex = 1
@@ -100,7 +99,7 @@ class NotificationsTables126to128MigrationTest : UserDatabaseMigrationTest(126, 
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allPushNotificationEvents()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/property/PropertyTables127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/property/PropertyTables127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.property
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class PropertyTables127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenKeyValueInsertedIntoMessagesTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenKeyValueInsertedIntoMessagesTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val key = "testKey"
         val value = "testValue"
@@ -22,7 +21,7 @@ class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
             value = value,
             openHelper = testOpenHelper)
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allKeyValues()[0]) {
@@ -33,7 +32,7 @@ class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
     }
 
     @Test
-    fun givenPropertyInsertedIntoPropertiesTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenPropertyInsertedIntoPropertiesTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val key = "testKey"
         val value = "testValue"
@@ -44,7 +43,7 @@ class PropertyTables126to128MigrationTest : UserDatabaseMigrationTest(126, 128) 
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allProperties()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/receipts/ReadReceiptsTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.receipts
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class ReadReceiptsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class ReadReceiptsTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenReceiptsInsertedIntoReadReceiptsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenReceiptsInsertedIntoReadReceiptsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val messageId = "messageId"
         val userId = "UserId"
@@ -25,7 +24,7 @@ class ReadReceiptsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 12
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(allReceipts()[0]) {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/sync/SyncJobsTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/sync/SyncJobsTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
-package com.waz.zclient.storage.userdatabase.clients
+package com.waz.zclient.storage.userdatabase.sync
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,30 +8,30 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class ClientsTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class SyncJobsTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenClientIntoClientsTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenSyncJobInsertedIntoSyncJobsTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val id = "testId"
         val data = "testData"
 
-        ClientsTableTestHelper.insertClient(
+        SyncJobsTableTestHelper.insertSyncJob(
             id = id,
             data = data,
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
-            with(allClients()[0]) {
+            with(allSyncJobs()[0]) {
                 assertEquals(this.id, id)
                 assertEquals(this.data, data)
             }
         }
     }
 
-    private suspend fun allClients() =
-        getDatabase().userClientDao().allClients()
+    private suspend fun allSyncJobs() =
+        getDatabase().syncJobsDao().allSyncJobs()
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UserTable127to128MigrationTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UserTable127to128MigrationTest.kt
@@ -1,6 +1,5 @@
 package com.waz.zclient.storage.userdatabase.users
 
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_126_TO_127
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
 import com.waz.zclient.storage.userdatabase.UserDatabaseMigrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,10 +8,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class UserTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
+class UserTable127to128MigrationTest : UserDatabaseMigrationTest(127, 128) {
 
     @Test
-    fun givenUserInsertedIntoUsersTableVersion126_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
+    fun givenUserInsertedIntoUsersTableVersion127_whenMigratedToVersion128_thenAssertDataIsStillIntact() {
 
         val userId = "testUserId"
         val teamId = "testTeamId"
@@ -71,7 +70,7 @@ class UserTable126to128MigrationTest : UserDatabaseMigrationTest(126, 128) {
             openHelper = testOpenHelper
         )
 
-        validateMigration(USER_DATABASE_MIGRATION_126_TO_127, USER_DATABASE_MIGRATION_127_TO_128)
+        validateMigration(USER_DATABASE_MIGRATION_127_TO_128)
 
         runBlocking {
             with(getAllUsers()[0]) {


### PR DESCRIPTION
The migration 126->127 was already removed, but migration tests still had references to it.
Which means they are not only not run, but not even compiled. Maybe we should remove them all?

#### APK
[Download build #3434](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3434/artifact/build/artifact/wire-dev-PR3285-3434.apk)