### PR TITLE
fix: A long click on the conversation list doesn't open the bottom dialog

### DIFF
--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
@@ -91,7 +91,7 @@ trait CollectionNormalItemView extends CollectionItemView with ClickableViewPart
 
   messageAndLikesResolver.onUi { mal => set(mal, content) }
 
-  onClicked.foreach { _ =>
+  onClicked.onUi { _ =>
     import Threading.Implicits.Ui
     for {
       false <- expired.head

--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionRecyclerView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionRecyclerView.scala
@@ -34,6 +34,7 @@ import com.waz.zclient.collection.controllers.{CollectionController, CollectionS
 import com.waz.zclient.collection.fragments.CollectionFragment
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.pages.main.conversation.collections.CollectionItemDecorator
+import com.waz.threading.Threading._
 
 class CollectionRecyclerView(context: Context, attrs: AttributeSet, style: Int)
   extends RecyclerView(context, attrs, style) with ViewHelper with DerivedLogTag {
@@ -60,7 +61,7 @@ class CollectionRecyclerView(context: Context, attrs: AttributeSet, style: Int)
 
     addItemDecoration(collectionItemDecorator)
 
-    scrollController.onScroll.foreach { case Scroll(pos, smooth) =>
+    scrollController.onScroll.onUi { case Scroll(pos, smooth) =>
       verbose(l"Scrolling to pos: $pos, smooth: $smooth")
       val scrollTo = math.min(adapter.getItemCount - 1, pos)
       if (smooth) {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListFragment.scala
@@ -132,12 +132,12 @@ abstract class ConversationListFragment extends BaseFragment[ConversationListFra
 
     subs += userAccountsController.currentUser.onUi(user => topToolbar.get.setTitle(adapterMode, user))
 
-    subs += adapter.onConversationClick.foreach { conv =>
+    subs += adapter.onConversationClick.onUi { conv =>
       verbose(l"handleItemClick, switching conv to $conv")
       conversationController.selectConv(Option(conv), ConversationChangeRequester.CONVERSATION_LIST)
     }
 
-    subs += adapter.onConversationLongClick.foreach { conv =>
+    subs += adapter.onConversationLongClick.onUi { conv =>
       if (Set(Group, OneToOne, WaitForConnection).contains(conv.convType))
         screenController.showConversationMenu(true, conv.id)
     }
@@ -164,7 +164,7 @@ class ArchiveListFragment extends ConversationListFragment with OnBackPressedLis
 
   override def onViewCreated(view: View, savedInstanceState: Bundle) = {
     super.onViewCreated(view, savedInstanceState)
-    topToolbar.foreach(toolbar => subs += toolbar.onRightButtonClick.foreach(_ => Option(getContainer).foreach(_.closeArchive())))
+    topToolbar.foreach(toolbar => subs += toolbar.onRightButtonClick.onUi(_ => Option(getContainer).foreach(_.closeArchive())))
   }
 
   override def onBackPressed() = {
@@ -254,7 +254,7 @@ class NormalConversationFragment extends ConversationListFragment {
     }
 
     topToolbar.foreach { toolbar =>
-      subs += toolbar.onRightButtonClick.foreach { _ =>
+      subs += toolbar.onRightButtonClick.onUi { _ =>
         getActivity.startActivityForResult(PreferencesActivity.getDefaultIntent(getContext), PreferencesActivity.SwitchAccountCode)
       }
     }

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -203,7 +203,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
       verbose(l"Outdated avatar info")
   }
 
-  badge.onClickEvent.foreach {
+  badge.onClickEvent.onUi {
     case ConversationBadge.IncomingCall =>
       (zms.map(_.selfUserId).currentValue, conversationData.map(_.id)) match {
         case (Some(acc), Some(cId)) => inject[CallStartController].startCall(acc, cId, forceOption = true)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
@@ -47,8 +47,8 @@ class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
       val fingerprintText = DevicesPreferencesUtil.getFormattedFingerprint(activity, fingerprint).toString
 
       returning(LegalHoldRequestDialog.newInstance(isSso = isSso, fingerprintText, showError = showError)) { dialog =>
-        dialog.onAccept.foreach(onLegalHoldAccepted)
-        dialog.onDecline.foreach(_ => setFinished())
+        dialog.onAccept.onUi(onLegalHoldAccepted)
+        dialog.onDecline.onUi(_ => setFinished())
       }.show(activity.getSupportFragmentManager, LegalHoldRequestDialog.TAG)
     }
 

--- a/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
@@ -47,16 +47,16 @@ class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, la
 
   val reachedQueuedScroll: SourceStream[Scroll] = EventStream[Scroll]
 
-  val onScroll: EventStream[Scroll] = EventStream.zip(
+  EventStream.zip(
     onListLoaded.map { pos => Scroll(pos, smooth = false, force = true) },
     onScrollToBottomRequested.filter(_ => queuedScroll.isEmpty).map { _ => BottomScroll(smooth = false) },
     onListHeightChanged.filter(_ => shouldScrollToBottom && lastVisiblePosition == LastMessageIndex).map { _ => BottomScroll(smooth = false) },
     onListHeightChanged.filter(_ => !shouldScrollToBottom && queuedScroll.nonEmpty).map { _ => queuedScroll.get },
     onMessageAdded.filter(_ => !dragging && queuedScroll.isEmpty && lastVisiblePosition == LastMessageIndex).map { _ => BottomScroll(smooth = false) },
     scrollToPositionRequested.map { pos => Scroll(pos, smooth = false, force = true) }
-  )
+  ).onUi(processScroll)
 
-  adapter.onScrollRequested.foreach(scrollToPositionRequested ! _._2)
+  adapter.onScrollRequested.map(_._2).pipeTo(scrollToPositionRequested)
 
   view.addOnScrollListener(new OnScrollListener {
     override def onScrollStateChanged(recyclerView: RecyclerView, newState: Int): Unit =
@@ -81,8 +81,6 @@ class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, la
     }
 
   })
-
-  onScroll.onUi(processScroll)
 
   def reset(unreadPos: Int): Unit = {
     verbose(l"reset $unreadPos")

--- a/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
@@ -80,7 +80,7 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
 
   user.map(_.id).foreach(userDetails.setUserId)
 
-  user.map(u => (u.isAutoConnect, u.isWireBot)).on(Threading.Ui) {
+  user.map(u => (u.isAutoConnect, u.isWireBot)).onUi {
     case (true, _) =>
       label.setText(R.string.content__message__connect_request__auto_connect__footer)
       TextViewUtils.linkifyText(label, getStyledColor(R.attr.wirePrimaryTextColor), true, true, new Runnable() {

--- a/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/EphemeralPartView.scala
@@ -34,6 +34,7 @@ import com.waz.zclient.ui.utils.{ColorUtils, TypefaceUtils}
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
 import com.wire.signals.ext.ClockSignal
+import com.waz.threading.Threading._
 
 trait EphemeralPartView extends MessageViewPart { self: ViewHelper =>
 
@@ -60,8 +61,8 @@ trait EphemeralPartView extends MessageViewPart { self: ViewHelper =>
       case false => Signal const Left(originalColor)
     }
 
-    typeface.foreach { textView.setTypeface }
-    color.foreach {
+    typeface.onUi { textView.setTypeface }
+    color.onUi {
       case Left(csl) => textView.setTextColor(csl)
       case Right(ac) => textView.setTextColor(ac.color)
     }
@@ -113,7 +114,7 @@ trait EphemeralIndicatorPartView
     angle <- timerAngle
   } yield (ephemeral, angle)
 
-  state.on(Threading.Ui) { _ => invalidate() }
+  state.onUi { _ => invalidate() }
   setWillNotDraw(false)
 
   override def onDraw(canvas: Canvas): Unit = state.currentValue match {


### PR DESCRIPTION
The operation of displaying the bottom dialog should be executed on the Ui thread, but was on the Background thread.
This was introduced with recent changes to wire-signals. I looked through the rest of the changes and modified some
of it to make sure that the operations are made on Ui. Especially in case of scrolling.

#### APK
[Download build #3460](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3460/artifact/build/artifact/wire-dev-PR3297-3460.apk)