### PR TITLE
[Fix] Display legal hold send anyway alert only once

### DIFF
--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -903,20 +903,22 @@ class ConversationFragment extends FragmentHelper {
         val positiveButton = getString(R.string.conversation__legal_hold_confirmation__positive_action)
 
         val callback = new ConfirmationCallback {
-          override def positiveButtonClicked(checkboxIsSelected: Boolean): Unit = {
-            messagesController.retryMessageSending(err.messages)
-            errorsController.dismissSyncError(err.id)
-          }
+          override def positiveButtonClicked(checkboxIsSelected: Boolean): Unit = for {
+            _ <- errorsController.dismissSyncError(err.id)
+            _ <- messagesController.retryMessageSending(err.messages)
+          } yield ()
 
-          override def negativeButtonClicked(): Unit = {
-            inject[LegalHoldController].onShowConversationLegalHoldInfo ! (())
-          }
+          override def negativeButtonClicked(): Unit = for {
+            _ <- errorsController.dismissSyncError(err.id)
+            _  = inject[LegalHoldController].onShowConversationLegalHoldInfo ! (())
+          } yield ()
 
-          override def neutralButtonClicked(): Unit = {
-            participantsController.onShowParticipants ! None
-          }
+          override def neutralButtonClicked(): Unit = for {
+            _ <- errorsController.dismissSyncError(err.id)
+            _  = participantsController.onShowParticipants ! None
+          } yield ()
 
-          override def canceled(): Unit = {}
+          override def canceled(): Unit = errorsController.dismissSyncError(err.id)
 
           override def onHideAnimationEnd(confirmed: Boolean, canceled: Boolean, checkboxIsSelected: Boolean): Unit = {}
         }


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-482

### Issues

According to the [spec](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/157255381/Use%2Bcase%2Bsending%2Bmessages%2Bto%2Ba%2Blegal%2Bhold%2Bconversation), the "send anyway" alert that is shown when legal hold is discovered should only be shown once. Currently, we will only stop asking for confirmation when the user taps "send anyway".

### Causes

When tapping "send anyway", we dismiss the error in the error controller, which will transition the conversation's legal hold status from "pending" to "enabled". This happens only when this button is tapped. So if the user cancels, the alert is shown again the next time they try to send a message.

### Solutions

Dismiss the error in all cases that the alert can be dismissed.


### Testing

Manually tested.

#### APK
[Download build #3558](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3558/artifact/build/artifact/wire-dev-PR3343-3558.apk)