### PR TITLE
fix: Update clients in batches

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -106,7 +106,7 @@ class LegalHoldServiceImpl(selfUserId: UserId,
   private def createLegalHoldClientAndSession(request: LegalHoldRequest): Future[Unit] = for {
     client          <- clientsService.getOrCreateClient(selfUserId, request.clientId)
     legalHoldClient = client.copy(devType = OtrClientType.LEGALHOLD)
-    _               <- clientsService.updateUserClients(selfUserId, Seq(legalHoldClient))
+    _               <- clientsService.updateUserClients(selfUserId, Seq(legalHoldClient), replace = false)
     sessionId       = SessionId(selfUserId, legalHoldClient.id)
     _               <- cryptoSessionService.getOrCreateSession(sessionId, request.lastPreKey)
   } yield ()

--- a/zmessaging/src/main/scala/com/waz/sync/SyncResult.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncResult.scala
@@ -52,4 +52,9 @@ object SyncResult {
     case Failure(error) => Some(error)
     case Retry(error) => Some(error)
   }
+
+  def isSuccess(result: SyncResult): Boolean = result match {
+    case Success => true
+    case _       => false
+  }
 }

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -367,7 +367,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
         })
 
       // Saving the client.
-      (clientsService.updateUserClients _)
+      (clientsService.updateUserClients(_: UserId, _: Seq[Client], _: Boolean))
         .expects(selfUserId, Seq(client), false)
         .once()
         .returning(Future.successful {


### PR DESCRIPTION
The yesterday fix for sending a first message in a conversation made it harder (or maybe even impossible) to handle large conversations. This is an attempt to merge both these problems. The clients are updated in batches (so, a fix to large conversations) and they are properly synced in new conversations.
