### PR TITLE
refactor: Changes required to work with wire-signals-0.4.2

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -142,7 +142,7 @@ class WebSocketService extends ServiceHelper with DerivedLogTag {
   private lazy val global              = inject[GlobalModule]
 
   private lazy val webSocketActiveSubscription =
-    Signal.zip(controller.accountWebsocketStates, global.network.networkMode) {
+    Signal.zip(controller.accountWebsocketStates, global.network.networkMode).foreach {
       case ((zmsWithWSActive, zmsWithWSInactive), networkMode) if NetworkModeService.isOnlineMode(networkMode) =>
         toggleWSPushServices(zmsWithWSActive, zmsWithWSInactive, stopIfNeeded = true)
       case ((zmsWithWSActive, zmsWithWSInactive), _) =>

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/FirstLaunchAfterLoginFragment.scala
@@ -156,7 +156,7 @@ class FirstLaunchAfterLoginFragment extends FragmentHelper with View.OnClickList
     case Some(backupUri) =>
       getBackupFile(backupUri).map { backupFile =>
         val fragment = returning(BackupPasswordDialog.newInstance(InputPasswordMode)) {
-          _.onPasswordEntered(password => enterWithBackup(userId, backupFile, password))
+          _.onPasswordEntered.foreach(password => enterWithBackup(userId, backupFile, password))
         }
         getActivity.asInstanceOf[BaseActivity]
           .getSupportFragmentManager

--- a/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingFragment.scala
@@ -90,7 +90,7 @@ class CallingFragment extends FragmentHelper {
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle): View =
     returning(inflater.inflate(R.layout.fragment_calling, container, false)) { v =>
-      controller.theme(t => v.asInstanceOf[ThemeControllingFrameLayout].theme ! Some(t))
+      controller.theme.foreach(t => v.asInstanceOf[ThemeControllingFrameLayout].theme ! Some(t))
     }
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
@@ -117,7 +117,7 @@ class CallingFragment extends FragmentHelper {
       case _                          => noActiveSpeakersLayout.foreach(_.setVisibility(View.GONE))
     }
 
-    controller.isGroupCall.onChanged {
+    controller.isGroupCall.onChanged.foreach {
       case true =>
         Toast.makeText(getContext, R.string.calling_double_tap_enter_fullscreen_message, Toast.LENGTH_LONG).show()
       case _ =>

--- a/app/src/main/scala/com/waz/zclient/collection/adapters/SearchAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/adapters/SearchAdapter.scala
@@ -112,12 +112,10 @@ class SearchAdapter()(implicit context: Context, injector: Injector, eventContex
   }
 }
 
-class SearchResultRowViewHolder(view: SearchResultRowView)(implicit eventContext: EventContext) extends RecyclerView.ViewHolder(view){
+class SearchResultRowViewHolder(view: SearchResultRowView)(implicit eventContext: EventContext)
+  extends RecyclerView.ViewHolder(view){
+  def setSearchQuerySignal(contentSearchQuery: Signal[ContentSearchQuery]): Unit =
+    contentSearchQuery.foreach {view.searchedQuery ! _ }
 
-  def setSearchQuerySignal(contentSearchQuery: Signal[ContentSearchQuery]): Unit = {
-    contentSearchQuery{view.searchedQuery ! _}
-  }
-
-  def set(message: MessageAndLikes): Unit =
-    view.set(message, None)
+  def set(message: MessageAndLikes): Unit = view.set(message, None)
 }

--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
@@ -91,7 +91,7 @@ trait CollectionNormalItemView extends CollectionItemView with ClickableViewPart
 
   messageAndLikesResolver.onUi { mal => set(mal, content) }
 
-  onClicked { _ =>
+  onClicked.foreach { _ =>
     import Threading.Implicits.Ui
     for {
       false <- expired.head
@@ -202,37 +202,36 @@ class CollectionSimpleWebLinkPartView(context: Context, attrs: AttributeSet, sty
   val urlText =
     message.map(msg => msg.content.find(c => URLUtil.isValidUrl(c.content)).map(_.content).getOrElse(msg.contentString))
 
-  urlText.on(Threading.Ui) {
+  urlText.onUi {
     urlTextView.setText
   }
 
-  onClicked { _ =>
+  onClicked.onUi { _ =>
     import Threading.Implicits.Ui
     for {
       false <- expired.head
-      text <- urlText.head
+      text  <- urlText.head
     } browser.openUrl(AndroidURIUtil.parse(text))
   }
   registerEphemeral(urlTextView)
 }
 
-case class CollectionItemViewHolder(view: CollectionNormalItemView)(implicit eventContext: EventContext) extends RecyclerView.ViewHolder(view) {
+case class CollectionItemViewHolder(view: CollectionNormalItemView)(implicit eventContext: EventContext)
+  extends RecyclerView.ViewHolder(view) {
 
-  def setMessageData(messageData: MessageData, content: Option[MessageContent]): Unit = {
+  def setMessageData(messageData: MessageData, content: Option[MessageContent]): Unit =
     view.setMessageData(messageData, content)
-  }
 
-  def setMessageData(messageData: MessageData): Unit = {
+  def setMessageData(messageData: MessageData): Unit =
     setMessageData(messageData, None)
-  }
 }
 
-case class CollectionImageViewHolder(view: CollectionImageView, listener: OnClickListener)(implicit eventContext: EventContext) extends RecyclerView.ViewHolder(view) {
-  view.onClicked { _ =>
+case class CollectionImageViewHolder(view: CollectionImageView, listener: OnClickListener)
+                                    (implicit eventContext: EventContext) extends RecyclerView.ViewHolder(view) {
+  view.onClicked.onUi { _ =>
     listener.onClick(view)
   }
 
-  def setMessageData(messageData: MessageData, width: Int, color: Int) = {
+  def setMessageData(messageData: MessageData, width: Int, color: Int): Unit =
     view.setMessageData(messageData, width, color)
-  }
 }

--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionRecyclerView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionRecyclerView.scala
@@ -60,7 +60,7 @@ class CollectionRecyclerView(context: Context, attrs: AttributeSet, style: Int)
 
     addItemDecoration(collectionItemDecorator)
 
-    scrollController.onScroll { case Scroll(pos, smooth) =>
+    scrollController.onScroll.foreach { case Scroll(pos, smooth) =>
       verbose(l"Scrolling to pos: $pos, smooth: $smooth")
       val scrollTo = math.min(adapter.getItemCount - 1, pos)
       if (smooth) {

--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -86,7 +86,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     zms.flatMap(_.userPrefs.preference(DownloadImagesAlways).signal).disableAutowiring()
 
   messageActionsController.onMessageAction
-    .collect { case (MessageAction.OpenFile, msg) => msg.assetId } {
+    .collect { case (MessageAction.OpenFile, msg) => msg.assetId }.foreach {
       case Some(id) => openFile(id)
       case _ =>
     }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/SoundController.scala
@@ -86,7 +86,7 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
   private val soundIntensity = zms.flatMap(_.mediamanager.soundIntensity)
 
   private var _mediaManager = Option.empty[MediaManager]
-  mediaManager(m => _mediaManager = Some(m))
+  mediaManager.foreach(m => _mediaManager = Some(m))
 
   //TODO Refactor MessageNotificationsController and remove this. Work with normal Signal.head method instead
   private implicit class RichSignal[T](val value: Signal[T]) {
@@ -124,7 +124,7 @@ class SoundControllerImpl(implicit inj: Injector, cxt: Context)
     pingTone <- zms.userPrefs.preference(UserPreferences.PingTone).signal
   } yield (ringTone, textTone, pingTone)).disableAutowiring()
 
-  tonePrefs {
+  tonePrefs.foreach {
     case (ring, text, ping) => setCustomSoundUrisFromPreferences(ring, text, ping)
   }
 

--- a/app/src/main/scala/com/waz/zclient/common/controllers/ThemeController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/ThemeController.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration._
 
 class ThemeController(implicit injector: Injector, context: Context)
   extends Injectable with DerivedLogTag {
-  
+
   import Threading.Implicits.Background
 
   val optionsDarkTheme:  OptionsTheme = new OptionsDarkTheme(context)
@@ -96,17 +96,17 @@ trait ThemedView extends View with ViewHelper {
 
   override def onAttachedToWindow(): Unit = {
     super.onAttachedToWindow()
-    getThemeFromParent(this)(currentTheme ! _)
+    getThemeFromParent(this).foreach(currentTheme ! _)
   }
 
-  private def getThemeFromParent(view: View): Signal[Option[Theme]] = {
+  @scala.annotation.tailrec
+  private def getThemeFromParent(view: View): Signal[Option[Theme]] =
     view.getParent match {
       case v: ThemeControllingView => v.theme
       case v: ThemedView => v.currentTheme
       case v: View => getThemeFromParent(v)
       case _ => Signal.const(None)
     }
-  }
 }
 
 object ThemeController {

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/KeyboardController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/KeyboardController.scala
@@ -31,10 +31,10 @@ class KeyboardController(implicit inj: Injector, cxt: WireContext, ec: EventCont
   extends ViewTreeObserver.OnGlobalLayoutListener with Injectable with DerivedLogTag {
 
   val isKeyboardVisible = Signal(false)
-  isKeyboardVisible(v => verbose(l"Keyboard visible: $v"))
+  isKeyboardVisible.foreach(v => verbose(l"Keyboard visible: $v"))
 
   val keyboardHeight = Signal(0)
-  keyboardHeight(h => verbose(l"Keyboard height: $h"))
+  keyboardHeight.foreach(h => verbose(l"Keyboard height: $h"))
 
   private val rootLayout = cxt match {
     case c: Activity => Some(c.getWindow.getDecorView.findViewById(android.R.id.content).asInstanceOf[View])

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -156,7 +156,7 @@ class ConversationController(implicit injector: Injector, context: Context)
     convId <- currentConvId.head
   } yield convs.setConversationRole(convId, userId, role)
 
-  currentConvIdOpt {
+  currentConvIdOpt.foreach {
     case Some(convId) =>
       if (!lastConvId.contains(convId)) { // to only catch changes coming from SE (we assume it's an account switch)
         verbose(l"a conversation change bypassed selectConv: last = $lastConvId, current = $convId")
@@ -427,7 +427,7 @@ class ConversationController(implicit injector: Injector, context: Context)
       */
     val lastActive = Signal((MessageId.Empty, Instant.EPOCH)) // message showing status info
 
-    currentConv.onChanged { _ => clear() }
+    currentConv.onChanged.foreach { _ => clear() }
 
     def clear() = {
       focused ! None

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageFragment.scala
@@ -131,7 +131,7 @@ class ImageFragment extends FragmentHelper {
 
     imageInput
 
-    EventStream.zip(bottomToolbar.topToolbar.onCursorButtonClicked, bottomToolbar.bottomToolbar.onCursorButtonClicked) {
+    EventStream.zip(bottomToolbar.topToolbar.onCursorButtonClicked, bottomToolbar.bottomToolbar.onCursorButtonClicked).foreach {
       case item: CursorActionToolbarItem =>
         import IDrawingController.DrawingMethod._
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ImageViewPager.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ImageViewPager.scala
@@ -52,7 +52,7 @@ class ImageViewPager(context: Context, attrs: AttributeSet) extends ViewPager(co
 
   private var imageAdapter: Option[PagerAdapter] = None
 
-  messageData { msg => imageAdapter match {
+  messageData.foreach { msg => imageAdapter match {
     case None => setImageAdapter(msg)
     case Some(adapter) => adapter match { // Maciek: needed for an AN-5315 corner case where focusedItem gives two different messages and the second one is correct
       case _: ImageSwipeAdapter if msg.isEphemeral => setImageAdapter(msg)

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyController.scala
@@ -52,7 +52,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     asset       <- assetsController.assetSignal(msg.assetId)
   } yield Option(ReplyContent(msg, asset, sender.name))).orElse(Signal.const(None))
 
-  messagesService.flatMap(ms => Signal.from(ms.msgEdited)) { case (from, to) =>
+  messagesService.flatMap(ms => Signal.from(ms.msgEdited)).foreach { case (from, to) =>
     replyData.mutate { data =>
       data.find(_._2 == from).map(_._1).fold(data) { conv =>
         data + (conv -> to)
@@ -60,7 +60,7 @@ class ReplyController(implicit injector: Injector, context: Context, ec: EventCo
     }
   }
 
-  messagesStorage.flatMap(ms => Signal.from(ms.onDeleted)) { deletedIds =>
+  messagesStorage.flatMap(ms => Signal.from(ms.onDeleted)).foreach { deletedIds =>
     replyData.mutate(_.filterNot(c => deletedIds.contains(c._2)))
   }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/AddParticipantsFragment.scala
@@ -69,7 +69,7 @@ class AddParticipantsFragment extends FragmentHelper {
   private lazy val adapter = AddParticipantsAdapter(newConvController.users, newConvController.integrations)
 
   private lazy val searchBox = returning(view[SearchEditText](R.id.search_box)) { vh =>
-    adapter.onSelectionChanged.mapAsync {
+    adapter.onSelectionChanged.mapSync {
       case (Left(userId), selected) =>
         zms.head.flatMap(_.usersStorage.get(userId).collect {
           case Some(u) => (Pickable(userId.str, u.name), selected)

--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
@@ -44,15 +44,15 @@ class CreateConversationController(implicit inj: Injector)
 
   private implicit lazy val uiStorage = inject[UiStorage]
 
-  val convId   = Signal(Option.empty[ConvId])
-  val name     = Signal("")
-  val users    = Signal(Set.empty[UserId])
+  val convId       = Signal(Option.empty[ConvId])
+  val name         = Signal("")
+  val users        = Signal(Set.empty[UserId])
   val integrations = Signal(Set.empty[(ProviderId, IntegrationId)])
-  val teamOnly = Signal(true)
+  val teamOnly     = Signal(true)
   val readReceipts = Signal(true)
-  val fromScreen = Signal[GroupConversationEvent.Method]()
+  val fromScreen   = Signal[GroupConversationEvent.Method]()
 
-  teamOnly.onChanged {
+  teamOnly.onChanged.foreach {
     case true =>
       for {
         z   <- zms.head

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -317,10 +317,10 @@ object ConversationListController {
         convId -> otherUsers.sortBy(_.str).take(4)
       }
 
-    val updatedEntries = EventStream.zip(
+    private val updatedEntries = EventStream.zip(
       zms.membersStorage.onAdded.map(_.map(_.convId).toSet),
       zms.membersStorage.onDeleted.map(_.map(_._2).toSet)
-    ).mapAsync { convs =>
+    ).mapSync { convs =>
       zms.membersStorage.getByConvs(convs).map(entries)
     }
 

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -132,12 +132,12 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
     subs += userAccountsController.currentUser.onUi(user => topToolbar.get.setTitle(adapterMode, user))
 
-    subs += adapter.onConversationClick { conv =>
+    subs += adapter.onConversationClick.foreach { conv =>
       verbose(l"handleItemClick, switching conv to $conv")
       conversationController.selectConv(Option(conv), ConversationChangeRequester.CONVERSATION_LIST)
     }
 
-    subs += adapter.onConversationLongClick { conv =>
+    subs += adapter.onConversationLongClick.foreach { conv =>
       if (Set(Group, OneToOne, WaitForConnection).contains(conv.convType))
         screenController.showConversationMenu(true, conv.id)
     }
@@ -164,7 +164,7 @@ class ArchiveListFragment extends ConversationListFragment with OnBackPressedLis
 
   override def onViewCreated(view: View, savedInstanceState: Bundle) = {
     super.onViewCreated(view, savedInstanceState)
-    topToolbar.foreach(toolbar => subs += toolbar.onRightButtonClick(_ => Option(getContainer).foreach(_.closeArchive())))
+    topToolbar.foreach(toolbar => subs += toolbar.onRightButtonClick.foreach(_ => Option(getContainer).foreach(_.closeArchive())))
   }
 
   override def onBackPressed() = {
@@ -243,7 +243,7 @@ class NormalConversationFragment extends ConversationListFragment {
     }.onUi(visibility => vh.foreach(_.setVisibility(visibility)))
   }
 
-  override def onViewCreated(v: View, savedInstanceState: Bundle) = {
+  override def onViewCreated(v: View, savedInstanceState: Bundle): Unit = {
     super.onViewCreated(v, savedInstanceState)
 
     subs += loading.onUi {
@@ -254,7 +254,7 @@ class NormalConversationFragment extends ConversationListFragment {
     }
 
     topToolbar.foreach { toolbar =>
-      subs += toolbar.onRightButtonClick { _ =>
+      subs += toolbar.onRightButtonClick.foreach { _ =>
         getActivity.startActivityForResult(PreferencesActivity.getDefaultIntent(getContext), PreferencesActivity.SwitchAccountCode)
       }
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -203,7 +203,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
       verbose(l"Outdated avatar info")
   }
 
-  badge.onClickEvent {
+  badge.onClickEvent.foreach {
     case ConversationBadge.IncomingCall =>
       (zms.map(_.selfUserId).currentValue, conversationData.map(_.id)) match {
         case (Some(acc), Some(cId)) => inject[CallStartController].startCall(acc, cId, forceOption = true)

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -138,7 +138,7 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
 
   private val actionsController = inject[MessageActionsController]
 
-  actionsController.onMessageAction {
+  actionsController.onMessageAction.foreach {
     case (MessageAction.Edit, message) =>
       editingMsg ! Some(message)
       CancellableFuture.delayed(100.millis) { keyboard ! KeyboardState.Shown }
@@ -148,7 +148,7 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
 
   // notify SE about typing state
   private var prevEnteredText = ""
-  enteredText {
+  enteredText.foreach {
     case (CursorText(text, _), EnteredTextSource.FromView) if text != prevEnteredText =>
       for {
         typing <- zms.map(_.typing).head
@@ -207,11 +207,6 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
         enteredText ! (CursorText.Empty, EnteredTextSource.FromController)
       }
     case false =>
-  }
-
-  editHasFocus {
-    case true => // TODO - reimplement for tablets
-    case false => // ignore
   }
 
   private val msgBeingSendInConv = Signal(Set.empty[ConvId])
@@ -306,10 +301,9 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   private lazy val screenController   = inject[ScreenController]
   private lazy val accentColorController  = inject[AccentColorController]
 
-
   import CursorMenuItem._
 
-  onCursorItemClick {
+  onCursorItemClick.foreach {
     case CursorMenuItem.More => secondaryToolbarVisible ! true
     case CursorMenuItem.Less => secondaryToolbarVisible ! false
     case AudioMessage =>

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -313,7 +313,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
 
   // allows the controller to "empty" the text field if necessary by resetting the signal.
   // specifying the source guards us from an infinite loop of the view and controller updating each other
-  controller.enteredText {
+  controller.enteredText.foreach {
     case (CursorText(text, mentions), EnteredTextSource.FromController) if text != cursorEditText.getText.toString => setText(text, mentions)
     case _ =>
   }
@@ -342,7 +342,7 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
     } (Threading.Ui)
   }
 
-  controller.onCursorItemClick {
+  controller.onCursorItemClick.foreach {
     case CursorMenuItem.Mention =>
       mentionQuery.head.map {
         case None =>

--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
@@ -39,7 +39,7 @@ class DeepLinkService(implicit injector: Injector) extends Injectable with Deriv
 
   val deepLink = Signal(Option.empty[CheckingResult])
 
-  deepLink { result =>
+  deepLink.foreach { result =>
     verbose(l"DeepLink checking result: $result")
   }
 

--- a/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
@@ -52,7 +52,9 @@ class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
         case _ =>
           CancellableFuture.failed(NotSupportedError("Unsupported image request"))
       }
-    }.withTimeout(30.seconds)
+    }
+
+    data.addTimeout(30.seconds)
 
     currentData.foreach(_.cancel())
     currentData = Some(data)

--- a/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
@@ -18,14 +18,13 @@ class AllLegalHoldSubjectsFragment extends BaseFragment[LegalHoldSubjectsContain
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
 
   private lazy val adapter = returning(new LegalHoldUsersAdapter(users)) {
-    _.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
+    _.onClick.pipeTo(legalHoldController.onLegalHoldSubjectClick)
   }
 
   private lazy val searchBox = view[SearchEditText](R.id.search_box)
 
   override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) =
     inflater.inflate(R.layout.all_participants_fragment, container, false)
-
 
   override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
     setUpRecyclerView()

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
@@ -5,6 +5,7 @@ import com.waz.model.AccountData.Password
 import com.waz.service.AccountsService
 import com.waz.sync.handler.LegalHoldError
 import com.waz.threading.Threading.Implicits.Ui
+import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient.preferences.DevicesPreferencesUtil
 import com.waz.zclient.utils.ContextUtils
@@ -23,7 +24,7 @@ class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
 
   private var activityRef: WeakReference[FragmentActivity] = _
 
-  legalHoldController.legalHoldRequest.onChanged {
+  legalHoldController.legalHoldRequest.onChanged.onUi {
     case None    => dismissDialog()
     case Some(_) =>
   }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
@@ -46,8 +46,8 @@ class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
       val fingerprintText = DevicesPreferencesUtil.getFormattedFingerprint(activity, fingerprint).toString
 
       returning(LegalHoldRequestDialog.newInstance(isSso = isSso, fingerprintText, showError = showError)) { dialog =>
-        dialog.onAccept(onLegalHoldAccepted)
-        dialog.onDecline(_ => setFinished())
+        dialog.onAccept.foreach(onLegalHoldAccepted)
+        dialog.onDecline.foreach(_ => setFinished())
       }.show(activity.getSupportFragmentManager, LegalHoldRequestDialog.TAG)
     }
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -22,8 +22,8 @@ class LegalHoldInfoFragment extends BaseFragment[LegalHoldSubjectsContainer]()
   private lazy val legalHoldController = inject[LegalHoldController]
 
   private lazy val adapter = returning(new LegalHoldUsersAdapter(users, Some(MAX_PARTICIPANTS))) { adapter =>
-    adapter.onClick(legalHoldController.onLegalHoldSubjectClick ! _)
-    adapter.onShowAllParticipantsClick(_ => legalHoldController.onAllLegalHoldSubjectsClick ! (()))
+    adapter.onClick.pipeTo(legalHoldController.onLegalHoldSubjectClick)
+    adapter.onShowAllParticipantsClick.pipeTo(legalHoldController.onAllLegalHoldSubjectsClick)
   }
 
   private lazy val users = getContainer.legalHoldUsers.map(_.toSet)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
@@ -2,7 +2,7 @@ package com.waz.zclient.legalhold
 
 import com.waz.zclient.security.ActivityLifecycleCallback
 import com.waz.zclient.{Injectable, Injector}
-
+import com.waz.threading.Threading._
 
 class LegalHoldStatusChangeListener(implicit injector: Injector) extends Injectable {
 
@@ -10,7 +10,7 @@ class LegalHoldStatusChangeListener(implicit injector: Injector) extends Injecta
   private lazy val legalHoldApprovalHandler  = inject[LegalHoldApprovalHandler]
   private lazy val activityLifecycleCallback = inject[ActivityLifecycleCallback]
 
-  legalHoldController.hasPendingRequest.onChanged {
+  legalHoldController.hasPendingRequest.onChanged.onUi {
     case true  => activityLifecycleCallback.withCurrentActivity(legalHoldApprovalHandler.showDialog)
     case false =>
   }

--- a/app/src/main/scala/com/waz/zclient/messages/LikesController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/LikesController.scala
@@ -29,14 +29,13 @@ import com.waz.model.MessageData
 class LikesController(implicit ec: EventContext, injector: Injector)
   extends Injectable with DerivedLogTag {
 
-  val zms = inject[Signal[ZMessaging]]
-  val reactions = zms.map(_.reactions)
+  private lazy val reactions = inject[Signal[ZMessaging]].map(_.reactions)
 
   val onLikeButtonClicked = EventStream[MessageAndLikes]()
   val onViewDoubleClicked = EventStream[MessageAndLikes]()
 
-  onLikeButtonClicked(toggleLike)
-  onViewDoubleClicked(toggleLike)
+  onLikeButtonClicked.foreach(toggleLike)
+  onViewDoubleClicked.foreach(toggleLike)
 
   private def toggleLike(msgAndLikes: MessageAndLikes): Unit = {
     if (!msgAndLikes.message.isEphemeral) {

--- a/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageBottomSheetDialog.scala
@@ -36,9 +36,9 @@ class MessageBottomSheetDialog(message: MessageData,
                                operations: Seq[MessageAction] = Seq.empty)(implicit injector: Injector, context: Context, ec: EventContext)
   extends OptionsMenuController with Injectable {
 
-  lazy val zmessaging = inject[Signal[ZMessaging]]
-  lazy val messageActionsController = inject[MessageActionsController]
-  lazy val assetsController = inject[AssetsController]
+  private lazy val zmessaging = inject[Signal[ZMessaging]]
+  private lazy val messageActionsController = inject[MessageActionsController]
+  private lazy val assetsController = inject[AssetsController]
 
   override val title: Signal[Option[String]] = Signal.const(None)
   override val optionItems: Signal[Seq[OptionsMenuController.MenuItem]] =
@@ -55,13 +55,12 @@ class MessageBottomSheetDialog(message: MessageData,
   override val onMenuItemClicked: SourceStream[OptionsMenuController.MenuItem] = EventStream()
   override val selectedItems: Signal[Set[OptionsMenuController.MenuItem]] = Signal.const(Set())
 
-  onMenuItemClicked {
+  onMenuItemClicked.foreach {
     case action: MessageAction =>
       messageActionsController.onMessageAction ! (action, message)
     case _ =>
   }
 }
-
 
 object MessageBottomSheetDialog {
   val CollectionExtra = "COLLECTION_EXTRA"

--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -76,7 +76,7 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
       zms.messagesStorage.onUpdated.map(_.exists { case (prev, updated) =>
         updated.convId == convId &&  !MessagesPagedListAdapter.areMessageContentsTheSame(prev, updated)
       }),
-      zms.reactionsStorage.onChanged.map(_.map(_.message)).mapAsync { msgs: Seq[MessageId] =>
+      zms.reactionsStorage.onChanged.map(_.map(_.message)).mapSync { msgs: Seq[MessageId] =>
         zms.messagesStorage.getMessages(msgs: _*).map(_.flatten.exists(_.convId == convId))
       }
     ).filter(identity)

--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewPart.scala
@@ -191,7 +191,7 @@ class UnreadDot(context: Context, attrs: AttributeSet, style: Int)
   val dotRadius = getDimenPx(R.dimen.conversation__unread_dot__radius)
   val dotPaint = new Paint(Paint.ANTI_ALIAS_FLAG)
 
-  accent { color =>
+  accent.onUi { color =>
     dotPaint.setColor(color.color)
     postInvalidate()
   }
@@ -228,7 +228,7 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
     case _ => None
   }
 
-  userId(chathead.loadUser)
+  userId.onUi(chathead.loadUser)
 
   user.map(_.name).onUi(tvName.setTransformedText(_))
   user.map(_.isWireBot).on(Threading.Ui) { isBot.setVisible }
@@ -237,9 +237,9 @@ class UserPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
     tvName.setTextColor(getNameColor(a))
   }
 
-  stateGlyph.map(_.isDefined) { tvStateGlyph.setVisible }
+  stateGlyph.map(_.isDefined).onUi { tvStateGlyph.setVisible }
 
-  stateGlyph.collect { case Some(glyph) => glyph } { tvStateGlyph.setText }
+  stateGlyph.collect { case Some(glyph) => glyph }.onUi { tvStateGlyph.setText }
 
   override def set(msg: MessageAndLikes, part: Option[MessageContent], opts: Option[MsgBindOptions]): Unit = {
     super.set(msg, part, opts)

--- a/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagesListView.scala
@@ -106,9 +106,7 @@ class MessagesListView(context: Context, attrs: AttributeSet, style: Int)
     adapter.notifyDataSetChanged()
   }
 
-  realViewHeight.onChanged {
-    scrollController.onListHeightChanged ! _
-  }
+  realViewHeight.onChanged.pipeTo(scrollController.onListHeightChanged)
 
   adapter.onScrollRequested.onUi { case (message, _) =>
     collectionsController.focusedItem ! None // needed in case we requested a scroll to the same message again

--- a/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
@@ -29,7 +29,8 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogShow.SafeToLog
 import com.waz.threading.Threading._
 
-class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, layoutManager: MessagesListLayoutManager)(implicit ec: EventContext)
+class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, layoutManager: MessagesListLayoutManager)
+                      (implicit ec: EventContext)
   extends DerivedLogTag {
 
   private var lastVisiblePosition = 0
@@ -55,7 +56,7 @@ class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, la
     scrollToPositionRequested.map { pos => Scroll(pos, smooth = false, force = true) }
   )
 
-  adapter.onScrollRequested(scrollToPositionRequested ! _._2)
+  adapter.onScrollRequested.foreach(scrollToPositionRequested ! _._2)
 
   view.addOnScrollListener(new OnScrollListener {
     override def onScrollStateChanged(recyclerView: RecyclerView, newState: Int): Unit =

--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -77,7 +77,7 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
 
   private var dialog = Option.empty[OptionsMenu]
 
-  onMessageAction {
+  onMessageAction.foreach {
     case (MessageAction.Copy, message)             => copyMessage(message)
     case (MessageAction.DeleteGlobal, message)     => recallMessage(message)
     case (MessageAction.DeleteLocal, message)      => deleteMessage(message)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ChatheadsRecyclerView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ChatheadsRecyclerView.scala
@@ -26,6 +26,7 @@ import com.waz.zclient.common.views.ChatHeadView
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.MessageViewFactory
 import com.waz.zclient.{R, ViewHelper}
+import com.waz.threading.Threading._
 
 trait ChatheadsRecyclerView extends ViewGroup with ViewHelper with DerivedLogTag {
   val cache = inject[MessageViewFactory]
@@ -33,14 +34,14 @@ trait ChatheadsRecyclerView extends ViewGroup with ViewHelper with DerivedLogTag
 
   val users = Signal[Seq[UserId]]()
 
-  users { ids =>
+  users.onUi { ids =>
     verbose(l"user id: $ids")
     if (getChildCount > ids.length) {
       for (i <- ids.length until getChildCount) cache.recycle(getChildAt(i), chatHeadResId)
       removeViewsInLayout(ids.length, getChildCount - ids.length)
     }
 
-    ids.zipWithIndex foreach { case (id, index) =>
+    ids.zipWithIndex.foreach { case (id, index) =>
       val view =
         if (index < getChildCount) getChildAt(index).asInstanceOf[ChatHeadView]
         else returning(cache.get[ChatHeadView](chatHeadResId, this)) { addView }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
@@ -50,9 +50,7 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
   private val users   = inject[UsersController]
   private val integrations = inject[Signal[IntegrationsService]]
 
-  val members = message.map(m => m.members + m.userId)
-
-  val user = for {
+  private val user = for {
     self <- inject[Signal[UserId]]
     members <-  message.map(m => Set(m.userId) ++ Set(m.recipient).flatten)
     Some(user) <- members.find(_ != self).fold {
@@ -63,7 +61,7 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
   } yield user
 
 
-  val integration = for {
+  private val integration = for {
     usr <- user
     intService <- integrations
     integration <- Signal.from((usr.integrationId, usr.providerId) match {
@@ -80,7 +78,7 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
     case (_, usr)     => chathead.loadUser(usr)
   }
 
-  user.map(_.id)(userDetails.setUserId)
+  user.map(_.id).foreach(userDetails.setUserId)
 
   user.map(u => (u.isAutoConnect, u.isWireBot)).on(Threading.Ui) {
     case (true, _) =>

--- a/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
@@ -60,17 +60,17 @@ trait EphemeralPartView extends MessageViewPart { self: ViewHelper =>
       case false => Signal const Left(originalColor)
     }
 
-    typeface { textView.setTypeface }
-    color {
+    typeface.foreach { textView.setTypeface }
+    color.foreach {
       case Left(csl) => textView.setTextColor(csl)
       case Right(ac) => textView.setTextColor(ac.color)
     }
   }
 
-  def ephemeralDrawable(drawable: Drawable) =
+  def ephemeralDrawable(drawable: Drawable): Signal[Drawable] =
     for {
       hide <- expired
-      acc <- accentController.accentColor
+      acc  <- accentController.accentColor
     } yield
       if (hide) new ColorDrawable(ColorUtils.injectAlpha(ThemeUtils.getEphemeralBackgroundAlpha(getContext), acc.color))
       else drawable

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ImagePartView.scala
@@ -63,7 +63,7 @@ class ImagePartView(context: Context, attrs: AttributeSet, style: Int)
     hide <- hideContent
   } yield !hide && noW).on(Threading.Ui)(imageIcon.setVisible)
 
-  onClicked { _ => message.head.map(assets.showSingleImage(_, this))(Threading.Ui) }
+  onClicked.onUi { _ => message.head.map(assets.showSingleImage(_, this))(Threading.Ui) }
 
   message.map(_.assetId).onUi { aId =>
     verbose(l"message asset id => $aId")

--- a/app/src/main/scala/com/waz/zclient/messages/parts/LocationPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/LocationPartView.scala
@@ -27,13 +27,13 @@ import com.bumptech.glide.request.target.ImageViewTarget
 import com.waz.api.MessageContent.Location
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.threading.Threading
+import com.waz.threading.Threading._
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views.ProgressDotsDrawable
 import com.waz.zclient.glide.WireGlide
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.messages.{ClickableViewPart, HighlightViewPart, MsgPart}
 import com.waz.zclient.{R, ViewHelper}
-
 
 class LocationPartView(context: Context, attrs: AttributeSet, style: Int)
   extends FrameLayout(context, attrs, style)
@@ -70,20 +70,19 @@ class LocationPartView(context: Context, attrs: AttributeSet, style: Int)
 
   private def setupTextView(): Unit = {
     registerEphemeral(textView)
-    name { textView.setText }
+    name.onUi { textView.setText }
   }
 
   private def setupPinView(): Unit = {
-    accentController.accentColor.map(_.color) (pinView.setTextColor)
+    accentController.accentColor.map(_.color).onUi(pinView.setTextColor)
     pinView.setVisibility(View.VISIBLE)
   }
 
-  private def setupImageView(): Unit = {
-    location {
+  private def setupImageView(): Unit =
+    location.onUi {
       case Some(loc) => loadMapPreview(loc)
       case None => warn(l"No location data.")
     }
-  }
 
   private def loadMapPreview(location: Location): Unit = {
     val options = new RequestOptions()
@@ -103,8 +102,8 @@ class LocationPartView(context: Context, attrs: AttributeSet, style: Int)
   }
 
   private def setupOnClickHandler(): Unit = {
-    onClicked { _ =>
-      expired.head foreach {
+    onClicked.onUi { _ =>
+      expired.head.foreach {
         case true => // ignore click on expired msg
         case false => message.currentValue.flatMap(_.location) foreach { browser.openLocation }
       }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MemberChangePartView.scala
@@ -44,7 +44,7 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
     with MessageViewPart
     with ViewHelper
     with DerivedLogTag {
-  
+
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
@@ -96,7 +96,7 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
       case Other(name) => name == users.DefaultDeletedName.str
       case _           => false
     }
-    
+
     (msg.msgType, displayName, msg.members.toSeq) match {
         //Create Conv
       case (MEMBER_JOIN, Me, _)       if msg.firstMessage && msg.name.isDefined && shorten => getQuantityString(R.plurals.content__system__with_others_only, othersCount, namesListString, othersCount.toString)
@@ -153,7 +153,7 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
     .map(_.map(toPx))
     .onUi(_.foreach(this.setMarginTop))
 
-  iconGlyph {
+  iconGlyph.onUi {
     case Left(i) => messageView.setIconGlyph(i)
     case Right(d) => messageView.setIcon(d)
   }
@@ -166,7 +166,7 @@ class MemberChangePartView(context: Context, attrs: AttributeSet, style: Int)
 
   servicesPresentWarning.onUi { text =>
     warningText.setVisible(text.isDefined)
-    text.foreach(warningText.setText(_))
+    text.foreach(warningText.setText)
   }
 
 }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/MentionsViewPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/MentionsViewPart.scala
@@ -33,7 +33,7 @@ import com.waz.zclient.utils.ContextUtils._
 
 trait MentionsViewPart extends MessageViewPart with ViewHelper {
 
-  private val participantsController = inject[ParticipantsController]
+  private lazy val participantsController = inject[ParticipantsController]
 
   def addMentionSpans(spannable: Spannable, mentions: Seq[Mention], selfId: Option[UserId], color: Int): Unit = {
       spannable.getSpans(0, spannable.length(), classOf[OtherMentionSpan]).foreach(spannable.removeSpan)

--- a/app/src/main/scala/com/waz/zclient/messages/parts/PingPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/PingPartView.scala
@@ -57,7 +57,7 @@ class PingPartView(context: Context, attrs: AttributeSet, style: Int) extends Li
     case Other(name) => getString(R.string.content__xxx_pinged, name.toUpperCase(locale))
   }
 
-  message.map(_.userId) { chatheadView.loadUser }
+  message.map(_.userId).foreach { chatheadView.loadUser }
 
   (for {
     t <- text

--- a/app/src/main/scala/com/waz/zclient/messages/parts/RenamePartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/RenamePartView.scala
@@ -21,7 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.{LinearLayout, TextView}
 import com.waz.model.Name
-import com.waz.threading.Threading
+import com.waz.threading.Threading._
 import com.waz.zclient.messages.UsersController.DisplayName.{Me, Other}
 import com.waz.zclient.messages.{MessageViewPart, MsgPart, SystemMessageView, UsersController}
 import com.waz.zclient.utils.ContextUtils._
@@ -52,9 +52,9 @@ class RenamePartView(context: Context, attrs: AttributeSet, style: Int) extends 
     case Other(name)  => getString(R.string.content__system__other_renamed_conv, name)
   }.map(_.toUpperCase)
 
-  text.on(Threading.Ui) { messageView.setText }
+  text.onUi { messageView.setText }
 
-  message.map(_.name) { name =>
+  message.map(_.name).onUi { name =>
     nameView.setVisible(name.isDefined)
     nameView.setText(name.getOrElse(Name.Empty))
   }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/assets/AssetPart.scala
@@ -107,7 +107,7 @@ trait PlayableAsset extends ActionableAssetPart {
   protected val durationView: TextView = findById(R.id.duration)
 
   protected lazy val playControls = controller.getPlaybackControls(asset)
-  playControls.flatMap(_.isPlaying) (isPlaying ! _)
+  playControls.flatMap(_.isPlaying).pipeTo(isPlaying)
 }
 
 trait FileLayoutAssetPart extends AssetPart with EphemeralIndicatorPartView {

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterPartView.scala
@@ -119,15 +119,15 @@ class FooterPartView(context: Context, attrs: AttributeSet, style: Int) extends 
   private val likeDetails: LikeDetailsView = findById(R.id.like_details)
 
   setClipChildren(true)
-  height { h =>
+  height.onUi { h =>
     ViewCompat.setClipBounds(this, new Rect(0, 0, getWidth, h))
   }
 
-  contentTranslate { likeButton.setTranslationY }
-  likesTranslate { likeDetails.setTranslationY }
-  statusTranslate { timeStampAndStatus.setTranslationY }
-  likesVisible { likeDetails.setVisible }
-  statusVisible { timeStampAndStatus.setVisible }
+  contentTranslate.onUi { likeButton.setTranslationY }
+  likesTranslate.onUi { likeDetails.setTranslationY }
+  statusTranslate.onUi { timeStampAndStatus.setTranslationY }
+  likesVisible.onUi { likeDetails.setVisible }
+  statusVisible.onUi { timeStampAndStatus.setVisible }
 
   likeButton.init(controller)
   likeDetails.init(controller)
@@ -252,7 +252,7 @@ object FooterPartView {
     val size = Signal(1f)
     val lp = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, expandedHeight)
 
-    size .map { s => (expandedHeight * s).toInt } { h =>
+    size .map { s => (expandedHeight * s).toInt }.onUi { h =>
       lp.height = h
       footer.setLayoutParams(lp)
     }

--- a/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/footer/FooterViewController.scala
@@ -73,7 +73,7 @@ class FooterViewController(implicit inj: Injector, context: Context, ec: EventCo
 
   //if the user likes OR dislikes something, we want to allow the timestamp/footer to disappear immediately
   val likedBySelfTime = Signal(Instant.EPOCH)
-  likedBySelf.onChanged(_ => likedBySelfTime ! Instant.now)
+  likedBySelf.onChanged.foreach(_ => likedBySelfTime ! Instant.now)
 
   val active =
     for {

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/NotificationManagerWrapper.scala
@@ -323,8 +323,7 @@ object NotificationManagerWrapper {
             error(l"Failed to add `ping from them` (${getString(R.string.wire_ping_name)}) to the external notification folder", ex)
         }
 
-      accountChannels { channels =>
-
+      accountChannels.foreach { channels =>
         notificationManager.getNotificationChannels.asScala.filter { ch =>
           !channels.flatMap(_.channels).exists(_.id == ch.getId) && !Set(OngoingNotificationsChannelId, IncomingCallNotificationsChannelId).contains(ch.getId)
         }.foreach(ch => notificationManager.deleteNotificationChannel(ch.getId))

--- a/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ConversationOptionsMenuController.scala
@@ -139,7 +139,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
             Unmute
 
         val isConvFavorite = favoriteConvIds.contains(convId)
-        
+
         (conv.archived, isConvFavorite) match {
           case (true, _)           => builder += Unarchive
           case (false, isFavorite) => builder ++= List(Archive, if (isFavorite) RemoveFromFavorites else AddToFavorites)
@@ -176,7 +176,7 @@ class ConversationOptionsMenuController(convId: ConvId, mode: Mode, fromDeepLink
       participantsController.onLeaveParticipants ! true
     }
 
-  new EventStreamWithAuxSignal(onMenuItemClicked, convState).apply {
+  new EventStreamWithAuxSignal(onMenuItemClicked, convState).foreach {
     case (item, Some((cId, user))) =>
       verbose(l"onMenuItemClicked: item: $item, conv: $cId, user: $user")
       item match {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/AllGroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/AllGroupParticipantsFragment.scala
@@ -32,7 +32,7 @@ class AllGroupParticipantsFragment extends FragmentHelper {
   private lazy val participantsController = inject[ParticipantsController]
 
   private lazy val participantsAdapter = returning(new ParticipantsAdapter(participantsController.participants, showPeopleOnly = true)) {
-    _.onClick(participantsController.onShowUser ! Some(_))
+    _.onClick.foreach(participantsController.onShowUser ! Some(_))
   }
 
   private lazy val searchBox = view[SearchEditText](R.id.search_box)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/GroupParticipantsFragment.scala
@@ -75,7 +75,7 @@ class GroupParticipantsFragment extends FragmentHelper {
   }
 
   private lazy val participantsAdapter = returning(new ParticipantsAdapter(participantsController.participants, Some(7))) { adapter =>
-    adapter.onClick.mapAsync(participantsController.getUser).onUi {
+    adapter.onClick.mapSync(participantsController.getUser).onUi {
       case Some(user) => (user.providerId, user.integrationId) match {
         case (Some(pId), Some(iId)) =>
           for {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -26,6 +26,7 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import com.waz.model._
 import com.waz.model.otr.ClientId
 import com.waz.threading.Threading
+import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.UserAccountsController
 import com.waz.zclient.controllers.singleimage.ISingleImageController
@@ -124,13 +125,14 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
     bodyContainer
     participantsContainerView
 
-    participantsController.onShowUser {
+    participantsController.onShowUser.onUi {
       case Some(userId) => showUser(userId)
       case _ =>
     }
-    headerFragment.onLegalHoldClick { _ => openLegalHoldInfoScreen() }
-    legalHoldController.onLegalHoldSubjectClick { userId => showUser(userId, forLegalHold = true) }
-    legalHoldController.onAllLegalHoldSubjectsClick { _ => showAllLegalHoldSubjects() }
+
+    headerFragment.onLegalHoldClick.onUi { _ => openLegalHoldInfoScreen() }
+    legalHoldController.onLegalHoldSubjectClick.onUi { userId => showUser(userId, forLegalHold = true) }
+    legalHoldController.onAllLegalHoldSubjectsClick.onUi { _ => showAllLegalHoldSubjects() }
   }
 
   override def onStart(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -111,7 +111,7 @@ class SingleParticipantFragment extends FragmentHelper {
       }
     }
 
-    subs += adapter.onHeaderClick { _ => inject[BrowserController].openOtrLearnWhy() }
+    subs += adapter.onHeaderClick.onUi { _ => inject[BrowserController].openOtrLearnWhy() }
   }
 
   private def initDevicesView(): Unit = returning(view[RecyclerView](R.id.devices_recycler_view)) { vh =>

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AboutView.scala
@@ -32,12 +32,13 @@ import com.waz.zclient.preferences.views.TextButton
 import com.waz.zclient.utils.BackStackKey
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
+import com.waz.threading.Threading._
 
 class AboutView(context: Context, attrs: AttributeSet, style: Int)
   extends LinearLayout(context, attrs, style)
     with ViewHelper
     with DerivedLogTag {
-  
+
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
 
@@ -55,17 +56,17 @@ class AboutView(context: Context, attrs: AttributeSet, style: Int)
   val versionTextButton = findById[TextButton](R.id.preferences_about_version)
   val copyrightButton = findById[TextButton](R.id.preferences_about_copyright)
 
-  websiteButton.onClickEvent { _ => browser.openAboutWebsite() }
-  termsButton.onClickEvent { _ =>
+  websiteButton.onClickEvent.onUi { _ => browser.openAboutWebsite() }
+  termsButton.onClickEvent.onUi { _ =>
     if (inject[Signal[Option[ZMessaging]]].map(_.flatMap(_.teamId)).currentValue.flatten.isDefined)
       browser.openTeamsTermsOfService()
     else
       browser.openPersonalTermsOfService()
   }
-  privacyPolicyButton.onClickEvent { _ => browser.openPrivacyPolicy() }
-  licenseButton.onClickEvent {_ => browser.openThirdPartyLicenses() }
+  privacyPolicyButton.onClickEvent.onUi { _ => browser.openPrivacyPolicy() }
+  licenseButton.onClickEvent.onUi {_ => browser.openThirdPartyLicenses() }
 
-  versionTextButton.onClickEvent{ _ =>
+  versionTextButton.onClickEvent.onUi { _ =>
     versionClickCounter += 1
     if (versionClickCounter >= A_BUNCH_OF_CLICKS_TO_PREVENT_ACCIDENTAL_TRIGGERING) {
       versionClickCounter = 0

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -271,7 +271,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
       case Right(hasPass) =>
         showPrefDialog(
           returning(ChangeEmailDialog(hasPassword = hasPass)) {
-            _.onEmailChanged { e =>
+            _.onEmailChanged.onUi { e =>
               val f = VerifyEmailPreferencesFragment(e)
               //hide the verification screen when complete
               self.map(_.email).onChanged.filter(_.contains(e)).onUi { _ =>
@@ -294,7 +294,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
     } {
       showPrefDialog(
         returning(ChangePhoneDialog(ph.map(_.str), email.isDefined)) {
-          _.onPhoneChanged {
+          _.onPhoneChanged.onUi {
             case Some(p) =>
               val f = VerifyPhoneFragment.newInstance(p.str)
               //hide the verification screen when complete
@@ -396,7 +396,7 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
 
   inject[UserAccountsController].readReceiptsEnabled.onUi(view.setReadReceipt)
 
-  view.onReadReceiptSwitch { enabled =>
+  view.onReadReceiptSwitch.foreach { enabled =>
     zms.head.flatMap(_.propertiesService.setReadReceiptsEnabled(enabled))(Threading.Background)
   }
 }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AdvancedView.scala
@@ -62,7 +62,7 @@ class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int)
   val submitLogs = returning(findById[TextButton](R.id.preferences_debug_report)) { v =>
     setButtonEnabled(v, initialLogsEnabled)
 
-    v.onClickEvent { _ =>
+    v.onClickEvent.onUi { _ =>
       DebugUtils.sendDebugReport(context.asInstanceOf[Activity])
     }
   }
@@ -70,14 +70,14 @@ class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int)
   val loggingSwitch = returning(findById[SwitchPreference](R.id.preferences_enable_logs)) { v =>
     v.setChecked(initialLogsEnabled)
 
-    v.onCheckedChange { enabled =>
+    v.onCheckedChange.onUi { enabled =>
       logsService.setLogsEnabled(enabled)
       setButtonEnabled(submitLogs, enabled)
     }
   }
 
   val resetPush = returning(findById[TextButton](R.id.preferences_reset_push)) { v =>
-    v.onClickEvent { _ =>
+    v.onClickEvent.onUi { _ =>
       ZMessaging.currentGlobal.tokenService.resetGlobalToken()
       Toast.makeText(getContext, getString(R.string.pref_advanced_reset_push_completed)(getContext), Toast.LENGTH_LONG).show()
       setButtonEnabled(v, enabled = false)
@@ -107,7 +107,7 @@ class AdvancedViewImpl(context: Context, attrs: AttributeSet, style: Int)
   }
 
   val slowSyncButton = returning(findById[TextButton](R.id.preferences_slow_sync)) { toggle =>
-    toggle.onClickEvent { _ =>
+    toggle.onClickEvent.onUi { _ =>
       showPrefDialog(FullSyncDialog.newInstance, FullSyncDialog.Tag)
     }
   }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
@@ -40,6 +40,7 @@ import com.waz.zclient._
 import com.waz.zclient.preferences.dialogs.BackupPasswordDialog.SetPasswordMode
 
 import scala.concurrent.Future
+import com.waz.threading.Threading._
 
 class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
   extends LinearLayout(context, attrs, style)
@@ -61,7 +62,7 @@ class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
 
   def requestPassword(): Future[Unit] = {
     val fragment = returning(BackupPasswordDialog.newInstance(SetPasswordMode)) {
-      _.onPasswordEntered(backupData)
+      _.onPasswordEntered.onUi(backupData)
     }
 
     context.asInstanceOf[BaseActivity]

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevSettingsView.scala
@@ -78,7 +78,7 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
   private val randomTrackingIdButton = findById[TextButton](R.id.preferences_dev_generate_random_trackingid)
 
   val registerAnotherClient = returning(findById[TextButton](R.id.register_another_client)) {
-    _.onClickEvent(_ => registerClient().foreach {
+    _.onClickEvent.onUi(_ => registerClient().foreach {
       case Right(registered) => if(!registered) dialog.show(context.asInstanceOf[PreferencesActivity])
       case Left(err) => dialog.showError(Some(err))
     })
@@ -89,11 +89,11 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
   }
 
   val checkPushTokenButton = returning(findById[TextButton](R.id.preferences_dev_check_push_tokens)) { v =>
-    v.onClickEvent(_ => PushTokenCheckJob())
+    v.onClickEvent.onUi(_ => PushTokenCheckJob())
   }
 
   val checkDeviceRootedButton = returning(findById[TextButton](R.id.preferences_dev_check_rooted_device)) { v =>
-    v.onClickEvent(_ => checkIfDeviceIsRooted())
+    v.onClickEvent.onUi(_ => checkIfDeviceIsRooted())
   }
 
   val newPicturePicButton = findById[TextButton](R.id.preferences_dev_new_unsplash_profile_pic)
@@ -157,7 +157,7 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
     case _ => // no biometric prompt allowed
   }
 
-  randomLastIdButton.onClickEvent { _ =>
+  randomLastIdButton.onClickEvent.onUi { _ =>
     val randomUid = Uid()
 
     new AlertDialog.Builder(context)
@@ -177,11 +177,11 @@ class DevSettingsViewImpl(context: Context, attrs: AttributeSet, style: Int)
       .setIcon(android.R.drawable.ic_dialog_alert).show
   }
 
-  randomTrackingIdButton.onClickEvent { _ =>
+  randomTrackingIdButton.onClickEvent.onUi { _ =>
     inject[GlobalTrackingController].setAndSendNewTrackingId()
   }
 
-  newPicturePicButton.onClickEvent { _ =>
+  newPicturePicButton.onClickEvent.onUi { _ =>
     am.head.flatMap(_.addUnsplashIfProfilePictureMissing()).foreach { _ =>
       showToast("The profile picture changed")
     }

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -127,7 +127,7 @@ class DeviceDetailsViewImpl(context: Context, attrs: AttributeSet, style: Int) e
     resetSessionView.setVisible(!removeOnly)
   }
 
-  fingerprintView.onClickEvent{ _ =>
+  fingerprintView.onClickEvent.onUi { _ =>
     val clip = ClipData.newPlainText(getContext.getString(R.string.pref_devices_device_fingerprint_copy_description), fingerprint)
     clipboard.setPrimaryClip(clip)
     showToast(R.string.pref_devices_device_fingerprint_copy_toast)
@@ -202,7 +202,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
   clientsController.selfFingerprint(clientId).onUi{ _.foreach(view.setFingerPrint) }
   clientsController.selfClientId.map(_.isEmpty).onUi(view.setRemoveOnly)
 
-  view.onVerifiedChecked { checked =>
+  view.onVerifiedChecked.onUi { checked =>
     //TODO should this be a signal? Will create a new subscription every time the view is clicked...
     for {
       userId     <- accountManager.map(_.userId)
@@ -211,7 +211,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
     } {}
   }
 
-  view.onSessionReset(_ => resetSession())
+  view.onSessionReset.onUi(_ => resetSession())
 
   private def resetSession(): Unit = {
     zms.head.flatMap { zms =>
@@ -230,7 +230,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
     }(Threading.Ui)
   }
 
-  view.onDeviceRemoved { _ =>
+  view.onDeviceRemoved.onUi { _ =>
     accountsService.accountPassword.head.map {
       case Some(p) => removeDevice(Some(p))
       case _       => showRemoveDeviceDialog()
@@ -265,7 +265,7 @@ case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: Client
 
   private def showRemoveDeviceDialog(error: Option[String] = None): Unit =
     Signal.zip(inject[PasswordController].ssoEnabled, client.map(_.model)).head.foreach { case (isSSO, name) =>
-      val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onAccept(removeDevice))
+      val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onAccept.onUi(removeDevice))
       context.asInstanceOf[BaseActivity]
         .getSupportFragmentManager
         .beginTransaction

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DevicesView.scala
@@ -59,7 +59,7 @@ class DevicesViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
       selfDeviceButton.setVisibility(View.VISIBLE)
       currentDeviceTitle.setVisibility(View.VISIBLE)
       selfDeviceButton.setDevice(device, self = true)
-      selfDeviceButton.onClickEvent { _ => navigator.goTo(DeviceDetailsBackStackKey(device.id.str)) }
+      selfDeviceButton.onClickEvent.onUi { _ => navigator.goTo(DeviceDetailsBackStackKey(device.id.str)) }
     }
 
   }
@@ -69,7 +69,7 @@ class DevicesViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     devices.foreach{ device =>
       val deviceButton = new DeviceButton(context, attrs, style)
       deviceButton.setDevice(device, self = false)
-      deviceButton.onClickEvent { _ => navigator.goTo(DeviceDetailsBackStackKey(device.id.str)) }
+      deviceButton.onClickEvent.onUi { _ => navigator.goTo(DeviceDetailsBackStackKey(device.id.str)) }
       deviceList.addView(deviceButton)
       val margin = context.getResources.getDimensionPixelSize(R.dimen.wire__padding__8)
       Option(deviceButton.getLayoutParams.asInstanceOf[MarginLayoutParams]).foreach(_.setMargins(0, 0, 0, margin))

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -136,22 +136,22 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     context.asInstanceOf[BaseActivity].startActivityForResult(intent, 0)
   }
 
-  ringToneButton.onClickEvent{ _ => showRingtonePicker(RingtoneManager.TYPE_RINGTONE, defaultRingToneUri, RingToneResultId, ringToneUri)}
-  textToneButton.onClickEvent{ _ =>
+  ringToneButton.onClickEvent.onUi { _ => showRingtonePicker(RingtoneManager.TYPE_RINGTONE, defaultRingToneUri, RingToneResultId, ringToneUri)}
+  textToneButton.onClickEvent.onUi { _ =>
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       openNotificationSettings(NotificationManagerWrapper.MessageNotificationsChannelId(accountId))
     } else {
       showRingtonePicker(RingtoneManager.TYPE_NOTIFICATION, defaultTextToneUri, TextToneResultId, textToneUri)
     }
   }
-  pingToneButton.onClickEvent{ _ =>
+  pingToneButton.onClickEvent.onUi { _ =>
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       openNotificationSettings(NotificationManagerWrapper.PingNotificationsChannelId(accountId))
     } else {
       showRingtonePicker(RingtoneManager.TYPE_NOTIFICATION, defaultPingToneUri, PingToneResultId, pingToneUri)
     }
   }
-  soundsButton.onClickEvent{ _ => showPrefDialog(SoundLevelDialog(soundLevel), SoundLevelDialog.Tag)}
+  soundsButton.onClickEvent.onUi { _ => showPrefDialog(SoundLevelDialog(soundLevel), SoundLevelDialog.Tag)}
 
   override def setSounds(level: IntensityLevel): Unit = {
     soundLevel = level

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SupportView.scala
@@ -26,6 +26,7 @@ import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.preferences.views.TextButton
 import com.waz.zclient.{R, ViewHelper}
 import com.waz.zclient.utils.BackStackKey
+import com.waz.threading.Threading._
 
 class SupportView(context: Context, attrs: AttributeSet, style: Int) extends LinearLayout(context, attrs, style) with ViewHelper {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
@@ -36,8 +37,8 @@ class SupportView(context: Context, attrs: AttributeSet, style: Int) extends Lin
   val websiteButton = findById[TextButton](R.id.settings_support_website)
   val contactButton = findById[TextButton](R.id.settings_support_contact)
 
-  websiteButton.onClickEvent{ _ => inject[BrowserController].openSupportPage() }
-  contactButton.onClickEvent{ _ => inject[BrowserController].openContactSupport() }
+  websiteButton.onClickEvent.onUi { _ => inject[BrowserController].openSupportPage() }
+  contactButton.onClickEvent.onUi { _ => inject[BrowserController].openContactSupport() }
 }
 
 case class SupportBackStackKey(args: Bundle = new Bundle()) extends BackStackKey(args) {

--- a/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
@@ -78,7 +78,7 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
   private lazy val multiPicker = getBooleanArg(MultiPickerArgumentKey)
 
   private lazy val adapter = returning(new ConversationSelectorAdapter(getContext, filterText, multiPicker)) { a =>
-    onClickEvent { _ =>
+    onClickEvent.onUi { _ =>
       a.selectedConversations.head.map { convs =>
         sharingController.onContentShared(getActivity, convs)
         if (multiPicker) showToast(R.string.multi_share_toast_sending, long = false)
@@ -199,7 +199,7 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
       list.setAdapter(adapter)
     }
 
-    accountTabs.map(_.onTabClick.map(a => Some(a.id))(accounts.setAccount)).foreach(subs += _)
+    accountTabs.map(_.onTabClick.map(a => Some(a.id)).foreach(accounts.setAccount)).foreach(subs += _)
 
     sendButton.foreach(_.onClick {
       if (!adapter.selectedConversations.currentValue.forall(_.isEmpty)) {

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -49,7 +49,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
   //helps us fire the "app.open" event at the right time.
   private val initialized = Signal(false)
 
-  initialized.onChanged { _ =>
+  initialized.onChanged.foreach { _ =>
     accountsService.activeAccount.foreach(_.foreach(user => tracking.appOpen(user.id)))
   }
 

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -131,7 +131,7 @@ class ConversationFragment extends FragmentHelper {
   private var assetIntentsManager: Option[AssetIntentsManager] = None
 
   private lazy val loadingIndicatorView = returning(view[LoadingIndicatorView](R.id.lbv__conversation__loading_indicator)) { vh =>
-    accentColor.map(_.color)(c => vh.foreach(_.setColor(c)))
+    accentColor.map(_.color).foreach(c => vh.foreach(_.setColor(c)))
   }
 
   private var containerPreview: ViewGroup = _

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -187,7 +187,7 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.4.0"
+    const val WIRE_SIGNALS = "0.4.2"
     const val WIRE_SIGNALS_EXTENSIONS = "0.4.0"
 
     //build

--- a/zmessaging/src/main/scala/com/waz/bitmap/gif/GifAnimator.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/gif/GifAnimator.scala
@@ -64,12 +64,7 @@ class GifAnimator(gif: Gif, reserveFrameMemory: () => Unit, frameCallback: Bitma
       } else done(decoder)
     }
 
-    new CancellableFuture[Unit](p) {
-      override def cancel(): Boolean = {
-        frameFuture.cancel()
-        super.cancel()
-      }
-    }
+    CancellableFuture.from(p).onCancel(frameFuture.cancel())
   }
 }
 

--- a/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
@@ -167,7 +167,8 @@ class CacheServiceImpl(context: Context, storage: Database, cacheStorage: CacheS
     }
   }
 
-  def move(key: CacheKey, entry: LocalData, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None)(implicit timeout: Expiration = CacheService.DefaultExpiryTime) = {
+  def move(key: CacheKey, entry: LocalData, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None)
+          (implicit timeout: Expiration = CacheService.DefaultExpiryTime) = {
     verbose(l"move($key)")
 
     def copy() = addStream(key, entry.inputStream, mime, name, cacheLocation, entry.length)

--- a/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -46,7 +46,7 @@ class CacheStorageImpl(storage: Database, context: Context)
 
   import com.waz.threading.Threading.Implicits.Background
 
-  onUpdated { _ foreach {
+  onUpdated.foreach { _.foreach {
     case (prev, updated) if prev.fileId != updated.fileId => cleanup(prev)
     case _ => // ignore
   } }

--- a/zmessaging/src/main/scala/com/waz/cache2/CacheService.scala
+++ b/zmessaging/src/main/scala/com/waz/cache2/CacheService.scala
@@ -180,7 +180,7 @@ abstract class LruFileCache[K] extends BaseFileCache[K] {
     .filter { size =>
       verbose(l"Current cache size: ${asSize(size)}")
       size > directorySizeThreshold
-    } { size =>
+    }.foreach { size =>
       var shouldBeCleared = size - directorySizeThreshold
       verbose(l"Cache directory size threshold reached. Current size: ${asSize(size)}. Should be cleared: ${asSize(shouldBeCleared)}")
       cacheDirectory

--- a/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -91,7 +91,7 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
         lastMessageFromSelf ! MessageDataDao.lastFromSelf(convId, selfUserId)
       }
     }.map { _ =>
-      Signal.zip(signals.unreadCount, signals.failedCount, signals.lastMissedCall, signals.incomingKnock).throttle(500.millis) {
+      Signal.zip(signals.unreadCount, signals.failedCount, signals.lastMissedCall, signals.incomingKnock).throttle(500.millis).foreach {
         case (unread, failed, missed, knock) =>
           convs.update(convId, _.copy(incomingKnockMessage = knock, missedCallMessage = missed, unreadCount = unread, failedCount = failed))
       }

--- a/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
@@ -52,12 +52,12 @@ class ConversationStorageImpl(storage: ZmsDatabase)
 
   import com.waz.threading.Threading.Implicits.Background
 
-  onAdded { cs => updateSearchKey(cs)}
+  onAdded.foreach { cs => updateSearchKey(cs)}
 
-  def setUnknownVerification(convId: ConvId) =
+  def setUnknownVerification(convId: ConvId): Future[Option[(ConversationData, ConversationData)]] =
     update(convId, { c => c.copy(verified = if (c.verified == Verification.UNVERIFIED) UNKNOWN else c.verified) })
 
-  onUpdated { cs =>
+  onUpdated.foreach { cs =>
     updateSearchKey(cs.collect {
       case (p, c) if p.name != c.name || (p.convType == Group) != (c.convType == Group) || (c.name.nonEmpty && c.searchKey.isEmpty) => c
     })

--- a/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -45,18 +45,18 @@ class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorag
   private def entry(m: MessageData) =
     MessageContentIndexEntry(m.id, m.convId, ContentSearchQuery.transliterated(m.contentString), m.time)
 
-  messagesStorage.onAdded { added =>
+  messagesStorage.onAdded.foreach { added =>
     insertAll(added.filter(m => TextMessageTypes.contains(m.msgType) && !m.isEphemeral).map(entry))
   }
 
-  messagesStorage.onUpdated { updated =>
+  messagesStorage.onUpdated.foreach { updated =>
     val entries = updated.collect { case (_, m) if TextMessageTypes.contains(m.msgType) && !m.isEphemeral => entry(m) }
     //FTS tables ignore UNIQUE or PKEY constraints so we have to force the replace
     removeAll(entries.map(_.messageId))
     insertAll(entries)
   }
 
-  messagesStorage.onDeleted { removed =>
+  messagesStorage.onDeleted.foreach { removed =>
     if (removed.nonEmpty) removeAll(removed)
   }
 

--- a/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -38,9 +38,9 @@ class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: M
   with ReadReceiptsStorage {
   import com.waz.threading.Threading.Implicits.Background
 
-  msgStorage.onDeleted { ids => removeAllForMessages(ids.toSet) }
+  msgStorage.onDeleted.foreach { ids => removeAllForMessages(ids.toSet) }
 
-  msgService.msgEdited { case (prev, cur) =>
+  msgService.msgEdited.foreach { case (prev, cur) =>
     // `updateAll2` is not going to work here, because we're updating the messageId of the receipts which is a part of the receipt's id.
     // `update*` methods assume that the ids are not going to be updated. Instead, we need to remove the old and insert the new receipts.
       for {

--- a/zmessaging/src/main/scala/com/waz/model/errors.scala
+++ b/zmessaging/src/main/scala/com/waz/model/errors.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 object errors {
 
   implicit class FutureOps[T](val value: Future[T]) extends AnyVal {
-    def toCancellable: CancellableFuture[T] = CancellableFuture.lift(value)
+    def toUncancellable: CancellableFuture[T] = CancellableFuture.lift(value)
     def modelToEither(implicit ec: ExecutionContext): Future[Either[ZError, T]] =
       value.map(Right(_): Either[ZError, T]).recover { case err => Left(UnexpectedError(err)) }
     def eitherToModel[A](implicit ev: T =:= Either[ZError, A], ec: ExecutionContext): Future[A] =

--- a/zmessaging/src/main/scala/com/waz/model/errors.scala
+++ b/zmessaging/src/main/scala/com/waz/model/errors.scala
@@ -26,7 +26,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 object errors {
 
   implicit class FutureOps[T](val value: Future[T]) extends AnyVal {
-    def lift: CancellableFuture[T] = CancellableFuture.lift(value)
     def modelToEither(implicit ec: ExecutionContext): Future[Either[ZError, T]] =
       value.map(Right(_): Either[ZError, T]).recover { case err => Left(UnexpectedError(err)) }
     def eitherToModel[A](implicit ev: T =:= Either[ZError, A], ec: ExecutionContext): Future[A] =

--- a/zmessaging/src/main/scala/com/waz/model/errors.scala
+++ b/zmessaging/src/main/scala/com/waz/model/errors.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 object errors {
 
   implicit class FutureOps[T](val value: Future[T]) extends AnyVal {
-    def toUncancellable: CancellableFuture[T] = CancellableFuture.lift(value)
+    def lift: CancellableFuture[T] = CancellableFuture.lift(value)
     def modelToEither(implicit ec: ExecutionContext): Future[Either[ZError, T]] =
       value.map(Right(_): Either[ZError, T]).recover { case err => Left(UnexpectedError(err)) }
     def eitherToModel[A](implicit ev: T =:= Either[ZError, A], ec: ExecutionContext): Future[A] =

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -108,7 +108,7 @@ class AccountManager(val userId:  UserId,
   }
 
   private var hasClient = false
-  otrCurrentClient.map(_.isDefined) { exists =>
+  otrCurrentClient.map(_.isDefined).foreach { exists =>
     if (hasClient && !exists) {
       info(l"client has been removed on backend, logging out")
       logoutAndResetClient()

--- a/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/MediaManagerService.scala
@@ -80,7 +80,7 @@ class DefaultMediaManagerService(context: Context) extends MediaManagerService w
     Signal.const(IntensityLevelCodec.default)
   }
 
-  soundIntensity { intensity =>
+  soundIntensity.foreach { intensity =>
     mediaManager.foreach(_.setIntensity(intensity))
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -394,11 +394,11 @@ class ExpiredUsersService(push:         PushService,
     }
   })
 
-  for {
+  (for {
     membersIds <- users.currentConvMembers
     members    <- Signal.sequence(membersIds.map(usersStorage.signal).toSeq: _*)
     wireless   =  members.filter(_.expiresAt.isDefined).toSet
-  } yield
+  } yield wireless).foreach { wireless =>
     push.beDrift.head.map { drift =>
       val woTimer = wireless.filter(u => (wireless.map(_.id) -- timers.keySet).contains(u.id))
       woTimer.foreach { u =>
@@ -409,4 +409,5 @@ class ExpiredUsersService(push:         PushService,
         }
       }
     }
+  }
 }

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -123,7 +123,7 @@ class UserServiceImpl(selfUserId:        UserId,
     membersIds   <- membersStorage.activeMembers(convId)
   } yield membersIds
 
-  currentConvMembers(syncIfNeeded(_))
+  currentConvMembers.foreach(syncIfNeeded(_))
 
   override lazy val userNames: Signal[Map[UserId, Name]] = {
     val added = usersStorage.onAdded.map(_.map(user => user.id -> user.name).toMap)
@@ -142,7 +142,7 @@ class UserServiceImpl(selfUserId:        UserId,
   }
 
   //Update user data for other accounts
-  accounts.accountsWithManagers.map(_ - selfUserId)(userIds => syncIfNeeded(userIds))
+  accounts.accountsWithManagers.map(_ - selfUserId).foreach(syncIfNeeded(_))
 
   override val selfUser: Signal[UserData] = usersStorage.optSignal(selfUserId) flatMap {
     case Some(data) => Signal.const(data)
@@ -385,7 +385,7 @@ class ExpiredUsersService(push:         PushService,
   private var timers = Map[UserId, CancellableFuture[Unit]]()
 
   //if a given user is removed from all conversations, drop the timer
-  members.onDeleted(_.foreach { m =>
+  members.onDeleted.foreach(_.foreach { m =>
     members.getByUsers(Set(m._1)).map(_.isEmpty).map {
       case true =>
         timers.get(m._1).foreach(_.cancel())
@@ -394,10 +394,11 @@ class ExpiredUsersService(push:         PushService,
     }
   })
 
-  (for {
+  for {
     membersIds <- users.currentConvMembers
     members    <- Signal.sequence(membersIds.map(usersStorage.signal).toSeq: _*)
-  } yield members.filter(_.expiresAt.isDefined).toSet){ wireless =>
+    wireless   =  members.filter(_.expiresAt.isDefined).toSet
+  } yield
     push.beDrift.head.map { drift =>
       val woTimer = wireless.filter(u => (wireless.map(_.id) -- timers.keySet).contains(u.id))
       woTimer.foreach { u =>
@@ -408,5 +409,4 @@ class ExpiredUsersService(push:         PushService,
         }
       }
     }
-  }
 }

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -330,7 +330,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
     )
   }
 
-  private lazy val blockStreamsWhenProcessing = push.processing(messagesStorage.blockStreams)
+  private lazy val blockStreamsWhenProcessing = push.processing.foreach(messagesStorage.blockStreams)
 
   // force loading of services which should run on start
   {

--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -166,7 +166,7 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
           contentCache
             .remove(asset.id)
             .map(_ => AssetInput(NotFoundRemote(s"Asset '$asset'")))
-            .toUncancellable
+            .lift
         case Left(err) =>
           CancellableFuture.successful(AssetInput(NetworkError(err)))
         case Right(fileWithSha) if fileWithSha.sha256 != asset.sha =>
@@ -178,7 +178,7 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
           contentCache.put(asset.id, fileWithSha.file, removeOriginal = true)
             .flatMap(_ => contentCache.getStream(asset.id).map(asset.encryption.decrypt(_)))
             .map(AssetInput(_))
-            .toUncancellable
+            .lift
       }
       .recoverWith { case err =>
         verbose(l"Can not load asset content from backend. ${showString(err.getMessage)}")
@@ -192,7 +192,7 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
         verbose(l"Can not load asset content from cache. $err")
         Future.failed(err)
       }
-      .toUncancellable
+      .lift
 
   private def loadFromFileSystem(localSource: LocalSource): Option[AssetInput] =
     uriHelper.extractMime(localSource.uri).map {
@@ -219,16 +219,16 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
         case (_, Some(ls))  => Future.successful(uriHelper.assetInput(ls.uri))
         case _              => uploadContentCache.get(uploadAssetId).map(AssetInput(_))
       }
-    }.toUncancellable
+    }.lift
 
   override def loadContentById(assetId: AssetId, callback: Option[ProgressCallback] = None): CancellableFuture[AssetInput] =
-    assetsStorage.get(assetId).flatMap(asset => loadContentFromAsset(asset, callback)).toUncancellable
+    assetsStorage.get(assetId).flatMap(asset => loadContentFromAsset(asset, callback)).lift
 
   override def loadContent(asset: Asset, callback: Option[ProgressCallback] = None): CancellableFuture[AssetInput] =
     assetsStorage.find(asset.id).flatMap {
       case None              => assetsStorage.save(asset).flatMap(_ => loadFromBackend(asset, callback))
       case Some(fromStorage) => loadContentFromAsset(fromStorage, callback)
-    }.toUncancellable
+    }.lift
 
   private def loadContentFromAsset(asset: Asset, callback: Option[ProgressCallback] = None): CancellableFuture[AssetInput] =
     asset.localSource match {
@@ -236,10 +236,10 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
       case Some(source) => loadFromFileSystem(source) match {
         case None =>
           verbose(l"Can not load content from file system for asset $asset.")
-          assetsStorage.save(asset.copy(localSource = None)).flatMap(_ => loadFromBackend(asset, callback)).toUncancellable
+          assetsStorage.save(asset.copy(localSource = None)).flatMap(_ => loadFromBackend(asset, callback)).lift
         case Some(AssetFailure(throwable))  =>
           verbose(l"Can not load content from file system for asset $asset. ${showString(throwable.getMessage)}")
-          assetsStorage.save(asset.copy(localSource = None)).flatMap(_ => loadFromBackend(asset, callback)).toUncancellable
+          assetsStorage.save(asset.copy(localSource = None)).flatMap(_ => loadFromBackend(asset, callback)).lift
         case Some(other) =>
           CancellableFuture.successful(other)
       }
@@ -309,11 +309,11 @@ class AssetServiceImpl(assetsStorage: AssetStorage,
 
     val cancellable = for {
       _                      <- CancellableFuture.lift(Future.successful(()))
-      uploadAsset            <- loadUploadAsset.toUncancellable
-      Some((_, uploadAsset)) <- uploadAssetStorage.update(uploadAsset.id, _.copy(uploaded = 0, status = UploadAssetStatus.InProgress)).toUncancellable
+      uploadAsset            <- loadUploadAsset.lift
+      Some((_, uploadAsset)) <- uploadAssetStorage.update(uploadAsset.id, _.copy(uploaded = 0, status = UploadAssetStatus.InProgress)).lift
       uploadResult           <- doUpload(uploadAsset)
-      asset                  <- handleUploadResult(uploadResult, uploadAsset).toUncancellable
-      _                      <- encryptAssetContentAndMoveToCache(asset).toUncancellable
+      asset                  <- handleUploadResult(uploadResult, uploadAsset).lift
+      _                      <- encryptAssetContentAndMoveToCache(asset).lift
     } yield asset
 
     cancellable.onCancel(actionsOnCancellation())

--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -34,13 +34,13 @@ import com.wire.signals.CancellableFuture
 import com.wire.signals.Signal
 import com.waz.utils.streams.CountInputStream
 import com.waz.utils.wrappers.Bitmap
-import com.waz.utils.{Cancellable, IoUtils}
+import com.waz.utils._
 import com.waz.znet2.http.HttpClient._
 import com.waz.znet2.http.ResponseCode
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Try}
+import scala.util.Try
 
 trait AssetService {
   def assetSignal(id: GeneralAssetId): Signal[GeneralAsset]

--- a/zmessaging/src/main/scala/com/waz/service/assets/AudioLevels.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AudioLevels.scala
@@ -76,7 +76,7 @@ case class AudioLevels(context: Context) extends DerivedLogTag {
           case NonFatal(cause) =>
             error(l"PCM overview generation failed", cause)
             None
-        })(_.onCancelled(cancelRequested.set(true)))
+        })(_.onCancel(cancelRequested.set(true)))
     }
 
   private def createOtherAudioOverview(content: URI, numBars: Int): CancellableFuture[Option[AssetMetaData.Loudness]] = {
@@ -104,7 +104,7 @@ case class AudioLevels(context: Context) extends DerivedLogTag {
       case NonFatal(cause) =>
         error(l"overview generation failed", cause)
         None
-    })(_.onCancelled(cancelRequested.set(true)))
+    })(_.onCancel(cancelRequested.set(true)))
   }
 
   private def extractAudioTrackInfo(extractor: MediaExtractor, content: URI): TrackInfo = {

--- a/zmessaging/src/main/scala/com/waz/service/assets/AudioTranscoder.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AudioTranscoder.scala
@@ -72,7 +72,7 @@ class AudioTranscoder(tempFiles: TempFileService, context: Context) {
         m4aFile
       })
 
-      new CancellableFuture(promisedFile)
+      CancellableFuture.from(promisedFile)
     } (Threading.IO)
 
   import AudioLevels.MediaCodecCleanedUp

--- a/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -55,13 +55,13 @@ class RecordAndPlayService(userId:        UserId,
                            accounts:      AccountsService) {
   import Threading.Implicits.Background
 
-  globalService.onError { err =>
+  globalService.onError.foreach { err =>
     err.tpe.foreach { tpe => errors.addErrorWhenActive(ErrorData(Uid(), tpe, responseMessage = err.message)) }
   }
 
-  accounts.accountState(userId).map(_ == InForeground).onChanged {
+  accounts.accountState(userId).map(_ == InForeground).onChanged.foreach {
     case false => globalService.AudioFocusListener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
-    case true =>
+    case true  =>
   }
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
@@ -42,7 +42,7 @@ class CallLoggingService(selfUserId:  UserId,
     * changes (note, we only ever add or change CallInfos, we never remove them from the Map of available calls), we then
     * subscribe to the state changes of each one, passing in the current value for each call to decide how we might react.
     */
-  calling.calls.onPartialUpdate(_.keySet) { calls =>
+  calling.calls.onPartialUpdate(_.keySet).foreach { calls =>
     val ids = calls.keySet
     verbose(l"Listening to calls: $ids")
 
@@ -53,12 +53,12 @@ class CallLoggingService(selfUserId:  UserId,
     toCreate.foreach { id =>
       val callSignal = calling.calls.map(_.get(id))
 
-      callSignal.onPartialUpdate(_.map(_.state)) {
+      callSignal.onPartialUpdate(_.map(_.state)).foreach {
         case Some(call) if call.state == Ended => onCallFinished(call)
         case _ =>
       }
 
-      callSignal.onPartialUpdate(_.map(c => (c.state, c.endReason))) {
+      callSignal.onPartialUpdate(_.map(c => (c.state, c.endReason))).foreach {
         //We don't want to track the Terminating state, or the Ended state if we don't yet have the end reason
         case Some(call) if call.state != Terminating && (call.state != Ended || call.endReason.isDefined) =>
           tracking.trackCallState(selfUserId, call)

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -184,7 +184,7 @@ class CallingServiceImpl(val accountId:       UserId,
      avs.setProxy(proxyAddress.getHostName, proxyAddress.getPort)
   }
 
-  callProfile(p => verbose(l"Call profile: ${p.calls}"))
+  callProfile.foreach(p => verbose(l"Call profile: ${p.calls}"))
 
   override val calls          = callProfile.map(_.calls).disableAutowiring() //all calls
   override val joinableCalls  = callProfile.map(_.joinableCalls).disableAutowiring() //any call a user can potentially join in the UI
@@ -200,7 +200,7 @@ class CallingServiceImpl(val accountId:       UserId,
   }
 
   Option(ZMessaging.currentAccounts).foreach(
-    _.accountsWithManagers.map(_.contains(accountId)) {
+    _.accountsWithManagers.map(_.contains(accountId)).foreach {
       case false =>
         verbose(l"Account $accountId logged out, unregistering from AVS")
         wCall.map(avs.unregisterAccount)
@@ -398,7 +398,7 @@ class CallingServiceImpl(val accountId:       UserId,
       call.copy(activeSpeakers = activeSpeakers)
     } ("onActiveSpeakersChanged")
 
-  network.networkMode.onChanged { _ =>
+  network.networkMode.onChanged.foreach { _ =>
     currentCall.head.flatMap {
       case Some(_) =>
         verbose(l"network mode changed during call - informing AVS")

--- a/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -52,7 +52,7 @@ class DefaultFlowManagerService(context:      Context,
 
   override val cameraFailedSig = Signal[Boolean](false)
 
-  network.networkMode.onChanged {  _ =>
+  network.networkMode.onChanged.foreach {  _ =>
     flowManager.fold { warn(l"unable to access flow manager") } { fm => Try { fm.networkChanged() } }
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -17,17 +17,16 @@
  */
 package com.waz.service.conversation
 
-import com.waz.log.LogSE._
 import com.waz.api.IConversation.{Access, AccessRole}
 import com.waz.content._
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.log.LogSE._
 import com.waz.model.ConversationData.ConversationType
-import com.waz.model.sync.ReceiptType
 import com.waz.model.{UserId, _}
 import com.waz.sync.SyncServiceHandle
-import com.wire.signals.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils._
+import com.wire.signals.CancellableFuture
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
@@ -75,9 +74,8 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
                                       messagesStorage: => MessagesStorage,
                                       syncHandler:     SyncServiceHandle) extends ConversationsContentUpdater with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
-  val conversationsFuture = Future successful storage
 
-  storage.onUpdated(_.foreach {
+  storage.onUpdated.foreach(_.foreach {
     case (prev, conv) if prev.cleared != conv.cleared =>
       verbose(l"cleared updated will clear messages, prev: $prev, updated: $conv")
       conv.cleared.foreach(messagesStorage.clear(conv.id, _).recoverWithLog())

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -26,6 +26,7 @@ import com.waz.log.LogSE._
 import com.waz.model.ConversationData.ConversationType.isOneToOne
 import com.waz.model.ConversationData.{ConversationType, Link, getAccessAndRoleForGroupConv}
 import com.waz.model._
+import com.waz.service.EventScheduler.Stage
 import com.waz.service._
 import com.waz.service.assets.AssetService
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
@@ -43,7 +44,7 @@ import scala.concurrent.Future.successful
 import scala.util.control.{NoStackTrace, NonFatal}
 
 trait ConversationsService {
-  def convStateEventProcessingStage: EventScheduler.Stage
+  def convStateEventProcessingStage: EventScheduler.Stage.Atomic
   def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0): Future[Any]
   def activeMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]]
   def convMembers(convId: ConvId): Signal[Map[UserId, ConversationRole]]
@@ -130,7 +131,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         _        =  verbose(l"Uncontacted team members removed for the team $teamId")
       } yield ()
 
-  override val convStateEventProcessingStage: EventScheduler.Stage = EventScheduler.Stage[ConversationStateEvent] { (_, events) =>
+  override val convStateEventProcessingStage: Stage.Atomic = EventScheduler.Stage[ConversationStateEvent] { (_, events) =>
     RichFuture.traverseSequential(events)(processConversationEvent(_, selfUserId))
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -102,7 +102,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
   import Threading.Implicits.Background
 
   //On conversation changed, update the state of the access roles as part of migration, then check for a link if necessary
-  selectedConv.selectedConversationId {
+  selectedConv.selectedConversationId.foreach {
     case Some(convId) => convsStorage.get(convId).flatMap {
       case Some(conv) if conv.accessRole.isEmpty =>
         for {
@@ -130,16 +130,16 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         _        =  verbose(l"Uncontacted team members removed for the team $teamId")
       } yield ()
 
-  val convStateEventProcessingStage = EventScheduler.Stage[ConversationStateEvent] { (_, events) =>
+  override val convStateEventProcessingStage: EventScheduler.Stage = EventScheduler.Stage[ConversationStateEvent] { (_, events) =>
     RichFuture.traverseSequential(events)(processConversationEvent(_, selfUserId))
   }
 
-  push.onHistoryLost { req =>
+  push.onHistoryLost.foreach { req =>
     verbose(l"onSlowSyncNeeded($req)")
     // TODO: this is just very basic implementation creating empty message
     // This should be updated to include information about possibly missed changes
     // this message will be shown rarely (when notifications stream skips data)
-    convsStorage.list.flatMap(messages.addHistoryLostMessages(_, selfUserId))
+    convsStorage.list().flatMap(messages.addHistoryLostMessages(_, selfUserId))
   }
 
   errors.onErrorDismissed {

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
@@ -27,7 +27,6 @@ import com.waz.model.messages.media.MediaAssetData
 import com.waz.service.messages.MessagesContentUpdater
 import com.waz.sync.SyncServiceHandle
 import com.waz.threading.Threading
-import com.wire.signals.EventContext
 import com.waz.utils.wrappers.URI
 import com.waz.sync.client.ErrorOr
 
@@ -51,9 +50,9 @@ class RichMediaService(msgsStorage: MessagesStorage,
     prev.content.size != updated.content.size || prev.content.zip(updated.content).exists { case (c1, c2) => c1.content != c2.content && isSyncable(c2) }
   }
 
-  msgsStorage.onAdded(msgs => scheduleSyncFor(msgs.filter(isSyncableMsg)))
+  msgsStorage.onAdded.foreach(msgs => scheduleSyncFor(msgs.filter(isSyncableMsg)))
 
-  msgsStorage.onUpdated { _ foreach {
+  msgsStorage.onUpdated.foreach { _ foreach {
     case (prev, updated) =>
       if (isSyncableMsg(updated) && syncableContentChanged(prev, updated)) {
         verbose(l"Updated rich media message: $updated, scheduling sync")

--- a/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -51,18 +51,18 @@ class EphemeralMessagesService(selfUserId: UserId,
 
   private val nextExpiryTime = Signal[LocalInstant](LocalInstant.Max)
 
-  val init = removeExpired()
+  private val init = removeExpired()
 
-  nextExpiryTime {
+  nextExpiryTime.foreach {
     case LocalInstant.Max => // nothing to expire
     case time => CancellableFuture.delayed((time.toEpochMilli - LocalInstant.Now.toEpochMilli).millis) { removeExpired() }
   }
 
-  storage.onAdded { msgs =>
+  storage.onAdded.foreach { msgs =>
     updateNextExpiryTime(msgs.flatMap(_.expiryTime))
   }
 
-  storage.onUpdated { updates =>
+  storage.onUpdated.foreach { updates =>
     updateNextExpiryTime(updates.flatMap(_._2.expiryTime))
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -111,7 +111,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
 
   def remoteFingerprint(sid: SessionId): Signal[Option[Array[Byte]]] = {
     def fingerprint = withSession(sid)(_.getRemoteFingerprint)
-    val stream = onCreate.filter(_ == sid).mapAsync(_ => fingerprint)
+    val stream = onCreate.filter(_ == sid).mapSync(_ => fingerprint)
 
     new AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]](
       () => fingerprint,

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
@@ -37,7 +37,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 trait OtrClientsService {
-
   val lastSelfClientsSyncPref: Preferences.Preference[Long]
   val otrClientsProcessingStage: Stage.Atomic
 
@@ -54,7 +53,6 @@ trait OtrClientsService {
   def updateUnknownToUnverified(userId: UserId): Future[Unit]
 }
 
-
 class OtrClientsServiceImpl(selfId:    UserId,
                             clientId:  ClientId,
                             netClient: OtrClient,
@@ -67,7 +65,7 @@ class OtrClientsServiceImpl(selfId:    UserId,
 
   override lazy val lastSelfClientsSyncPref: Preferences.Preference[Long] = userPrefs.preference(LastSelfClientsSyncRequestedTime)
 
-  accounts.accountState(selfId) {
+  accounts.accountState(selfId).foreach {
     case _: Active => requestSyncIfNeeded()
     case _ =>
   }

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -94,7 +94,7 @@ class OtrServiceImpl(selfUserId:     UserId,
     // request self clients sync to update prekeys on backend
     // we've just created a session from message, this means that some user had to obtain our prekey from backend (so we can upload it)
     // using signal and sync interval parameter to limit requests to one an hour
-    Signal.from(sessions.onCreateFromMessage).throttle(15.seconds) { _ => clients.requestSyncIfNeeded(1.hour) }
+    Signal.from(sessions.onCreateFromMessage).throttle(15.seconds).foreach { _ => clients.requestSyncIfNeeded(1.hour) }
   }
 
   override def parseGenericMessage(otrMsg: OtrMessageEvent, genericMsg: GenericMessage): Option[MessageEvent] = {

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -76,13 +76,13 @@ class NotificationServiceImpl(selfUserId:      UserId,
 
   private val schedulePushNotificationsToUi = Signal(false)
 
-  Signal.zip(schedulePushNotificationsToUi, pushService.processing).onChanged {
+  Signal.zip(schedulePushNotificationsToUi, pushService.processing).onChanged.foreach {
     case (true, false) =>
       pushNotificationsToUi().map { _ => schedulePushNotificationsToUi ! false }
     case _ =>
   }
 
-  uiController.notificationsSourceVisible { sources =>
+  uiController.notificationsSourceVisible.foreach { sources =>
     sources.get(selfUserId).map(Some(_)).foreach(dismissNotifications)
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
@@ -112,7 +112,7 @@ class PushNotificationEventsStorageImpl(context: Context, storage: Database, cli
   //This method is called once on app start, so invoke the handler in case there are any events to be processed
   //This is safe as the handler only allows one invocation at a time.
   override def registerEventHandler(handler: EventHandler)(implicit ec: EventContext): Future[Unit] = {
-    onAdded(_ => handler())
+    onAdded.foreach(_ => handler())
     processStoredEvents(handler)
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -192,7 +192,7 @@ class PushServiceImpl(selfUserId:           UserId,
   private val timeOffset = System.currentTimeMillis()
   @inline private def timePassed = System.currentTimeMillis() - timeOffset
 
-  wsPushService.notifications { nots =>
+  wsPushService.notifications.foreach { nots =>
     syncNotifications(StoreNotifications(nots))
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -263,8 +263,8 @@ class MessagesSyncHandler(selfUserId: UserId,
       for {
         time <- otrSync.postOtrMessage(conv.id, message).flatMap { case Left(errorResponse) => Future.failed(errorResponse)
           case Right(time) => Future.successful(time)
-        }.toUncancellable
-        _ <- msgContent.updateMessage(msg.id)(_.copy(genericMsgs = Seq(message), time = time, assetId = Some(id))).toUncancellable
+        }.lift
+        _ <- msgContent.updateMessage(msg.id)(_.copy(genericMsgs = Seq(message), time = time, assetId = Some(id))).lift
       } yield time
     }
 
@@ -293,7 +293,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         }
         time <- postOriginal(rawAssetWithMetadata)
         uploadAssetOriginal <- uploadAssetOriginal.preview match {
-          case PreviewNotReady => assets.createAndSavePreview(rawAssetWithMetadata).toUncancellable
+          case PreviewNotReady => assets.createAndSavePreview(rawAssetWithMetadata).lift
           case _ => CancellableFuture.successful(rawAssetWithMetadata)
         }
         previewAsset <- uploadAssetOriginal.preview match {
@@ -308,7 +308,7 @@ class MessagesSyncHandler(selfUserId: UserId,
               _ <- postAssetMessage(proto, uploadAssetOriginal.id)
             } yield Some(previewAsset)
           case PreviewUploaded(assetId) =>
-            assetStorage.get(assetId).map(Some.apply).toUncancellable
+            assetStorage.get(assetId).map(Some.apply).lift
           case PreviewEmpty =>
             CancellableFuture.successful(None)
           case PreviewNotReady =>
@@ -317,7 +317,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         _ <- (previewAsset match {
           case Some(p) => uploadAssetStorage.update(uploadAssetOriginal.id, _.copy(preview = PreviewUploaded(p.id)))
           case None => Future.successful(())
-        }).toUncancellable
+        }).lift
         asset <- assets.uploadAsset(uploadAssetOriginal.id)
         proto = GenericMessage(
           msg.id.uid,
@@ -330,8 +330,8 @@ class MessagesSyncHandler(selfUserId: UserId,
 
     //want to wait until asset meta and preview data is loaded before we send any messages
     for {
-      _ <- AssetProcessing.get(ProcessingTaskKey(msg.assetId.get)).toUncancellable
-      rawAsset <- uploadAssetStorage.find(msg.assetId.collect { case id: UploadAssetId => id }.get).toUncancellable
+      _ <- AssetProcessing.get(ProcessingTaskKey(msg.assetId.get)).lift
+      rawAsset <- uploadAssetStorage.find(msg.assetId.collect { case id: UploadAssetId => id }.get).lift
       result <- rawAsset match {
         case None =>
           CancellableFuture.successful(Left(internalError(s"no asset found for msg: $msg")))

--- a/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
@@ -166,7 +166,7 @@ class OpenGraphSyncHandler(convs:           ConversationStorage,
       val content = ContentForUpload(s"open_graph_image_${prev.proto.getPermanentUrl}", Content.File(Mime.Image.Jpg, imageFile))
       val encryption = AES_CBC_Encryption.random
       for {
-        rawAsset <- assets.createAndSaveUploadAsset(content, encryption, public = false, retention, Some(messageId)).toCancellable
+        rawAsset <- assets.createAndSaveUploadAsset(content, encryption, public = false, retention, Some(messageId)).toUncancellable
         asset <- assets.uploadAsset(rawAsset.id)
       } yield asset
     }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
@@ -166,7 +166,7 @@ class OpenGraphSyncHandler(convs:           ConversationStorage,
       val content = ContentForUpload(s"open_graph_image_${prev.proto.getPermanentUrl}", Content.File(Mime.Image.Jpg, imageFile))
       val encryption = AES_CBC_Encryption.random
       for {
-        rawAsset <- assets.createAndSaveUploadAsset(content, encryption, public = false, retention, Some(messageId)).toUncancellable
+        rawAsset <- assets.createAndSaveUploadAsset(content, encryption, public = false, retention, Some(messageId)).lift
         asset <- assets.uploadAsset(rawAsset.id)
       } yield asset
     }

--- a/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors
 import android.os.{Handler, HandlerThread, Looper}
 import com.waz.utils.returning
 import com.waz.zms.BuildConfig
-import com.wire.signals.Subscription.Subscriber
 import com.wire.signals.Threading.Cpus
 import com.wire.signals.{DispatchQueue, EventContext, EventStream, Signal, Subscription}
 
@@ -32,12 +31,12 @@ import scala.util.control.NonFatal
 object Threading {
 
   implicit class RichSignal[E](val signal: Signal[E]) extends AnyVal {
-    def onUi(subscriber: Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
+    def onUi(subscriber: E => Unit)(implicit context: EventContext = EventContext.Global): Subscription =
       signal.on(Threading.Ui)(subscriber)(context)
   }
 
   implicit class RichEventStream[E](val stream: EventStream[E]) extends AnyVal {
-    def onUi(subscriber: Subscriber[E])(implicit context: EventContext = EventContext.Global): Subscription =
+    def onUi(subscriber: E => Unit)(implicit context: EventContext = EventContext.Global): Subscription =
       stream.on(Threading.Ui)(subscriber)(context)
   }
 

--- a/zmessaging/src/main/scala/com/waz/ui/SignalLoading.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/SignalLoading.scala
@@ -24,6 +24,7 @@ import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
 import com.waz.ui.SignalLoader.{LoaderHandle, LoadingReference, ZmsLoaderHandle}
+import com.waz.utils.returning
 import com.wire.signals.Signal
 
 import scala.ref.{ReferenceQueue, WeakReference}
@@ -55,7 +56,9 @@ abstract class SignalLoader[A](handle: LoaderHandle[A])(implicit ui: UiModule)
   extends LoaderSubscription with DerivedLogTag {
   import ui.eventContext
 
-  ui.onStarted { _ => SignalLoader.dropQueue() }
+  returning(ui.onStarted.foreach { _ => SignalLoader.dropQueue() }) {
+    _.disablePauseWithContext()
+  }
 
   val ref = new LoadingReference(this, handle)
 

--- a/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
@@ -20,9 +20,8 @@ package com.waz.ui
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.service._
 import com.waz.threading.Threading
-import com.wire.signals._
 
-import scala.concurrent.Future
+import com.wire.signals._
 
 trait UiEventContext {
   implicit lazy val eventContext: EventContext = EventContext()
@@ -30,8 +29,7 @@ trait UiEventContext {
   private[ui] var createCount = 0
   private[ui] var startCount = 0
 
-  val onStarted = new SourceSignal[Boolean]() with ForcedEventSource[Boolean]
-  val onReset = new SourceStream[Boolean] with ForcedEventSource[Boolean]
+  val onStarted = new SourceSignal[Boolean]()
 
   def onStart(): Unit = {
     Threading.assertUiThread()
@@ -65,9 +63,5 @@ class UiModule(val global: GlobalModule) extends UiEventContext with DerivedLogT
   private lazy val accounts: AccountsService = global.accountsService
 
   val currentZms: Signal[Option[ZMessaging]] = accounts.activeZms
-
-  currentZms.onChanged { _ => onReset ! true }
-
-  def getCurrent: Future[Option[ZMessaging]] = accounts.activeZms.head
 }
 

--- a/zmessaging/src/test/scala/com/waz/BlockingSyntax.scala
+++ b/zmessaging/src/test/scala/com/waz/BlockingSyntax.scala
@@ -44,7 +44,7 @@ object BlockingSyntax {
     private val defaultTimeout: Duration = 3.seconds
 
     def subscribe(implicit ev: EventContext): Unit = {
-      subscription = eventStream { e =>
+      subscription = eventStream.foreach { e =>
         println(s"BlockingEventStream. Received event: $e")
         events.append(e)
       }

--- a/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -62,7 +62,7 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     (users.currentConvMembers _).expects().once().returning(Signal.const(convUsers.map(_.id)))
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId => convSignals(id) }
 
-    getService //trigger creation of service
+    val service = getService //trigger creation of service
 
     val finished = EventStream[Unit]()
     (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -246,7 +246,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint3 = callCheckpoint(_.get(_1to1Conv.id).exists(c => c.convId == _1to1Conv.id && c.state == Ended && c.endReason.contains(AvsClosedReason.Normal) && c.endTime.isEmpty), _.isEmpty)
 
       var terminatingPhaseEntered = false
-      service.currentCall.map(_.map(_.state)) {
+      service.currentCall.map(_.map(_.state)).foreach {
         case Some(Terminating) => terminatingPhaseEntered = true
         case _ =>
       }
@@ -409,7 +409,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint2 = callCheckpoint(_.get(_1to1Conv.id).exists(c => c.convId == _1to1Conv.id && c.state == Ended && c.endReason.contains(AvsClosedReason.Normal)), _.isEmpty)
 
       var terminatingPhaseEntered = false
-      service.currentCall.map(_.map(_.state)) {
+      service.currentCall.map(_.map(_.state)).foreach {
         case Some(Terminating) => terminatingPhaseEntered = true
         case _ =>
       }
@@ -871,7 +871,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint3 = callCheckpoint(_.contains(_1to1Conv2.id), cur => cur.exists(_.state == OtherCalling) && cur.exists(_.allParticipants.isEmpty))
 
       var terminatingPhaseEntered = false
-      service.currentCall.map(_.map(_.state)) {
+      service.currentCall.map(_.map(_.state)).foreach {
         case Some(Terminating) => terminatingPhaseEntered = true
         case _ =>
       }
@@ -911,7 +911,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val checkpoint3 = callCheckpoint(_.contains(_1to1Conv2.id), cur => cur.exists(_.state == OtherCalling) && cur.exists(_.allParticipants.isEmpty))
 
       var terminatingPhaseEntered = false
-      service.currentCall.map(_.map(_.state)) {
+      service.currentCall.map(_.map(_.state)).foreach {
         case Some(Terminating) => terminatingPhaseEntered = true
         case _ =>
       }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -179,7 +179,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       }).once().returning(Future.successful(None))
 
       // WHEN
-      result(service.convStateEventProcessingStage.apply(rConvId, events))
+      result(service.convStateEventProcessingStage(rConvId, events))
     }
 
     scenario("Does not archive conversation when the user is removed by someone else") {

--- a/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
@@ -145,7 +145,7 @@ import scala.concurrent.duration._
       val responseContent = JsonObjectResponse(notification.toJson)
 
       var gotNotification = false
-      service.notifications { _ =>
+      service.notifications.foreach { _ =>
         gotNotification = true
       }
 
@@ -171,7 +171,7 @@ import scala.concurrent.duration._
       val responseContent = JsonObjectResponse(new JSONObject())
 
       var gotNotification = false
-      service.notifications { _ =>
+      service.notifications.foreach { _ =>
         gotNotification = true
       }
 

--- a/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -100,7 +100,7 @@ package object testutils {
 
     class SignalSink[A] {
       @volatile private var sub = Option.empty[Subscription]
-      def subscribe(s: Signal[A])(implicit ctx: EventContext = EventContext.Global): Unit = sub = Some(s(v => value = Some(v)))
+      def subscribe(s: Signal[A])(implicit ctx: EventContext = EventContext.Global): Unit = sub = Some(s.foreach(v => value = Some(v)))
       def unsubscribe: Unit = sub.foreach { s =>
         s.destroy()
         sub = None


### PR DESCRIPTION
The new version of Wire Signals brings some changes in API and Wire Android code needed some modifications.
The most important changes are:
1. I removed subscriptions to event streams and signals with the `apply` method. Until now you could have seen in the code things like `signal { _ => ... }` which was a shorthand to `signal.apply(...)` and that in turn was an alternative to `signal.foreach { _ => ... }` or `signal.onUi { _ => ... }`. It was a bit confusing because it looked as if `signal` was a method, not an object, and on top of that, sometimes it was possible to make the signal execute on the wrong execution context (in those cases, usually `Ui` was used instead of `Background`, which wasn't a bug, but we shouldn't do too much on the Ui thread if it's not necessary). So in all those places I added `.foreach` or `.onUi`.
2. `CancellableFuture` is not always cancellable. For example, if we wrap a regular future in `CancellableFuture`, the original future still can't be cancelled. Or if the cancellable future is already completed, of course. Until now there was no way to check it (it's still not as clear I would like, but it's better) and in some places in Wire Android I have found code which tried very hard to cancel an uncancellable future. Besides, those uncancellable-cancellable futures should work a bit faster now.
3. The `mapAsync` method in signals and event streams became `mapSync`, because that's a better name for a method which synchronizes mapping of events.

#### APK
[Download build #3433](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3433/artifact/build/artifact/wire-dev-PR3287-3433.apk)
[Download build #3448](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3448/artifact/build/artifact/wire-dev-PR3287-3448.apk)