### PR TITLE
Display full exception when exceptions happen during tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id(ScriptPlugins.variants)
     id(ScriptPlugins.quality)
     id(ScriptPlugins.compilation)
+    id(ScriptPlugins.testing)
 }
 
 android {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,6 +35,7 @@ object ScriptPlugins {
     const val variants = "scripts.variants"
     const val quality = "scripts.quality"
     const val compilation = "scripts.compilation"
+    const val testing = "scripts.testing"
 }
 
 object Repositories {

--- a/buildSrc/src/main/kotlin/scripts/testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/testing.gradle.kts
@@ -1,0 +1,11 @@
+package scripts
+
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.kotlin.dsl.withType
+
+tasks.withType(Test::class) {
+    testLogging {
+        exceptionFormat = TestExceptionFormat.FULL
+    }
+}


### PR DESCRIPTION
When running `./gradlew :app:testDebugUnitTests` for example, and an exception happens, this is what we get in return:

```
com.wire.android.feature.profile.ui.ProfileViewModelTest > given fetchProfileInfo called & curr user is fetched, when getUserTeamUC fails w NotATeamUser, then propagates null team name FAILED

    io.mockk.MockKException at ProfileViewModelTest.kt:75

```

Many times this lacks more useful information (like the exception message), especially useful when checking the results on Jenkins.

By enabling full exception format, we get this:

```
com.wire.android.feature.profile.ui.ProfileViewModelTest > given fetchProfileInfo called & curr user is fetched, when getUserTeamUC fails w NotATeamUser, then propagates null team name FAILED
    io.mockk.MockKException: Failed matching mocking signature for
    SignedCall(retValue=, isRetValueMock=true, retType=class kotlin.Any, self=GetCurrentUserUseCase(getCurrentUserUseCase#118), method=run(Unit, Continuation), args=[kotlin.Unit, Continuation at com.wire.android.feature.profile.ui.ProfileViewModelTest$given fetchProfileInfo called & curr user is fetched, when getUserTeamUC fails w NotATeamUser, then propagates null team name$1.invokeSuspend(ProfileViewModelTest.kt:75)], invocationStr=GetCurrentUserUseCase(getCurrentUserUseCase#118).run(kotlin.Unit, continuation {}))
    left matchers: [any()]
        at io.mockk.impl.recording.SignatureMatcherDetector.detect(SignatureMatcherDetector.kt:99)
        at io.mockk.impl.recording.states.RecordingState.signMatchers(RecordingState.kt:39)
        at io.mockk.impl.recording.states.RecordingState.round(RecordingState.kt:31)
        at io.mockk.impl.recording.CommonCallRecorder.round(CommonCallRecorder.kt:50)
        at io.mockk.impl.eval.RecordedBlockEvaluator.record(RecordedBlockEvaluator.kt:59)
        at io.mockk.impl.eval.EveryBlockEvaluator.every(EveryBlockEvaluator.kt:30)
        at io.mockk.MockKDsl.internalCoEvery(API.kt:98)
        at io.mockk.MockKKt.coEvery(MockK.kt:116)
        at com.wire.android.feature.profile.ui.ProfileViewModelTest.given fetchProfileInfo called & curr user is fetched, when getUserTeamUC fails w NotATeamUser, then propagates null team name(ProfileViewModelTest.kt:75)
```