### PR TITLE
[Calling] Bugfix - Large conference calls - show profile pictures only when feature is flag is enabled

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
@@ -81,11 +81,12 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     }
   }
 
-  participantInfo.onUi {
-    case Some(p) if (p.picture.isDefined) => setProfilePicture(p.picture.get)
-    case _ =>
+  if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS) {
+    participantInfo.onUi {
+      case Some(p) if (p.picture.isDefined) => setProfilePicture(p.picture.get)
+      case _ =>
+    }
   }
-
 
   if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS)
     callController.controlsVisible.map { !_ }.onUi(participantInfoCardView.setVisible)


### PR DESCRIPTION
## What's new in this PR?

This PR hides the profile picture in grid tiles when the feature flags is set to false

#### APK
[Download build #3662](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3662/artifact/build/artifact/wire-dev-PR3384-3662.apk)