### PR TITLE
Feature: Deep Link - Part 2 - Get conversation overview, open conversation if already joined

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -411,8 +411,8 @@ class ConversationController(implicit injector: Injector, context: Context)
 
   convChanged.onUi { ev => convChangedCallbackSet.foreach(callback => callback.callback(ev)) }
 
-  def getJoinConversationInfo(key: String, code: String): Future[Either[ErrorResponse, JoinConversationInfo]] =
-    conversations.head.flatMap(_.getJoinConversationInfo(key, code))
+  def getGuestroomInfo(key: String, code: String): Future[Either[ErrorResponse, GuestRoomInfo]] =
+    conversations.head.flatMap(_.getGuestroomInfo(key, code))
 
   object messages {
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -22,6 +22,7 @@ import java.net.URI
 import android.content.Context
 import android.graphics.{Bitmap, BitmapFactory}
 import com.waz.api
+import com.waz.api.impl.ErrorResponse
 import com.waz.api.{IConversation, Verification}
 import com.waz.content.{ConversationStorage, OtrClientsStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -34,7 +35,7 @@ import com.waz.service.conversation.{ConversationsService, ConversationsUiServic
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
 import com.waz.threading.Threading._
-import com.wire.signals.{Serialized, EventStream, Signal, SourceStream}
+import com.wire.signals.{EventStream, Serialized, Signal, SourceStream}
 import com.waz.utils.{returning, _}
 import com.waz.zclient.calling.controllers.CallStartController
 import com.waz.zclient.common.controllers.global.AccentColorController
@@ -409,6 +410,9 @@ class ConversationController(implicit injector: Injector, context: Context)
   def removeConvChangedCallback(callback: Callback[ConversationChange]): Unit = convChangedCallbackSet -= callback
 
   convChanged.onUi { ev => convChangedCallbackSet.foreach(callback => callback.callback(ev)) }
+
+  def getJoinConversationInfo(key: String, code: String): Future[Either[ErrorResponse, JoinConversationInfo]] =
+    conversations.head.flatMap(_.getJoinConversationInfo(key, code))
 
   object messages {
 

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -192,7 +192,7 @@ class MainPhoneFragment extends FragmentHelper
         deepLinkService.deepLink ! None
 
       case OpenDeepLink(JoinConversationToken(key, code), _) =>
-        conversationController.getJoinConversationInfo(key, code).foreach {
+        conversationController.getGuestroomInfo(key, code).foreach {
           case Right(ExistingConversation(convData)) => openConversationFromDeepLink(convData.id)
           case Right(ConversationOverview(name))     => /*TODO show confirmation pop up*/
           case Left(errorResponse)                   => /*TODO show error pop up*/

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -27,7 +27,7 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.fragment.app.FragmentManager
 import com.waz.content.UserPreferences.{CrashesAndAnalyticsRequestShown, TrackingEnabled}
 import com.waz.content.{GlobalPreferences, UserPreferences}
-import com.waz.model.{ErrorData, Uid}
+import com.waz.model.{ConvId, ConversationOverview, ErrorData, ExistingConversation, Uid}
 import com.waz.permissions.PermissionsService
 import com.waz.service.tracking.GroupConversationEvent
 import com.waz.service.{AccountManager, GlobalModule, NetworkModeService, ZMessaging}
@@ -183,13 +183,7 @@ class MainPhoneFragment extends FragmentHelper
         deepLinkService.deepLink ! None
 
       case OpenDeepLink(ConversationToken(convId), _) =>
-        pickUserController.hideUserProfile()
-        participantsController.onLeaveParticipants ! true
-        participantsController.selectedParticipant ! None
-
-        CancellableFuture.delay(750.millis).map { _ =>
-          conversationController.switchConversation(convId)
-        }
+        openConversationFromDeepLink(convId)
         deepLinkService.deepLink ! None
 
       case DoNotOpenDeepLink(Conversation, reason) =>
@@ -198,7 +192,11 @@ class MainPhoneFragment extends FragmentHelper
         deepLinkService.deepLink ! None
 
       case OpenDeepLink(JoinConversationToken(key, code), _) =>
-        //TODO: Join conversation & open it
+        conversationController.getJoinConversationInfo(key, code).foreach {
+          case Right(ExistingConversation(convData)) => openConversationFromDeepLink(convData.id)
+          case Right(ConversationOverview(name))     => /*TODO show confirmation pop up*/
+          case Left(errorResponse)                   => /*TODO show error pop up*/
+        }
         deepLinkService.deepLink ! None
 
       case DoNotOpenDeepLink(User, reason) =>
@@ -214,6 +212,16 @@ class MainPhoneFragment extends FragmentHelper
         deepLinkService.deepLink ! None
 
       case _ =>
+    }
+  }
+
+  private def openConversationFromDeepLink(convId: ConvId): Unit = {
+    pickUserController.hideUserProfile()
+    participantsController.onLeaveParticipants ! true
+    participantsController.selectedParticipant ! None
+
+    CancellableFuture.delay(750.millis).map { _ =>
+      conversationController.switchConversation(convId)
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
@@ -1,0 +1,5 @@
+package com.waz.model
+
+sealed trait GuestRoomInfo
+case class ConversationOverview(name: String) extends GuestRoomInfo
+case class ExistingConversation(conversationData: ConversationData) extends GuestRoomInfo

--- a/zmessaging/src/main/scala/com/waz/model/JoinConversationInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/JoinConversationInfo.scala
@@ -1,0 +1,5 @@
+package com.waz.model
+
+sealed trait JoinConversationInfo
+case class ConversationOverview(name: String) extends JoinConversationInfo
+case class ExistingConversation(conversationData: ConversationData) extends JoinConversationInfo

--- a/zmessaging/src/main/scala/com/waz/model/JoinConversationInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/JoinConversationInfo.scala
@@ -1,5 +1,0 @@
-package com.waz.model
-
-sealed trait JoinConversationInfo
-case class ConversationOverview(name: String) extends JoinConversationInfo
-case class ExistingConversation(conversationData: ConversationData) extends JoinConversationInfo

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -74,7 +74,7 @@ trait ConversationsService {
   def conversationName(convId: ConvId): Signal[Name]
   def deleteMembersFromConversations(members: Set[UserId]): Future[Unit]
   def remoteIds: Future[Set[RConvId]]
-  def getJoinConversationInfo(key: String, code: String): ErrorOr[JoinConversationInfo]
+  def getGuestroomInfo(key: String, code: String): ErrorOr[GuestRoomInfo]
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -673,8 +673,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       _        <- sync.postConversationRole(convId, userId, newRole, origRole.getOrElse(ConversationRole.MemberRole))
     } yield ()
 
-  override def getJoinConversationInfo(key: String, code: String): ErrorOr[JoinConversationInfo] =
-    client.getJoinConversationOverview(key, code).future.flatMap {
+  override def getGuestroomInfo(key: String, code: String): ErrorOr[GuestRoomInfo] =
+    client.getGuestroomOverview(key, code).future.flatMap {
       case Right(ConversationOverviewResponse(rConvId, name)) =>
         convsStorage.getByRemoteId(rConvId).map {
           case Some(conversationData) => Right(ExistingConversation(conversationData))

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -31,7 +31,7 @@ import com.waz.service._
 import com.waz.service.assets.AssetService
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.{NotificationService, PushService}
-import com.waz.sync.client.ConversationsClient.ConversationResponse
+import com.waz.sync.client.ConversationsClient.{ConversationOverviewResponse, ConversationResponse}
 import com.waz.sync.client.{ConversationsClient, ErrorOr}
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.threading.Threading
@@ -74,6 +74,7 @@ trait ConversationsService {
   def conversationName(convId: ConvId): Signal[Name]
   def deleteMembersFromConversations(members: Set[UserId]): Future[Unit]
   def remoteIds: Future[Set[RConvId]]
+  def getJoinConversationInfo(key: String, code: String): ErrorOr[JoinConversationInfo]
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -557,7 +558,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       else Future.successful(())
     }
 
-  def onMemberAddFailed(conv: ConvId, users: Set[UserId], err: Option[ErrorType], resp: ErrorResponse) =
+  def onMemberAddFailed(conv: ConvId, users: Set[UserId], err: Option[ErrorType], resp: ErrorResponse): Future[Unit] =
     for {
       _ <- err.fold(Future.successful(()))(e => errors.addErrorWhenActive(ErrorData(e, resp, conv, users)).map(_ => ()))
       _ <- membersStorage.remove(conv, users)
@@ -588,12 +589,12 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
 
   override def isGroupConversation(convId: ConvId): Future[Boolean] = groupConversation(convId).head
 
-  def isWithService(convId: ConvId) =
+  def isWithService(convId: ConvId): Future[Boolean] =
     membersStorage.getActiveUsers(convId)
       .flatMap(usersStorage.getAll)
       .map(_.flatten.exists(_.isWireBot))
 
-  def setToTeamOnly(convId: ConvId, teamOnly: Boolean) =
+  def setToTeamOnly(convId: ConvId, teamOnly: Boolean): ErrorOr[Unit] =
     teamId match {
       case None => Future.successful(Left(ErrorResponse.internalError("Private accounts can't be set to team-only or guest room access modes")))
       case Some(_) =>
@@ -618,7 +619,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         }
     }
 
-  override def createLink(convId: ConvId) =
+  override def createLink(convId: ConvId): ErrorOr[Link] =
     (for {
       Some(conv) <- content.convById(convId) if conv.isGuestRoom || conv.isWirelessLegacy
       modeResp   <- if (conv.isWirelessLegacy) setToTeamOnly(convId, teamOnly = false) else Future.successful(Right({})) //upgrade legacy convs
@@ -637,7 +638,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
           Left(ErrorResponse.internalError("Unable to create link for conversation"))
       }
 
-  override def removeLink(convId: ConvId) =
+  override def removeLink(convId: ConvId): ErrorOr[Unit] =
     (for {
       Some(conv) <- content.convById(convId)
       resp       <- client.removeLink(conv.remoteId).future
@@ -671,6 +672,17 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       _        <- membersStorage.updateOrCreate(convId, userId, newRole)
       _        <- sync.postConversationRole(convId, userId, newRole, origRole.getOrElse(ConversationRole.MemberRole))
     } yield ()
+
+  override def getJoinConversationInfo(key: String, code: String): ErrorOr[JoinConversationInfo] =
+    client.getJoinConversationOverview(key, code).future.flatMap {
+      case Right(ConversationOverviewResponse(rConvId, name)) =>
+        convsStorage.getByRemoteId(rConvId).map {
+          case Some(conversationData) => Right(ExistingConversation(conversationData))
+          case None                   => Right(ConversationOverview(name))
+        }
+
+      case Left(error) => Future.successful(Left(error))
+    }
 }
 
 object ConversationsService {

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -56,7 +56,7 @@ trait ConversationsClient {
   def postReceiptMode(conv: RConvId, receiptMode: Int): ErrorOrResponse[Unit]
   def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse]
   def postConversationRole(id: RConvId, userId: UserId, role: ConversationRole): ErrorOrResponse[Unit]
-  def getJoinConversationOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse]
+  def getGuestroomOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse]
 }
 
 class ConversationsClientImpl(implicit
@@ -255,8 +255,8 @@ class ConversationsClientImpl(implicit
       .executeSafe
   }
 
-  override def getJoinConversationOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse] = {
-    verbose(l"getJoinConversationOverview($key, $code)")
+  override def getGuestroomOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse] = {
+    verbose(l"getGuestroomOverview($key, $code)")
     Request.Get(
       relativePath = JoinConversationPath,
       queryParameters("key" -> key, "code" -> code)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -18,6 +18,7 @@
 package com.waz.service.conversation
 
 import com.waz.api.Message
+import com.waz.api.impl.ErrorResponse
 import com.waz.content._
 import com.waz.log.BasicLogging.LogTag
 import com.waz.model.ConversationData.ConversationType
@@ -28,8 +29,8 @@ import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.{NotificationService, PushService}
 import com.waz.service.teams.{TeamsService, TeamsServiceImpl}
 import com.waz.specs.AndroidFreeSpec
-import com.waz.sync.client.ConversationsClient
-import com.waz.sync.client.ConversationsClient.ConversationResponse
+import com.waz.sync.client.{ConversationsClient, ErrorOr, ErrorOrResponse}
+import com.waz.sync.client.ConversationsClient.{ConversationOverviewResponse, ConversationResponse}
 import com.waz.sync.{SyncRequestService, SyncResult, SyncServiceHandle}
 import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 import com.wire.signals.{CancellableFuture, EventStream, Signal, SourceSignal}
@@ -894,6 +895,89 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       result(members.head.map(_.head.userId)) shouldEqual selfUserId
       result(service.conversationName(convId).head) shouldEqual user2.name
     }
+  }
+
+  feature("Join Conversation") {
+
+    scenario("Parse conversation overview response") {
+      val rConvId = RConvId("remote-conv-id")
+      val convName = "Test Squad Meeting"
+      val jsonStr =
+        s"""
+           |{
+           | "id": "${rConvId.str}",
+           | "name": "$convName"
+           |}
+        """.stripMargin
+
+      val jsonObject = new JSONObject(jsonStr)
+      val response: ConversationOverviewResponse = ConversationOverviewResponse.Decoder(jsonObject)
+
+      response.id shouldBe rConvId
+      response.name shouldBe convName
+    }
+  }
+
+  scenario("Get conversation info for already joined conversation") {
+    val key = "join_key"
+    val code = "join_code"
+    val convName = "Services Squad Conv"
+    val response = ConversationOverviewResponse(rConvId, convName)
+
+    (convsClient.getJoinConversationOverview _)
+      .expects(key, code)
+      .anyNumberOfTimes()
+      .returning(CancellableFuture.successful(Right(response)))
+
+    val conversationData = ConversationData()
+    (convsStorage.getByRemoteId _)
+      .expects(rConvId)
+      .anyNumberOfTimes()
+      .returning(Future.successful(Some(conversationData)))
+
+    val convInfo = result(service.getJoinConversationInfo(key, code))
+
+    convInfo shouldBe Right(ExistingConversation(conversationData))
+  }
+
+  scenario("Get conversation info for new conversation") {
+    val key = "join_key"
+    val code = "join_code"
+    val convName = "Services Squad Conv"
+    val response = ConversationOverviewResponse(rConvId, convName)
+
+    (convsClient.getJoinConversationOverview _)
+      .expects(key, code)
+      .anyNumberOfTimes()
+      .returning(CancellableFuture.successful(Right(response)))
+
+    (convsStorage.getByRemoteId _)
+      .expects(rConvId)
+      .anyNumberOfTimes()
+      .returning(Future.successful(None))
+
+    val convInfo = result(service.getJoinConversationInfo(key, code))
+
+    convInfo shouldBe Right(ConversationOverview(convName))
+  }
+
+  scenario("Get conversation info returns error") {
+    val key = "join_key"
+    val code = "join_code"
+    val error = ErrorResponse.InternalError
+
+    (convsClient.getJoinConversationOverview _)
+      .expects(key, code)
+      .anyNumberOfTimes()
+      .returning(CancellableFuture.successful(Left(error)))
+
+    (convsStorage.getByRemoteId _)
+      .expects(rConvId)
+      .never()
+
+    val convInfo = result(service.getJoinConversationInfo(key, code))
+
+    convInfo shouldBe Left(error)
   }
 
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -897,7 +897,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     }
   }
 
-  feature("Join Conversation") {
+  feature("Join Guestroom Conversation") {
 
     scenario("Parse conversation overview response") {
       val rConvId = RConvId("remote-conv-id")
@@ -918,13 +918,13 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     }
   }
 
-  scenario("Get conversation info for already joined conversation") {
+  scenario("Get guestroom info for already joined conversation") {
     val key = "join_key"
     val code = "join_code"
     val convName = "Services Squad Conv"
     val response = ConversationOverviewResponse(rConvId, convName)
 
-    (convsClient.getJoinConversationOverview _)
+    (convsClient.getGuestroomOverview _)
       .expects(key, code)
       .anyNumberOfTimes()
       .returning(CancellableFuture.successful(Right(response)))
@@ -935,18 +935,18 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       .anyNumberOfTimes()
       .returning(Future.successful(Some(conversationData)))
 
-    val convInfo = result(service.getJoinConversationInfo(key, code))
+    val convInfo = result(service.getGuestroomInfo(key, code))
 
     convInfo shouldBe Right(ExistingConversation(conversationData))
   }
 
-  scenario("Get conversation info for new conversation") {
+  scenario("Get guestroom info for new conversation") {
     val key = "join_key"
     val code = "join_code"
     val convName = "Services Squad Conv"
     val response = ConversationOverviewResponse(rConvId, convName)
 
-    (convsClient.getJoinConversationOverview _)
+    (convsClient.getGuestroomOverview _)
       .expects(key, code)
       .anyNumberOfTimes()
       .returning(CancellableFuture.successful(Right(response)))
@@ -956,17 +956,17 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       .anyNumberOfTimes()
       .returning(Future.successful(None))
 
-    val convInfo = result(service.getJoinConversationInfo(key, code))
+    val convInfo = result(service.getGuestroomInfo(key, code))
 
     convInfo shouldBe Right(ConversationOverview(convName))
   }
 
-  scenario("Get conversation info returns error") {
+  scenario("Get guestroom info returns error") {
     val key = "join_key"
     val code = "join_code"
     val error = ErrorResponse.InternalError
 
-    (convsClient.getJoinConversationOverview _)
+    (convsClient.getGuestroomOverview _)
       .expects(key, code)
       .anyNumberOfTimes()
       .returning(CancellableFuture.successful(Left(error)))
@@ -975,7 +975,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       .expects(rConvId)
       .never()
 
-    val convInfo = result(service.getJoinConversationInfo(key, code))
+    val convInfo = result(service.getGuestroomInfo(key, code))
 
     convInfo shouldBe Left(error)
   }


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-500](https://wearezeta.atlassian.net/browse/SQSERVICES-500)

If the user is already a member of the conversation in the JoinConversation deep link, we directly open the conversation.

### Solutions

A new endpoint, `GET /conversations/join?key=...&code=...` is created by backend, which returns minimum information about the conversation: its remote id and name. We check if user is already a member of the conversation with the returned remote id, and if s/he is, we directly open the conversation.

### Testing

Tested with adb command and mocking backend response (as it's not ready yet)


#### APK
[Download build #3611](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3611/artifact/build/artifact/wire-dev-PR3368-3611.apk)
[Download build #3615](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3615/artifact/build/artifact/wire-dev-PR3368-3615.apk)
[Download build #3627](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3627/artifact/build/artifact/wire-dev-PR3368-3627.apk)
[Download build #3628](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3628/artifact/build/artifact/wire-dev-PR3368-3628.apk)
[Download build #3633](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3633/artifact/build/artifact/wire-dev-PR3368-3633.apk)