### PR TITLE
Chore: Add QA automation locator for legal hold icon on share sheet

### DIFF
--- a/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
@@ -349,6 +349,8 @@ case class SelectableConversationRowViewHolder(view: SelectableConversationRow)(
     with Injectable
     with DerivedLogTag {
 
+  import SelectableConversationRowViewHolder._
+
   private val conversationId = Signal[ConvId]()
   private lazy val convController = inject[ConversationController]
   private lazy val legalHoldController = inject[LegalHoldController]
@@ -364,10 +366,11 @@ case class SelectableConversationRowViewHolder(view: SelectableConversationRow)(
     cid      <- conversationId
     lhActive <- legalHoldController.isLegalHoldActive(cid)
   } yield lhActive).map {
-    case true  => Some(R.drawable.ic_legal_hold_active)
-    case false => None
-  }.onUi { iconRes =>
+    case true  => (Some(R.drawable.ic_legal_hold_active), LegalHoldLocator)
+    case false => (None, "")
+  }.onUi { case (iconRes, contentDesc) =>
     view.nameView.setCompoundDrawablesWithIntrinsicBounds(0, 0, iconRes.getOrElse(0), 0)
+    view.nameView.setContentDescription(contentDesc)
   }
 
   def setConversation(convId: ConvId, checked: Boolean): Unit = {
@@ -376,6 +379,10 @@ case class SelectableConversationRowViewHolder(view: SelectableConversationRow)(
     view.checkBox.setTag(convId)
     conversationId ! convId
   }
+}
+
+object SelectableConversationRowViewHolder {
+  val LegalHoldLocator = "Legal hold active"
 }
 
 class SelectableConversationRow(context: Context, checkBoxListener: CompoundButton.OnCheckedChangeListener) extends LinearLayout(context, null, 0) {


### PR DESCRIPTION
## What's new in this PR?

[SQSERVICES-347](https://wearezeta.atlassian.net/browse/SQSERVICES-347)

Appium cannot resolve compound drawables, so QA needs a locator for legal hold indicator icon on share sheet.
#### APK
[Download build #3526](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3526/artifact/build/artifact/wire-dev-PR3324-3526.apk)