### PR TITLE
[Feature] Show info when blocked due to legal hold

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1616,9 +1616,9 @@
     <string name="legal_hold_deactivated_dialog_title">Legal Hold Deactivated</string>
     <string name="legal_hold_deactivated_dialog_message">Future messages will not be recorded.</string>
     <string name="legal_hold_activated_dialog_title">Legal Hold is Active</string>
-
     <string name="legal_hold_participant_missing_consent_alert_title">Guests cannot be added</string>
     <string name="legal_hold_participant_missing_consent_alert_message">Due to legal hold, only team members can be added to this conversation.</string>
     <string name="legal_hold_participant_missing_consent_alert_negative_button">LEARN MORE</string>
+    <string name="legal_hold_user_blocked_message">This user is blocked due to legal hold. _LEARN MORE_</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
@@ -130,7 +130,7 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
     val greyScale = !(user.isConnected || user.isSelf || user.isWireBot || teamMember) && attributes.greyScaleOnConnected
     val initials = NameParts.parseFrom(user.name).initials
     val icon =
-      if (user.connection == ConnectionStatus.Blocked)
+      if (user.isBlocked)
         Some(OverlayIcon.Blocked)
       else if (pendingConnectionStatuses.contains(user.connection) && attributes.showWaiting && !user.isWireBot)
         Some(OverlayIcon.Waiting)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -309,12 +309,13 @@ class ConversationListManagerFragment extends Fragment
             )
             navController.setLeftPage(Page.PENDING_CONNECT_REQUEST, Tag)
 
-          case BLOCKED =>
+          case BLOCKED | BLOCKED_DUE_TO_MISSING_LEGAL_HOLD_CONSENT =>
             show(
               BlockedUserFragment.newInstance(userId, userRequester),
               BlockedUserFragment.Tag
             )
             navController.setLeftPage(Page.PENDING_CONNECT_REQUEST, Tag)
+
           case _ => //
         }
       case _ => //

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/BlockedUserFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/BlockedUserFragment.scala
@@ -1,18 +1,22 @@
 package com.waz.zclient.participants.fragments
 
 import android.os.Bundle
-import com.waz.model.UserId
+import com.waz.model.UserData.ConnectionStatus
+import com.waz.model.{UserData, UserId}
+import com.waz.threading.Threading._
 import com.waz.utils.returning
 import com.waz.zclient.R
+import com.waz.zclient.common.controllers.BrowserController
+import com.waz.zclient.common.controllers.global.AccentColorController
 import com.waz.zclient.conversation.ConversationController
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.participants.UserRequester
 import com.waz.zclient.views.menus.{FooterMenu, FooterMenuCallback}
-import com.waz.threading.Threading._
+
+import scala.concurrent.Future
 
 class BlockedUserFragment extends UntabbedRequestFragment {
-
   import com.waz.threading.Threading.Implicits.Ui
 
   override protected val Tag: String = BlockedUserFragment.Tag
@@ -31,18 +35,38 @@ class BlockedUserFragment extends UntabbedRequestFragment {
   }
 
   override protected def initFooterMenu(): Unit = returning( view[FooterMenu](R.id.not_tabbed_footer) ) { vh =>
-    vh.foreach { menu =>
-      menu.setLeftActionText(getString(R.string.glyph__block))
-      menu.setLeftActionLabelText(getString(R.string.connect_request__unblock__button__text))
-      menu.setCallback(footerCallback)
-    }
+    for {
+      Some(user) <- participantsController.getUser(userToConnectId)
+      false       = user.connection == ConnectionStatus.BlockedDueToMissingLegalHoldConsent
+    } yield {
+      vh.foreach { menu =>
+        menu.setLeftActionText(getString(R.string.glyph__block))
+        menu.setLeftActionLabelText(getString(R.string.connect_request__unblock__button__text))
+        menu.setCallback(footerCallback)
+      }
 
-    if (fromParticipants) {
-      subs += removeMemberPermission.map { remPerm =>
-        getString(if (remPerm)  R.string.glyph__more else R.string.empty_string)
-      }.onUi(text => vh.foreach(_.setRightActionText(text)))
+      if (fromParticipants) {
+        subs += removeMemberPermission.map { remPerm =>
+          getString(if (remPerm)  R.string.glyph__more else R.string.empty_string)
+        }.onUi(text => vh.foreach(_.setRightActionText(text)))
+      }
     }
   }
+
+  override protected def linkedText(user: UserData): Future[Option[(String, Int)]] = user.connection match {
+    case ConnectionStatus.BlockedDueToMissingLegalHoldConsent =>
+      val accentColor = inject[AccentColorController].accentColor
+      accentColor.map(_.color).head.map { color =>
+        Some((getString(R.string.legal_hold_user_blocked_message), color))
+      }
+    case _ =>
+      Future.successful(None)
+  }
+
+  override protected def onLinkedTextClick(): Unit = {
+    inject[BrowserController].openAboutLegalHold()
+  }
+
 }
 
 object BlockedUserFragment {

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -460,7 +460,7 @@ object SearchUIFragment {
   private val PERFORM_SEARCH_DELAY = 500.millis
 
   import ConnectionStatus._
-  private val connectionsForOpenProfile = Set(PendingFromUser, Blocked, Ignored, Cancelled, Unconnected)
+  private val connectionsForOpenProfile = Set(PendingFromUser, Blocked, BlockedDueToMissingLegalHoldConsent, Ignored, Cancelled, Unconnected)
 
   def newInstance(): SearchUIFragment = new SearchUIFragment
 

--- a/zmessaging/src/main/java/com/waz/api/ConnectionStatus.java
+++ b/zmessaging/src/main/java/com/waz/api/ConnectionStatus.java
@@ -8,7 +8,8 @@ public enum ConnectionStatus {
     BLOCKED("blocked"),
     IGNORED("ignored"),
     SELF("self"),
-    CANCELLED("cancelled");
+    CANCELLED("cancelled"),
+    BLOCKED_DUE_TO_MISSING_LEGAL_HOLD_CONSENT("missing-legalhold-consent");
 
     public String code;
 

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -62,7 +62,9 @@ final case class UserData(override val id:       UserId,
                           permissions:           PermissionsMasks       = (0,0),
                           createdBy:             Option[UserId]         = None) extends Identifiable[UserId] {
 
-  lazy val isConnected: Boolean         = ConnectionStatus.isConnected(connection)
+  lazy val isConnected: Boolean = ConnectionStatus.isConnected(connection)
+  lazy val isBlocked: Boolean   = ConnectionStatus.isBlocked(connection)
+
   lazy val hasEmailOrPhone: Boolean     = email.isDefined || phone.isDefined
   lazy val isSelf: Boolean              = connection == ConnectionStatus.Self
   lazy val isAcceptedOrPending: Boolean = connection == ConnectionStatus.Accepted || connection == ConnectionStatus.PendingFromOther || connection == ConnectionStatus.PendingFromUser
@@ -172,7 +174,8 @@ object UserData {
 
     def apply(code: String) = codeMap.getOrElse(code, Unconnected)
 
-    def isConnected(status: ConnectionStatus) = status == Accepted || status == Blocked || status == Self
+    def isConnected(status: ConnectionStatus): Boolean = status == Accepted || status == Blocked || status == Self
+    def isBlocked(status: ConnectionStatus): Boolean = status == Blocked
   }
 
   // used for testing only

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -114,7 +114,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
 
         val userId = convToUser(conv.id)
         val user   = eventMap(userId).user
-        val hidden = user.connection == ConnectionStatus.Ignored || user.connection == ConnectionStatus.Blocked || user.connection == ConnectionStatus.Cancelled
+        val hidden = user.isBlocked || user.connection == ConnectionStatus.Ignored || user.connection == ConnectionStatus.Cancelled
 
         //TODO For some reasons we are loosing convType after getOrCreateOneToOneConversations. Flow is very messy and should be refactored.
         val convType = getConvTypeForUser(user)
@@ -135,7 +135,7 @@ class ConnectionServiceImpl(selfUserId:      UserId,
         } map { _ =>
           val userId = convToUser(conv.id)
           val user = eventMap(userId).user
-          val hidden = user.connection == ConnectionStatus.Ignored || user.connection == ConnectionStatus.Blocked || user.connection == ConnectionStatus.Cancelled
+          val hidden = user.isBlocked || user.connection == ConnectionStatus.Ignored || user.connection == ConnectionStatus.Cancelled
           if (conv.hidden && !hidden) sync.syncConversations(Set(conv.id))
           conv
         }

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -140,7 +140,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
         (includeSelf || selfUserId != user.id) &&
           !user.isWireBot &&
           user.expiresAt.isEmpty &&
-          user.connection != ConnectionStatus.Blocked
+          !user.isBlocked
       }
 
       def cmpHandle(u: UserData, fn: String => Boolean) = u.handle match {
@@ -174,7 +174,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
           !user.deleted &&
           user.expiresAt.isEmpty &&
           user.matchesQuery(query) &&
-          (showBlockedUsers || (user.connection != ConnectionStatus.Blocked))
+          (showBlockedUsers || !user.isBlocked)
       }.toIndexedSeq
 
       sortUsers(included, query)


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-448

If a legal hold policy conflict occurs between two users then the backend will force a mutual block from both sides and send a connection update event to each user. On the profile of blocked user, we show a message informing the user why their contact is blocked and provide a link where they can learn more. Additionally, the blocked user cannot be unblocked, so we remove the unblock button from the bottom of the screen.

### Testing

Manually tested

## Attachments

![Wire 2021-05-25 at 6 54 PM](https://user-images.githubusercontent.com/28632506/119537800-b7b28a80-bd8a-11eb-8ecc-bbe15a17daa8.png)

#### APK
[Download build #3535](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3535/artifact/build/artifact/wire-dev-PR3330-3535.apk)