### PR TITLE
wire-signals version bump to 0.5.2

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -295,7 +295,7 @@ class MainActivity extends BaseActivity
 
   def startFirstFragment(): Unit = {
     verbose(l"startFirstFragment, intent: ${RichIntent(getIntent)}")
-    account.head.flatMap {
+    account.head.foreach {
       case Some(am) =>
         am.getOrRegisterClient().map {
           case Right(Registered(_)) =>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -187,8 +187,8 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.4.3"
-    const val WIRE_SIGNALS_EXTENSIONS = "0.4.3"
+    const val WIRE_SIGNALS = "0.5.2"
+    const val WIRE_SIGNALS_EXTENSIONS = "0.5.2"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -100,7 +100,7 @@ class PushServiceImpl(selfUserId:           UserId,
   implicit val logTag: LogTag = accountTag[PushServiceImpl](selfUserId)
   private implicit val dispatcher = SerialDispatchQueue(name = "PushService")
 
-  override val onHistoryLost = new SourceSignal[Instant]
+  override val onHistoryLost = SourceSignal[Instant]()
   override val processing = Signal(false)
 
   override def waitProcessing =

--- a/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/UiModule.scala
@@ -29,7 +29,7 @@ trait UiEventContext {
   private[ui] var createCount = 0
   private[ui] var startCount = 0
 
-  val onStarted = new SourceSignal[Boolean]()
+  val onStarted = SourceSignal[Boolean]()
 
   def onStart(): Unit = {
     Threading.assertUiThread()

--- a/zmessaging/src/test/scala/com/waz/permissions/PermissionsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/permissions/PermissionsServiceSpec.scala
@@ -29,7 +29,7 @@ class PermissionsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   val service = new PermissionsService()
 
-  val requestInput  = new SourceSignal[ListSet[Permission]]
+  val requestInput  = SourceSignal[ListSet[Permission]]()
 
   //Some system permission we haven't yet discovered
   val systemState = Signal(ListSet(

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -238,7 +238,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val expected = ids('g, 'h)
       val query = SearchQuery("fr")
 
-      val querySignal = new SourceSignal[Option[IndexedSeq[UserData]]]()
+      val querySignal = SourceSignal[Option[IndexedSeq[UserData]]]()
       val queryResults = IndexedSeq.empty[UserData]
 
       (userService.acceptedOrBlockedUsers _).expects().once().returning(Signal.const(expected.map(key => key -> users(key)).toMap))
@@ -282,7 +282,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
                           connectedUsers: Set[UserId] = Set()): PreparedSearch = {
       val convId = ConvId("e7969e91-366d-4ec5-9d85-4e8a4f9d53e6")
 
-      val querySignal = new SourceSignal[Option[Vector[UserId]]]()
+      val querySignal = SourceSignal[Option[Vector[UserId]]]()
       val queryResults = Vector.empty[UserId]
 
       (usersStorage.get _).stubs(*).onCall { id: UserId =>

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -64,7 +64,7 @@ class UserServiceSpec extends AndroidFreeSpec {
 
   (usersStorage.optSignal _).expects(*).anyNumberOfTimes().onCall((id: UserId) => Signal.const(users.find(_.id == id)))
   (accountsService.accountsWithManagers _).expects().anyNumberOfTimes().returning(Signal.empty)
-  (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal(Some(Instant.now())))
+  (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(SourceSignal(Instant.now()))
   (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -123,7 +123,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   (membersStorage.onUpdated _).expects().anyNumberOfTimes().returning(EventStream())
   (membersStorage.onDeleted _).expects().anyNumberOfTimes().returning(EventStream())
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))
-  (push.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal[Instant])
+  (push.onHistoryLost _).expects().anyNumberOfTimes().returning(SourceSignal[Instant]())
   (errors.onErrorDismissed _).expects(*).anyNumberOfTimes().returning(CancellableFuture.successful(()))
 
   (sync.syncTeam _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))


### PR DESCRIPTION
In signals we have an optimization that if there is no subscriber to a signal (i.e. no `.foreach`, `.head`, `.onUi`, etc. - calls to methods that create subscriptions) then the signal might decide that the intermediate computations, done in methods like `.map`, are not necessary, because there is nobody who would consume their results. (That's why we should becareful with putting side-effects in `.map`, but that's not the issue here).

There was an inconsistency in SourceSignal - if created with an `apply` method, this optimization in the new source signal
was disabled. But if created with `new SourceSignal`, it was on, In wire-signals 0.5.1 I decided to remove the inconsistency
by making all ways to create a source signal disable the optimization. It looked harmless enough and I thought it's safer
this way. However, to the contrary, it turns out our logging in flow actually relies on that the source signal will not
compute its state immediately, but only after some time later in the flow. If the computation is done too early, the value
of the signal `account` in `MainActivity` will be `None` and the flow will decide to move the user back to the logging in
screen. Only if the value is not computed (because there are no subscriptions) until the moment we need it, the computation will result in the valid account manager and the user will progress in the flow.

This points at a problem with the logging in flow. We shouldn't rely on when the computation occurs. But for now I'm not able to look into it - the flow is quite complex - so I decided that instead I will remove the inconsistency the other way around. In wire-signals 0.5.2, every way we create a source signal, the optimization is on. I looked through the code, and tested the app, and I think it's safe, but automatic tests are needed to ensure that the UI (where we have a lot of source signalswaiting for input from the user) works fine. And if the optimized version works, I'm happy with keeping it this way in wire-signals.

#### APK
[Download build #3637](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3637/artifact/build/artifact/wire-dev-PR3374-3637.apk)