### PR TITLE
fix: Scroll to position

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessagePagedListController.scala
@@ -91,7 +91,7 @@ class MessagePagedListController()(implicit inj: Injector, ec: EventContext, cxt
     _                       =  verbose(l"cursor changed")
     list                    =  PagedListWrapper(getPagedList(cursor))
     lastRead                <- convController.currentConv.map(_.lastRead)
-    messageToReveal         <- messageActionsController.messageToReveal.map(_.map(_.id))
+    messageToReveal         <- messageActionsController.messageToReveal
   } yield (MessageAdapterData(cId, lastRead, isGroup, canHaveLink, z.selfUserId, z.teamId), list, messageToReveal)
 }
 

--- a/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/ScrollController.scala
@@ -82,12 +82,6 @@ class ScrollController(adapter: MessagesPagedListAdapter, view: RecyclerView, la
 
   })
 
-  def reset(unreadPos: Int): Unit = {
-    verbose(l"reset $unreadPos")
-    queuedScroll = None
-    onListLoaded ! unreadPos
-  }
-
   def onPagedListChanged(): Unit = {
     verbose(l"onPagedListChanged")
     queuedScroll.foreach(processScroll)

--- a/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/controllers/MessageActionsController.scala
@@ -61,8 +61,8 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   private lazy val userPrefsController  = inject[IUserPreferencesController]
   private lazy val clipboard            = inject[ClipboardUtils]
   private lazy val replyController      = inject[ReplyController]
-  private lazy val screenController = inject[ScreenController]
-  private lazy val externalFileSharing = inject[ExternalFileSharing]
+  private lazy val screenController     = inject[ScreenController]
+  private lazy val externalFileSharing  = inject[ExternalFileSharing]
 
   private lazy val assetsController     = inject[AssetsController]
 
@@ -73,7 +73,7 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
   val onDeleteConfirmed = EventStream[(MessageData, Boolean)]() // Boolean == isRecall(true) or localDelete(false)
   val onAssetSaved = EventStream[AssetData]()
 
-  val messageToReveal = Signal[Option[MessageData]](None)
+  val messageToReveal = Signal(Option.empty[MessageId])
 
   private var dialog = Option.empty[OptionsMenu]
 
@@ -229,11 +229,8 @@ class MessageActionsController(implicit injector: Injector, ctx: Context, ec: Ev
       }
   }
 
-  private def revealMessageInConversation(message: MessageData) = {
-    zms.head.flatMap(z => z.messagesStorage.get(message.id)).onComplete {
-      case Success(msg) =>  messageToReveal ! msg
-      case _ =>
-    }
+  private def revealMessageInConversation(message: MessageData): Unit = {
+    messageToReveal ! Some(message.id)
   }
 }
 


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-648

There was a race condtion, probably caused by changes in wire-signals - the code that previously run on the UI thread (and was synchronous because of that) and looked for the searched message AND then scrolled the conversation to that message, is now split between the Background thread (the first part) and the UI thread (the second part). I guess that scrolling happened before the message was found. That would also explain why it worked if the user searched for their own message - it was in the memory cache. For other messages, the app had to access DB and it was a bit slower.

I simplified the code. The old version performed some additional operations which I think have no more use (such as checking the id of the previous conversation (?)).
#### APK
[Download build #3481](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3481/artifact/build/artifact/wire-dev-PR3309-3481.apk)