### PR TITLE
fix: Search results are empty when User searches on group details page

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -48,6 +48,8 @@ import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.{RichView, ViewUtils}
 import com.waz.zclient.{Injectable, Injector, R}
 
+import scala.language.postfixOps
+
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
 import com.wire.signals.ext.ClockSignal
@@ -93,7 +95,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
     tId          <- team
     participants <- participants
     users        <- usersStorage.listSignal(participants.keys)
-    f            <- filter
+    f            <- filter.throttle(FilterThrottleMs)
   } yield
     users
       .filter(u => f.isEmpty || u.matchesQuery(SearchQuery(f)))
@@ -106,12 +108,12 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
       .sortBy(_.userData.name.str)
 
   protected lazy val positions: Signal[List[Either[ParticipantData, Int]]] = for {
-    tId               <- team
-    users             <- users
-    currentConv       <- convController.currentConv
-    convActive        =  currentConv.isActive
-    isTeamConv        =  currentConv.team.nonEmpty
-    selfRole          <- participantsController.selfRole
+    tId         <- team
+    users       <- users
+    currentConv <- convController.currentConv
+    convActive  =  currentConv.isActive
+    isTeamConv  =  currentConv.team.nonEmpty
+    selfRole    <- participantsController.selfRole
   } yield {
     val (bots, people)    = users.toList.partition(_.userData.isWireBot)
     val (admins, members) = people.partition(_.isAdmin)
@@ -271,6 +273,8 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
 }
 
 object ParticipantsAdapter {
+  val FilterThrottleMs: FiniteDuration = 500 millis
+
   val UserRow                  = 0
   val MembersSeparator         = 1
   val ServicesSeparator        = 2
@@ -287,10 +291,12 @@ object ParticipantsAdapter {
 
   val separators = Set(AdminsSeparator, MembersSeparator, ServicesSeparator, OptionsSeparator)
 
-  case class ParticipantData(userData: UserData, isGuest: Boolean, isAdmin: Boolean, isSelf: Boolean)
+  final case class ParticipantData(userData: UserData, isGuest: Boolean, isAdmin: Boolean, isSelf: Boolean)
 
-  case class GuestOptionsButtonViewHolder(view: View, convController: ConversationController)(implicit eventContext: EventContext) extends ViewHolder(view) {
-    private implicit val ctx = view.getContext
+  final case class GuestOptionsButtonViewHolder(view: View, convController: ConversationController)
+                                               (implicit eventContext: EventContext)
+    extends ViewHolder(view) {
+    private implicit val ctx: Context = view.getContext
     view.setId(R.id.guest_options)
     view.findViewById[TextView](R.id.options_divider).setVisibility(View.VISIBLE)
     view.findViewById[ImageView](R.id.icon).setImageDrawable(GuestIconWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
@@ -303,8 +309,10 @@ object ParticipantsAdapter {
     view.setContentDescription("Guest Options")
   }
 
-  case class EphemeralOptionsButtonViewHolder(view: View, convController: ConversationController)(implicit eventContext: EventContext) extends ViewHolder(view) {
-    private implicit val ctx = view.getContext
+  final case class EphemeralOptionsButtonViewHolder(view: View, convController: ConversationController)
+                                                   (implicit eventContext: EventContext)
+    extends ViewHolder(view) {
+    private implicit val ctx: Context = view.getContext
     view.setId(R.id.timed_messages_options)
     view.findViewById[ImageView](R.id.icon).setImageDrawable(HourGlassIcon(getStyledColor(R.attr.wirePrimaryTextColor)))
     view.findViewById[TextView](R.id.name_text).setText(R.string.ephemeral_options_title)
@@ -317,8 +325,10 @@ object ParticipantsAdapter {
     view.setContentDescription("Ephemeral Options")
   }
 
-  case class NotificationsButtonViewHolder(view: View, convController: ConversationController)(implicit eventContext: EventContext) extends ViewHolder(view) {
-    private implicit val ctx = view.getContext
+  final case class NotificationsButtonViewHolder(view: View, convController: ConversationController)
+                                                (implicit eventContext: EventContext)
+    extends ViewHolder(view) {
+    private implicit val ctx: Context = view.getContext
     view.setId(R.id.notifications_options)
     view.findViewById[ImageView](R.id.icon).setImageDrawable(NotificationsIcon(getStyledColor(R.attr.wirePrimaryTextColor)))
     view.findViewById[TextView](R.id.name_text).setText(R.string.notifications_options_title)
@@ -329,7 +339,7 @@ object ParticipantsAdapter {
     view.setContentDescription("Notifications")
   }
 
-  case class SeparatorViewHolder(separator: View) extends ViewHolder(separator) {
+  final case class SeparatorViewHolder(separator: View) extends ViewHolder(separator) {
     private val textView = ViewUtils.getView[TextView](separator, R.id.separator_title)
     private val emptySectionView = ViewUtils.getView[TextView](separator, R.id.empty_section_info)
 
@@ -348,13 +358,13 @@ object ParticipantsAdapter {
     def setContentDescription(text: String): Unit = textView.setContentDescription(text)
   }
 
-  case class NoResultsInfoViewHolder(view: View) extends ViewHolder(view) {
+  final case class NoResultsInfoViewHolder(view: View) extends ViewHolder(view) {
     view.setId(R.id.no_results_info)
     view.setContentDescription(s"No Results")
   }
 
-  case class ParticipantRowViewHolder(view: SingleUserRowView, onClick: SourceStream[UserId]) extends ViewHolder(view) {
-
+  final case class ParticipantRowViewHolder(view: SingleUserRowView, onClick: SourceStream[UserId])
+    extends ViewHolder(view) {
     private var userId = Option.empty[UserId]
 
     view.onClick(userId.foreach(onClick ! _))
@@ -366,8 +376,7 @@ object ParticipantsAdapter {
       if (participant.isSelf) {
         view.showArrow(false)
         userId = None
-      }
-      else {
+      } else {
         view.showArrow(showArrow)
         userId = Some(participant.userData.id)
       }
@@ -380,13 +389,17 @@ object ParticipantsAdapter {
     }
   }
 
-  case class ReadReceiptsViewHolder(view: View, convController: ConversationController)(implicit eventContext: EventContext) extends ViewHolder(view) {
-    private implicit val ctx = view.getContext
+  final case class ReadReceiptsViewHolder(view: View, convController: ConversationController)
+                                         (implicit eventContext: EventContext)
+    extends ViewHolder(view) {
+    private implicit val ctx: Context = view.getContext
 
     private val switch = view.findViewById[SwitchCompat](R.id.participants_read_receipts_toggle)
     private var readReceipts = Option.empty[Boolean]
 
-    view.findViewById[ImageView](R.id.participants_read_receipts_icon).setImageDrawable(ViewWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
+    view
+      .findViewById[ImageView](R.id.participants_read_receipts_icon)
+      .setImageDrawable(ViewWithColor(getStyledColor(R.attr.wirePrimaryTextColor)))
     view.setId(R.id.read_receipts_button)
 
     switch.setOnCheckedChangeListener(new OnCheckedChangeListener {
@@ -401,14 +414,14 @@ object ParticipantsAdapter {
       if (!readReceipts.contains(readReceiptsEnabled)) switch.setChecked(readReceiptsEnabled)
   }
 
-  case class ConversationNameViewHolder(view: View, convController: ConversationController) extends ViewHolder(view) {
-    private val callInfo = view.findViewById[TextView](R.id.call_info)
-    private val editText = view.findViewById[TypefaceEditText](R.id.conversation_name_edit_text)
-    private val penGlyph = view.findViewById[GlyphTextView](R.id.conversation_name_edit_glyph)
+  final case class ConversationNameViewHolder(view: View, convController: ConversationController)
+    extends ViewHolder(view) {
+    private val callInfo       = view.findViewById[TextView](R.id.call_info)
+    private val editText       = view.findViewById[TypefaceEditText](R.id.conversation_name_edit_text)
+    private val penGlyph       = view.findViewById[GlyphTextView](R.id.conversation_name_edit_glyph)
     private val verifiedShield = view.findViewById[ImageView](R.id.conversation_verified_shield)
 
     private var convName = Option.empty[String]
-
     private var isBeingEdited = false
 
     def setEditingEnabled(enabled: Boolean): Unit = {
@@ -417,7 +430,7 @@ object ParticipantsAdapter {
       editText.setEnabled(enabled)
     }
 
-    private def stopEditing() = {
+    private def stopEditing(): Unit = {
       editText.setSelected(false)
       editText.clearFocus()
       Selection.removeSelection(editText.getText)
@@ -465,7 +478,7 @@ object ParticipantsAdapter {
       } else false
   }
 
-  case class ShowAllParticipantsViewHolder(view: View) extends ViewHolder(view) {
+  final case class ShowAllParticipantsViewHolder(view: View) extends ViewHolder(view) {
     private implicit val ctx: Context = view.getContext
 
     view.findViewById[ImageView](R.id.next_indicator).setImageDrawable(ForwardNavigationIcon(R.color.light_graphite_40))
@@ -484,8 +497,8 @@ object ParticipantsAdapter {
 
 }
 
-class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle:  Option[UserData => String] = None)
-                          (implicit context: Context, injector: Injector, eventContext: EventContext)
+final class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle:  Option[UserData => String] = None)
+                                (implicit context: Context, injector: Injector, eventContext: EventContext)
   extends ParticipantsAdapter(Signal.empty, None, true, false, createSubtitle) {
   import ParticipantsAdapter._
 

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -139,12 +139,10 @@ final case class UserData(override val id:       UserId,
     domain.getOrElse("") != selfDomain
 
   def matchesQuery(query: SearchQuery): Boolean =
-    query.domain == domain.getOrElse("") &&
-      (handle.exists(_.startsWithQuery(query.query)) ||
-        (!query.handleOnly &&
-          (SearchKey(query.query).isAtTheStartOfAnyWordIn(searchKey) ||
-           email.exists(e => query.query.trim.equalsIgnoreCase(e.str))
-          )
+    handle.exists(_.startsWithQuery(query.query)) ||
+      (!query.handleOnly &&
+        (SearchKey(query.query).isAtTheStartOfAnyWordIn(searchKey) ||
+         email.exists(e => query.query.trim.equalsIgnoreCase(e.str))
         )
       )
 


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-727

The main cause of the bug was that UserData.matchesQuery tried to check if the domain of the matched user is the same
as the domain of the current user and that doesn't work without the rest of the Federation feature in place - we would
need to be able to get the domain of the other user from the backend. For now, I removed the check for domain, so
matchesQuery works like before.

I also add a "throttle" on the filter signal. Currently the user search among conversation participants is performed
with each keystroke. For large conversations that may be too CPU-heavy, especially that users usually type a few
characters before expecting the search to work. A throttle, set to 500 milliseconds, means that if the user will
quickly type a few characters, the search will be performed only when it's finished.

And I used this opportunity to add the "final" keyword to classes in the ParticipantAdapter file, as well as to
correct indentation, etc.

#### APK
[Download build #3660](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3660/artifact/build/artifact/wire-dev-PR3382-3660.apk)