### PR TITLE
trying to make the app more responsive to getting offline/online

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
@@ -93,8 +93,7 @@ class GenericMessageService(selfUserId: UserId,
           buttonConfirmations += msgId -> buttonId
         case dt: DataTransfer if from == selfUserId =>
           newTrackingIds += dt.unpack
-        case unknown =>
-          warn(l"An unknown event content is being processed: $unknown")
+        case _ =>
       }
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -39,8 +39,7 @@ import com.waz.service.tracking.TrackingService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.PushNotificationsClient.LoadNotificationsResult
 import com.waz.sync.client.{PushNotificationEncoded, PushNotificationsClient}
-import com.wire.signals.CancellableFuture.lift
-import com.wire.signals.{CancellableFuture, EventSource, SerialDispatchQueue, Signal, SourceSignal, Serialized}
+import com.wire.signals.{CancellableFuture, SerialDispatchQueue, Signal, SourceSignal, Serialized}
 import com.waz.utils.{RichInstant, _}
 import com.waz.znet2.http.ResponseCode
 import org.json.JSONObject
@@ -266,12 +265,12 @@ class PushServiceImpl(selfUserId:           UserId,
           //OR on a websocket state change
           val retry = Promise[Unit]()
 
-          network.networkMode.onChanged.filter(!NetworkOff.contains(_)).next.map(_ => retry.trySuccess({}))
+          network.isOnline.onTrue.map(_ => retry.trySuccess({}))
           wsPushService.connected.onChanged.next.map(_ => retry.trySuccess({}))
 
           for {
-            _ <- CancellableFuture.delay(syncHistoryBackoff.delay(attempts))
-            _ <- lift(network.networkMode.filter(!NetworkOff.contains(_)).head)
+            _ <- CancellableFuture.delay(syncHistoryBackoff.delay(attempts)).future
+            _ <- network.isOnline.onTrue
           } yield retry.trySuccess({})
 
           retry.future.flatMap { _ => load(lastId, firstSync, attempts + 1) }
@@ -302,8 +301,6 @@ class PushServiceImpl(selfUserId:           UserId,
 }
 
 object PushService {
-  val NetworkOff = Set(UNKNOWN, OFFLINE)
-
   //These are the most important event types that generate push notifications
   val TrackingEvents = Set("conversation.otr-message-add", "conversation.create", "conversation.rename", "conversation.member-join")
 

--- a/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
@@ -178,7 +178,7 @@ class GlobalTokenServiceImpl(googleApi: GoogleApi,
         error(l"Failed action on google APIs, probably due to server connectivity error, will retry again", ex)
         for {
           _ <- CancellableFuture.delay(ResetBackoff.delay(attempts)).future
-          _ <- network.networkMode.filter(_ != NetworkMode.OFFLINE).head
+          _ <- network.isOnline.onTrue
           t <- retry(f, attempts + 1)
         } yield t
     })(_.failed.foreach(throw _))

--- a/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/push/WSPushServiceSpec.scala
@@ -22,6 +22,7 @@ import java.net.URL
 import com.waz.api.impl.ErrorResponse
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{Uid, UserId}
+import com.waz.service.NetworkModeService
 import com.waz.service.push.WSPushServiceImpl.RequestCreator
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.AuthenticationManager.AccessToken
@@ -42,6 +43,7 @@ import scala.concurrent.duration._
   private val accessTokenProvider = mock[AccessTokenProvider]
   private val webSocketFactory = mock[WebSocketFactory]
   private val webSocket = mock[WebSocket]
+  private val network = mock[NetworkModeService]
 
   private val accessTokenSuccess = Future.successful(Right(AccessToken("token", "type")))
   private val accessTokenError = Future.successful(Left(ErrorResponse.InternalError))
@@ -54,7 +56,7 @@ import scala.concurrent.duration._
                                   requestCreator:      RequestCreator = _ => httpRequest,
                                   webSocketFactory:    WebSocketFactory = webSocketFactory,
                                   backoff:             Backoff = ExponentialBackoff.constantBackof(100.millis)) = {
-    new WSPushServiceImpl(userId, accessTokenProvider, requestCreator, webSocketFactory, backoff)
+    new WSPushServiceImpl(userId, accessTokenProvider, requestCreator, webSocketFactory, network, backoff)
   }
 
   feature("WSPushService") {


### PR DESCRIPTION
When the app goes offline, we can see in the logs that certain services stil try to contact the backend - they fail, they schdule a retry, and then the retry fails again. It is possible that after a few retries the service will give up and then, when we go online, it won't contact the backend. 

I made a few changes that pause the retries until the app is online, so they don't produce failures and are not counted towards the maximum number of tries before giving up. The direct reason for working on this are these two tickets:
* https://wearezeta.atlassian.net/browse/SQCORE-823
* https://wearezeta.atlassian.net/browse/SQCORE-831

but those bugs (which can be the same bug) are still sometimes present. I hope these changes will at least make them happen less often.


#### APK
[Download build #3756](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3756/artifact/build/artifact/wire-dev-PR3425-3756.apk)