### PR TITLE
fix mismatched NotificationResponse with the API return

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/events/datasource/remote/NotificationApi.kt
+++ b/app/src/main/kotlin/com/wire/android/core/events/datasource/remote/NotificationApi.kt
@@ -7,14 +7,14 @@ import retrofit2.http.Query
 interface NotificationApi {
 
     @GET("$NOTIFICATIONS$LAST")
-    suspend fun lastNotification(@Query(CLIENT_QUERY_KEY) client: String): Response<NotificationPageResponse>
+    suspend fun lastNotification(@Query(CLIENT_QUERY_KEY) client: String): Response<NotificationResponse>
 
     @GET(NOTIFICATIONS)
     suspend fun notificationsByBatch(
         @Query(SIZE_QUERY_KEY) size: Int,
         @Query(CLIENT_QUERY_KEY) client: String,
         @Query(SINCE_QUERY_KEY) since: String
-    ): Response<NotificationResponse>
+    ): Response<NotificationPageResponse>
 
     companion object {
         private const val NOTIFICATIONS = "/notifications"

--- a/app/src/main/kotlin/com/wire/android/core/events/datasource/remote/NotificationRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/core/events/datasource/remote/NotificationRemoteDataSource.kt
@@ -10,7 +10,7 @@ class NotificationRemoteDataSource(
     override val networkHandler: NetworkHandler
 ) : ApiService() {
 
-    suspend fun lastNotification(client: String): Either<Failure, NotificationPageResponse> = request {
+    suspend fun lastNotification(client: String): Either<Failure, NotificationResponse> = request {
         notificationApi.lastNotification(client)
     }
 
@@ -18,7 +18,7 @@ class NotificationRemoteDataSource(
         size: Int,
         client: String,
         since: String
-    ): Either<Failure, NotificationResponse> =
+    ): Either<Failure, NotificationPageResponse> =
         request { notificationApi.notificationsByBatch(size, client, since) }
 
 }

--- a/app/src/test/kotlin/com/wire/android/core/events/datasource/remote/NotificationRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/events/datasource/remote/NotificationRemoteDataSourceTest.kt
@@ -41,9 +41,9 @@ class NotificationRemoteDataSourceTest : UnitTest() {
 
     @Test
     fun `given lastNotification is called, when notificationApi returns response, then returns LastNotificationResponse`() {
-        every { notificationPageRetrofitResponse.body() } returns notificationPageResponse
-        every { notificationPageRetrofitResponse.isSuccessful } returns true
-        coEvery { notificationApi.lastNotification(any()) } returns notificationPageRetrofitResponse
+        every { notificationRetrofitResponse.body() } returns notificationResponse
+        every { notificationRetrofitResponse.isSuccessful } returns true
+        coEvery { notificationApi.lastNotification(any()) } returns notificationRetrofitResponse
 
         val result = runBlocking {
             notificationRemoteDataSource.lastNotification(CLIENT_ID)
@@ -55,9 +55,9 @@ class NotificationRemoteDataSourceTest : UnitTest() {
 
     @Test
     fun `given lastNotification is called, when notificationApi returns failure, then returns the failure`() {
-        every { notificationPageRetrofitResponse.body() } returns null
-        every { notificationPageRetrofitResponse.isSuccessful } returns false
-        coEvery { notificationApi.lastNotification(any()) } returns notificationPageRetrofitResponse
+        every { notificationRetrofitResponse.body() } returns null
+        every { notificationRetrofitResponse.isSuccessful } returns false
+        coEvery { notificationApi.lastNotification(any()) } returns notificationRetrofitResponse
 
         val result = runBlocking {
             notificationRemoteDataSource.lastNotification(CLIENT_ID)
@@ -71,9 +71,9 @@ class NotificationRemoteDataSourceTest : UnitTest() {
     fun `given notificationsByBatch is called, when notificationApi returns response, then returns NotificationResponse`() {
         val size = 100
         val since = "15"
-        every { notificationRetrofitResponse.body() } returns notificationResponse
-        every { notificationRetrofitResponse.isSuccessful } returns true
-        coEvery { notificationApi.notificationsByBatch(any(), any(), any()) } returns notificationRetrofitResponse
+        every { notificationPageRetrofitResponse.body() } returns notificationPageResponse
+        every { notificationPageRetrofitResponse.isSuccessful } returns true
+        coEvery { notificationApi.notificationsByBatch(any(), any(), any()) } returns notificationPageRetrofitResponse
 
         val result = runBlocking {
             notificationRemoteDataSource.notificationsByBatch(size, CLIENT_ID, since)
@@ -85,9 +85,9 @@ class NotificationRemoteDataSourceTest : UnitTest() {
 
     @Test
     fun `given notificationsByBatch is called, when notificationApi returns failure, then returns the failure`() {
-        every { notificationRetrofitResponse.body() } returns null
-        every { notificationRetrofitResponse.isSuccessful } returns false
-        coEvery { notificationApi.notificationsByBatch(any(), any(), any()) } returns notificationRetrofitResponse
+        every { notificationPageRetrofitResponse.body() } returns null
+        every { notificationPageRetrofitResponse.isSuccessful } returns false
+        coEvery { notificationApi.notificationsByBatch(any(), any(), any()) } returns notificationPageRetrofitResponse
 
         val result = runBlocking { notificationRemoteDataSource.notificationsByBatch(any(), any(), any()) }
 


### PR DESCRIPTION
In last PR, the return type of `lastNotification()`and `notificationsByBatch()` is switched after renaming `NotificationResponse` and `NotificationPageResponse` classes.
I am fixing that in this PR.