### PR TITLE
Remove UserAgent header from HTTP requests

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/network/UserAgentInterceptor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/UserAgentInterceptor.kt
@@ -1,28 +1,25 @@
 package com.wire.android.core.network
 
-import com.wire.android.core.extension.EMPTY
 import com.wire.android.core.network.NetworkConfig.Companion.USER_AGENT_HEADER_KEY
 import okhttp3.Interceptor
 
-class UserAgentInterceptor(private val config: NetworkConfig) : Interceptor {
+class UserAgentInterceptor : Interceptor {
 
-    override fun intercept(chain: Interceptor.Chain) =
-        if (requestHasUserHeader(chain)) {
-            chain.proceed(chain.request())
-        } else addUserAgentHeader(chain)
+    override fun intercept(chain: Interceptor.Chain) = if (requestHasUserHeader(chain))
+        removeUserAgent(chain)
+    else
+        chain.proceed(chain.request())
 
-    private fun addUserAgentHeader(chain: Interceptor.Chain) =
-        chain.proceed(chain.request()
+    private fun removeUserAgent(chain: Interceptor.Chain) = chain.proceed(
+        chain.request()
             .newBuilder()
-            .addHeader(USER_AGENT_HEADER_KEY, buildUserAgentHeader())
-            .build())
+            .removeHeader(USER_AGENT_HEADER_KEY)
+            .build()
+    )
 
     private fun requestHasUserHeader(chain: Interceptor.Chain): Boolean =
         when (chain.request().header(USER_AGENT_HEADER_KEY)) {
-            null, String.EMPTY -> false
+            null -> false
             else -> true
         }
-
-    private fun buildUserAgentHeader(): String =
-        config.osVersion + " / " + config.appVersion + " / " + config.userAgent
 }

--- a/app/src/main/kotlin/com/wire/android/core/network/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/di/NetworkModule.kt
@@ -71,7 +71,7 @@ val networkModule: Module = module {
     single { HttpRequestParams() }
     single { AccessTokenAuthenticator(get(), get()) }
     single { AccessTokenInterceptor(get()) }
-    single { UserAgentInterceptor(get()) }
+    single { UserAgentInterceptor() }
     factory { AuthenticationManager() }
 
     val networkClientForNoAuth = "NETWORK_CLIENT_NO_AUTH_REQUEST"


### PR DESCRIPTION
Based on: https://wearezeta.atlassian.net/browse/AR-718

OkHttp adds a `User-Agent` with its information by default, so this aims to remove it as well.

Should we add tests to verify if `UserAgentInterceptor` is actually being used? Or at least create a simple `OkHttpClient` instance and test it against a `MockWebServer`, checking if requests include the default `User-Agent` header that OkHttp includes?

