### PR TITLE
Federation: Handle info about a new conversation started on another backend

### DIFF
--- a/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
+++ b/app/src/main/kotlin/com/waz/zclient/feature/backup/conversations/ConversationsBackupDataSource.kt
@@ -43,7 +43,8 @@ data class ConversationsBackUpModel(
     val unreadMentionsCount: Int = 0,
     val unreadQuoteCount: Int = 0,
     val receiptMode: Int? = null,
-    val legalHoldStatus: Int = 0
+    val legalHoldStatus: Int = 0,
+    val domain: String? = null
 )
 
 class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, ConversationsEntity> {
@@ -81,7 +82,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = entity.unreadMentionsCount,
         unreadQuoteCount = entity.unreadQuoteCount,
         receiptMode = entity.receiptMode,
-        legalHoldStatus = entity.legalHoldStatus
+        legalHoldStatus = entity.legalHoldStatus,
+        domain = entity.domain
     )
 
     override fun toEntity(model: ConversationsBackUpModel) = ConversationsEntity(
@@ -118,7 +120,8 @@ class ConversationsBackupMapper : BackUpDataMapper<ConversationsBackUpModel, Con
         unreadMentionsCount = model.unreadMentionsCount,
         unreadQuoteCount = model.unreadQuoteCount,
         receiptMode = model.receiptMode,
-        legalHoldStatus = model.legalHoldStatus
+        legalHoldStatus = model.legalHoldStatus,
+        domain = model.domain
     )
 }
 

--- a/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
+++ b/app/src/test/kotlin/com/waz/zclient/feature/backup/conversations/ConversationBackupMapperTest.kt
@@ -53,7 +53,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val model = backupMapper.fromEntity(entity)
@@ -128,7 +129,8 @@ class ConversationBackupMapperTest : UnitTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
 
         val entity = backupMapper.toEntity(model)

--- a/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
+++ b/common-test/src/main/kotlin/com/waz/zclient/framework/data/conversations/ConversationsTestDataProvider.kt
@@ -36,7 +36,8 @@ data class ConversationsTestData(
     val unreadMentionsCount: Int,
     val unreadQuoteCount: Int,
     val receiptMode: Int?,
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+    val domain: String?
 )
 
 object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>() {
@@ -74,6 +75,7 @@ object ConversationsTestDataProvider : TestDataProvider<ConversationsTestData>()
         unreadMentionsCount = 0,
         unreadQuoteCount = 0,
         receiptMode = null,
-        legalHoldStatus = 0
+        legalHoldStatus = 0,
+        domain = "staging"
     )
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -58,6 +58,7 @@ import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
 import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
+import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_133_TO_134
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -107,7 +108,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 133
+        const val VERSION = 134
 
         @JvmStatic
         val migrations = arrayOf(
@@ -116,7 +117,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_129_TO_130,
             USER_DATABASE_MIGRATION_130_TO_131,
             USER_DATABASE_MIGRATION_131_TO_132,
-            USER_DATABASE_MIGRATION_132_TO_133
+            USER_DATABASE_MIGRATION_132_TO_133,
+            USER_DATABASE_MIGRATION_133_TO_134
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/conversations/ConversationsEntity.kt
@@ -113,5 +113,8 @@ data class ConversationsEntity(
     val receiptMode: Int?,
 
     @ColumnInfo(name = "legal_hold_status")
-    val legalHoldStatus: Int
+    val legalHoldStatus: Int,
+
+    @ColumnInfo(name = "domain")
+    val domain: String?
 )

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase133To134Migration.kt
@@ -1,0 +1,16 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val USER_DATABASE_MIGRATION_133_TO_134 = object : Migration(133, 134) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        MigrationUtils.addColumn(
+            database = database,
+            tableName = "Conversations",
+            columnName = "domain",
+            columnType = MigrationUtils.ColumnType.TEXT
+        )
+    }
+}

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -34,46 +34,48 @@ import org.json.JSONArray
 import scala.concurrent.duration._
 import scala.util.Try
 
-case class ConversationData(override val id:      ConvId                 = ConvId(),
-                            remoteId:             RConvId                = RConvId(),
-                            name:                 Option[Name]           = None,
-                            creator:              UserId                 = UserId(),
-                            convType:             ConversationType       = ConversationType.Group,
-                            team:                 Option[TeamId]         = None,
-                            lastEventTime:        RemoteInstant          = RemoteInstant.Epoch,
-                            isActive:             Boolean                = true,
-                            lastRead:             RemoteInstant          = RemoteInstant.Epoch,
-                            muted:                MuteSet                = MuteSet.AllAllowed,
-                            muteTime:             RemoteInstant          = RemoteInstant.Epoch,
-                            archived:             Boolean                = false,
-                            archiveTime:          RemoteInstant          = RemoteInstant.Epoch,
-                            cleared:              Option[RemoteInstant]  = None,
-                            generatedName:        Name                   = Name.Empty, // deprecated
-                            searchKey:            Option[SearchKey]      = None,
-                            unreadCount:          UnreadCount            = UnreadCount(0, 0, 0, 0, 0),
-                            failedCount:          Int                    = 0,
-                            missedCallMessage:    Option[MessageId]      = None,
-                            incomingKnockMessage: Option[MessageId]      = None,
-                            hidden:               Boolean                = false,
-                            verified:             Verification           = Verification.UNKNOWN,
-                            localEphemeral:       Option[FiniteDuration] = None,
-                            globalEphemeral:      Option[FiniteDuration] = None,
-                            access:               Set[Access]            = Set.empty,
-                            accessRole:           Option[AccessRole]     = None, //option for migration purposes only - at some point we do a fetch and from that point it will always be defined
-                            link:                 Option[Link]           = None,
-                            receiptMode:          Option[Int]            = None,  //Some(1) if both users have RR enabled in a 1-to-1 convo
-                            legalHoldStatus:      LegalHoldStatus        = LegalHoldStatus.Disabled,
-                            domain:               Option[String]         = None
-                           ) extends Identifiable[ConvId] {
+final case class ConversationData(override val id:      ConvId                 = ConvId(),
+                                  remoteId:             RConvId                = RConvId(),
+                                  name:                 Option[Name]           = None,
+                                  creator:              UserId                 = UserId(),
+                                  convType:             ConversationType       = ConversationType.Group,
+                                  team:                 Option[TeamId]         = None,
+                                  lastEventTime:        RemoteInstant          = RemoteInstant.Epoch,
+                                  isActive:             Boolean                = true,
+                                  lastRead:             RemoteInstant          = RemoteInstant.Epoch,
+                                  muted:                MuteSet                = MuteSet.AllAllowed,
+                                  muteTime:             RemoteInstant          = RemoteInstant.Epoch,
+                                  archived:             Boolean                = false,
+                                  archiveTime:          RemoteInstant          = RemoteInstant.Epoch,
+                                  cleared:              Option[RemoteInstant]  = None,
+                                  generatedName:        Name                   = Name.Empty, // deprecated
+                                  searchKey:            Option[SearchKey]      = None,
+                                  unreadCount:          UnreadCount            = UnreadCount(0, 0, 0, 0, 0),
+                                  failedCount:          Int                    = 0,
+                                  missedCallMessage:    Option[MessageId]      = None,
+                                  incomingKnockMessage: Option[MessageId]      = None,
+                                  hidden:               Boolean                = false,
+                                  verified:             Verification           = Verification.UNKNOWN,
+                                  localEphemeral:       Option[FiniteDuration] = None,
+                                  globalEphemeral:      Option[FiniteDuration] = None,
+                                  access:               Set[Access]            = Set.empty,
+                                  accessRole:           Option[AccessRole]     = None, //option for migration purposes only - at some point we do a fetch and from that point it will always be defined
+                                  link:                 Option[Link]           = None,
+                                  receiptMode:          Option[Int]            = None,  //Some(1) if both users have RR enabled in a 1-to-1 convo
+                                  legalHoldStatus:      LegalHoldStatus        = LegalHoldStatus.Disabled,
+                                  domain:               Option[String]         = None
+                                 ) extends Identifiable[ConvId] {
+  lazy val qualifiedId: Option[RConvQualifiedId] = domain.map(RConvQualifiedId(remoteId, _))
+
   def getName(): String = name.fold("")(_.str) // still used in Java
 
-  def withFreshSearchKey = copy(searchKey = freshSearchKey)
-  def savedOrFreshSearchKey = searchKey.orElse(freshSearchKey)
-  def freshSearchKey = if (convType == ConversationType.Group) name.map(SearchKey(_)) else None
+  def withFreshSearchKey: ConversationData = copy(searchKey = freshSearchKey)
+  def savedOrFreshSearchKey: Option[SearchKey] = searchKey.orElse(freshSearchKey)
+  def freshSearchKey: Option[SearchKey] = if (convType == ConversationType.Group) name.map(SearchKey(_)) else None
 
-  lazy val completelyCleared = cleared.exists(!_.isBefore(lastEventTime))
+  lazy val completelyCleared: Boolean = cleared.exists(!_.isBefore(lastEventTime))
 
-  lazy val isManaged = team.map(_ => false) //can be returned to parameter list when we need it.
+  lazy val isManaged: Option[Boolean] = team.map(_ => false) //can be returned to parameter list when we need it.
 
   lazy val ephemeralExpiration: Option[EphemeralDuration] = (globalEphemeral, localEphemeral) match {
     case (Some(d), _) => Some(ConvExpiry(d)) //global ephemeral takes precedence over local
@@ -81,9 +83,9 @@ case class ConversationData(override val id:      ConvId                 = ConvI
     case _ => None
   }
 
-  def withLastRead(time: RemoteInstant) = copy(lastRead = lastRead max time)
+  def withLastRead(time: RemoteInstant): ConversationData = copy(lastRead = lastRead max time)
 
-  def withCleared(time: RemoteInstant) = copy(cleared = Some(cleared.fold(time)(_ max time)))
+  def withCleared(time: RemoteInstant): ConversationData = copy(cleared = Some(cleared.fold(time)(_ max time)))
 
   def withNewLegalHoldStatus(detectedLegalHoldDevice: Boolean): ConversationData = {
     import LegalHoldStatus._

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -62,7 +62,8 @@ case class ConversationData(override val id:      ConvId                 = ConvI
                             accessRole:           Option[AccessRole]     = None, //option for migration purposes only - at some point we do a fetch and from that point it will always be defined
                             link:                 Option[Link]           = None,
                             receiptMode:          Option[Int]            = None,  //Some(1) if both users have RR enabled in a 1-to-1 convo
-                            legalHoldStatus:      LegalHoldStatus        = LegalHoldStatus.Disabled
+                            legalHoldStatus:      LegalHoldStatus        = LegalHoldStatus.Disabled,
+                            domain:               Option[String]         = None
                            ) extends Identifiable[ConvId] {
   def getName(): String = name.fold("")(_.str) // still used in Java
 
@@ -251,6 +252,7 @@ object ConversationData {
     val UnreadQuotesCount   = int('unread_quote_count)(_.unreadCount.quotes)
     val ReceiptMode         = opt(int('receipt_mode))(_.receiptMode)
     val LegalHoldStatus     = int[LegalHoldStatus]('legal_hold_status, _.value, ConversationData.LegalHoldStatus.apply)(_.legalHoldStatus)
+    val Domain              = opt(text('domain))(_.domain)
 
     private def getVerification(name: String): Verification =
       Try(Verification.valueOf(name)).getOrElse(Verification.UNKNOWN)
@@ -291,7 +293,8 @@ object ConversationData {
       UnreadMentionsCount,
       UnreadQuotesCount,
       ReceiptMode,
-      LegalHoldStatus
+      LegalHoldStatus,
+      Domain
     )
 
     override def apply(implicit cursor: DBCursor): ConversationData =
@@ -324,7 +327,8 @@ object ConversationData {
         AccessRole,
         Link,
         ReceiptMode,
-        LegalHoldStatus
+        LegalHoldStatus,
+        Domain
       )
 
     import com.waz.model.ConversationData.ConversationType._

--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -1,0 +1,34 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder.opt
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import org.json.{JSONArray, JSONObject}
+
+final case class RConvQualifiedId(id: RConvId, domain: String) {
+  def hasDomain: Boolean = domain.nonEmpty
+}
+
+object RConvQualifiedId {
+  def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
+
+  private val IdFieldName = "id"
+  private val DomainFieldName  = "domain"
+
+  implicit val Encoder: JsonEncoder[RConvQualifiedId] =
+    JsonEncoder.build(qId => js => {
+      js.put(IdFieldName, qId.id.str)
+      js.put(DomainFieldName, qId.domain)
+    })
+
+  private def decode(js: JSONObject): RConvQualifiedId =
+    RConvQualifiedId(RConvId(js.getString(IdFieldName)), js.getString(DomainFieldName))
+
+  implicit val Decoder: JsonDecoder[RConvQualifiedId] =
+    JsonDecoder.lift(implicit js => decode(js))
+
+  def decodeOpt(s: Symbol)(implicit js: JSONObject): Option[RConvQualifiedId] =
+    opt(s, js => decode(js.getJSONObject(s.name)))
+
+  def encode(qIds: Set[RConvQualifiedId]): JSONArray =
+    JsonEncoder.array(qIds) { case (arr, qid) => arr.put(RConvQualifiedId.Encoder(qid)) }
+}

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -48,7 +48,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _: OtrErrorEvent           => true
       case _: ConnectRequestEvent     => true
       case _: OtrMessageEvent         => true
-      case MemberJoinEvent(_, _, _, added, _, _) if added.contains(selfUserId) => true
+      case MemberJoinEvent(_, _, _, _, _, added, _, _) if added.contains(selfUserId) => true
       case MemberLeaveEvent(_, _, _, leaving, _) if leaving.contains(selfUserId) => true
       case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
         gm.unpackContent match {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -357,6 +357,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     returning(prev.getOrElse(ConversationData(id = newLocalId, hidden = isOneToOne(resp.convType) && resp.members.size <= 1))
       .copy(
         remoteId        = resp.id,
+        domain          = resp.domain,
         name            = resp.name.filterNot(_.isEmpty),
         creator         = resp.creator,
         convType        = prev.map(_.convType).filter(oldType => isOneToOne(oldType) && resp.convType != ConversationType.OneToOne).getOrElse(resp.convType),

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -106,8 +106,8 @@ class MessageEventProcessor(selfUserId:           UserId,
         RichMessage(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
       case MessageTimerEvent(_, time, from, duration) =>
         RichMessage(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
-      case MemberJoinEvent(_, time, from, userIds, users, firstEvent) =>
-        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
+      case MemberJoinEvent(_, _, time, from, _, userIds, users, firstEvent) =>
+        RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys.map(_.id) ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
       case ConversationReceiptModeEvent(_, time, from, 0) =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
       case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -41,9 +41,10 @@ import scala.util.control.NonFatal
 
 trait ConversationsClient {
   import ConversationsClient._
-  def loadConversationIds(start: Option[RConvId] = None): ErrorOrResponse[ConversationsResult]
   def loadConversations(start: Option[RConvId] = None, limit: Int = ConversationsPageSize): ErrorOrResponse[ConversationsResult]
+  def loadQualifiedConversations(start: Option[RConvQualifiedId] = None, limit: Int = ConversationsPageSize): ErrorOrResponse[ConversationsResult]
   def loadConversations(ids: Set[RConvId]): ErrorOrResponse[Seq[ConversationResponse]]
+  def loadQualifiedConversations(ids: Set[RConvQualifiedId]): ErrorOrResponse[Seq[ConversationResponse]]
   def loadConversationRoles(remoteIds: Set[RConvId], defRoles: Set[ConversationRole]): Future[Map[RConvId, Set[ConversationRole]]]
   def postName(convId: RConvId, name: Name): ErrorOrResponse[Option[RenameConversationEvent]]
   def postConversationState(convId: RConvId, state: ConversationState): ErrorOrResponse[Unit]
@@ -57,6 +58,7 @@ trait ConversationsClient {
   def postAccessUpdate(conv: RConvId, access: Set[Access], accessRole: AccessRole): ErrorOrResponse[Unit]
   def postReceiptMode(conv: RConvId, receiptMode: Int): ErrorOrResponse[Unit]
   def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse]
+  def postQualifiedConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse]
   def postConversationRole(id: RConvId, userId: UserId, role: ConversationRole): ErrorOrResponse[Unit]
   def getGuestroomOverview(key: String, code: String): ErrorOrResponse[ConversationOverviewResponse]
   def postJoinConversation(key: String, code: String): ErrorOrResponse[Option[MemberJoinEvent]]
@@ -82,17 +84,6 @@ class ConversationsClientImpl(implicit
       ConversationsResult(ids, hasMore)
     }
 
-  override def loadConversationIds(start: Option[RConvId] = None): ErrorOrResponse[ConversationsResult] = {
-    Request
-      .Get(
-        relativePath = ConversationIdsPath,
-        queryParameters = queryParameters("size" -> ConversationIdsPageSize, "start" -> start)
-      )
-      .withResultType[ConversationsResult]
-      .withErrorType[ErrorResponse]
-      .executeSafe
-  }
-
   override def loadConversations(start: Option[RConvId] = None, limit: Int = ConversationsPageSize): ErrorOrResponse[ConversationsResult] = {
     Request
       .Get(
@@ -104,9 +95,32 @@ class ConversationsClientImpl(implicit
       .executeSafe
   }
 
+  override def loadQualifiedConversations(start: Option[RConvQualifiedId] = None, limit: Int = ConversationsPageSize): ErrorOrResponse[ConversationsResult] = {
+    Request
+      .Post(
+        relativePath = ListConversationsPath,
+        queryParameters = queryParameters("size" -> limit, "start_id" -> start)
+      )
+      .withResultType[ConversationsResult]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+  }
+
   override def loadConversations(ids: Set[RConvId]): ErrorOrResponse[Seq[ConversationResponse]] = {
     Request
       .Get(relativePath = ConversationsPath, queryParameters = queryParameters("ids" -> ids.mkString(",")))
+      .withResultType[ConversationsResult]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+      .map(_.map(_.conversations))
+  }
+
+  override def loadQualifiedConversations(ids: Set[RConvQualifiedId]): ErrorOrResponse[Seq[ConversationResponse]] = {
+    Request
+      .Post(
+        relativePath = ConversationsPath,
+        queryParameters = queryParameters("qualified_ids" -> RConvQualifiedId.encode(ids))
+      )
       .withResultType[ConversationsResult]
       .withErrorType[ErrorResponse]
       .executeSafe
@@ -249,9 +263,17 @@ class ConversationsClientImpl(implicit
       .executeSafe
   }
 
-  def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse] = {
+  override def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse] = {
     verbose(l"postConversation($state)")
     Request.Post(relativePath = ConversationsPath, body = state)
+      .withResultType[ConversationsResult]
+      .withErrorType[ErrorResponse]
+      .executeSafe(_.conversations.head)
+  }
+
+  override def postQualifiedConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse] = {
+    verbose(l"postQualifiedConversation($state)")
+    Request.Post(relativePath = QualifiedConversationsPath, body = state)
       .withResultType[ConversationsResult]
       .withErrorType[ErrorResponse]
       .executeSafe(_.conversations.head)
@@ -302,7 +324,8 @@ class ConversationsClientImpl(implicit
 
 object ConversationsClient {
   val ConversationsPath = "/conversations"
-  val ConversationIdsPath = "/conversations/ids"
+  val ListConversationsPath = "/list-conversations"
+  val QualifiedConversationsPath = "/conversations/one2one"
   val JoinConversationPath = "/conversations/join"
   val ConversationsPageSize = 100
   val ConversationIdsPageSize = 1000
@@ -314,19 +337,21 @@ object ConversationsClient {
   def membersPath(id: RConvId) = s"$ConversationsPath/${id.str}/members"
   def qualifiedMembersPath(id: RConvId) = s"$ConversationsPath/${id.str}/members/v2"
 
-  case class ConversationInitState(users:            Set[UserId],
-                                   name:             Option[Name] = None,
-                                   team:             Option[TeamId],
-                                   access:           Set[Access],
-                                   accessRole:       AccessRole,
-                                   receiptMode:      Option[Int],
-                                   conversationRole: ConversationRole
-                                  )
+  final case class ConversationInitState(users:            Set[UserId],
+                                         qualifiedUsers:   Set[QualifiedId],
+                                         name:             Option[Name] = None,
+                                         team:             Option[TeamId],
+                                         access:           Set[Access],
+                                         accessRole:       AccessRole,
+                                         receiptMode:      Option[Int],
+                                         conversationRole: ConversationRole
+                                        )
 
   object ConversationInitState {
     implicit lazy val Encoder: JsonEncoder[ConversationInitState] = new JsonEncoder[ConversationInitState] {
       override def apply(state: ConversationInitState): JSONObject = JsonEncoder { o =>
-        o.put("users", Json(state.users))
+        if (state.users.nonEmpty) o.put("users", Json(state.users))
+        if (state.qualifiedUsers.nonEmpty) o.put("qualified_users", QualifiedId.encode(state.qualifiedUsers))
         state.name.foreach(o.put("name", _))
         state.team.foreach(t => o.put("team", returning(new json.JSONObject()) { o =>
           o.put("teamid", t.str)
@@ -340,22 +365,25 @@ object ConversationsClient {
     }
   }
 
-  case class ConversationResponse(id:           RConvId,
-                                  name:         Option[Name],
-                                  creator:      UserId,
-                                  convType:     ConversationType,
-                                  team:         Option[TeamId],
-                                  muted:        MuteSet,
-                                  mutedTime:    RemoteInstant,
-                                  archived:     Boolean,
-                                  archivedTime: RemoteInstant,
-                                  access:       Set[Access],
-                                  accessRole:   Option[AccessRole],
-                                  link:         Option[Link],
-                                  messageTimer: Option[FiniteDuration],
-                                  members:      Map[UserId, ConversationRole],
-                                  receiptMode:  Option[Int]
-                                 )
+  final case class ConversationResponse(id:           RConvId,
+                                        domain:       Option[String],
+                                        name:         Option[Name],
+                                        creator:      UserId,
+                                        convType:     ConversationType,
+                                        team:         Option[TeamId],
+                                        muted:        MuteSet,
+                                        mutedTime:    RemoteInstant,
+                                        archived:     Boolean,
+                                        archivedTime: RemoteInstant,
+                                        access:       Set[Access],
+                                        accessRole:   Option[AccessRole],
+                                        link:         Option[Link],
+                                        messageTimer: Option[FiniteDuration],
+                                        members:      Map[UserId, ConversationRole],
+                                        receiptMode:  Option[Int]
+                                       ) {
+    lazy val qualifiedId: Option[RConvQualifiedId] = domain.map(RConvQualifiedId(id, _))
+  }
 
   object ConversationResponse extends DerivedLogTag {
     import ConversationRole._
@@ -371,8 +399,14 @@ object ConversationsClient {
           case _                      => Map.empty
         }
 
+        val (id, domain) =
+          RConvQualifiedId.decodeOpt('qualified_id)
+            .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
+            .getOrElse((JsonDecoder.decodeRConvId('id), None))
+
         ConversationResponse(
-          'id,
+          id,
+          domain,
           'name,
           'creator,
           'type,
@@ -391,10 +425,10 @@ object ConversationsClient {
       }
     }
 
-    case class ConversationsResult(conversations: Seq[ConversationResponse], hasMore: Boolean)
+    final case class ConversationsResult(conversations: Seq[ConversationResponse], hasMore: Boolean)
   }
 
-  case class ConvRole(conversation_role: String, actions: Seq[String]) {
+  final case class ConvRole(conversation_role: String, actions: Seq[String]) {
     def toConversationRole: ConversationRole = ConversationRole(conversation_role, actions.flatMap(a => ConversationAction.allActions.find(_.name == a)).toSet)
   }
 
@@ -405,7 +439,7 @@ object ConversationsClient {
     }
   }
 
-  case class ConvRoles(conversation_roles: Seq[ConvRole]) {
+  final case class ConvRoles(conversation_roles: Seq[ConvRole]) {
     def toConversationRoles: Set[ConversationRole] = conversation_roles.map(_.toConversationRole).toSet
   }
 
@@ -445,7 +479,7 @@ object ConversationsClient {
     }
   }
 
-  case class ConversationOverviewResponse(id: RConvId, name: String)
+  final case class ConversationOverviewResponse(id: RConvId, name: String)
 
   object ConversationOverviewResponse extends DerivedLogTag {
     import com.waz.utils.JsonDecoder._

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -66,8 +66,10 @@ class ConversationsSyncHandler(selfUserId:      UserId,
   private def loadConversationRoles(resps: Seq[ConversationResponse]) = {
     val (otherTeamResps, teamAndPrivResps) = resps.partition(r => r.team.isDefined && r.team != teamId)
     rolesService.defaultRoles.head.flatMap { defRoles =>
+      // @todo: for now we have no way to check conversation roles on a federated backend
+      val convIds = otherTeamResps.filterNot(_.hasDomain).map(_.id).toSet
       convClient
-        .loadConversationRoles(otherTeamResps.map(_.id).toSet, defRoles)
+        .loadConversationRoles(convIds, defRoles)
         .map(_ ++ teamAndPrivResps.map(r => r.id -> defRoles).toMap)
     }
   }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -29,10 +29,11 @@ import com.waz.service.conversation.{ConversationOrderEventsService, Conversatio
 import com.waz.service.messages.MessagesService
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.{Retry, Success}
-import com.waz.sync.client.ConversationsClient
+import com.waz.sync.client.{ConversationsClient, ErrorOr}
 import com.waz.sync.client.ConversationsClient.ConversationResponse.ConversationsResult
 import com.waz.sync.client.ConversationsClient.{ConversationInitState, ConversationResponse}
 import com.waz.threading.Threading
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.Future
 import scala.util.Right
@@ -42,20 +43,20 @@ object ConversationsSyncHandler {
   val PostMembersLimit = 256
 }
 
-class ConversationsSyncHandler(selfUserId:          UserId,
-                               teamId:              Option[TeamId],
-                               userService:         UserService,
-                               messagesStorage:     MessagesStorage,
-                               messagesService:     MessagesService,
-                               convService:         ConversationsService,
-                               convs:               ConversationsContentUpdater,
-                               convEvents:          ConversationOrderEventsService,
-                               convStorage:         ConversationStorage,
-                               errorsService:       ErrorsService,
-                               conversationsClient: ConversationsClient,
-                               genericMessages:     GenericMessageService,
-                               rolesService:        ConversationRolesService,
-                               membersStorage:      MembersStorage
+class ConversationsSyncHandler(selfUserId:      UserId,
+                               teamId:          Option[TeamId],
+                               userService:     UserService,
+                               messagesStorage: MessagesStorage,
+                               messagesService: MessagesService,
+                               convService:     ConversationsService,
+                               convUpdater:     ConversationsContentUpdater,
+                               convEvents:      ConversationOrderEventsService,
+                               convStorage:     ConversationStorage,
+                               errorsService:   ErrorsService,
+                               convClient:      ConversationsClient,
+                               genericMessages: GenericMessageService,
+                               rolesService:    ConversationRolesService,
+                               membersStorage:  MembersStorage
                               ) extends DerivedLogTag {
 
   import Threading.Implicits.Background
@@ -65,19 +66,44 @@ class ConversationsSyncHandler(selfUserId:          UserId,
   private def loadConversationRoles(resps: Seq[ConversationResponse]) = {
     val (otherTeamResps, teamAndPrivResps) = resps.partition(r => r.team.isDefined && r.team != teamId)
     rolesService.defaultRoles.head.flatMap { defRoles =>
-      conversationsClient
+      convClient
         .loadConversationRoles(otherTeamResps.map(_.id).toSet, defRoles)
         .map(_ ++ teamAndPrivResps.map(r => r.id -> defRoles).toMap)
     }
   }
 
   def syncConversations(ids: Set[ConvId]): Future[SyncResult] =
-    Future.sequence(ids.map(convs.convById)).flatMap { convs =>
-      val remoteIds = convs.collect { case Some(conv) => conv.remoteId }
+    convStorage.getAll(ids).flatMap { convs =>
+      val load: ErrorOr[Seq[ConversationResponse]] =
+        if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+          val (qIds, remoteIds) = convs.foldLeft((Set.empty[RConvQualifiedId], Set.empty[RConvId])) {
+            case ((qIds, remoteIds), Some(conv)) if conv.qualifiedId.nonEmpty =>
+              (qIds + conv.qualifiedId.get, remoteIds)
+            case ((qIds, remoteIds), Some(conv)) =>
+              (qIds, remoteIds + conv.remoteId)
+            case (acc, _) =>
+              error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+              acc
+          }
 
-      if (remoteIds.size != convs.size) error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+          (for {
+            qResps <- if (qIds.nonEmpty) convClient.loadQualifiedConversations(qIds).future
+                      else Future.successful(Right(Seq.empty))
+            resps  <- if (remoteIds.nonEmpty) convClient.loadConversations(remoteIds).future
+                      else Future.successful(Right(Seq.empty))
+          } yield (qResps, resps)).map {
+            case (Left(error), _)        => Left(error)
+            case (_, Left(error))        => Left(error)
+            case (Right(qrs), Right(rs)) => Right(qrs ++ rs)
+          }
+        } else {
+          val remoteIds = convs.collect { case Some(conv) => conv.remoteId }.toSet
+          if (remoteIds.size != convs.size)
+            error(l"syncConversations($ids) - some conversations were not found in local db, skipping")
+          convClient.loadConversations(remoteIds).future
+        }
 
-      conversationsClient.loadConversations(remoteIds).future flatMap {
+      load.flatMap {
         case Right(resps) =>
           loadConversationRoles(resps).flatMap { roles =>
             debug(l"syncConversations received ${resps.size}, ${roles.size}")
@@ -90,8 +116,15 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       }
     }
 
-  def syncConversations(start: Option[RConvId] = None, rIdsFromBackend: Set[RConvId] = Set.empty): Future[SyncResult] =
-    conversationsClient.loadConversations(start).future.flatMap {
+  def syncConversations(): Future[SyncResult] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      syncQualifiedConversations(None, Set.empty)
+    } else {
+      syncConversations(None, Set.empty)
+    }
+
+  private def syncConversations(start: Option[RConvId], rIdsFromBackend: Set[RConvId]): Future[SyncResult] =
+    convClient.loadConversations(start).future.flatMap {
       case Right(ConversationsResult(responses, hasMore)) =>
         loadConversationRoles(responses).flatMap { roles =>
           convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
@@ -99,6 +132,24 @@ class ConversationsSyncHandler(selfUserId:          UserId,
               syncConversations(responses.lastOption.map(_.id), rIdsFromBackend ++ responses.map(_.id))
             else
               removeConvsMissingOnBackend(rIdsFromBackend ++ responses.map(_.id)).map(_ => Success)
+          }
+        }
+      case Left(error) =>
+        Future.successful(SyncResult(error))
+    }
+
+  private def syncQualifiedConversations(start: Option[RConvQualifiedId], rIdsFromBackend: Set[RConvQualifiedId]): Future[SyncResult] =
+    convClient.loadQualifiedConversations(start).future.flatMap {
+      case Right(ConversationsResult(responses, hasMore)) =>
+        loadConversationRoles(responses).flatMap { roles =>
+          convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
+            if (hasMore)
+              syncQualifiedConversations(
+                responses.lastOption.flatMap(_.qualifiedId),
+                rIdsFromBackend ++ responses.flatMap(_.qualifiedId)
+              )
+            else
+              removeConvsMissingOnBackend(rIdsFromBackend.map(_.id) ++ responses.map(_.id)).map(_ => Success)
           }
         }
       case Left(error) =>
@@ -113,16 +164,16 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     } yield ()
 
   def postConversationName(id: ConvId, name: Name): Future[SyncResult] =
-    postConv(id) { conv => conversationsClient.postName(conv.remoteId, name).future }
+    postConv(id) { conv => convClient.postName(conv.remoteId, name).future }
 
   def postConversationReceiptMode(id: ConvId, receiptMode: Int): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postReceiptMode(conv.remoteId, receiptMode).map(SyncResult(_))
+      convClient.postReceiptMode(conv.remoteId, receiptMode).map(SyncResult(_))
     }
 
   def postConversationRole(id: ConvId, userId: UserId, newRole: ConversationRole, origRole: ConversationRole): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postConversationRole(conv.remoteId, userId, newRole).future.flatMap {
+      convClient.postConversationRole(conv.remoteId, userId, newRole).future.flatMap {
         case Right(_) =>
           Future.successful(Success)
         case Left(error) =>
@@ -149,7 +200,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
   def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncResult] =
     withConversation(id) { conv =>
       def post(users: Set[UserId]) =
-        conversationsClient
+        convClient
           .postMemberJoin(conv.remoteId, users, defaultRole).future
           .flatMap(handleMemberJoinResponse(id, members, _))
 
@@ -158,9 +209,8 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncResult] =
     withConversation(id) { conv =>
-      verbose(l"FED here!")
       def post(users: Set[QualifiedId]) =
-        conversationsClient
+        convClient
           .postQualifiedMemberJoin(conv.remoteId, users, defaultRole).future
           .flatMap(handleMemberJoinResponse(id, members.map(_.id), _))
 
@@ -168,12 +218,12 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     }
 
   def postConversationMemberLeave(id: ConvId, user: UserId): Future[SyncResult] =
-    if (user != selfUserId) postConv(id) { conv => conversationsClient.postMemberLeave(conv.remoteId, user) }
+    if (user != selfUserId) postConv(id) { conv => convClient.postMemberLeave(conv.remoteId, user) }
     else withConversation(id) { conv =>
-      conversationsClient.postMemberLeave(conv.remoteId, user).future flatMap {
+      convClient.postMemberLeave(conv.remoteId, user).future flatMap {
         case Right(Some(event: MemberLeaveEvent)) =>
           event.localTime = LocalInstant.Now
-          conversationsClient.postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(event.time))).future flatMap {
+          convClient.postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(event.time))).future flatMap {
             case Right(_) =>
               verbose(l"postConversationState finished")
               convEvents.handlePostConversationEvent(event)
@@ -183,7 +233,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
           }
         case Right(None) =>
           debug(l"member $user already left, just updating the conversation state")
-          conversationsClient
+          convClient
             .postConversationState(conv.remoteId, ConversationState(archived = Some(true), archiveTime = Some(conv.lastEventTime)))
             .future
             .map(_ => Success)
@@ -195,7 +245,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncResult] =
     withConversation(id) { conv =>
-      conversationsClient.postConversationState(conv.remoteId, state).map(SyncResult(_))
+      convClient.postConversationState(conv.remoteId, state).map(SyncResult(_))
     }
 
   def postConversation(convId:      ConvId,
@@ -211,6 +261,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     val (toCreate, toAdd) = users.splitAt(PostMembersLimit)
     val initState = ConversationInitState(
       users                 = toCreate,
+      qualifiedUsers        = Set.empty,
       name                  = name,
       team                  = team,
       access                = access,
@@ -218,7 +269,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
       receiptMode           = receiptMode,
       conversationRole      = defaultRole
     )
-    conversationsClient.postConversation(initState).future.flatMap {
+    convClient.postConversation(initState).future.flatMap {
       case Right(response) =>
         convService.updateRemoteId(convId, response.id).flatMap { _ =>
           loadConversationRoles(Seq(response)).flatMap { roles =>
@@ -248,7 +299,6 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     }
   }
 
-
   def postQualifiedConversation(convId:      ConvId,
                                 users:       Set[QualifiedId],
                                 name:        Option[Name],
@@ -261,16 +311,17 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     debug(l"postQualifiedConversation($convId, $users, $name, $defaultRole)")
 
     val initState = ConversationInitState(
-      users                 = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
-      name                  = name,
-      team                  = team,
-      access                = access,
-      accessRole            = accessRole,
-      receiptMode           = receiptMode,
-      conversationRole      = defaultRole
+      users            = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
+      qualifiedUsers   = users,
+      name             = name,
+      team             = team,
+      access           = access,
+      accessRole       = accessRole,
+      receiptMode      = receiptMode,
+      conversationRole = defaultRole
     )
 
-    conversationsClient.postConversation(initState).future.flatMap {
+    convClient.postQualifiedConversation(initState).future.flatMap {
       case Right(response) =>
         convService.updateRemoteId(convId, response.id).flatMap { _ =>
           loadConversationRoles(Seq(response)).flatMap { roles =>
@@ -302,8 +353,8 @@ class ConversationsSyncHandler(selfUserId:          UserId,
 
   def syncConvLink(convId: ConvId): Future[SyncResult] = {
     (for {
-      Some(conv) <- convs.convById(convId)
-      resp       <- conversationsClient.getLink(conv.remoteId).future
+      Some(conv) <- convUpdater.convById(convId)
+      resp       <- convClient.getLink(conv.remoteId).future
       res        <- resp match {
         case Right(l)  => convStorage.update(conv.id, _.copy(link = l)).map(_ => Success)
         case Left(err) => Future.successful(SyncResult(err))
@@ -331,7 +382,7 @@ class ConversationsSyncHandler(selfUserId:          UserId,
   }
 
   private def withConversation(id: ConvId)(body: ConversationData => Future[SyncResult]): Future[SyncResult] =
-    convs.convById(id) flatMap {
+    convUpdater.convById(id) flatMap {
       case Some(conv) => body(conv)
       case _ =>
         Future.successful(Retry(s"No conversation found for id: $id")) // XXX: does it make sense to retry ?

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -101,7 +101,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       )
 
       clock.advance(5.seconds)
-      val event = MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap)
+      val event = MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      )
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, MEMBER_JOIN, sender).returning(Future.successful(false))
       (storage.getLastSentMessage _).expects(conv.id).anyNumberOfTimes().returning(Future.successful(None))
@@ -143,7 +151,15 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
         result(processor.processEvents(conv, isGroup = false, Seq(event))) shouldEqual Set.empty
 
       clock.advance(1.second) //conv will have time EPOCH, needs to be later than that
-      testRound(MemberJoinEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, membersAdded.map(_ -> ConversationRole.AdminRole).toMap))
+      testRound(MemberJoinEvent(
+        conv.remoteId,
+        None,
+        RemoteInstant(clock.instant()),
+        sender,
+        None,
+        membersAdded,
+        membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
+      ))
       clock.advance(1.second)
       testRound(MemberLeaveEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, reason = None))
       clock.advance(1.second)

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -262,7 +262,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (users.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(Option(SyncId())))
+      (users.syncUsers _).expects(Set(otherUser.id), *).returning(Future.successful(Option(SyncId())))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
@@ -340,7 +340,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (users.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
+    (users.syncUsers _).expects(*, *).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -129,7 +129,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   (errors.onErrorDismissed _).expects(*).anyNumberOfTimes().returning(CancellableFuture.successful(()))
 
   (sync.syncTeam _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
-  (userService.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Option(SyncId())))
+  (userService.syncUsers _).expects(*, *).anyNumberOfTimes().returning(Future.successful(Option(SyncId())))
   (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
 
   feature("Archive conversation") {
@@ -152,7 +152,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val events = Seq(
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(selfUserId), reason = None)
       )
-      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(*, *, *).anyNumberOfTimes().returning(Future.successful(None))
 
       // check if the self is still in any conversation (they are - with self)
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
@@ -203,7 +203,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), removerId, Seq(selfUserId), reason = None)
       )
 
-      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(*, *, *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(selfUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)))
       )
@@ -249,7 +249,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(otherUserId), reason = None)
       )
 
-      (userService.syncIfNeeded _).expects(Set(otherUserId), *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(Set(otherUserId), *, *).anyNumberOfTimes().returning(Future.successful(None))
       (membersStorage.getByUsers _).expects(Set(otherUserId)).anyNumberOfTimes().returning(
         Future.successful(IndexedSeq(ConversationMemberData(otherUserId, convId, ConversationRole.MemberRole)))
       )
@@ -603,6 +603,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val creatorId = UserId("bea00721-4af0-4204-82a7-e152c9722ddc")
       val selfId = UserId("0ec303f8-b6dc-4daf-8215-e43f6be22dd8")
       val otherId = UserId("b937e85e-3611-4e29-9bda-6fe39dfd4bd0")
+      val domain = "anta"
       val jsonStr =
         s"""
           |{"access":["invite","code"],
@@ -625,8 +626,8 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
           |     "otr_archived_ref":null
           |   },
           |   "others":[
-          |     {"status":0, "conversation_role":"${ConversationRole.AdminRole.label}", "id":"${creatorId.str}"},
-          |     {"status":0, "conversation_role":"${ConversationRole.MemberRole.label}", "id":"${otherId.str}"}
+          |     {"status":0, "conversation_role":"${ConversationRole.AdminRole.label}", "id":"${creatorId.str}", "qualified_id": { "id": "${creatorId.str}", "domain": "$domain" } },
+          |     {"status":0, "conversation_role":"${ConversationRole.MemberRole.label}", "id":"${otherId.str}", "qualified_id": { "id": "${otherId.str}", "domain": "$domain" } }
           |   ]
           | },
           | "name":"www",
@@ -646,13 +647,13 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       response.creator shouldEqual creatorId
       response.members.size shouldEqual 3
-      response.members.get(creatorId) shouldEqual Some(ConversationRole.AdminRole)
-      response.members.get(selfId) shouldEqual Some(ConversationRole.AdminRole)
-      response.members.get(otherId) shouldEqual Some(ConversationRole.MemberRole)
+      response.members.get(QualifiedId(creatorId, domain)) shouldEqual Some(ConversationRole.AdminRole)
+      response.members.get(QualifiedId(selfId)) shouldEqual Some(ConversationRole.AdminRole)
+      response.members.get(QualifiedId(otherId, domain)) shouldEqual Some(ConversationRole.MemberRole)
     }
 
     scenario("updateConversationsWithDeviceStartMessage happy path") {
-
+      val domain = "anta"
       val rConvId = RConvId("conv")
       val from = UserId("User1")
       val convId = ConvId(rConvId.str)
@@ -671,7 +672,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         None,
         None,
         None,
-        Map(account1Id -> AdminRole, from -> AdminRole),
+        Map(QualifiedId(account1Id, domain) -> AdminRole, QualifiedId(from, domain) -> AdminRole),
         None
       )
 
@@ -693,7 +694,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         Future.successful(userIds.map(uId => ConversationMemberData(uId, convId, AdminRole)).toIndexedSeq)
       }
 
-      (userService.syncIfNeeded _).expects(*, *).returning(Future.successful(Option(SyncId())))
+      (userService.syncIfNeeded _).expects(*, *, *).returning(Future.successful(Option(SyncId())))
 
       (messages.addDeviceStartMessages _).expects(*, *).onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
         convs.headOption.flatMap(_.name) should be (Some(Name("conv")))
@@ -877,7 +878,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (membersStorage.getByConv _).expects(convId).anyNumberOfTimes().onCall { _: ConvId => members.head }
       (membersStorage.onChanged _).expects().anyNumberOfTimes().onCall(_ => EventStream.from(membersOnChanged))
       (userService.userNames _).expects().anyNumberOfTimes().returning(Signal.const(userNames))
-      (userService.syncIfNeeded _).expects(*, *).anyNumberOfTimes().returning(Future.successful(None))
+      (userService.syncIfNeeded _).expects(*, *, *).anyNumberOfTimes().returning(Future.successful(None))
       (content.convByRemoteId _).expects(rConvId).anyNumberOfTimes().returning(convSignal.head)
       (membersStorage.remove(_: ConvId, _:Iterable[UserId])).expects(convId, *).anyNumberOfTimes().onCall { (_: ConvId, userIds: Iterable[UserId]) =>
         members.head.map { ms =>

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -658,6 +658,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val convId = ConvId(rConvId.str)
       val response = ConversationResponse(
         rConvId,
+        None,
         Some(Name("conv")),
         from,
         ConversationType.Group,

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -529,7 +529,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     scenario("Group creation events") {
       val generatedMessageId = MessageId()
       val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
-        rConvId, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
+        rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
         Map(account1Id -> MemberRole, from -> AdminRole), None
       ))

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -527,11 +527,12 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   feature ("Conversation state events") {
 
     scenario("Group creation events") {
+      val domain = "anta"
       val generatedMessageId = MessageId()
       val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
         rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
-        Map(account1Id -> MemberRole, from -> AdminRole), None
+        Map(QualifiedId(account1Id, domain) -> MemberRole, QualifiedId(from, domain) -> AdminRole), None
       ))
 
       val memberJoinMsg = MessageData(

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -138,7 +138,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val syncId1 = SyncId("syncId1")
 
       (userService.syncIfNeeded _)
-        .expects(Set(user1, user2), *)
+        .expects(Set(user1, user2), *, *)
         .once()
         .returning(Future.successful(Some(syncId1)))
 


### PR DESCRIPTION
- [x] A new field 'domain' in ConversationData
- [x] Retrieve conversation data from the new endpoint, together with the domain
- [x] Parse member-join events for conversations started on federated backends
#### APK
[Download build #3714](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3714/artifact/build/artifact/wire-dev-PR3406-3714.apk)
[Download build #3715](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3715/artifact/build/artifact/wire-dev-PR3406-3715.apk)
[Download build #3718](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3718/artifact/build/artifact/wire-dev-PR3406-3718.apk)
[Download build #3722](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3722/artifact/build/artifact/wire-dev-PR3406-3722.apk)
[Download build #3726](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3726/artifact/build/artifact/wire-dev-PR3406-3726.apk)