### PR TITLE
Feature: Deep Link - Part 3 -Send request to join conversation, handle errors

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1625,5 +1625,10 @@
     <string name="legal_hold_cannot_connect_alert_title">Cannot connect to this user</string>
     <string name="legal_hold_cannot_connect_alert_message">You cannot connect to this user due to legal hold.</string>
     <string name="legal_hold_cannot_connect_alert_negative_button">LEARN MORE</string>
+
+    <!-- Join Conversation via Deep Link -->
+    <string name="join_conversation_confirmation_message">You are about to join the guestroom conversation \"%s\" with your account.</string>
+    <string name="join_conversation_cannot_join_error">You cannot be added to this group conversation.</string>
+    <string name="join_conversation_member_limit_reached_error">You cannot be added to this guestroom because the limit is reached.</string>
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -414,6 +414,9 @@ class ConversationController(implicit injector: Injector, context: Context)
   def getGuestroomInfo(key: String, code: String): Future[Either[ErrorResponse, GuestRoomInfo]] =
     conversations.head.flatMap(_.getGuestroomInfo(key, code))
 
+  def joinConversation(key: String, code: String): Future[JoinConversationResult] =
+    conversations.head.flatMap(_.joinConversation(key, code))
+
   object messages {
 
     val ActivityTimeout = 3.seconds

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -22,7 +22,6 @@ import java.net.URI
 import android.content.Context
 import android.graphics.{Bitmap, BitmapFactory}
 import com.waz.api
-import com.waz.api.impl.ErrorResponse
 import com.waz.api.{IConversation, Verification}
 import com.waz.content.{ConversationStorage, OtrClientsStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
@@ -411,10 +410,10 @@ class ConversationController(implicit injector: Injector, context: Context)
 
   convChanged.onUi { ev => convChangedCallbackSet.foreach(callback => callback.callback(ev)) }
 
-  def getGuestroomInfo(key: String, code: String): Future[Either[ErrorResponse, GuestRoomInfo]] =
+  def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]] =
     conversations.head.flatMap(_.getGuestroomInfo(key, code))
 
-  def joinConversation(key: String, code: String): Future[JoinConversationResult] =
+  def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Unit]] =
     conversations.head.flatMap(_.joinConversation(key, code))
 
   object messages {

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -27,7 +27,8 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.fragment.app.FragmentManager
 import com.waz.content.UserPreferences.{CrashesAndAnalyticsRequestShown, TrackingEnabled}
 import com.waz.content.{GlobalPreferences, UserPreferences}
-import com.waz.model.{ConvId, ConversationOverview, ErrorData, ExistingConversation, Uid}
+import com.waz.model.GuestRoomInfo.{ExistingConversation, Overview}
+import com.waz.model.{ConvId, ErrorData, JoinConversationResult, Uid}
 import com.waz.permissions.PermissionsService
 import com.waz.service.tracking.GroupConversationEvent
 import com.waz.service.{AccountManager, GlobalModule, NetworkModeService, ZMessaging}
@@ -194,7 +195,10 @@ class MainPhoneFragment extends FragmentHelper
       case OpenDeepLink(JoinConversationToken(key, code), _) =>
         conversationController.getGuestroomInfo(key, code).foreach {
           case Right(ExistingConversation(convData)) => openConversationFromDeepLink(convData.id)
-          case Right(ConversationOverview(name))     => /*TODO show confirmation pop up*/
+          case Right(Overview(name))                 => confirmJoiningNewConversation(name).foreach {
+                                                          case true  => joinConversation(key, code)
+                                                          case false =>
+                                                        }
           case Left(errorResponse)                   => /*TODO show error pop up*/
         }
         deepLinkService.deepLink ! None
@@ -222,6 +226,27 @@ class MainPhoneFragment extends FragmentHelper
 
     CancellableFuture.delay(750.millis).map { _ =>
       conversationController.switchConversation(convId)
+    }
+  }
+
+  private def confirmJoiningNewConversation(convName: String): Future[Boolean] =
+    accentColorController.accentColor.head.flatMap(color =>
+      //TODO: copies aren't final, we're probably gonna have titles too..
+      showConfirmationDialog(
+        null,
+        getString(R.string.join_conversation_confirmation_message, convName),
+        color
+      )
+    )
+
+  private def joinConversation(key: String, code: String): Future[Unit] = {
+    import JoinConversationResult._
+    //TODO: copies aren't final, we're probably gonna have titles too..
+    conversationController.joinConversation(key, code).flatMap {
+      case Success            => /*TODO Open new conv. */ Future.successful(())
+      case CannotJoin         => showErrorDialog(headerText = null, msg = getString(R.string.join_conversation_cannot_join_error))
+      case MemberLimitReached => showErrorDialog(headerText = null, msg = getString(R.string.join_conversation_member_limit_reached_error))
+      case GeneralError(_)    => showGenericErrorDialog()
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
@@ -1,5 +1,17 @@
 package com.waz.model
 
+import com.waz.api.impl.ErrorResponse
+
 sealed trait GuestRoomInfo
-case class ConversationOverview(name: String) extends GuestRoomInfo
-case class ExistingConversation(conversationData: ConversationData) extends GuestRoomInfo
+object GuestRoomInfo {
+  case class Overview(name: String) extends GuestRoomInfo
+  case class ExistingConversation(conversationData: ConversationData) extends GuestRoomInfo
+}
+
+sealed trait JoinConversationResult
+object JoinConversationResult {
+  object Success extends JoinConversationResult
+  object CannotJoin extends JoinConversationResult
+  object MemberLimitReached extends JoinConversationResult
+  case class GeneralError(error: ErrorResponse) extends JoinConversationResult
+}

--- a/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/GuestRoomInfo.scala
@@ -1,17 +1,14 @@
 package com.waz.model
 
-import com.waz.api.impl.ErrorResponse
-
 sealed trait GuestRoomInfo
 object GuestRoomInfo {
   case class Overview(name: String) extends GuestRoomInfo
   case class ExistingConversation(conversationData: ConversationData) extends GuestRoomInfo
 }
 
-sealed trait JoinConversationResult
-object JoinConversationResult {
-  object Success extends JoinConversationResult
-  object CannotJoin extends JoinConversationResult
-  object MemberLimitReached extends JoinConversationResult
-  case class GeneralError(error: ErrorResponse) extends JoinConversationResult
+sealed trait GuestRoomStateError
+object GuestRoomStateError {
+  object NotAllowed extends GuestRoomStateError
+  object MemberLimitReached extends GuestRoomStateError
+  object GeneralError extends GuestRoomStateError
 }

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -30,6 +30,7 @@ import com.waz.utils.{Json, JsonDecoder, JsonEncoder, returning, _}
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http._
+import com.wire.signals.CancellableFuture
 import org.json
 import org.json.JSONObject
 
@@ -57,6 +58,7 @@ trait ConversationsClient {
   def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse]
   def postConversationRole(id: RConvId, userId: UserId, role: ConversationRole): ErrorOrResponse[Unit]
   def getGuestroomOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse]
+  def postJoinConversation(key: String, code: String): ErrorOrResponse[Unit]
 }
 
 class ConversationsClientImpl(implicit
@@ -262,6 +264,17 @@ class ConversationsClientImpl(implicit
       queryParameters("key" -> key, "code" -> code)
     )
       .withResultType[ConversationOverviewResponse]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+  }
+
+  override def postJoinConversation(key: String, code: String): ErrorOrResponse[Unit] = {
+    verbose(l"postJoinConversation($key, $code)")
+    Request.Post(
+      relativePath = JoinConversationPath,
+      body = Json("key" -> key, "code" -> code)
+    )
+      .withResultType[Unit]
       .withErrorType[ErrorResponse]
       .executeSafe
   }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -937,7 +937,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
     val convInfo = result(service.getGuestroomInfo(key, code))
 
-    convInfo shouldBe Right(ExistingConversation(conversationData))
+    convInfo shouldBe Right(GuestRoomInfo.ExistingConversation(conversationData))
   }
 
   scenario("Get guestroom info for new conversation") {
@@ -958,7 +958,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
     val convInfo = result(service.getGuestroomInfo(key, code))
 
-    convInfo shouldBe Right(ConversationOverview(convName))
+    convInfo shouldBe Right(GuestRoomInfo.Overview(convName))
   }
 
   scenario("Get guestroom info returns error") {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a `conversation-join` deep link is received, ask the user to confirm joining ([SQSERVICES-505](https://wearezeta.atlassian.net/browse/SQSERVICES-505)). If s/he accepts, send a request, and show appropriate error pop-ups ([SQSERVICES-508](https://wearezeta.atlassian.net/browse/SQSERVICES-508), [SQSERVICES-517](https://wearezeta.atlassian.net/browse/SQSERVICES-517)).


### Testing

Manually tested with adb commands. Special deep links for different test cases are provided in parent jira stories.


#### APK
[Download build #3638](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3638/artifact/build/artifact/wire-dev-PR3372-3638.apk)
[Download build #3639](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3639/artifact/build/artifact/wire-dev-PR3372-3639.apk)
[Download build #3640](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3640/artifact/build/artifact/wire-dev-PR3372-3640.apk)