### PR TITLE
[Fix] Add legal hold device description

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -870,6 +870,7 @@
     <string name="otr__participant__device_header">Wire gives every device a unique fingerprint. Compare them with %1$s and verify your conversation.</string>
     <string name="otr__participant__device_header__no_devices">%1$s is using an old version of Wire. No devices are shown here.</string>
     <string name="otr__participant__device_header__link_text">_Why verify conversations?_</string>
+    <string name="otr__participant__device_class__unknown">Unknown</string>
     <string name="otr__participant__device_class__phone">Phone</string>
     <string name="otr__participant__device_class__tablet">Tablet</string>
     <string name="otr__participant__device_class__desktop">Desktop computer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -870,7 +870,6 @@
     <string name="otr__participant__device_header">Wire gives every device a unique fingerprint. Compare them with %1$s and verify your conversation.</string>
     <string name="otr__participant__device_header__no_devices">%1$s is using an old version of Wire. No devices are shown here.</string>
     <string name="otr__participant__device_header__link_text">_Why verify conversations?_</string>
-    <string name="otr__participant__device_class__unknown">Unknown</string>
     <string name="otr__participant__device_class__phone">Phone</string>
     <string name="otr__participant__device_class__tablet">Tablet</string>
     <string name="otr__participant__device_class__desktop">Desktop computer</string>

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -134,6 +134,7 @@ object ClientsController {
       case Phone     => R.string.otr__participant__device_class__phone
       case Tablet    => R.string.otr__participant__device_class__tablet
       case LegalHold => R.string.otr__participant__device_class__legal_hold
+      case _         => R.string.otr__participant__device_class__unknown
     })
   }
 

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -130,10 +130,10 @@ object ClientsController {
   def getDeviceClassName(otrType: DeviceClass)(implicit context: Context): String = {
     import DeviceClass._
     getString(otrType match {
-      case Desktop  => R.string.otr__participant__device_class__desktop
-      case Phone    => R.string.otr__participant__device_class__phone
-      case Tablet   => R.string.otr__participant__device_class__tablet
-      case _        => R.string.otr__participant__device_class__unknown
+      case Desktop   => R.string.otr__participant__device_class__desktop
+      case Phone     => R.string.otr__participant__device_class__phone
+      case Tablet    => R.string.otr__participant__device_class__tablet
+      case LegalHold => R.string.otr__participant__device_class__legal_hold
     })
   }
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
@@ -117,7 +117,7 @@ object ParticipantOtrDeviceAdapter {
       case DeviceClass.Phone     => R.string.otr__participant__device_class__phone
       case DeviceClass.Tablet    => R.string.otr__participant__device_class__tablet
       case DeviceClass.LegalHold => R.string.otr__participant__device_class__legal_hold
-      case _                       => R.string.otr__participant__device_class__unknown
+      case _                     => R.string.otr__participant__device_class__unknown
     }
   )
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
@@ -117,7 +117,6 @@ object ParticipantOtrDeviceAdapter {
       case DeviceClass.Phone     => R.string.otr__participant__device_class__phone
       case DeviceClass.Tablet    => R.string.otr__participant__device_class__tablet
       case DeviceClass.LegalHold => R.string.otr__participant__device_class__legal_hold
-      case _                     => R.string.otr__participant__device_class__unknown
     }
   )
 

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantOtrDeviceAdapter.scala
@@ -117,6 +117,7 @@ object ParticipantOtrDeviceAdapter {
       case DeviceClass.Phone     => R.string.otr__participant__device_class__phone
       case DeviceClass.Tablet    => R.string.otr__participant__device_class__tablet
       case DeviceClass.LegalHold => R.string.otr__participant__device_class__legal_hold
+      case _                     => R.string.otr__participant__device_class__unknown
     }
   )
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When looking at the device info screen of a legal hold device, the type label says "UNKNOWN".

### Causes

We aren't checking for the legal hold device class, so we fallback on the unknown string.

### Solutions

Also match against the legal hold device class.


#### APK
[Download build #3516](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3516/artifact/build/artifact/wire-dev-PR3320-3516.apk)