### PR TITLE
[Fix] Legal hold system messages shown when they should not

### DIFF
--- a/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
@@ -73,7 +73,8 @@ class ClientSpec extends AndroidFreeSpec {
       verified = Verification.VERIFIED,
       deviceClass = DeviceClass.Tablet,
       deviceType = Some(DeviceType.Temporary),
-      regTime = Some(Instant.now())
+      regTime = Some(Instant.now()),
+      isTemporary = true
     )
 
     scenario("Deserialize client from JSON") {
@@ -90,7 +91,8 @@ class ClientSpec extends AndroidFreeSpec {
            |      "verification": "${client.verified.name}",
            |      "class": "${client.deviceClass.value}",
            |      "type": "${client.deviceType.get.value}",
-           |      "regTime": ${client.regTime.get.toEpochMilli}
+           |      "regTime": ${client.regTime.get.toEpochMilli},
+           |      "isTemporary": true
            |    }
            |  ]
            |}
@@ -113,6 +115,7 @@ class ClientSpec extends AndroidFreeSpec {
       decodedClient.deviceClass shouldEqual client.deviceClass
       decodedClient.deviceType shouldEqual client.deviceType
       decodedClient.regTime shouldEqual client.regTime
+      decodedClient.isTemporary shouldEqual true
     }
 
     scenario("Deserialize client from legacy JSON") {
@@ -151,6 +154,7 @@ class ClientSpec extends AndroidFreeSpec {
       decodedClient.deviceClass shouldEqual client.deviceClass
       decodedClient.deviceType shouldEqual None
       decodedClient.regTime shouldEqual client.regTime
+      decodedClient.isTemporary shouldEqual false
     }
 
     scenario("Serialize client to JSON") {
@@ -172,7 +176,8 @@ class ClientSpec extends AndroidFreeSpec {
             |      "verification": "${client.verified.name}",
             |      "class": "${client.deviceClass.value}",
             |      "type": "${client.deviceType.get.value}",
-            |      "regTime": ${client.regTime.get.toEpochMilli}
+            |      "regTime": ${client.regTime.get.toEpochMilli},
+            |      "isTemporary": true
             |    }
             |  ]
             |}""".stripMargin

--- a/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/ClientSpec.scala
@@ -92,7 +92,7 @@ class ClientSpec extends AndroidFreeSpec {
            |      "class": "${client.deviceClass.value}",
            |      "type": "${client.deviceType.get.value}",
            |      "regTime": ${client.regTime.get.toEpochMilli},
-           |      "isTemporary": true
+           |      "isTemporary": ${client.isTemporary}
            |    }
            |  ]
            |}
@@ -177,7 +177,7 @@ class ClientSpec extends AndroidFreeSpec {
             |      "class": "${client.deviceClass.value}",
             |      "type": "${client.deviceType.get.value}",
             |      "regTime": ${client.regTime.get.toEpochMilli},
-            |      "isTemporary": true
+            |      "isTemporary": ${client.isTemporary}
             |    }
             |  ]
             |}""".stripMargin


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-479

### Issues

If the user attempts to approve legal hold but it fails (for instance, if the password is incorrect), system messages will appear indicating that legal hold was activated, then immediately deactivated.

### Causes

System messages are created whenever the legal hold status of a conversation changes. This status is calculated automatically whenever the list of clients in that conversation changes. When approving a legal hold request, we first create a local legal hold device and crypto session (triggering the enabled legal hold status and accompanying system message), and when the approval fails, we tear down the session and delete the device (triggering the disabled state and accompanying system message).

### Solutions

Delaying client creation until after successful approval goes against the technical specs, so instead we add a new flag to `ClIent` indicating whether a client `isTemporary`. We set this value to `true` when creating the legal hold device, on only set it to `false` once the legal hold request has been successfully approved. Only non temporary legal hold clients will be considered as being under legal hold, which means that creation of a temporary legal hold client won't trigger the system messages.

### Testing

Updated existing tests to take the new flag into account.

#### APK
[Download build #3597](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3597/artifact/build/artifact/wire-dev-PR3363-3597.apk)
[Download build #3598](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3598/artifact/build/artifact/wire-dev-PR3363-3598.apk)