### PR TITLE
Fix `FileSystemTest` not working on Windows

### DIFF
--- a/app/src/test/kotlin/com/wire/android/core/io/FileSystemTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/io/FileSystemTest.kt
@@ -86,7 +86,7 @@ class FileSystemTest : AndroidTest() {
 
     companion object {
         private const val TEST_DIRECTORY = "file_system_test_files"
-        private const val TEST_PATH = "file_system_test/test_file.txt"
+        private val TEST_PATH = "file_system_test${File.separator}test_file.txt"
 
         private const val TEST_FILE_CONTENT = "some content"
         private val TEST_INPUT_STREAM = ByteArrayInputStream(TEST_FILE_CONTENT.toByteArray())


### PR DESCRIPTION
`FileSystemTest.TEST_PATH` currently has a hardcoded `/` in it.

Hardcoded file separators may lead to not so graceful runs on Windows, that uses `\` as the file separator.


Example:
```
java.lang.AssertionError: Expected the CharSequence C:\Users\[...]\file_system_test\test_file.txt to end with file_system_test/test_file.txt
```

I replaced the `/` with Java's system-dependent `File.separator`.