### PR TITLE
Feature: Build Config - Add a build config to keep web socket on by default

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,7 @@ android {
         buildConfigField 'String',  'FILE_RESTRICTION_LIST',         "\"$buildtimeConfiguration.configuration.file_restriction_list\""
         buildConfigField 'String',  'COUNTLY_SERVER_URL',            "\"$buildtimeConfiguration.configuration.countly_server_url\""
         buildConfigField 'String',  'COUNTLY_APP_KEY',               "\"$buildtimeConfiguration.configuration.countly_app_key\""
+        buildConfigField 'boolean', 'KEEP_WEBSOCKET_ON',             "$buildtimeConfiguration.configuration.keep_websocket_on"
 
         //Feature Flags
         buildConfigField 'boolean', 'LARGE_VIDEO_CONFERENCE_CALLS', "$largeVideoConferenceCalls"

--- a/default.json
+++ b/default.json
@@ -44,5 +44,6 @@
   "file_restriction_enabled": false,
   "file_restriction_list":  "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
   "countly_server_url": "https://countly.wire.com",
-  "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6"
+  "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
+  "keep_websocket_on": false
 }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -311,6 +311,7 @@ object GlobalPreferences {
   lazy val V31AssetsEnabledKey = PrefKey[Boolean]("PREF_V31_ASSETS_ENABLED")
   lazy val WsForegroundKey = PrefKey[Boolean]("websocket_foreground_service_enabled_1", customDefault = false)
   lazy val CheckedForPlayServices = PrefKey[Boolean]("checked_for_google_play_services", customDefault = false)
+  lazy val CheckedWebSocketConfig = PrefKey[Boolean]("checked_web_socket_config", customDefault = false)
   lazy val SkipTerminatingState = PrefKey[Boolean]("skip_terminating_state") //for calling
 
   lazy val PushEnabledKey = PrefKey[Boolean]("PUSH_ENABLED", customDefault = true)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Jira: [SQSERVICES-497](https://wearezeta.atlassian.net/browse/SQSERVICES-497)

Some customers want web socket to keep running by default even when app is killed.

### Solutions

Added a new flag `keep_websocket_on` to default.json. When this flag is set to true during custom builds, the websocket will be on by default. User may still turn the switch off via Settings > Advanced.

### Testing

Manually tested.


#### APK
[Download build #3586](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3586/artifact/build/artifact/wire-dev-PR3358-3586.apk)