### PR TITLE
wire-signals update to 0.5.1 (and wire-signals-extensions to 0.5.1)

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -187,8 +187,8 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.4.2"
-    const val WIRE_SIGNALS_EXTENSIONS = "0.4.0"
+    const val WIRE_SIGNALS = "0.5.1"
+    const val WIRE_SIGNALS_EXTENSIONS = "0.5.0"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -188,7 +188,7 @@ object LegacyDependencies {
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
     const val WIRE_SIGNALS = "0.5.1"
-    const val WIRE_SIGNALS_EXTENSIONS = "0.5.0"
+    const val WIRE_SIGNALS_EXTENSIONS = "0.5.1"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"


### PR DESCRIPTION
This is - hopefully - the last update before the 1.0 version. No other changes in the wire-android code that the signals version bump. On the wire-signals side, there was some minor refactoring which shouldn't have any impact of wire-android.

#### APK
[Download build #3608](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3608/artifact/build/artifact/wire-dev-PR3366-3608.apk)