### PR TITLE
[Calling]: Large conference calls - Bugfix : Caller profile picture shown after establishing a call

### DIFF
--- a/app/src/main/res/layout/fragment_new_calling.xml
+++ b/app/src/main/res/layout/fragment_new_calling.xml
@@ -82,7 +82,7 @@
         android:elevation="1dp"
         android:visibility="gone"
         app:cardCornerRadius="@dimen/calling_preview_card_radius"
-        app:cardElevation="4dp" />
+         />
 
     <FrameLayout
         android:id="@+id/controls_layout"

--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -232,8 +232,7 @@ class CallingGridFragment extends FragmentHelper {
       }
     }
 
-    if (!participantsToShow.filter(_.clientId == selfClientId).isEmpty)
-      callController.isSelfViewVisible ! true
+    if (participantsToShow.exists(_.clientId == selfClientId)) callController.isSelfViewVisible ! true
     else callController.isSelfViewVisible ! false
 
     participantsToShow.map { participant => viewMap.getOrElse(participant, createView(participant)) }

--- a/app/src/main/scala/com/waz/zclient/calling/NewCallingFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/NewCallingFragment.scala
@@ -151,9 +151,10 @@ class NewCallingFragment extends FragmentHelper {
     Signal.zip(
       callController.selfParticipant,
       callController.showTopSpeakers,
-      callController.allParticipants.map(_.size)
+      callController.allParticipants.map(_.size),
+      callController.isCallEstablished
     ).foreach {
-      case (selfParticipant, showTopSpeakers, participantsCount) =>
+      case (selfParticipant, showTopSpeakers, participantsCount, true) =>
 
         val selfVideoView = new SelfVideoView(getContext, selfParticipant)
 

--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -246,8 +246,9 @@ class CallController(implicit inj: Injector, cxt: WireContext)
 
   val memberForPicture: Signal[Option[UserId]] =
     if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS)
-      Signal.zip(isCallIncoming, videoSendState).flatMap {
-        case (true, VideoState.Started) => Signal.const(None)
+      Signal.zip(isCallEstablished, videoSendState).flatMap {
+        case (true, _) => Signal.const(None)
+        case (false, VideoState.Started) => Signal.const(None)
         case _ => fetchMember()
       }
      else

--- a/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
@@ -70,7 +70,8 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
   protected val participantInfo: Signal[Option[CallParticipantInfo]] =
     for {
       isGroup <- callController.isGroupCall
-      infos   <- if (isGroup) callController.participantsInfo else Signal.const(Vector.empty)
+      infos   <- if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS) callController.participantsInfo
+                 else { if (isGroup) callController.participantsInfo else Signal.const(Vector.empty)}
     } yield infos.find(_.id == participant.userId)
 
   protected val nameTextView = returning(findById[TextView](R.id.name_text_view)) { view =>
@@ -82,8 +83,8 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
   }
 
   if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS) {
-    Signal.zip(participantInfo, callController.isCallIncoming).onUi {
-      case (Some(p), false) if (p.picture.isDefined) => setProfilePicture(p.picture.get)
+    Signal.zip(participantInfo, callController.isCallEstablished).onUi {
+      case (Some(p), true) if (p.picture.isDefined) => setProfilePicture(p.picture.get)
       case _ =>
     }
   }


### PR DESCRIPTION
## What's new in this PR?

This PR fixes a bug caused by the changes related to pre calling UI implemented in #3422 : the caller profile picture is shown after establishing a call on call controls.
#### APK
[Download build #3772](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3772/artifact/build/artifact/wire-dev-PR3429-3772.apk)
[Download build #3778](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3778/artifact/build/artifact/wire-dev-PR3429-3778.apk)