### PR TITLE
fix: A bug in syncing conversations after the Federation feature is merged

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -96,10 +96,12 @@ class ConversationsClientImpl(implicit
   }
 
   override def loadQualifiedConversations(start: Option[RConvQualifiedId] = None, limit: Int = ConversationsPageSize): ErrorOrResponse[ConversationsResult] = {
+    val jsonBody = Json("size" -> limit)
+    start.foreach(startId => jsonBody.put("start_id", RConvQualifiedId.Encoder(startId)))
     Request
       .Post(
         relativePath = ListConversationsPath,
-        queryParameters = queryParameters("size" -> limit, "start_id" -> start)
+        body = jsonBody
       )
       .withResultType[ConversationsResult]
       .withErrorType[ErrorResponse]


### PR DESCRIPTION
We switched the endpoint for syncing conversations and the new one is handled a bit differently:
POST instead of GET and "body" instead of "queryParameters".

#### APK
[Download build #3741](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3741/artifact/build/artifact/wire-dev-PR3415-3741.apk)