### PR TITLE
Federation: Add users from fake 1-to-1 conversations to the results of user search

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
@@ -43,7 +43,8 @@ data class ConversationsBackUpModel(
     val unreadMentionsCount: Int = 0,
     val unreadQuoteCount: Int = 0,
     val receiptMode: Int? = null,
-    val legalHoldStatus: Int = 0
+    val legalHoldStatus: Int = 0,
+    val domain: String? = null
 )
 
 class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, ConversationsEntity> {
@@ -81,7 +82,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = entity.unreadMentionsCount,
         unreadQuoteCount = entity.unreadQuoteCount,
         receiptMode = entity.receiptMode,
-        legalHoldStatus = entity.legalHoldStatus
+        legalHoldStatus = entity.legalHoldStatus,
+        domain = entity.domain
     )
 
     override fun toEntity(model: ConversationsBackUpModel) = ConversationsEntity(
@@ -118,7 +120,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = model.unreadMentionsCount,
         unreadQuoteCount = model.unreadQuoteCount,
         receiptMode = model.receiptMode,
-        legalHoldStatus = model.legalHoldStatus
+        legalHoldStatus = model.legalHoldStatus,
+        domain = model.domain
     )
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -396,15 +396,15 @@ class ConversationController(implicit injector: Injector, context: Context)
     (conv, _) <- convsUi.createGroupConversation(name, userIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
-  def createQualifiedGroupConversation(name:         Name,
-                                       qualifiedIds: Set[QualifiedId],
-                                       teamOnly:     Boolean,
-                                       readReceipts: Boolean,
-                                       defaultRole:  ConversationRole = ConversationRole.MemberRole
-                                      ): Future[ConversationData] = for {
+  def createConvWithFederatedUser(name:         Name,
+                                  qId:          QualifiedId,
+                                  teamOnly:     Boolean,
+                                  readReceipts: Boolean,
+                                  defaultRole:  ConversationRole = ConversationRole.MemberRole
+                                 ): Future[ConversationData] = for {
     convsUi   <- convsUi.head
     _         <- inject[FolderStateController].update(Folder.GroupId, isExpanded = true)
-    (conv, _) <- convsUi.createQualifiedGroupConversation(name, qualifiedIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
+    (conv, _) <- convsUi.createConvWithFederatedUser(name, qId, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
   def withCurrentConvName(callback: Callback[String]): Unit = currentConvName.head.map(_.str).foreach(callback.callback)(Threading.Ui)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
@@ -33,16 +33,9 @@ class SendConnectRequestFragment extends UntabbedRequestFragment {
       for {
         Some(user)  <- userToConnect
         isFederated <- usersCtrl.isFederated(user)
-        conv        <- if (isFederated) {
-                         user.qualifiedId match {
-                           case Some(qId) =>
-                             convCtrl.createQualifiedGroupConversation(user.name, Set(qId), false, false)
-                                     .map(Option(_))
-                           case None =>
-                             Future.successful(None)
-                         }
-                       } else {
-                         usersCtrl.connectToUser(user.id)
+        conv        <- (isFederated, user.qualifiedId) match {
+                         case (true, Some(qId)) => convCtrl.createConvWithFederatedUser(user.name, qId, false, false).map(Option(_))
+                         case _                 => usersCtrl.connectToUser(user.id)
                        }
         _           <- conv.fold(
                          Future.successful(pickUserCtrl.hideUserProfile())

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
@@ -53,7 +53,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val model = backupMapper.fromEntity(entity)
@@ -128,7 +129,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val entity = backupMapper.toEntity(model)

--- a/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
+++ b/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
@@ -36,7 +36,8 @@ data class ConversationsTestData(
     val unreadMentionsCount: Int,
     val unreadQuoteCount: Int,
     val receiptMode: Int?,
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+    val domain: String?
 )
 
 object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>() {
@@ -74,6 +75,7 @@ object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>()
         unreadMentionsCount = 0,
         unreadQuoteCount = 0,
         receiptMode = null,
-        legalHoldStatus = 0
+        legalHoldStatus = 0,
+        domain = "staging"
     )
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -58,6 +58,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_133_TO_134
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -107,7 +108,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 133
+        const val VERSION = 134
 
         @JvmStatic
         val migrations = arrayOf(
@@ -116,7 +117,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_129_TO_130,
             USER_DATABASE_MIGRATION_130_TO_131,
             USER_DATABASE_MIGRATION_131_TO_132,
-            USER_DATABASE_MIGRATION_132_TO_133
+            USER_DATABASE_MIGRATION_132_TO_133,
+            USER_DATABASE_MIGRATION_133_TO_134
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
@@ -113,5 +113,8 @@ data class ConversationsEntity(
     val receiptMode: Int?,
 
     @ColumnInfo(name = "legal_hold_status")
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+
+    @ColumnInfo(name = "domain")
+    val domain: String?
 )

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
@@ -1,0 +1,16 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val USER_DATABASE_MIGRATION_133_TO_134 = object : Migration(133, 134) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        MigrationUtils.addColumn(
+            database = database,
+            tableName = "Conversations",
+            columnName = "domain",
+            columnType = MigrationUtils.ColumnType.TEXT
+        )
+    }
+}

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -56,6 +56,7 @@ public enum SyncCommand {
     PostDeleted("post-deleted"),
     PostRecalled("post-recalled"),
     PostConvJoin("post-conv-join"),
+    PostQualifiedConvJoin("post-qualified-conv-join"),
     PostConvLeave("post-conv-leave"),
     PostConnection("post-connection"),
     PostQualifiedConnection("post-qualified-connection"),

--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -1,0 +1,34 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder.opt
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import org.json.{JSONArray, JSONObject}
+
+final case class RConvQualifiedId(id: RConvId, domain: String) {
+  def hasDomain: Boolean = domain.nonEmpty
+}
+
+object RConvQualifiedId {
+  def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
+
+  private val IdFieldName = "id"
+  private val DomainFieldName  = "domain"
+
+  implicit val Encoder: JsonEncoder[RConvQualifiedId] =
+    JsonEncoder.build(qId => js => {
+      js.put(IdFieldName, qId.id.str)
+      js.put(DomainFieldName, qId.domain)
+    })
+
+  private def decode(js: JSONObject): RConvQualifiedId =
+    RConvQualifiedId(RConvId(js.getString(IdFieldName)), js.getString(DomainFieldName))
+
+  implicit val Decoder: JsonDecoder[RConvQualifiedId] =
+    JsonDecoder.lift(implicit js => decode(js))
+
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[RConvQualifiedId] =
+    opt(s, js => decode(js.getJSONObject(s.name)))
+
+  def encode(qIds: Set[RConvQualifiedId]): JSONArray =
+    JsonEncoder.array(qIds) { case (arr, qid) => arr.put(RConvQualifiedId.Encoder(qid)) }
+}

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -156,9 +156,10 @@ class UserSearchServiceImpl(selfUserId:           UserId,
   private def searchLocal(query: SearchQuery, excluded: Set[UserId] = Set.empty, showBlockedUsers: Boolean = false): Signal[IndexedSeq[UserData]] =
     for {
       connected <- userService.acceptedOrBlockedUsers.map(_.values)
+      fake1To1s <- conversationsService.onlyFake1To1ConvUsers
       members   <- teamId.fold(Signal.const(Set.empty[UserData]))(_ => teamsService.searchTeamMembers(query))
     } yield {
-      val included = (connected.toSet ++ members).filter { user =>
+      val included = (connected.toSet ++ fake1To1s.toSet ++ members).filter { user =>
         !excluded.contains(user.id) &&
           selfUserId != user.id &&
           !user.isWireBot &&

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -37,7 +37,6 @@ import com.waz.sync.client.{CredentialsUpdateClient, ErrorOr, UsersClient}
 import com.waz.threading.Threading
 import com.waz.utils._
 import com.wire.signals._
-
 import com.waz.zms.BuildConfig
 
 import scala.collection.breakOut
@@ -49,23 +48,26 @@ trait UserService {
   def userUpdateEventsStage: Stage.Atomic
   def userDeleteEventsStage: Stage.Atomic
 
-  def deleteUsers(ids: Set[UserId]): Future[Unit]
+  def deleteUsers(ids: Set[UserId], sendLeaveMessage: Boolean = true): Future[Unit]
 
   def selfUser: Signal[UserData]
   def currentConvMembers: Signal[Set[UserId]]
   def userNames: Signal[Map[UserId, Name]]
 
   def getSelfUser: Future[Option[UserData]]
+  def isFederated(id: UserId): Future[Boolean]
+  def isFederated(user: UserData): Future[Boolean]
   def findUser(id: UserId): Future[Option[UserData]]
+  def findUsers(ids: Seq[UserId]): Future[Seq[Option[UserData]]]
   def qualifiedId(userId: UserId): Future[QualifiedId]
   def getOrCreateUser(id: UserId): Future[UserData]
   def updateUserData(id: UserId, updater: UserData => UserData): Future[Option[(UserData, UserData)]]
-  def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]]
+  def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan, qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]]
+  def syncUsers(userIds: Set[UserId], qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]]
   def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): Future[Option[UserData]]
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
   def syncUser(userId: UserId): Future[Option[UserData]]
-  def syncQualifiedUser(qId: QualifiedId): Future[Option[UserData]]
   def acceptedOrBlockedUsers: Signal[Map[UserId, UserData]]
 
   def updateSyncedUsers(users: Seq[UserInfo], timestamp: LocalInstant = LocalInstant.Now): Future[Set[UserData]]
@@ -120,10 +122,12 @@ class UserServiceImpl(selfUserId:        UserId,
     shouldSync <- shouldSyncUsers()
   } if (shouldSync) {
     verbose(l"Syncing user data to get team ids")
-    usersStorage.list()
-      .flatMap(users => sync.syncUsers(users.map(_.id).toSet))
-      .flatMap(_ => shouldSyncUsers := false)
-    }
+    for {
+      userMap <- usersStorage.contents.head
+      _       <- syncUsers(userMap.keySet)
+      _       <- shouldSyncUsers := false
+    } yield ()
+  }
 
   override val currentConvMembers = for {
     Some(convId) <- selectedConv.selectedConversationId
@@ -151,7 +155,7 @@ class UserServiceImpl(selfUserId:        UserId,
   //Update user data for other accounts
   accounts.accountsWithManagers.map(_ - selfUserId).foreach(syncIfNeeded(_))
 
-  override val selfUser: Signal[UserData] = usersStorage.optSignal(selfUserId) flatMap {
+  override val selfUser: Signal[UserData] = usersStorage.optSignal(selfUserId).flatMap {
     case Some(data) => Signal.const(data)
     case None =>
       sync.syncSelfUser()
@@ -181,14 +185,17 @@ class UserServiceImpl(selfUserId:        UserId,
     }
   }
 
-  override def deleteUsers(ids: Set[UserId]): Future[Unit] =
+  override def deleteUsers(ids: Set[UserId], sendLeaveMessage: Boolean = true): Future[Unit] =
     for {
       members       <- membersStorage.getByUsers(ids)
       _             <- membersStorage.removeAll(members.map(_.id).toSet)
       memberInConvs =  members.groupBy(_.convId)
-      _             <- Future.traverse(memberInConvs) {
-                         case (convId, ms) => messages.addMemberLeaveMessage(convId, selfUserId, ms.map(_.userId).toSet, reason = None)
-                       }
+      _             <- if (sendLeaveMessage)
+                         Future.traverse(memberInConvs) {
+                           case (convId, ms) => messages.addMemberLeaveMessage(convId, selfUserId, ms.map(_.userId).toSet, reason = None)
+                         }
+                       else
+                         Future.successful(())
       _             <- usersStorage.updateAll2(ids, _.copy(deleted = true))
     } yield ()
 
@@ -204,29 +211,19 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def findUser(id: UserId): Future[Option[UserData]] = usersStorage.get(id)
 
+  override def findUsers(ids: Seq[UserId]): Future[Seq[Option[UserData]]] = usersStorage.getAll(ids)
+
   override def qualifiedId(userId: UserId): Future[QualifiedId] =
     findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
 
   override def getOrCreateUser(id: UserId): Future[UserData] =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      qualifiedId(id).flatMap { qId =>
-        usersStorage.getOrCreate(id, {
-          sync.syncQualifiedUsers(Set(qId))
-          UserData(
-            id, if (qId.hasDomain) Some(qId.domain) else None, None, Name.Empty, None, None,
-            connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None
-          )
-        })
-      }
-    } else {
-      usersStorage.getOrCreate(id, {
-        sync.syncUsers(Set(id))
-        UserData(
-          id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
-          searchKey = SearchKey.Empty, handle = None
-        )
-      })
-    }
+    usersStorage.getOrCreate(id, {
+      syncUsers(Set(id))
+      UserData(
+        id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
+        searchKey = SearchKey.Empty, handle = None
+      )
+    })
 
   override def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None) =
     usersStorage.update(id, { _.updateConnectionStatus(status, time, message)}).map {
@@ -250,25 +247,27 @@ class UserServiceImpl(selfUserId:        UserId,
     }
   }
 
-  override def syncUser(userId: UserId): Future[Option[UserData]] =
-    usersClient.loadUser(userId).future.flatMap {
-      case Left(e) =>
-        Future.failed(e)
-      case Right(Some(info)) =>
-        updateSyncedUsers(Seq(info)).map(_.headOption)
-      case Right(None) =>
-        deleteUsers(Set(userId)).map(_ => None)
-    }
+  override def syncUser(userId: UserId): Future[Option[UserData]] = {
+    val updateResult =
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        for {
+          Some(user) <- findUser(userId)
+          federated  <- isFederated(user)
+          res        <- ((federated, user.qualifiedId) match {
+                          case (true, Some(qId)) => usersClient.loadQualifiedUser(qId)
+                          case _                 => usersClient.loadUser(userId)
+                        }).future
+        } yield res
+      } else {
+          usersClient.loadUser(userId).future
+      }
 
-  override def syncQualifiedUser(qId: QualifiedId): Future[Option[UserData]] =
-    usersClient.loadQualifiedUser(qId).future.flatMap {
-      case Left(e) =>
-        Future.failed(e)
-      case Right(Some(info)) =>
-        updateSyncedUsers(Seq(info)).map(_.headOption)
-      case Right(None) =>
-        deleteUsers(Set(qId.id)).map(_ => None)
+    updateResult.flatMap {
+      case Left(e)           => Future.failed(e)
+      case Right(Some(info)) => updateSyncedUsers(Seq(info)).map(_.headOption)
+      case Right(None)       => deleteUsers(Set(userId)).map(_ => None)
     }
+  }
 
   def syncSelfNow: Future[Option[UserData]] = Serialized.future(s"syncSelfNow $selfUserId") {
     usersClient.loadSelf().future.flatMap {
@@ -282,24 +281,90 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def deleteAccount(): Future[SyncId] = sync.deleteAccount()
 
+  // @todo: replace with selfUser.head
   override def getSelfUser: Future[Option[UserData]] =
-    usersStorage.get(selfUserId) flatMap {
-      case Some(userData) => Future successful Some(userData)
-      case _ => syncSelfNow
+    usersStorage.get(selfUserId).flatMap {
+      case Some(userData) => Future.successful(Some(userData))
+      case _              => syncSelfNow
     }
+
+  override def isFederated(user: UserData): Future[Boolean] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      selfUser.head.map(_.domain).map {
+        case Some(selfDomain) => user.domain.exists(_ != selfDomain)
+        case _                => false
+      }
+    } else
+      Future.successful(false)
+
+  override def isFederated(id: UserId): Future[Boolean] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      findUser(id).flatMap {
+        case Some(user) => isFederated(user)
+        case _          => Future.successful(false)
+      }
+    } else
+      Future.successful(false)
 
   /**
    * Schedules user data sync if user with given id doesn't exist or has old timestamp.
   */
+  override def syncIfNeeded(userIds:         Set[UserId],
+                            olderThan:       FiniteDuration = SyncIfOlderThan,
+                            qIds:            Set[QualifiedId] = Set.empty): Future[Option[SyncId]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      val allIds = userIds ++ qIds.map(_.id)
+      for {
+        found                 <- usersStorage.listAll(allIds)
+        foundMap              =  found.toIdMap
+        newIds                =  allIds -- foundMap.keySet
+        offset                =  LocalInstant.Now - olderThan
+        existing              =  foundMap.filter {
+                                   case (_, u) => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset))
+                                 }
+        toSync                =  newIds ++ existing.keySet
+        qualified             =  qIds.filter(qId => newIds.contains(qId.id)) ++
+                                   existing.collect { case (_, u) if u.qualifiedId.nonEmpty => u.qualifiedId.get }.toSet
+        nonQualified          =  toSync -- qualified.map(_.id)
+        _                     =  verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size}) (qualified: ${qualified.size})")
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      usersStorage.listAll(userIds).flatMap { found =>
+        val newIds   = userIds -- found.map(_.id)
+        val offset   = LocalInstant.Now - olderThan
+        val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
+        val toSync   = newIds ++ existing.map(_.id)
+        verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
+        if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_)) else Future.successful(None)
+      }
+    }
 
-  override def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]] =
-    usersStorage.listAll(userIds).flatMap { found =>
-      val newIds = userIds -- found.map(_.id)
-      val offset = LocalInstant.Now - olderThan
-      val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
-      val toSync = newIds ++ existing.map(_.id)
-      verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
-      if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_))(Threading.Background) else Future.successful(None)
+  def syncUsers(userIds: Set[UserId], qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      for {
+        found                 <- usersStorage.listAll(userIds -- qIds.map(_.id))
+        qualified             =  qIds ++ found.collect { case u if u.qualifiedId.nonEmpty => u.qualifiedId.get }.toSet
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        nonQualified          =  userIds -- qualified.map(_.id)
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      if (userIds.nonEmpty) sync.syncUsers(userIds).map(Some(_))
+      else Future.successful(None)
     }
 
   override def updateSyncedUsers(users: Seq[UserInfo], syncTime: LocalInstant = LocalInstant.Now): Future[Set[UserData]] = {
@@ -448,12 +513,12 @@ class ExpiredUsersService(push:         PushService,
     members    <- Signal.sequence(membersIds.map(usersStorage.signal).toSeq: _*)
     wireless   =  members.filter(_.expiresAt.isDefined).toSet
   } yield wireless).foreach { wireless =>
-    push.beDrift.head.map { drift =>
+    push.beDrift.head.foreach { drift =>
       val woTimer = wireless.filter(u => (wireless.map(_.id) -- timers.keySet).contains(u.id))
       woTimer.foreach { u =>
         val delay = LocalInstant.Now.toRemote(drift).remainingUntil(u.expiresAt.get + 10.seconds)
         timers += u.id -> CancellableFuture.delay(delay).map { _ =>
-          sync.syncUsers(Set(u.id))
+          users.syncUser(u.id)
           timers -= u.id
         }
       }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -48,7 +48,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _: OtrErrorEvent           => true
       case _: ConnectRequestEvent     => true
       case _: OtrMessageEvent         => true
-      case MemberJoinEvent(_, _, _, added, _, _) if added.contains(selfUserId) => true
+      case MemberJoinEvent(_, _, _, _, _, added, _, _) if added.contains(selfUserId) => true
       case MemberLeaveEvent(_, _, _, leaving, _) if leaving.contains(selfUserId) => true
       case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
         gm.unpackContent match {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -78,9 +78,9 @@ trait ConversationsService {
   def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]]
   def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]]
 
-  def fake1To1Conversations: Signal[Seq[ConversationData]]
-  def isFake1To1(convId: ConvId): Future[Boolean]
   def onlyFake1To1ConvUsers: Signal[Seq[UserData]]
+
+  def generateTempConversationId(users: Set[UserId]): RConvId
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -186,7 +186,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         messages.addConversationStartMessage(
           created.id,
           from,
-          (data.members.keySet + selfUserId).filter(_ != from),
+          (data.memberIds + selfUserId).filter(_ != from),
           created.name,
           readReceiptsAllowed = created.readReceiptsAllowed,
           time = Some(time)
@@ -199,12 +199,12 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         case None if retryCount > 3 => successful(())
         case None =>
           ev match {
-            case MemberJoinEvent(_, time, from, ids, us, _) if selfRequested || from != selfUserId =>
+            case MemberJoinEvent(_, convDomain, time, from, _, ids, us, _) if selfRequested || from != selfUserId =>
               // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-              val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+              val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
               // this happens when we are added to group conversation
               for {
-                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time))
+                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time, domain = convDomain))
                 _          <- membersStorage.updateOrCreateAll(conv.id, Map(from -> ConversationRole.AdminRole) ++ membersWithRoles)
                 sId        <- sync.syncConversations(Set(conv.id))
                 _          <- syncReqService.await(sId)
@@ -230,13 +230,13 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
 
     case RenameConversationEvent(_, _, _, name) => content.updateConversationName(conv.id, name)
 
-    case MemberJoinEvent(_, _, _, ids, us, _) =>
+    case MemberJoinEvent(_, _, _, _, _, ids, us, _) =>
       // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-      val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
-      val selfAdded = membersWithRoles.keySet.contains(selfUserId)//we were re-added to a group and in the meantime might have missed events
+      val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+      val selfAdded = membersWithRoles.keySet.contains(selfUserId) //we were re-added to a group and in the meantime might have missed events
       for {
         convSync   <- if (selfAdded) sync.syncConversations(Set(conv.id)).map(Option(_)) else Future.successful(None)
-        syncId     <- users.syncIfNeeded(membersWithRoles.keySet)
+        syncId     <- users.syncIfNeeded(membersWithRoles.keySet, qIds = us.keySet.filter(_.hasDomain))
         _          <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
         _          <- membersStorage.updateOrCreateAll(conv.id, membersWithRoles)
         _          <- if (selfAdded) content.setConvActive(conv.id, active = true) else successful(None)
@@ -324,7 +324,11 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
   private def updateConversation(response: ConversationResponse): Future[(Seq[ConversationData], Seq[ConversationData])] =
     for {
       defRoles <- rolesService.defaultRoles.head
-      roles    <- client.loadConversationRoles(Set(response.id), defRoles)
+      // @todo: for now we have no way to check conversation roles on a federated backend
+      roles    <- if (!response.hasDomain)
+                    client.loadConversationRoles(Set(response.id), defRoles)
+                  else
+                    Future.successful(Map(response.id -> defRoles))
       results  <- updateConversations(Seq(response), roles)
     } yield results
 
@@ -334,14 +338,14 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     responses.map { resp =>
       val newId =
         if (isOneToOne(resp.convType))
-          resp.members.keys.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
+          resp.memberIds.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
         else
           ConvId(resp.id.str)
 
       val matching = convsByRId.get(resp.id).orElse {
         convsById.get(newId).orElse {
           if (isOneToOne(resp.convType)) None
-          else convsByRId.get(ConversationsService.generateTempConversationId(resp.members.keySet + selfUserId))
+          else convsByRId.get(generateTempConversationId(resp.memberIds))
         }
       }
 
@@ -355,6 +359,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     returning(prev.getOrElse(ConversationData(id = newLocalId, hidden = isOneToOne(resp.convType) && resp.members.size <= 1))
       .copy(
         remoteId        = resp.id,
+        domain          = resp.domain,
         name            = resp.name.filterNot(_.isEmpty),
         creator         = resp.creator,
         convType        = prev.map(_.convType).filter(oldType => isOneToOne(oldType) && resp.convType != ConversationType.OneToOne).getOrElse(resp.convType),
@@ -387,7 +392,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     for {
       convs         <- content.convsByRemoteId(responses.map(_.id).toSet)
       toUpdate      =  responses.map(c => (c.id, c.members)).flatMap {
-                         case (remoteId, members) => convs.get(remoteId).map(c => c.id -> (members + (c.creator -> ConversationRole.AdminRole)))
+                         case (remoteId, members) =>
+                           val userIdsWithRoles = members.map { case (qId, role) => qId.id -> role }
+                           convs.get(remoteId).map(c => c.id -> (userIdsWithRoles + (c.creator -> ConversationRole.AdminRole)))
                        }.toMap
       activeUsers   <- membersStorage.getActiveUsers2(convs.map(_._2.id).toSet)
       _             <- membersStorage.setAll(toUpdate)
@@ -487,7 +494,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       (convs, created) <- updateConversationData(responses)
       _                <- updateRoles(convs.map(data => data.id -> data.remoteId).toMap, roles)
       _                <- updateMembers(responses)
-      _                <- users.syncIfNeeded(responses.flatMap(_.members.keys).toSet)
+      _                <- users.syncIfNeeded(responses.flatMap(_.memberIds).toSet, qIds = responses.flatMap(_.qualifiedMemberIds).toSet)
     } yield (convs.toSeq, created)
 
   def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit] =
@@ -720,40 +727,32 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         warn(l"joinConversation(key: $key, code: $code) error: $error")
         Future.successful(Left(GeneralError))
     }
-
-  private lazy val fake1To1s =
+  
+  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
       for {
-        convs            <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
-        convsWithMembers <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
-        fakes            = convsWithMembers.filter { case (_, ms) => ms.size == 2 && ms.contains(selfUserId) }
-      } yield fakes
+        convs             <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
+        convsWithMembers  <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
+        acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
+        userIds           =  convsWithMembers.collect {
+                               case (_, userIds) if userIds.size == 2 && userIds.contains(selfUserId) => userIds - selfUserId
+                             }.flatten.toSet
+        fake1To1UserIds   =  userIds -- acceptedOrBlocked
+        fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
+      } yield fake1To1Users
     } else {
-      Signal.const(Seq.empty[(ConversationData, Set[UserId])])
+      Signal.const(Seq.empty[UserData])
     }
 
-  override lazy val fake1To1Conversations: Signal[Seq[ConversationData]] = fake1To1s.map(_.map(_._1))
-
-  override def isFake1To1(convId: ConvId): Future[Boolean] = fake1To1s.head.map(_.exists(_._1.id == convId))
-
-  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
-    for {
-      fake1To1Convs     <- fake1To1s
-      userIds           =  fake1To1Convs.flatMap(_._2).toSet
-      acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
-      fake1To1UserIds   =  userIds -- acceptedOrBlocked
-      fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
-    } yield fake1To1Users
+  /**
+   * Generate temp ConversationID to identify conversations which don't have a RConvId yet
+   */
+  override def generateTempConversationId(users: Set[UserId]): RConvId =
+    RConvId((users + selfUserId).toSeq.map(_.toString).sorted.foldLeft("")(_ + _))
 }
 
 object ConversationsService {
   import scala.concurrent.duration._
 
   val RetryBackoff = new ExponentialBackoff(500.millis, 3.seconds)
-
-  /**
-   * Generate temp ConversationID to identify conversations which don't have a RConvId yet
-   */
-  def generateTempConversationId(users: Set[UserId]) =
-    RConvId(users.toSeq.map(_.toString).sorted.foldLeft("")(_ + _))
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -35,10 +35,9 @@ import com.waz.service.ZMessaging.currentBeDrift
 import com.waz.service._
 import com.waz.service.assets.{AES_CBC_Encryption, AssetService, ContentForUpload, UploadAsset, UriHelper}
 import com.waz.service.assets.Asset.Video
-import com.waz.service.conversation.ConversationsService.generateTempConversationId
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.tracking.{ContributionEvent, TrackingService}
-import com.waz.sync.SyncServiceHandle
+import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.sync.client.{ConversationsClient, ErrorOr}
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
@@ -49,8 +48,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
-
-import com.waz.zms.BuildConfig
 
 trait ConversationsUiService {
   import ConversationsUiService._
@@ -104,12 +101,12 @@ trait ConversationsUiService {
                               receiptMode: Int = 0,
                               defaultRole: ConversationRole = ConversationRole.MemberRole
                              ): Future[(ConversationData, SyncId)]
-  def createQualifiedGroupConversation(name:        Name,
-                                       members:     Set[QualifiedId] = Set.empty,
-                                       teamOnly:    Boolean = false,
-                                       receiptMode: Int = 0,
-                                       defaultRole: ConversationRole = ConversationRole.MemberRole
-                                      ): Future[(ConversationData, SyncId)]
+  def createConvWithFederatedUser(name:        Name,
+                                  qId:         QualifiedId,
+                                  teamOnly:    Boolean = false,
+                                  receiptMode: Int = 0,
+                                  defaultRole: ConversationRole = ConversationRole.MemberRole
+                                 ): Future[(ConversationData, SyncId)]
 
   def assetUploadCancelled : EventStream[Mime]
   def assetUploadFailed    : EventStream[ErrorResponse]
@@ -126,7 +123,7 @@ object ConversationsUiService {
 class ConversationsUiServiceImpl(selfUserId:        UserId,
                                  teamId:            Option[TeamId],
                                  assets:            AssetService,
-                                 usersStorage:      UsersStorage,
+                                 userService:       UserService,
                                  messages:          MessagesService,
                                  messagesStorage:   MessagesStorage,
                                  messagesContent:   MessagesContentUpdater,
@@ -136,6 +133,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
                                  network:           NetworkModeService,
                                  convs:             ConversationsService,
                                  sync:              SyncServiceHandle,
+                                 syncRequests:      SyncRequestService,
                                  client:            ConversationsClient,
                                  accounts:          AccountsService,
                                  tracking:          TrackingService,
@@ -302,29 +300,44 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
   override def addRestrictedFileMessage(convId: ConvId, from: Option[UserId] = None, extension: Option[String] = None): Future[Option[MessageData]]
     = messages.addRestrictedFileMessage(convId, from, extension)
 
-  override def addConversationMembers(conv: ConvId, users: Set[UserId], defaultRole: ConversationRole): Future[Option[SyncId]] =
+  private def partitionForQualified(userIds: Set[UserId]) =
+    for {
+      users        <- userService.findUsers(userIds.toSeq)
+      qualified    =  users.collect { case Some(u) if u.qualifiedId.nonEmpty => u.id -> u.qualifiedId }.toMap
+      nonQualified =  userIds -- qualified.keySet
+    } yield (qualified.values.flatten.toSet, nonQualified)
+
+  override def addConversationMembers(conv: ConvId, userIds: Set[UserId], defaultRole: ConversationRole): Future[Option[SyncId]] =
     (for {
-      true      <- canModifyMembers(conv)
-      contacted <- members.getByUsers(users)
-      toSync    =  users -- contacted.map(_.userId).toSet
-      _         <- sync.syncUsers(toSync) // data of users found through Search UI is not yet in db
-      added     <- members.updateOrCreateAll(conv, users.map(_ -> defaultRole).toMap) if added.nonEmpty
-      _         <- messages.addMemberJoinMessage(conv, selfUserId, added.map(_.userId))
-      syncId    <- sync.postConversationMemberJoin(conv, added.map(_.userId), defaultRole)
-    } yield Option(syncId))
+      true                  <- canModifyMembers(conv)
+      contacted             <- members.getByUsers(userIds)
+      toSync                =  userIds -- contacted.map(_.userId).toSet
+      _                     <- if (toSync.nonEmpty) userService.syncUsers(toSync) else Future.successful(())
+      _                     <- members.updateOrCreateAll(conv, userIds.map(_ -> defaultRole).toMap)
+      _                     <- messages.addMemberJoinMessage(conv, selfUserId, userIds)
+      (qIds, nonQIds)       <- partitionForQualified(userIds)
+      syncId1               <- if (qIds.nonEmpty)
+                                 sync.postQualifiedConversationMemberJoin(conv, qIds, defaultRole).map(Option(_))
+                               else
+                                 Future.successful(None)
+      syncId2               <- if (nonQIds.nonEmpty)
+                                 sync.postConversationMemberJoin(conv, nonQIds, defaultRole).map(Option(_))
+                               else
+                                 Future.successful(None)
+    } yield syncId2.orElse(syncId1))
       .recover {
         case NonFatal(e) =>
-          warn(l"Failed to add members: $users to conv: $conv", e)
+          warn(l"Failed to add members: $userIds to conv: $conv", e)
           Option.empty[SyncId]
       }
 
-  override def removeConversationMember(conv: ConvId, user: UserId) = {
+  override def removeConversationMember(conv: ConvId, user: UserId): Future[Option[SyncId]] = {
     (for {
       true     <- canModifyMembers(conv)
       Some(_)  <- members.remove(conv, user)
       toDelete <- if (user != selfUserId) members.getByUsers(Set(user)).map(_.isEmpty)
                   else Future.successful(false)
-      _        <- if (toDelete) usersStorage.remove(user) else Future.successful(())
+      _        <- if (toDelete) userService.deleteUsers(Set(user), sendLeaveMessage = false) else Future.successful(())
       _        <- messages.addMemberLeaveMessage(conv, selfUserId, Set(user), reason = None)
       syncId   <- sync.postConversationMemberLeave(conv, user)
     } yield Option(syncId))
@@ -336,11 +349,14 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
   }
 
   private def canModifyMembers(convId: ConvId) =
-    for {
-      selfActive    <- members.isActiveMember(convId, selfUserId)
-      isGroup       <- convs.isGroupConversation(convId)
-      isWithService <- convs.isWithService(convId)
-    } yield selfActive && (isGroup || isWithService)
+    members.isActiveMember(convId, selfUserId).flatMap {
+      case false => Future.successful(false)
+      case true  =>
+        convs.isGroupConversation(convId).flatMap {
+          case true  => Future.successful(true)
+          case false => convs.isWithService(convId)
+        }
+    }
 
   override def leaveConversation(conv: ConvId) = {
     verbose(l"leaveConversation($conv)")
@@ -351,7 +367,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
     } yield {}
   }
 
-  override def clearConversation(id: ConvId): Future[Option[ConversationData]] = convsContent.convById(id) flatMap {
+  override def clearConversation(id: ConvId): Future[Option[ConversationData]] = convsContent.convById(id).flatMap {
     case Some(conv) if conv.convType == ConversationType.Group || conv.convType == ConversationType.OneToOne =>
       verbose(l"clearConversation($conv)")
 
@@ -379,7 +395,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
     def createReal1to1() =
       convsContent.convById(ConvId(otherUserId.str)) flatMap {
         case Some(conv) => Future.successful(conv)
-        case _ => usersStorage.get(otherUserId).flatMap {
+        case _ => userService.findUser(otherUserId).flatMap {
           case Some(u) if u.connection == ConnectionStatus.Ignored =>
             for {
               conv <- convsContent.createConversationWithMembers(
@@ -429,24 +445,27 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
         case Some(conv) =>
           Future.successful(conv)
         case _ if isFederated =>
-          val qualifiedIdSet = otherUser.flatMap(_.qualifiedId).toSet
-          createAndPostQualifiedConversation(ConvId(), None, qualifiedIdSet, defaultRole = ConversationRole.AdminRole).map(_._1)
+          (otherUser.flatMap(_.qualifiedId) match {
+            case Some(qId) => createAndPostConvWithFederatedUser(ConvId(), None, qId, defaultRole = ConversationRole.AdminRole)
+            case None      => Future.failed(new IllegalStateException(s"A federated user without a qualified id: $otherUser"))
+          }).map(_._1)
         case _ =>
-          createAndPostConversation(ConvId(), None, Set(otherUserId), defaultRole = ConversationRole.AdminRole).map(_._1)
+          val tempRConvId = convs.generateTempConversationId(Set(otherUserId))
+          createAndPostConversation(
+            ConvId(),
+            name        = None,
+            members     = Set(otherUserId),
+            defaultRole = ConversationRole.AdminRole,
+            tempRConvId = tempRConvId
+          ).map(_._1)
       }
     }
 
     teamId match {
       case Some(tId) =>
         for {
-          otherUser   <- usersStorage.get(otherUserId)
-          selfUser    <- usersStorage.get(selfUserId)
-          isFederated =  if (BuildConfig.FEDERATION_USER_DISCOVERY)
-                           (selfUser.flatMap(_.domain), otherUser) match {
-                             case (Some(selfDomain), Some(user)) => user.domain.exists(_ != selfDomain)
-                             case _ => false
-                           }
-                         else false
+          otherUser   <- userService.findUser(otherUserId)
+          isFederated <- userService.isFederated(otherUserId)
           isGuest     =  otherUser.exists(_.isGuest(tId))
           conv        <- if (isGuest && !isFederated)
                            createReal1to1()
@@ -458,21 +477,39 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
     }
   }
 
+  private def partitionForFederated(userIds: Set[UserId]) =
+    for {
+      users                 <- userService.findUsers(userIds.toSeq)
+      usersAndFederation    <- Future.sequence(users.flatten.map(user => userService.isFederated(user).map((user, _))))
+      (federated, standard) =  usersAndFederation.partition(_._2)
+    } yield (federated.flatMap(_._1.qualifiedId).toSet, standard.map(_._1.id).toSet)
+
   override def createGroupConversation(name:        Name,
-                                       members:     Set[UserId] = Set.empty,
-                                       teamOnly:    Boolean = false,
-                                       receiptMode: Int = 0,
+                                       members:     Set[UserId]      = Set.empty,
+                                       teamOnly:    Boolean          = false,
+                                       receiptMode: Int              = 0,
                                        defaultRole: ConversationRole = ConversationRole.MemberRole
                                       ): Future[(ConversationData, SyncId)] =
-    createAndPostConversation(ConvId(), Some(name), members, teamOnly, receiptMode, defaultRole)
+    for {
+      (federated, standard) <- partitionForFederated(members)
+      tempRConvId           =  convs.generateTempConversationId(members)
+      (conv, syncId)        <- createAndPostConversation(ConvId(), Some(name), standard, teamOnly, receiptMode, defaultRole, tempRConvId)
+      _                     <- syncRequests.await(syncId)
+      // @todo: The next step involves again partitioning for qualified users
+      //        I decided not to optimize it yet as the way to add qualified users to conversations will change again
+      _                      <- if (federated.nonEmpty) {
+                                   addConversationMembers(conv.id, federated.map(_.id), defaultRole)
+                                } else
+                                   Future.successful(())
+    } yield (conv, syncId)
 
-  override def createQualifiedGroupConversation(name:        Name,
-                                                members:     Set[QualifiedId] = Set.empty,
-                                                teamOnly:    Boolean = false,
-                                                receiptMode: Int = 0,
-                                                defaultRole: ConversationRole = ConversationRole.MemberRole
-                                               ): Future[(ConversationData, SyncId)] =
-    createAndPostQualifiedConversation(ConvId(), Some(name), members, teamOnly, receiptMode, defaultRole)
+  override def createConvWithFederatedUser(name:        Name,
+                                           qId:         QualifiedId,
+                                           teamOnly:    Boolean = false,
+                                           receiptMode: Int = 0,
+                                           defaultRole: ConversationRole = ConversationRole.MemberRole
+                                          ): Future[(ConversationData, SyncId)] =
+    createAndPostConvWithFederatedUser(ConvId(), Some(name), qId, teamOnly, receiptMode, defaultRole)
 
   private def createConversation(id:          ConvId,
                                  name:        Option[Name],
@@ -480,11 +517,13 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
                                  access:      Set[Access],
                                  accessRole:  AccessRole,
                                  receiptMode: Int,
-                                 defaultRole: ConversationRole): Future[ConversationData] =
+                                 defaultRole: ConversationRole,
+                                 tempRConvId: RConvId
+                                ): Future[ConversationData] =
     for {
       conv <- convsContent.createConversationWithMembers(
                 convId      = id,
-                remoteId    = generateTempConversationId(members + selfUserId),
+                remoteId    = tempRConvId,
                 convType    = ConversationType.Group,
                 creator     = selfUserId,
                 members     = members,
@@ -503,27 +542,28 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
                                         members:     Set[UserId] = Set.empty,
                                         teamOnly:    Boolean = false,
                                         receiptMode: Int = 0,
-                                        defaultRole: ConversationRole
+                                        defaultRole: ConversationRole,
+                                        tempRConvId: RConvId
                                        ): Future[(ConversationData, SyncId)] = {
     val (ac, ar) = getAccessAndRoleForGroupConv(teamOnly, teamId)
     for {
-      conv   <- createConversation(id, name, members, ac, ar, receiptMode, defaultRole)
+      conv   <- createConversation(id, name, members, ac, ar, receiptMode, defaultRole, tempRConvId)
       syncId <- sync.postConversation(id, members, conv.name, teamId, ac, ar, Some(receiptMode), defaultRole)
     } yield (conv, syncId)
   }
 
-  private def createAndPostQualifiedConversation(id:          ConvId,
+  private def createAndPostConvWithFederatedUser(id:          ConvId,
                                                  name:        Option[Name],
-                                                 members:     Set[QualifiedId] = Set.empty,
+                                                 qId:         QualifiedId,
                                                  teamOnly:    Boolean = false,
                                                  receiptMode: Int = 0,
                                                  defaultRole: ConversationRole
                                                 ): Future[(ConversationData, SyncId)] = {
-    val (ac, ar)  = getAccessAndRoleForGroupConv(teamOnly, teamId)
-    val memberIds = members.map(_.id)
+    val (ac, ar)    = getAccessAndRoleForGroupConv(teamOnly, teamId)
+    val tempRConvId = convs.generateTempConversationId(Set(qId.id))
     for {
-      conv   <- createConversation(id, name, memberIds, ac, ar, receiptMode, defaultRole)
-      syncId <- sync.postQualifiedConversation(id, members, conv.name, teamId, ac, ar, Some(receiptMode), defaultRole)
+      conv   <- createConversation(id, name, Set.empty, ac, ar, receiptMode, defaultRole, tempRConvId)
+      syncId <- sync.postQualifiedConversation(id, Set(qId), conv.name, teamId, ac, ar, Some(receiptMode), defaultRole)
     } yield (conv, syncId)
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -106,8 +106,8 @@ class MessageEventProcessor(selfUserId:           UserId,
         RichMessage(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
       case MessageTimerEvent(_, time, from, duration) =>
         RichMessage(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
-      case MemberJoinEvent(_, time, from, userIds, users, firstEvent) =>
-        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
+      case MemberJoinEvent(_, _, time, from, _, userIds, users, firstEvent) =>
+        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys.map(_.id) ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
       case ConversationReceiptModeEvent(_, time, from, 0) =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
       case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -78,6 +78,7 @@ trait SyncServiceHandle {
   def postReceiptMode(id: ConvId, receiptMode: Int): Future[SyncId]
   def postConversationName(id: ConvId, name: Name): Future[SyncId]
   def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncId]
+  def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId]
   def postConversationMemberLeave(id: ConvId, member: UserId): Future[SyncId]
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncId]
   def postConversation(id:          ConvId,
@@ -159,7 +160,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def syncSearchResults(users: Set[UserId]) = addRequest(SyncSearchResults(users))
   def syncQualifiedSearchResults(qIds: Set[QualifiedId]) = addRequest(SyncQualifiedSearchResults(qIds))
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
-  def syncUsers(ids: Set[UserId]) = addRequest(SyncUser(ids))
+  def syncUsers(ids: Set[UserId]): Future[SyncId] = addRequest(SyncUser(ids))
   def syncQualifiedUsers(qIds: Set[QualifiedId]) = addRequest(SyncQualifiedUsers(qIds))
   def syncSelfUser() = addRequest(SyncSelf, priority = Priority.High)
   def deleteAccount() = addRequest(DeleteAccount)
@@ -192,7 +193,10 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postTypingState(conv: ConvId, typing: Boolean) = addRequest(PostTypingState(conv, typing))
   def postConversationName(id: ConvId, name: Name) = addRequest(PostConvName(id, name))
   def postConversationState(id: ConvId, state: ConversationState) = addRequest(PostConvState(id, state))
-  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole) = addRequest(PostConvJoin(id, members, defaultRole))
+  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncId] =
+    addRequest(PostConvJoin(id, members, defaultRole))
+  def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId] =
+    addRequest(PostQualifiedConvJoin(id, members, defaultRole))
   def postConversationMemberLeave(id: ConvId, member: UserId) = addRequest(PostConvLeave(id, member))
   def postConversation(id: ConvId,
                        users: Set[UserId],
@@ -245,22 +249,30 @@ class AndroidSyncServiceHandle(account:         UserId,
   override def performFullSync(): Future[Unit] = {
     verbose(l"performFullSync")
     for {
-      id1     <- syncSelfUser()
-      id2     <- syncSelfClients()
-      id3     <- syncSelfPermissions()
-      id4     <- syncTeam()
-      id5     <- syncConversations()
-      id6     <- syncConnections()
-      id7     <- syncProperties()
-      userIds <- usersStorage.list().map(_.map(_.id).toSet)
-      id8     <- syncUsers(userIds)
-      id9     <- syncFolders()
-      id10    <- syncLegalHoldRequest()
-      _       =  verbose(l"waiting for full sync to finish...")
-      _       <- service.await(Set(id1, id2, id3, id4, id5, id6, id7, id8, id9, id10))
-      _       =  verbose(l"... and done")
+      id1        <- syncSelfUser()
+      id2        <- syncSelfClients()
+      id3        <- syncSelfPermissions()
+      id4        <- syncTeam()
+      id5        <- syncConversations()
+      id6        <- syncConnections()
+      id7        <- syncProperties()
+      (id8, id9) <- syncUsers()
+      id10       <- syncFolders()
+      id11       <- syncLegalHoldRequest()
+      _          =  verbose(l"waiting for full sync to finish...")
+      _          <- service.await(Set(id1, id2, id3, id4, id5, id6, id7, id8, id9, id10, id11))
+      _          =  verbose(l"... and done")
     } yield ()
   }
+
+  private def syncUsers(): Future[(SyncId, SyncId)] =
+    for {
+      userMap      <- usersStorage.contents.head
+      qualified    =  userMap.collect { case (id, u) if u.qualifiedId.nonEmpty => id -> u.qualifiedId }
+      id1          <- syncQualifiedUsers(qualified.flatMap(_._2).toSet)
+      nonQualified =  userMap.keySet -- qualified.keySet
+      id2          <- syncUsers(nonQualified)
+    } yield (id1, id2)
 
   override def deleteGroupConversation(teamId: TeamId, rConvId: RConvId) = {
     addRequest(DeleteGroupConversation(teamId, rConvId)).recoverWith {
@@ -335,6 +347,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostMessage(convId, messageId, time)            => zms.messagesSync.postMessage(convId, messageId, time)
           case PostAssetStatus(cid, mid, exp, status)          => zms.messagesSync.postAssetStatus(cid, mid, exp, status)
           case PostConvJoin(convId, u, role)                   => zms.conversationSync.postConversationMemberJoin(convId, u, role)
+          case PostQualifiedConvJoin(convId, u, role)          => zms.conversationSync.postQualifiedConversationMemberJoin(convId, u, role)
           case PostConvLeave(convId, u)                        => zms.conversationSync.postConversationMemberLeave(convId, u)
           case PostConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>
             zms.conversationSync.postConversation(convId, u, name, team, access, accessRole, receiptMode, defRole)

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -29,10 +29,11 @@ import com.waz.service.conversation.{ConversationOrderEventsService, Conversatio
 import com.waz.service.messages.MessagesService
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.{Retry, Success}
-import com.waz.sync.client.ConversationsClient
+import com.waz.sync.client.{ConversationsClient, ErrorOr}
 import com.waz.sync.client.ConversationsClient.ConversationResponse.ConversationsResult
 import com.waz.sync.client.ConversationsClient.{ConversationInitState, ConversationResponse}
 import com.waz.threading.Threading
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.Future
 import scala.util.Right
@@ -42,20 +43,20 @@ object ConversationsSyncHandler {
   val PostMembersLimit = 256
 }
 
-class ConversationsSyncHandler(selfUserId:          UserId,
-                               teamId:              Option[TeamId],
-                               userService:         UserService,
-                               messagesStorage:     MessagesStorage,
-                               messagesService:     MessagesService,
-                               convService:         ConversationsService,
-                               convs:               ConversationsContentUpdater,
-                               convEvents:          ConversationOrderEventsService,
-                               convStorage:         ConversationStorage,
-                               errorsService:       ErrorsService,
-                               conversationsClient: ConversationsClient,
-                               genericMessages:     GenericMessageService,
-                               rolesService:        ConversationRolesService,
-                               membersStorage:      MembersStorage
+class ConversationsSyncHandler(selfUserId:      UserId,
+                               teamId:          Option[TeamId],
+                               userService:     UserService,
+                               messagesStorage: MessagesStorage,
+                               messagesService: MessagesService,
+                               convService:     ConversationsService,
+                               convUpdater:     ConversationsContentUpdater,
+                               convEvents:      ConversationOrderEventsService,
+                               convStorage:     ConversationStorage,
+                               errorsService:   ErrorsService,
+                               convClient:      ConversationsClient,
+                               genericMessages: GenericMessageService,
+                               rolesService:    ConversationRolesService,
+                               membersStorage:  MembersStorage
                               ) extends DerivedLogTag {
 
   import Threading.Implicits.Background
@@ -65,19 +66,46 @@ class ConversationsSyncHandler(selfUserId:          UserId,
   private def loadConversationRoles(resps: Seq[ConversationResponse]) = {
     val (otherTeamResps, teamAndPrivResps) = resps.partition(r => r.team.isDefined && r.team != teamId)
     rolesService.defaultRoles.head.flatMap { defRoles =>
-      conversationsClient
-        .loadConversationRoles(otherTeamResps.map(_.id).toSet, defRoles)
+      // @todo: for now we have no way to check conversation roles on a federated backend
+      val convIds = otherTeamResps.filterNot(_.hasDomain).map(_.id).toSet
+      convClient
+        .loadConversationRoles(convIds, defRoles)
         .map(_ ++ teamAndPrivResps.map(r => r.id -> defRoles).toMap)
     }
   }
 
   def syncConversations(ids: Set[ConvId]): Future[SyncResult] =
-    Future.sequence(ids.map(convs.convById)).flatMap { convs =>
-      val remoteIds = convs.collect { case Some(conv) => conv.remoteId }
+    convStorage.getAll(ids).flatMap { convs =>
+      val load: ErrorOr[Seq[ConversationResponse]] =
+        if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+          val (qIds, remoteIds) = convs.foldLeft((Set.empty[RConvQualifiedId], Set.empty[RConvId])) {
+            case ((qIds, remoteIds), Some(conv)) if conv.qualifiedId.nonEmpty =>
+              (qIds + conv.qualifiedId.get, remoteIds)
+            case ((qIds, remoteIds), Some(conv)) =>
+              (qIds, remoteIds + conv.remoteId)
+            case (acc, _) =>
+              error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+              acc
+          }
 
-      if (remoteIds.size != convs.size) error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+          (for {
+            qResps <- if (qIds.nonEmpty) convClient.loadQualifiedConversations(qIds).future
+                      else Future.successful(Right(Seq.empty))
+            resps  <- if (remoteIds.nonEmpty) convClient.loadConversations(remoteIds).future
+                      else Future.successful(Right(Seq.empty))
+          } yield (qResps, resps)).map {
+            case (Left(error), _)        => Left(error)
+            case (_, Left(error))        => Left(error)
+            case (Right(qrs), Right(rs)) => Right(qrs ++ rs)
+          }
+        } else {
+          val remoteIds = convs.collect { case Some(conv) => conv.remoteId }.toSet
+          if (remoteIds.size != convs.size)
+            error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+          convClient.loadConversations(remoteIds).future
+        }
 
-      conversationsClient.loadConversations(remoteIds).future flatMap {
+      load.flatMap {
         case Right(resps) =>
           loadConversationRoles(resps).flatMap { roles =>
             debug(l"syncConversations received ${resps.size}, ${roles.size}")
@@ -90,8 +118,15 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       }
     }
 
-  def syncConversations(start: Option[RConvId] = None, rIdsFromBackend: Set[RConvId] = Set.empty): Future[SyncResult] =
-    conversationsClient.loadConversations(start).future.flatMap {
+  def syncConversations(): Future[SyncResult] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      syncQualifiedConversations(None, Set.empty)
+    } else {
+      syncConversations(None, Set.empty)
+    }
+
+  private def syncConversations(start: Option[RConvId], rIdsFromBackend: Set[RConvId]): Future[SyncResult] =
+    convClient.loadConversations(start).future.flatMap {
       case Right(ConversationsResult(responses, hasMore)) =>
         loadConversationRoles(responses).flatMap { roles =>
           convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
@@ -99,6 +134,24 @@ class ConversationsSyncHandler(selfUserId:          UserId,
               syncConversations(responses.lastOption.map(_.id), rIdsFromBackend ++ responses.map(_.id))
             else
               removeConvsMissingOnBackend(rIdsFromBackend ++ responses.map(_.id)).map(_ => Success)
+          }
+        }
+      case Left(error) =>
+        Future.successful(SyncResult(error))
+    }
+
+  private def syncQualifiedConversations(start: Option[RConvQualifiedId], rIdsFromBackend: Set[RConvQualifiedId]): Future[SyncResult] =
+    convClient.loadQualifiedConversations(start).future.flatMap {
+      case Right(ConversationsResult(responses, hasMore)) =>
+        loadConversationRoles(responses).flatMap { roles =>
+          convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
+            if (hasMore)
+              syncQualifiedConversations(
+                responses.lastOption.flatMap(_.qualifiedId),
+                rIdsFromBackend ++ responses.flatMap(_.qualifiedId)
+              )
+            else
+              removeConvsMissingOnBackend(rIdsFromBackend.map(_.id) ++ responses.map(_.id)).map(_ => Success)
           }
         }
       case Left(error) =>
@@ -113,16 +166,16 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     } yield ()
 
   def postConversationName(id: ConvId, name: Name): Future[SyncResult] =
-    postConv(id) { conv => conversationsClient.postName(conv.remoteId, name).future }
+    postConv(id) { conv => convClient.postName(conv.remoteId, name).future }
 
   def postConversationReceiptMode(id: ConvId, receiptMode: Int): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postReceiptMode(conv.remoteId, receiptMode).map(SyncResult(_))
+      convClient.postReceiptMode(conv.remoteId, receiptMode).map(SyncResult(_))
     }
 
   def postConversationRole(id: ConvId, userId: UserId, newRole: ConversationRole, origRole: ConversationRole): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postConversationRole(conv.remoteId, userId, newRole).future.flatMap {
+      convClient.postConversationRole(conv.remoteId, userId, newRole).future.flatMap {
         case Right(_) =>
           Future.successful(Success)
         case Left(error) =>
@@ -130,8 +183,8 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       }
     }
 
-  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncResult] = withConversation(id) { conv =>
-    def post(users: Set[UserId]) = conversationsClient.postMemberJoin(conv.remoteId, users, defaultRole).future flatMap {
+  private def handleMemberJoinResponse(id: ConvId, users: Set[UserId], response: Either[ErrorResponse, Option[MemberJoinEvent]]) =
+    response match {
       case Left(resp @ ErrorResponse(status, _, label)) =>
         val errTpe = (status, label) match {
           case (403, "not-connected")             => Some(ErrorType.CANNOT_ADD_UNCONNECTED_USER_TO_CONVERSATION)
@@ -143,42 +196,36 @@ class ConversationsSyncHandler(selfUserId:          UserId,
           .onMemberAddFailed(id, users, errTpe, resp)
           .map(_ => SyncResult(resp))
       case resp =>
-        verbose(l"postConversationMemberJoin($id, $members, $defaultRole): $resp")
         postConvRespHandler(resp)
     }
 
-    Future.traverse(members.grouped(PostMembersLimit))(post) map { _.find(_ != Success).getOrElse(Success) }
-  }
+  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncResult] =
+    withConversation(id) { conv =>
+      def post(users: Set[UserId]) =
+        convClient
+          .postMemberJoin(conv.remoteId, users, defaultRole).future
+          .flatMap(handleMemberJoinResponse(id, members, _))
+
+      Future.traverse(members.grouped(PostMembersLimit))(post) map { _.find(_ != Success).getOrElse(Success) }
+    }
 
   def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncResult] =
     withConversation(id) { conv =>
       def post(users: Set[QualifiedId]) =
-        conversationsClient.postQualifiedMemberJoin(conv.remoteId, users, defaultRole).future flatMap {
-          case Left(resp @ ErrorResponse(status, _, label)) =>
-            val errTpe = (status, label) match {
-              case (403, "not-connected")             => Some(ErrorType.CANNOT_ADD_UNCONNECTED_USER_TO_CONVERSATION)
-              case (403, "too-many-members")          => Some(ErrorType.CANNOT_ADD_USER_TO_FULL_CONVERSATION)
-              case (412, "missing-legalhold-consent") => Some(ErrorType.CANNOT_ADD_PARTICIPANT_WITH_MISSING_LEGAL_HOLD_CONSENT)
-              case _                                  => None
-            }
-            convService
-              .onMemberAddFailed(id, users.map(_.id), errTpe, resp)
-              .map(_ => SyncResult(resp))
-          case resp =>
-            verbose(l"postConversationMemberJoin($id, $members, $defaultRole): $resp")
-            postConvRespHandler(resp)
-        }
+        convClient
+          .postQualifiedMemberJoin(conv.remoteId, users, defaultRole).future
+          .flatMap(handleMemberJoinResponse(id, members.map(_.id), _))
 
       Future.traverse(members.grouped(PostMembersLimit))(post) map { _.find(_ != Success).getOrElse(Success) }
     }
 
   def postConversationMemberLeave(id: ConvId, user: UserId): Future[SyncResult] =
-    if (user != selfUserId) postConv(id) { conv => conversationsClient.postMemberLeave(conv.remoteId, user) }
+    if (user != selfUserId) postConv(id) { conv => convClient.postMemberLeave(conv.remoteId, user) }
     else withConversation(id) { conv =>
-      conversationsClient.postMemberLeave(conv.remoteId, user).future flatMap {
+      convClient.postMemberLeave(conv.remoteId, user).future flatMap {
         case Right(Some(event: MemberLeaveEvent)) =>
           event.localTime = LocalInstant.Now
-          conversationsClient.postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(event.time))).future flatMap {
+          convClient.postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(event.time))).future flatMap {
             case Right(_) =>
               verbose(l"postConversationState finished")
               convEvents.handlePostConversationEvent(event)
@@ -188,7 +235,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
           }
         case Right(None) =>
           debug(l"member $user already left, just updating the conversation state")
-          conversationsClient
+          convClient
             .postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(conv.lastEventTime)))
             .future
             .map(_ => Success)
@@ -200,7 +247,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postConversationState(conv.remoteId, state).map(SyncResult(_))
+      convClient.postConversationState(conv.remoteId, state).map(SyncResult(_))
     }
 
   def postConversation(convId:      ConvId,
@@ -216,6 +263,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     val (toCreate, toAdd) = users.splitAt(PostMembersLimit)
     val initState = ConversationInitState(
       users                 = toCreate,
+      qualifiedUsers        = Set.empty,
       name                  = name,
       team                  = team,
       access                = access,
@@ -223,7 +271,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       receiptMode           = receiptMode,
       conversationRole      = defaultRole
     )
-    conversationsClient.postConversation(initState).future.flatMap {
+    convClient.postConversation(initState).future.flatMap {
       case Right(response) =>
         convService.updateRemoteId(convId, response.id).flatMap { _ =>
           loadConversationRoles(Seq(response)).flatMap { roles =>
@@ -253,7 +301,6 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     }
   }
 
-
   def postQualifiedConversation(convId:      ConvId,
                                 users:       Set[QualifiedId],
                                 name:        Option[Name],
@@ -266,16 +313,17 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     debug(l"postQualifiedConversation($convId, $users, $name, $defaultRole)")
 
     val initState = ConversationInitState(
-      users                 = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
-      name                  = name,
-      team                  = team,
-      access                = access,
-      accessRole            = accessRole,
-      receiptMode           = receiptMode,
-      conversationRole      = defaultRole
+      users            = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
+      qualifiedUsers   = users,
+      name             = name,
+      team             = team,
+      access           = access,
+      accessRole       = accessRole,
+      receiptMode      = receiptMode,
+      conversationRole = defaultRole
     )
 
-    conversationsClient.postConversation(initState).future.flatMap {
+    convClient.postQualifiedConversation(initState).future.flatMap {
       case Right(response) =>
         convService.updateRemoteId(convId, response.id).flatMap { _ =>
           loadConversationRoles(Seq(response)).flatMap { roles =>
@@ -307,8 +355,8 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   def syncConvLink(convId: ConvId): Future[SyncResult] = {
     (for {
-      Some(conv) <- convs.convById(convId)
-      resp       <- conversationsClient.getLink(conv.remoteId).future
+      Some(conv) <- convUpdater.convById(convId)
+      resp       <- convClient.getLink(conv.remoteId).future
       res        <- resp match {
         case Right(l)  => convStorage.update(conv.id, _.copy(link = l)).map(_ => Success)
         case Left(err) => Future.successful(SyncResult(err))
@@ -336,7 +384,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
   }
 
   private def withConversation(id: ConvId)(body: ConversationData => Future[SyncResult]): Future[SyncResult] =
-    convs.convById(id) flatMap {
+    convUpdater.convById(id) flatMap {
       case Some(conv) => body(conv)
       case _ =>
         Future.successful(Retry(s"No conversation found for id: $id")) // XXX: does it make sense to retry ?

--- a/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -44,32 +44,29 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
   //All user expiry times have an extra 10 seconds to factor in the buffer we leave in the service
   scenario("Start timer for user soon to expire") {
     val conv = ConvId("conv")
-
-    currentConv ! Some(conv)
-
-    clock + 10.seconds
-
     val wirelessId = UserId("wirelessUser")
-
+    val wirelessUser = UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+    val finished = EventStream[Unit]()
     val convUsers = Set(
       UserData("user1").copy(id = UserId("user1")),
       UserData("user2").copy(id = UserId("user2")),
-      UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+      wirelessUser
     )
-
     val convSignals = convUsers.map(u => u.id -> Signal.const(u)).toMap
+
+    (users.syncUser _).expects(wirelessId).once().onCall { _: UserId =>
+      finished ! {}
+      Future.successful(Some(wirelessUser))
+    }
 
     (users.currentConvMembers _).expects().once().returning(Signal.const(convUsers.map(_.id)))
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId => convSignals(id) }
 
     val service = getService //trigger creation of service
 
-    val finished = EventStream[Unit]()
-    (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessId)) fail("Called sync for wrong user")
-      finished ! {}
-      Future.successful(SyncId())
-    }
+    currentConv ! Some(conv)
+
+    clock + 10.seconds
 
     result(finished.next)
   }
@@ -106,14 +103,11 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     awaitAllTasks
 
     Thread.sleep(500)
-    (sync.syncUsers _).expects(*).never()
+    (users.syncUser _).expects(*).never()
   }
 
   scenario("Wireless member added to conversation also triggers a timer") {
     val conv = ConvId("conv")
-
-    currentConv ! Some(conv)
-
     val wirelessUser = UserData("wireless").copy(id = UserId("wirelessUser"), expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
 
     val convUsers = Set(
@@ -123,23 +117,24 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
 
     val activeMembers = Signal(convUsers.map(_.id))
 
+    val finished = EventStream[Unit]()
+    (users.syncUser _).expects(wirelessUser.id).once().onCall { _: UserId =>
+      finished ! {}
+      Future.successful(Some(wirelessUser))
+    }
+
     (users.currentConvMembers _).expects().anyNumberOfTimes().returning(activeMembers)
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId =>
       (convUsers + wirelessUser).find(_.id == id).map(Signal.const).getOrElse(Signal.empty[UserData])
     }
+
+    currentConv ! Some(conv)
 
     getService //trigger creation of service
 
     activeMembers.mutate(_ + wirelessUser.id)
 
     awaitAllTasks
-
-    val finished = EventStream[Unit]()
-    (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessUser.id)) fail("Called sync for wrong user")
-      finished ! {}
-      Future.successful(SyncId())
-    }
 
     result(finished.next)
   }

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -101,7 +101,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       )
 
       clock.advance(5.seconds)
-      val event = MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap)
+      val event = MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      )
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, MEMBER_JOIN, sender).returning(Future.successful(false))
       (storage.getLastSentMessage _).expects(conv.id).anyNumberOfTimes().returning(Future.successful(None))
@@ -143,7 +151,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
         result(processor.processEvents(conv, isGroup = false, Seq(event))) shouldEqual Set.empty
 
       clock.advance(1.second) //conv will have time EPOCH, needs to be later than that
-      testRound(MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap))
+      testRound(MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      ))
       clock.advance(1.second)
       testRound(MemberLeaveEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, reason = None))
       clock.advance(1.second)

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -262,7 +262,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(SyncId()))
+      (users.syncUsers _).expects(Set(otherUser.id), *).returning(Future.successful(Option(SyncId())))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
@@ -340,7 +340,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (sync.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(SyncId()))
+    (users.syncUsers _).expects(*, *).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -22,10 +22,10 @@ import com.waz.model._
 import com.waz.service.assets.{AssetService, UriHelper}
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.PushService
-import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService}
+import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
-import com.waz.sync.SyncServiceHandle
+import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.testutils.TestGlobalPreferences
 
 import scala.concurrent.duration._
@@ -35,11 +35,12 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
 
   val selfUserId = UserId()
   val push =            mock[PushService]
-  val usersStorage =    mock[UsersStorage]
+  val users =           mock[UserService]
   val convsStorage =    mock[ConversationStorage]
   val content =         mock[ConversationsContentUpdater]
   val convsService =    mock[ConversationsService]
   val sync =            mock[SyncServiceHandle]
+  val requests =        mock[SyncRequestService]
   val errors =          mock[ErrorsService]
   val uriHelper =       mock[UriHelper]
   val messages =        mock[MessagesService]
@@ -57,8 +58,8 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
 
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
-    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, usersStorage, messages, messagesStorage,
-      msgContent, members, content, convsStorage, network, convsService, sync, client,
+    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
+      msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)
   }
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -18,30 +18,53 @@
 package com.waz.service.conversation
 
 import com.waz.api.IConversation.{Access, AccessRole}
-import com.waz.content.{ConversationStorage, MembersStorage, UsersStorage}
+import com.waz.content.{ButtonsStorage, ConversationStorage, MembersStorage, MessagesStorage, MsgDeletionStorage, UsersStorage}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.ConversationData.ConversationType._
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{ConversationMemberData, _}
-import com.waz.service.SearchKey
-import com.waz.service.messages.MessagesService
+import com.waz.service.assets.{AssetService, UriHelper}
+import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, SearchKey, UserService}
+import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
-import com.waz.sync.SyncServiceHandle
+import com.waz.sync.client.ConversationsClient
+import com.waz.sync.{SyncRequestService, SyncServiceHandle}
+import com.waz.testutils.TestGlobalPreferences
 
 import scala.concurrent.Future
 
 class TeamConversationSpec extends AndroidFreeSpec {
   import ConversationRole._
 
-  val selfId       = UserId()
-  val team         = Some(TeamId("team"))
-  val selfUser     = UserData(selfId, None, team, Name("self"), searchKey = SearchKey.simple("self"))
-  val userStorage  = mock[UsersStorage]
-  val members      = mock[MembersStorage]
-  val convsContent = mock[ConversationsContentUpdater]
-  val convsStorage = mock[ConversationStorage]
-  val sync         = mock[SyncServiceHandle]
-  val messages     = mock[MessagesService]
+  val selfId          = UserId()
+  val team            = Some(TeamId("team"))
+  val selfUser        = UserData(selfId, None, team, Name("self"), searchKey = SearchKey.simple("self"))
+  val users           = mock[UserService]
+  val members         = mock[MembersStorage]
+  val convsContent    = mock[ConversationsContentUpdater]
+  val convsStorage    = mock[ConversationStorage]
+  val convsService    = mock[ConversationsService]
+  val sync            = mock[SyncServiceHandle]
+  val requests        = mock[SyncRequestService]
+  val messages        = mock[MessagesService]
+  val messagesStorage = mock[MessagesStorage]
+  val deletions       = mock[MsgDeletionStorage]
+  val assetService    = mock[AssetService]
+  val network         = mock[NetworkModeService]
+  val properties      = mock[PropertiesService]
+  val buttons         = mock[ButtonsStorage]
+  val client          = mock[ConversationsClient]
+  val errors          = mock[ErrorsService]
+  val uriHelper       = mock[UriHelper]
+
+  val prefs = new TestGlobalPreferences()
+
+  def initService: ConversationsUiService = {
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
+    new ConversationsUiServiceImpl(selfId, team, assetService, users, messages, messagesStorage,
+      msgContent, members, convsContent, convsStorage, network, convsService, sync, requests, client,
+      accounts, tracking, errors, uriHelper, properties)
+  }
 
   feature("Creating team conversations") {
 
@@ -51,8 +74,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
       val existingConv = ConversationData(creator = selfId, convType = Group, team = team)
 
-      (userStorage.get _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -75,8 +98,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val name = Some(Name("Conv Name"))
       val existingConv = ConversationData(creator = selfId, name = name, convType = Group, team = team)
 
-      (userStorage.get _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -99,6 +122,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
         .once()
         .returning(Future.successful(SyncId()))
 
+      (convsService.generateTempConversationId _).expects(*).anyNumberOfTimes().returning(RConvId())
+
       val conv = result(initService.getOrCreateOneToOneConversation(otherUserId))
       conv shouldNot equal(existingConv)
     }
@@ -111,10 +136,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val otherUserId = UserId("otherUser")
       val otherUser = UserData(otherUserId, None, Some(TeamId("different_team")), Name("other"), searchKey = SearchKey.simple("other"), connection = ConnectionStatus.Ignored)
 
-      val expectedConv = ConversationData(ConvId("otherUser"), creator = selfId, convType = OneToOne, team = None)
-
-      (userStorage.get _).expects(otherUserId).twice().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).twice().returning(Future.successful(Some(otherUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (convsContent.convById _).expects(ConvId("otherUser")).returning(Future.successful(None))
       (convsContent.createConversationWithMembers _)
@@ -129,7 +152,4 @@ class TeamConversationSpec extends AndroidFreeSpec {
       conv.id shouldEqual ConvId("otherUser")
     }
   }
-
-  def initService: ConversationsUiService =
-    new ConversationsUiServiceImpl(selfId, team, null, userStorage, messages, null, null, members, convsContent, convsStorage, null, null, sync, null, null, null, null, null, null)
 }

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -527,11 +527,12 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   feature ("Conversation state events") {
 
     scenario("Group creation events") {
+      val domain = "anta"
       val generatedMessageId = MessageId()
       val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
-        rConvId, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
+        rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
-        Map(account1Id -> MemberRole, from -> AdminRole), None
+        Map(QualifiedId(account1Id, domain) -> MemberRole, QualifiedId(from, domain) -> AdminRole), None
       ))
 
       val memberJoinMsg = MessageData(

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -138,7 +138,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val syncId1 = SyncId("syncId1")
 
       (userService.syncIfNeeded _)
-        .expects(Set(user1, user2), *)
+        .expects(Set(user1, user2), *, *)
         .once()
         .returning(Future.successful(Some(syncId1)))
 


### PR DESCRIPTION
This is needed for now so that we will be able to search for federated users in the local data. Currently, every conversation with a federated user is a fake 1-to-1 group conversations and they are treated as if they were unconnected with the current user. This should change in the future so maybe this code could be deleted, but it also works in general as a way to include fake 1-to-1 conversations in our user search, so maybe it could stay.

#### APK
[Download build #3690](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3690/artifact/build/artifact/wire-dev-PR3393-3690.apk)
[Download build #3691](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3691/artifact/build/artifact/wire-dev-PR3393-3691.apk)