### PR TITLE
fix: Syncing clients on fresh install is broken

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
@@ -4,7 +4,9 @@ import com.waz.utils.JsonDecoder.opt
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 
-final case class QualifiedId(id: UserId, domain: String)
+final case class QualifiedId(id: UserId, domain: String) {
+  def hasDomain: Boolean = domain.nonEmpty
+}
 
 object QualifiedId {
   def apply(userId: UserId): QualifiedId = QualifiedId(userId, "")


### PR DESCRIPTION
The bug is in the code which should update the clients data fetched from the backend. It looks like it was introduced when I changed it to take advantage from the fact we can do it not one by one client, but in batches, it stopped working at least in the corner case where we try to send a message immediately after a fresh install.

At least in part the bug was also connected with that the endpoint /list-clients/v2 requires qualifiable ids (userId + domain) but it's possible that we won't have the information about the domain for some (or all) users. /list-clients/v2 doesn't accept an empty domain field as valid. In such case we have to revert to the old endpoint as well. 

So now, the code in OtrClientsSync tries to do both: 
1. It splits the set qualifiable ids it gets int two subsets - one for qualifiable ids with domains, and the other for those without.
2. It uses the new endpoint (/list-clients/v2) to get information about clients for users with domains.
3. It uses the old endpoint (/users/$user/clients) to get information about clients for users without domains.
4. If the new endpoint doesn't work it uses the old endpoint as fallback.
5. After getting all the information about clients in any way, it updates the clients one by one. This part could be improved - we are capable of updating clients faster - but at least we know it's not bugged.

By the way, @johnxnguyen noticed that we no longer get any information about clients other than clientId and the "class" - a field we don't recognize. This needs to be fixed in another ticket.

#### APK
[Download build #3465](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3465/artifact/build/artifact/wire-dev-PR3301-3465.apk)