### PR TITLE
fix: Download assets on Android 7 & 9

### DIFF
--- a/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
+++ b/app/src/main/java/com/waz/zclient/utils/DeprecationUtils.java
@@ -111,5 +111,9 @@ public class DeprecationUtils {
     public static File getPicturesDirectory() {
         return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
     }
+
+    public static File getDownloadsDirectory() {
+        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+    }
 }
 

--- a/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/AssetsController.scala
@@ -24,14 +24,16 @@ import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.{Build, Environment}
 import android.provider.MediaStore
-import android.provider.MediaStore.{Downloads, MediaColumns}
+import android.provider.MediaStore.MediaColumns
 import android.text.TextUtils
 import android.util.TypedValue
 import android.view.{Gravity, View}
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatDialog
+import android.Manifest.permission.{READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE}
 import com.waz.content.MessagesStorage
 import com.waz.content.UserPreferences.DownloadImagesAlways
+import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model._
 import com.waz.permissions.PermissionsService
@@ -60,7 +62,7 @@ import org.threeten.bp.Duration
 
 import scala.collection.immutable.ListSet
 import scala.concurrent.Future
-import scala.util.Success
+import scala.util.{Success, Try}
 
 class AssetsController(implicit context: Context, inj: Injector, ec: EventContext)
   extends Injectable with DerivedLogTag { controller =>
@@ -228,7 +230,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
       noAppFoundLabel.setVisibility(View.GONE)
       openButton.setAlpha(1f)
       openButton.setOnClickListener(new View.OnClickListener() {
-        def onClick(v: View) = {
+        def onClick(v: View): Unit = {
           context.startActivity(intent)
           dialog.dismiss()
         }
@@ -241,7 +243,7 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     }
 
     saveButton.setOnClickListener(new View.OnClickListener() {
-      def onClick(v: View) = {
+      def onClick(v: View): Unit = {
         dialog.dismiss()
         saveToDownloads(asset)
       }
@@ -250,72 +252,72 @@ class AssetsController(implicit context: Context, inj: Injector, ec: EventContex
     dialog.show()
   }
 
-  private def prepareAssetContentForFile(asset: Asset, targetDir: File): Future[(File, Array[Byte])] =
+  private def prepareAssetContentForFile(asset: Asset, targetDir: File): Future[(File, Array[Byte])] = try {
     for {
       permissions <- permissions.head
-      _           <- permissions.ensurePermissions(ListSet(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE))
+      _           <- permissions.ensurePermissions(ListSet(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
       assets      <- assets.head
       assetInput  <- assets.loadContent(asset).future
       bytes       <- Future.fromTry(assetInput.toByteArray)
       // even if the asset input is a file it has to be copied to the "target file", visible from the outside
       targetFile  =  getTargetFile(asset, targetDir)
     } yield (targetFile, bytes)
+  } catch {
+    case exception: Exception => Future.failed(exception)
+  }
 
-  def saveImageToGallery(asset: Asset): Unit = {
-    prepareAssetContentForFile(asset, wireImageDirectory).onComplete {
-      case Success((file, bytes)) if inject[FileRestrictionList].isAllowed(file.getName) =>
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-          val contentResolver = context.getContentResolver
-          val wireImageRelativePath = wireImageDirectory.getPath.stripPrefix(context.getExternalFilesDir(null).getPath).drop(1)
-          val contentValues = returning(contentValuesForAsset(asset)) {
-            _.put(MediaStore.MediaColumns.RELATIVE_PATH, wireImageRelativePath)
+  def saveImageToGallery(asset: Asset): Unit = saveAsset(asset, ImageType)
+
+  def saveToDownloads(asset: Asset): Unit = saveAsset(asset, FileType)
+
+  private lazy val fileRestrictionList = inject[FileRestrictionList]
+
+  private def saveAsset(asset: Asset, assetType: AssetType): Unit =
+    wireDirectory(assetType).map { targetDir =>
+      prepareAssetContentForFile(asset, targetDir).onComplete {
+        case Success((file, bytes)) if fileRestrictionList.isAllowed(file.getName) =>
+          if (UseNewDownloadsApi)
+            saveAssetWithNewApi(assetType, targetDir, asset, bytes)
+          else
+            saveAssetWithOldApi(file, asset, bytes)
+
+          val messageId = assetType match {
+            case ImageType => R.string.message_bottom_menu_action_save_ok
+            case FileType  => R.string.content__file__action__save_completed
           }
-          val insertUri = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
-          IoUtils.withResource(contentResolver.openOutputStream(insertUri)) { _.write(bytes) }
-        } else {
-          IoUtils.writeBytesToFile(file, bytes)
+          showToast(messageId)
+          MediaScannerConnection.scanFile(context, Array(file.toString), Array(file.getName), null)
+        case _ =>
+          showToast(R.string.content__file__action__save_error)
+      }
+    }.getOrElse(showToast(R.string.content__file__action__save_error))
+
+  private def saveAssetWithNewApi(assetType: AssetType, targetDir: File, asset: Asset, bytes: Array[Byte]): Unit = {
+    val contentResolver = context.getContentResolver
+    val insertUri = assetType match {
+      case ImageType =>
+        val wireRelativePath = targetDir.getPath.stripPrefix(context.getExternalFilesDir(null).getPath).drop(1)
+        val contentValues = returning(contentValuesForAsset(asset)) {
+          _.put(MediaStore.MediaColumns.RELATIVE_PATH, wireRelativePath)
         }
-        val uri = URIWrapper.fromFile(file)
-        imageNotifications.showImageSavedNotification(asset.id, uri)
-        showToast(R.string.message_bottom_menu_action_save_ok)
-        MediaScannerConnection.scanFile(context, Array(file.toString), Array(file.getName), null)
-      case _             =>
-        showToast(R.string.content__file__action__save_error)
+        contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+      case FileType =>
+        val contentValues = contentValuesForAsset(asset)
+        contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
     }
+    IoUtils.withResource(contentResolver.openOutputStream(insertUri)) { _.write(bytes) }
   }
 
-  private lazy val wireImageDirectory = {
-    val parentDir =
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-        context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-      else
-        DeprecationUtils.getPicturesDirectory
-
-    returning(new File(parentDir, "Wire Images")) { IoUtils.createDirectory }
+  private def saveAssetWithOldApi(file: File, asset: Asset, bytes: Array[Byte]): Unit = {
+    IoUtils.writeBytesToFile(file, bytes)
+    DeprecationUtils.addCompletedDownload(
+      context,
+      asset.name,
+      asset.mime.orDefault.str,
+      URIWrapper.fromFile(file).getPath,
+      asset.size
+    )
   }
-
-  def saveToDownloads(asset: Asset): Unit =
-    prepareAssetContentForFile(asset, context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)).onComplete {
-      case Success((file, bytes)) if inject[FileRestrictionList].isAllowed(file.getName) =>
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-          val contentResolver = context.getContentResolver
-          val insertUri = contentResolver.insert(Downloads.EXTERNAL_CONTENT_URI, contentValuesForAsset(asset))
-          IoUtils.withResource(contentResolver.openOutputStream(insertUri)) { _.write(bytes) }
-        } else {
-          IoUtils.writeBytesToFile(file, bytes)
-          DeprecationUtils.addCompletedDownload(
-            context,
-            asset.name,
-            asset.mime.orDefault.str,
-            URIWrapper.fromFile(file).getPath,
-            asset.size
-          )
-        }
-        showToast(R.string.content__file__action__save_completed)
-        MediaScannerConnection.scanFile(context, Array(file.toString), Array(file.getName), null)
-      case _ =>
-        showToast(R.string.content__file__action__save_error)
-    }
 
   private def contentValuesForAsset(asset: Asset) =
     returning(new ContentValues) { cv =>
@@ -394,4 +396,34 @@ object AssetsController {
 
   def fileTypeCanBeOpened(context: Context, intent: Intent): Boolean =
     context.getPackageManager.queryIntentActivities(intent, 0).size > 0
+
+  val UseNewDownloadsApi: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+  sealed trait AssetType
+  case object ImageType extends AssetType
+  case object FileType extends AssetType
+
+  def wireDirectory(assetType: AssetType)(implicit context: Context, tag: LogTag): Option[File] = {
+    val parentDir = (assetType, UseNewDownloadsApi) match {
+      case (ImageType, true)  => context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+      case (ImageType, false) => DeprecationUtils.getPicturesDirectory
+      case (FileType, true)   => context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+      case (FileType, false)  => DeprecationUtils.getDownloadsDirectory
+    }
+
+    assetType match {
+      case ImageType =>
+        val subDir = new File(parentDir, "Wire Images")
+        // if the subdirectory already exists, nothing will happen
+        Try(IoUtils.createDirectory(subDir))
+          .recover {
+            case ex => error(l"Failure when creating a subdirectory ${subDir.getAbsolutePath}", ex)
+          }
+        verbose(l"wire image directory: ${subDir.getAbsolutePath}, exists: ${subDir.exists()}")
+        // in case we can't create the subdirectory, we will use the parent one
+        if (subDir.exists()) Some(subDir) else Some(parentDir)
+      case FileType =>
+        Some(parentDir) // for downloads we use the parent directory directly
+    }
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/ImageNotificationsController.scala
@@ -46,13 +46,12 @@ class ImageNotificationsController(implicit cxt: WireContext, inj: Injector)
   val savedImageId = Signal[Option[AssetId]](None)
   val savedImageUri = Signal[URI]()
 
-  def showImageSavedNotification(imageId: AssetId, uri: URI): Unit = Option(imageId).zip(Option(uri)).foreach {
-    case (id, ur) =>
-      savedImageId ! Some(id)
-      savedImageUri ! uri
+  def showImageSavedNotification(imageId: AssetId, uri: URI): Unit = {
+    savedImageId ! Option(imageId)
+    savedImageUri ! uri
   }
 
-  def dismissImageSavedNotification() = {
+  def dismissImageSavedNotification(): Unit = {
     notManager.cancel(ZETA_SAVE_IMAGE_NOTIFICATION_ID)
     savedImageId ! None
   }

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -161,7 +161,7 @@ class GlobalModuleImpl(val context:             AContext,
   lazy val accountsStorage:     AccountStorage                   = wire[AccountStorageImpl]
 
   val generalCacheDir = new File(context.getExternalCacheDir, s"general_cache")
-  IoUtils.createDirectory(generalCacheDir )
+  IoUtils.createDirectory(generalCacheDir)
 
   lazy val generalFileCache =
     new GeneralFileCacheImpl(generalCacheDir)(Threading.Background)

--- a/zmessaging/src/main/scala/com/waz/utils/IoUtils.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/IoUtils.scala
@@ -40,9 +40,8 @@ object IoUtils {
     override def initialValue(): Array[Byte] = new Array[Byte](8096)
   }
 
-  def createDirectory(file: File): Unit =
-    if (!file.mkdirs() && !file.isDirectory)
-      throw FileSystemError(s"Can not create directory: $file")
+  def createDirectory(file: File): Boolean =
+    !file.mkdirs() && !file.isDirectory
 
   def copy(in: InputStream, out: OutputStream): Long = {
     try {


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-53

This PR contains changes to how we download assets to the Android device.
The previous fix (https://github.com/wireapp/wire-android/pull/3305) didn't work for all devices. It looks like in some cases we are unable to create subfolders from the app
(in our case, we tried to create a "Wire Images" subfolder), but saving an image to the original folder works fine.
When we weren't able to create a subfolder, the method was throwing an exception and aborting the whole operation.
Now it just returns `false`. I checked the other places where it is used - there should be no problems.

I also refactored the code to have the same functionality for saving images and other files with the new and the old API.
This gives me a bit more confidence in the situation when this functionality might work differently depending on the device.

#### APK
[Download build #3480](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3480/artifact/build/artifact/wire-dev-PR3308-3480.apk)