### PR TITLE
Add ui automation locators for LH indicator

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,7 +539,7 @@
     <string name="pref_devices_device_id">ID: %1$s</string>
     <string name="pref_devices_device_verified">Verified</string>
     <string name="pref_devices_device_not_verified">Not verified</string>
-    <string name="pref_devices_device_legal_hold">Legal Hold device</string>
+    <string name="legal_hold_device_content_description">Legal Hold device</string>
     <string name="pref_devices_warning_summary">If you don\'t recognize a device above, remove it and reset your passcode.</string>
     <string name="pref_devices_device_screen_title">Device details</string>
     <string name="pref_devices_device_fingerprint_category_title">Key Fingerprint</string>

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -140,14 +140,15 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
     pendingApproval <- legalHoldController.hasPendingRequest
   } yield (legalHoldActive, pendingApproval))
     .map {
-      case (true, _)     => Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_active))
-      case (false, true) => Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_pending))
-      case _             => None
+      case (true, _)     => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_active)), "Active")
+      case (false, true) => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_pending)), "Pending approval")
+      case _             => (None, "")
     }
-    .onUi {
-      case Some(drawable) => legalHoldIndicatorButton.setVisible(true)
-                             legalHoldIndicatorButton.setImageDrawable(drawable)
-      case None           => legalHoldIndicatorButton.setVisibility(View.INVISIBLE)
+    .onUi { params =>
+      val (drawable, contentDesc) = params
+      legalHoldIndicatorButton.setVisibility(if (drawable.isDefined) View.VISIBLE else View.INVISIBLE)
+      drawable.foreach(legalHoldIndicatorButton.setImageDrawable)
+      legalHoldIndicatorButton.setContentDescription(contentDesc)
     }
 
   def setIndicatorVisible(visible: Boolean): Unit = settingsIndicator.setVisible(visible)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -94,6 +94,8 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null)
 
+  import NormalTopToolbar._
+
   private val drawable = new TeamIconDrawable
 
   private val profileButton = returning(findById[ImageView](R.id.conversation_list_settings)) { button =>
@@ -140,8 +142,8 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
     pendingApproval <- legalHoldController.hasPendingRequest
   } yield (legalHoldActive, pendingApproval))
     .map {
-      case (true, _)     => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_active)), "Active")
-      case (false, true) => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_pending)), "Pending approval")
+      case (true, _)     => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_active)), LegalHoldActive)
+      case (false, true) => (Some(ContextCompat.getDrawable(context, R.drawable.ic_legal_hold_pending)), LegalHoldPendingApproval)
       case _             => (None, "")
     }
     .onUi { params =>
@@ -159,6 +161,10 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
     profileButton.setImageDrawable(if (loading) getDrawable(R.drawable.list_row_chathead_loading) else drawable)
 }
 
+object NormalTopToolbar {
+  val LegalHoldActive = "Active"
+  val LegalHoldPendingApproval = "Pending approval"
+}
 
 class ArchiveTopToolbar(override val context: Context, override val attrs: AttributeSet, override val defStyleAttr: Int)
   extends ConversationListTopToolbar(context, attrs, defStyleAttr){

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
@@ -183,7 +183,7 @@ object ParticipantOtrDeviceAdapter {
 
       ViewUtils.getView[ImageView](itemView, R.id.iv__row_otr_icon).setImageResource(
         if (client.isLegalHoldDevice) {
-          textView.setContentDescription(itemView.context.getString(R.string.pref_devices_device_legal_hold))
+          textView.setContentDescription(itemView.context.getString(R.string.legal_hold_device_content_description))
           R.drawable.ic_legal_hold_active
         } else if (client.verified == Verification.VERIFIED) {
           textView.setContentDescription("Device " + itemView.context.getString(R.string.pref_devices_device_verified))


### PR DESCRIPTION
## What's new in this PR?

[SQSERVICES-342](https://wearezeta.atlassian.net/browse/SQSERVICES-342)
Added locators to legal hold indicator icon on conversation list toolbar for UI automation.
Updated string resource name of legal hold device locator.


#### APK
[Download build #3509](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3509/artifact/build/artifact/wire-dev-PR3318-3509.apk)
[Download build #3510](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3510/artifact/build/artifact/wire-dev-PR3318-3510.apk)