### PR TITLE
fix: The user can create a conversation with another user that blocked them

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ConversationController.scala
@@ -393,18 +393,17 @@ class ConversationController(implicit injector: Injector, context: Context)
                              ): Future[ConversationData] = for {
     convsUi   <- convsUi.head
     _         <- inject[FolderStateController].update(Folder.GroupId, isExpanded = true)
-    (conv, _) <- convsUi.createGroupConversation(name, userIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
+    (conv, _) <- convsUi.createGroupConversation(Some(name), userIds, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
-  def createConvWithFederatedUser(name:         Name,
-                                  qId:          QualifiedId,
+  def createConvWithFederatedUser(qId:          QualifiedId,
                                   teamOnly:     Boolean,
                                   readReceipts: Boolean,
                                   defaultRole:  ConversationRole = ConversationRole.MemberRole
                                  ): Future[ConversationData] = for {
     convsUi   <- convsUi.head
     _         <- inject[FolderStateController].update(Folder.GroupId, isExpanded = true)
-    (conv, _) <- convsUi.createConvWithFederatedUser(name, qId, teamOnly, if (readReceipts) 1 else 0, defaultRole)
+    (conv, _) <- convsUi.createConvWithFederatedUser(qId, teamOnly, if (readReceipts) 1 else 0, defaultRole)
   } yield conv
 
   def withCurrentConvName(callback: Callback[String]): Unit = currentConvName.head.map(_.str).foreach(callback.callback)(Threading.Ui)

--- a/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/pages/main/MainPhoneFragment.scala
@@ -427,7 +427,7 @@ class MainPhoneFragment extends FragmentHelper
         case CANNOT_ADD_UNCONNECTED_USER_TO_CONVERSATION =>
           if (error.users.size == 1)
             usersController.user(error.users.head).head
-              .map(getString(R.string.in_app_notification__sync_error__add_user__body, _))
+              .map(user => getString(R.string.in_app_notification__sync_error__add_user__body, user.name.str))
           else
             Future.successful(getString(R.string.in_app_notification__sync_error__add_multiple_user__body))
         case CANNOT_CREATE_GROUP_CONVERSATION_WITH_UNCONNECTED_USER =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SendConnectRequestFragment.scala
@@ -34,7 +34,7 @@ class SendConnectRequestFragment extends UntabbedRequestFragment {
         Some(user)  <- userToConnect
         isFederated <- usersCtrl.isFederated(user)
         conv        <- (isFederated, user.qualifiedId) match {
-                         case (true, Some(qId)) => convCtrl.createConvWithFederatedUser(user.name, qId, false, false).map(Option(_))
+                         case (true, Some(qId)) => convCtrl.createConvWithFederatedUser(qId, false, false).map(Option(_))
                          case _                 => usersCtrl.connectToUser(user.id)
                        }
         _           <- conv.fold(

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -24,7 +24,7 @@ import android.widget.TextView
 import androidx.annotation.Nullable
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.google.android.material.tabs.TabLayout
-import com.waz.model.UserField
+import com.waz.model.{ConversationRole, UserField}
 import com.waz.service.ZMessaging
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
@@ -166,7 +166,7 @@ class SingleParticipantFragment extends FragmentHelper {
           participantsController.otherParticipant.map(_.fields),
           timerText,
           readReceipts,
-          participantsController.participants.map(_(userId)),
+          participantsController.participants.map(_.getOrElse(userId, ConversationRole.MemberRole)),
           participantsController.selfRole
         ).onUi {
           case (fields, tt, rr, pRole, sRole) if isTeamTheSame =>

--- a/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MembersStorage.scala
@@ -18,7 +18,6 @@
 package com.waz.content
 
 import android.content.Context
-import com.waz.api.Message
 import com.waz.log.BasicLogging.LogTag
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationMemberData.ConversationMemberDataDao
@@ -27,7 +26,6 @@ import com.waz.utils.TrimmingLruCache.Fixed
 import com.wire.signals.{AggregatingSignal, Signal}
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 trait MembersStorage extends CachedStorage[(UserId, ConvId), ConversationMemberData] {
@@ -97,8 +95,13 @@ final class MembersStorageImpl(context: Context, storage: ZmsDatabase)
   override def updateOrCreateAll(conv: ConvId, user: UserId, role: ConversationRole): Future[Option[ConversationMemberData]] =
     updateOrCreateAll(conv, Map(user -> role)).map(_.headOption)
 
-  override def remove(conv: ConvId, users: Iterable[UserId]): Future[Set[ConversationMemberData]] =
-    getAll(users.map(_ -> conv)).flatMap(toBeRemoved => removeAll(users.map(_ -> conv)).map(_ => toBeRemoved.flatten.toSet))
+  override def remove(conv: ConvId, users: Iterable[UserId]): Future[Set[ConversationMemberData]] = {
+    val keys = users.map(_ -> conv)
+    for {
+      toBeRemoved <- getAll(keys)
+      _           <- removeAll(keys)
+    } yield toBeRemoved.flatten.toSet
+  }
 
   override def remove(conv: ConvId, user: UserId): Future[Option[ConversationMemberData]] =
     remove(conv, Set(user)).map(_.headOption)

--- a/zmessaging/src/main/scala/com/waz/service/IntegrationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/IntegrationsService.scala
@@ -88,10 +88,10 @@ class IntegrationsServiceImpl(selfUserId:   UserId,
       }.toSeq
   }
 
-  override def getOrCreateConvWithService(pId: ProviderId, serviceId: IntegrationId) = {
-    def createConv =
+  override def getOrCreateConvWithService(pId: ProviderId, serviceId: IntegrationId): ErrorOr[ConvId] = {
+    def createConv: ErrorOr[ConvId] =
       for {
-        (conv, syncId) <- convsUi.createGroupConversation(Name.Empty)
+        (conv, syncId) <- convsUi.createGroupConversation(None)
         res <- syncRequests.await(syncId).flatMap {
           case Success =>
             for {
@@ -127,7 +127,7 @@ class IntegrationsServiceImpl(selfUserId:   UserId,
   }
 
   // pId here is redundant - we can take it from our 'integrations' map
-  override def addBotToConversation(cId: ConvId, pId: ProviderId, iId: IntegrationId) =
+  override def addBotToConversation(cId: ConvId, pId: ProviderId, iId: IntegrationId): ErrorOr[Unit] =
     (for {
       syncId <- sync.postAddBot(cId, pId, iId)
       result <- syncRequests.await(syncId)
@@ -137,7 +137,7 @@ class IntegrationsServiceImpl(selfUserId:   UserId,
       case _              => Left(internalError("Await should not have completed with SyncResult.Retry"))
     }
 
-  override def removeBotFromConversation(cId: ConvId, botId: UserId) =
+  override def removeBotFromConversation(cId: ConvId, botId: UserId): ErrorOr[Unit] =
     (for {
       syncId <- sync.postRemoveBot(cId, botId)
       result <- syncRequests.await(syncId)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -51,18 +51,17 @@ trait ConversationsContentUpdater {
   def updateConversationState(id: ConvId, state: ConversationState): Future[Option[(ConversationData, ConversationData)]]
   def updateAccessMode(id: ConvId, access: Set[Access], accessRole: Option[AccessRole], link: Option[ConversationData.Link] = None): Future[Option[(ConversationData, ConversationData)]]
 
-  def createConversationWithMembers(convId:      ConvId,
-                                    remoteId:    RConvId,
-                                    convType:    ConversationType,
-                                    creator:     UserId,
-                                    members:     Set[UserId],
-                                    defaultRole: ConversationRole,
-                                    name:        Option[Name],
-                                    hidden:      Boolean = false,
-                                    access:      Set[Access] = Set(Access.PRIVATE),
-                                    accessRole:  AccessRole = AccessRole.PRIVATE,
-                                    receiptMode: Int = 0
-                                   ): Future[ConversationData]
+  def createConversation(convId:      ConvId,
+                         remoteId:    RConvId,
+                         convType:    ConversationType,
+                         creator:     UserId,
+                         defaultRole: ConversationRole,
+                         name:        Option[Name],
+                         hidden:      Boolean = false,
+                         access:      Set[Access] = Set(Access.PRIVATE),
+                         accessRole:  AccessRole = AccessRole.PRIVATE,
+                         receiptMode: Int = 0
+                        ): Future[ConversationData]
 }
 
 class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
@@ -169,18 +168,17 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
 
   override def setConversationHidden(id: ConvId, hidden: Boolean) = storage.update(id, _.copy(hidden = hidden))
 
-  override def createConversationWithMembers(convId:      ConvId,
-                                             remoteId:    RConvId,
-                                             convType:    ConversationType,
-                                             creator:     UserId,
-                                             members:     Set[UserId],
-                                             defaultRole: ConversationRole,
-                                             name:        Option[Name],
-                                             hidden:      Boolean = false,
-                                             access:      Set[Access] = Set(Access.PRIVATE),
-                                             accessRole:  AccessRole = AccessRole.PRIVATE,
-                                             receiptMode: Int = 0
-                                            ): Future[ConversationData] =
+  override def createConversation(convId:      ConvId,
+                                  remoteId:    RConvId,
+                                  convType:    ConversationType,
+                                  creator:     UserId,
+                                  defaultRole: ConversationRole,
+                                  name:        Option[Name],
+                                  hidden:      Boolean = false,
+                                  access:      Set[Access] = Set(Access.PRIVATE),
+                                  accessRole:  AccessRole = AccessRole.PRIVATE,
+                                  receiptMode: Int = 0
+                                 ): Future[ConversationData] =
     for {
       conv <- storage.insert(
         ConversationData(
@@ -195,7 +193,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
           accessRole    = Some(accessRole),
           receiptMode   = Some(receiptMode)
         ))
-      _  <- membersStorage.updateOrCreateAll(convId, Map(creator -> ConversationRole.AdminRole) ++ members.map(_ -> defaultRole))
+      _  <- membersStorage.updateOrCreate(convId, creator, ConversationRole.AdminRole)
     } yield conv
 
   override def hideIncomingConversation(user: UserId) = storage.update(ConvId(user.str), { conv =>

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -462,13 +462,15 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val conv = ConversationData(team = Some(teamId), name = Some(convName))
       val syncId = SyncId()
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set.empty[UserId], *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, Set.empty[UserId], *, *, *).once().returning(Future.successful(()))
+      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
       (sync.postConversation _).expects(*, Set.empty[UserId], Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (userService.findUsers _).expects(Seq.empty).once().returning(Future.successful(Seq.empty))
+      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
+      (userService.findUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
+      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
 
       val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = convName, defaultRole = ConversationRole.MemberRole))
+      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), defaultRole = ConversationRole.MemberRole))
       data shouldEqual conv
       sId shouldEqual syncId
     }
@@ -478,19 +480,37 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val convName = Name("conv")
       val conv = ConversationData(team = Some(teamId), name = Some(convName))
       val syncId = SyncId()
-      val self = UserData(selfUserId.str)
+
       val user1 = UserData("user1")
       val user2 = UserData("user2")
-      val users = Set(self, user1, user2)
+      val users = Set(user1, user2)
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, users.map(_.id), *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, users.map(_.id), *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, users.map(_.id), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (userService.findUsers _).expects(Seq(self.id, user1.id, user2.id)).once().returning(Future.successful(Seq(Some(self), Some(user1), Some(user2))))
-      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().returning(Future.successful(false))
+      val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+      val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
+
+      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId/*, users.map(_.id)*/, *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
+      (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
+      (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
+      (userService.findUsers _).expects(Seq(user1.id, user2.id)).once().returning(Future.successful(Seq(Some(user1), Some(user2))))
+      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+      (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
+      (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
+        .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
+        .once()
+        .returning(Future.successful(Set(member1, member2)))
+      (messages.addMemberJoinMessage _)
+        .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
+        .once()
+        .returning(Future.successful(None))
+      (sync.postConversationMemberJoin _)
+        .expects(conv.id, Set(user1.id, user2.id), *)
+        .once()
+        .returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
+      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
       data shouldEqual conv
       sId shouldEqual syncId
     }
@@ -511,9 +531,10 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
       val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
+      (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
       (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
         Future.successful {
           userIds.map { id =>
@@ -542,7 +563,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
+      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
       data shouldEqual conv
       sId shouldEqual syncId
     }
@@ -556,13 +577,14 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
       val user1 = UserData("user1").copy(domain = Some(domain))
       val user2 = UserData("user2").copy(domain = Some(domain))
-      val users = Set(self, user1, user2)
+
       val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
       val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
-      (content.createConversationWithMembers _).expects(*, *, ConversationType.Group, selfUserId, Set(selfUserId), *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, Set(selfUserId), *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, Set(selfUserId), Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
+      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
+      (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
       (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
         Future.successful {
           userIds.map { id =>
@@ -591,7 +613,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(SyncId()))
 
       val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = convName, members = users.map(_.id), defaultRole = ConversationRole.MemberRole))
+      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
       data shouldEqual conv
       sId shouldEqual syncId
     }


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQCORE-646

It's also a simplification of how group and fake 1-to-1 conversations are created. From now on, a group conversation
will be created only with the author as the initial participant, and all others will be added separately.
This way it's much easier to control what happens if the conversation creation failed or when adding a user failed.
#### APK
[Download build #3743](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3743/artifact/build/artifact/wire-dev-PR3416-3743.apk)