### PR TITLE
refactor: Remove exact match search

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -129,10 +129,6 @@ object SyncRequest {
     override val mergeKey: Any = (cmd, query)
   }
 
-  final case class ExactMatchHandle(handle: Handle) extends BaseRequest(Cmd.ExactMatchHandle) {
-    override val mergeKey: Any = (cmd, handle)
-  }
-
   final case class SyncRichMedia(messageId: MessageId) extends BaseRequest(Cmd.SyncRichMedia) {
     override val mergeKey: Any = (cmd, messageId)
   }
@@ -415,7 +411,6 @@ object SyncRequest {
           case Cmd.SyncConvLink              => SyncConvLink('conv)
           case Cmd.SyncSearchQuery           => SyncSearchQuery(SearchQuery.fromCacheKey(decodeString('queryCacheKey)))
           case Cmd.SyncSearchResults         => SyncSearchResults(users)
-          case Cmd.ExactMatchHandle          => ExactMatchHandle(Handle(decodeString('handle)))
           case Cmd.PostConv                  => PostConv(convId, decodeStringSeq('users).map(UserId(_)).toSet, 'name, 'team, 'access, 'access_role, 'receipt_mode, 'default_role)
           case Cmd.PostConvName              => PostConvName(convId, 'name)
           case Cmd.PostConvReceiptMode       => PostConvReceiptMode(convId, 'receipt_mode)
@@ -510,7 +505,6 @@ object SyncRequest {
           putId("message", messageId)
           putId("button", buttonId)
           putId("sender", senderId)
-        case ExactMatchHandle(handle)         => o.put("handle", handle.string)
         case SyncTeamMember(userId)           => o.put("user", userId.str)
         case DeletePushToken(token)           => putId("token", token)
         case RegisterPushToken(token)         => putId("token", token)

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -42,7 +42,6 @@ import scala.concurrent.duration._
 trait SyncServiceHandle {
   def syncSearchResults(ids: Set[UserId]): Future[SyncId]
   def syncSearchQuery(query: SearchQuery): Future[SyncId]
-  def exactMatchHandle(handle: Handle): Future[SyncId]
   def syncUsers(ids: Set[UserId]): Future[SyncId]
   def syncSelfUser(): Future[SyncId]
   def deleteAccount(): Future[SyncId]
@@ -147,7 +146,6 @@ class AndroidSyncServiceHandle(account:         UserId,
   def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users))
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
   def syncUsers(ids: Set[UserId]) = addRequest(SyncUser(ids))
-  def exactMatchHandle(handle: Handle) = addRequest(ExactMatchHandle(handle), priority = Priority.High)
   def syncSelfUser() = addRequest(SyncSelf, priority = Priority.High)
   def deleteAccount() = addRequest(DeleteAccount)
   def syncConversations(ids: Set[ConvId], dependsOn: Option[SyncId]) =
@@ -276,7 +274,6 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case SyncUser(u)                                     => zms.usersSync.syncUsers(u.toSeq: _*)
           case SyncSearchResults(u)                            => zms.usersSync.syncSearchResults(u.toSeq: _*)
           case SyncSearchQuery(query)                          => zms.usersearchSync.syncSearchQuery(query)
-          case ExactMatchHandle(query)                         => zms.usersearchSync.exactMatchHandle(query)
           case SyncRichMedia(messageId)                        => zms.richmediaSync.syncRichMedia(messageId)
           case DeletePushToken(token)                          => zms.gcmSync.deleteGcmToken(token)
           case PostConnection(userId, name, message)           => zms.connectionsSync.postConnection(userId, name, message)

--- a/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -35,7 +35,6 @@ import scala.util.Right
 trait UsersClient {
   def loadUser(id: UserId): ErrorOrResponse[Option[UserInfo]]
   def loadUsers(ids: Seq[UserId]): ErrorOrResponse[Seq[UserInfo]]
-  def loadByHandle(handle: Handle): ErrorOrResponse[Option[UserInfo]]
   def loadSelf(): ErrorOrResponse[UserInfo]
   def loadRichInfo(user: UserId): ErrorOrResponse[Seq[UserField]]
   def updateSelf(info: UserInfo): ErrorOrResponse[Unit]
@@ -83,17 +82,6 @@ class UsersClientImpl(implicit
       CancellableFuture.lift(result)
     }
   }
-
-  override def loadByHandle(handle: Handle): ErrorOrResponse[Option[UserInfo]] =
-    Request.Get(
-      relativePath = UsersPath,
-      queryParameters = queryParameters("handles" -> handle.string.toLowerCase)
-    )
-      .withResultType[Seq[UserInfo]]
-      .withErrorType[ErrorResponse]
-      .execute
-      .map(res => Right(res.headOption))
-      .recover { case e: ErrorResponse => Left(e) }
 
   override def loadSelf(): ErrorOrResponse[UserInfo] = {
     Request.Get(relativePath = SelfPath)

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -19,38 +19,21 @@ package com.waz.sync.handler
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.Handle
 import com.waz.service.{SearchQuery, UserSearchService}
 import com.waz.sync.SyncResult
-import com.waz.sync.client.{UserSearchClient, UsersClient}
+import com.waz.sync.client.UserSearchClient
 import com.waz.threading.Threading
 
 import scala.concurrent.Future
 
 class UserSearchSyncHandler(userSearch:  UserSearchService,
-                            client:      UserSearchClient,
-                            usersClient: UsersClient
-                           )
-  extends DerivedLogTag {
-
+                            client:      UserSearchClient) extends DerivedLogTag {
   import Threading.Implicits.Background
 
   def syncSearchQuery(query: SearchQuery): Future[SyncResult] = client.search(query).future.map {
     case Right(results) =>
       debug(l"syncSearchQuery got: ${results.documents.map(_.team)}")
       userSearch.updateSearchResults(query, results)
-      SyncResult.Success
-    case Left(error) =>
-      SyncResult(error)
-  }
-
-  def exactMatchHandle(handle: Handle): Future[SyncResult] = usersClient.loadByHandle(handle).future.map {
-    case Right(Some(user)) =>
-      debug(l"exactMatchHandle, got: ${user.id} for the handle $handle")
-      userSearch.updateExactMatch(user)
-      SyncResult.Success
-    case Right(None) =>
-      debug(l"exactMatchHandle, No user id for the handle $handle")
       SyncResult.Success
     case Left(error) =>
       SyncResult(error)

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
@@ -1,11 +1,10 @@
 package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{Handle, UserId, UserInfo}
 import com.waz.service.{SearchQuery, UserSearchService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
-import com.waz.sync.client.{UserSearchClient, UsersClient}
+import com.waz.sync.client.UserSearchClient
 import com.waz.sync.client.UserSearchClient.UserSearchResponse
 import com.waz.sync.client.UserSearchClient.UserSearchResponse.User
 import com.wire.signals.CancellableFuture
@@ -16,7 +15,6 @@ class UserSearchSyncHandlerSpec extends AndroidFreeSpec {
 
   private val userSearch       = mock[UserSearchService]
   private val userSearchClient = mock[UserSearchClient]
-  private val usersClient      = mock[UsersClient]
 
   private val dummyUser = User(
     id = "d9700541-9b05-47b5-b85f-4a195593af71",
@@ -54,25 +52,6 @@ class UserSearchSyncHandlerSpec extends AndroidFreeSpec {
 
   }
 
-  feature("Exact Match Handle query request") {
-
-    scenario("Given handle is queried, when exactMatchHandle is successful, then update exact matches") {
-      val dummyInfo = UserInfo(UserId())
-      val handle = Handle("ma75")
-      (usersClient.loadByHandle(_: Handle)).expects(handle).once().returning(CancellableFuture.successful(Right(Some(dummyInfo))))
-      (userSearch.updateExactMatch(_: UserInfo)).expects(dummyInfo).once().returning(Future.successful(Unit))
-      result(initHandler().exactMatchHandle(handle)) shouldEqual SyncResult.Success
-    }
-
-    scenario("Given handle is queried, when exactMatchHandle fails. then return SyncResult.Failure") {
-      val handle = Handle("ma75")
-      val timeoutError = ErrorResponse(ErrorResponse.ConnectionErrorCode, s"Request failed with timeout", "connection-error")
-
-      (usersClient.loadByHandle(_: Handle)).expects(handle).once().returning(CancellableFuture.successful(Left(timeoutError)))
-      result(initHandler().exactMatchHandle(handle)) shouldEqual SyncResult(timeoutError)
-    }
-  }
-
-  def initHandler() = new UserSearchSyncHandler(userSearch, userSearchClient, usersClient)
+  def initHandler() = new UserSearchSyncHandler(userSearch, userSearchClient)
 
 }


### PR DESCRIPTION
Exact match search is deprecated. For a while now, regular search returned the exact match search result included,
so asking for it the second time was redundant. With the federation feature the endpoint was marked for removal
in the future.

#### APK
[Download build #3531](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3531/artifact/build/artifact/wire-dev-PR3328-3531.apk)