### PR TITLE
Chore: Remove User-Agent header from requests

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/core/config/Config.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/config/Config.kt
@@ -20,7 +20,6 @@ object Config {
 
 val configModule: Module = module {
     factory { HostUrlConfig(Config.websiteUrl()) }
-    factory { AppVersionNameConfig(Config.versionName()) }
     factory { AppDetailsConfig("${Config.versionCode()} ${Config.versionName()}") }
     factory { AccountUrlConfig(Config.accountsUrl()) }
     factory { DeveloperOptionsConfig(Config.developerSettingsEnabled()) }
@@ -28,7 +27,6 @@ val configModule: Module = module {
 }
 
 data class DeveloperOptionsConfig(val isDeveloperSettingsEnabled: Boolean) : ConfigItem()
-data class AppVersionNameConfig(val versionName: String) : ConfigItem()
 data class AppDetailsConfig(val versionDetails: String) : ConfigItem()
 data class AccountUrlConfig(val url: String) : ConfigItem()
 data class HostUrlConfig(val url: String) : ConfigItem()

--- a/app/src/main/kotlin/com/waz/zclient/core/network/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/di/NetworkModule.kt
@@ -24,7 +24,6 @@ import com.waz.zclient.core.network.di.NetworkDependencyProvider.createHttpClien
 import com.waz.zclient.core.network.di.NetworkDependencyProvider.createHttpClientForToken
 import com.waz.zclient.core.network.di.NetworkDependencyProvider.retrofit
 import com.waz.zclient.core.network.pinning.CertificatePinnerFactory
-import com.waz.zclient.core.network.useragent.UserAgentConfig
 import com.waz.zclient.core.network.useragent.UserAgentInterceptor
 import com.waz.zclient.storage.db.GlobalDatabase
 import okhttp3.OkHttpClient
@@ -96,9 +95,8 @@ val networkModule: Module = module {
     single { AccessTokenLocalDataSource(get(), get<GlobalDatabase>().activeAccountsDao()) }
     single { AccessTokenMapper() }
     single { RefreshTokenMapper() }
-    single { UserAgentInterceptor(get()) }
+    single { UserAgentInterceptor() }
     single { CustomBackendInterceptor(get()) }
-    factory { UserAgentConfig(get()) }
     single { AccessTokenRepository(get(), get(), get(), get()) }
     single { AccessTokenAuthenticator(get(), get()) }
     single { AccessTokenInterceptor(get()) }

--- a/app/src/main/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptor.kt
+++ b/app/src/main/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptor.kt
@@ -1,45 +1,21 @@
 package com.waz.zclient.core.network.useragent
 
-import com.waz.zclient.core.config.AppVersionNameConfig
-import com.waz.zclient.core.extension.empty
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 
-class UserAgentInterceptor(
-    private val userAgentConfig: UserAgentConfig
-) : Interceptor {
+class UserAgentInterceptor : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response =
         when (chain.request().header(USER_AGENT_HEADER_KEY)) {
-            null, String.empty() -> determineUserAgentRequest(chain)
-            else -> chain.proceed(chain.request())
+            null -> chain.proceed(chain.request())
+            else -> chain.proceed(removeUserAgentHeader(chain))
         }
 
-    private fun determineUserAgentRequest(chain: Interceptor.Chain) =
-        chain.proceed(chain.request()
-            .newBuilder()
-            .addHeader(USER_AGENT_HEADER_KEY, newUserAgentHeader())
-            .build())
-
-    private fun newUserAgentHeader() =
-        "${androidVersion()} / ${wireVersion()} / ${httpVersion()}"
-
-    private fun androidVersion(): String =
-        "Android ${userAgentConfig.androidVersion}"
-
-    private fun wireVersion(): String =
-        "Wire ${userAgentConfig.appVersionNameConfig.versionName}"
-
-    private fun httpVersion(): String =
-        "HttpLibrary ${userAgentConfig.httpUserAgent}"
+    private fun removeUserAgentHeader(chain: Interceptor.Chain): Request =
+        chain.request().newBuilder().removeHeader(USER_AGENT_HEADER_KEY).build()
 
     companion object {
         private const val USER_AGENT_HEADER_KEY = "User-Agent"
     }
 }
-
-data class UserAgentConfig(
-    val appVersionNameConfig: AppVersionNameConfig,
-    val androidVersion: String = android.os.Build.VERSION.RELEASE,
-    val httpUserAgent: String = okhttp3.internal.Version.userAgent()
-)

--- a/app/src/test/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptorTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptorTest.kt
@@ -28,16 +28,10 @@ class UserAgentInterceptorTest : UnitTest() {
         `when`(chain.request()).thenReturn(initialRequest)
         `when`(initialRequest.header(USER_AGENT_HEADER_KEY)).thenReturn(null)
 
-        val requestBuilder = mock(Request.Builder::class.java)
-        `when`(initialRequest.newBuilder()).thenReturn(requestBuilder)
-
-        val request = mock(Request::class.java)
-        `when`(requestBuilder.build()).thenReturn(request)
-
         userAgentInterceptor.intercept(chain)
 
-        verify(chain).proceed(request)
-        verify(requestBuilder, never()).removeHeader(USER_AGENT_HEADER_KEY)
+        verify(chain).proceed(initialRequest)
+        verify(initialRequest, never()).newBuilder()
     }
 
     @Test

--- a/app/src/test/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptorTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/core/network/useragent/UserAgentInterceptorTest.kt
@@ -1,90 +1,66 @@
 package com.waz.zclient.core.network.useragent
 
 import com.waz.zclient.UnitTest
-import com.waz.zclient.core.config.AppVersionNameConfig
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.*
 
 class UserAgentInterceptorTest : UnitTest() {
 
     private lateinit var userAgentInterceptor: UserAgentInterceptor
 
     @Mock
-    private lateinit var userAgentConfig: UserAgentConfig
-
-    @Mock
-    private lateinit var appVersionNameConfig: AppVersionNameConfig
+    private lateinit var chain: Interceptor.Chain
 
     @Before
     fun setup() {
-        userAgentInterceptor = UserAgentInterceptor(userAgentConfig)
-        `when`(userAgentConfig.androidVersion).thenReturn(ANDROID_VERSION)
-        `when`(userAgentConfig.appVersionNameConfig).thenReturn(appVersionNameConfig)
-        `when`(userAgentConfig.httpUserAgent).thenReturn(HTTP_LIBRARY_VERSION)
-
-        `when`(appVersionNameConfig.versionName).thenReturn(WIRE_VERSION)
+        userAgentInterceptor = UserAgentInterceptor()
+        `when`(chain.proceed(any())).thenReturn(mock(Response::class.java))
     }
 
-
     @Test
-    fun `Given HttpRequest header User-Agent does not exist already, then add new header to request with user-agent details`() {
-        val chain = mock(Interceptor.Chain::class.java)
+    fun `given a chain, when request does not have a User-Agent header, then proceeds with request`() {
         val initialRequest = mock(Request::class.java)
         `when`(chain.request()).thenReturn(initialRequest)
+        `when`(initialRequest.header(USER_AGENT_HEADER_KEY)).thenReturn(null)
 
         val requestBuilder = mock(Request.Builder::class.java)
         `when`(initialRequest.newBuilder()).thenReturn(requestBuilder)
-        `when`(requestBuilder.addHeader(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(requestBuilder)
 
-        val requestWithoutHeader = mock(Request::class.java)
-        `when`(requestBuilder.build()).thenReturn(requestWithoutHeader)
-        `when`(chain.proceed(requestWithoutHeader)).thenReturn(mock(Response::class.java))
+        val request = mock(Request::class.java)
+        `when`(requestBuilder.build()).thenReturn(request)
 
         userAgentInterceptor.intercept(chain)
 
-        verify(requestBuilder).addHeader(USER_AGENT_HEADER_KEY, USER_AGENT)
-        verify(chain).proceed(requestWithoutHeader)
+        verify(chain).proceed(request)
         verify(requestBuilder, never()).removeHeader(USER_AGENT_HEADER_KEY)
     }
 
     @Test
-    fun `Given current User-Agent header does exist already, then proceed with initial request`() {
-        val chain = mock(Interceptor.Chain::class.java)
+    fun `given a chain, when request has a User-Agent header, then removes the header`() {
         val initialRequest = mock(Request::class.java)
         `when`(chain.request()).thenReturn(initialRequest)
+        `when`(initialRequest.header(USER_AGENT_HEADER_KEY)).thenReturn(HEADER_VALUE)
 
         val requestBuilder = mock(Request.Builder::class.java)
         `when`(initialRequest.newBuilder()).thenReturn(requestBuilder)
-        `when`(requestBuilder.addHeader(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(requestBuilder)
+        `when`(requestBuilder.removeHeader(any())).thenReturn(requestBuilder)
 
-        val requestWithHeader = mock(Request::class.java)
-        requestBuilder.addHeader(USER_AGENT_HEADER_KEY, USER_AGENT)
-        `when`(requestBuilder.build()).thenReturn(requestWithHeader)
-        `when`(chain.proceed(requestWithHeader)).thenReturn(mock(Response::class.java))
+        val request = mock(Request::class.java)
+        `when`(requestBuilder.build()).thenReturn(request)
 
         userAgentInterceptor.intercept(chain)
 
-        verify(chain).proceed(requestWithHeader)
-        verify(requestBuilder, never()).removeHeader(USER_AGENT_HEADER_KEY)
+        verify(chain).proceed(request)
+        verify(requestBuilder).removeHeader(USER_AGENT_HEADER_KEY)
     }
 
     companion object {
         private const val USER_AGENT_HEADER_KEY = "User-Agent"
-        private const val ANDROID_VERSION = "10.0"
-        private const val WIRE_VERSION = "3.12.300"
-        private const val HTTP_LIBRARY_VERSION = "4.1.0"
-        private const val ANDROID_DETAILS = "Android $ANDROID_VERSION"
-        private const val WIRE_DETAILS = "Wire $WIRE_VERSION"
-        private const val HTTP_DETAILS = "HttpLibrary $HTTP_LIBRARY_VERSION"
-        private const val USER_AGENT = "$ANDROID_DETAILS / $WIRE_DETAILS / $HTTP_DETAILS"
+        private const val HEADER_VALUE = "header value"
     }
 }

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -146,7 +146,7 @@ class GlobalModuleImpl(val context:             AContext,
   lazy val regClient:           RegistrationClient               = new RegistrationClientImpl()(urlCreator, httpClient)
 
   lazy val urlCreator:          UrlCreator                       = UrlCreator.simpleAppender(() => backend.baseUrl.toString)
-  private val customUserAgentHttpInterceptor: Interceptor        = new OkHttpUserAgentInterceptor(metadata)
+  private val customUserAgentHttpInterceptor: Interceptor        = new OkHttpUserAgentInterceptor()
   implicit lazy val httpClient: HttpClient                       = HttpClientOkHttpImpl(enableLogging = BuildConfig.DEBUG, pin = backend.pin, customUserAgentInterceptor = Some(customUserAgentHttpInterceptor), proxy = httpProxy)(Threading.IO)
   lazy val httpClientForLongRunning: HttpClient                  = HttpClientOkHttpImpl(enableLogging = BuildConfig.DEBUG, timeout = Some(30.seconds), pin = backend.pin, customUserAgentInterceptor = Some(customUserAgentHttpInterceptor), proxy = httpProxy)(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4)))
 

--- a/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
@@ -57,8 +57,6 @@ class MetaDataService(context: Context) {
     s"$MANUFACTURER $MODEL"
   }
 
-  lazy val androidVersion: String = android.os.Build.VERSION.RELEASE
-
   lazy val localBluetoothName: String =
     Try(Option(BluetoothAdapter.getDefaultAdapter.getName).getOrElse("")).getOrElse("")
 

--- a/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -64,10 +64,8 @@ object WSPushServiceImpl {
         else backend.websocketUrl.buildUpon.appendPath("await").build
 
       val uri = webSocketUri.buildUpon.appendQueryParameter("client", clientId.str).build
-      val headers = token.headers ++ Map(
-        "Accept-Encoding" -> "identity", // XXX: this is a hack for Backend In The Box problem: 'Accept-Encoding: gzip' header causes 500
-        "User-Agent" -> client.userAgent()
-      )
+      // XXX: this is a hack for Backend In The Box problem: 'Accept-Encoding: gzip' header causes 500
+      val headers = token.headers + ("Accept-Encoding" -> "identity")
 
       Request.create(
         method = Method.Get,

--- a/zmessaging/src/main/scala/com/waz/sync/client/package.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/package.scala
@@ -26,11 +26,6 @@ import scala.concurrent.Future
 
 package object client {
 
-  def userAgent(appVersion: String = "*", zmsVersion: String = "*"): String = {
-    import android.os.Build._
-    s"Wire/$appVersion (zms $zmsVersion; Android ${VERSION.RELEASE}; $MANUFACTURER $MODEL)"
-  }
-
   //TODO Use only one from this two.
   type ErrorOr[T] = Future[Either[ErrorResponse, T]]
   type ErrorOrResponse[T] = CancellableFuture[Either[ErrorResponse, T]]

--- a/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
@@ -17,24 +17,15 @@
  */
 package com.waz.znet2
 
-import com.waz.service.MetaDataService
 import okhttp3.{Interceptor, Response}
 
-class OkHttpUserAgentInterceptor(metadata: MetaDataService) extends Interceptor {
+class OkHttpUserAgentInterceptor extends Interceptor {
 
-  private val WireUserAgent = {
-    val androidVersion = metadata.androidVersion
-    val wireVersion = metadata.versionName
-    val okHttpDefaultUserAgent = okhttp3.internal.Version.userAgent()
-
-    s"Android $androidVersion / Wire $wireVersion / HttpLibrary $okHttpDefaultUserAgent"
-  }
-
-  override def intercept(chain: Interceptor.Chain): Response = 
+  override def intercept(chain: Interceptor.Chain): Response =
     chain.proceed(
-      if (Option(chain.request.header("User-Agent")).isDefined) 
+      if (Option(chain.request.header("User-Agent")).isEmpty)
         chain.request
-      else 
-        chain.request.newBuilder.header("User-Agent", WireUserAgent).build
+      else
+        chain.request.newBuilder().removeHeader("User-Agent").build()
     )
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-488](https://wearezeta.atlassian.net/browse/SQSERVICES-488)

The User-Agent header that we send with each request contains some information that can be used for targeting vulnerable set-ups, hence, it needs to be removed.

### Solutions

Removed User-Agent info, along with okHttp's default User-Agent information from headers.

### Testing

Manually tested some network requests. For Kotlin part, unit test is updated. I couldn't add unit tests for the Scala side as I couldn't mock final classes from okHttp.

#### APK
[Download build #3572](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3572/artifact/build/artifact/wire-dev-PR3348-3572.apk)