### PR TITLE
Chore: Enable largeVideoConferenceCalls flag back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ allprojects {
 }
 
 ext {
-    largeVideoConferenceCalls = false
+    largeVideoConferenceCalls = true
     legalHold = true
 }
 


### PR DESCRIPTION
## What's new in this PR?

The flag was disabled for the release. Now we're enabling it back for QA automation tests.

#### APK
[Download build #3554](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3554/artifact/build/artifact/wire-dev-PR3342-3554.apk)