### PR TITLE
fix: Glide exception in user notifications

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/MessageNotificationsController.scala
@@ -53,6 +53,8 @@ import org.threeten.bp.Instant
 import scala.concurrent.Future
 import com.waz.threading.Threading._
 
+import scala.util.Try
+
 class MessageNotificationsController(applicationId: String = BuildConfig.APPLICATION_ID)
                                     (implicit inj: Injector, cxt: Context)
   extends Injectable
@@ -401,7 +403,7 @@ class MessageNotificationsController(applicationId: String = BuildConfig.APPLICA
     }
     else Future.successful(None)
 
-  private def loadPicture(picture: Picture): Future[Option[Bitmap]] = {
+  private def loadPicture(picture: Picture): Future[Option[Bitmap]] = Try {
     Threading.ImageDispatcher {
       Option(WireGlide(cxt)
         .asBitmap()
@@ -410,7 +412,7 @@ class MessageNotificationsController(applicationId: String = BuildConfig.APPLICA
         .submit(128, 128)
         .get()).map(Bitmap.fromAndroid)
     }.future
-  }
+  }.getOrElse(Future.successful(None))
 
   private def getSound(ns: Seq[NotificationData]) = {
     if (soundController.soundIntensityNone) None


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-51

The issue was described in here https://github.com/wireapp/wire-android/issues/777#issuecomment-531071779
Since then it stopped being so important because we fixed the problem with missing avatars (the notifications were not displayed if the sender had no avatar). So, this fix is basically just a safeguard against it happening again.
#### APK
[Download build #3452](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3452/artifact/build/artifact/wire-dev-PR3292-3452.apk)