### PR TITLE
Feature: Deep Link - Part 4- Handle conversation/join response, open conversation after joining

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -413,7 +413,7 @@ class ConversationController(implicit injector: Injector, context: Context)
   def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]] =
     conversations.head.flatMap(_.getGuestroomInfo(key, code))
 
-  def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Unit]] =
+  def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]] =
     conversations.head.flatMap(_.joinConversation(key, code))
 
   object messages {

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -242,8 +242,9 @@ class MainPhoneFragment extends FragmentHelper
 
   private def joinConversation(key: String, code: String): Future[Unit] = {
     conversationController.joinConversation(key, code).flatMap {
-      case Right(_)    => /*TODO Open new conv. */ Future.successful(())
-      case Left(error) => showGuestRoomErrorDialog(error)
+      case Right(Some(convId)) => Future.successful(openConversationFromDeepLink(convId))
+      case Right(None)         => showGenericErrorDialog()
+      case Left(error)         => showGuestRoomErrorDialog(error)
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -699,7 +699,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     }
   }
 
-  override def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]] = {
+  override def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]] =
     client.postJoinConversation(key, code).future.flatMap {
       case Right(Some(event: MemberJoinEvent)) =>
         for {
@@ -715,7 +715,6 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         warn(l"joinConversation(key: $key, code: $code) error: $error")
         Future.successful(Left(GeneralError))
     }
-  }
 }
 
 object ConversationsService {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -37,16 +37,15 @@ import com.waz.sync.client.{ConversationsClient, ErrorOr}
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.wire.signals.{AggregatingSignal, EventContext, Signal}
+import com.wire.signals.{AggregatingSignal, Signal}
 
 import scala.collection.{breakOut, mutable}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
-import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.control.NonFatal
 
 trait ConversationsService {
   def convStateEventProcessingStage: EventScheduler.Stage.Atomic
-  def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0): Future[Any]
   def activeMembersData(conv: ConvId): Signal[Seq[ConversationMemberData]]
   def convMembers(convId: ConvId): Signal[Map[UserId, ConversationRole]]
   def updateConversationsWithDeviceStartMessage(conversations: Seq[ConversationResponse], roles: Map[RConvId, Set[ConversationRole]]): Future[Unit]
@@ -76,7 +75,7 @@ trait ConversationsService {
   def deleteMembersFromConversations(members: Set[UserId]): Future[Unit]
   def remoteIds: Future[Set[RConvId]]
   def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]]
-  def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Unit]]
+  def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]]
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -167,7 +166,16 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       } yield ()
   }
 
-  def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0) = ev match {
+  /**
+   *
+   * @param ev event to process
+   * @param selfUserId user id of the current user
+   * @param retryCount number of retries so far
+   * @param selfRequested true if this method is triggered by ourselves,
+   *                      false if it is triggered by an event via backend.
+   * @return
+   */
+  private def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0, selfRequested: Boolean = false) = ev match {
     case CreateConversationEvent(_, time, from, data) =>
       updateConversation(data).flatMap { case (_, created) => Future.traverse(created) { created =>
         messages.addConversationStartMessage(
@@ -186,7 +194,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         case None if retryCount > 3 => successful(())
         case None =>
           ev match {
-            case MemberJoinEvent(_, time, from, ids, us, _) if from != selfUserId =>
+            case MemberJoinEvent(_, time, from, ids, us, _) if selfRequested || from != selfUserId =>
               // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
               val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
               // this happens when we are added to group conversation
@@ -691,14 +699,21 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     }
   }
 
-  override def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Unit]] = {
-    client.postJoinConversation(key, code).future.map {
-      case Right(_)                                          => Right(())
-      case Left(ErrorResponse(_, _, "no-conversation-code")) => Left(NotAllowed)
-      case Left(ErrorResponse(_, _, "too-many-members"))     => Left(MemberLimitReached)
+  override def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]] = {
+    client.postJoinConversation(key, code).future.flatMap {
+      case Right(Some(event: MemberJoinEvent)) =>
+        for {
+          _     <- processConversationEvent(event, selfUserId, selfRequested = true)
+          conv  <- convsStorage.getByRemoteId(event.convId)
+        } yield Right(conv.map(_.id))
+
+      case Right(_) => Future.successful(Right(None))
+
+      case Left(ErrorResponse(_, _, "no-conversation-code")) => Future.successful(Left(NotAllowed))
+      case Left(ErrorResponse(_, _, "too-many-members"))     => Future.successful(Left(MemberLimitReached))
       case Left(error) =>
         warn(l"joinConversation(key: $key, code: $code) error: $error")
-        Left(GeneralError)
+        Future.successful(Left(GeneralError))
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -1019,18 +1019,18 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     convInfo shouldBe Left(GeneralError)
   }
 
-  scenario("Join conversation with key and code") {
+  scenario("Join conversation returns None when client returns None") {
     val key = "join_key"
     val code = "join_code"
 
     (convsClient.postJoinConversation _)
       .expects(key, code)
       .anyNumberOfTimes()
-      .returning(CancellableFuture.successful(Right(())))
+      .returning(CancellableFuture.successful(Right(None)))
 
     val convInfo = result(service.joinConversation(key, code))
 
-    convInfo shouldBe Right(())
+    convInfo shouldBe Right(None)
   }
 
   scenario("Join conversation returns NotAllowed when client returns no-conversation-code") {


### PR DESCRIPTION
## What's new in this PR?

### Issues

[SQSERVICES-500](https://wearezeta.atlassian.net/browse/SQSERVICES-500)

As a response to conversation/join BE call, 
- if the user is already a member, we get 204 with empty body. Show an error in that case. 
- if the user successfully joined, we get 200 with a MemberJoinEvent as body. Process that event as if it came from EventStream, and open the conversation afterwards.

### Solutions

Added a `MemberJoinEvent` response deserializer. Passed the response to `processConversationEvent` method, which is also used by `convStateEventProcessingStage`.

### Testing

Manually tested with using deep links
- for a new conversation
- for a conversation which the user is already a member of
- for a conversation which the user was used to be a member, but later left

#### APK
[Download build #3645](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3645/artifact/build/artifact/wire-dev-PR3376-3645.apk)
[Download build #3646](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3646/artifact/build/artifact/wire-dev-PR3376-3646.apk)