### PR TITLE
Refactor: Legal Hold - Add event to LegalHoldController for opening LH info screen 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -20,6 +20,7 @@ class LegalHoldController(implicit injector: Injector)
   private lazy val userPreferences  = inject[Signal[UserPreferences]]
 
   val showingLegalHoldInfo: SourceStream[Boolean] = EventStream[Boolean]
+  val onShowConversationLegalHoldInfo: SourceStream[Unit] = EventStream[Unit]
 
   val onLegalHoldSubjectClick: SourceStream[UserId] = EventStream[UserId]
   val onAllLegalHoldSubjectsClick: SourceStream[Unit] = EventStream[Unit]

--- a/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/conversation/ConversationManagerFragment.scala
@@ -53,6 +53,7 @@ import com.waz.zclient.utils.ContextUtils
 import com.waz.zclient.views.ConversationFragment
 import com.waz.zclient.{FragmentHelper, R}
 import com.waz.threading.Threading._
+import com.waz.zclient.legalhold.{LegalHoldController, LegalHoldInfoFragment}
 
 class ConversationManagerFragment extends FragmentHelper
   with ConversationScreenControllerObserver
@@ -73,6 +74,7 @@ class ConversationManagerFragment extends FragmentHelper
   private lazy val createConvController   = inject[CreateConversationController]
   private lazy val participantsController = inject[ParticipantsController]
   private lazy val keyboard               = inject[KeyboardController]
+  private lazy val legalHoldController    = inject[LegalHoldController]
 
   private var subs = Set.empty[com.wire.signals.Subscription]
 
@@ -176,6 +178,18 @@ class ConversationManagerFragment extends FragmentHelper
     subs += screenController.hideSketch.onUi { dest =>
       hideFragment(DrawingFragment.Tag)
       if (dest == CAMERA_PREVIEW_VIEW) cameraController.closeCamera(CameraContext.MESSAGE)
+    }
+
+    subs += legalHoldController.onShowConversationLegalHoldInfo.onUi { _ =>
+      findChildFragment[ParticipantFragment](ParticipantFragment.TAG) match {
+        case Some(fragment) => fragment.openLegalHoldInfoScreen()
+        case None =>
+          // open ParticipantFragment to display info screen
+          keyboard.hideKeyboardIfVisible()
+          navigationController.setRightPage(Page.PARTICIPANT, ConversationManagerFragment.Tag)
+          val page = Some(LegalHoldInfoFragment.Tag)
+          showFragment(ParticipantFragment.newInstance(page), ParticipantFragment.TAG)
+      }
     }
   }
 

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -96,6 +96,8 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
             Future.successful((new GuestOptionsFragment, GuestOptionsFragment.Tag))
           case Some(SingleParticipantFragment.DevicesTab.str) =>
             Future.successful((SingleParticipantFragment.newInstance(Some(SingleParticipantFragment.DevicesTab.str)), SingleParticipantFragment.Tag))
+          case Some(LegalHoldInfoFragment.Tag) =>
+            createLegalHoldInfoFragment.map((_, LegalHoldInfoFragment.Tag))
           case _ =>
             participantsController.isGroupOrBot.head.map {
               case true if getStringArg(UserToOpenArg).isEmpty =>
@@ -121,7 +123,6 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       case _ =>
     }
 
-    headerFragment.onLegalHoldClick.onUi { _ => openLegalHoldInfoScreen() }
     legalHoldController.onLegalHoldSubjectClick.onUi { userId => showUser(userId, forLegalHold = true) }
     legalHoldController.onAllLegalHoldSubjectsClick.onUi { _ => showAllLegalHoldSubjects() }
   }
@@ -212,8 +213,8 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
       .addToBackStack(tag)
       .commit
 
-  private def openLegalHoldInfoScreen(): Unit =
-    participantsController.conv.map(_.id).head.foreach(convId =>
+  def openLegalHoldInfoScreen(): Unit =
+    createLegalHoldInfoFragment.foreach(frag =>
       getChildFragmentManager.beginTransaction
         .setCustomAnimations(
           R.anim.slide_in_from_bottom_pick_user,
@@ -222,12 +223,14 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
           R.anim.slide_out_to_bottom_pick_user)
         .replace(
           R.id.fl__participant__container,
-          LegalHoldInfoFragment.newInstance(Some(convId)),
-          LegalHoldInfoFragment.Tag
+          frag, LegalHoldInfoFragment.Tag
         )
         .addToBackStack(LegalHoldInfoFragment.Tag)
         .commit
     )
+
+  private def createLegalHoldInfoFragment: Future[LegalHoldInfoFragment] =
+    participantsController.conv.head.map(conv => LegalHoldInfoFragment.newInstance(Some(conv.id)))
 
   private def showAllLegalHoldSubjects(): Unit =
     withSlideAnimation(getChildFragmentManager.beginTransaction)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantHeaderFragment.scala
@@ -38,7 +38,7 @@ import com.waz.zclient.utils.ContextUtils.{getColor, getDimenPx, getDrawable}
 import com.waz.zclient.utils.{ContextUtils, RichView, ViewUtils, _}
 import com.waz.zclient.views.AvailabilityView
 import com.waz.zclient.{FragmentHelper, ManagerFragment, R}
-import com.wire.signals.{CancellableFuture, EventStream, Signal, SourceStream}
+import com.wire.signals.{CancellableFuture, Signal}
 import scala.concurrent.duration._
 
 class ParticipantHeaderFragment extends FragmentHelper {
@@ -189,8 +189,6 @@ class ParticipantHeaderFragment extends FragmentHelper {
     }
   }
 
-  val onLegalHoldClick: SourceStream[Unit] = EventStream[Unit]()
-
   private lazy val legalHoldIndicatorButton =
     returning(view[ImageButton](R.id.participants_header_toolbar_image_button_legal_hold)) { button =>
       Signal.zip(Signal.from(false, legalHoldController.showingLegalHoldInfo), legalHoldActive).onUi {
@@ -256,7 +254,7 @@ class ParticipantHeaderFragment extends FragmentHelper {
 
   private def setUpLegalHoldIndicator(): Unit =
     legalHoldIndicatorButton.foreach { button =>
-      button.onClick { onLegalHoldClick ! Unit}
+      button.onClick { legalHoldController.onShowConversationLegalHoldInfo ! (()) }
     }
 
   private def fromDeepLink() = getBooleanArg(ARG_FROM_DEEP_LINK)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-346](https://wearezeta.atlassian.net/browse/SQSERVICES-346)

When LH becomes active or inactive for the current conversation, we display system messages. Those system messages will have a clickable part, "Learn More", which should open `LegalHoldInfoFragment` for the conversation when clicked. 

This is the same screen that we open by clicking the header on `ParticipantFragment`. During the conversation, we're inside `ConversationFragment`, hence, `ParticipantFragment` does not exist. Both fragments have the parent `ConversationManagerFragment`.

### Solutions

I created a new event called `onShowConversationLegalHoldInfo` in `LegalHoldController`. Now, whoever wants to see `LegalHoldInfoFragment` can trigger this event, and it'll be picked up by `ConversationManagerFragment` to display the correct screen.

If the `ParticipantFragment` already exists, it simply triggers the `openLegalHoldInfoScreen` method, which already exists (this is the previous flow). If no `ParticipantFragment` exist yet (as in system message case), we create a new one and have it open `LegalHoldInfoFragment` as the first screen.


#### APK
[Download build #3498](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3498/artifact/build/artifact/wire-dev-PR3313-3498.apk)