### PR TITLE
Federation: Proper handling of responses to user search queries

### DIFF
--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -33,6 +33,7 @@ public enum SyncCommand {
     SyncConvLink("sync-conv-link"),
     SyncSearchQuery("sync-search"),
     SyncSearchResults("sync-search-results"),
+    SyncQualifiedSearchResults("sync-qualified-search-results"),
     SyncProperties("sync-properties"),
     ExactMatchHandle("exact-match"),
     PostConv("post-conv"),

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -199,7 +199,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
     val query = SearchQuery(queryStr)
 
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      if (query.hasDomain)
+      if (query.hasDomain || query.isEmpty)
         search(query)
       else
         userService.selfUser.map(_.domain.getOrElse("")).flatMap {

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -31,13 +31,14 @@ import com.waz.service.assets.{AssetService, AssetStorage, Content, ContentForUp
 import com.waz.service.conversation.SelectedConversationService
 import com.waz.service.messages.MessagesService
 import com.waz.service.push.PushService
-import com.waz.sync.{SyncRequestService, SyncServiceHandle}
+import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.AssetClient.Retention
 import com.waz.sync.client.{CredentialsUpdateClient, ErrorOr, UsersClient}
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.signals._
-import com.waz.utils.wrappers.AndroidURIUtil
+
+import com.waz.zms.BuildConfig
 
 import scala.collection.breakOut
 import scala.concurrent.Future
@@ -64,6 +65,7 @@ trait UserService {
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
   def syncUser(userId: UserId): Future[Option[UserData]]
+  def syncQualifiedUser(qId: QualifiedId): Future[Option[UserData]]
   def acceptedOrBlockedUsers: Signal[Map[UserId, UserData]]
 
   def updateSyncedUsers(users: Seq[UserInfo], timestamp: LocalInstant = LocalInstant.Now): Future[Set[UserData]]
@@ -205,10 +207,15 @@ class UserServiceImpl(selfUserId:        UserId,
   override def qualifiedId(userId: UserId): Future[QualifiedId] =
     findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
 
-  override def getOrCreateUser(id: UserId) = usersStorage.getOrCreate(id, {
-    sync.syncUsers(Set(id))
-    UserData(id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None)
-  })
+  override def getOrCreateUser(id: UserId): Future[UserData] =
+    usersStorage.getOrCreate(id, {
+      sync.syncUsers(Set(id))
+      UserData(
+        id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
+        searchKey = SearchKey.Empty, handle = None
+      )
+    })
+
 
   override def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None) =
     usersStorage.update(id, { _.updateConnectionStatus(status, time, message)}).map {
@@ -240,6 +247,16 @@ class UserServiceImpl(selfUserId:        UserId,
         updateSyncedUsers(Seq(info)).map(_.headOption)
       case Right(None) =>
         deleteUsers(Set(userId)).map(_ => None)
+    }
+
+  override def syncQualifiedUser(qId: QualifiedId): Future[Option[UserData]] =
+    usersClient.loadQualifiedUser(qId).future.flatMap {
+      case Left(e) =>
+        Future.failed(e)
+      case Right(Some(info)) =>
+        updateSyncedUsers(Seq(info)).map(_.headOption)
+      case Right(None) =>
+        deleteUsers(Set(qId.id)).map(_ => None)
     }
 
   def syncSelfNow: Future[Option[UserData]] = Serialized.future(s"syncSelfNow $selfUserId") {

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -41,6 +41,7 @@ import scala.concurrent.duration._
 
 trait SyncServiceHandle {
   def syncSearchResults(ids: Set[UserId]): Future[SyncId]
+  def syncQualifiedSearchResults(qIds: Set[QualifiedId]): Future[SyncId]
   def syncSearchQuery(query: SearchQuery): Future[SyncId]
   def syncUsers(ids: Set[UserId]): Future[SyncId]
   def syncSelfUser(): Future[SyncId]
@@ -144,6 +145,7 @@ class AndroidSyncServiceHandle(account:         UserId,
     service.addRequest(account, req, priority, dependsOn, forceRetry, delay)
 
   def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users))
+  def syncQualifiedSearchResults(qIds: Set[QualifiedId]) = addRequest(SyncQualifiedSearchResults(qIds))
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
   def syncUsers(ids: Set[UserId]) = addRequest(SyncUser(ids))
   def syncSelfUser() = addRequest(SyncSelf, priority = Priority.High)
@@ -273,6 +275,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case SyncConvLink(conv)                              => zms.conversationSync.syncConvLink(conv)
           case SyncUser(u)                                     => zms.usersSync.syncUsers(u.toSeq: _*)
           case SyncSearchResults(u)                            => zms.usersSync.syncSearchResults(u.toSeq: _*)
+          case SyncQualifiedSearchResults(qIds)                => zms.usersSync.syncQualifiedSearchResults(qIds)
           case SyncSearchQuery(query)                          => zms.usersearchSync.syncSearchQuery(query)
           case SyncRichMedia(messageId)                        => zms.richmediaSync.syncRichMedia(messageId)
           case DeletePushToken(token)                          => zms.gcmSync.deleteGcmToken(token)

--- a/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -35,6 +35,10 @@ import scala.util.Right
 trait UsersClient {
   def loadUser(id: UserId): ErrorOrResponse[Option[UserInfo]]
   def loadUsers(ids: Seq[UserId]): ErrorOrResponse[Seq[UserInfo]]
+
+  def loadQualifiedUser(qId: QualifiedId): ErrorOrResponse[Option[UserInfo]]
+  def loadQualifiedUsers(qIds: Set[QualifiedId]): ErrorOrResponse[Seq[UserInfo]]
+
   def loadSelf(): ErrorOrResponse[UserInfo]
   def loadRichInfo(user: UserId): ErrorOrResponse[Seq[UserField]]
   def updateSelf(info: UserInfo): ErrorOrResponse[Unit]
@@ -69,6 +73,20 @@ class UsersClientImpl(implicit
         case e: ErrorResponse => Left(e)
       }
 
+  override def loadQualifiedUser(qId: QualifiedId): ErrorOrResponse[Option[UserInfo]] =
+    Request.Get(relativePath = qualifiedPath(qId))
+      .withResultType[UserInfo]
+      .withErrorType[ErrorResponse]
+      .execute
+      .map {
+        case res if res.deleted => Right(None)
+        case res => Right(Some(res))
+      }
+      .recover {
+        case e: ErrorResponse if e.code == ErrorResponse.NotFound => Right(None)
+        case e: ErrorResponse => Left(e)
+      }
+
   override def loadUsers(ids: Seq[UserId]): ErrorOrResponse[Seq[UserInfo]] = {
     if (ids.isEmpty) CancellableFuture.successful(Right(Vector()))
     else {
@@ -82,6 +100,15 @@ class UsersClientImpl(implicit
       CancellableFuture.lift(result)
     }
   }
+
+  override def loadQualifiedUsers(qIds: Set[QualifiedId]): ErrorOrResponse[Seq[UserInfo]] =
+    if (qIds.isEmpty)
+      CancellableFuture.successful(Right(Vector()))
+    else
+      Request.Post(relativePath = ListUsersPath, body = ListUsersRequest(qIds.toSeq).encode)
+        .withResultType[Seq[UserInfo]]
+        .withErrorType[ErrorResponse]
+        .executeSafe
 
   override def loadSelf(): ErrorOrResponse[UserInfo] = {
     Request.Get(relativePath = SelfPath)
@@ -124,19 +151,36 @@ class UsersClientImpl(implicit
 
 object UsersClient {
   val UsersPath = "/users"
+  val ListUsersPath = "/list-users"
   val SelfPath = "/self"
   def RichInfoPath(user: UserId) = s"$UsersPath/${user.str}/rich-info"
   val ConnectionsPath = "/self/connections"
   val SearchablePath = "/self/searchable"
   val IdsCountThreshold = 64
 
-  def usersPath(user: UserId) = s"$UsersPath/${user.str}"
+  def usersPath(user: UserId): String = s"$UsersPath/${user.str}"
+  def qualifiedPath(qId: QualifiedId): String = s"$UsersPath/${qId.domain}/${qId.id}"
 
   case class DeleteAccount(password: Option[String])
 
   implicit lazy val DeleteAccountEncoder: JsonEncoder[DeleteAccount] = new JsonEncoder[DeleteAccount] {
     override def apply(v: DeleteAccount): JSONObject = JsonEncoder { o =>
       v.password foreach (o.put("password", _))
+    }
+  }
+
+  final case class ListUsersRequest(qIds: Seq[QualifiedId]) {
+    def encode: JSONObject = JsonEncoder { o =>
+      o.put(
+        "qualified_ids",
+        JsonEncoder.array(qIds) { case (arr, qid) => arr.put(QualifiedId.Encoder(qid)) }
+      )
+    }
+  }
+
+  object ListClientsRequest {
+    implicit object Encoder extends JsonEncoder[ListUsersRequest] {
+      override def apply(request: ListUsersRequest): JSONObject = request.encode
     }
   }
 }


### PR DESCRIPTION
Adding a domain to search queries in a previous PR already affected the user search functionality
and introduced a few bugs. This PR updates the user search functionality with handling of queries
and search results with domains. Some changes were also made in preparation of the next step -
adding connections with a user from another domain.

#### APK
[Download build #3578](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3578/artifact/build/artifact/wire-dev-PR3353-3578.apk)