### PR TITLE
[Fix] Send anyway alert shown too often

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -57,6 +57,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_128_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO_130
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -106,7 +107,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 132
+        const val VERSION = 133
 
         @JvmStatic
         val migrations = arrayOf(
@@ -114,7 +115,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_128_TO_129,
             USER_DATABASE_MIGRATION_129_TO_130,
             USER_DATABASE_MIGRATION_130_TO_131,
-            USER_DATABASE_MIGRATION_131_TO_132
+            USER_DATABASE_MIGRATION_131_TO_132,
+            USER_DATABASE_MIGRATION_132_TO_133
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase132To133Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase132To133Migration.kt
@@ -1,0 +1,27 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.waz.zclient.storage.db.users.migration.MigrationUtils.addColumn
+
+private const val TABLE = "Conversations"
+private const val COLUMN = "legal_hold_status"
+private const val PENDING_APPROVAL = "1"
+private const val ENABLED = "2"
+
+val USER_DATABASE_MIGRATION_132_TO_133 = object : Migration(132, 133) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        with(database) {
+            // The "pending approval" legal hold status is deprecated and should
+            // be treated as "enabled".
+            val update = """
+                UPDATE $TABLE
+                SET $COLUMN = $ENABLED
+                WHERE $COLUMN = $PENDING_APPROVAL
+            """.trimIndent()
+
+            execSQL(update)
+        }
+    }
+}

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase132To133Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase132To133Migration.kt
@@ -3,7 +3,6 @@ package com.waz.zclient.storage.db.users.migration
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.waz.zclient.storage.db.users.migration.MigrationUtils.addColumn
 
 private const val TABLE = "Conversations"
 private const val COLUMN = "legal_hold_status"

--- a/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConversationStorage.scala
@@ -60,13 +60,8 @@ class ConversationStorageImpl(storage: ZmsDatabase)
   def setUnknownVerification(convId: ConvId): Future[Option[(ConversationData, ConversationData)]] =
     update(convId, { c => c.copy(verified = if (c.verified == Verification.UNVERIFIED) UNKNOWN else c.verified) })
 
-  def setLegalHoldEnabledStatus(convId: ConvId): Future[Option[(ConversationData, ConversationData)]] = {
-    import LegalHoldStatus._
-    update(convId, { conv =>
-      if (conv.legalHoldStatus == PendingApproval) conv.copy(legalHoldStatus = Enabled)
-      else conv
-    })
-  }
+  def setLegalHoldEnabledStatus(convId: ConvId): Future[Option[(ConversationData, ConversationData)]] =
+    update(convId, (_.copy(legalHoldStatus = LegalHoldStatus.Enabled)))
 
   onUpdated.foreach { cs =>
     updateSearchKey(cs.collect {

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -86,15 +86,7 @@ case class ConversationData(override val id:      ConvId                 = ConvI
 
   def withNewLegalHoldStatus(detectedLegalHoldDevice: Boolean): ConversationData = {
     import LegalHoldStatus._
-
-    val status = (legalHoldStatus, detectedLegalHoldDevice) match {
-      case (Disabled, true) => PendingApproval
-      case (PendingApproval, false) => Disabled
-      case (Enabled, false) => Disabled
-      case (existingStatus, _) => existingStatus
-    }
-
-    copy(legalHoldStatus = status)
+    copy(legalHoldStatus = if (detectedLegalHoldDevice) Enabled else Disabled)
   }
 
   def isUnderLegalHold: Boolean = legalHoldStatus != LegalHoldStatus.Disabled
@@ -207,8 +199,10 @@ object ConversationData {
   final case class LegalHoldStatus(value: Int)
   object LegalHoldStatus {
     val Disabled = LegalHoldStatus(0)
-    val PendingApproval = LegalHoldStatus(1)
     val Enabled = LegalHoldStatus(2)
+
+    @deprecated("'PendingApproval' status shouldn't be used, it will be treated as 'Enabled'")
+    val PendingApproval = LegalHoldStatus(1)
   }
 
   def getAccessAndRoleForGroupConv(teamOnly: Boolean, teamId: Option[TeamId]): (Set[Access], AccessRole) = {

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -201,7 +201,7 @@ object ConversationData {
     val Disabled = LegalHoldStatus(0)
     val Enabled = LegalHoldStatus(2)
 
-    @deprecated("'PendingApproval' status shouldn't be used, it will be treated as 'Enabled'")
+    @deprecated("'PendingApproval' status is no longer used. Existing occurrences should be treated as 'Enabled'")
     val PendingApproval = LegalHoldStatus(1)
   }
 

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -201,6 +201,7 @@ object ConversationData {
     val Disabled = LegalHoldStatus(0)
     val Enabled = LegalHoldStatus(2)
 
+    // TODO: Delete at end of 2021.
     @deprecated("'PendingApproval' status is no longer used. Existing occurrences should be treated as 'Enabled'")
     val PendingApproval = LegalHoldStatus(1)
   }

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -154,6 +154,7 @@ object Client {
 final case class UserClients(user: UserId, clients: Map[ClientId, Client]) extends Identifiable[UserId] {
   override val id: UserId = user
   def -(clientId: ClientId): UserClients = UserClients(user, clients - clientId)
+  def containsLegalHoldDevice: Boolean = clients.values.exists(_.isLegalHoldDevice)
 }
 
 object UserClients {

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -141,7 +141,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
                             err                = SyncResult.unapply(syncResult)
                             _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
                             needsConfirmation <- needsLegalHoldConfirmation(conv, isHidden, missing.keys.toSet)
-                            _                  = if (needsConfirmation) throw UnapprovedLegalHoldException
+                            _                  = if (needsConfirmation) throw LegalHoldDiscoveredException
                             result            <- encryptAndSend(msg, external, retries + 1, content)
                           } yield result
                         case _: MessageResponse.Failure =>
@@ -169,7 +169,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case UnverifiedException =>
         if (!message.proto.hasCalling) errors.addConvUnverifiedError(convId, MessageId(message.proto.getMessageId))
         Left(ErrorResponse.Unverified)
-      case UnapprovedLegalHoldException =>
+      case LegalHoldDiscoveredException =>
         errors.addUnapprovedLegalHoldStatusError(convId, MessageId(message.proto.getMessageId))
         Left(ErrorResponse.UnapprovedLegalHold)
       case NonFatal(e) =>
@@ -324,7 +324,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
 object OtrSyncHandler {
 
   final case object UnverifiedException extends Exception
-  final case object UnapprovedLegalHoldException extends Exception
+  final case object LegalHoldDiscoveredException extends Exception
 
   final case class OtrMessage(sender:         ClientId,
                               recipients:     EncryptedContent,

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -109,7 +109,6 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       for {
         _          <- push.waitProcessing
         Some(conv) <- convStorage.get(convId)
-        _          =  if (!isHidden && conv.legalHoldStatus == LegalHoldStatus.PendingApproval) throw UnapprovedLegalHoldException
         _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
         recipients <- clientsMap(targetRecipients, convId)
         content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
@@ -137,16 +136,34 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         retry      <- resp.flatMapFuture {
                         case MessageResponse.Failure(ClientMismatch(_, missing, _, _)) if retries < 3 =>
                           warn(l"a message response failure with client mismatch with $missing, self client id is: $selfClientId")
-                          syncClients(missing.keys.toSet).flatMap { syncResult =>
-                            val err = SyncResult.unapply(syncResult)
-                            if (err.isDefined) error(l"syncClients for missing clients failed: $err")
-                            encryptAndSend(msg, external, retries + 1, content)
-                          }
+                          for {
+                            syncResult        <- syncClients(missing.keys.toSet)
+                            err                = SyncResult.unapply(syncResult)
+                            _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
+                            needsConfirmation <- needsLegalHoldConfirmation(conv, isHidden, missing.keys.toSet)
+                            _                  = if (needsConfirmation) throw UnapprovedLegalHoldException
+                            result            <- encryptAndSend(msg, external, retries + 1, content)
+                          } yield result
                         case _: MessageResponse.Failure =>
                           successful(Left(internalError(s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries")))
                         case resp => Future.successful(Right(resp))
                       }
       } yield retry
+
+    def needsLegalHoldConfirmation(conv: ConversationData,
+                                   isMessageHidden: Boolean,
+                                   usersWithMissingClients: Set[UserId]): Future[Boolean] = {
+      if (isMessageHidden || conv.isUnderLegalHold) {
+        Future.successful(false)
+      } else {
+        clientsStorage.getAll(usersWithMissingClients).map {
+          _.exists {
+            case Some(userClients) => userClients.containsLegalHoldDevice
+            case None => false
+          }
+        }
+      }
+    }
 
     encryptAndSend(message).recover {
       case UnverifiedException =>

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -618,13 +618,8 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
   feature("it calculates correct legal hold status") {
 
     scenario("existing status is disabled") {
-      assert(existingStatus = Disabled, detectedLegalHoldDevice = true, expectation = PendingApproval)
+      assert(existingStatus = Disabled, detectedLegalHoldDevice = true, expectation = Enabled)
       assert(existingStatus = Disabled, detectedLegalHoldDevice = false, expectation = Disabled)
-    }
-
-    scenario("existing status is pending approval") {
-      assert(existingStatus = PendingApproval, detectedLegalHoldDevice = true, expectation = PendingApproval)
-      assert(existingStatus = PendingApproval, detectedLegalHoldDevice = false, expectation = Disabled)
     }
 
     scenario("existing status is enabled") {
@@ -690,7 +685,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       result(pipeline.apply(Seq(event)))
 
       // Then
-      updatedStatus shouldEqual LegalHoldStatus.PendingApproval
+      updatedStatus shouldEqual LegalHoldStatus.Enabled
     }
 
     scenario("it triggers client sync if it discovers legal hold to be disabled") {


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** 
- ["Send anyway?" alert to be shown only once through all conversation (align with iOS)](https://wearezeta.atlassian.net/browse/SQSERVICES-483)
- ["Send anyway?" alert shown even LH is already discovered and alert Legal Hold is active was shown](https://wearezeta.atlassian.net/browse/SQSERVICES-487)


### Issues

The "send anyway" confirmation alert is being shown too often. Currently, it is shown the first time the self user sends a message after legal hold is discovered (either by sending that message, or by other means). This happens for every conversation under legal hold. As per the spec, it should only be shown once when legal hold is discovered by sending a message and not again when sending messages in other legal hold conversations.

### Causes

The confusion stems from the three legal hold states defined in the specs: "disabled", "pending approval", and "enabled". I understood the pending state as a transitional state between the disabled and enabled states, whereby the user needed to actively confirm to move to the enabled state. Since each conversation has a legal hold status, the user needed to confirm legal hold per conversation. Furthermore, we were always presenting the alert even if legal hold was already discovered because we did not distinguish where the discovery came from.

### Solutions

The send anyway alert is shown when handling a particular exception that is thrown when trying to send a message. This exception now only thrown when we detect a legal hold device as part of the missing clients. A consequence of this is that the "pending approval" legal hold status is not needed and has therefore been deprecated.

### Testing

Updated existing tests and performed manual tests.
#### APK
[Download build #3573](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3573/artifact/build/artifact/wire-dev-PR3349-3573.apk)
[Download build #3574](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3574/artifact/build/artifact/wire-dev-PR3349-3574.apk)
[Download build #3576](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3576/artifact/build/artifact/wire-dev-PR3349-3576.apk)
[Download build #3589](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3589/artifact/build/artifact/wire-dev-PR3349-3589.apk)