### PR TITLE
fix: Save images to the gallery on older phones

### DIFF
--- a/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
@@ -20,6 +20,7 @@ package com.waz.zclient.utils;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.os.Environment;
 import android.os.PowerManager;
 import android.os.Vibrator;
 import android.telephony.PhoneNumberUtils;
@@ -32,6 +33,8 @@ import android.view.WindowManager;
 import androidx.core.app.NotificationCompat;
 import androidx.core.view.ViewCompat;
 import android.os.Build;
+
+import java.io.File;
 
 @SuppressWarnings("Deprecation")
 /*
@@ -103,6 +106,10 @@ public class DeprecationUtils {
         }
 
         window.setSoftInputMode(mode);
+    }
+
+    public static File getPicturesDirectory() {
+        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
     }
 }
 


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-53

For older Androids we used a wrong method to get the path to the gallery.
The one that is used now is deprecated in SDK 30 so it had to be wrapped in another method and put in DeprecationUtils.

#### APK
[Download build #3473](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3473/artifact/build/artifact/wire-dev-PR3305-3473.apk)