### PR TITLE
Refactor: Confirmation Menu - Add neutral button

### DIFF
--- a/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationCallback.java
+++ b/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationCallback.java
@@ -20,6 +20,7 @@ package com.waz.zclient.controllers.confirmation;
 public interface ConfirmationCallback {
     void positiveButtonClicked(boolean checkboxIsSelected);
     void negativeButtonClicked();
+    default void neutralButtonClicked() {}
     void canceled();
     void onHideAnimationEnd(boolean confirmed, boolean canceled, boolean checkboxIsSelected);
 }

--- a/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationRequest.java
+++ b/app/src/main/java/com/waz/zclient/controllers/confirmation/ConfirmationRequest.java
@@ -20,6 +20,7 @@ package com.waz.zclient.controllers.confirmation;
 import android.text.TextUtils;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.Nullable;
 
 import com.waz.zclient.ui.theme.OptionsTheme;
 
@@ -28,6 +29,8 @@ public class ConfirmationRequest {
     public String message;
     public String positiveButton;
     public String negativeButton;
+    @Nullable
+    public String neutralButton;
     public boolean cancelVisible;
     public String checkboxLabel;
     public boolean checkboxSelectedByDefault;
@@ -64,6 +67,11 @@ public class ConfirmationRequest {
 
         public Builder withNegativeButton(String negativeButton) {
             confirmationRequest.negativeButton = negativeButton;
+            return this;
+        }
+
+        public Builder withNeutralButton(String neutralButton) {
+            confirmationRequest.neutralButton = neutralButton;
             return this;
         }
 

--- a/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
+++ b/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
@@ -63,6 +63,9 @@ public class ConfirmationMenu extends LinearLayout {
     private ZetaButton positiveButton;
     private GlyphTextView cancelButton;
     private ZetaButton negativeButton;
+    private ZetaButton neutralButton;
+    private LinearLayout buttonsLayout;
+    private View buttonSeparator;
     private CheckBoxView checkBoxView;
     private ImageView headerIconView;
     private ImageView backgroundImageView;
@@ -89,6 +92,10 @@ public class ConfirmationMenu extends LinearLayout {
                     break;
                 case R.id.negative:
                     callback.negativeButtonClicked();
+                    animateToShow(false);
+                    break;
+                case R.id.neutral:
+                    callback.neutralButtonClicked();
                     animateToShow(false);
                     break;
                 case R.id.cancel:
@@ -141,9 +148,12 @@ public class ConfirmationMenu extends LinearLayout {
 
     public void setNegativeButton(String text) {
         updateText(negativeButton, text);
-        if (negativeButton.getVisibility() == GONE) {
-            ViewUtils.setMarginLeft(positiveButton, 0);
-        }
+        updateButtonsLayout();
+    }
+
+    public void setNeutralButton(String text) {
+        updateText(neutralButton, text);
+        updateButtonsLayout();
     }
 
     public void setCancelVisible(boolean visible) {
@@ -176,14 +186,29 @@ public class ConfirmationMenu extends LinearLayout {
         }
     }
 
+    // if 3 buttons are visible, show them vertically stacked.
+    // if 2 buttons are visible, show them side by side (horizontally)
+    // if 1 button is visible, it stretches to fill whole screen
+    private void updateButtonsLayout() {
+        if (neutralButton.getVisibility() == GONE) {
+            buttonsLayout.setOrientation(LinearLayout.HORIZONTAL);
+            buttonSeparator.setVisibility(negativeButton.getVisibility());
+        } else {
+            buttonsLayout.setOrientation(LinearLayout.VERTICAL);
+        }
+    }
+
     public void setButtonColor(int color) {
         positiveButton.setIsFilled(true);
         positiveButton.setAccentColor(color);
 
         negativeButton.setIsFilled(false);
         negativeButton.setAccentColor(color);
+        neutralButton.setIsFilled(false);
+        neutralButton.setAccentColor(color);
         if (optionsTheme != null && optionsTheme.getType() == OptionsTheme.Type.LIGHT) {
             negativeButton.setTextColor(color);
+            neutralButton.setTextColor(color);
         }
 
         backgroundImageView.setColorFilter(ColorUtils.injectAlpha(0.1f, color));
@@ -322,6 +347,12 @@ public class ConfirmationMenu extends LinearLayout {
         negativeButton.setText(negativeButtonText);
         negativeButton.setOnClickListener(onClickListener);
 
+        neutralButton = ViewUtils.getView(this, R.id.neutral);
+        neutralButton.setOnClickListener(onClickListener);
+
+        buttonsLayout = ViewUtils.getView(this, R.id.confirmation_menu_buttons_layout);
+        buttonSeparator = ViewUtils.getView(this, R.id.confirmation_menu_button_separator);
+
         cancelButton = ViewUtils.getView(this, R.id.cancel);
         cancelButton.setVisibility(cancelVisible ? VISIBLE : GONE);
         cancelButton.setOnClickListener(onClickListener);
@@ -352,6 +383,7 @@ public class ConfirmationMenu extends LinearLayout {
         checkBoxView.setOptionsTheme(optionsTheme);
         if (optionsTheme.getType() == OptionsTheme.Type.DARK) {
             negativeButton.setTextColor(optionsTheme.getTextColorPrimary());
+            neutralButton.setTextColor(optionsTheme.getTextColorPrimary());
         }
         setBackground(optionsTheme.getOverlayColor());
     }
@@ -367,6 +399,7 @@ public class ConfirmationMenu extends LinearLayout {
         setText(confirmationRequest.message);
         setPositiveButton(confirmationRequest.positiveButton);
         setNegativeButton(confirmationRequest.negativeButton);
+        setNeutralButton(confirmationRequest.neutralButton);
         setCancelVisible(confirmationRequest.cancelVisible);
         setIcon(confirmationRequest.headerIconRes);
         setBackgroundImage(confirmationRequest.backgroundImage);

--- a/app/src/main/res/layout/confirmation_menu_light.xml
+++ b/app/src/main/res/layout/confirmation_menu_light.xml
@@ -19,10 +19,10 @@
 
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             xmlns:app="http://schemas.android.com/apk/res-auto"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <FrameLayout
         android:id="@+id/fl__confirmation_dialog__background"
@@ -90,18 +90,18 @@
             />
 
         <LinearLayout
+            android:id="@+id/confirmation_menu_buttons_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:paddingTop="@dimen/framework_confirmation_menu_button_padding_top"
             >
 
             <com.waz.zclient.ui.views.ZetaButton
                 android:id="@+id/negative"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/framework_confirmation_menu_button_height"
                 android:layout_marginBottom="@dimen/framework_confirmation_menu_button_padding_bottom"
-                android:layout_marginEnd="@dimen/framework_confirmation_menu_button_space_between"
-                android:layout_marginTop="@dimen/framework_confirmation_menu_button_padding_top"
                 android:layout_weight="1"
                 android:gravity="center"
                 android:minHeight="@dimen/touch_target_buttons"
@@ -112,14 +112,32 @@
                 android:textAllCaps="true"
                 />
 
+            <com.waz.zclient.ui.views.ZetaButton
+                android:id="@+id/neutral"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/framework_confirmation_menu_button_height"
+                android:layout_marginBottom="@dimen/framework_confirmation_menu_button_padding_bottom"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:minHeight="@dimen/touch_target_buttons"
+                android:minWidth="@dimen/touch_target_buttons"
+                android:textColor="@color/framework_confirmation_menu_button"
+                android:textSize="@dimen/wire__text_size__small"
+                app:w_font="@string/wire__typeface__light"
+                android:textAllCaps="true"
+                android:visibility="gone"
+                />
+
+            <View
+                android:id="@+id/confirmation_menu_button_separator"
+                android:layout_width="@dimen/wire__padding__16"
+                android:layout_height="0dp"/>
 
             <com.waz.zclient.ui.views.ZetaButton
                 android:id="@+id/positive"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/framework_confirmation_menu_button_height"
                 android:layout_marginBottom="@dimen/framework_confirmation_menu_button_padding_bottom"
-                android:layout_marginStart="@dimen/framework_confirmation_menu_button_space_between"
-                android:layout_marginTop="@dimen/framework_confirmation_menu_button_padding_top"
                 android:layout_weight="1"
                 android:gravity="center"
                 android:minHeight="@dimen/touch_target_buttons"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -254,7 +254,7 @@
     <dimen name="framework_confirmation_menu_button_corner_radius">@dimen/button__corner_radius</dimen>
     <dimen name="framework_confirmation_menu_button_height">40dp</dimen>
     <dimen name="framework_confirmation_menu_button_padding_top">24dp</dimen>
-    <dimen name="framework_confirmation_menu_button_padding_bottom">0dp</dimen>
+    <dimen name="framework_confirmation_menu_button_padding_bottom">8dp</dimen>
     <dimen name="framework_confirmation_menu_button_space_between">8dp</dimen>
     <dimen name="framework_confirmation_menu_button_max_width">204dp</dimen>
     <dimen name="framework__checkbox__dimension">24dp</dimen>


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira issue: [SQSERVICES-462](https://wearezeta.atlassian.net/browse/SQSERVICES-462)

When legal hold is discovered in a conversation, then we must alert the user and ask for a confirmation to send messages (see [SQSERVICES-436](https://wearezeta.atlassian.net/browse/SQSERVICES-436)). This confirmation message can have 3 options. Our current confirmation screen supports only 2 options.

### Solutions

Added a 3rd, optional, "neutral" button to ConfirmationMenu. When neutral button is not set, the UI looks same as before, with horizontally placed buttons. When the neutral button is set, we display the buttons vertically.

### Testing

Manually tested by mocking some values on existing use cases.

| 2 Buttons | 3 Buttons |
|---|---|
| <img src="https://user-images.githubusercontent.com/2143283/119013648-7e97a600-b997-11eb-8f67-ccde4026730a.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/2143283/119013560-6758b880-b997-11eb-8456-b78f6416817b.png" width="300px" /> |

#### APK
[Download build #3502](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3502/artifact/build/artifact/wire-dev-PR3316-3502.apk)