### PR TITLE
fix: app crashes when user types "@" in group details page search bar

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -37,7 +37,7 @@ object Handle extends (String => Handle){
   val Empty: Handle = Handle("")
   def apply(): Handle = Empty
   def random: Handle = Handle(UUID.randomUUID().toString)
-  val handlePattern = """@(.+)""".r
+  private val handlePattern = """@(.*)""".r
   def transliterated(s: String): String = Locales.transliterate(s)
 
   def isHandle(input: String): Boolean = input.startsWith("@")


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-726

A very trivial mistake. This worked before because we didn't look for another '@' in the handle - now we do.

#### APK
[Download build #3652](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3652/artifact/build/artifact/wire-dev-PR3380-3652.apk)
[Download build #3653](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3653/artifact/build/artifact/wire-dev-PR3380-3653.apk)