### PR TITLE
Feature: Legal Hold Info Modal - Prevent opening legal hold info screen again from participant screen

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -17,6 +17,8 @@ class LegalHoldController(implicit injector: Injector)
 
   private lazy val legalHoldService = inject[Signal[LegalHoldService]]
 
+  val showingLegalHoldInfo: SourceStream[Boolean] = EventStream[Boolean]
+
   val onLegalHoldSubjectClick: SourceStream[UserId] = EventStream[UserId]
   val onAllLegalHoldSubjectsClick: SourceStream[Unit] = EventStream[Unit]
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -1,5 +1,6 @@
 package com.waz.zclient.legalhold
 
+import android.content.Context
 import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
@@ -34,6 +35,16 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldSubjectsContainer]()
     super.onViewCreated(view, savedInstanceState)
     setMessage()
     setUpRecyclerView()
+  }
+
+  override def onAttach(context: Context): Unit = {
+    super.onAttach(context)
+    legalHoldController.showingLegalHoldInfo ! true
+  }
+
+  override def onPreDetach(): Unit = {
+    super.onPreDetach()
+    legalHoldController.showingLegalHoldInfo ! false
   }
 
   private def setMessage(): Unit =


### PR DESCRIPTION
## What's new in this PR?

### Issues

There's a possible cycle of `LegalHoldInfoFragment` and `ParticipantHeaderFragment` as we always display legal hold indicator in header. Clicking on the indicator might open `LegalHoldInfoFragment` again:

**Steps:**
1. Open a 1-1 conversation with a LH subject
2. Click conversation details
3. See participant page
4. Click on LH indicator on header
5. See LH info modal
6. Click on user in the LH Subjects list
7. See participant page again

**Actual result:**
On participant page, we see LH indicator again, which might result in a cycle of steps 4-7.

**Expected result:**
After step 7, we shouldn't see LH indicator again to avoid this cycle.

### Solutions

Keep a flag that tracks whether we've seen legal hold info screen before (`showingLegalHoldInfo`). Once the user sees  `LegalHoldInfoFragment`, set the flag to true. When user leaves `LegalHoldInfoFragment` and any pages after that either by clicking back or close icon, set the flag to false.

On `ParticipantHeaderFragment`, check this flag. A true flag means that we're showing participant's screen on top of legal hold info modal. In that case, force hide the indicator to prevent cycles. If the flag is false, we may show the indicator.

### Testing

Manually tested with steps above, and saw that icon is hidden.

#### APK
[Download build #3428](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3428/artifact/build/artifact/wire-dev-PR3286-3428.apk)
[Download build #3430](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3430/artifact/build/artifact/wire-dev-PR3286-3430.apk)