### PR TITLE
Refactor: Legal Hold - Simplify isLegalHoldActive method for self user

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListTopToolbar.scala
@@ -137,8 +137,7 @@ class NormalTopToolbar(override val context: Context, override val attrs: Attrib
   }
 
   (for {
-    selfUser        <- usersController.selfUser
-    legalHoldActive <- legalHoldController.isLegalHoldActive(selfUser.id)
+    legalHoldActive <- legalHoldController.isLegalHoldActiveForSelfUser
     pendingApproval <- legalHoldController.hasPendingRequest
   } yield (legalHoldActive, pendingApproval))
     .map {

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldController.scala
@@ -25,8 +25,8 @@ class LegalHoldController(implicit injector: Injector)
   val onLegalHoldSubjectClick: SourceStream[UserId] = EventStream[UserId]
   val onAllLegalHoldSubjectsClick: SourceStream[Unit] = EventStream[Unit]
 
-  def isLegalHoldActive(userId: UserId): Signal[Boolean] =
-    legalHoldService.flatMap(_.isLegalHoldActive(userId))
+  val isLegalHoldActiveForSelfUser: Signal[Boolean] =
+    legalHoldService.flatMap(_.isLegalHoldActiveForSelfUser)
 
   def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] =
     legalHoldService.flatMap(_.isLegalHoldActive(conversationId))

--- a/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
@@ -17,7 +17,7 @@ class DisabledLegalHoldService extends LegalHoldService {
 
   override def messageEventStage: Stage.Atomic = EventScheduler.Stage[Event]((_, _) => successful(()))
 
-  override def isLegalHoldActive(userId: UserId): Signal[Boolean] = Signal.const(false)
+  override def isLegalHoldActiveForSelfUser(): Signal[Boolean] = Signal.const(false)
 
   override def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] = Signal.const(false)
 

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 trait LegalHoldService {
   def legalHoldEventStage: Stage.Atomic
-  def isLegalHoldActive(userId: UserId): Signal[Boolean]
+  def isLegalHoldActiveForSelfUser: Signal[Boolean]
   def isLegalHoldActive(conversationId: ConvId): Signal[Boolean]
   def legalHoldUsers(conversationId: ConvId): Signal[Seq[UserId]]
   def legalHoldRequest: Signal[Option[LegalHoldRequest]]
@@ -71,7 +71,9 @@ class LegalHoldServiceImpl(selfUserId: UserId,
       Future.successful({})
   }
 
-  override def isLegalHoldActive(userId: UserId): Signal[Boolean] =
+  override def isLegalHoldActiveForSelfUser: Signal[Boolean] = isLegalHoldActive(selfUserId)
+
+  private def isLegalHoldActive(userId: UserId): Signal[Boolean] =
     clientsStorage.optSignal(userId).map(_.fold(false)(_.clients.values.exists(_.isLegalHoldDevice)))
 
   override def isLegalHoldActive(conversationId: ConvId): Signal[Boolean] =

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -100,16 +100,15 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
 
   // Tests
 
-  feature("Is legal hold active for user") {
+  feature("Is legal hold active for self user") {
 
     scenario("with a legal hold device") {
       // Given
       val service = createService()
-      val userId = UserId("user1")
-      mockUserDevices(userId, Seq(DeviceClass.Phone, DeviceClass.LegalHold))
+      mockUserDevices(selfUserId, Seq(DeviceClass.Phone, DeviceClass.LegalHold))
 
       // When
-      val actualResult = result(service.isLegalHoldActive(userId).future)
+      val actualResult = result(service.isLegalHoldActiveForSelfUser.future)
 
       // Then
       actualResult shouldBe true
@@ -118,11 +117,10 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
     scenario("without a legal hold device") {
       // Given
       val service = createService()
-      val userId = UserId("user1")
-      mockUserDevices(userId, Seq(DeviceClass.Phone))
+      mockUserDevices(selfUserId, Seq(DeviceClass.Phone))
 
       // When
-      val actualResult = result(service.isLegalHoldActive(userId).future)
+      val actualResult = result(service.isLegalHoldActiveForSelfUser.future)
 
       // Then
       actualResult shouldBe false


### PR DESCRIPTION
## What's new in this PR?

### Issues

`isLegalHoldActive(userId)` method was only used for self user, so it doesn't actually need to accept a userId.

### Solutions

We already have the `selfUserId` in `LegalHoldService`. Simplified the method to use that id.


#### APK
[Download build #3538](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3538/artifact/build/artifact/wire-dev-PR3334-3538.apk)