### PR TITLE
fix: Empty query in user search returns zero results

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
+++ b/zmessaging/src/main/scala/com/waz/service/SearchQuery.scala
@@ -24,7 +24,7 @@ import com.waz.log.LogSE._
 import com.waz.utils.returning
 
 final case class SearchQuery private (query: String, domain: String, handleOnly: Boolean) {
-  val isEmpty: Boolean = query.isEmpty && domain.isEmpty
+  val isEmpty: Boolean = query.isEmpty
 
   def hasDomain: Boolean = domain.nonEmpty
 

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -164,7 +164,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
           !user.isWireBot &&
           !user.deleted &&
           user.expiresAt.isEmpty &&
-          user.matchesQuery(query) &&
+          (query.isEmpty || user.matchesQuery(query)) &&
           (showBlockedUsers || !user.isBlocked)
       }.toIndexedSeq
 

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -126,7 +126,7 @@ class TeamsServiceImpl(selfUser:           UserId,
         if (!query.isEmpty) userStorage.searchByTeam(tId, query)
         else userStorage.getByTeam(Set(tId))
 
-      def userMatches(data: UserData) = data.isInTeam(teamId) && data.matchesQuery(query)
+      def userMatches(data: UserData) = data.isInTeam(teamId) && (query.isEmpty || data.matchesQuery(query))
 
       new AggregatingSignal[Seq[ContentChange[UserId, UserData]], Set[UserData]](
         () => load,


### PR DESCRIPTION
This is a very simple bug but it was obscured by another bug on the backend which also affected search results.
Before, `UserData.matchQuery(query: SearchQuery): Boolean` returned `true` if the query was empty, but that was
misleading - it should have returned true only if the user matched the query after all. I changed that but forgot
that our user search actually depends on it, the rule being that with the empty query we should return all local
results.
Now, I simply  moved the check for empty query to the user search logic.

I also added the return types to the lists of users and conversations, because Android Studio asked me to do it. 
#### APK
[Download build #3591](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3591/artifact/build/artifact/wire-dev-PR3361-3591.apk)