### PR TITLE
Refactor:  Legal Hold - Remove Container from LegalHoldInfoFragment

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/AllLegalHoldSubjectsFragment.scala
@@ -3,21 +3,27 @@ package com.waz.zclient.legalhold
 import android.os.Bundle
 import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
+import com.waz.model.UserId
 import com.waz.utils.returning
 import com.waz.zclient.{FragmentHelper, R}
 import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.common.views.PickableElement
-import com.waz.zclient.pages.BaseFragment
+import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.usersearch.views.{PickerSpannableEditText, SearchEditText}
+import com.wire.signals.Signal
 
-class AllLegalHoldSubjectsFragment extends BaseFragment[LegalHoldSubjectsContainer]()
-  with FragmentHelper {
+class AllLegalHoldSubjectsFragment extends FragmentHelper {
 
-  private lazy val legalHoldController = inject[LegalHoldController]
+  private lazy val legalHoldController    = inject[LegalHoldController]
+  private lazy val conversationController = inject[ConversationController]
 
-  private lazy val users = getContainer.legalHoldUsers.map(_.toSet)
+  private lazy val users: Signal[Seq[UserId]] =
+    for {
+      convId <- conversationController.currentConvId
+      users  <- legalHoldController.legalHoldUsers(convId)
+    } yield users
 
-  private lazy val adapter = returning(new LegalHoldUsersAdapter(users)) {
+  private lazy val adapter = returning(new LegalHoldUsersAdapter(users.map(_.toSet))) {
     _.onClick.pipeTo(legalHoldController.onLegalHoldSubjectClick)
   }
 

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldInfoFragment.scala
@@ -51,10 +51,13 @@ class LegalHoldInfoFragment extends FragmentHelper {
     super.onDetach()
   }
 
-  private def setMessage(): Unit =
-    infoMessageTextView.foreach { textView =>
-      getIntArg(ARG_MESSAGE_RES_ID).foreach(textView.setText)
+  private def setMessage(): Unit = {
+    val message = getStringArg(ARG_CONV_ID) match {
+      case Some(_) => R.string.legal_hold_conversation_info_message
+      case None    => R.string.legal_hold_self_user_info_message
     }
+    infoMessageTextView.foreach(_.setText(message))
+  }
 
   private def setUpRecyclerView(): Unit =
     subjectsRecyclerView.foreach { recyclerView =>
@@ -67,13 +70,11 @@ object LegalHoldInfoFragment {
 
   val Tag = "LegalHoldInfoFragment"
   private val MAX_PARTICIPANTS = 4
-  val ARG_MESSAGE_RES_ID = "legalHoldInfo_messageResId_Arg"
   val ARG_CONV_ID = "legalHoldInfo_convId_Arg"
 
-  def newInstance(messageResId: Int, convId: Option[ConvId]): LegalHoldInfoFragment =
+  def newInstance(convId: Option[ConvId]): LegalHoldInfoFragment =
     returning(new LegalHoldInfoFragment()) { frag =>
       val args = returning(new Bundle()) { b =>
-        b.putInt(ARG_MESSAGE_RES_ID, messageResId)
         convId.foreach(id => b.putString(ARG_CONV_ID, id.str))
       }
       frag.setArguments(args)

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -23,7 +23,7 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity {
     getSupportFragmentManager.beginTransaction()
       .replace(
         R.id.legal_hold_info_fragment_container_layout,
-        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message, None)
+        LegalHoldInfoFragment.newInstance(None)
       ).commit()
 
   override def finish(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/SelfUserLegalHoldInfoActivity.scala
@@ -2,19 +2,13 @@ package com.waz.zclient.legalhold
 
 import android.content.{Context, Intent}
 import android.os.Bundle
-import com.waz.model.UserId
 import com.waz.zclient.{BaseActivity, R}
 import com.waz.zclient.common.views.GlyphButton
-import com.waz.zclient.messages.UsersController
 import com.waz.zclient.utils.RichView
-import com.wire.signals.Signal
 
-class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldSubjectsContainer {
+class SelfUserLegalHoldInfoActivity extends BaseActivity {
 
   private lazy val closeButton = findById[GlyphButton](R.id.legal_hold_info_close_button)
-
-  override lazy val legalHoldUsers: Signal[Seq[UserId]] =
-    inject[UsersController].selfUser.map(user => Seq(user.id))
 
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
@@ -29,7 +23,7 @@ class SelfUserLegalHoldInfoActivity extends BaseActivity with LegalHoldSubjectsC
     getSupportFragmentManager.beginTransaction()
       .replace(
         R.id.legal_hold_info_fragment_container_layout,
-        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message)
+        LegalHoldInfoFragment.newInstance(R.string.legal_hold_self_user_info_message, None)
       ).commit()
 
   override def finish(): Unit = {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -222,7 +222,7 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
           R.anim.slide_out_to_bottom_pick_user)
         .replace(
           R.id.fl__participant__container,
-          LegalHoldInfoFragment.newInstance(R.string.legal_hold_conversation_info_message, Some(convId)),
+          LegalHoldInfoFragment.newInstance(Some(convId)),
           LegalHoldInfoFragment.Tag
         )
         .addToBackStack(LegalHoldInfoFragment.Tag)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Removed `Container` from `LegalHoldInfoFragment`. We now only pass an optional `ConvId` to the fragment to indicate whether we open it for a conversation, or for the self user. `legalHoldUsers` is now calculated inside the fragment, rather than the `Container`. Not the best solution in terms of SRP, but was needed for reusability purposes (I'll make another PR using this).

Nothing should change from user's perspective.

### Testing

Tested manually. 


#### APK
[Download build #3487](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3487/artifact/build/artifact/wire-dev-PR3312-3487.apk)
[Download build #3488](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3488/artifact/build/artifact/wire-dev-PR3312-3488.apk)
[Download build #3489](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3489/artifact/build/artifact/wire-dev-PR3312-3489.apk)