### PR TITLE
fix: crash after login

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/list/datasources/ConversationListDataSource.kt
@@ -26,11 +26,9 @@ class ConversationListDataSource(
         excludeType: ConversationType
     ): Flow<PagingData<ConversationListItem>> {
         val type = conversationTypeMapper.toIntValue(excludeType)
-        val pagingSourceFactory = conversationListLocalDataSource.conversationListInBatch(excludeType = type)
-        return Pager(
-            config = PagingConfig(pageSize = pageSize),
-            pagingSourceFactory = { pagingSourceFactory }
-        ).flow.map { it.map { conversationItem -> conversationListMapper.fromEntity(conversationItem) } }
+        return Pager(config = PagingConfig(pageSize = pageSize)) {
+            conversationListLocalDataSource.conversationListInBatch(excludeType = type)
+        }.flow.map { it.map { conversationItem -> conversationListMapper.fromEntity(conversationItem) } }
     }
 
     override suspend fun conversationListInBatch(start: Int, count: Int): Either<Failure, List<ConversationListItem>> =


### PR DESCRIPTION
The app crashes only after the first login throwing `IllegalStateException`

Log:
```
java.lang.IllegalStateException: An instance of PagingSource was re-used when Pager expected to create a new
instance. Ensure that the pagingSourceFactory passed to Pager always returns a
new instance of PagingSource.
```

The same instance of PagingSource was re-used as I am passing a `val` value to `pagingSourceFactory`

Fixing the issue would be by calling the localDataSource to request a new PagingSource in Pager parameter