### PR TITLE
Fix: Legal Hold request popup on small screens

### DIFF
--- a/app/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
+++ b/app/src/main/java/com/waz/zclient/ui/utils/KeyboardUtils.java
@@ -45,6 +45,10 @@ public class KeyboardUtils {
         }
     }
 
+    public static void hideKeyboard(View view) {
+        getInputMethodManager(view.getContext()).hideSoftInputFromWindow(view.getWindowToken(), 0);
+    }
+
     public static boolean showKeyboard(Activity activity) {
         if (activity != null && activity.getCurrentFocus() != null) {
             getInputMethodManager(activity).showSoftInput(activity.getCurrentFocus(), InputMethodManager.SHOW_IMPLICIT);

--- a/app/src/main/res/layout/confirmation_with_password_dialog.xml
+++ b/app/src/main/res/layout/confirmation_with_password_dialog.xml
@@ -18,19 +18,27 @@
 
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingStart="@dimen/prefs__dialog__padding"
-    android:paddingEnd="@dimen/prefs__dialog__padding">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <ScrollView
-        android:id="@+id/confirmation_with_password_scrollview"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:overScrollMode="ifContentScrolls">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/prefs__dialog__padding"
+        android:paddingEnd="@dimen/prefs__dialog__padding">
+
+        <com.waz.zclient.ui.text.TypefaceTextView
+            android:id="@+id/confirmation_with_password_message_text_view"
+            style="@style/TextAppearance.AppCompat.Subhead"
+            android:layout_marginTop="@dimen/wire__padding__12"
+            android:layout_marginStart="@dimen/wire__padding__4"
+            android:layout_marginEnd="@dimen/wire__padding__4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/confirmation_with_password_text_input_layout"
@@ -46,17 +54,18 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-    </ScrollView>
+        <com.waz.zclient.ui.text.TypefaceTextView
+            android:id="@+id/confirmation_with_password_forgot_password_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/wire__padding__4"
+            android:text="@string/new_reg__password__forgot"
+            android:textAllCaps="true"
+            android:textColor="@color/accent_blue"
+            android:textSize="@dimen/wire__text_size__small"
+            app:w_font="@string/wire__typeface__medium" />
 
-    <com.waz.zclient.ui.text.TypefaceTextView
-        android:id="@+id/confirmation_with_password_forgot_password_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/wire__padding__4"
-        android:text="@string/new_reg__password__forgot"
-        android:textAllCaps="true"
-        android:textColor="@color/accent_blue"
-        android:textSize="@dimen/wire__text_size__small"
-        app:w_font="@string/wire__typeface__medium" />
+    </LinearLayout>
 
-</LinearLayout>
+</ScrollView>
+

--- a/app/src/main/res/layout/confirmation_with_password_dialog.xml
+++ b/app/src/main/res/layout/confirmation_with_password_dialog.xml
@@ -21,8 +21,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1601,8 +1601,8 @@
     <string name="legal_hold_conversation_info_message">Legal Hold has been activated for at least one person in this conversation.\n\nAll Messages will be preserved for future access, including deleted, edited, and timed messages.</string>
     <string name="legal_hold_info_list_title">Legal Hold Subjects</string>
     <string name="legal_hold_request_dialog_title">Legal Hold Requested</string>
-    <string name="legal_hold_request_dialog_message_for_sso">All future messages will be recorded by the device with fingerprint:\n%1$s\nThis includes deleted, edited and timed messages in all conversations.</string>
-    <string name="legal_hold_request_dialog_message">All future messages will be recorded by the device with fingerprint:\n%1$s\nThis includes deleted, edited and timed messages in all conversations.\n\nEnter your password to confirm.</string>
+    <string name="legal_hold_request_dialog_message_for_sso">All future messages will be recorded by the device with fingerprint:\n%1$sThis includes deleted, edited and timed messages in all conversations.</string>
+    <string name="legal_hold_request_dialog_message">All future messages will be recorded by the device with fingerprint:\n%1$sThis includes deleted, edited and timed messages in all conversations.\nEnter your password to confirm.</string>
     <string name="legal_hold_request_dialog_positive_button_text">Accept</string>
     <string name="legal_hold_request_dialog_negative_button_text">Not Now</string>
     <string name="legal_hold_request_dialog_wrong_password_error">Wrong password</string>

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
@@ -13,6 +13,7 @@ import com.waz.model.AccountData.Password
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.ui.text.TypefaceTextView
+import com.waz.zclient.ui.utils.KeyboardUtils
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{FragmentHelper, R}
 import com.wire.signals.EventStream
@@ -25,8 +26,14 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
   private lazy val root = LayoutInflater.from(getActivity).inflate(R.layout.confirmation_with_password_dialog, null)
 
   private def providePassword(password: Option[Password]): Unit = {
+    KeyboardUtils.hideKeyboard(textInputLayout)
     onAccept ! password
     dismiss() // if the password is wrong a new dialog will appear
+  }
+
+  private def onNegativeClick(): Unit = {
+    KeyboardUtils.hideKeyboard(textInputLayout)
+    onDecline ! (())
   }
 
   private lazy val passwordEditText = returning(findById[EditText](root, R.id.confirmation_with_password_edit_text)) { v =>
@@ -51,12 +58,12 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
   private lazy val dialogClickListener = new DialogInterface.OnClickListener {
     override def onClick(dialog: DialogInterface, which: Int): Unit = which match {
       case DialogInterface.BUTTON_POSITIVE => providePassword(if (isSSO) None else Some(Password(passwordEditText.getText.toString)))
-      case DialogInterface.BUTTON_NEGATIVE => onDecline ! (())
+      case DialogInterface.BUTTON_NEGATIVE => onNegativeClick()
       case _ =>
     }
   }
 
-  def isSSO : Boolean
+  def isSSO: Boolean
   def errorMessage: Option[String]
   def title: String
   def message: String

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
@@ -4,7 +4,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.inputmethod.EditorInfo
-import android.view.{KeyEvent, LayoutInflater, View, WindowManager}
+import android.view.{KeyEvent, LayoutInflater, WindowManager}
 import android.widget.{EditText, TextView}
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
@@ -12,6 +12,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.waz.model.AccountData.Password
 import com.waz.utils.returning
 import com.waz.zclient.common.controllers.BrowserController
+import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.RichView
 import com.waz.zclient.{FragmentHelper, R}
 import com.wire.signals.EventStream
@@ -40,6 +41,7 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
     })
   }
 
+  private lazy val messageTextView = findById[TypefaceTextView](root, R.id.confirmation_with_password_message_text_view)
   private lazy val textInputLayout = findById[TextInputLayout](root, R.id.confirmation_with_password_text_input_layout)
 
   private lazy val forgotPasswordButton = returning(findById[TextView](root, R.id.confirmation_with_password_forgot_password_button)) {
@@ -62,17 +64,14 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
   def negativeButtonText: Int
 
   override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
-    if(isSSO){
-      findById[View](root, R.id.confirmation_with_password_scrollview).setVisible(false)
-    }
     passwordEditText.setVisible(!isSSO)
     textInputLayout.setVisible(!isSSO)
     forgotPasswordButton.setVisible(!isSSO)
+    messageTextView.setText(message)
     errorMessage.foreach(textInputLayout.setError)
     new AlertDialog.Builder(getActivity)
       .setView(root)
       .setTitle(title)
-      .setMessage(message)
       .setPositiveButton(positiveButtonText, dialogClickListener)
       .setNegativeButton(negativeButtonText, dialogClickListener)
       .create


### PR DESCRIPTION
## What's new in this PR?

### Issues

In small screens, the buttons for the LH request pop up weren't visible because of the keyboard

<img src="https://user-images.githubusercontent.com/2143283/119164403-ae5cb180-ba5c-11eb-9010-17202e2229b6.png" width="300px"/>

### Causes

The `AlertDialog` tries to make whole `message` visible.

### Solutions

- Instead of the `AlertDialog`'s built-in `message` property, I added a new `TextView` for the message to our custom view, and wrapped everything inside a `ScrollView` so that the content can shrink and becomes scrollable. I used the `AlertDialog`'s message style, `TextAppearance.AppCompat.Subhead`, for the new TextView in order to keep native look.
- As an extra effort, I deleted excessive blank lines from text message.
- When we close the dialog with either one of the buttons, the keyboard used to stay visible since `MainActivity` couldn't handle that properly. Added a `hideKeyboard` method to prevent this.

<img src="https://user-images.githubusercontent.com/2143283/119164671-f380e380-ba5c-11eb-9177-93621eef1b62.png" width="300px"/>

### Testing

This pop up shares code with `RemoveDeviceDialog`. However, since it was already a compact dialog, nothing is changed UI-wise. I tested both pop ups in small in big screens.


#### APK
[Download build #3517](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3517/artifact/build/artifact/wire-dev-PR3321-3517.apk)