### PR TITLE
wire-signals bump to 1.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -189,8 +189,8 @@ object LegacyDependencies {
     const val SCALA_MAJOR_VERSION = "2.11"
     const val SCALA_VERSION = SCALA_MAJOR_VERSION.plus(".12")
     // signals
-    const val WIRE_SIGNALS = "0.5.2"
-    const val WIRE_SIGNALS_EXTENSIONS = "0.5.2"
+    const val WIRE_SIGNALS = "1.0.0"
+    const val WIRE_SIGNALS_EXTENSIONS = "1.0.0"
 
     //build
     val scalaLibrary = "org.scala-lang:scala-library:$SCALA_VERSION"


### PR DESCRIPTION
No code changes. The version 0.5.2 becomes 1.0.0. Officially we will make it public on Tuesday.
You can read more at https://wire.engineering/wire-signals :)
#### APK
[Download build #3702](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3702/artifact/build/artifact/wire-dev-PR3398-3702.apk)