### PR TITLE
fix: conversation-join deep link doesn't work

### DIFF
--- a/app/src/main/scala/com/waz/zclient/deeplinks/DeepLink.scala
+++ b/app/src/main/scala/com/waz/zclient/deeplinks/DeepLink.scala
@@ -48,7 +48,7 @@ object DeepLink extends DerivedLogTag {
 
   case class RawToken(value: String) extends AnyVal
 
-  def getAll: Seq[DeepLink] = Seq(SSOLogin, User, Conversation, JoinConversation, Access)
+  def getAll: Seq[DeepLink] = Seq(SSOLogin, User, JoinConversation, Conversation, Access)
 }
 
 object DeepLinkParser {
@@ -68,21 +68,30 @@ object DeepLinkParser {
 
   def isDeepLink(str: String): Boolean = str.startsWith(s"$Scheme://")
 
-  def parseLink(str: String): Option[(DeepLink, RawToken)] = {
+  def parseLink(str: String): Option[(DeepLink, RawToken)] =
     getAll.view
       .map { link =>
-        val prefix = s"$Scheme://${hostBy(link)}/"
+        val prefix = s"$Scheme://${hostBy(link)}"
         if (str.length > prefix.length && str.startsWith(prefix))
           Some(link -> rawToken(link, str, prefix))
         else
           None
       }
       .collectFirst { case Some(res) => res }
-  }
 
   private def rawToken(link: DeepLink, str: String, prefix: String): RawToken = link match {
-    case JoinConversation => RawToken(str)
-    case _                => RawToken(str.substring(prefix.length))
+    case JoinConversation =>
+      RawToken(str)
+    case _ =>
+      val tokenStr = str.substring(prefix.length).trim
+      RawToken(
+        if (tokenStr.startsWith("/?"))
+          tokenStr.substring(2)
+        else if (tokenStr.startsWith("?") || tokenStr.startsWith("/"))
+          tokenStr.substring(1)
+        else
+          tokenStr
+      )
   }
 
   def parseToken(link: DeepLink, raw: RawToken): Option[Token] = link match {

--- a/app/src/test/scala/com/waz/zclient/deeplinks/DeepLinkParserTest.scala
+++ b/app/src/test/scala/com/waz/zclient/deeplinks/DeepLinkParserTest.scala
@@ -33,6 +33,18 @@ class DeepLinkParserTest extends JUnitSuite {
   }
 
   @Test
+  def parseLink_conversation_returnsJoinConversationDeepLink(): Unit = {
+    val key = "0q1VerOvOmu33z6Zrej4"
+    val code = "WHQicv4TurzL64K-tEZs"
+    val deepLink = s"wire://conversation-join?key=$key&code=$code"
+
+    val parsedLink = DeepLinkParser.parseLink(deepLink)
+
+    val expectedToken = RawToken(deepLink) // JoinConversation should have the whole like as the token
+    assert(parsedLink.contains((DeepLink.JoinConversation, expectedToken)))
+  }
+
+  @Test
   def parseLink_user_returnsUserDeepLink(): Unit = {
     val userId = "test-user-id-1234"
     val deepLink = s"wire://user/$userId"
@@ -46,11 +58,11 @@ class DeepLinkParserTest extends JUnitSuite {
   @Test
   def parseLink_customBackend_returnsAccessDeepLink(): Unit = {
     val customBackendUrl = "test-url"
-    val deepLink = s"wire://access/?config=$customBackendUrl"
+    val deepLink = s"wire://access?config=$customBackendUrl"
 
     val parsedLink = DeepLinkParser.parseLink(deepLink)
 
-    val expectedToken = RawToken(s"?config=$customBackendUrl")
+    val expectedToken = RawToken(s"config=$customBackendUrl")
     assert(parsedLink.contains((DeepLink.Access, expectedToken)))
   }
 


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-638

The problem was that on Android we expected the deep link with the format
wire://conversation-join/?key=key&code=code
And on other platforms it's
wire://conversation-join?key=key&code=code
without the slash / after conversation-join

We needed that / to properly parse the deep link. I made some quick changes to make it work.
It would be nice to write it better in the future.

#### APK
[Download build #3735](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3735/artifact/build/artifact/wire-dev-PR3413-3735.apk)