### PR TITLE
fix: Bump down wire-signals to 0.4.3 to fix logging in

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -187,8 +187,8 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.5.1"
-    const val WIRE_SIGNALS_EXTENSIONS = "0.5.1"
+    const val WIRE_SIGNALS = "0.4.3"
+    const val WIRE_SIGNALS_EXTENSIONS = "0.4.3"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"


### PR DESCRIPTION
wire-signals 0.5.1 contains a change in how signals are initialized. I thought that changes was minor and in fact improves
the consistency of signals behaviour. Now I'm not so sure anymore. I will have to take another look in the wire-signals code
and meanwhile bumping down to 0.4.3 will be a workaround.