### PR TITLE
Refactor: Blocked Participant Screen - Add LinkTextView support

### DIFF
--- a/app/src/main/res/layout/participant_linked_info_row.xml
+++ b/app/src/main/res/layout/participant_linked_info_row.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/wire__padding__16"
+    android:paddingTop="@dimen/wire__padding__16"
+    android:paddingEnd="@dimen/wire__padding__16"
+    style="?wireBackground"
+    >
+
+    <com.waz.zclient.common.views.LinkTextView
+        android:id="@+id/participant_linked_info_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:lineSpacingExtra="@dimen/wire__text_spacing__medium"
+        android:textColor="?wirePrimaryTextColor"
+        android:textSize="@dimen/wire__text_size__regular_small"
+        app:w_font="@string/wire__typeface__light"/>
+
+</LinearLayout>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/BaseSingleParticipantAdapter.scala
@@ -87,6 +87,7 @@ object BaseSingleParticipantAdapter {
   val GroupAdmin   = 2
   val ReadReceipts = 3
   val UserName     = 4
+  val LinkedInfo   = 5
 
   case class ParticipantHeaderRowViewHolder(view: View) extends ViewHolder(view) {
     private lazy val imageView            = view.findViewById[ChatHeadView](R.id.chathead)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -1,10 +1,8 @@
 package com.waz.zclient.participants.fragments
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
-import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{ConversationRole, UserData, UserId}
 import com.waz.service.ZMessaging
 import com.wire.signals.CancellableFuture


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a user is blocked due to Legal Hold, we want to show an info text with a clickable part ([SQSERVICES-448](https://wearezeta.atlassian.net/browse/SQSERVICES-448)) There is no such field in the current design, so we need to add it.

### Solutions

Added a new `LinkedInfoViewHolder` to be used on `UnconnectedParticipantAdapter`, which is the adapter that `BlockedUserFragment` uses. Exposed 2 new methods, 

`protected def linkedText(user: UserData): Future[Option[(String, Int)]] ` and
`protected def onLinkedTextClick()`

to handle the text and click event.

`BlockedUserFragment` can override those 2 methods to display Legal Hold message.

### Testing

Manually tested all places that uses `UnconnectedParticipantAdapter`: `BlockedUserFragment`, `ConnectRequestFragment`, `PendingConnectRequestFragment` and `SendConnectRequestFragment`.

| Self user is an admin | Self user is not an admin |
| ----| ----|
| <img src="https://user-images.githubusercontent.com/2143283/119514890-af038980-bd75-11eb-873d-9e72750993e5.png" width="300px"/> | <img src="https://user-images.githubusercontent.com/2143283/119514933-b88cf180-bd75-11eb-94df-ea4f97de7c1b.png" width="300px" /> |


#### APK
[Download build #3530](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3530/artifact/build/artifact/wire-dev-PR3327-3530.apk)