### PR TITLE
Feature: Legal Hold - Show info pop ups when Legal Hold is activated & deactivated

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1596,5 +1596,8 @@
     <string name="legal_hold_request_dialog_wrong_password_error">Wrong password</string>
     <string name="legal_hold_all_subjects_title">LEGAL HOLD SUBJECTS</string>
     <string name="legal_hold_device_name">Legal Hold</string>
+    <string name="legal_hold_deactivated_dialog_title">Legal Hold Deactivated</string>
+    <string name="legal_hold_deactivated_dialog_message">Future messages will not be recorded.</string>
+    <string name="legal_hold_activated_dialog_title">Legal Hold is Active</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -1,6 +1,8 @@
 package com.waz.zclient.legalhold
 
+import com.waz.content.UserPreferences
 import com.waz.model.AccountData.Password
+import com.waz.model.ConversationData.LegalHoldStatus
 import com.waz.model.{ConvId, LegalHoldRequest, UserId}
 import com.waz.service.LegalHoldService
 import com.waz.sync.handler.LegalHoldError
@@ -15,6 +17,7 @@ class LegalHoldController(implicit injector: Injector)
   import com.waz.threading.Threading.Implicits.Background
 
   private lazy val legalHoldService = inject[Signal[LegalHoldService]]
+  private lazy val userPreferences  = inject[Signal[UserPreferences]]
 
   val showingLegalHoldInfo: SourceStream[Boolean] = EventStream[Boolean]
 
@@ -34,6 +37,16 @@ class LegalHoldController(implicit injector: Injector)
     legalHoldService.flatMap(_.legalHoldRequest)
 
   val hasPendingRequest: Signal[Boolean] = legalHoldRequest.map(_.isDefined)
+
+  val legalHoldDisclosureType: Signal[Option[LegalHoldStatus]] =
+    userPreferences.flatMap(_.preference(UserPreferences.LegalHoldDisclosureType).signal)
+
+  def clearLegalHoldDisclosureType: Future[Unit] =
+    for {
+      prefs <- userPreferences.head
+      pref  =  prefs.preference(UserPreferences.LegalHoldDisclosureType)
+      _     <- pref := None
+    } yield()
 
   def getFingerprint(request: LegalHoldRequest): Future[Option[String]] =
     legalHoldService.head.map(_.getFingerprint(request))

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldStatusChangeListener.scala
@@ -1,8 +1,12 @@
 package com.waz.zclient.legalhold
 
+import android.content.Context
+import com.waz.model.ConversationData.LegalHoldStatus
 import com.waz.zclient.security.ActivityLifecycleCallback
-import com.waz.zclient.{Injectable, Injector}
+import com.waz.zclient.{Injectable, Injector, R}
 import com.waz.threading.Threading._
+import com.waz.threading.Threading.Implicits.Ui
+import com.waz.zclient.utils.ContextUtils
 
 class LegalHoldStatusChangeListener(implicit injector: Injector) extends Injectable {
 
@@ -15,5 +19,27 @@ class LegalHoldStatusChangeListener(implicit injector: Injector) extends Injecta
     case false =>
   }
 
-  //TODO: show "LH no longer active" pop up when LH is disabled
+  legalHoldController.legalHoldDisclosureType.onUi {
+    case Some(LegalHoldStatus.Enabled)  =>
+      showDisclosureDialog(
+        R.string.legal_hold_activated_dialog_title,
+        R.string.legal_hold_self_user_info_message)
+    case Some(LegalHoldStatus.Disabled) =>
+      showDisclosureDialog(
+        R.string.legal_hold_deactivated_dialog_title,
+        R.string.legal_hold_deactivated_dialog_message)
+    case _                              =>
+  }
+
+  private def showDisclosureDialog(titleRes: Int, messageRes: Int): Unit =
+    activityLifecycleCallback.withCurrentActivity { activity =>
+      implicit val context: Context = activity
+
+      ContextUtils.showInfoDialog(
+        title = activity.getString(titleRes),
+        msg = activity.getString(messageRes)
+      ).foreach(_ =>
+        legalHoldController.clearLegalHoldDisclosureType
+      )
+    }
 }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -25,6 +25,7 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.media.manager.context.IntensityLevel
+import com.waz.model.ConversationData.LegalHoldStatus
 import com.waz.model.KeyValueData.KeyValueDataDao
 import com.waz.model._
 import com.waz.model.otr.ClientId
@@ -40,6 +41,7 @@ import org.threeten.bp.{Duration, Instant}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 trait Preferences {
 
@@ -182,6 +184,12 @@ object Preferences {
       implicit lazy val LegalHoldRequestCodec = apply[Option[LegalHoldRequest]](
         { d =>  d.fold("")(r => LegalHoldRequest.Encoder(r).toString) },
         { s => if (s.isEmpty) None else Some(LegalHoldRequest.Decoder(new JSONObject(s))) },
+        defaultVal = None
+      )
+
+      implicit lazy val LegalHoldStatusCodec = apply[Option[LegalHoldStatus]](
+        { d =>  d.fold("")(r => r.value.toString) },
+        { s => if (s.isEmpty) None else Try(Integer.parseInt(s)).map(LegalHoldStatus(_)).toOption },
         defaultVal = None
       )
     }
@@ -424,4 +432,6 @@ object UserPreferences {
   lazy val AppLockTimeout: PrefKey[Option[FiniteDuration]] = PrefKey[Option[FiniteDuration]]("app_lock_timeout", customDefault = None)
 
   lazy val LegalHoldRequest: PrefKey[Option[LegalHoldRequest]] = PrefKey[Option[LegalHoldRequest]]("legal_hold_request", customDefault = None)
+  lazy val LegalHoldDisclosureType: PrefKey[Option[LegalHoldStatus]] =
+    PrefKey[Option[LegalHoldStatus]]("legal_hold_disclosure_type", customDefault = None)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issues: 
[SQSERVICES-338](https://wearezeta.atlassian.net/browse/SQSERVICES-338)
[SQSERVICES-355](https://wearezeta.atlassian.net/browse/SQSERVICES-355)

-- Activation cases:
Given that I accept LH request from one device
When I log into another device
Then I should see disclosure pop up that says LH is activated

Given that I accept LH request from one device
When I'm using another device
Then I should immediately see disclosure pop up that says LH is activated

Given that I accept LH request from one device
When I'm using that device
Then I should not see disclosure pop up in the current device

-- Deactivation case:
Given that admin disables LH for me
When I log into any device
Then I should see disclosure pop up that says LH is deactivated

### Solutions

Added a new flag, `LegalHoldDisclosureType`, to `UserPreferences`. The flag denotes if we need to display a pop up, and if we do, which type. We set the flag value when we receive LH events from backend, and clear it once the user acknowledges that s/he saw the pop up.

### Testing

Manually tested by accepting LH from a web client, and deactivating from Team settings.

| Activated | Deactivated |
|---|---|
| <img src="https://user-images.githubusercontent.com/2143283/118806304-30a37500-b8a7-11eb-85b7-901ce9a92bb9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/2143283/118806337-39944680-b8a7-11eb-95f7-e3f641db0c56.png" width="300px" /> |


#### APK
[Download build #3484](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3484/artifact/build/artifact/wire-dev-PR3311-3484.apk)
[Download build #3485](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3485/artifact/build/artifact/wire-dev-PR3311-3485.apk)
[Download build #3486](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3486/artifact/build/artifact/wire-dev-PR3311-3486.apk)