### PR TITLE
WIP: Add flag for disabling the sending of assets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,7 @@ android {
         buildConfigField 'String',  'COUNTLY_APP_KEY',               "\"$buildtimeConfiguration.configuration.countly_app_key\""
         buildConfigField 'boolean', 'KEEP_WEBSOCKET_ON',             "$buildtimeConfiguration.configuration.keep_websocket_on"
         buildConfigField 'boolean', 'FORCE_CONSTANT_BITRATE_CALLS',  "$buildtimeConfiguration.configuration.force_constant_bitrate_calls"
+        buildConfigField 'boolean', 'ENABLE_ASSET_MESSAGE_SENDING',  "$buildtimeConfiguration.configuration.enable_asset_message_sending"
 
         //Feature Flags
         buildConfigField 'boolean', 'LARGE_VIDEO_CONFERENCE_CALLS', "$largeVideoConferenceCalls"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -925,6 +925,7 @@
     <string name="conversation_toolbar__call_audio">Audio call</string>
 
     <!-- Asset upload errors -->
+    <string name="asset_upload_error__sending_disabled">Sending files is disabled for this app</string>
     <string name="asset_upload_error__not_found__title">File not found</string>
     <string name="asset_upload_error__not_found__message">Unable to retrieve the specified file</string>
     <string name="asset_upload_error__not_found__button">OK</string>

--- a/default.json
+++ b/default.json
@@ -46,5 +46,6 @@
   "countly_server_url": "https://countly.wire.com",
   "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
   "keep_websocket_on": false,
-  "force_constant_bitrate_calls": false
+  "force_constant_bitrate_calls": false,
+  "enable_asset_message_sending": true
 }


### PR DESCRIPTION
## What's new in this PR?

Add flag `enable_asset_message_sending` for disabling the sending of assets

### Testing

Manually tested

## Notes

New string resource, `asset_upload_error__sending_disabled`.

#### APK
[Download build #3744](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3744/artifact/build/artifact/wire-dev-PR3417-3744.apk)