### PR TITLE
Fix: Legal Hold Status - Check whether LH is active for a user that has just logged in

### DIFF
--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationsDaoTest.kt
@@ -72,7 +72,8 @@ class ConversationsDaoTest : IntegrationTest() {
                     link = it.link,
                     unreadMentionsCount = it.unreadMentionsCount,
                     unreadQuoteCount = it.unreadQuoteCount,
-                    receiptMode = it.receiptMode
+                    receiptMode = it.receiptMode,
+                    legalHoldStatus = it.legalHoldStatus
                 )
             )
         }
@@ -144,7 +145,8 @@ class ConversationsDaoTest : IntegrationTest() {
             link = data.link,
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
-            receiptMode = data.receiptMode
+            receiptMode = data.receiptMode,
+            legalHoldStatus = data.legalHoldStatus
         )
     }
 

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UsersDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UsersDaoTest.kt
@@ -91,7 +91,8 @@ class UsersDaoTest : IntegrationTest() {
             managedBy = data.managedBy,
             selfPermission = data.selfPermission,
             copyPermission = data.copyPermission,
-            createdBy = data.createdBy
+            createdBy = data.createdBy,
+            domain = data.domain
         )
     }
 

--- a/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/DisabledLegalHoldService.scala
@@ -1,6 +1,5 @@
 package com.waz.service
-import com.waz.model.otr.UserClients
-import com.waz.model.{ConvId, Event, LegalHoldRequest, MessageEvent, UserId}
+import com.waz.model.{ConvId, Event, LegalHoldRequest, UserId}
 import com.waz.service.EventScheduler.Stage
 import com.waz.sync.handler.LegalHoldError
 import com.wire.signals.Signal
@@ -30,9 +29,7 @@ class DisabledLegalHoldService extends LegalHoldService {
   override def approveRequest(request: LegalHoldRequest, password: Option[String]): Future[Either[LegalHoldError, Unit]] =
     Future.successful(Right(()))
 
-  override def storeLegalHoldRequest(request: LegalHoldRequest): Future[Unit] = Future.successful(())
-
-  override def deleteLegalHoldRequest(): Future[Unit] = Future.successful(())
+  override def onLegalHoldRequestSynced(request: Option[LegalHoldRequest]): Future[Unit] = Future.successful(())
 
   override def updateLegalHoldStatusAfterFetchingClients(): Unit = Future.successful(())
 }

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -28,8 +28,7 @@ trait LegalHoldService {
   def legalHoldUsers(conversationId: ConvId): Signal[Seq[UserId]]
   def legalHoldRequest: Signal[Option[LegalHoldRequest]]
   def getFingerprint(request: LegalHoldRequest): Option[String]
-  def deleteLegalHoldRequest(): Future[Unit]
-  def storeLegalHoldRequest(request: LegalHoldRequest): Future[Unit]
+  def onLegalHoldRequestSynced(request: Option[LegalHoldRequest]): Future[Unit]
   def approveRequest(request: LegalHoldRequest,
                      password: Option[String]): Future[Either[LegalHoldError, Unit]]
   def messageEventStage: Stage.Atomic
@@ -140,10 +139,22 @@ class LegalHoldServiceImpl(selfUserId: UserId,
     _ <- legalHoldDisclosurePref := Some(LegalHoldStatus.Disabled)
   } yield()
 
-  def storeLegalHoldRequest(request: LegalHoldRequest): Future[Unit] =
+  override def onLegalHoldRequestSynced(request: Option[LegalHoldRequest]): Future[Unit] =
+    request match {
+      case Some(request) => storeLegalHoldRequest(request)
+      case None =>
+        for {
+          _        <- deleteLegalHoldRequest()
+          isActive <- isLegalHoldActiveForSelfUser.head
+          _        <- if (isActive) legalHoldDisclosurePref := Some(LegalHoldStatus.Enabled)
+                      else Future.successful(())
+        } yield ()
+    }
+
+  private def storeLegalHoldRequest(request: LegalHoldRequest): Future[Unit] =
     legalHoldRequestPref := Some(request)
 
-  def deleteLegalHoldRequest(): Future[Unit] =
+  private def deleteLegalHoldRequest(): Future[Unit] =
     legalHoldRequestPref := None
 
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
@@ -31,9 +31,8 @@ class LegalHoldSyncHandlerImpl(teamId: Option[TeamId],
       Future.successful(SyncResult.Success)
     case Some(teamId) =>
       apiClient.fetchLegalHoldRequest(teamId, userId).future.flatMap {
-        case Left(error)          => Future.successful(SyncResult.Failure(error))
-        case Right(None)          => legalHoldService.deleteLegalHoldRequest().map(_ => SyncResult.Success)
-        case Right(Some(request)) => legalHoldService.storeLegalHoldRequest(request).map(_ => SyncResult.Success)
+        case Left(error)    => Future.successful(SyncResult.Failure(error))
+        case Right(request) => legalHoldService.onLegalHoldRequestSynced(request).map(_ => SyncResult.Success)
       }
   }
 

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -39,7 +39,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
 
   feature("Fetching a legal hold request") {
 
-    scenario("It fetches and stores the legal hold request if it exists") {
+    scenario("It fetches the request and notifies the service if it exists") {
       // Given
       val syncHandler = createSyncHandler(Some("team1"), "user1")
 
@@ -48,8 +48,8 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
         .once()
         .returning(CancellableFuture.successful(Right(Some(legalHoldRequest))))
 
-      (service.storeLegalHoldRequest _)
-        .expects(legalHoldRequest)
+      (service.onLegalHoldRequestSynced _)
+        .expects(Some(legalHoldRequest))
         .once()
         .returning(Future.successful({}))
 
@@ -60,7 +60,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       actualResult shouldBe SyncResult.Success
     }
 
-    scenario("It deletes the existing legal hold request if none fetched") {
+    scenario("It fetches the request and notifies the service if none fetched") {
       // Given
       val syncHandler = createSyncHandler(Some("team1"), "user1")
 
@@ -69,8 +69,8 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
         .once()
         .returning(CancellableFuture.successful(Right(None)))
 
-      (service.deleteLegalHoldRequest _)
-        .expects()
+      (service.onLegalHoldRequestSynced _)
+        .expects(None)
         .once()
         .returning(Future.successful({}))
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-355](https://wearezeta.atlassian.net/browse/SQSERVICES-355)

We get any updates to LH state changes through event mechanism. However, past events for "Enabled" and "Pending Approval" doesn't get delivered when the user logs in. We need to be able to present the correct LH state to the user.

Given LH is enabled for a user, when user logs into a new device, we want to show a pop up indicating active legal hold status. 

### Solutions

We already have a solution for "Pending Approval" (Requested) scenario. When the user logs into a new device, we ask the backend if there's a pending request and store the result in the database. I added an extra check at the end of this call to see if the LH is active. If it is, we update the flag for disclosure pop up.  

### Testing

Unit tests are added/updated. Manually tested the login flow for all 3 different LH states.

#### APK
[Download build #3544](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3544/artifact/build/artifact/wire-dev-PR3339-3544.apk)