### PR TITLE
fix: MissingFieldException: Field 'domain' is required, but it was missing

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpModel.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/users/UsersBackUpModel.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UsersBackUpModel(
     val id: String,
-    val domain: String?,
+    val domain: String? = null,
     val teamId: String? = null,
     val name: String = String.empty(),
     val email: String? = null,


### PR DESCRIPTION
The 'domain' field in UsersBackUpModel needs the default value 'null'.
