### PR TITLE
Fix: LegalHoldService unit tests

### DIFF
--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -134,7 +134,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val service = createService()
 
       //When
-      service.onLegalHoldRequestSynced(Some(legalHoldRequest))
+      await(service.onLegalHoldRequestSynced(Some(legalHoldRequest)))
 
       //Then
       val storedLegalHoldRequest = result(userPrefs.preference(UserPreferences.LegalHoldRequest).apply())
@@ -152,7 +152,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       mockUserDevices(selfUserId, Seq(DeviceClass.Phone, DeviceClass.LegalHold))
 
       //When
-      service.onLegalHoldRequestSynced(None)
+      await(service.onLegalHoldRequestSynced(None))
 
       //Then
       val storedLegalHoldRequest = result(userPrefs.preference(UserPreferences.LegalHoldRequest).apply())
@@ -170,7 +170,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       mockUserDevices(selfUserId, Seq(DeviceClass.Phone))
 
       //When
-      service.onLegalHoldRequestSynced(None)
+      await(service.onLegalHoldRequestSynced(None))
 
       //Then
       val storedLegalHoldRequest = result(userPrefs.preference(UserPreferences.LegalHoldRequest).apply())


### PR DESCRIPTION
## What's new in this PR?

### Issues

The test method didn't wait for the operation to be finished before moving into assertions, resulting in flaky tests.

### Solution

Added `await` calls for operations.


#### APK
[Download build #3548](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3548/artifact/build/artifact/wire-dev-PR3341-3548.apk)