### PR TITLE
Feature: Deep Link - Part 1 - Parse conversation-join deep link 

### DIFF
--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLinkService.scala
@@ -103,6 +103,8 @@ class DeepLinkService(implicit injector: Injector) extends Injectable with Deriv
         Future.successful(DoNotOpenDeepLink(deepLink, UserLoggedIn))
       case (_, _, DeepLink.CustomBackendToken(_)) =>
         Future.successful(OpenDeepLink(token))
+      case (_, _, DeepLink.JoinConversationToken(_, _)) =>
+        Future.successful(OpenDeepLink(token))
       case _ =>
         Future.successful(OpenDeepLink(token))
     }

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -197,6 +197,10 @@ class MainPhoneFragment extends FragmentHelper
         showErrorDialog(R.string.deep_link_conversation_error_title, R.string.deep_link_conversation_error_message)
         deepLinkService.deepLink ! None
 
+      case OpenDeepLink(JoinConversationToken(key, code), _) =>
+        //TODO: Join conversation & open it
+        deepLinkService.deepLink ! None
+
       case DoNotOpenDeepLink(User, reason) =>
         verbose(l"do not open, user deep link error. Reason: $reason")
         showErrorDialog(R.string.deep_link_user_error_title, R.string.deep_link_user_error_message)


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-500](https://wearezeta.atlassian.net/browse/SQSERVICES-500)

Handle deep links in the format of `wire://conversation-join/?key={ckey}&code={ccode}` is received. This link will be used to join a public conversation.


### Solutions

Added a new deep link type: `JoinConversation`

### Testing

Manually tested with adb command: 
`adb shell am start -a android.intent.action.VIEW -d "wire://conversation-join/?key=dummykey\&code=dummycode"`

#### APK
[Download build #3612](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3612/artifact/build/artifact/wire-dev-PR3367-3612.apk)
[Download build #3614](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3614/artifact/build/artifact/wire-dev-PR3367-3614.apk)
[Download build #3616](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3616/artifact/build/artifact/wire-dev-PR3367-3616.apk)