### PR TITLE
[Feature] Add compile time flag to force constant bitrate calls

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ android {
         buildConfigField 'String',  'COUNTLY_SERVER_URL',            "\"$buildtimeConfiguration.configuration.countly_server_url\""
         buildConfigField 'String',  'COUNTLY_APP_KEY',               "\"$buildtimeConfiguration.configuration.countly_app_key\""
         buildConfigField 'boolean', 'KEEP_WEBSOCKET_ON',             "$buildtimeConfiguration.configuration.keep_websocket_on"
+        buildConfigField 'boolean', 'FORCE_CONSTANT_BITRATE_CALLS',  "$buildtimeConfiguration.configuration.force_constant_bitrate_calls"
 
         //Feature Flags
         buildConfigField 'boolean', 'LARGE_VIDEO_CONFERENCE_CALLS', "$largeVideoConferenceCalls"

--- a/app/src/main/res/layout/preferences_options_layout.xml
+++ b/app/src/main/res/layout/preferences_options_layout.xml
@@ -33,6 +33,7 @@
             android:orientation="vertical">
 
             <com.waz.zclient.ui.text.TypefaceTextView
+                android:id="@+id/pref_options_calls_category_title"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/preference_button_height"
                 android:gravity="center_vertical"

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -196,7 +196,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
   val flowManager = callingZms.map(_.flowmanager)
 
   def continueDegradedCall(): Unit = callingServiceAndCurrentConvId.head.map {
-    case (cs, _) => cs.continueDegradedCall()
+    case (cs, _) => cs.continueDegradedCall(BuildConfig.FORCE_CONSTANT_BITRATE_CALLS)
   }
 
   val captureDevices = flowManager.flatMap(fm => Signal.from(fm.getVideoCaptureDevices))

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallStartController.scala
@@ -118,7 +118,7 @@ class CallStartController(implicit inj: Injector, cxt: WireContext, ec: EventCon
         hasPerms          <- inject[PermissionsService].requestAllPermissions(if (curWithVideo) ListSet(CAMERA, RECORD_AUDIO) else ListSet(RECORD_AUDIO)) //check or request permissions
         _                 <-
           if (hasPerms)
-            newCallZms.calling.startCall(newCallConv.id, curWithVideo, forceOption)
+            newCallZms.calling.startCall(newCallConv.id, curWithVideo, forceOption, BuildConfig.FORCE_CONSTANT_BITRATE_CALLS)
           else showPermissionsErrorDialog(
             R.string.calling__cannot_start__title,
             if (curWithVideo) R.string.calling__cannot_start__no_camera_permission__message else R.string.calling__cannot_start__no_permission__message

--- a/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/ControlsView.scala
@@ -157,7 +157,7 @@ class ControlsView(val context: Context, val attrs: AttributeSet, val defStyleAt
     val callingZms    = await(controller.callingZms.head)
 
     if (audioGranted)
-      callingZms.calling.startCall(callingConvId, await(controller.isVideoCall.head))
+      callingZms.calling.startCall(callingConvId, await(controller.isVideoCall.head), BuildConfig.FORCE_CONSTANT_BITRATE_CALLS)
     else
       showPermissionsErrorDialog(R.string.calling__cannot_start__title,
         R.string.calling__cannot_start__no_permission__message,

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/OptionsView.scala
@@ -25,7 +25,7 @@ import android.provider.Settings
 import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
+import android.widget.{LinearLayout, TextView}
 import com.waz.content.UserPreferences._
 import com.waz.media.manager.context.IntensityLevel
 import com.waz.service.{UiLifeCycle, ZMessaging}
@@ -73,6 +73,7 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
 
   private lazy val passwordController = inject[PasswordController]
 
+  private val callsCategoryTitle      = findById[TextView](R.id.pref_options_calls_category_title)
   private val vbrSwitch               = findById[SwitchPreference](R.id.preferences_vbr)
   private val vibrationSwitch         = findById[SwitchPreference](R.id.preferences_vibration)
   private val darkThemeSwitch         = findById[SwitchPreference](R.id.preferences_dark_theme)
@@ -127,6 +128,12 @@ class OptionsViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
   if (BuildConfig.FORCE_HIDE_SCREEN_CONTENT) {
     hideScreenContentSwitch.setVisible(false)
     hideScreenContentSwitch.pref.foreach(_ := true)
+  }
+
+  if (BuildConfig.FORCE_CONSTANT_BITRATE_CALLS) {
+    callsCategoryTitle.setVisible(false)
+    vbrSwitch.setVisible(false)
+    vbrSwitch.pref.foreach(_ := false)
   }
 
   private def openNotificationSettings(channelId: String): Unit = {

--- a/default.json
+++ b/default.json
@@ -45,5 +45,6 @@
   "file_restriction_list":  "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
   "countly_server_url": "https://countly.wire.com",
   "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
-  "keep_websocket_on": false
+  "keep_websocket_on": false,
+  "force_constant_bitrate_calls": false
 }

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -100,9 +100,12 @@ trait CallingService {
     * @param forceOption used to ignore the current calls video send state (useful for when a user joins a video call using the audio button, for example)
     *                    //TODO we could turn isVideo into an Option[Boolean], where defined = force, and undefined means use current call state
     */
-  def startCall(convId: ConvId, isVideo: Boolean = false, forceOption: Boolean = false): Future[Unit]
+  def startCall(convId: ConvId,
+                isVideo: Boolean = false,
+                forceOption: Boolean = false,
+                forceConstantBitRate: Boolean = false): Future[Unit]
 
-  def continueDegradedCall(): Unit
+  def continueDegradedCall(forceConstantBitRate: Boolean = false): Unit
 
   def setCallMuted(muted: Boolean): Unit
 
@@ -421,7 +424,10 @@ class CallingServiceImpl(val accountId:       UserId,
       }
     }
 
-  override def startCall(convId: ConvId, isVideo: Boolean = false, forceOption: Boolean = false) =
+  override def startCall(convId: ConvId,
+                         isVideo: Boolean = false,
+                         forceOption: Boolean = false,
+                         forceConstantBitRate: Boolean = false) =
     Serialized.future(self.accountId.str) {
       verbose(l"startCall $convId, isVideo: $isVideo, forceOption: $forceOption")
       (for {
@@ -430,6 +436,7 @@ class CallingServiceImpl(val accountId:       UserId,
         profile                  <- callProfile.head
         isGroup                  <- convsService.isGroupConversation(convId)
         vbr                      <- userPrefs.preference(UserPreferences.VBREnabled).apply()
+        useConstantBitRate       = forceConstantBitRate || !vbr
         convSize                 <- convsService.activeMembersData(conv.id).map(_.size).head
         callType =
           if (isVideo) Avs.WCallType.Video
@@ -445,7 +452,7 @@ class CallingServiceImpl(val accountId:       UserId,
                 call.state match {
                   case OtherCalling =>
                     verbose(l"Answering call")
-                    avs.answerCall(w, conv.remoteId, callType, !vbr)
+                    avs.answerCall(w, conv.remoteId, callType, useConstantBitRate)
                     updateActiveCall(_.updateCallState(SelfJoining))("startCall/OtherCalling")
                     setCallMuted(muted = isGroup)
                     if (forceOption)
@@ -461,7 +468,7 @@ class CallingServiceImpl(val accountId:       UserId,
                 case Some(call) if !Set[CallState](Ended, Terminating)(call.state) =>
                   Future.successful {
                     verbose(l"Joining an ongoing background call")
-                    avs.answerCall(w, conv.remoteId, callType, !vbr)
+                    avs.answerCall(w, conv.remoteId, callType, useConstantBitRate)
                     val active = call.updateCallState(SelfJoining).copy(joinedTime = None, estabTime = None) // reset previous call state if exists
                     callProfile.mutate(_.copy(calls = profile.calls + (convId -> active)))
                     setCallMuted(muted = true)
@@ -470,7 +477,7 @@ class CallingServiceImpl(val accountId:       UserId,
                   }
                 case _ =>
                   verbose(l"No active call, starting new call")
-                  avs.startCall(w, conv.remoteId, callType, convType, !vbr).map {
+                  avs.startCall(w, conv.remoteId, callType, convType, useConstantBitRate).map {
                     case 0 =>
                       //Assume that when a video call starts, sendingVideo will be true. From here on, we can then listen to state handler
                       val newCall = CallInfo(
@@ -493,12 +500,12 @@ class CallingServiceImpl(val accountId:       UserId,
       }
     }
 
-  override def continueDegradedCall() =
+  override def continueDegradedCall(forceConstantBitRate: Boolean = false) =
     currentCall.head.map {
       case Some(info) =>
         (info.outstandingMsg, info.state) match {
           case (Some(message), _)   => convs.storage.setUnknownVerification(info.convId).map(_ => sendOutstandingCallMessage(info.convId, message))
-          case (None, OtherCalling) => convs.storage.setUnknownVerification(info.convId).map(_ => startCall(info.convId))
+          case (None, OtherCalling) => convs.storage.setUnknownVerification(info.convId).map(_ => startCall(info.convId, forceConstantBitRate = forceConstantBitRate))
           case _                    => error(l"Tried resending message on invalid info: ${info.convId} in state ${info.state}")
         }
       case None => warn(l"Tried to continue degraded call without a current active call")


### PR DESCRIPTION
## What's new in this PR?

**Jira:** https://wearezeta.atlassian.net/browse/SQSERVICES-607

A white label customer requires that all calls use constant bitrate encoding. This PR adds a compile time flag to force CBR calls. When it is enabled, then the switch to use variable bitrate encoding (in the options screen) is not visible, and all calls will be started or joined with CBR enabled.

### Testing

Tested manually.

## Notes

Configurations that use the flags can be seen here: https://github.com/wireapp/android-customization/pull/8

#### APK
[Download build #3706](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3706/artifact/build/artifact/wire-dev-PR3401-3706.apk)