### PR TITLE
[Fix] Legal hold info list out of sync

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -58,11 +58,14 @@ class LegalHoldServiceImpl(selfUserId: UserId,
     case LegalHoldRequestEvent(userId, request) if userId == selfUserId =>
       storeLegalHoldRequest(request)
 
-    case LegalHoldEnableEvent(userId) if userId == selfUserId =>
-      onLegalHoldApprovedFromAnotherDevice()
+    case LegalHoldEnableEvent(userId) =>
+      if (userId == selfUserId) onLegalHoldApprovedFromAnotherDevice()
+      else sync.syncClients(userId).map(_ => ())
 
-    case LegalHoldDisableEvent(userId) if userId == selfUserId =>
-      onLegalHoldDisabled()
+
+    case LegalHoldDisableEvent(userId) =>
+      if (userId == selfUserId) onLegalHoldDisabled()
+      else  sync.syncClients(userId).map(_ => ())
 
     case _ =>
       Future.successful({})

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -299,6 +299,11 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
 
+      (sync.syncClients(_: UserId))
+        .expects(*)
+        .anyNumberOfTimes()
+        .returning(Future.successful(SyncId("syncId")))
+
       // When
       result(pipeline.apply(Seq(LegalHoldEnableEvent(UserId("someOtherUser")))))
 
@@ -322,6 +327,11 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       // Given
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
+
+      (sync.syncClients(_: UserId))
+        .expects(*)
+        .anyNumberOfTimes()
+        .returning(Future.successful(SyncId("syncId")))
 
       // When
       result(pipeline.apply(Seq(LegalHoldDisableEvent(UserId("someOtherUser")))))

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -330,6 +330,36 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       result(userPrefs.preference(UserPreferences.LegalHoldRequest).apply()).isEmpty shouldBe false
     }
 
+    scenario("it syncs clients when legal hold is enabled for another user") {
+      // Given
+      val otherUserId = UserId("someOtherUser")
+      val pipeline = createEventPipeline()
+
+      // Expectation
+      (sync.syncClients(_: UserId))
+          .expects(otherUserId)
+          .once()
+          .returning(Future.successful(SyncId("syncId")))
+
+      // When
+      result(pipeline.apply(Seq(LegalHoldEnableEvent(otherUserId))))
+    }
+
+    scenario("it syncs clients when legal hold is disabled for another user") {
+      // Given
+      val otherUserId = UserId("someOtherUser")
+      val pipeline = createEventPipeline()
+
+      // Expectation
+      (sync.syncClients(_: UserId))
+        .expects(otherUserId)
+        .once()
+        .returning(Future.successful(SyncId("syncId")))
+
+      // When
+      result(pipeline.apply(Seq(LegalHoldDisableEvent(otherUserId))))
+    }
+
   }
 
   feature("Approve legal hold request") {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The legal hold info page shows the list of all legal hold subjects in the conversation. However, it doesn't always show all the legal hold subjects.

### Causes

The list only displays discovered subjects, which may only happen after the conversation is opened or a message is sent. Even if legal hold is discovered generally, some users may become subjects before their clients are discovered, so they won't appear in the list of subjects just yet.

### Solutions

We get update events when the legal hold status of other users changes, so we request a sync of their clients when this happens, which will allow us to discover their legal hold devices.

### Testing

Added unit tests that we request a sync of the user clients when:

1. the non-self user has legal hold enabled
2. the non-self user has legal hold disabled

#### APK
[Download build #3525](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3525/artifact/build/artifact/wire-dev-PR3323-3525.apk)