### PR TITLE
fix: Partner inside of team can't be found

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -147,7 +147,7 @@ final case class UserData(override val id:       UserId,
       )
 
   def exactMatchQuery(query: SearchQuery): Boolean =
-    query.domain == domain.getOrElse("") && handle.exists(_.exactMatchQuery(query.query))
+    handle.exists(_.exactMatchQuery(query.query))
 }
 
 trait Picture

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -95,9 +95,9 @@ class UserSearchServiceImpl(selfUserId:           UserId,
           searchResults.filter { u =>
             u.createdBy.contains(selfUserId) ||
             knownUsersIds.contains(u.id) ||
-              u.teamId != teamId ||
-              (u.teamId == teamId && !u.isExternal(teamId)) ||
-              u.exactMatchQuery(query)
+            u.teamId != teamId ||
+            (u.teamId == teamId && !u.isExternal(teamId)) ||
+            u.exactMatchQuery(query)
           }
         }
       case _ => Future.successful(searchResults)
@@ -253,11 +253,10 @@ class UserSearchServiceImpl(selfUserId:           UserId,
   def syncSearchResults(query: SearchQuery): Unit = if (!query.isEmpty) sync.syncSearchQuery(query)
 
   private def directoryResults(query: SearchQuery): Signal[IndexedSeq[UserData]] =
-    returning {
-      if (!query.isEmpty)
-        userSearchResult.map(_.filter(u => !u.isWireBot && u.expiresAt.isEmpty)).map(sortUsers(_, query))
-      else Signal.const(IndexedSeq.empty[UserData])
-    } { dir =>  verbose(l"directory search results: $dir") }
+    if (!query.isEmpty)
+      userSearchResult.map(_.filter(u => !u.isWireBot && u.expiresAt.isEmpty)).map(sortUsers(_, query))
+    else
+      Signal.const(IndexedSeq.empty[UserData])
 
   override def updateSearchResults(results: UserSearchResponse): Future[Unit] =
     usersStorage.contents.head.flatMap { usersInStorage =>


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-786

Similar to a previous bug about user search (https://github.com/wireapp/wire-android/pull/3382) this one too
was because the exact match search tried to compare domains. Without the ability to learn about the domain
of the remote user, which is not implemented yet, this always failed, resulting in that the external/partner
user was always filtered out from the user search.
