### PR TITLE
File sharing restrictions (part 7)

### DIFF
--- a/app/src/main/res/layout/message_image_content.xml
+++ b/app/src/main/res/layout/message_image_content.xml
@@ -18,9 +18,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-       android:layout_width="match_parent"
-       android:layout_height="match_parent"
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     >
 
     <FrameLayout
@@ -80,14 +82,15 @@
                     android:textColor="?wirePrimaryTextColor"
                     android:textSize="@dimen/wire__icon_button__text_size"/>
 
-                <TextView
+                <com.waz.zclient.ui.text.TypefaceTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:gravity="center"
                     android:text="@string/file_sharing_restriction_info_image"
                     android:textColor="?wireSecondaryTextColor"
-                    android:textSize="@dimen/wire__text_size__small"/>
+                    android:textSize="@dimen/wire__text_size__small"
+                    app:w_font="@string/wire__typeface__light"/>
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/message_reply_content_image.xml
+++ b/app/src/main/res/layout/message_reply_content_image.xml
@@ -20,16 +20,19 @@
 -->
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/image_container"
     android:layout_width="match_parent"
-    android:layout_height="88dp"
+    android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/wire__padding__8"
     android:layout_marginBottom="@dimen/wire__padding__8">
+
+    <!-- Image -->
 
     <ImageView
         android:id="@+id/image"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="88dp"/>
 
     <com.waz.zclient.ui.text.GlyphTextView
         android:id="@+id/image_icon"
@@ -43,6 +46,50 @@
         android:textSize="@dimen/wire__icon_button__text_size"
         android:visibility="gone"
     />
+
+    <!-- Restriction view -->
+
+    <LinearLayout
+        android:id="@+id/restriction_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="@dimen/wire__padding__8">
+
+            <com.waz.zclient.ui.text.GlyphTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:layout_marginEnd="@dimen/wire__padding__8"
+                android:text="@string/glyph__picture"
+                android:textColor="?wirePrimaryTextColor"
+                android:textSize="@dimen/wire__icon_button__text_size"/>
+
+            <com.waz.zclient.ui.text.TypefaceTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:textColor="?wirePrimaryTextColor"
+                app:w_font="@string/wire__typeface__medium"
+                android:text="@string/reply_message_type_image"/>
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?wireSecondaryTextColor"
+            android:textSize="@dimen/wire__text_size__small"
+            android:text="@string/file_sharing_restriction_info_image"/>
+
+    </LinearLayout>
 
 </FrameLayout>
 

--- a/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
+++ b/app/src/main/scala/com/waz/zclient/conversation/ReplyView.scala
@@ -29,7 +29,6 @@ import com.waz.api.Message.Type
 import com.waz.content.UserPreferences
 import com.waz.model.{AssetId, GeneralAssetId, MessageData}
 import com.waz.service.assets.{Asset, GeneralAsset}
-import com.waz.threading.Threading
 import com.waz.utils.returning
 import com.waz.zclient.conversation.ReplyView.ReplyBackgroundDrawable
 import com.waz.zclient.glide.WireGlide
@@ -42,9 +41,13 @@ import com.waz.zclient.utils.{RichTextView, RichView}
 import com.waz.zclient.{R, ViewHelper}
 import com.wire.signals.Signal
 
+import scala.concurrent.Future
+
 class ReplyView(context: Context, attrs: AttributeSet, defStyle: Int) extends FrameLayout(context, attrs, defStyle) with ViewHelper {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) = this(context, null, 0)
+
+  import com.waz.threading.Threading.Implicits.Ui
 
   inflate(R.layout.reply_view)
 
@@ -57,9 +60,10 @@ class ReplyView(context: Context, attrs: AttributeSet, defStyle: Int) extends Fr
   private var onClose: () => Unit = () => {}
 
   private lazy val userPrefs = inject[Signal[UserPreferences]]
-  lazy val isFileSharingRestricted: Signal[Boolean] = userPrefs
-    .flatMap(_.preference(UserPreferences.FileSharingFeatureEnabled).signal)
-    .map(isEnabled => !isEnabled)
+  private def isFileSharingRestricted: Future[Boolean] =
+    userPrefs.head
+      .flatMap(_.preference(UserPreferences.FileSharingFeatureEnabled).apply())
+      .map(isEnabled => !isEnabled)
 
   closeButton.onClick(onClose())
 
@@ -113,7 +117,7 @@ class ReplyView(context: Context, attrs: AttributeSet, defStyle: Int) extends Fr
     }
     setStartIcon(drawMethod)
 
-    isFileSharingRestricted.head.foreach { isRestricted =>
+    isFileSharingRestricted.foreach { isRestricted =>
       imageAsset match {
         case Some(a: AssetId) if !isRestricted =>
           WireGlide(context)
@@ -125,7 +129,7 @@ class ReplyView(context: Context, attrs: AttributeSet, defStyle: Int) extends Fr
           WireGlide(context).clear(image)
           image.setVisibility(View.GONE)
       }
-    }(Threading.Ui)
+    }
   }
 
   private def setStartIcon(drawMethod: Option[(Canvas, RectF, ResizingBehavior, Int) => Unit]): Unit =


### PR DESCRIPTION
## What's new in this PR?

**Jira:** https://wearezeta.atlassian.net/browse/SQSERVICES-612

In this PR we restrict image content in both the reply view (in the input cursor) and reply message view (in the conversation content). For the former, this means to hide the little image preview, and for the latter, to replace the preview with a restriction label (see screenshot).

Additionally, I fixed the some layout from the previous PR (I forgot to set the typeface of a text view). 

### Testing

Manually tested.

## Notes

![Wire 2021-08-12 at 6 03 PM](https://user-images.githubusercontent.com/28632506/129230625-7517c176-89c5-4d37-8e56-d593f26d2496.png)


#### APK
[Download build #3771](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3771/artifact/build/artifact/wire-dev-PR3428-3771.apk)
[Download build #3783](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3783/artifact/build/artifact/wire-dev-PR3428-3783.apk)