### PR TITLE
Federation: Add domain to the search query

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ android {
 
         //Feature Flags
         buildConfigField 'boolean', 'LARGE_VIDEO_CONFERENCE_CALLS', "$largeVideoConferenceCalls"
+        buildConfigField 'boolean', 'FEDERATION_USER_DISCOVERY', "$federationUserDiscovery"
     }
 
     packagingOptions {

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -185,8 +185,8 @@ class SearchUIFragment extends BaseFragment[Container]
     subs += (for {
       zms         <- zms
       permissions <- userAccountsController.selfPermissions.orElse(Signal.const(Set.empty[UserPermissions.Permission]))
-      members <- zms.teams.searchTeamMembers(SearchQuery.Empty).orElse(Signal.const(Set.empty[UserData]))
-      searching <- searchController.filter.map(_.nonEmpty)
+      members     <- zms.teams.searchTeamMembers(SearchQuery.Empty).orElse(Signal.const(Set.empty[UserData]))
+      searching   <- searchController.filter.map(_.nonEmpty)
      } yield
        zms.teamId.nonEmpty && permissions(UserPermissions.Permission.AddTeamMember) && !members.exists(_.id != zms.selfUserId) && !searching
     ).onUi(visible => v.foreach(_.setVisible(visible)))

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ allprojects {
 ext {
     largeVideoConferenceCalls = false
     legalHold = true
+    federationUserDiscovery = true
 }
 
 apply from: "./scripts/avs.gradle"

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -18,6 +18,7 @@ android {
         }
 
         buildConfigField 'boolean', 'LEGAL_HOLD_ENABLED', "$legalHold"
+        buildConfigField 'boolean', 'FEDERATION_USER_DISCOVERY', "$federationUserDiscovery"
     }
 
     externalNativeBuild {

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -101,6 +101,7 @@ final case class UserData(override val id:       UserId,
 
   def updated(user: UserSearchEntry): UserData = copy(
     name      = user.name,
+    domain    = if (user.qualifiedId.hasDomain) Some(user.qualifiedId.domain) else None,
     teamId    = user.teamId,
     searchKey = SearchKey(user.name),
     accent    = user.colorId.getOrElse(accent),
@@ -192,7 +193,8 @@ object UserData {
 
   def apply(entry: UserSearchEntry): UserData =
     UserData(
-      id        = entry.id,
+      id        = entry.qualifiedId.id,
+      domain    = Some(entry.qualifiedId.domain),
       teamId    = entry.teamId,
       name      = entry.name,
       accent    = entry.colorId.getOrElse(0),

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -135,18 +135,17 @@ final case class UserData(override val id:       UserId,
   def isInTeam(otherTeamId: Option[TeamId]): Boolean = teamId.isDefined && teamId == otherTeamId
 
   def matchesQuery(query: SearchQuery): Boolean =
-      handle.exists(_.startsWithQuery(query.str)) ||
+    query.domain == domain.getOrElse("") &&
+      (handle.exists(_.startsWithQuery(query.query)) ||
         (!query.handleOnly &&
-          (SearchKey(query.str).isAtTheStartOfAnyWordIn(searchKey) ||
-           email.exists(e => query.str.trim.equalsIgnoreCase(e.str))
+          (SearchKey(query.query).isAtTheStartOfAnyWordIn(searchKey) ||
+           email.exists(e => query.query.trim.equalsIgnoreCase(e.str))
           )
         )
+      )
 
-  def matchesQuery(query: Option[SearchKey] = None, handleOnly: Boolean = false): Boolean = query match {
-    case Some(q) =>
-      this.handle.map(_.string).contains(q.asciiRepresentation.toLowerCase) || (!handleOnly && q.isAtTheStartOfAnyWordIn(this.searchKey))
-    case _ => true
-  }
+  def exactMatchQuery(query: SearchQuery): Boolean =
+    query.domain == domain.getOrElse("") && handle.exists(_.exactMatchQuery(query.query))
 }
 
 trait Picture
@@ -293,7 +292,7 @@ object UserData {
       iterating(db.query(table.name, null, whereClause, args, null, null,
         s"case when ${Conn.name} = '${Conn(ConnectionStatus.Accepted)}' then 0 when ${Rel.name} != '${Relation.Other.name}' then 1 else 2 end ASC, ${Name.name} ASC"))
 
-    def search(prefix: SearchKey, handleOnly: Boolean, teamId: Option[TeamId])(implicit db: DB): Set[UserData] = {
+    def search(prefix: SearchKey, domain: String, handleOnly: Boolean, teamId: Option[TeamId])(implicit db: DB): Set[UserData] = {
       val select = s"SELECT u.* FROM ${table.name} u WHERE "
       val handleCondition =
         if (handleOnly){
@@ -304,9 +303,10 @@ object UserData {
              |     OR u.${SKey.name} LIKE '% ${SKey(prefix)}%'
              |     OR u.${Handle.name} LIKE '%${prefix.asciiRepresentation}%')""".stripMargin
         }
-      val teamCondition = teamId.map(tId => s"AND u.${TeamId.name} = '$tId'")
+      val teamCondition = teamId.map(tId => s" AND u.${TeamId.name} = '$tId'").getOrElse("")
+      val domainCondition = if (domain.nonEmpty) s" AND u.${Domain.name} = '$domain'" else ""
 
-      list(db.rawQuery(select + " " + handleCondition + teamCondition.map(qu => s" $qu").getOrElse(""))).toSet
+      list(db.rawQuery(select + " " + handleCondition + teamCondition + domainCondition)).toSet
     }
 
     def findForTeams(teams: Set[TeamId])(implicit db: DB) = iteratingMultiple(findInSet(TeamId, teams.map(Option(_))))

--- a/zmessaging/src/main/scala/com/waz/service/SearchKey.scala
+++ b/zmessaging/src/main/scala/com/waz/service/SearchKey.scala
@@ -23,8 +23,8 @@ import com.waz.utils.Locales
 
 final class SearchKey private (val asciiRepresentation: String) extends Serializable {
   private[this] lazy val pattern = compile(s"(.+ )?${quote(asciiRepresentation.toLowerCase)}.*")
-  def isAtTheStartOfAnyWordIn(other: SearchKey) = pattern.matcher(other.asciiRepresentation.toLowerCase).matches
-  def isEmpty = asciiRepresentation.isEmpty
+  def isAtTheStartOfAnyWordIn(other: SearchKey): Boolean = pattern.matcher(other.asciiRepresentation.toLowerCase).matches
+  def isEmpty: Boolean = asciiRepresentation.isEmpty
 
   override def equals(any: Any): Boolean = any match {
     case other: SearchKey => other.asciiRepresentation.equalsIgnoreCase(asciiRepresentation)

--- a/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
+++ b/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
@@ -21,29 +21,41 @@ import com.waz.log.BasicLogging.LogTag
 import com.waz.log.LogShow
 import com.waz.model.Handle
 import com.waz.log.LogSE._
+import com.waz.utils.returning
 
-case class SearchQuery private (str: String, handleOnly: Boolean) {
-  val isEmpty: Boolean = str.isEmpty
+final case class SearchQuery private (query: String, domain: String, handleOnly: Boolean) {
+  val isEmpty: Boolean = query.isEmpty && domain.isEmpty
 
-  lazy val cacheKey: String = (if (handleOnly) SearchQuery.recommendedHandlePrefix else SearchQuery.recommendedPrefix) + str
+  def hasDomain: Boolean = domain.nonEmpty
+
+  lazy val cacheKey: String = {
+    val prefix = if (handleOnly) SearchQuery.recommendedHandlePrefix else SearchQuery.recommendedPrefix
+    if (domain.isEmpty) s"$prefix$query" else s"$prefix$query@$domain"
+  }
 }
 
 object SearchQuery {
-  val Empty = SearchQuery("", handleOnly = false)
+  val Empty: SearchQuery = SearchQuery("", "", handleOnly = false)
 
-  val recommendedPrefix = "##recommended##"
-  val recommendedHandlePrefix = "##recommendedhandle##"
+  private val recommendedPrefix = "##recommended##"
+  private val recommendedHandlePrefix = "##recommendedhandle##"
 
-  implicit val SearchQueryLogShow: LogShow[SearchQuery] = LogShow.create(sq => s"SearchQuery(${sq.str}, ${sq.handleOnly})")
+  implicit val SearchQueryLogShow: LogShow[SearchQuery] = LogShow.create(sq => s"SearchQuery(${sq.query}, ${sq.handleOnly})")
 
-  def apply(str: String): SearchQuery =
-    if (Handle.isHandle(str)) {
-      verbose(l"SearchQuery.apply, str: $str, is handle")(LogTag("SearchQuery"))
-      SearchQuery(Handle.stripSymbol(str), handleOnly = true)
-    } else {
-      verbose(l"SearchQuery.apply, str: $str, not a handle")(LogTag("SearchQuery"))
-      SearchQuery(str, handleOnly = false)
+  def apply(str: String): SearchQuery = {
+    val isHandle = Handle.isHandle(str)
+    val query = if (isHandle) Handle.stripSymbol(str) else str
+    val (queryWithoutDomain, domain) =
+      if (query.contains("@")) {
+        val split = query.split("@")
+        (split(0).trim, split(1).trim) // the domain shouldn't contain the @ sign, so we can assume there are only two elements in the split
+      } else
+        (query.trim, "")
+
+    returning(SearchQuery(queryWithoutDomain, domain, isHandle)) { sq =>
+      verbose(l"SearchQuery.apply, str: $str, search query: $sq")(LogTag("SearchQuery"))
     }
+  }
 
   def fromCacheKey(key: String): SearchQuery =
     if (key.startsWith(recommendedPrefix)) SearchQuery(key.substring(recommendedPrefix.length))

--- a/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
+++ b/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
@@ -28,6 +28,8 @@ final case class SearchQuery private (query: String, domain: String, handleOnly:
 
   def hasDomain: Boolean = domain.nonEmpty
 
+  def withDomain(domain: String): SearchQuery = copy(domain = domain)
+
   lazy val cacheKey: String = {
     val prefix = if (handleOnly) SearchQuery.recommendedHandlePrefix else SearchQuery.recommendedPrefix
     if (domain.isEmpty) s"$prefix$query" else s"$prefix$query@$domain"

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -220,7 +220,7 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def updateUsers(entries: Seq[UserSearchEntry]) = {
     def updateOrAdd(entry: UserSearchEntry) = (_: Option[UserData]).fold(UserData(entry))(_.updated(entry))
-    usersStorage.updateOrCreateAll(entries.map(entry => entry.id -> updateOrAdd(entry)).toMap)
+    usersStorage.updateOrCreateAll(entries.map(entry => entry.qualifiedId.id -> updateOrAdd(entry)).toMap)
   }
 
   override def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]] = Serialized.future(s"syncRichInfoNow $id") {

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -123,7 +123,7 @@ class TeamsServiceImpl(selfUser:           UserId,
       )
 
       def load =
-        if (!query.isEmpty) userStorage.searchByTeam(tId, SearchKey(query.str), query.handleOnly)
+        if (!query.isEmpty) userStorage.searchByTeam(tId, query)
         else userStorage.getByTeam(Set(tId))
 
       def userMatches(data: UserData) = data.isInTeam(teamId) && data.matchesQuery(query)

--- a/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -26,6 +26,7 @@ import com.waz.utils.CirceJSONSupport
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http._
+import com.waz.zms.BuildConfig
 
 trait UserSearchClient {
   def search(query: SearchQuery, limit: Int = DefaultLimit): ErrorOrResponse[UserSearchResponse]
@@ -44,7 +45,7 @@ class UserSearchClientImpl(implicit
   override def search(query: SearchQuery, limit: Int = DefaultLimit): ErrorOrResponse[UserSearchResponse] = {
     verbose(l"search($query, $limit)")
     val params =
-      if (query.hasDomain)
+      if (BuildConfig.FEDERATION_USER_DISCOVERY && query.hasDomain)
         queryParameters("q" -> query.query, "domain" -> query.domain, "size" -> limit)
       else
         queryParameters("q" -> query.query, "size" -> limit)

--- a/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -43,11 +43,13 @@ class UserSearchClientImpl(implicit
 
   override def search(query: SearchQuery, limit: Int = DefaultLimit): ErrorOrResponse[UserSearchResponse] = {
     verbose(l"search($query, $limit)")
+    val params =
+      if (query.hasDomain)
+        queryParameters("q" -> query.query, "domain" -> query.domain, "size" -> limit)
+      else
+        queryParameters("q" -> query.query, "size" -> limit)
     Request
-      .Get(
-        relativePath = SearchPath,
-        queryParameters = queryParameters("q" -> query.str, "size" -> limit)
-      )
+      .Get(relativePath = SearchPath, queryParameters = params)
       .withResultType[UserSearchResponse]
       .withErrorType[ErrorResponse]
       .executeSafe
@@ -57,7 +59,7 @@ class UserSearchClientImpl(implicit
 object UserSearchClient extends DerivedLogTag {
   val SearchPath = "/search/contacts"
 
-  val DefaultLimit = 10
+  val DefaultLimit = 15
 
   // Response types
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -20,6 +20,7 @@ package com.waz.sync.client
 import com.waz.api.impl.ErrorResponse
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
+import com.waz.model.QualifiedId
 import com.waz.service.SearchQuery
 import com.waz.sync.client.UserSearchClient.{DefaultLimit, UserSearchResponse}
 import com.waz.utils.CirceJSONSupport
@@ -64,10 +65,23 @@ object UserSearchClient extends DerivedLogTag {
 
   // Response types
 
-  case class UserSearchResponse(took: Int, found: Int, returned: Int, documents: Seq[UserSearchResponse.User])
+  final case class UserSearchResponse(
+    took:      Int,
+    found:     Int,
+    returned:  Int,
+    documents: Seq[UserSearchResponse.User]
+  )
 
   object UserSearchResponse {
-    case class User(id: String, name: String, handle: Option[String], accent_id: Option[Int], team: Option[String], assets: Option[Seq[Asset]])
-    case class Asset(key: String, size: String, `type`: String)
+    final case class User(
+      qualified_id: QualifiedId,
+      name:         String,
+      handle:       Option[String],
+      accent_id:    Option[Int],
+      team:         Option[String],
+      assets:       Option[Seq[Asset]]
+    )
+
+    final case class Asset(key: String, size: String, `type`: String)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -33,7 +33,7 @@ class UserSearchSyncHandler(userSearch:  UserSearchService,
   def syncSearchQuery(query: SearchQuery): Future[SyncResult] = client.search(query).future.map {
     case Right(results) =>
       debug(l"syncSearchQuery got: ${results.documents.map(_.team)}")
-      userSearch.updateSearchResults(query, results)
+      userSearch.updateSearchResults(results)
       SyncResult.Success
     case Left(error) =>
       SyncResult(error)

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -223,6 +223,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         .expects(*, *, *, *).once().returning(Future.successful(expected.map(users).toVector))
 
       (userService.acceptedOrBlockedUsers _).expects().returns(Signal.const(Map.empty[UserId, UserData]))
+      (userService.selfUser _).expects().anyNumberOfTimes().returning(Signal.const(users(id('me))))
       (messagesStorage.countLaterThan _).expects(*, *).repeated(3).returning(Future.successful(1L))
       (usersStorage.onAdded _).expects().anyNumberOfTimes().returning(EventStream[Seq[UserData]]())
       (usersStorage.onUpdated _).expects().anyNumberOfTimes().returning(EventStream[Seq[(UserData, UserData)]]())
@@ -241,6 +242,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val queryResults = IndexedSeq.empty[UserData]
 
       (userService.acceptedOrBlockedUsers _).expects().once().returning(Signal.const(expected.map(key => key -> users(key)).toMap))
+      (userService.selfUser _).expects().anyNumberOfTimes().returning(Signal.const(users(id('me))))
 
       (convsStorage.findGroupConversations _).expects(*, *, *, *).returns(Future.successful(IndexedSeq.empty[ConversationData]))
 
@@ -290,6 +292,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         .stubs(*, *, *, *).returning(Future.successful(Vector.empty[UserData]))
       (userService.acceptedOrBlockedUsers _).stubs().returning(Signal.const(users.filterKeys(connectedUsers.contains)))
       (userService.getSelfUser _).stubs().onCall(_ => Future.successful(users.get(selfId)))
+      (userService.selfUser _).expects().anyNumberOfTimes().returning(Signal.const(users(selfId)))
 
       (convsStorage.findGroupConversations _).stubs(*, *, *, *).returns(Future.successful(IndexedSeq.empty[ConversationData]))
 

--- a/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -104,11 +104,13 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     val member2 = UserData(UserId(), None, teamId, Name("rick2"), handle = Some(Handle()), searchKey = SearchKey.simple("rick2"))
     val member2Updated = member2.copy(name = Name("user2"), searchKey = SearchKey.simple("user2"))
 
-    (userStorage.searchByTeam _).expects(teamId.get, SearchKey.simple("user"), false).once().returning(Future.successful(Set(member1)))
+    val query = SearchQuery("user")
+
+    (userStorage.searchByTeam _).expects(teamId.get, query).once().returning(Future.successful(Set(member1)))
 
     val service = createService
 
-    val res = service.searchTeamMembers(SearchQuery("user")).disableAutowiring() //disable autowiring to prevent multiple loads
+    val res = service.searchTeamMembers(query).disableAutowiring() //disable autowiring to prevent multiple loads
     result(res.filter(_ == Set(member1)).head)
 
     userStorageOnUpdated ! Seq(member2 -> member2Updated)

--- a/zmessaging/src/test/scala/com/waz/sync/client/UserSearchClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/UserSearchClientSpec.scala
@@ -3,6 +3,7 @@ package com.waz.sync.client
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.UserSearchClient._
 import UserSearchResponse._
+import com.waz.model.{QualifiedId, UserId}
 import com.waz.utils.CirceJSONSupport
 
 class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
@@ -20,12 +21,18 @@ class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
           |   {
           |     "handle": "ma75",
           |     "name": "ma",
-          |     "id": "d9700541-9b05-47b5-b85f-4a195593af71",
+          |     "qualified_id": {
+          |       "id": "d9700541-9b05-47b5-b85f-4a195593af71",
+          |       "domain":"staging.zinfra.io"
+          |     },
           |     "team": "399a5fd1-9a2b-4339-a005-09518baba91b"
           |   },
           |   {
           |     "name": "MA",
-          |     "id": "b8864084-454c-4458-8e81-caf3a32780a7",
+          |     "qualified_id": {
+          |       "id": "b8864084-454c-4458-8e81-caf3a32780a7",
+          |       "domain":"staging.zinfra.io"
+          |     },
           |     "accent_id": 0
           |   }
           | ],
@@ -40,7 +47,7 @@ class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
 
       // Then
       val user1 = User(
-        id = "d9700541-9b05-47b5-b85f-4a195593af71",
+        qualified_id = QualifiedId(UserId("d9700541-9b05-47b5-b85f-4a195593af71"), "staging.zinfra.io"),
         name = "ma",
         handle = Some("ma75"),
         accent_id = None,
@@ -49,7 +56,7 @@ class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       )
 
       val user2 = User(
-        id = "b8864084-454c-4458-8e81-caf3a32780a7",
+        qualified_id = QualifiedId(UserId("b8864084-454c-4458-8e81-caf3a32780a7"), "staging.zinfra.io"),
         name = "MA",
         handle = None,
         accent_id = Some(0),
@@ -70,7 +77,7 @@ class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       val response =
         """
           |{
-          |  "id": "d3410a8f-8903-4e2c-93e3-4fa039410e4f",
+          |  "qualified_id": { "id": "d3410a8f-8903-4e2c-93e3-4fa039410e4f", "domain": "staging.zinfra.io" },
           |  "assets": [
           |    {
           |      "key": "3-2-78d7e7a8-357b-47bd-be69-c3be68056c9b",
@@ -96,7 +103,7 @@ class UserSearchClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       )
 
       val user = User(
-        id = "d3410a8f-8903-4e2c-93e3-4fa039410e4f",
+        qualified_id = QualifiedId(UserId("d3410a8f-8903-4e2c-93e3-4fa039410e4f"), "staging.zinfra.io"),
         name = "aaa",
         handle = Some("aaa"),
         accent_id = Some(2),

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
@@ -28,12 +28,12 @@ class UserSearchSyncHandlerSpec extends AndroidFreeSpec {
   feature("Sync Search Query request") {
 
     scenario("Given search query is synced, when contacts request is successful, then update search results") {
-      val searchQuery = SearchQuery("Test query", handleOnly = false)
+      val searchQuery = SearchQuery("Test query", "", handleOnly = false)
       val documents = Seq(dummyUser)
       val results = UserSearchResponse(took = 13, found = 2, returned = 2, documents = documents)
 
       (userSearchClient.search(_: SearchQuery, _: Int)).expects(searchQuery, *).once().returning(CancellableFuture.successful(Right(results)))
-      (userSearch.updateSearchResults(_: SearchQuery, _: UserSearchClient.UserSearchResponse)).expects(searchQuery, results).once().returning(Future.successful(Unit))
+      (userSearch.updateSearchResults(_: UserSearchClient.UserSearchResponse)).expects(results).once().returning(Future.successful(Unit))
 
       result(initHandler().syncSearchQuery(searchQuery)) shouldEqual SyncResult.Success
 
@@ -43,7 +43,7 @@ class UserSearchSyncHandlerSpec extends AndroidFreeSpec {
 
       val timeoutError = ErrorResponse(ErrorResponse.ConnectionErrorCode, s"Request failed with timeout", "connection-error")
 
-      val searchQuery = SearchQuery("Test query", handleOnly = false)
+      val searchQuery = SearchQuery("Test query", "", handleOnly = false)
 
       (userSearchClient.search(_: SearchQuery, _: Int)).expects(searchQuery, *).once().returning(CancellableFuture.successful(Left(timeoutError)))
 

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UserSearchSyncHandlerSpec.scala
@@ -1,6 +1,7 @@
 package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
+import com.waz.model.{QualifiedId, UserId}
 import com.waz.service.{SearchQuery, UserSearchService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -17,7 +18,7 @@ class UserSearchSyncHandlerSpec extends AndroidFreeSpec {
   private val userSearchClient = mock[UserSearchClient]
 
   private val dummyUser = User(
-    id = "d9700541-9b05-47b5-b85f-4a195593af71",
+    qualified_id = QualifiedId(UserId("d9700541-9b05-47b5-b85f-4a195593af71"), "staging.zinfra.io"),
     name = "ma",
     handle = Some("ma75"),
     accent_id = None,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQCORE-672

SearchQuery class gets a new field - the domain. If the user searches for other users as before, using only the name or the handle, nothing changes. But now it's possible as well to add the domain to the search query string using the format: "\<username\>@<domain\>" or "@\<handle\>@<domain\>". This means that we want to look for the user \<username\> (or @\<handle\>) only on the given domain.

#### APK
[Download build #3539](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3539/artifact/build/artifact/wire-dev-PR3335-3539.apk)
[Download build #3549](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3549/artifact/build/artifact/wire-dev-PR3335-3549.apk)
[Download build #3551](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3551/artifact/build/artifact/wire-dev-PR3335-3551.apk)
[Download build #3556](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3556/artifact/build/artifact/wire-dev-PR3335-3556.apk)
[Download build #3557](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3557/artifact/build/artifact/wire-dev-PR3335-3557.apk)