### PR TITLE
fix: Send a message to a large conversation

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
@@ -39,7 +39,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 trait CryptoBoxService {
-  val sessions: CryptoSessionService
+  def sessions: CryptoSessionService
   def cryptoBox: Future[Option[CryptoBox]]
   def apply[A](f: CryptoBox => Future[A]): Future[Option[A]]
   def deleteCryptoBox(): Future[Unit]

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -70,7 +70,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
     }
 
   def deleteSession(id: SessionId): Future[Unit] = dispatch(id) { cb =>
-    verbose(l"FIX deleteSession($id)")
+    verbose(l"deleteSession($id)")
     cb.foreach(_.deleteSession(id.toString))
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -23,7 +23,6 @@ import com.waz.api.impl.ErrorResponse.internalError
 import com.waz.content.{ConversationStorage, MembersStorage, OtrClientsStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
-import com.waz.model.ConversationData.LegalHoldStatus
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
 import com.waz.model.otr.ClientId
@@ -112,7 +111,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
         recipients <- clientsMap(targetRecipients, convId)
         content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
-        resp       <- if (content.estimatedSize < MaxContentSize) {
+        resp       <- if (external.isDefined || content.estimatedSize < MaxContentSize) {
                         val (shouldIgnoreMissingClients, targetUsers) = missingClientsStrategy(targetRecipients) match {
                           case DoNotIgnoreMissingClients                    => (false, None)
                           case IgnoreMissingClientsExceptFromUsers(userIds) => (false, Some(userIds))

--- a/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
@@ -3,14 +3,18 @@ package com.waz.sync.handler
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences.ShouldPostClientCapabilities
 import com.waz.model.UserId
-import com.waz.model.otr.ClientId
-import com.waz.service.otr.{CryptoBoxService, OtrClientsService}
+import com.waz.model.otr.{Client, ClientId, UserClients}
+import com.waz.service.otr.{CryptoBoxService, CryptoSessionService, OtrClientsService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
 import com.waz.sync.client.OtrClient
 import com.waz.sync.otr.OtrClientsSyncHandlerImpl
 import com.waz.testutils.TestUserPreferences
+import com.wire.cryptobox.{CryptoSession, PreKey}
 import com.wire.signals.CancellableFuture
+
+import scala.collection.immutable.Map
+import scala.concurrent.Future
 
 class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
 
@@ -19,7 +23,11 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
   private val netClient = mock[OtrClient]
   private val otrClients = mock[OtrClientsService]
   private val cryptoBox =  mock[CryptoBoxService]
+  private val cryptoBoxSessions = mock[CryptoSessionService]
   private val userPrefs = new TestUserPreferences()
+
+  private val otherUserId = UserId("otherUserId")
+  private val otherClientId = ClientId("otherClientId")
 
   private def createHandler() = new OtrClientsSyncHandlerImpl(
     selfUserId,
@@ -70,4 +78,56 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
     }
   }
 
+  feature("sync sessions") {
+    scenario("sync one client") {
+      // Given
+      val handler = createHandler()
+      val clients = Map(otherUserId -> Seq(otherClientId))
+      val responsePreKey = new PreKey(0, Array[Byte](0))
+      val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] =
+        Right(Map(otherUserId -> Seq((otherClientId, responsePreKey))))
+      val responseUserClients = UserClients(otherUserId, Map(otherClientId -> Client(otherClientId)))
+
+      (netClient.loadPreKeys(_ : Map[UserId, Seq[ClientId]])).expects(clients).once().returning(
+        CancellableFuture.successful(response)
+      )
+      (otrClients.updateUserClients(_: Map[UserId, Seq[Client]], _: Boolean)).expects(*, *).once().returning(
+        Future.successful(Set(responseUserClients))
+      )
+      (cryptoBox.sessions _).expects().anyNumberOfTimes().returning(cryptoBoxSessions)
+      (cryptoBoxSessions.getOrCreateSession _).expects(*, *).anyNumberOfTimes().returning(
+        Future.successful(Option.empty[CryptoSession])
+      )
+
+      result(handler.syncSessions(clients)) shouldEqual Option.empty[ErrorResponse]
+    }
+  }
+
+  scenario("sync more clients than the request limit") {
+    // Given
+    val handler = createHandler()
+    val clients = (0 to (OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients/4 + 1)).map { _ =>
+      UserId() -> Seq(ClientId(), ClientId(), ClientId(), ClientId())
+    }.toMap
+    val responsePreKey = new PreKey(0, Array[Byte](0))
+    val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] =
+      Right(Map(otherUserId -> Seq((otherClientId, responsePreKey))))
+    val responseUserClients = UserClients(otherUserId, Map(otherClientId -> Client(otherClientId)))
+
+    (netClient.loadPreKeys(_ : Map[UserId, Seq[ClientId]])).expects(*).twice().onCall { cs: Map[UserId, Seq[ClientId]] =>
+      (cs.size <  OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients) shouldBe true
+      val result = cs.map { case (userId, clientIds) => userId -> clientIds.map(cId => (cId, responsePreKey)) }
+      val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] = Right(result)
+      CancellableFuture.successful(response)
+    }
+    (otrClients.updateUserClients(_: Map[UserId, Seq[Client]], _: Boolean)).expects(*, *).once().returning(
+      Future.successful(Set(responseUserClients))
+    )
+    (cryptoBox.sessions _).expects().anyNumberOfTimes().returning(cryptoBoxSessions)
+    (cryptoBoxSessions.getOrCreateSession _).expects(*, *).anyNumberOfTimes().returning(
+      Future.successful(Option.empty[CryptoSession])
+    )
+
+    result(handler.syncSessions(clients)) shouldEqual Option.empty[ErrorResponse]
+  }
 }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-532

In fact, this fixes two problems:
1. In OtrClientsSyncHandler, when we load prekeys, there is a limit to the size of the request we can do. If we try to load prekeys for more than 128 clients at once, the backend will return an error "413 Request Entity Too Large" which the Android app can't handle. The fix divides the request into smaller chunks, send a request for each chunk, and then merges the responses.
2. In OtrSyncHandler, we encrypt the message for all clients - the more clients, the bigger will be the encrypted message. Then, if the encrypted message is bigger than the limit we set, instead of sending it in a regular way, we try to send it as "External" - a blob of data which we hope the backend will be able to handle. But here comes the bug: after turning the message into the "External" we again check its size against the limit, and if it's still bigger than the limit, we try again to turn it into an "External"... in the end, the procedure crashes and we never send the message. The fix breaks the loop - if we have the message as the "External" we don't care about the limit size anymore.

#### APK
[Download build #3642](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3642/artifact/build/artifact/wire-dev-PR3375-3642.apk)
[Download build #3643](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3643/artifact/build/artifact/wire-dev-PR3375-3643.apk)
[Download build #3644](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3644/artifact/build/artifact/wire-dev-PR3375-3644.apk)
[Download build #3650](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3650/artifact/build/artifact/wire-dev-PR3375-3650.apk)