### PR TITLE
[Calling]: Large conference calls - Bugfix : Extra self tile in 1:1 calls

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -109,7 +109,6 @@ class CallingGridFragment extends FragmentHelper {
 
           val startIndex = pageNumber * MAX_PARTICIPANTS_PER_PAGE
           val endIndex = startIndex + MAX_PARTICIPANTS_PER_PAGE
-          var participantsToShow = participants.slice(startIndex, endIndex).toSeq
 
           val participantsToShow = (participants.slice(startIndex, endIndex), size) match {
             case (ps, 2) => ps.filter(_.clientId != selfClientId)

--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -100,15 +100,20 @@ class CallingGridFragment extends FragmentHelper {
       Signal.zip(
         participantsData,
         callController.isFullScreenEnabled,
-        callController.showTopSpeakers
+        callController.showTopSpeakers,
+        callController.allParticipants.map(_.size)
       ).foreach {
-        case ((selfUserId, selfClientId, participantsInfo, participants, activeParticipants), false, true) =>
+        case ((selfUserId, selfClientId, participantsInfo, participants, activeParticipants), false, true, _) =>
           refreshVideoGrid(grid, selfUserId, selfClientId, activeParticipants, participantsInfo, participants, true)
-        case ((selfUserId, selfClientId, participantsInfo, participants, _), false, false) =>
+        case ((selfUserId, selfClientId, participantsInfo, participants, _), false, false, size) =>
 
           val startIndex = pageNumber * MAX_PARTICIPANTS_PER_PAGE
           val endIndex = startIndex + MAX_PARTICIPANTS_PER_PAGE
-          val participantsToShow = participants.slice(startIndex, endIndex).toSeq
+          var participantsToShow = participants.slice(startIndex, endIndex).toSeq
+
+          if (size == 2) participantsToShow = participantsToShow
+            .filter(_.userId != selfUserId)
+            .filter(_.clientId != selfClientId)
 
           refreshVideoGrid(grid, selfUserId, selfClientId, participantsToShow, participantsInfo, participants, false)
         case _ =>

--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -111,9 +111,12 @@ class CallingGridFragment extends FragmentHelper {
           val endIndex = startIndex + MAX_PARTICIPANTS_PER_PAGE
           var participantsToShow = participants.slice(startIndex, endIndex).toSeq
 
-          if (size == 2) participantsToShow = participantsToShow.filter(_.clientId != selfClientId)
+          val participantsToShow = (participants.slice(startIndex, endIndex), size) match {
+            case (ps, 2) => ps.filter(_.clientId != selfClientId)
+            case (ps, _) => ps
+          }
 
-          refreshVideoGrid(grid, selfUserId, selfClientId, participantsToShow, participantsInfo, participants, false)
+          refreshVideoGrid(grid, selfUserId, selfClientId, participantsToShow.toSeq, participantsInfo, participants, false)
         case _ =>
       }
     }

--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -111,9 +111,7 @@ class CallingGridFragment extends FragmentHelper {
           val endIndex = startIndex + MAX_PARTICIPANTS_PER_PAGE
           var participantsToShow = participants.slice(startIndex, endIndex).toSeq
 
-          if (size == 2) participantsToShow = participantsToShow
-            .filter(_.userId != selfUserId)
-            .filter(_.clientId != selfClientId)
+          if (size == 2) participantsToShow = participantsToShow.filter(_.clientId != selfClientId)
 
           refreshVideoGrid(grid, selfUserId, selfClientId, participantsToShow, participantsInfo, participants, false)
         case _ =>

--- a/app/src/main/scala/com/waz/zclient/calling/NewCallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/NewCallingFragment.scala
@@ -171,8 +171,6 @@ class NewCallingFragment extends FragmentHelper {
 
   private def showFloatingSelfPreview(selfVideoView: UserVideoView, cardView: CardView): Unit = {
     verbose(l"Showing card preview")
-    // Todo: find a solution to remove the selfVideoPreview from from CallingGridFragment
-    // grid.removeView(selfVideoView)
     selfVideoView.setLayoutParams(
       new FrameLayout.LayoutParams(
         ViewGroup.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
## What's new in this PR?

This PR fixes an UI caused by large video conference calls implementation :  I mute myself, on 1-1 call, an extra tile appears.

https://wearezeta.atlassian.net/browse/SQCALL-346

#### APK
[Download build #3724](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3724/artifact/build/artifact/wire-dev-PR3410-3724.apk)
[Download build #3738](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3738/artifact/build/artifact/wire-dev-PR3410-3738.apk)
[Download build #3739](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3739/artifact/build/artifact/wire-dev-PR3410-3739.apk)
[Download build #3740](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3740/artifact/build/artifact/wire-dev-PR3410-3740.apk)