### PR TITLE
refactor: A possible performance boost to the data retrieval from the storage

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/creation/CreateConversationController.scala
@@ -88,7 +88,7 @@ class CreateConversationController(implicit inj: Injector)
       shouldFullConv <- inject[GlobalPreferences].preference(ShouldCreateFullConversation).apply()
       userIds        <-
         if (userIds.isEmpty && integrationIds.isEmpty && shouldFullConv)
-          z.usersStorage.list().map(
+          z.usersStorage.values.map(
             _.filter(u => (u.isConnected || (u.teamId.isDefined && u.teamId == z.teamId)) && u.id != z.selfUserId)
               .map(_.id).toSet
               .take(ConversationController.MaxParticipants - 1)

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListController.scala
@@ -325,7 +325,7 @@ object ConversationListController {
     }
 
     val members = new AggregatingSignal[Map[ConvId, Seq[UserId]], Map[ConvId, Seq[UserId]]](
-      () => zms.membersStorage.list().map(entries),
+      () => zms.membersStorage.values.map(entries),
       updatedEntries,
       _ ++ _
     )

--- a/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
+++ b/app/src/main/scala/com/waz/zclient/tracking/GlobalTrackingController.scala
@@ -139,7 +139,7 @@ class GlobalTrackingController(implicit inj: Injector, cxt: WireContext)
       teamId          =  z.teamId.getOrElse(TeamId("n/a"))
       teamSize        <- z.teamId.fold(Future.successful(0))(tId => z.usersStorage.getByTeam(Set(tId)).map(_.size))
       userAccountType <- getSelfAccountType
-      contacts        <- z.usersStorage.list().map(_.count(!_.isSelf))
+      contacts        <- z.usersStorage.values.map(_.count(!_.isSelf))
     } yield {
       val predefinedFields = new util.HashMap[String, String]()
       val customFields = new util.HashMap[String, String]()

--- a/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration._
 
 trait CacheStorage extends CachedStorage[CacheKey, CacheEntryData]
 
-class CacheStorageImpl(storage: Database, context: Context)
+final class CacheStorageImpl(storage: Database, context: Context)
   extends CachedStorageImpl[CacheKey, CacheEntryData](new EntryCache(context), storage)(CacheEntryDao, LogTag("CacheStorage"))
     with CacheStorage
     with DerivedLogTag {

--- a/zmessaging/src/main/scala/com/waz/content/AccountsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/AccountsStorage.scala
@@ -24,4 +24,6 @@ import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
 trait AccountStorage extends CachedStorage[UserId, AccountData]
-class AccountStorageImpl(context: Context, storage: Database) extends CachedStorageImpl[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)), storage)(AccountDataDao) with AccountStorage
+final class AccountStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)), storage)(AccountDataDao)
+    with AccountStorage

--- a/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/AssetsStorage.scala
@@ -35,9 +35,10 @@ trait AssetsStorage extends CachedStorage[AssetId, AssetData] {
   def mergeOrCreateAsset(newData: Option[AssetData]): Future[Option[AssetData]]
 }
 
-class AssetsStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[AssetId, AssetData](new TrimmingLruCache(context, Fixed(100)), storage)(AssetDataDao, LogTag("AssetsStorage"))
-    with AssetsStorage {
+final class AssetsStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[AssetId, AssetData](
+    new TrimmingLruCache(context, Fixed(100)), storage)(AssetDataDao, LogTag("AssetsStorage")
+  ) with AssetsStorage {
 
   import com.waz.threading.Threading.Implicits.Background
 

--- a/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ButtonsStorage.scala
@@ -15,9 +15,10 @@ trait ButtonsStorage extends CachedStorage[(MessageId, ButtonId), ButtonData] {
   def deleteAllForMessage(messageId: MessageId): Future[Unit]
 }
 
-class ButtonsStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[ButtonDataDaoId, ButtonData](new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(ButtonDataDao, LogTag("ButtonsStorage"))
-    with ButtonsStorage with DerivedLogTag {
+final class ButtonsStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[ButtonDataDaoId, ButtonData](
+    new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(ButtonDataDao, LogTag("ButtonsStorage")
+  ) with ButtonsStorage with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
   override def findByMessage(messageId: MessageId): Future[Seq[ButtonData]] =

--- a/zmessaging/src/main/scala/com/waz/content/ConversationRolesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConversationRolesStorage.scala
@@ -31,7 +31,7 @@ trait ConversationRolesStorage extends CachedStorage[(String, String, ConvId), C
   def getRolesByConvId(convId: ConvId): Future[Set[ConversationRole]]
 }
 
-class ConversationRolesStorageImpl(context: Context, storage: ZmsDatabase)
+final class ConversationRolesStorageImpl(context: Context, storage: ZmsDatabase)
   extends CachedStorageImpl[(String, String, ConvId), ConversationRoleAction](
     new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationRoleActionDao, LogTag("ConversationRolesStorage_Cached")
   ) with ConversationRolesStorage {

--- a/zmessaging/src/main/scala/com/waz/content/EditHistoryStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/EditHistoryStorage.scala
@@ -36,9 +36,10 @@ trait EditHistoryStorage extends CachedStorage[MessageId, EditHistory]
   * Edit history is only needed for short time to resolve race conditions when some message is edited on two devices at the same time.
   * We don't want to store it permanently, so will drop items older than 1 week.
   */
-class EditHistoryStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[MessageId, EditHistory](new TrimmingLruCache(context, Fixed(512)), storage)(EditHistoryDao, LogTag("EditHistoryStorage_Cached"))
-    with EditHistoryStorage{
+final class EditHistoryStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[MessageId, EditHistory](
+    new TrimmingLruCache(context, Fixed(512)), storage)(EditHistoryDao, LogTag("EditHistoryStorage_Cached")
+  ) with EditHistoryStorage {
 
   import EditHistoryStorage._
   import Threading.Implicits.Background

--- a/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/FoldersStorage.scala
@@ -32,10 +32,12 @@ trait FoldersStorage extends CachedStorage[FolderId, FolderData] {
   def getByType(folderType: Int): Future[Seq[FolderData]]
 }
 
-class FoldersStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[FolderId, FolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(FolderDataDao, LogTag("FolderStorage_Cached"))
-    with FoldersStorage {
-  override def getByType(folderType: Int): Future[Seq[FolderData]] = find(_.folderType == folderType, FolderDataDao.findForType(folderType)(_), identity)
+final class FoldersStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[FolderId, FolderData](
+    new TrimmingLruCache(context, Fixed(1024)), storage)(FolderDataDao, LogTag("FolderStorage_Cached")
+  ) with FoldersStorage {
+  override def getByType(folderType: Int): Future[Seq[FolderData]] =
+    find(_.folderType == folderType, FolderDataDao.findForType(folderType)(_), identity)
 }
 
 trait ConversationFoldersStorage extends CachedStorage[(ConvId, FolderId), ConversationFolderData] {
@@ -45,9 +47,10 @@ trait ConversationFoldersStorage extends CachedStorage[(ConvId, FolderId), Conve
   def put(convId: ConvId, folderId: FolderId): Future[Unit]
 }
 
-class ConversationFoldersStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[(ConvId, FolderId), ConversationFolderData](new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationFolderDataDao, LogTag("ConversationFoldersStorage"))
-    with ConversationFoldersStorage {
+final class ConversationFoldersStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[(ConvId, FolderId), ConversationFolderData](
+    new TrimmingLruCache(context, Fixed(1024)), storage)(ConversationFolderDataDao, LogTag("ConversationFoldersStorage")
+  ) with ConversationFoldersStorage {
   import com.waz.threading.Threading.Implicits.Background
 
   override def findForConv(convId: ConvId): Future[Set[FolderId]] =

--- a/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessageIndexStorage.scala
@@ -33,9 +33,14 @@ import com.waz.utils._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-class MessageIndexStorage(context: Context, storage: ZmsDatabase, messagesStorage: MessagesStorage, loader: MessageAndLikesStorage, conversationStorage: ConversationStorage)
-  extends CachedStorageImpl[MessageId, MessageContentIndexEntry](new TrimmingLruCache(context, Fixed(MessageContentIndex.MaxSearchResults)), storage)(MessageContentIndexDao, LogTag("MessageIndexStorage_Cached"))
-    with DerivedLogTag {
+final class MessageIndexStorage(context:             Context,
+                                storage:             ZmsDatabase,
+                                messagesStorage:     MessagesStorage,
+                                loader:              MessageAndLikesStorage,
+                                conversationStorage: ConversationStorage)
+  extends CachedStorageImpl[MessageId, MessageContentIndexEntry](
+    new TrimmingLruCache(context, Fixed(MessageContentIndex.MaxSearchResults)), storage)(MessageContentIndexDao, LogTag("MessageIndexStorage_Cached")
+  ) with DerivedLogTag {
 
   import MessageIndexStorage._
   import MessageContentIndex.TextMessageTypes

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -82,14 +82,14 @@ trait MessagesStorage extends CachedStorage[MessageId, MessageData] {
   def countUnread(conv: ConvId, lastReadTime: RemoteInstant): Future[UnreadCount]
 }
 
-class MessagesStorageImpl(context:     Context,
-                          storage:     ZmsDatabase,
-                          selfUserId:  UserId,
-                          convs:       ConversationStorage,
-                          users:       UsersStorage,
-                          msgAndLikes: => MessageAndLikesStorage,
-                          timeouts:    Timeouts,
-                          tracking:    TrackingService)
+final class MessagesStorageImpl(context:     Context,
+                                storage:     ZmsDatabase,
+                                selfUserId:  UserId,
+                                convs:       ConversationStorage,
+                                users:       UsersStorage,
+                                msgAndLikes: => MessageAndLikesStorage,
+                                timeouts:    Timeouts,
+                                tracking:    TrackingService)
   extends CachedStorageImpl[MessageId, MessageData](
     new TrimmingLruCache[MessageId, Option[MessageData]](context, Fixed(MessagesStorage.cacheSize)),
     storage

--- a/zmessaging/src/main/scala/com/waz/content/MsgDeletionStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MsgDeletionStorage.scala
@@ -37,9 +37,10 @@ trait MsgDeletionStorage extends CachedStorage[MessageId, MsgDeletion]
   * We need that to discard new versions of previously deleted messages.
   * We don't want to store it permanently, so will drop items older than 2 weeks.
   */
-class MsgDeletionStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[MessageId, MsgDeletion](new TrimmingLruCache(context, Fixed(512)), storage)(MsgDeletionDao, LogTag("MsgDeletionStorage_Cached"))
-    with MsgDeletionStorage {
+final class MsgDeletionStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[MessageId, MsgDeletion](
+    new TrimmingLruCache(context, Fixed(512)), storage)(MsgDeletionDao, LogTag("MsgDeletionStorage_Cached")
+  ) with MsgDeletionStorage {
 
   import MsgDeletionStorage._
   import Threading.Implicits.Background

--- a/zmessaging/src/main/scala/com/waz/content/NotificationStorageImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/content/NotificationStorageImpl.scala
@@ -26,6 +26,7 @@ import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
 trait NotificationStorage extends CachedStorage[NotId, NotificationData]
 
-class NotificationStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[NotId, NotificationData](new TrimmingLruCache(context, Fixed(128)), storage)(NotificationDataDao, LogTag("NotificationStorage"))
-    with NotificationStorage
+final class NotificationStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[NotId, NotificationData](
+    new TrimmingLruCache(context, Fixed(128)), storage)(NotificationDataDao, LogTag("NotificationStorage")
+  ) with NotificationStorage

--- a/zmessaging/src/main/scala/com/waz/content/OtrClientsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/OtrClientsStorage.scala
@@ -40,10 +40,10 @@ trait OtrClientsStorage extends CachedStorage[UserId, UserClients] {
   def updateClients(ucs: Map[UserId, Seq[Client]], replace: Boolean = false): Future[Set[UserClients]]
 }
 
-class OtrClientsStorageImpl(userId: UserId, context: Context, storage: Database)
-  extends CachedStorageImpl[UserId, UserClients](new TrimmingLruCache(context, Fixed(2000)), storage)(UserClientsDao, LogTag("OtrClientsStorage"))
-    with OtrClientsStorage
-    with DerivedLogTag {
+final class OtrClientsStorageImpl(userId: UserId, context: Context, storage: Database)
+  extends CachedStorageImpl[UserId, UserClients](
+    new TrimmingLruCache(context, Fixed(2000)), storage)(UserClientsDao, LogTag("OtrClientsStorage")
+  ) with OtrClientsStorage with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Background
 

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -229,7 +229,7 @@ class GlobalPreferences(context: Context, val prefs: SharedPreferences) extends 
     }).asInstanceOf[A]
   }
 
-  override protected def buildPreference[A: PrefCodec](key: PrefKey[A]) =
+  override protected def buildPreference[A: PrefCodec](key: PrefKey[A]): Preference[A] =
     new Preference[A](this, key) {
 
       //No need to update the signal. The SharedPreferences Listener will do this for us.
@@ -277,8 +277,9 @@ class GlobalPreferences(context: Context, val prefs: SharedPreferences) extends 
   * Per-user preference storage in user db.
   */
 class UserPreferences(context: Context, storage: ZmsDatabase)
-  extends CachedStorageImpl[String, KeyValueData](new TrimmingLruCache(context, Fixed(128)), storage)(KeyValueDataDao, LogTag("KeyValueStorage_Cached"))
-    with Preferences {
+  extends CachedStorageImpl[String, KeyValueData](
+    new TrimmingLruCache(context, Fixed(128)), storage)(KeyValueDataDao, LogTag("KeyValueStorage_Cached")
+  ) with Preferences {
 
   override protected implicit val dispatcher: DispatchQueue = Threading.Background
   override protected implicit val logTag: LogTag = LogTag[UserPreferences]

--- a/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ReactionsStorage.scala
@@ -38,10 +38,10 @@ trait ReactionsStorage extends CachedStorage[(MessageId, UserId), Liking] {
   def likes(msg:MessageId): Signal[Likes]
 }
 
-class ReactionsStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[(MessageId, UserId), Liking](new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(LikingDao, LogTag("LikingStorage"))
-    with ReactionsStorage
-    with DerivedLogTag {
+final class ReactionsStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[(MessageId, UserId), Liking](
+    new TrimmingLruCache(context, Fixed(MessagesStorage.cacheSize)), storage)(LikingDao, LogTag("LikingStorage")
+  ) with ReactionsStorage with DerivedLogTag {
 
   import ReactionsStorageImpl._
 

--- a/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ReadReceiptsStorage.scala
@@ -33,9 +33,13 @@ trait ReadReceiptsStorage extends CachedStorage[ReadReceipt.Id, ReadReceipt] {
   def removeAllForMessages(message: Set[MessageId]): Future[Unit]
 }
 
-class ReadReceiptsStorageImpl(context: Context, storage: Database, msgStorage: MessagesStorage, msgService: MessagesService)
-  extends CachedStorageImpl[ReadReceipt.Id, ReadReceipt](new TrimmingLruCache(context, Fixed(ReadReceiptsStorage.cacheSize)), storage)(ReadReceiptDao, LogTag("ReadReceiptsStorage"))
-  with ReadReceiptsStorage {
+final class ReadReceiptsStorageImpl(context: Context,
+                                    storage: Database,
+                                    msgStorage: MessagesStorage,
+                                    msgService: MessagesService)
+  extends CachedStorageImpl[ReadReceipt.Id, ReadReceipt](
+    new TrimmingLruCache(context, Fixed(ReadReceiptsStorage.cacheSize)), storage)(ReadReceiptDao, LogTag("ReadReceiptsStorage")
+  ) with ReadReceiptsStorage {
   import com.waz.threading.Threading.Implicits.Background
 
   msgStorage.onDeleted.foreach { ids => removeAllForMessages(ids.toSet) }

--- a/zmessaging/src/main/scala/com/waz/content/TeamsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/TeamsStorage.scala
@@ -26,6 +26,7 @@ import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
 trait TeamsStorage extends CachedStorage[TeamId, TeamData]
 
-class TeamsStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[TeamId, TeamData](new TrimmingLruCache(context, Fixed(1024)), storage)(TeamDataDao, LogTag("TeamStorage_Cached"))
-    with TeamsStorage
+final class TeamsStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[TeamId, TeamData](
+    new TrimmingLruCache(context, Fixed(1024)), storage)(TeamDataDao, LogTag("TeamStorage_Cached")
+  ) with TeamsStorage

--- a/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -40,9 +40,10 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
   def findUsersForService(id: IntegrationId): Future[Set[UserData]]
 }
 
-class UsersStorageImpl(context: Context, storage: ZmsDatabase)
-  extends CachedStorageImpl[UserId, UserData](new TrimmingLruCache(context, Fixed(2000)), storage)(UserDataDao, LogTag("UsersStorage_Cached"))
-    with UsersStorage {
+final class UsersStorageImpl(context: Context, storage: ZmsDatabase)
+  extends CachedStorageImpl[UserId, UserData](
+    new UnlimitedLruCache(), storage)(UserDataDao, LogTag("UsersStorage_Cached")
+  ) with UsersStorage {
   import com.waz.threading.Threading.Implicits.Background
 
   override def listAll(ids: Traversable[UserId]): Future[Vector[UserData]] = getAll(ids).map(_.collect { case Some(x) => x }(breakOut))

--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -164,7 +164,7 @@ class AccountsServiceImpl(global: GlobalModule, kotlinLogoutEnabled: Boolean = f
 
   private def calculateAccountManagers() =
     (for {
-      ids      <- storage.list().map(_.map(_.id).toSet)
+      ids      <- storage.keySet
       managers <- Future.sequence(ids.map(createAccountManager(_, None, None)))
       _        <- Serialized.future(AccountManagersKey)(Future(accountManagers ! managers.flatten))
      } yield ()).recoverWith {

--- a/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
@@ -114,7 +114,7 @@ class GlobalReportingService(context: Context, cache: CacheService, metadata: Me
   val ZUsersReporter = Reporter("ZUsers", { writer =>
     val current = ZMessaging.currentAccounts.activeAccount.currentValue.flatten
     writer.println(l"current: $current".buildMessageSafe)
-    storage.list() map { all =>
+    storage.values.map { all =>
       all.filter(!current.contains(_)).foreach { u =>
         writer.println(l"$u".buildMessageSafe)
       }

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -123,9 +123,9 @@ class UserServiceImpl(selfUserId:        UserId,
   } if (shouldSync) {
     verbose(l"Syncing user data to get team ids")
     for {
-      userMap <- usersStorage.contents.head
-      _       <- syncUsers(userMap.keySet)
-      _       <- shouldSyncUsers := false
+      users <- usersStorage.keySet
+      _     <- syncUsers(users)
+      _     <- shouldSyncUsers := false
     } yield ()
   }
 
@@ -143,7 +143,7 @@ class UserServiceImpl(selfUserId:        UserId,
       case (o, n) if o.name != n.name => n.id -> n.name
     }.toMap).filter(_.nonEmpty)
 
-    def initialLoad = usersStorage.list().map(_.map(user => user.id -> user.name).toMap)
+    def initialLoad = usersStorage.values.map(_.map(user => user.id -> user.name).toMap)
 
     new AggregatingSignal[Map[UserId, Name], Map[UserId, Name]](
       () => initialLoad,

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -243,7 +243,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
       } yield ()
 
     for {
-      convs      <- storage.list()
+      convs      <- storage.values
       duplicates =  convs.groupBy(_.remoteId).filter(_._2.size > 1).map(_._2.map(_.id))
       convIds    =  duplicates.flatten.toSet
       users      <- usersStorage.listAll(convIds.map(id => UserId(id.str)))
@@ -276,7 +276,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
       Future.successful({})
     } else
       for {
-        convs        <- storage.list()
+        convs        <- storage.values
         mentionsOnly =  convs.filter(_.onlyMentionsAllowed).map(_.id)
         _            <- storage.updateAll2(mentionsOnly, _.copy(muted = MuteSet.AllMuted))
         _            <- syncHandler.syncConversations()

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -129,9 +129,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       removeTeamMembers <- userPrefs.preference(UserPreferences.RemoveUncontactedTeamMembers).apply()
     } if (removeTeamMembers)
       for {
-        members  <- membersStorage.contents.map(_.keys.map(_._1)).head
-        users    <- usersStorage.contents.map(_.withFilter(!_._2.deleted).map(_._1)).head
-        toRemove =  users.toSet -- members.toSet
+        members  <- membersStorage.keySet
+        users    <- usersStorage.values.map(_.filterNot(_.deleted).map(_.id))
+        toRemove =  users.toSet -- members.map(_._1)
         _        <- if (toRemove.nonEmpty) usersStorage.updateAll2(toRemove, _.copy(deleted = true))
                     else Future.successful(())
         _        <- userPrefs.setValue(UserPreferences.RemoveUncontactedTeamMembers, false)
@@ -147,7 +147,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     // TODO: this is just very basic implementation creating empty message
     // This should be updated to include information about possibly missed changes
     // this message will be shown rarely (when notifications stream skips data)
-    convsStorage.list().flatMap(messages.addHistoryLostMessages(_, selfUserId))
+    convsStorage.values.flatMap(messages.addHistoryLostMessages(_, selfUserId))
   }
 
   errors.onErrorDismissed {
@@ -419,7 +419,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
                      })
     } yield ()
 
-  override def remoteIds: Future[Set[RConvId]] = convsStorage.list.map(_.map(_.remoteId).toSet)
+  override def remoteIds: Future[Set[RConvId]] = convsStorage.values.map(_.map(_.remoteId).toSet)
 
   private def deleteMembers(convId: ConvId): Future[Unit] =
     for {

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -95,7 +95,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
   def dismissNotifications(forConvs: Option[Set[ConvId]] = None): Future[Unit] = {
     verbose(l"dismissNotifications: $forConvs")
     for {
-      nots <- storage.list().map(_.toSet)
+      nots <- storage.values.map(_.toSet)
       toRemove = forConvs match {
         case None        => nots
         case Some(convs) => nots.filter(n => convs.contains(n.conv))
@@ -116,7 +116,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
     if (events.nonEmpty) {
       for {
         (undoneLikes, likes) <- getReactionChanges(events)
-        currentNotifications <- storage.list().map(_.toSet)
+        currentNotifications <- storage.values.map(_.toSet)
         msgNotifications     <- getMessageNotifications(c, events)
 
         (afterEditsApplied, beforeEditsApplied) = applyEdits(currentNotifications ++ msgNotifications, events)
@@ -204,8 +204,8 @@ class NotificationServiceImpl(selfUserId:      UserId,
     }
   }
 
-  private def pushNotificationsToUi(): Future[Unit] = storage.list().map {
-    case Nil    => Future.successful(())
+  private def pushNotificationsToUi(): Future[Unit] = storage.values.map {
+    case v if v.isEmpty => Future.successful(())
     case toShow =>
       verbose(l"pushNotificationsToUi, toShow: ${toShow.size}")
       (for {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -135,7 +135,7 @@ class UsersSyncHandlerImpl(userService:      UserService,
     val gm = GenericMessage(Uid(), GenericContent.AvailabilityStatus(availability))
     for {
       Some(self)     <- userService.getSelfUser
-      users          <- usersStorage.list()
+      users          <- usersStorage.values
       (team, others) = users.filterNot(u => u.deleted || u.isWireBot).partition(_.isInTeam(self.teamId))
       recipients     = (List(self.id) ++
                         team.filter(_.id != self.id).map(_.id).toList.sorted ++

--- a/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/FoldersServiceSpec.scala
@@ -67,8 +67,12 @@ class FoldersServiceSpec extends AndroidFreeSpec with DerivedLogTag with CirceJS
     }.map(_ => folder)
   }
 
-  (foldersStorage.list _).expects().anyNumberOfTimes().onCall { _ =>
-    Future(folders.toList)
+  (foldersStorage.values _).expects().anyNumberOfTimes().onCall { _ =>
+    Future(folders.toVector)
+  }
+
+  (foldersStorage.keySet _).expects().anyNumberOfTimes().onCall { _ =>
+    Future.successful(folders.map(_.id).toSet)
   }
 
   (foldersStorage.optSignal _).expects(*).anyNumberOfTimes().onCall { folderId: FolderId =>

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -86,7 +86,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   (pushService.processing _).expects().anyNumberOfTimes().onCall(_ => processing)
 
-  (storage.list _).expects().anyNumberOfTimes().onCall { _ => storedNotifications.head.map(_.toSeq) }
+  (storage.values _).expects().anyNumberOfTimes().onCall { _ => storedNotifications.head.map(_.toVector) }
   (storage.removeAll _).expects(*).anyNumberOfTimes().onCall { toRemove: Iterable[NotId] =>
     Future.successful[Unit] { storedNotifications.mutate { _.filterNot(n => toRemove.toSet.contains(n.id)) }; }
   }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -52,8 +52,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(connection = Blocked)
       val user3 = UserData("user3").copy(connection = Unconnected)
       val user4 = UserData("user4").copy(connection = PendingFromOther)
-      (usersStorage.list _).expects().anyNumberOfTimes().returning(
-        Future.successful(Seq(user1, user2, user3, user4))
+      (usersStorage.values _).expects().anyNumberOfTimes().returning(
+        Future.successful(Vector(user1, user2, user3, user4))
       )
 
       // then
@@ -79,8 +79,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Blocked)
       val user3 = UserData("user3").copy(teamId = Some(teamId), connection = Unconnected)
       val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther)
-      (usersStorage.list _).expects().anyNumberOfTimes().returning(
-        Future.successful(Seq(user1, user2, user3, user4))
+      (usersStorage.values _).expects().anyNumberOfTimes().returning(
+        Future.successful(Vector(user1, user2, user3, user4))
       )
 
       // then
@@ -108,8 +108,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther)
       val user5 = UserData("user5").copy(connection = Accepted)
       val user6 = UserData("user6").copy(connection = Unconnected)
-      (usersStorage.list _).expects().anyNumberOfTimes().returning(
-        Future.successful(Seq(user1, user2, user3, user4, user5, user6))
+      (usersStorage.values _).expects().anyNumberOfTimes().returning(
+        Future.successful(Vector(user1, user2, user3, user4, user5, user6))
       )
 
       // then
@@ -135,8 +135,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
       val user3 = UserData("user3").copy(connection = Accepted)
       val user4 = UserData("user4").copy(connection = Accepted)
-      (usersStorage.list _).expects().anyNumberOfTimes().returning(
-        Future.successful(Seq(user1, user2, user3, user4))
+      (usersStorage.values _).expects().anyNumberOfTimes().returning(
+        Future.successful(Vector(user1, user2, user3, user4))
       )
 
       // then
@@ -163,8 +163,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
       val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
       val user3 = UserData("user3").copy(connection = Accepted)
       val user4 = UserData("user4").copy(connection = Accepted)
-      (usersStorage.list _).expects().anyNumberOfTimes().returning(
-        Future.successful(Seq(user1, user2, user3, user4))
+      (usersStorage.values _).expects().anyNumberOfTimes().returning(
+        Future.successful(Vector(user1, user2, user3, user4))
       )
 
       // then

--- a/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -29,6 +29,7 @@ import com.waz.utils.{CachedStorageImpl, Cleanup, Managed, returning}
 import org.scalactic.Equality
 import org.scalatest.enablers.Emptiness
 
+import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.util.Random
 
@@ -151,10 +152,9 @@ package object testutils {
     }
   }
 
-
   implicit class RichStorage[K, V <: com.waz.utils.Identifiable[K]](storage: CachedStorageImpl[K, V]) {
-    def deleteAll() = storage.list().flatMap { vs => storage.removeAll(vs.map(_.id)) }
+    def deleteAll(): Future[Unit] = storage.keySet.flatMap(storage.removeAll)
   }
 
-  def randomPhoneNumber = PhoneNumber("+0" + (Random.nextInt(9) + 1).toString + Array.fill(13)(Random.nextInt(10)).mkString)
+  def randomPhoneNumber: PhoneNumber = PhoneNumber("+0" + (Random.nextInt(9) + 1).toString + Array.fill(13)(Random.nextInt(10)).mkString)
 }


### PR DESCRIPTION
I decided to make a short break from Federation and make the refactoring I thought about for some time now.
I guess it should help with large conversations, but since it trades memory for speed, it's possible that
we will hit the GC limit and the performance boost will be wasted. Anyway, I'd like to try it out.

There are a few changes:
1. The simplest one. I added "final" to our storage classes declarations. From the work on signals I know
   that it actually helps the compiler a bit - the generated bytecode is a bit shorter. If we ever need
   to create a subclass of one of those classes, we can simply remove the "final" keyword from it.
  I also used this opportunity to split very long lines of those declarations into a few shorter ones.
2. In `UserStorage` I switched from a fixed size cache to an unlimited size cache. If the user has large
   conversations, it's possible that he or she will hit the cache limit for users which slows down
   database access.
3. The most complex change. Currently we have two ways to get all data in the storage as one big map/sequence:
   directly, through the `list()` method, or through a signal `contents` that keeps copy of data and gets updated
   with every update to the underlying storage. The signal ia there anyway so I decided to use it instead of
   the `list()` method, hoping for better performance. So, `list()` is gone, and instead we have `values` which
   returns a vector of data taken from `contents`, and `keySet`, which returns the set of keys (d'oh) from
   `contents` - in some cases this is all that we need and currently we retrieve all data with `list()` and
   then use only keys.
4. The old `list()` method returned a `Seq` which is a trait and its implementation is unsure. The new method
   `values` returns a `Vector` so we can be sure that iterating through data will be O(n).

You may ask, if there is a cache already in the storage, then shouldn't it be all the same which one we use?
And my answer is - I guess it should? But we have `contents` anyway and right now, after all the work with
signals, I'm inclined to believe that this signal is pretty fast. I made some rough tests on my device and
the dev build and the initial sync time for a reasonably big client got around 10% faster with those changes.
But of course that may be a coincidence. QA tests on large conversations will give us a better idea.

#### APK
[Download build #3710](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3710/artifact/build/artifact/wire-dev-PR3405-3710.apk)
[Download build #3711](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3711/artifact/build/artifact/wire-dev-PR3405-3711.apk)
[Download build #3712](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3712/artifact/build/artifact/wire-dev-PR3405-3712.apk)
[Download build #3742](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3742/artifact/build/artifact/wire-dev-PR3405-3742.apk)