### PR TITLE
Federation: Fixing the user syncing of qualified and non-qualified users

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
@@ -43,7 +43,8 @@ data class ConversationsBackUpModel(
     val unreadMentionsCount: Int = 0,
     val unreadQuoteCount: Int = 0,
     val receiptMode: Int? = null,
-    val legalHoldStatus: Int = 0
+    val legalHoldStatus: Int = 0,
+    val domain: String? = null
 )
 
 class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, ConversationsEntity> {
@@ -81,7 +82,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = entity.unreadMentionsCount,
         unreadQuoteCount = entity.unreadQuoteCount,
         receiptMode = entity.receiptMode,
-        legalHoldStatus = entity.legalHoldStatus
+        legalHoldStatus = entity.legalHoldStatus,
+        domain = entity.domain
     )
 
     override fun toEntity(model: ConversationsBackUpModel) = ConversationsEntity(
@@ -118,7 +120,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = model.unreadMentionsCount,
         unreadQuoteCount = model.unreadQuoteCount,
         receiptMode = model.receiptMode,
-        legalHoldStatus = model.legalHoldStatus
+        legalHoldStatus = model.legalHoldStatus,
+        domain = model.domain
     )
 }
 

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
@@ -53,7 +53,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val model = backupMapper.fromEntity(entity)
@@ -128,7 +129,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val entity = backupMapper.toEntity(model)

--- a/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
+++ b/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
@@ -36,7 +36,8 @@ data class ConversationsTestData(
     val unreadMentionsCount: Int,
     val unreadQuoteCount: Int,
     val receiptMode: Int?,
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+    val domain: String?
 )
 
 object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>() {
@@ -74,6 +75,7 @@ object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>()
         unreadMentionsCount = 0,
         unreadQuoteCount = 0,
         receiptMode = null,
-        legalHoldStatus = 0
+        legalHoldStatus = 0,
+        domain = "staging"
     )
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -58,6 +58,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_133_TO_134
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -107,7 +108,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 133
+        const val VERSION = 134
 
         @JvmStatic
         val migrations = arrayOf(
@@ -116,7 +117,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_129_TO_130,
             USER_DATABASE_MIGRATION_130_TO_131,
             USER_DATABASE_MIGRATION_131_TO_132,
-            USER_DATABASE_MIGRATION_132_TO_133
+            USER_DATABASE_MIGRATION_132_TO_133,
+            USER_DATABASE_MIGRATION_133_TO_134
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
@@ -113,5 +113,8 @@ data class ConversationsEntity(
     val receiptMode: Int?,
 
     @ColumnInfo(name = "legal_hold_status")
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+
+    @ColumnInfo(name = "domain")
+    val domain: String?
 )

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
@@ -1,0 +1,16 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val USER_DATABASE_MIGRATION_133_TO_134 = object : Migration(133, 134) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        MigrationUtils.addColumn(
+            database = database,
+            tableName = "Conversations",
+            columnName = "domain",
+            columnType = MigrationUtils.ColumnType.TEXT
+        )
+    }
+}

--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -1,0 +1,34 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder.opt
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import org.json.{JSONArray, JSONObject}
+
+final case class RConvQualifiedId(id: RConvId, domain: String) {
+  def hasDomain: Boolean = domain.nonEmpty
+}
+
+object RConvQualifiedId {
+  def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
+
+  private val IdFieldName = "id"
+  private val DomainFieldName  = "domain"
+
+  implicit val Encoder: JsonEncoder[RConvQualifiedId] =
+    JsonEncoder.build(qId => js => {
+      js.put(IdFieldName, qId.id.str)
+      js.put(DomainFieldName, qId.domain)
+    })
+
+  private def decode(js: JSONObject): RConvQualifiedId =
+    RConvQualifiedId(RConvId(js.getString(IdFieldName)), js.getString(DomainFieldName))
+
+  implicit val Decoder: JsonDecoder[RConvQualifiedId] =
+    JsonDecoder.lift(implicit js => decode(js))
+
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[RConvQualifiedId] =
+    opt(s, js => decode(js.getJSONObject(s.name)))
+
+  def encode(qIds: Set[RConvQualifiedId]): JSONArray =
+    JsonEncoder.array(qIds) { case (arr, qid) => arr.put(RConvQualifiedId.Encoder(qid)) }
+}

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -63,6 +63,7 @@ trait UserService {
   def getOrCreateUser(id: UserId): Future[UserData]
   def updateUserData(id: UserId, updater: UserData => UserData): Future[Option[(UserData, UserData)]]
   def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]]
+  def syncUsers(userIds: Set[UserId]): Future[Option[SyncId]]
   def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): Future[Option[UserData]]
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
@@ -121,10 +122,12 @@ class UserServiceImpl(selfUserId:        UserId,
     shouldSync <- shouldSyncUsers()
   } if (shouldSync) {
     verbose(l"Syncing user data to get team ids")
-    usersStorage.list()
-      .flatMap(users => sync.syncUsers(users.map(_.id).toSet))
-      .flatMap(_ => shouldSyncUsers := false)
-    }
+    for {
+      userMap <- usersStorage.contents.head
+      _       <- syncUsers(userMap.keySet)
+      _       <- shouldSyncUsers := false
+    } yield ()
+  }
 
   override val currentConvMembers = for {
     Some(convId) <- selectedConv.selectedConversationId
@@ -214,25 +217,13 @@ class UserServiceImpl(selfUserId:        UserId,
     findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
 
   override def getOrCreateUser(id: UserId): Future[UserData] =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      qualifiedId(id).flatMap { qId =>
-        usersStorage.getOrCreate(id, {
-          sync.syncQualifiedUsers(Set(qId))
-          UserData(
-            id, if (qId.hasDomain) Some(qId.domain) else None, None, Name.Empty, None, None,
-            connection = ConnectionStatus.Unconnected, searchKey = SearchKey.Empty, handle = None
-          )
-        })
-      }
-    } else {
-      usersStorage.getOrCreate(id, {
-        sync.syncUsers(Set(id))
-        UserData(
-          id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
-          searchKey = SearchKey.Empty, handle = None
-        )
-      })
-    }
+    usersStorage.getOrCreate(id, {
+      syncUsers(Set(id))
+      UserData(
+        id, None, None, Name.Empty, None, None, connection = ConnectionStatus.Unconnected,
+        searchKey = SearchKey.Empty, handle = None
+      )
+    })
 
   override def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None) =
     usersStorage.update(id, { _.updateConnectionStatus(status, time, message)}).map {
@@ -318,16 +309,60 @@ class UserServiceImpl(selfUserId:        UserId,
   /**
    * Schedules user data sync if user with given id doesn't exist or has old timestamp.
   */
-
   override def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan): Future[Option[SyncId]] =
-    usersStorage.listAll(userIds).flatMap { found =>
-      val newIds = userIds -- found.map(_.id)
-      val offset = LocalInstant.Now - olderThan
-      val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
-      val toSync = newIds ++ existing.map(_.id)
-      verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
-      if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_))(Threading.Background) else Future.successful(None)
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      for {
+        found                 <- usersStorage.listAll(userIds)
+        foundMap              =  found.toIdMap
+        newIds                =  userIds -- foundMap.keySet
+        offset                =  LocalInstant.Now - olderThan
+        existing              =  foundMap.filter {
+                                   case (_, u) => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset))
+                                 }
+        toSync                =  newIds ++ existing.keySet
+        qualified             =  existing.collect { case (id, u) if u.qualifiedId.nonEmpty => id -> u.qualifiedId }
+        nonQualified          =  toSync -- qualified.keySet
+        _                     =  verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size}) (qualified: ${qualified.size})")
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified.flatMap(_._2).toSet).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      usersStorage.listAll(userIds).flatMap { found =>
+        val newIds   = userIds -- found.map(_.id)
+        val offset   = LocalInstant.Now - olderThan
+        val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
+        val toSync   = newIds ++ existing.map(_.id)
+        verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
+        if (toSync.nonEmpty) sync.syncUsers(toSync).map(Some(_)) else Future.successful(None)
+      }
     }
+
+  def syncUsers(userIds: Set[UserId]): Future[Option[SyncId]] = {
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      for {
+        found                 <- usersStorage.listAll(userIds)
+        qualified             =  found.collect { case u if u.qualifiedId.nonEmpty => u.id -> u.qualifiedId }.toMap
+        syncId1               <- if (qualified.nonEmpty)
+                                   sync.syncQualifiedUsers(qualified.flatMap(_._2).toSet).map(Option(_))
+                                 else
+                                   Future.successful(None)
+        nonQualified          =  userIds -- qualified.keySet
+        syncId2               <- if (nonQualified.nonEmpty)
+                                   sync.syncUsers(nonQualified).map(Option(_))
+                                 else
+                                   Future.successful(None)
+      } yield syncId2.orElse(syncId1)
+    } else {
+      if (userIds.nonEmpty) sync.syncUsers(userIds).map(Some(_))
+      else Future.successful(None)
+    }
+  }
 
   override def updateSyncedUsers(users: Seq[UserInfo], syncTime: LocalInstant = LocalInstant.Now): Future[Set[UserData]] = {
     verbose(l"update synced ${users.size} users")
@@ -480,7 +515,7 @@ class ExpiredUsersService(push:         PushService,
       woTimer.foreach { u =>
         val delay = LocalInstant.Now.toRemote(drift).remainingUntil(u.expiresAt.get + 10.seconds)
         timers += u.id -> CancellableFuture.delay(delay).map { _ =>
-          sync.syncUsers(Set(u.id))
+          users.syncUser(u.id)
           timers -= u.id
         }
       }

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -510,7 +510,7 @@ class ExpiredUsersService(push:         PushService,
     members    <- Signal.sequence(membersIds.map(usersStorage.signal).toSeq: _*)
     wireless   =  members.filter(_.expiresAt.isDefined).toSet
   } yield wireless).foreach { wireless =>
-    push.beDrift.head.map { drift =>
+    push.beDrift.head.foreach { drift =>
       val woTimer = wireless.filter(u => (wireless.map(_.id) -- timers.keySet).contains(u.id))
       woTimer.foreach { u =>
         val delay = LocalInstant.Now.toRemote(drift).remainingUntil(u.expiresAt.get + 10.seconds)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -48,7 +48,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _: OtrErrorEvent           => true
       case _: ConnectRequestEvent     => true
       case _: OtrMessageEvent         => true
-      case MemberJoinEvent(_, _, _, added, _, _) if added.contains(selfUserId) => true
+      case MemberJoinEvent(_, _, _, _, _, added, _, _) if added.contains(selfUserId) => true
       case MemberLeaveEvent(_, _, _, leaving, _) if leaving.contains(selfUserId) => true
       case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
         gm.unpackContent match {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -78,8 +78,6 @@ trait ConversationsService {
   def getGuestroomInfo(key: String, code: String): Future[Either[GuestRoomStateError, GuestRoomInfo]]
   def joinConversation(key: String, code: String): Future[Either[GuestRoomStateError, Option[ConvId]]]
 
-  def fake1To1Conversations: Signal[Seq[ConversationData]]
-  def isFake1To1(convId: ConvId): Future[Boolean]
   def onlyFake1To1ConvUsers: Signal[Seq[UserData]]
 
   def generateTempConversationId(users: Set[UserId]): RConvId
@@ -188,7 +186,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         messages.addConversationStartMessage(
           created.id,
           from,
-          (data.members.keySet + selfUserId).filter(_ != from),
+          (data.memberIds + selfUserId).filter(_ != from),
           created.name,
           readReceiptsAllowed = created.readReceiptsAllowed,
           time = Some(time)
@@ -201,12 +199,12 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         case None if retryCount > 3 => successful(())
         case None =>
           ev match {
-            case MemberJoinEvent(_, time, from, ids, us, _) if selfRequested || from != selfUserId =>
+            case MemberJoinEvent(_, convDomain, time, from, _, ids, us, _) if selfRequested || from != selfUserId =>
               // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-              val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+              val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
               // this happens when we are added to group conversation
               for {
-                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time))
+                conv       <- convsStorage.insert(ConversationData(ConvId(), rConvId, None, from, ConversationType.Group, lastEventTime = time, domain = convDomain))
                 _          <- membersStorage.updateOrCreateAll(conv.id, Map(from -> ConversationRole.AdminRole) ++ membersWithRoles)
                 sId        <- sync.syncConversations(Set(conv.id))
                 _          <- syncReqService.await(sId)
@@ -232,13 +230,13 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
 
     case RenameConversationEvent(_, _, _, name) => content.updateConversationName(conv.id, name)
 
-    case MemberJoinEvent(_, _, _, ids, us, _) =>
+    case MemberJoinEvent(_, _, _, _, _, ids, us, _) =>
       // usually ids should be exactly the same set as members, but if not, we add surplus ids as members with the Member role
-      val membersWithRoles = us ++ ids.map(_ -> ConversationRole.MemberRole).toMap
-      val selfAdded = membersWithRoles.keySet.contains(selfUserId)//we were re-added to a group and in the meantime might have missed events
+      val membersWithRoles = us.map { case (qId, role) => qId.id -> role } ++ ids.map(_ -> ConversationRole.MemberRole).toMap
+      val selfAdded = membersWithRoles.keySet.contains(selfUserId) //we were re-added to a group and in the meantime might have missed events
       for {
         convSync   <- if (selfAdded) sync.syncConversations(Set(conv.id)).map(Option(_)) else Future.successful(None)
-        syncId     <- users.syncIfNeeded(membersWithRoles.keySet)
+        syncId     <- users.syncIfNeeded(membersWithRoles.keySet, qIds = us.keySet.filter(_.hasDomain))
         _          <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
         _          <- membersStorage.updateOrCreateAll(conv.id, membersWithRoles)
         _          <- if (selfAdded) content.setConvActive(conv.id, active = true) else successful(None)
@@ -326,7 +324,11 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
   private def updateConversation(response: ConversationResponse): Future[(Seq[ConversationData], Seq[ConversationData])] =
     for {
       defRoles <- rolesService.defaultRoles.head
-      roles    <- client.loadConversationRoles(Set(response.id), defRoles)
+      // @todo: for now we have no way to check conversation roles on a federated backend
+      roles    <- if (!response.hasDomain)
+                    client.loadConversationRoles(Set(response.id), defRoles)
+                  else
+                    Future.successful(Map(response.id -> defRoles))
       results  <- updateConversations(Seq(response), roles)
     } yield results
 
@@ -336,14 +338,14 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     responses.map { resp =>
       val newId =
         if (isOneToOne(resp.convType))
-          resp.members.keys.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
+          resp.memberIds.find(_ != selfUserId).fold(ConvId())(m => ConvId(m.str))
         else
           ConvId(resp.id.str)
 
       val matching = convsByRId.get(resp.id).orElse {
         convsById.get(newId).orElse {
           if (isOneToOne(resp.convType)) None
-          else convsByRId.get(generateTempConversationId(resp.members.keySet))
+          else convsByRId.get(generateTempConversationId(resp.memberIds))
         }
       }
 
@@ -357,6 +359,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     returning(prev.getOrElse(ConversationData(id = newLocalId, hidden = isOneToOne(resp.convType) && resp.members.size <= 1))
       .copy(
         remoteId        = resp.id,
+        domain          = resp.domain,
         name            = resp.name.filterNot(_.isEmpty),
         creator         = resp.creator,
         convType        = prev.map(_.convType).filter(oldType => isOneToOne(oldType) && resp.convType != ConversationType.OneToOne).getOrElse(resp.convType),
@@ -389,7 +392,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     for {
       convs         <- content.convsByRemoteId(responses.map(_.id).toSet)
       toUpdate      =  responses.map(c => (c.id, c.members)).flatMap {
-                         case (remoteId, members) => convs.get(remoteId).map(c => c.id -> (members + (c.creator -> ConversationRole.AdminRole)))
+                         case (remoteId, members) =>
+                           val userIdsWithRoles = members.map { case (qId, role) => qId.id -> role }
+                           convs.get(remoteId).map(c => c.id -> (userIdsWithRoles + (c.creator -> ConversationRole.AdminRole)))
                        }.toMap
       activeUsers   <- membersStorage.getActiveUsers2(convs.map(_._2.id).toSet)
       _             <- membersStorage.setAll(toUpdate)
@@ -489,7 +494,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       (convs, created) <- updateConversationData(responses)
       _                <- updateRoles(convs.map(data => data.id -> data.remoteId).toMap, roles)
       _                <- updateMembers(responses)
-      _                <- users.syncIfNeeded(responses.flatMap(_.members.keys).toSet)
+      _                <- users.syncIfNeeded(responses.flatMap(_.memberIds).toSet, qIds = responses.flatMap(_.qualifiedMemberIds).toSet)
     } yield (convs.toSeq, created)
 
   def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit] =
@@ -722,30 +727,22 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         warn(l"joinConversation(key: $key, code: $code) error: $error")
         Future.successful(Left(GeneralError))
     }
-
-  private lazy val fake1To1s =
+  
+  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
       for {
-        convs            <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
-        convsWithMembers <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
-        fakes            = convsWithMembers.filter { case (_, ms) => ms.size == 2 && ms.contains(selfUserId) }
-      } yield fakes
+        convs             <- convsStorage.contents.map(_.values.filter(c => c.convType == ConversationType.Group && c.name.isEmpty))
+        convsWithMembers  <- Signal.sequence(convs.map(c => membersStorage.activeMembers(c.id).map((c, _))).toSeq: _*)
+        acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
+        userIds           =  convsWithMembers.collect {
+                               case (_, userIds) if userIds.size == 2 && userIds.contains(selfUserId) => userIds - selfUserId
+                             }.flatten.toSet
+        fake1To1UserIds   =  userIds -- acceptedOrBlocked
+        fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
+      } yield fake1To1Users
     } else {
-      Signal.const(Seq.empty[(ConversationData, Set[UserId])])
+      Signal.const(Seq.empty[UserData])
     }
-
-  override lazy val fake1To1Conversations: Signal[Seq[ConversationData]] = fake1To1s.map(_.map(_._1))
-
-  override def isFake1To1(convId: ConvId): Future[Boolean] = fake1To1s.head.map(_.exists(_._1.id == convId))
-
-  override lazy val onlyFake1To1ConvUsers: Signal[Seq[UserData]] =
-    for {
-      fake1To1Convs     <- fake1To1s
-      userIds           =  fake1To1Convs.flatMap(_._2).toSet
-      acceptedOrBlocked <- users.acceptedOrBlockedUsers.map(_.keySet)
-      fake1To1UserIds   =  userIds -- acceptedOrBlocked
-      fake1To1Users     <- usersStorage.listSignal(fake1To1UserIds)
-    } yield fake1To1Users
 
   /**
    * Generate temp ConversationID to identify conversations which don't have a RConvId yet

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -106,8 +106,8 @@ class MessageEventProcessor(selfUserId:           UserId,
         RichMessage(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
       case MessageTimerEvent(_, time, from, duration) =>
         RichMessage(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
-      case MemberJoinEvent(_, time, from, userIds, users, firstEvent) =>
-        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
+      case MemberJoinEvent(_, _, time, from, _, userIds, users, firstEvent) =>
+        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys.map(_.id) ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
       case ConversationReceiptModeEvent(_, time, from, 0) =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
       case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>

--- a/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -44,32 +44,29 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
   //All user expiry times have an extra 10 seconds to factor in the buffer we leave in the service
   scenario("Start timer for user soon to expire") {
     val conv = ConvId("conv")
-
-    currentConv ! Some(conv)
-
-    clock + 10.seconds
-
     val wirelessId = UserId("wirelessUser")
-
+    val wirelessUser = UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+    val finished = EventStream[Unit]()
     val convUsers = Set(
       UserData("user1").copy(id = UserId("user1")),
       UserData("user2").copy(id = UserId("user2")),
-      UserData("wireless").copy(id = wirelessId, expiresAt = Some(RemoteInstant(clock.instant()) - 10.seconds + 200.millis))
+      wirelessUser
     )
-
     val convSignals = convUsers.map(u => u.id -> Signal.const(u)).toMap
+
+    (users.syncUser _).expects(wirelessId).once().onCall { _: UserId =>
+      finished ! {}
+      Future.successful(Some(wirelessUser))
+    }
 
     (users.currentConvMembers _).expects().once().returning(Signal.const(convUsers.map(_.id)))
     (usersStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: UserId => convSignals(id) }
 
     val service = getService //trigger creation of service
 
-    val finished = EventStream[Unit]()
-    (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessId)) fail("Called sync for wrong user")
-      finished ! {}
-      Future.successful(SyncId())
-    }
+    currentConv ! Some(conv)
+
+    clock + 10.seconds
 
     result(finished.next)
   }
@@ -106,7 +103,7 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     awaitAllTasks
 
     Thread.sleep(500)
-    (sync.syncUsers _).expects(*).never()
+    (users.syncUser _).expects(*).never()
   }
 
   scenario("Wireless member added to conversation also triggers a timer") {
@@ -121,10 +118,9 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     val activeMembers = Signal(convUsers.map(_.id))
 
     val finished = EventStream[Unit]()
-    (users.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
-      if (!us.contains(wirelessUser.id)) fail("Called sync for wrong user")
+    (users.syncUser _).expects(wirelessUser.id).once().onCall { _: UserId =>
       finished ! {}
-      Future.successful(Option(SyncId()))
+      Future.successful(Some(wirelessUser))
     }
 
     (users.currentConvMembers _).expects().anyNumberOfTimes().returning(activeMembers)

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -101,7 +101,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       )
 
       clock.advance(5.seconds)
-      val event = MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap)
+      val event = MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      )
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, MEMBER_JOIN, sender).returning(Future.successful(false))
       (storage.getLastSentMessage _).expects(conv.id).anyNumberOfTimes().returning(Future.successful(None))
@@ -143,7 +151,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
         result(processor.processEvents(conv, isGroup = false, Seq(event))) shouldEqual Set.empty
 
       clock.advance(1.second) //conv will have time EPOCH, needs to be later than that
-      testRound(MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap))
+      testRound(MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      ))
       clock.advance(1.second)
       testRound(MemberLeaveEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, reason = None))
       clock.advance(1.second)

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -262,7 +262,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(SyncId()))
+      (users.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(Option(SyncId())))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
@@ -340,7 +340,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (sync.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(SyncId()))
+    (users.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -262,7 +262,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (users.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(Option(SyncId())))
+      (users.syncUsers _).expects(Set(otherUser.id), *).returning(Future.successful(Option(SyncId())))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
@@ -340,7 +340,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (users.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
+    (users.syncUsers _).expects(*, *).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -129,7 +129,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   (errors.onErrorDismissed _).expects(*).anyNumberOfTimes().returning(CancellableFuture.successful(()))
 
   (sync.syncTeam _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
-  (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
+  (userService.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Option(SyncId())))
   (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
 
   feature("Archive conversation") {
@@ -519,9 +519,18 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-
-      //(userService.findUsers _).expects(Seq(user1.id, user2.id)).once().returning(Future.successful(Seq(Some(user1), Some(user2))))
-      //(sync.syncQualifiedUsers _).expects(Set(user1.qualifiedId.get, user2.qualifiedId.get)).once().returning(Future.successful(SyncId()))
+      (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
+        .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
+        .once()
+        .returning(Future.successful(Set(member1, member2)))
+      (messages.addMemberJoinMessage _)
+        .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
+        .once()
+        .returning(Future.successful(None))
+      (sync.postQualifiedConversationMemberJoin _)
+        .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
+        .once()
+        .returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
       val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
@@ -540,6 +549,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(domain = Some(domain))
       val users = Set(self, user1, user2)
       val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+      val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
       (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
@@ -558,7 +568,18 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-      (sync.syncQualifiedUsers _).expects(Set(user2.qualifiedId.get)).once().returning(Future.successful(SyncId()))
+      (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
+        .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
+        .once()
+        .returning(Future.successful(Set(member1, member2)))
+      (messages.addMemberJoinMessage _)
+        .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
+        .once()
+        .returning(Future.successful(None))
+      (sync.postQualifiedConversationMemberJoin _)
+        .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
+        .once()
+        .returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
       val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -514,7 +514,16 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
       (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
+      (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
+        Future.successful {
+          userIds.map { id =>
+            if (id == selfUserId) Some(self)
+            else if (id == user1.id) Some(user1)
+            else if (id == user2.id) Some(user2)
+            else None
+          }
+        }
+      }
       (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -527,11 +527,12 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   feature ("Conversation state events") {
 
     scenario("Group creation events") {
+      val domain = "anta"
       val generatedMessageId = MessageId()
       val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
-        rConvId, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
+        rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
-        Map(account1Id -> MemberRole, from -> AdminRole), None
+        Map(QualifiedId(account1Id, domain) -> MemberRole, QualifiedId(from, domain) -> AdminRole), None
       ))
 
       val memberJoinMsg = MessageData(

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -138,7 +138,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val syncId1 = SyncId("syncId1")
 
       (userService.syncIfNeeded _)
-        .expects(Set(user1, user2), *)
+        .expects(Set(user1, user2), *, *)
         .once()
         .returning(Future.successful(Some(syncId1)))
 


### PR DESCRIPTION
With the federation feature, if we now want to sync `UserData` for some users, we should send a request to one of two new endpoints:
1. /list-users, POST, for syncing many users at once
2. /users/{domain}/{userId}, GET, for syncing one user
If the domain of the synced user is the same as the domain of the current user, the old endpoints will still work, but we can also use new ones. However, for now, there is a risk that the new code will be still working with a backend that doesn't have the new endpoints, and then we should have the federation feature flag switched off and we should use only the old endpoints.

All this introduces quite a bit of complication that this PR addresses. In the UI code I keep using only UserId, as before, because user ids are guaranteed to be unique anyway. The domain is needed only when the app contacts the backend. So, in two methods in `UserService`: `syncIfNeeded` and `syncUsers`, and in `ConversationUiService.addConversationMembers` I made changes to handle all three cases: when we know the domain of the user to sync, when we don't, and when the feature flag is off. In the future only the first of those cases should remain and we will be able to simplify the code.

Please note that the code in this PR was changed in https://github.com/wireapp/wire-android/pull/3406
The main idea stayed the same, but, for example, after the last PR we sync with the new endpoints also if we have the domain and it's the same as the domain of the current user - in this PR we did it only if domains were different.  



#### APK
[Download build #3708](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3708/artifact/build/artifact/wire-dev-PR3402-3708.apk)