### PR TITLE
[Calling] revert AVS version to 7.1.6

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -6,7 +6,7 @@ final String AVS_PRIVATE_GROUP = "com.wearezeta.avs"
 final String AVS_NAME = "avs"
 
 String avsPublicVersion = "6.6.239"
-String avsPrivateVersion = "7.2.3"
+String avsPrivateVersion = "7.1.6"
 
 if (!rootProject.ext.nexusUrlExt.isEmpty()) {
     ext {


### PR DESCRIPTION
## What's new in this PR?

We need to revert AVS version to 7.1.6 for the candidate build, to fix an issue with automation.

#### APK
[Download build #3663](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3663/artifact/build/artifact/wire-dev-PR3385-3663.apk)