### PR TITLE
Federation: Add a user from a different domain to a new group conversation

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
@@ -43,7 +43,8 @@ data class ConversationsBackUpModel(
     val unreadMentionsCount: Int = 0,
     val unreadQuoteCount: Int = 0,
     val receiptMode: Int? = null,
-    val legalHoldStatus: Int = 0
+    val legalHoldStatus: Int = 0,
+    val domain: String? = null
 )
 
 class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, ConversationsEntity> {
@@ -81,7 +82,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = entity.unreadMentionsCount,
         unreadQuoteCount = entity.unreadQuoteCount,
         receiptMode = entity.receiptMode,
-        legalHoldStatus = entity.legalHoldStatus
+        legalHoldStatus = entity.legalHoldStatus,
+        domain = entity.domain
     )
 
     override fun toEntity(model: ConversationsBackUpModel) = ConversationsEntity(
@@ -118,7 +120,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = model.unreadMentionsCount,
         unreadQuoteCount = model.unreadQuoteCount,
         receiptMode = model.receiptMode,
-        legalHoldStatus = model.legalHoldStatus
+        legalHoldStatus = model.legalHoldStatus,
+        domain = model.domain
     )
 }
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -396,15 +396,15 @@ class ConversationController(implicit injector: Injector, context: Context)
     (conv, _) <- convsUi.createGroupConversation(name, userIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
-  def createQualifiedGroupConversation(name:         Name,
-                                       qualifiedIds: Set[QualifiedId],
-                                       teamOnly:     Boolean,
-                                       readReceipts: Boolean,
-                                       defaultRole:  ConversationRole = ConversationRole.MemberRole
-                                      ): Future[ConversationData] = for {
+  def createConvWithFederatedUser(name:         Name,
+                                  qId:          QualifiedId,
+                                  teamOnly:     Boolean,
+                                  readReceipts: Boolean,
+                                  defaultRole:  ConversationRole = ConversationRole.MemberRole
+                                 ): Future[ConversationData] = for {
     convsUi   <- convsUi.head
     _         <- inject[FolderStateController].update(Folder.GroupId, isExpanded = true)
-    (conv, _) <- convsUi.createQualifiedGroupConversation(name, qualifiedIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
+    (conv, _) <- convsUi.createConvWithFederatedUser(name, qId, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
   def withCurrentConvName(callback: Callback[String]): Unit = currentConvName.head.map(_.str).foreach(callback.callback)(Threading.Ui)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
@@ -33,16 +33,9 @@ class SendConnectRequestFragment extends UntabbedRequestFragment {
       for {
         Some(user)  <- userToConnect
         isFederated <- usersCtrl.isFederated(user)
-        conv        <- if (isFederated) {
-                         user.qualifiedId match {
-                           case Some(qId) =>
-                             convCtrl.createQualifiedGroupConversation(user.name, Set(qId), false, false)
-                                     .map(Option(_))
-                           case None =>
-                             Future.successful(None)
-                         }
-                       } else {
-                         usersCtrl.connectToUser(user.id)
+        conv        <- (isFederated, user.qualifiedId) match {
+                         case (true, Some(qId)) => convCtrl.createConvWithFederatedUser(user.name, qId, false, false).map(Option(_))
+                         case _                 => usersCtrl.connectToUser(user.id)
                        }
         _           <- conv.fold(
                          Future.successful(pickUserCtrl.hideUserProfile())

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
@@ -53,7 +53,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val model = backupMapper.fromEntity(entity)
@@ -128,7 +129,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val entity = backupMapper.toEntity(model)

--- a/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
+++ b/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
@@ -36,7 +36,8 @@ data class ConversationsTestData(
     val unreadMentionsCount: Int,
     val unreadQuoteCount: Int,
     val receiptMode: Int?,
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+    val domain: String?
 )
 
 object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>() {
@@ -74,6 +75,7 @@ object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>()
         unreadMentionsCount = 0,
         unreadQuoteCount = 0,
         receiptMode = null,
-        legalHoldStatus = 0
+        legalHoldStatus = 0,
+        domain = "staging"
     )
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -58,6 +58,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_133_TO_134
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -107,7 +108,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 133
+        const val VERSION = 134
 
         @JvmStatic
         val migrations = arrayOf(
@@ -116,7 +117,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_129_TO_130,
             USER_DATABASE_MIGRATION_130_TO_131,
             USER_DATABASE_MIGRATION_131_TO_132,
-            USER_DATABASE_MIGRATION_132_TO_133
+            USER_DATABASE_MIGRATION_132_TO_133,
+            USER_DATABASE_MIGRATION_133_TO_134
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
@@ -113,5 +113,8 @@ data class ConversationsEntity(
     val receiptMode: Int?,
 
     @ColumnInfo(name = "legal_hold_status")
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+
+    @ColumnInfo(name = "domain")
+    val domain: String?
 )

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
@@ -1,0 +1,16 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val USER_DATABASE_MIGRATION_133_TO_134 = object : Migration(133, 134) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        MigrationUtils.addColumn(
+            database = database,
+            tableName = "Conversations",
+            columnName = "domain",
+            columnType = MigrationUtils.ColumnType.TEXT
+        )
+    }
+}

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -56,6 +56,7 @@ public enum SyncCommand {
     PostDeleted("post-deleted"),
     PostRecalled("post-recalled"),
     PostConvJoin("post-conv-join"),
+    PostQualifiedConvJoin("post-qualified-conv-join"),
     PostConvLeave("post-conv-leave"),
     PostConnection("post-connection"),
     PostQualifiedConnection("post-qualified-connection"),

--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -1,0 +1,34 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder.opt
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import org.json.{JSONArray, JSONObject}
+
+final case class RConvQualifiedId(id: RConvId, domain: String) {
+  def hasDomain: Boolean = domain.nonEmpty
+}
+
+object RConvQualifiedId {
+  def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
+
+  private val IdFieldName = "id"
+  private val DomainFieldName  = "domain"
+
+  implicit val Encoder: JsonEncoder[RConvQualifiedId] =
+    JsonEncoder.build(qId => js => {
+      js.put(IdFieldName, qId.id.str)
+      js.put(DomainFieldName, qId.domain)
+    })
+
+  private def decode(js: JSONObject): RConvQualifiedId =
+    RConvQualifiedId(RConvId(js.getString(IdFieldName)), js.getString(DomainFieldName))
+
+  implicit val Decoder: JsonDecoder[RConvQualifiedId] =
+    JsonDecoder.lift(implicit js => decode(js))
+
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[RConvQualifiedId] =
+    opt(s, js => decode(js.getJSONObject(s.name)))
+
+  def encode(qIds: Set[RConvQualifiedId]): JSONArray =
+    JsonEncoder.array(qIds) { case (arr, qid) => arr.put(RConvQualifiedId.Encoder(qid)) }
+}

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -62,7 +62,8 @@ trait UserService {
   def qualifiedId(userId: UserId): Future[QualifiedId]
   def getOrCreateUser(id: UserId): Future[UserData]
   def updateUserData(id: UserId, updater: UserData => UserData): Future[Option[(UserData, UserData)]]
-  def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]]
+  def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan, qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]]
+  def syncUsers(userIds: Set[UserId], qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]]
   def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): Future[Option[UserData]]
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
@@ -121,10 +122,12 @@ class UserServiceImpl(selfUserId:        UserId,
     shouldSync <- shouldSyncUsers()
   } if (shouldSync) {
     verbose(l"Syncing user data to get team ids")
-    usersStorage.list()
-      .flatMap(users => sync.syncUsers(users.map(_.id).toSet))
-      .flatMap(_ => shouldSyncUsers := false)
-    }
+    for {
+      userMap <- usersStorage.contents.head
+      _       <- syncUsers(userMap.keySet)
+      _       <- shouldSyncUsers := false
+    } yield ()
+  }
 
   override val currentConvMembers = for {
     Some(convId) <- selectedConv.selectedConversationId
@@ -214,25 +217,13 @@ class UserServiceImpl(selfUserId:        UserId,
     findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
 
   override def getOrCreateUser(id: UserId): Future[UserData] =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      qualifiedId(id).flatMap { qId =>
-        usersStorage.getOrCreate(id, {
-          sync.syncQualifiedUsers(Set(qId))
-          UserData(
-            id, if (qId.hasDomain) Some(qId.domain) else None, None, Name.Empty, None, None,
-            connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None
-          )
-        })
-      }
-    } else {
-      usersStorage.getOrCreate(id, {
-        sync.syncUsers(Set(id))
-        UserData(
-          id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
-          searchKey = SearchKey.Empty, handle = None
-        )
-      })
-    }
+    usersStorage.getOrCreate(id, {
+      syncUsers(Set(id))
+      UserData(
+        id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
+        searchKey = SearchKey.Empty, handle = None
+      )
+    })
 
   override def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None) =
     usersStorage.update(id, { _.updateConnectionStatus(status, time, message)}).map {
@@ -318,15 +309,62 @@ class UserServiceImpl(selfUserId:        UserId,
   /**
    * Schedules user data sync if user with given id doesn't exist or has old timestamp.
   */
+  override def syncIfNeeded(userIds:         Set[UserId],
+                            olderThan:       FiniteDuration = SyncIfOlderThan,
+                            qIds:            Set[QualifiedId] = Set.empty): Future[Option[SyncId]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      val allIds = userIds ++ qIds.map(_.id)
+      for {
+        found                 <- usersStorage.listAll(allIds)
+        foundMap              =  found.toIdMap
+        newIds                =  allIds -- foundMap.keySet
+        offset                =  LocalInstant.Now - olderThan
+        existing              =  foundMap.filter {
+                                   case (_, u) => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset))
+                                 }
+        toSync                =  newIds ++ existing.keySet
+        qualified             =  qIds.filter(qId => newIds.contains(qId.id)) ++
+                                   existing.collect { case (_, u) if u.qualifiedId.nonEmpty => u.qualifiedId.get }.toSet
+        nonQualified          =  toSync -- qualified.map(_.id)
+        _                     =  verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size}) (qualified: ${qualified.size})")
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      usersStorage.listAll(userIds).flatMap { found =>
+        val newIds   = userIds -- found.map(_.id)
+        val offset   = LocalInstant.Now - olderThan
+        val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
+        val toSync   = newIds ++ existing.map(_.id)
+        verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
+        if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_)) else Future.successful(None)
+      }
+    }
 
-  override def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]] =
-    usersStorage.listAll(userIds).flatMap { found =>
-      val newIds = userIds -- found.map(_.id)
-      val offset = LocalInstant.Now - olderThan
-      val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
-      val toSync = newIds ++ existing.map(_.id)
-      verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
-      if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_))(Threading.Background) else Future.successful(None)
+  def syncUsers(userIds: Set[UserId], qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      for {
+        found                 <- usersStorage.listAll(userIds -- qIds.map(_.id))
+        qualified             =  qIds ++ found.collect { case u if u.qualifiedId.nonEmpty => u.qualifiedId.get }.toSet
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        nonQualified          =  userIds -- qualified.map(_.id)
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      if (userIds.nonEmpty) sync.syncUsers(userIds).map(Some(_))
+      else Future.successful(None)
     }
 
   override def updateSyncedUsers(users: Seq[UserInfo], syncTime: LocalInstant = LocalInstant.Now): Future[Set[UserData]] = {
@@ -475,12 +513,12 @@ class ExpiredUsersService(push:         PushService,
     members    <- Signal.sequence(membersIds.map(usersStorage.signal).toSeq: _*)
     wireless   =  members.filter(_.expiresAt.isDefined).toSet
   } yield wireless).foreach { wireless =>
-    push.beDrift.head.map { drift =>
+    push.beDrift.head.foreach { drift =>
       val woTimer = wireless.filter(u => (wireless.map(_.id) -- timers.keySet).contains(u.id))
       woTimer.foreach { u =>
         val delay = LocalInstant.Now.toRemote(drift).remainingUntil(u.expiresAt.get + 10.seconds)
         timers += u.id -> CancellableFuture.delay(delay).map { _ =>
-          sync.syncUsers(Set(u.id))
+          users.syncUser(u.id)
           timers -= u.id
         }
       }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -48,7 +48,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _: OtrErrorEvent           => true
       case _: ConnectRequestEvent     => true
       case _: OtrMessageEvent         => true
-      case MemberJoinEvent(_, _, _, added, _, _) if added.contains(selfUserId) => true
+      case MemberJoinEvent(_, _, _, _, _, added, _, _) if added.contains(selfUserId) => true
       case MemberLeaveEvent(_, _, _, leaving, _) if leaving.contains(selfUserId) => true
       case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
         gm.unpackContent match {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -81,6 +81,8 @@ trait ConversationsService {
   def fake1To1Conversations: Signal[Seq[ConversationData]]
   def isFake1To1(convId: ConvId): Future[Boolean]
   def onlyFake1To1ConvUsers: Signal[Seq[UserData]]
+
+  def generateTempConversationId(users: Set[UserId]): RConvId
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -341,7 +343,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       val matching = convsByRId.get(resp.id).orElse {
         convsById.get(newId).orElse {
           if (isOneToOne(resp.convType)) None
-          else convsByRId.get(ConversationsService.generateTempConversationId(resp.members.keySet + selfUserId))
+          else convsByRId.get(generateTempConversationId(resp.members.keySet))
         }
       }
 
@@ -744,16 +746,16 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       fake1To1UserIds   =  userIds -- acceptedOrBlocked
       fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
     } yield fake1To1Users
+
+  /**
+   * Generate temp ConversationID to identify conversations which don't have a RConvId yet
+   */
+  override def generateTempConversationId(users: Set[UserId]): RConvId =
+    RConvId((users + selfUserId).toSeq.map(_.toString).sorted.foldLeft("")(_ + _))
 }
 
 object ConversationsService {
   import scala.concurrent.duration._
 
   val RetryBackoff = new ExponentialBackoff(500.millis, 3.seconds)
-
-  /**
-   * Generate temp ConversationID to identify conversations which don't have a RConvId yet
-   */
-  def generateTempConversationId(users: Set[UserId]): RConvId =
-    RConvId(users.toSeq.map(_.toString).sorted.foldLeft("")(_ + _))
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -78,8 +78,6 @@ trait ConversationsService {
   def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]]
   def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]]
 
-  def fake1To1Conversations: Signal[Seq[ConversationData]]
-  def isFake1To1(convId: ConvId): Future[Boolean]
   def onlyFake1To1ConvUsers: Signal[Seq[UserData]]
 
   def generateTempConversationId(users: Set[UserId]): RConvId
@@ -188,7 +186,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         messages.addConversationStartMessage(
           created.id,
           from,
-          (data.members.keySet + selfUserId).filter(_ != from),
+          (data.memberIds + selfUserId).filter(_ != from),
           created.name,
           readReceiptsAllowed = created.readReceiptsAllowed,
           time = Some(time)
@@ -201,12 +199,12 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         case None if retryCount > 3 => successful(())
         case None =>
           ev match {
-            case MemberJoinEvent(_, time, from, ids, us, _) if selfRequested || from != selfUserId =>
+            case MemberJoinEvent(_, convDomain, time, from, _, ids, us, _) if selfRequested || from != selfUserId =>
               // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-              val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+              val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
               // this happens when we are added to group conversation
               for {
-                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time))
+                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time, domain = convDomain))
                 _          <- membersStorage.updateOrCreateAll(conv.id, Map(from -> ConversationRole.AdminRole) ++ membersWithRoles)
                 sId        <- sync.syncConversations(Set(conv.id))
                 _          <- syncReqService.await(sId)
@@ -232,13 +230,13 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
 
     case RenameConversationEvent(_, _, _, name) => content.updateConversationName(conv.id, name)
 
-    case MemberJoinEvent(_, _, _, ids, us, _) =>
+    case MemberJoinEvent(_, _, _, _, _, ids, us, _) =>
       // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-      val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
-      val selfAdded = membersWithRoles.keySet.contains(selfUserId)//we were re-added to a group and in the meantime might have missed events
+      val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+      val selfAdded = membersWithRoles.keySet.contains(selfUserId) //we were re-added to a group and in the meantime might have missed events
       for {
         convSync   <- if (selfAdded) sync.syncConversations(Set(conv.id)).map(Option(_)) else Future.successful(None)
-        syncId     <- users.syncIfNeeded(membersWithRoles.keySet)
+        syncId     <- users.syncIfNeeded(membersWithRoles.keySet, qIds = us.keySet.filter(_.hasDomain))
         _          <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
         _          <- membersStorage.updateOrCreateAll(conv.id, membersWithRoles)
         _          <- if (selfAdded) content.setConvActive(conv.id, active = true) else successful(None)
@@ -326,7 +324,11 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
   private def updateConversation(response: ConversationResponse): Future[(Seq[ConversationData], Seq[ConversationData])] =
     for {
       defRoles <- rolesService.defaultRoles.head
-      roles    <- client.loadConversationRoles(Set(response.id), defRoles)
+      // @todo: for now we have no way to check conversation roles on a federated backend
+      roles    <- if (!response.hasDomain)
+                    client.loadConversationRoles(Set(response.id), defRoles)
+                  else
+                    Future.successful(Map(response.id -> defRoles))
       results  <- updateConversations(Seq(response), roles)
     } yield results
 
@@ -336,14 +338,14 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     responses.map { resp =>
       val newId =
         if (isOneToOne(resp.convType))
-          resp.members.keys.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
+          resp.memberIds.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
         else
           ConvId(resp.id.str)
 
       val matching = convsByRId.get(resp.id).orElse {
         convsById.get(newId).orElse {
           if (isOneToOne(resp.convType)) None
-          else convsByRId.get(generateTempConversationId(resp.members.keySet))
+          else convsByRId.get(generateTempConversationId(resp.memberIds))
         }
       }
 
@@ -357,6 +359,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     returning(prev.getOrElse(ConversationData(id = newLocalId, hidden = isOneToOne(resp.convType) && resp.members.size <= 1))
       .copy(
         remoteId        = resp.id,
+        domain          = resp.domain,
         name            = resp.name.filterNot(_.isEmpty),
         creator         = resp.creator,
         convType        = prev.map(_.convType).filter(oldType => isOneToOne(oldType) && resp.convType != ConversationType.OneToOne).getOrElse(resp.convType),
@@ -389,7 +392,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     for {
       convs         <- content.convsByRemoteId(responses.map(_.id).toSet)
       toUpdate      =  responses.map(c => (c.id, c.members)).flatMap {
-                         case (remoteId, members) => convs.get(remoteId).map(c => c.id -> (members + (c.creator -> ConversationRole.AdminRole)))
+                         case (remoteId, members) =>
+                           val userIdsWithRoles = members.map { case (qId, role) => qId.id -> role }
+                           convs.get(remoteId).map(c => c.id -> (userIdsWithRoles + (c.creator -> ConversationRole.AdminRole)))
                        }.toMap
       activeUsers   <- membersStorage.getActiveUsers2(convs.map(_._2.id).toSet)
       _             <- membersStorage.setAll(toUpdate)
@@ -489,7 +494,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       (convs, created) <- updateConversationData(responses)
       _                <- updateRoles(convs.map(data => data.id -> data.remoteId).toMap, roles)
       _                <- updateMembers(responses)
-      _                <- users.syncIfNeeded(responses.flatMap(_.members.keys).toSet)
+      _                <- users.syncIfNeeded(responses.flatMap(_.memberIds).toSet, qIds = responses.flatMap(_.qualifiedMemberIds).toSet)
     } yield (convs.toSeq, created)
 
   def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit] =
@@ -722,30 +727,22 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         warn(l"joinConversation(key: $key, code: $code) error: $error")
         Future.successful(Left(GeneralError))
     }
-
-  private lazy val fake1To1s =
+  
+  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
       for {
-        convs            <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
-        convsWithMembers <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
-        fakes            = convsWithMembers.filter { case (_, ms) => ms.size == 2 && ms.contains(selfUserId) }
-      } yield fakes
+        convs             <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
+        convsWithMembers  <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
+        acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
+        userIds           =  convsWithMembers.collect {
+                               case (_, userIds) if userIds.size == 2 && userIds.contains(selfUserId) => userIds - selfUserId
+                             }.flatten.toSet
+        fake1To1UserIds   =  userIds -- acceptedOrBlocked
+        fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
+      } yield fake1To1Users
     } else {
-      Signal.const(Seq.empty[(ConversationData, Set[UserId])])
+      Signal.const(Seq.empty[UserData])
     }
-
-  override lazy val fake1To1Conversations: Signal[Seq[ConversationData]] = fake1To1s.map(_.map(_._1))
-
-  override def isFake1To1(convId: ConvId): Future[Boolean] = fake1To1s.head.map(_.exists(_._1.id == convId))
-
-  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
-    for {
-      fake1To1Convs     <- fake1To1s
-      userIds           =  fake1To1Convs.flatMap(_._2).toSet
-      acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
-      fake1To1UserIds   =  userIds -- acceptedOrBlocked
-      fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
-    } yield fake1To1Users
 
   /**
    * Generate temp ConversationID to identify conversations which don't have a RConvId yet

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -754,6 +754,6 @@ object ConversationsService {
   /**
    * Generate temp ConversationID to identify conversations which don't have a RConvId yet
    */
-  def generateTempConversationId(users: Set[UserId]) =
+  def generateTempConversationId(users: Set[UserId]): RConvId =
     RConvId(users.toSeq.map(_.toString).sorted.foldLeft("")(_ + _))
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -334,7 +334,7 @@ class ConversationsUiServiceImpl(selfUserId:        UserId,
       Some(_)  <- members.remove(conv, user)
       toDelete <- if (user != selfUserId) members.getByUsers(Set(user)).map(_.isEmpty)
                   else Future.successful(false)
-      _        <- if (toDelete) userService.deleteUsers(Set(user)) else Future.successful(())
+      _        <- if (toDelete) userService.deleteUsers(Set(user), sendLeaveMessage = false) else Future.successful(())
       _        <- messages.addMemberLeaveMessage(conv, selfUserId, Set(user), reason = None)
       syncId   <- sync.postConversationMemberLeave(conv, user)
     } yield Option(syncId))

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -106,8 +106,8 @@ class MessageEventProcessor(selfUserId:           UserId,
         RichMessage(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
       case MessageTimerEvent(_, time, from, duration) =>
         RichMessage(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
-      case MemberJoinEvent(_, time, from, userIds, users, firstEvent) =>
-        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
+      case MemberJoinEvent(_, _, time, from, _, userIds, users, firstEvent) =>
+        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys.map(_.id) ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
       case ConversationReceiptModeEvent(_, time, from, 0) =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
       case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -78,6 +78,7 @@ trait SyncServiceHandle {
   def postReceiptMode(id: ConvId, receiptMode: Int): Future[SyncId]
   def postConversationName(id: ConvId, name: Name): Future[SyncId]
   def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncId]
+  def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId]
   def postConversationMemberLeave(id: ConvId, member: UserId): Future[SyncId]
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncId]
   def postConversation(id:          ConvId,
@@ -192,7 +193,10 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postTypingState(conv: ConvId, typing: Boolean) = addRequest(PostTypingState(conv, typing))
   def postConversationName(id: ConvId, name: Name) = addRequest(PostConvName(id, name))
   def postConversationState(id: ConvId, state: ConversationState) = addRequest(PostConvState(id, state))
-  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole) = addRequest(PostConvJoin(id, members, defaultRole))
+  def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncId] =
+    addRequest(PostConvJoin(id, members, defaultRole))
+  def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId] =
+    addRequest(PostQualifiedConvJoin(id, members, defaultRole))
   def postConversationMemberLeave(id: ConvId, member: UserId) = addRequest(PostConvLeave(id, member))
   def postConversation(id: ConvId,
                        users: Set[UserId],
@@ -335,6 +339,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostMessage(convId, messageId, time)            => zms.messagesSync.postMessage(convId, messageId, time)
           case PostAssetStatus(cid, mid, exp, status)          => zms.messagesSync.postAssetStatus(cid, mid, exp, status)
           case PostConvJoin(convId, u, role)                   => zms.conversationSync.postConversationMemberJoin(convId, u, role)
+          case PostQualifiedConvJoin(convId, u, role)          => zms.conversationSync.postQualifiedConversationMemberJoin(convId, u, role)
           case PostConvLeave(convId, u)                        => zms.conversationSync.postConversationMemberLeave(convId, u)
           case PostConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>
             zms.conversationSync.postConversation(convId, u, name, team, access, accessRole, receiptMode, defRole)

--- a/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -44,32 +44,29 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
   //All user expiry times have an extra 10 seconds to factor in the buffer we leave in the service
   scenario("Start timer for user soon to expire") {
     val conv = ConvId("conv")
-
-    currentConv ! Some(conv)
-
-    clock + 10.seconds
-
     val wirelessId = UserId("wirelessUser")
-
+    val wirelessUser = UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+    val finished = EventStream[Unit]()
     val convUsers = Set(
       UserData("user1").copy(id = UserId("user1")),
       UserData("user2").copy(id = UserId("user2")),
-      UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+      wirelessUser
     )
-
     val convSignals = convUsers.map(u => u.id -> Signal.const(u)).toMap
+
+    (users.syncUser _).expects(wirelessId).once().onCall { _: UserId =>
+      finished ! {}
+      Future.successful(Some(wirelessUser))
+    }
 
     (users.currentConvMembers _).expects().once().returning(Signal.const(convUsers.map(_.id)))
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId => convSignals(id) }
 
     val service = getService //trigger creation of service
 
-    val finished = EventStream[Unit]()
-    (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessId)) fail("Called sync for wrong user")
-      finished ! {}
-      Future.successful(SyncId())
-    }
+    currentConv ! Some(conv)
+
+    clock + 10.seconds
 
     result(finished.next)
   }
@@ -106,14 +103,11 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     awaitAllTasks
 
     Thread.sleep(500)
-    (sync.syncUsers _).expects(*).never()
+    (users.syncUser _).expects(*).never()
   }
 
   scenario("Wireless member added to conversation also triggers a timer") {
     val conv = ConvId("conv")
-
-    currentConv ! Some(conv)
-
     val wirelessUser = UserData("wireless").copy(id = UserId("wirelessUser"), expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
 
     val convUsers = Set(
@@ -123,23 +117,24 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
 
     val activeMembers = Signal(convUsers.map(_.id))
 
+    val finished = EventStream[Unit]()
+    (users.syncUser _).expects(wirelessUser.id).once().onCall { _: UserId =>
+      finished ! {}
+      Future.successful(Some(wirelessUser))
+    }
+
     (users.currentConvMembers _).expects().anyNumberOfTimes().returning(activeMembers)
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId =>
       (convUsers + wirelessUser).find(_.id == id).map(Signal.const).getOrElse(Signal.empty[UserData])
     }
+
+    currentConv ! Some(conv)
 
     getService //trigger creation of service
 
     activeMembers.mutate(_ + wirelessUser.id)
 
     awaitAllTasks
-
-    val finished = EventStream[Unit]()
-    (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessUser.id)) fail("Called sync for wrong user")
-      finished ! {}
-      Future.successful(SyncId())
-    }
 
     result(finished.next)
   }

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -101,7 +101,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       )
 
       clock.advance(5.seconds)
-      val event = MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap)
+      val event = MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      )
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, MEMBER_JOIN, sender).returning(Future.successful(false))
       (storage.getLastSentMessage _).expects(conv.id).anyNumberOfTimes().returning(Future.successful(None))
@@ -143,7 +151,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
         result(processor.processEvents(conv, isGroup = false, Seq(event))) shouldEqual Set.empty
 
       clock.advance(1.second) //conv will have time EPOCH, needs to be later than that
-      testRound(MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap))
+      testRound(MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      ))
       clock.advance(1.second)
       testRound(MemberLeaveEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, reason = None))
       clock.advance(1.second)

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -262,7 +262,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(SyncId()))
+      (users.syncUsers _).expects(Set(otherUser.id), *).returning(Future.successful(Option(SyncId())))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
@@ -340,7 +340,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (sync.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(SyncId()))
+    (users.syncUsers _).expects(*, *).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -106,7 +106,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private def createConvsUi(teamId: Option[TeamId] = Some(TeamId())): ConversationsUiService = {
     new ConversationsUiServiceImpl(
-      selfUserId, teamId, assets, usersStorage, messages, msgStorage,
+      selfUserId, teamId, assets, users, messages, msgStorage,
       msgUpdater, membersStorage, content, convsStorage, network,
       service, sync, convsClient, accounts, tracking, errors, uriHelper,
       properties
@@ -887,7 +887,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         members.head.map(_.filter(m => userIds.contains(m.userId)))
       }
       (usersStorage.updateAll2 _).expects(*, *).anyNumberOfTimes().returning(Future.successful(Seq.empty))
-      (users.deleteUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(()))
+      (users.deleteUsers _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
 
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(convSignal.head)
       (content.updateConversationName _).expects(convId, *).once().onCall { (_: ConvId, name: Name) =>

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -47,7 +47,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   private lazy val messages       = mock[MessagesService]
   private lazy val msgStorage     = mock[MessagesStorage]
   private lazy val membersStorage = mock[MembersStorage]
-  private lazy val users          = mock[UserService]
+  private lazy val userService    = mock[UserService]
   private lazy val sync           = mock[SyncServiceHandle]
   private lazy val push           = mock[PushService]
   private lazy val usersStorage   = mock[UsersStorage]
@@ -75,7 +75,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   val teamsStorage                = mock[TeamsStorage]
   val errorsService               = mock[ErrorsService]
 
-  private val selfUserId = UserId("user1")
+  private val selfUserId = UserId("selfUser")
   private val convId = ConvId("conv_id1")
   private val rConvId = RConvId("r_conv_id1")
 
@@ -83,7 +83,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     None,
     selfUserId,
     push,
-    users,
+    userService,
     usersStorage,
     membersStorage,
     convsStorage,
@@ -106,7 +106,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private def createConvsUi(teamId: Option[TeamId] = Some(TeamId())): ConversationsUiService = {
     new ConversationsUiServiceImpl(
-      selfUserId, teamId, assets, users, messages, msgStorage,
+      selfUserId, teamId, assets, userService, messages, msgStorage,
       msgUpdater, membersStorage, content, convsStorage, network,
       service, sync, convsClient, accounts, tracking, errors, uriHelper,
       properties
@@ -152,7 +152,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val events = Seq(
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(selfUserId), reason = None)
       )
-      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
 
       // check if the self is still in any conversation (they are - with self)
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
@@ -173,7 +173,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         Future.successful(())
       )
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
 
       // EXPECT
       (content.updateConversationState _).expects(where { (id, state) =>
@@ -203,7 +203,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), removerId, Seq(selfUserId), reason = None)
       )
 
-      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)))
       )
@@ -218,7 +218,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         Future.successful(())
       )
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(convData)))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(removerId))
       )
@@ -249,7 +249,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(otherUserId), reason = None)
       )
 
-      (users.syncIfNeeded _).expects(Set(otherUserId), *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(Set(otherUserId), *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(otherUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(otherUserId, convId, ConversationRole.MemberRole)))
       )
@@ -441,7 +441,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       }
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().returning(Future.successful(Seq.empty))
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(Future.successful(Some(conversationData)))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(Map.empty))
 
 
       //EXPECT
@@ -465,6 +465,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set.empty[UserId], *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, Set.empty[UserId], *, *, *).once().returning(Future.successful(()))
       (sync.postConversation _).expects(*, Set.empty[UserId], Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (userService.findUsers _).expects(Seq.empty).once().returning(Future.successful(Seq.empty))
 
       val convsUi = createConvsUi(Some(teamId))
       val (data, sId) = result(convsUi.createGroupConversation(name = convName, defaultRole = ConversationRole.MemberRole))
@@ -485,6 +486,8 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, users.map(_.id), *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, users.map(_.id), *, *, *).once().returning(Future.successful(()))
       (sync.postConversation _).expects(*, users.map(_.id), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
+      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().returning(Future.successful(false))
 
       val convsUi = createConvsUi(Some(teamId))
       val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
@@ -495,7 +498,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   feature("Create a group conversation with qualified users") {
 
-    scenario("Create a group conversation with the creator and two users") {
+    scenario("Create a group conversation with the creator and two users, both contacted") {
       val teamId = TeamId()
       val convName = Name("conv")
       val conv = ConversationData(team = Some(teamId), name = Some(convName))
@@ -505,13 +508,52 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val user1 = UserData("user1").copy(domain = Some(domain))
       val user2 = UserData("user2").copy(domain = Some(domain))
       val users = Set(self, user1, user2)
+      val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+      val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set.empty[UserId], *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, Set.empty[UserId], *, *, *).once().returning(Future.successful(()))
-      (sync.postQualifiedConversation _).expects(*, users.map(_.qualifiedId.get), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
+      (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
+      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+      (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
+      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+      (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
+
+      //(userService.findUsers _).expects(Seq(user1.id, user2.id)).once().returning(Future.successful(Seq(Some(user1), Some(user2))))
+      //(sync.syncQualifiedUsers _).expects(Set(user1.qualifiedId.get, user2.qualifiedId.get)).once().returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createQualifiedGroupConversation(name = convName, members = users.map(_.qualifiedId.get), defaultRole = ConversationRole.MemberRole))
+      val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
+      data shouldEqual conv
+      sId shouldEqual syncId
+    }
+
+    scenario("Create a group conversation with the creator and two users, one uncontacted") {
+      val teamId = TeamId()
+      val convName = Name("conv")
+      val conv = ConversationData(team = Some(teamId), name = Some(convName))
+      val syncId = SyncId()
+      val domain = "chala.wire.link"
+      val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
+      val user1 = UserData("user1").copy(domain = Some(domain))
+      val user2 = UserData("user2").copy(domain = Some(domain))
+      val users = Set(self, user1, user2)
+      val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+
+      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
+      (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
+      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+      (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
+      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+      (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
+      (userService.findUsers _).expects(Seq(user2.id)).once().returning(Future.successful(Seq(Some(user2))))
+      (sync.syncQualifiedUsers _).expects(Set(user2.qualifiedId.get)).once().returning(Future.successful(SyncId()))
+
+      val convsUi = createConvsUi(Some(teamId))
+      val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
       data shouldEqual conv
       sId shouldEqual syncId
     }
@@ -612,7 +654,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         Future.successful(userIds.map(uId => ConversationMemberData(uId, convId, AdminRole)).toIndexedSeq)
       }
 
-      (users.syncIfNeeded _).expects(*, *).returning(Future.successful(Option(SyncId())))
+      (userService.syncIfNeeded _).expects(*, *).returning(Future.successful(Option(SyncId())))
 
       (messages.addDeviceStartMessages _).expects(*, *).onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
         convs.headOption.flatMap(_.name) should be (Some(Name("conv")))
@@ -662,7 +704,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val userNames = Map(selfUserId -> self.name, user2.id -> user2.name)
 
       (convsStorage.optSignal _).expects(convId).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
 
       result(service.conversationName(convId).head) shouldEqual user2.name
     }
@@ -686,7 +728,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         ))
       )
       (membersStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream())
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
 
       result(service.conversationName(convId).head) shouldEqual user2.name
     }
@@ -711,7 +753,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         ))
       )
       (membersStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream())
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
 
       result(service.conversationName(convId).head) shouldEqual name
     }
@@ -737,7 +779,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         ))
       )
       (membersStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream())
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
 
       val generatedName = Name(List(user2, user3).map(_.name).mkString(", "))
       result(service.conversationName(convId).head) shouldEqual generatedName
@@ -764,7 +806,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         ))
       )
       (membersStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream())
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
 
       result(service.conversationName(convId).head) shouldEqual user3.name
     }
@@ -795,8 +837,8 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head.map(_.map(_.userId)) }
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
       (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.from(membersOnChanged))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
-      (users.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
       (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>
         members.head.map { ms =>
@@ -871,7 +913,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getActiveUsers _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head.map(_.map(_.userId)) }
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
       (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.from(membersOnChanged))
-      (users.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
+      (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
       (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>
         members.head.map { ms =>
@@ -887,7 +929,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         members.head.map(_.filter(m => userIds.contains(m.userId)))
       }
       (usersStorage.updateAll2 _).expects(*, *).anyNumberOfTimes().returning(Future.successful(Seq.empty))
-      (users.deleteUsers _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
+      (userService.deleteUsers _).expects(*, *).anyNumberOfTimes().returning(Future.successful(()))
 
       (convsStorage.get _).expects(convId).anyNumberOfTimes().returning(convSignal.head)
       (content.updateConversationName _).expects(convId, *).once().onCall { (_: ConvId, name: Name) =>
@@ -907,7 +949,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       val teamsService: TeamsService =
         new TeamsServiceImpl(
-          selfUserId, Some(teamId), teamsStorage, users, usersStorage, convsStorage, membersStorage,
+          selfUserId, Some(teamId), teamsStorage, userService, usersStorage, convsStorage, membersStorage,
           content, service, sync, requests, userPrefs, errorsService, rolesService
         )
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -108,7 +108,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     new ConversationsUiServiceImpl(
       selfUserId, teamId, assets, userService, messages, msgStorage,
       msgUpdater, membersStorage, content, convsStorage, network,
-      service, sync, convsClient, accounts, tracking, errors, uriHelper,
+      service, sync, requests, convsClient, accounts, tracking, errors, uriHelper,
       properties
     )
   }
@@ -544,12 +544,20 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
       (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
+      (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
+        Future.successful {
+          userIds.map { id =>
+            if (id == selfUserId) Some(self)
+            else if (id == user1.id) Some(user1)
+            else if (id == user2.id) Some(user2)
+            else None
+          }
+        }
+      }
       (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-      (userService.findUsers _).expects(Seq(user2.id)).once().returning(Future.successful(Seq(Some(user2))))
       (sync.syncQualifiedUsers _).expects(Set(user2.qualifiedId.get)).once().returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -506,8 +506,8 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(domain = Some(domain))
       val users = Set(self, user1, user2)
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, users.map(_.id), *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, users.map(_.id), *, *, *).once().returning(Future.successful(()))
+      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set.empty[UserId], *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, Set.empty[UserId], *, *, *).once().returning(Future.successful(()))
       (sync.postQualifiedConversation _).expects(*, users.map(_.qualifiedId.get), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
 
       val convsUi = createConvsUi(Some(teamId))

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -25,7 +25,7 @@ import com.waz.service.push.PushService
 import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
-import com.waz.sync.SyncServiceHandle
+import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.testutils.TestGlobalPreferences
 
 import scala.concurrent.duration._
@@ -40,6 +40,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   val content =         mock[ConversationsContentUpdater]
   val convsService =    mock[ConversationsService]
   val sync =            mock[SyncServiceHandle]
+  val requests =        mock[SyncRequestService]
   val errors =          mock[ErrorsService]
   val uriHelper =       mock[UriHelper]
   val messages =        mock[MessagesService]
@@ -58,7 +59,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
     new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
-      msgContent, members, content, convsStorage, network, convsService, sync, client,
+      msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)
   }
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -22,7 +22,7 @@ import com.waz.model._
 import com.waz.service.assets.{AssetService, UriHelper}
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.PushService
-import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService}
+import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.SyncServiceHandle
@@ -35,7 +35,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
 
   val selfUserId = UserId()
   val push =            mock[PushService]
-  val usersStorage =    mock[UsersStorage]
+  val users =           mock[UserService]
   val convsStorage =    mock[ConversationStorage]
   val content =         mock[ConversationsContentUpdater]
   val convsService =    mock[ConversationsService]
@@ -57,7 +57,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
 
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
-    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, usersStorage, messages, messagesStorage,
+    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, client,
       accounts, tracking, errors, uriHelper, properties)
   }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -52,7 +52,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val existingConv = ConversationData(creator = selfId, convType = Group, team = team)
 
       (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -76,7 +76,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val existingConv = ConversationData(creator = selfId, name = name, convType = Group, team = team)
 
       (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -111,10 +111,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val otherUserId = UserId("otherUser")
       val otherUser = UserData(otherUserId, None, Some(TeamId("different_team")), Name("other"), searchKey = SearchKey.simple("other"), connection = ConnectionStatus.Ignored)
 
-      val expectedConv = ConversationData(ConvId("otherUser"), creator = selfId, convType = OneToOne, team = None)
-
       (users.findUser _).expects(otherUserId).twice().returning(Future.successful(Some(otherUser)))
-      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.isFederated(_: UserId)).expects(otherUserId).once().returning(Future.successful(false))
 
       (convsContent.convById _).expects(ConvId("otherUser")).returning(Future.successful(None))
       (convsContent.createConversationWithMembers _)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -23,7 +23,7 @@ import com.waz.model.ConversationData.ConversationType
 import com.waz.model.ConversationData.ConversationType._
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{ConversationMemberData, _}
-import com.waz.service.SearchKey
+import com.waz.service.{SearchKey, UserService}
 import com.waz.service.messages.MessagesService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
@@ -36,7 +36,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
   val selfId       = UserId()
   val team         = Some(TeamId("team"))
   val selfUser     = UserData(selfId, None, team, Name("self"), searchKey = SearchKey.simple("self"))
-  val userStorage  = mock[UsersStorage]
+  val users        = mock[UserService]
   val members      = mock[MembersStorage]
   val convsContent = mock[ConversationsContentUpdater]
   val convsStorage = mock[ConversationStorage]
@@ -51,8 +51,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
       val existingConv = ConversationData(creator = selfId, convType = Group, team = team)
 
-      (userStorage.get _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
+      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -75,8 +75,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
       val name = Some(Name("Conv Name"))
       val existingConv = ConversationData(creator = selfId, name = name, convType = Group, team = team)
 
-      (userStorage.get _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).once().returning(Future.successful(Some(otherUser)))
+      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
 
       (members.getByUsers _).expects(Set(otherUserId)).once().returning(Future.successful(IndexedSeq(
         ConversationMemberData(otherUserId, existingConv.id, AdminRole)
@@ -113,8 +113,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
       val expectedConv = ConversationData(ConvId("otherUser"), creator = selfId, convType = OneToOne, team = None)
 
-      (userStorage.get _).expects(otherUserId).twice().returning(Future.successful(Some(otherUser)))
-      (userStorage.get _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
+      (users.findUser _).expects(otherUserId).twice().returning(Future.successful(Some(otherUser)))
+      (users.findUser _).expects(selfId).once().returning(Future.successful(Some(selfUser)))
 
       (convsContent.convById _).expects(ConvId("otherUser")).returning(Future.successful(None))
       (convsContent.createConversationWithMembers _)
@@ -131,5 +131,5 @@ class TeamConversationSpec extends AndroidFreeSpec {
   }
 
   def initService: ConversationsUiService =
-    new ConversationsUiServiceImpl(selfId, team, null, userStorage, messages, null, null, members, convsContent, convsStorage, null, null, sync, null, null, null, null, null, null)
+    new ConversationsUiServiceImpl(selfId, team, null, users , messages, null, null, members, convsContent, convsStorage, null, null, sync, null, null, null, null, null, null)
 }

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -527,11 +527,12 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   feature ("Conversation state events") {
 
     scenario("Group creation events") {
+      val domain = "anta"
       val generatedMessageId = MessageId()
       val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
-        rConvId, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
+        rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
-        Map(account1Id -> MemberRole, from -> AdminRole), None
+        Map(QualifiedId(account1Id, domain) -> MemberRole, QualifiedId(from, domain) -> AdminRole), None
       ))
 
       val memberJoinMsg = MessageData(

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -138,7 +138,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val syncId1 = SyncId("syncId1")
 
       (userService.syncIfNeeded _)
-        .expects(Set(user1, user2), *)
+        .expects(Set(user1, user2), *, *)
         .once()
         .returning(Future.successful(Some(syncId1)))
 


### PR DESCRIPTION
Three ways are possible:
1. Go to the user search, find a federated user, click on them, send a connection request. Instead of waiting for acceptance, the conversation will be created immediately. This is done through the path which you can follow starting from `ConversationController.createConvWithFederatedUser`. In the future the logic will be merged with `ConnectionService.connectWithUser`, but the backend does not support this yet.
2. Go to the user search, click on "Create group conversation", find the federated user (and maybe some others), create the conversation. The group conversation will be created as usual, but the list of members will be split in two and the federated users will be added to the conversation as in the point 3.
3. Go to an existing conversation, go to the participants view, click on "Add participants", and find and add a federated user. Both this path and the one from the point 2 go through `ConversationsUiService.addConversationMembers` which was pretty much rewritten.

#### APK
[Download build #3693](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3693/artifact/build/artifact/wire-dev-PR3395-3693.apk)
[Download build #3698](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3698/artifact/build/artifact/wire-dev-PR3395-3698.apk)
[Download build #3699](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3699/artifact/build/artifact/wire-dev-PR3395-3699.apk)
[Download build #3700](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3700/artifact/build/artifact/wire-dev-PR3395-3700.apk)
[Download build #3703](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3703/artifact/build/artifact/wire-dev-PR3395-3703.apk)