### PR TITLE
Federation: Add the conversation domain and the sender ("from") domain to events

### DIFF
--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/conversations/ConversationsDaoTest.kt
@@ -73,7 +73,8 @@ class ConversationsDaoTest : IntegrationTest() {
                     unreadMentionsCount = it.unreadMentionsCount,
                     unreadQuoteCount = it.unreadQuoteCount,
                     receiptMode = it.receiptMode,
-                    legalHoldStatus = it.legalHoldStatus
+                    legalHoldStatus = it.legalHoldStatus,
+                    domain = it.domain
                 )
             )
         }
@@ -146,7 +147,8 @@ class ConversationsDaoTest : IntegrationTest() {
             unreadMentionsCount = data.unreadMentionsCount,
             unreadQuoteCount = data.unreadQuoteCount,
             receiptMode = data.receiptMode,
-            legalHoldStatus = data.legalHoldStatus
+            legalHoldStatus = data.legalHoldStatus,
+            domain = data.domain
         )
     }
 

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -111,49 +111,49 @@ final case class UnknownConvEvent(json: JSONObject) extends ConversationEvent {
   override val time: RemoteInstant = RemoteInstant.Epoch //TODO: epoch?
 }
 
-final case class CreateConversationEvent(convId: RConvId,
+final case class CreateConversationEvent(convId:     RConvId,
                                          convDomain: Option[String],
-                                         time: RemoteInstant,
-                                         from: UserId,
+                                         time:       RemoteInstant,
+                                         from:       UserId,
                                          fromDomain: Option[String],
-                                         data: ConversationResponse)
+                                         data:       ConversationResponse)
   extends ConversationStateEvent
 
-final case class DeleteConversationEvent(convId: RConvId,
+final case class DeleteConversationEvent(convId:     RConvId,
                                          convDomain: Option[String],
-                                         time: RemoteInstant,
-                                         from: UserId,
+                                         time:       RemoteInstant,
+                                         from:       UserId,
                                          fromDomain: Option[String])
   extends ConversationStateEvent
 
-final case class MessageTimerEvent(convId: RConvId,
+final case class MessageTimerEvent(convId:     RConvId,
                                    convDomain: Option[String],
-                                   time: RemoteInstant,
-                                   from: UserId,
+                                   time:       RemoteInstant,
+                                   from:       UserId,
                                    fromDomain: Option[String],
-                                   duration: Option[FiniteDuration])
+                                   duration:   Option[FiniteDuration])
   extends MessageEvent with ConversationStateEvent
 
-final case class RenameConversationEvent(convId: RConvId,
+final case class RenameConversationEvent(convId:     RConvId,
                                          convDomain: Option[String],
-                                         time: RemoteInstant,
-                                         from: UserId,
+                                         time:       RemoteInstant,
+                                         from:       UserId,
                                          fromDomain: Option[String],
-                                         name: Name)
+                                         name:       Name)
   extends MessageEvent with ConversationStateEvent
 
-final case class GenericMessageEvent(convId: RConvId,
+final case class GenericMessageEvent(convId:     RConvId,
                                      convDomain: Option[String],
-                                     time: RemoteInstant,
-                                     from: UserId,
+                                     time:       RemoteInstant,
+                                     from:       UserId,
                                      fromDomain: Option[String],
-                                     content: GenericMessage)
+                                     content:     GenericMessage)
   extends MessageEvent
 
-final case class CallMessageEvent(convId: RConvId,
+final case class CallMessageEvent(convId:     RConvId,
                                   convDomain: Option[String],
-                                  time: RemoteInstant,
-                                  from: UserId,
+                                  time:       RemoteInstant,
+                                  from:       UserId,
                                   fromDomain: Option[String],
                                   sender: ClientId,
                                   content: String)
@@ -163,9 +163,9 @@ sealed trait OtrError
 
 case object Duplicate extends OtrError
 
-final case class DecryptionError(msg: String,
-                                 code: Option[Int],
-                                 from: UserId,
+final case class DecryptionError(msg:    String,
+                                 code:   Option[Int],
+                                 from:   UserId,
                                  sender: ClientId)
   extends OtrError
 
@@ -173,28 +173,28 @@ final case class IdentityChangedError(from: UserId, sender: ClientId) extends Ot
 
 final case class UnknownOtrErrorEvent(json: JSONObject) extends OtrError
 
-final case class OtrErrorEvent(convId: RConvId,
+final case class OtrErrorEvent(convId:     RConvId,
                                convDomain: Option[String],
-                               time: RemoteInstant,
-                               from: UserId,
+                               time:       RemoteInstant,
+                               from:       UserId,
                                fromDomain: Option[String],
-                               error: OtrError)
+                               error:      OtrError)
   extends MessageEvent
 
-final case class SessionReset(convId: RConvId,
+final case class SessionReset(convId:     RConvId,
                               convDomain: Option[String],
-                              time: RemoteInstant,
-                              from: UserId,
+                              time:       RemoteInstant,
+                              from:       UserId,
                               fromDomain: Option[String],
-                              sender: ClientId)
+                              sender:     ClientId)
   extends MessageEvent
 
-final case class TypingEvent(convId: RConvId,
+final case class TypingEvent(convId:     RConvId,
                              convDomain: Option[String],
-                             time: RemoteInstant,
-                             from: UserId,
+                             time:       RemoteInstant,
+                             from:       UserId,
                              fromDomain: Option[String],
-                             isTyping: Boolean)
+                             isTyping:   Boolean)
   extends ConversationEvent
 
 final case class MemberJoinEvent(convId:     RConvId,
@@ -207,13 +207,13 @@ final case class MemberJoinEvent(convId:     RConvId,
                                  firstEvent: Boolean = false)
   extends MessageEvent with ConversationStateEvent
 
-final case class MemberLeaveEvent(convId: RConvId,
+final case class MemberLeaveEvent(convId:     RConvId,
                                   convDomain: Option[String],
-                                  time: RemoteInstant,
-                                  from: UserId,
+                                  time:       RemoteInstant,
+                                  from:       UserId,
                                   fromDomain: Option[String],
-                                  userIds: Seq[UserId],
-                                  reason: Option[MemberLeaveReason])
+                                  userIds:    Seq[UserId],
+                                  reason:     Option[MemberLeaveReason])
   extends MessageEvent with ConversationStateEvent
 
 final case class MemberLeaveReason(value: String) extends AnyVal
@@ -221,54 +221,54 @@ object MemberLeaveReason {
   val LegalHoldPolicyConflict = MemberLeaveReason("legalhold-policy-conflict")
 }
 
-final case class MemberUpdateEvent(convId: RConvId,
+final case class MemberUpdateEvent(convId:     RConvId,
                                    convDomain: Option[String],
-                                   time: RemoteInstant,
-                                   from: UserId,
+                                   time:       RemoteInstant,
+                                   from:       UserId,
                                    fromDomain: Option[String],
-                                   state: ConversationState)
+                                   state:      ConversationState)
   extends ConversationStateEvent
 
-final case class ConversationReceiptModeEvent(convId: RConvId,
-                                              convDomain: Option[String],
-                                              time: RemoteInstant,
-                                              from: UserId,
-                                              fromDomain: Option[String],
+final case class ConversationReceiptModeEvent(convId:      RConvId,
+                                              convDomain:  Option[String],
+                                              time:        RemoteInstant,
+                                              from:        UserId,
+                                              fromDomain:  Option[String],
                                               receiptMode: Int)
   extends MessageEvent with ConversationStateEvent
 
-final case class ConnectRequestEvent(convId: RConvId,
+final case class ConnectRequestEvent(convId:     RConvId,
                                      convDomain: Option[String],
-                                     time: RemoteInstant,
-                                     from: UserId,
+                                     time:       RemoteInstant,
+                                     from:       UserId,
                                      fromDomain: Option[String],
-                                     message: String,
-                                     recipient: UserId,
-                                     name: Name,
-                                     email: Option[String])
+                                     message:    String,
+                                     recipient:  UserId,
+                                     name:       Name,
+                                     email:      Option[String])
   extends MessageEvent with ConversationStateEvent
 
-final case class ConversationAccessEvent(convId: RConvId,
+final case class ConversationAccessEvent(convId:     RConvId,
                                          convDomain: Option[String],
-                                         time: RemoteInstant,
-                                         from: UserId,
+                                         time:       RemoteInstant,
+                                         from:       UserId,
                                          fromDomain: Option[String],
-                                         access: Set[Access],
+                                         access:     Set[Access],
                                          accessRole: AccessRole)
   extends ConversationStateEvent
 
-final case class ConversationCodeUpdateEvent(convId: RConvId,
+final case class ConversationCodeUpdateEvent(convId:     RConvId,
                                              convDomain: Option[String],
-                                             time: RemoteInstant,
-                                             from: UserId,
+                                             time:       RemoteInstant,
+                                             from:       UserId,
                                              fromDomain: Option[String],
-                                             link: ConversationData.Link)
+                                             link:       ConversationData.Link)
   extends ConversationStateEvent
 
-final case class ConversationCodeDeleteEvent(convId: RConvId,
+final case class ConversationCodeDeleteEvent(convId:     RConvId,
                                              convDomain: Option[String],
-                                             time: RemoteInstant,
-                                             from: UserId,
+                                             time:       RemoteInstant,
+                                             from:       UserId,
                                              fromDomain: Option[String])
   extends ConversationStateEvent
 
@@ -278,14 +278,14 @@ sealed trait OtrEvent extends ConversationEvent {
   val ciphertext: Array[Byte]
 }
 
-final case class OtrMessageEvent(convId: RConvId,
-                                 convDomain: Option[String],
-                                 time: RemoteInstant,
-                                 from: UserId,
-                                 fromDomain: Option[String],
-                                 sender: ClientId,
-                                 recipient: ClientId,
-                                 ciphertext: Array[Byte],
+final case class OtrMessageEvent(convId:       RConvId,
+                                 convDomain:   Option[String],
+                                 time:         RemoteInstant,
+                                 from:         UserId,
+                                 fromDomain:   Option[String],
+                                 sender:       ClientId,
+                                 recipient:    ClientId,
+                                 ciphertext:   Array[Byte],
                                  externalData: Option[Array[Byte]] = None)
   extends OtrEvent
 
@@ -357,7 +357,10 @@ object Event {
   def decodeRConvId(implicit js: JSONObject): (RConvId, Option[String]) =
     RConvQualifiedId.decodeOpt('qualified_conversation)
       .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
-      .getOrElse((RConvId('conversation), None))
+      .getOrElse {
+        if (js.has("convId")) (RConvId('convId), None)
+        else (RConvId('conversation), None)
+      }
 
   def decodeQUserId(implicit js: JSONObject): (UserId, Option[String]) =
     QualifiedId.decodeOpt('qualified_from)
@@ -377,23 +380,21 @@ object Event {
       PushTokenRemoveEvent(token = 'token, senderId = 'app, client = 'client)
 
     override def apply(implicit js: JSONObject): Event = Try {
-      verbose(l"JSN event: ${js.toString(2)}")
-
       decodeString('type) match {
         case tpe if tpe.startsWith("conversation") => ConversationEventDecoder(js)
         case tpe if tpe.startsWith("team")         => TeamEvent.TeamEventDecoder(js)
-        case "user.update" => UserUpdateEvent(JsonDecoder[UserInfo]('user))
-        case "user.identity-remove" => UserUpdateEvent(JsonDecoder[UserInfo]('user), true)
-        case "user.connection" => connectionEvent(js.getJSONObject("connection"), JsonDecoder.opt('user, _.getJSONObject("user")) flatMap (JsonDecoder.decodeOptName('name)(_)))
-        case "user.push-remove" => gcmTokenRemoveEvent(js.getJSONObject("token"))
-        case "user.delete" => UserDeleteEvent(user = 'id)
-        case "user.client-add" => OtrClientAddEvent(OtrClient.ClientsResponse.Decoder(js.getJSONObject("client")))
-        case "user.client-remove" => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
-        case "user.properties-set" => PropertyEvent.Decoder(js)
-        case "user.properties-delete" => PropertyEvent.Decoder(js)
-        case "user.legalhold-request" => LegalHoldRequestEvent(decodeId[UserId]('id), LegalHoldRequest.Decoder(js))
-        case "user.legalhold-enable" => LegalHoldEnableEvent(decodeId[UserId]('id))
-        case "user.legalhold-disable" => LegalHoldDisableEvent(decodeId[UserId]('id))
+        case "user.update"                         => UserUpdateEvent(JsonDecoder[UserInfo]('user))
+        case "user.identity-remove"                => UserUpdateEvent(JsonDecoder[UserInfo]('user), true)
+        case "user.connection"                     => connectionEvent(js.getJSONObject("connection"), JsonDecoder.opt('user, _.getJSONObject("user")) flatMap (JsonDecoder.decodeOptName('name)(_)))
+        case "user.push-remove"                    => gcmTokenRemoveEvent(js.getJSONObject("token"))
+        case "user.delete"                         => UserDeleteEvent(user = 'id)
+        case "user.client-add"                     => OtrClientAddEvent(OtrClient.ClientsResponse.Decoder(js.getJSONObject("client")))
+        case "user.client-remove"                  => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
+        case "user.properties-set"                 => PropertyEvent.Decoder(js)
+        case "user.properties-delete"              => PropertyEvent.Decoder(js)
+        case "user.legalhold-request"              => LegalHoldRequestEvent(decodeId[UserId]('id), LegalHoldRequest.Decoder(js))
+        case "user.legalhold-enable"               => LegalHoldEnableEvent(decodeId[UserId]('id))
+        case "user.legalhold-disable"              => LegalHoldDisableEvent(decodeId[UserId]('id))
         case _ =>
           error(l"unhandled event: $js")
           UnknownEvent(js)
@@ -526,6 +527,7 @@ object MessageEvent {
       fromDomain.foreach { domain =>
         json.put("qualified_from", QualifiedEncoder.apply((convId, domain)) )
       }
+
       json
     }
 

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -61,15 +61,19 @@ sealed trait OtrClientEvent extends UserEvent
 
 sealed trait RConvEvent extends Event {
   val convId: RConvId
+  val convDomain: Option[String]
 }
+
 object RConvEvent extends (Event => RConvId) {
   def apply(ev: Event): RConvId = ev match {
     case ev: RConvEvent => ev.convId
     case _              => RConvId.Empty
   }
 }
+
 case class UserUpdateEvent(user: UserInfo, removeIdentity: Boolean = false) extends UserEvent
 case class UserConnectionEvent(convId:       RConvId,
+                               convDomain:   Option[String],
                                from:         UserId,
                                to:           UserId,
                                message:      Option[String],
@@ -86,95 +90,222 @@ case class PushTokenRemoveEvent(token: PushToken, senderId: String, client: Opti
 sealed trait ConversationEvent extends RConvEvent {
   val time: RemoteInstant
   val from: UserId
+  val fromDomain: Option[String]
 }
 
 // events that affect conversation state
-sealed trait ConversationStateEvent extends ConversationEvent
+sealed trait ConversationStateEvent extends ConversationEvent {
+  val convId: RConvId
+  val convDomain: Option[String]
+}
 
 // events that add or modify some message
 sealed trait MessageEvent extends ConversationEvent
 
-case class UnknownEvent(json: JSONObject) extends Event
-case class UnknownConvEvent(json: JSONObject) extends ConversationEvent {
+final case class UnknownEvent(json: JSONObject) extends Event
+final case class UnknownConvEvent(json: JSONObject) extends ConversationEvent {
   override val convId: RConvId = RConvId()
+  override val convDomain: Option[String] = None
   override val from: UserId = UserId()
+  override val fromDomain: Option[String] = None
   override val time: RemoteInstant = RemoteInstant.Epoch //TODO: epoch?
 }
 
-case class CreateConversationEvent(convId: RConvId, time: RemoteInstant, from: UserId, data: ConversationResponse) extends ConversationStateEvent
+final case class CreateConversationEvent(convId: RConvId,
+                                         convDomain: Option[String],
+                                         time: RemoteInstant,
+                                         from: UserId,
+                                         fromDomain: Option[String],
+                                         data: ConversationResponse)
+  extends ConversationStateEvent
 
-case class DeleteConversationEvent(convId: RConvId, time: RemoteInstant, from: UserId) extends ConversationStateEvent
+final case class DeleteConversationEvent(convId: RConvId,
+                                         convDomain: Option[String],
+                                         time: RemoteInstant,
+                                         from: UserId,
+                                         fromDomain: Option[String])
+  extends ConversationStateEvent
 
-case class MessageTimerEvent(convId: RConvId, time: RemoteInstant, from: UserId, duration: Option[FiniteDuration]) extends MessageEvent with ConversationStateEvent
-
-case class RenameConversationEvent(convId: RConvId, time: RemoteInstant, from: UserId, name: Name) extends MessageEvent with ConversationStateEvent
-
-case class GenericMessageEvent(convId: RConvId, time: RemoteInstant, from: UserId, content: GenericMessage) extends MessageEvent
-
-case class CallMessageEvent(convId: RConvId, time: RemoteInstant, from: UserId, sender: ClientId, content: String) extends MessageEvent
-
-sealed trait OtrError
-case object Duplicate extends OtrError
-case class DecryptionError(msg: String, code: Option[Int], from: UserId, sender: ClientId) extends OtrError
-case class IdentityChangedError(from: UserId, sender: ClientId) extends OtrError
-case class UnknownOtrErrorEvent(json: JSONObject) extends OtrError
-
-case class OtrErrorEvent(convId: RConvId, time: RemoteInstant, from: UserId, error: OtrError) extends MessageEvent
-case class SessionReset(convId: RConvId, time: RemoteInstant, from: UserId, sender: ClientId) extends MessageEvent
-
-case class TypingEvent(convId: RConvId, time: RemoteInstant, from: UserId, isTyping: Boolean) extends ConversationEvent
-
-case class MemberJoinEvent(convId:     RConvId,
-                           convDomain: Option[String],
-                           time:       RemoteInstant,
-                           from:       UserId,
-                           fromDomain: Option[String],
-                           userIds:    Seq[UserId],
-                           users:      Map[QualifiedId, ConversationRole],
-                           firstEvent: Boolean = false)
+final case class MessageTimerEvent(convId: RConvId,
+                                   convDomain: Option[String],
+                                   time: RemoteInstant,
+                                   from: UserId,
+                                   fromDomain: Option[String],
+                                   duration: Option[FiniteDuration])
   extends MessageEvent with ConversationStateEvent
 
-case class MemberLeaveEvent(convId: RConvId, time: RemoteInstant, from: UserId, userIds: Seq[UserId], reason: Option[MemberLeaveReason]) extends MessageEvent with ConversationStateEvent
+final case class RenameConversationEvent(convId: RConvId,
+                                         convDomain: Option[String],
+                                         time: RemoteInstant,
+                                         from: UserId,
+                                         fromDomain: Option[String],
+                                         name: Name)
+  extends MessageEvent with ConversationStateEvent
+
+final case class GenericMessageEvent(convId: RConvId,
+                                     convDomain: Option[String],
+                                     time: RemoteInstant,
+                                     from: UserId,
+                                     fromDomain: Option[String],
+                                     content: GenericMessage)
+  extends MessageEvent
+
+final case class CallMessageEvent(convId: RConvId,
+                                  convDomain: Option[String],
+                                  time: RemoteInstant,
+                                  from: UserId,
+                                  fromDomain: Option[String],
+                                  sender: ClientId,
+                                  content: String)
+  extends MessageEvent
+
+sealed trait OtrError
+
+case object Duplicate extends OtrError
+
+final case class DecryptionError(msg: String,
+                                 code: Option[Int],
+                                 from: UserId,
+                                 sender: ClientId)
+  extends OtrError
+
+final case class IdentityChangedError(from: UserId, sender: ClientId) extends OtrError
+
+final case class UnknownOtrErrorEvent(json: JSONObject) extends OtrError
+
+final case class OtrErrorEvent(convId: RConvId,
+                               convDomain: Option[String],
+                               time: RemoteInstant,
+                               from: UserId,
+                               fromDomain: Option[String],
+                               error: OtrError)
+  extends MessageEvent
+
+final case class SessionReset(convId: RConvId,
+                              convDomain: Option[String],
+                              time: RemoteInstant,
+                              from: UserId,
+                              fromDomain: Option[String],
+                              sender: ClientId)
+  extends MessageEvent
+
+final case class TypingEvent(convId: RConvId,
+                             convDomain: Option[String],
+                             time: RemoteInstant,
+                             from: UserId,
+                             fromDomain: Option[String],
+                             isTyping: Boolean)
+  extends ConversationEvent
+
+final case class MemberJoinEvent(convId:     RConvId,
+                                 convDomain: Option[String],
+                                 time:       RemoteInstant,
+                                 from:       UserId,
+                                 fromDomain: Option[String],
+                                 userIds:    Seq[UserId],
+                                 users:      Map[QualifiedId, ConversationRole],
+                                 firstEvent: Boolean = false)
+  extends MessageEvent with ConversationStateEvent
+
+final case class MemberLeaveEvent(convId: RConvId,
+                                  convDomain: Option[String],
+                                  time: RemoteInstant,
+                                  from: UserId,
+                                  fromDomain: Option[String],
+                                  userIds: Seq[UserId],
+                                  reason: Option[MemberLeaveReason])
+  extends MessageEvent with ConversationStateEvent
 
 final case class MemberLeaveReason(value: String) extends AnyVal
 object MemberLeaveReason {
   val LegalHoldPolicyConflict = MemberLeaveReason("legalhold-policy-conflict")
 }
 
-case class MemberUpdateEvent(convId: RConvId, time: RemoteInstant, from: UserId, state: ConversationState) extends ConversationStateEvent
+final case class MemberUpdateEvent(convId: RConvId,
+                                   convDomain: Option[String],
+                                   time: RemoteInstant,
+                                   from: UserId,
+                                   fromDomain: Option[String],
+                                   state: ConversationState)
+  extends ConversationStateEvent
 
-case class ConversationReceiptModeEvent(convId: RConvId, time: RemoteInstant, from: UserId, receiptMode: Int) extends MessageEvent with ConversationStateEvent
+final case class ConversationReceiptModeEvent(convId: RConvId,
+                                              convDomain: Option[String],
+                                              time: RemoteInstant,
+                                              from: UserId,
+                                              fromDomain: Option[String],
+                                              receiptMode: Int)
+  extends MessageEvent with ConversationStateEvent
 
-case class ConnectRequestEvent(convId: RConvId, time: RemoteInstant, from: UserId, message: String, recipient: UserId, name: Name, email: Option[String]) extends MessageEvent with ConversationStateEvent
+final case class ConnectRequestEvent(convId: RConvId,
+                                     convDomain: Option[String],
+                                     time: RemoteInstant,
+                                     from: UserId,
+                                     fromDomain: Option[String],
+                                     message: String,
+                                     recipient: UserId,
+                                     name: Name,
+                                     email: Option[String])
+  extends MessageEvent with ConversationStateEvent
 
-case class ConversationAccessEvent(convId: RConvId, time: RemoteInstant, from: UserId, access: Set[Access], accessRole: AccessRole) extends ConversationStateEvent
-case class ConversationCodeUpdateEvent(convId: RConvId, time: RemoteInstant, from: UserId, link: ConversationData.Link) extends ConversationStateEvent
-case class ConversationCodeDeleteEvent(convId: RConvId, time: RemoteInstant, from: UserId) extends ConversationStateEvent
+final case class ConversationAccessEvent(convId: RConvId,
+                                         convDomain: Option[String],
+                                         time: RemoteInstant,
+                                         from: UserId,
+                                         fromDomain: Option[String],
+                                         access: Set[Access],
+                                         accessRole: AccessRole)
+  extends ConversationStateEvent
+
+final case class ConversationCodeUpdateEvent(convId: RConvId,
+                                             convDomain: Option[String],
+                                             time: RemoteInstant,
+                                             from: UserId,
+                                             fromDomain: Option[String],
+                                             link: ConversationData.Link)
+  extends ConversationStateEvent
+
+final case class ConversationCodeDeleteEvent(convId: RConvId,
+                                             convDomain: Option[String],
+                                             time: RemoteInstant,
+                                             from: UserId,
+                                             fromDomain: Option[String])
+  extends ConversationStateEvent
 
 sealed trait OtrEvent extends ConversationEvent {
   val sender: ClientId
   val recipient: ClientId
   val ciphertext: Array[Byte]
 }
-case class OtrMessageEvent(convId: RConvId, time: RemoteInstant, from: UserId, sender: ClientId, recipient: ClientId, ciphertext: Array[Byte], externalData: Option[Array[Byte]] = None) extends OtrEvent
+
+final case class OtrMessageEvent(convId: RConvId,
+                                 convDomain: Option[String],
+                                 time: RemoteInstant,
+                                 from: UserId,
+                                 fromDomain: Option[String],
+                                 sender: ClientId,
+                                 recipient: ClientId,
+                                 ciphertext: Array[Byte],
+                                 externalData: Option[Array[Byte]] = None)
+  extends OtrEvent
 
 sealed trait PropertyEvent extends UserEvent
 
-case class ReadReceiptEnabledPropertyEvent(value: Int) extends PropertyEvent
+final case class ReadReceiptEnabledPropertyEvent(value: Int) extends PropertyEvent
 
 // An event that contains a new folders/favorites list
-case class FoldersEvent(folders: Seq[RemoteFolderData]) extends PropertyEvent
+final case class FoldersEvent(folders: Seq[RemoteFolderData]) extends PropertyEvent
 
-case class UnknownPropertyEvent(key: PropertyKey, value: String) extends PropertyEvent
+final case class UnknownPropertyEvent(key: PropertyKey, value: String) extends PropertyEvent
 
-case class ConversationState(archived:         Option[Boolean] = None,
-                             archiveTime:      Option[RemoteInstant] = None,
-                             muted:            Option[Boolean] = None,
-                             muteTime:         Option[RemoteInstant] = None,
-                             mutedStatus:      Option[Int] = None,
-                             target:           Option[UserId] = None,
-                             conversationRole: Option[ConversationRole] = None
-                            ) extends SafeToLog
+final case class ConversationState(archived:         Option[Boolean] = None,
+                                   archiveTime:      Option[RemoteInstant] = None,
+                                   muted:            Option[Boolean] = None,
+                                   muteTime:         Option[RemoteInstant] = None,
+                                   mutedStatus:      Option[Int] = None,
+                                   target:           Option[UserId] = None,
+                                   conversationRole: Option[ConversationRole] = None
+                                  ) extends SafeToLog
 
 object ConversationState {
   private def encode(state: ConversationState, o: JSONObject) = {
@@ -223,16 +354,30 @@ object ConversationState {
 }
 
 object Event {
+  def decodeRConvId(implicit js: JSONObject): (RConvId, Option[String]) =
+    RConvQualifiedId.decodeOpt('qualified_conversation)
+      .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
+      .getOrElse((RConvId('conversation), None))
+
+  def decodeQUserId(implicit js: JSONObject): (UserId, Option[String]) =
+    QualifiedId.decodeOpt('qualified_from)
+      .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
+      .getOrElse((UserId('from), None))
 
   implicit object EventDecoder extends JsonDecoder[Event] with DerivedLogTag {
 
     import com.waz.utils.JsonDecoder._
 
-    def connectionEvent(implicit js: JSONObject, name: Option[Name]) = UserConnectionEvent('conversation, 'from, 'to, 'message, ConnectionStatus('status), JsonDecoder.decodeISORemoteInstant('last_update), fromUserName = name)
+    def connectionEvent(implicit js: JSONObject, name: Option[Name]): UserConnectionEvent = {
+      val (convId, convDomain) = Event.decodeRConvId
+      UserConnectionEvent(convId, convDomain, 'from, 'to, 'message, ConnectionStatus('status), JsonDecoder.decodeISORemoteInstant('last_update), fromUserName = name)
+    }
 
-    def gcmTokenRemoveEvent(implicit js: JSONObject) = PushTokenRemoveEvent(token = 'token, senderId = 'app, client = 'client)
+    def gcmTokenRemoveEvent(implicit js: JSONObject): PushTokenRemoveEvent =
+      PushTokenRemoveEvent(token = 'token, senderId = 'app, client = 'client)
 
     override def apply(implicit js: JSONObject): Event = Try {
+      verbose(l"JSN event: ${js.toString(2)}")
 
       decodeString('type) match {
         case tpe if tpe.startsWith("conversation") => ConversationEventDecoder(js)
@@ -272,16 +417,10 @@ object ConversationEvent extends DerivedLogTag {
     Some((e.convId, e.time, e.from))
 
   implicit lazy val ConversationEventDecoder: JsonDecoder[ConversationEvent] = new JsonDecoder[ConversationEvent] {
-    private def decodeMemberJoinEvent(data: JSONObject, time: RemoteInstant)(implicit js: JSONObject): MemberJoinEvent = {
-      val (convId, convDomain) =
-        RConvQualifiedId.decodeOpt('qualified_conversation)
-          .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
-          .getOrElse((RConvId('conversation), None))
 
-      val (from, fromDomain) =
-        QualifiedId.decodeOpt('qualified_from)
-          .map(qId => (qId.id, if (qId.hasDomain) Some(qId.domain) else None))
-          .getOrElse((UserId('from), None))
+    private def decodeMemberJoinEvent(data: JSONObject, time: RemoteInstant)(implicit js: JSONObject): MemberJoinEvent = {
+      val (convId, convDomain) = Event.decodeRConvId
+      val (from, fromDomain) = Event.decodeQUserId
 
       MemberJoinEvent(
         convId,
@@ -296,31 +435,32 @@ object ConversationEvent extends DerivedLogTag {
     }
 
     override def apply(implicit js: JSONObject): ConversationEvent = Try {
-
+      val (rConvId, convDomain) = Event.decodeRConvId
+      val (from, fromDomain) = Event.decodeQUserId
       lazy val d = if (js.has("data") && !js.isNull("data")) Try(js.getJSONObject("data")).toOption else None
 
       val time = RemoteInstant(decodeISOInstant('time))
 
       decodeString('type) match {
-        case "conversation.create"               => CreateConversationEvent('conversation, time, 'from, JsonDecoder[ConversationResponse]('data))
-        case "conversation.delete"               => DeleteConversationEvent('conversation, time, 'from)
-        case "conversation.rename"               => RenameConversationEvent('conversation, time, 'from, decodeName('name)(d.get))
+        case "conversation.create"               => CreateConversationEvent(rConvId, convDomain, time, from, fromDomain, JsonDecoder[ConversationResponse]('data))
+        case "conversation.delete"               => DeleteConversationEvent(rConvId, convDomain, time, from, fromDomain)
+        case "conversation.rename"               => RenameConversationEvent(rConvId, convDomain, time, from, fromDomain, decodeName('name)(d.get))
         case "conversation.member-join"          => decodeMemberJoinEvent(d.get, time)
-        case "conversation.member-leave"         => MemberLeaveEvent('conversation, time, 'from, decodeUserIdSeq('user_ids)(d.get), decodeOptString('reason)(d.get).map(MemberLeaveReason(_)))
-        case "conversation.member-update"        => MemberUpdateEvent('conversation, time, 'from, ConversationState.Decoder(d.get))
-        case "conversation.connect-request"      => ConnectRequestEvent('conversation, time, 'from, decodeString('message)(d.get), decodeUserId('recipient)(d.get), decodeName('name)(d.get), decodeOptString('email)(d.get))
-        case "conversation.typing"               => TypingEvent('conversation, time, 'from, isTyping = d.fold(false)(data => decodeString('status)(data) == "started"))
-        case "conversation.otr-message-add"      => OtrMessageEvent('conversation, time, 'from, decodeClientId('sender)(d.get), decodeClientId('recipient)(d.get), decodeByteString('text)(d.get), decodeOptByteString('data)(d.get))
-        case "conversation.access-update"        => ConversationAccessEvent('conversation, time, 'from, decodeAccess('access)(d.get), decodeAccessRole('access_role)(d.get))
-        case "conversation.code-update"          => ConversationCodeUpdateEvent('conversation, time, 'from, ConversationData.Link(d.get.getString("uri")))
-        case "conversation.code-delete"          => ConversationCodeDeleteEvent('conversation, time, 'from)
-        case "conversation.receipt-mode-update"  => ConversationReceiptModeEvent('conversation, time, 'from, decodeInt('receipt_mode)(d.get))
-        case "conversation.message-timer-update" => MessageTimerEvent('conversation, time, 'from, decodeOptLong('message_timer)(d.get).map(EphemeralDuration(_)))
+        case "conversation.member-leave"         => MemberLeaveEvent(rConvId, convDomain, time, from, fromDomain, decodeUserIdSeq('user_ids)(d.get), decodeOptString('reason)(d.get).map(MemberLeaveReason(_)))
+        case "conversation.member-update"        => MemberUpdateEvent(rConvId, convDomain, time, from, fromDomain, ConversationState.Decoder(d.get))
+        case "conversation.connect-request"      => ConnectRequestEvent(rConvId, convDomain, time, from, fromDomain, decodeString('message)(d.get), decodeUserId('recipient)(d.get), decodeName('name)(d.get), decodeOptString('email)(d.get))
+        case "conversation.typing"               => TypingEvent(rConvId, convDomain, time, from, fromDomain, isTyping = d.fold(false)(data => decodeString('status)(data) == "started"))
+        case "conversation.otr-message-add"      => OtrMessageEvent(rConvId, convDomain, time, from, fromDomain, decodeClientId('sender)(d.get), decodeClientId('recipient)(d.get), decodeByteString('text)(d.get), decodeOptByteString('data)(d.get))
+        case "conversation.access-update"        => ConversationAccessEvent(rConvId, convDomain, time, from, fromDomain, decodeAccess('access)(d.get), decodeAccessRole('access_role)(d.get))
+        case "conversation.code-update"          => ConversationCodeUpdateEvent(rConvId, convDomain, time, from, fromDomain, ConversationData.Link(d.get.getString("uri")))
+        case "conversation.code-delete"          => ConversationCodeDeleteEvent(rConvId, convDomain, time, from, fromDomain)
+        case "conversation.receipt-mode-update"  => ConversationReceiptModeEvent(rConvId, convDomain, time, from, fromDomain, decodeInt('receipt_mode)(d.get))
+        case "conversation.message-timer-update" => MessageTimerEvent(rConvId, convDomain, time, from, fromDomain, decodeOptLong('message_timer)(d.get).map(EphemeralDuration(_)))
 
           //Note, the following events are not from the backend, but are the result of decrypting and re-encoding conversation.otr-message-add events - hence the different name for `convId
-        case "conversation.generic-message"      => GenericMessageEvent('convId, time, 'from, 'content)
-        case "conversation.otr-error"            => OtrErrorEvent('convId, time, 'from, decodeOtrError('error))
-        case "conversation.session-reset"        => SessionReset('convId, time, 'from, 'sender)
+        case "conversation.generic-message"      => GenericMessageEvent(rConvId, convDomain, time, from, fromDomain, 'content)
+        case "conversation.otr-error"            => OtrErrorEvent(rConvId, convDomain, time, from, fromDomain, decodeOtrError('error))
+        case "conversation.session-reset"        => SessionReset(rConvId, convDomain, time, from, fromDomain, 'sender)
         case _ =>
           error(l"unhandled event (1): ${js.toString}")
           UnknownConvEvent(js)
@@ -361,28 +501,48 @@ object MessageEvent {
 
   implicit lazy val MessageEventEncoder: JsonEncoder[MessageEvent] = new JsonEncoder[MessageEvent] {
 
-    private def setFields(json: JSONObject, convId: RConvId, time: RemoteInstant, from: UserId, eventType: String) =
+    val QualifiedEncoder: JsonEncoder[(RConvId, String)] =
+      JsonEncoder.build { case (id, domain) => js => {
+        js.put("id", id.str)
+        js.put("domain", domain)
+      } }
+
+    private def setFields(json: JSONObject,
+                          convId: RConvId,
+                          convDomain: Option[String],
+                          time: RemoteInstant,
+                          from: UserId,
+                          fromDomain: Option[String],
+                          eventType: String): JSONObject = {
       json
         .put("convId", convId.str)
         .put("time", JsonEncoder.encodeISOInstant(time.instant))
         .put("from", from.str)
         .put("type", eventType)
         .setType(eventType)
+      convDomain.foreach { domain =>
+        json.put("qualified_conversation", QualifiedEncoder.apply((convId, domain)) )
+      }
+      fromDomain.foreach { domain =>
+        json.put("qualified_from", QualifiedEncoder.apply((convId, domain)) )
+      }
+      json
+    }
 
     override def apply(event: MessageEvent): JSONObject = JsonEncoder { json =>
       event match {
-        case GenericMessageEvent(convId, time, from, content) =>
-          setFields(json, convId, time, from, "conversation.generic-message")
+        case GenericMessageEvent(convId, convDomain, time, from, fromDomain, content) =>
+          setFields(json, convId, convDomain, time, from, fromDomain, "conversation.generic-message")
             .put("content", AESUtils.base64(content.proto.toByteArray))
-        case OtrErrorEvent(convId, time, from, error) =>
-          setFields(json, convId, time, from, "conversation.otr-error")
+        case OtrErrorEvent(convId, convDomain, time, from, fromDomain, error) =>
+          setFields(json, convId, convDomain, time, from, fromDomain, "conversation.otr-error")
             .put("error", OtrError.OtrErrorEncoder(error))
-        case CallMessageEvent(convId, time, from, sender, content) =>
-          setFields(json, convId, time, from, "conversation.call-message")
+        case CallMessageEvent(convId, convDomain, time, from, fromDomain, sender, content) =>
+          setFields(json, convId, convDomain, time, from, fromDomain, "conversation.call-message")
             .put("sender", sender.str)
             .put("content", content)
-        case SessionReset(convId, time, from, sender) =>
-          setFields(json, convId, time, from, "conversation.session-reset")
+        case SessionReset(convId, convDomain, time, from, fromDomain, sender) =>
+          setFields(json, convId, convDomain, time, from, fromDomain, "conversation.session-reset")
             .put("sender", sender.str)
         case e => throw new JSONException(s"Encoder for event $e not implemented")
       }
@@ -497,6 +657,6 @@ object PropertyEvent {
 }
 
 sealed trait LegalHoldEvent extends UserEvent
-case class LegalHoldRequestEvent(userId: UserId, request: LegalHoldRequest) extends LegalHoldEvent
-case class LegalHoldEnableEvent(userId: UserId) extends LegalHoldEvent
-case class LegalHoldDisableEvent(userId: UserId) extends LegalHoldEvent
+final case class LegalHoldRequestEvent(userId: UserId, request: LegalHoldRequest) extends LegalHoldEvent
+final case class LegalHoldEnableEvent(userId: UserId) extends LegalHoldEvent
+final case class LegalHoldDisableEvent(userId: UserId) extends LegalHoldEvent

--- a/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
@@ -70,7 +70,7 @@ class GenericMessageService(selfUserId: UserId,
 
   private def updateCaches(events: Seq[GenericMessageEvent]): Unit = {
     clearCaches()
-    events.foreach { case GenericMessageEvent(_, time, from, content) =>
+    events.foreach { case GenericMessageEvent(_, _, time, from, _, content) =>
       content.unpackContent match {
         case r: Reaction =>
           val (msg, action) = r.unpack

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -230,7 +230,7 @@ class LegalHoldServiceImpl(selfUserId: UserId,
 
   override def messageEventStage: Stage.Atomic = EventScheduler.Stage[MessageEvent] { (_, events) =>
     Future.traverse(events) {
-      case GenericMessageEvent(convId, time, _, content) =>
+      case GenericMessageEvent(convId, _, time, _, _, content) =>
         updateStatusFromMessageHint(convId, content.legalHoldStatus, time)
       case _ =>
         Future.successful(())

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -49,8 +49,8 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _: ConnectRequestEvent     => true
       case _: OtrMessageEvent         => true
       case MemberJoinEvent(_, _, _, _, _, added, _, _) if added.contains(selfUserId) => true
-      case MemberLeaveEvent(_, _, _, leaving, _) if leaving.contains(selfUserId) => true
-      case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
+      case MemberLeaveEvent(_, _, _, _, _, leaving, _) if leaving.contains(selfUserId) => true
+      case GenericMessageEvent(_, _, _, _, _, gm: GenericMessage) =>
         gm.unpackContent match {
           case _: Asset               => true
           case _: Calling             => true
@@ -77,7 +77,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
 
   private[service] def shouldUnarchive(event: ConversationEvent): Boolean =
     event match {
-      case MemberLeaveEvent(_, _, _, leaving, _) if leaving contains selfUserId => false
+      case MemberLeaveEvent(_, _, _, _, _, leaving, _) if leaving contains selfUserId => false
       case _ => shouldChangeOrder(event)
     }
 
@@ -146,7 +146,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
 
   private def unarchiveMuted(events: Seq[ConversationEvent]): Boolean =
     events.exists {
-      case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
+      case GenericMessageEvent(_, _, _, _, _, gm: GenericMessage) =>
         gm.unpackContent match {
           case _: Knock => true
           case _ => false
@@ -155,7 +155,7 @@ class ConversationOrderEventsService(selfUserId: UserId,
     }
 
   private def hasMentions(events: Seq[ConversationEvent]): Boolean = events.exists {
-    case GenericMessageEvent(_, _, _, gm: GenericMessage) =>
+    case GenericMessageEvent(_, _, _, _, _, gm: GenericMessage) =>
       gm.unpackContent match {
         case text: Text =>
           val (_, mentions, _, _, _) = text.unpack

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -66,7 +66,7 @@ class MessageEventProcessor(selfUserId:           UserId,
     verbose(l"processEvents: ${conv.id} isGroup:$isGroup ${events.map(_.from)}")
 
     val toProcess = events.filter {
-      case GenericMessageEvent(_, _, _, msg) if msg.isBroadcastMessage => false
+      case GenericMessageEvent(_, _, _, _, _, msg) if msg.isBroadcastMessage => false
       case e => conv.cleared.forall(_.isBefore(e.time))
     }
 
@@ -100,31 +100,31 @@ class MessageEventProcessor(selfUserId:           UserId,
                             acc:           List[RichMessage]): RichMessage = {
     lazy val id = MessageId()
     event match {
-      case ConnectRequestEvent(_, time, from, text, recipient, name, email) =>
+      case ConnectRequestEvent(_, _, time, from, _, text, recipient, name, email) =>
         RichMessage(MessageData(id, conv.id, CONNECT_REQUEST, from, content = MessageData.textContent(text), recipient = Some(recipient), email = email, name = Some(name), time = time, localTime = event.localTime))
-      case RenameConversationEvent(_, time, from, name) =>
+      case RenameConversationEvent(_, _, time, from, _, name) =>
         RichMessage(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
-      case MessageTimerEvent(_, time, from, duration) =>
+      case MessageTimerEvent(_, _, time, from, _, duration) =>
         RichMessage(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
       case MemberJoinEvent(_, _, time, from, _, userIds, users, firstEvent) =>
         RichMessage(MessageData(id, conv.id, MEMBER_JOIN, from, members = (users.keys.map(_.id) ++ userIds).toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
-      case ConversationReceiptModeEvent(_, time, from, 0) =>
+      case ConversationReceiptModeEvent(_, _, time, from, _, 0) =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
-      case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>
+      case ConversationReceiptModeEvent(_, _, time, from, _, receiptMode) if receiptMode > 0 =>
         RichMessage(MessageData(id, conv.id, READ_RECEIPTS_ON, from, time = time, localTime = event.localTime))
-      case MemberLeaveEvent(_, time, from, userIds, Some(MemberLeaveReason.LegalHoldPolicyConflict)) =>
+      case MemberLeaveEvent(_, _, time, from, _, userIds, Some(MemberLeaveReason.LegalHoldPolicyConflict)) =>
         RichMessage(MessageData(id, conv.id, MEMBER_LEAVE_DUE_TO_LEGAL_HOLD, from, members = userIds.toSet, time = time, localTime = event.localTime))
-      case MemberLeaveEvent(_, time, from, userIds, _) =>
+      case MemberLeaveEvent(_, _, time, from, _, userIds, _) =>
         RichMessage(MessageData(id, conv.id, MEMBER_LEAVE, from, members = userIds.toSet, time = time, localTime = event.localTime))
-      case OtrErrorEvent(_, time, from, IdentityChangedError(_, sender)) =>
+      case OtrErrorEvent(_, _, time, from, _, IdentityChangedError(_, sender)) =>
         RichMessage(MessageData(id, conv.id, OTR_IDENTITY_CHANGED, from, error = Some(ErrorContent(sender, OtrError.ERROR_CODE_IDENTITY_CHANGED)), time = time, localTime = event.localTime))
-      case OtrErrorEvent(_, time, from, DecryptionError(_, code, _, sender)) =>
+      case OtrErrorEvent(_, _, time, from, _, DecryptionError(_, code, _, sender)) =>
         RichMessage(MessageData(id, conv.id, OTR_ERROR, from, error = Some(ErrorContent(sender, code.getOrElse(OtrError.ERROR_CODE_DECRYPTION_OTHER))), time = time, localTime = event.localTime))
-      case OtrErrorEvent(_, time, from, _) =>
+      case OtrErrorEvent(_, _, time, from, _, _) =>
         RichMessage(MessageData(id, conv.id, OTR_ERROR, from, time = time, localTime = event.localTime))
-      case SessionReset(_, time, from, _) =>
+      case SessionReset(_, _, time, from, _, _) =>
         RichMessage(MessageData(id, conv.id, SESSION_RESET, from, time = time, localTime = event.localTime))
-      case GenericMessageEvent(_, time, from, proto) =>
+      case GenericMessageEvent(_, _, time, from, _, proto) =>
         val (uid, msgContent) = proto.unpack
         content(acc, MessageId(uid.str), conv.id, msgContent, from, event.localTime, time, conv.receiptMode.filter(_ => isGroup), downloadAsset, proto)
       case _: CallMessageEvent =>
@@ -344,8 +344,8 @@ class MessageEventProcessor(selfUserId:           UserId,
   private def assetForEvent(event: MessageEvent) = {
     for {
       message <- event match {
-        case GenericMessageEvent(_, _, _, c) => storage.get(MessageId(c.proto.getMessageId))
-        case _                               => Future.successful(None)
+        case GenericMessageEvent(_, _, _, _, _, c) => storage.get(MessageId(c.proto.getMessageId))
+        case _                                     => Future.successful(None)
       }
       asset <- message.flatMap(_.assetId) match {
         case Some(dId: DownloadAssetId) => downloadAssetStorage.find(dId)
@@ -374,7 +374,7 @@ class MessageEventProcessor(selfUserId:           UserId,
   private def applyRecalls(convId: ConvId, toProcess: Seq[MessageEvent]) = {
     object Recall {
       def unapply(event: MessageEvent): Option[(MessageId, UserId, MessageId, RemoteInstant)] = event match {
-        case GenericMessageEvent(_, time, from, msg) =>
+        case GenericMessageEvent(_, _, time, from, _, msg) =>
           msg.unpack match {
             case (id, MsgRecall(proto)) => Some((MessageId(proto.getMessageId), from, MessageId(id.str), time))
             case _ => None
@@ -396,7 +396,7 @@ class MessageEventProcessor(selfUserId:           UserId,
   private def applyEdits(convId: ConvId, toProcess: Seq[MessageEvent]) = {
     object Edit {
       def unapply(event: MessageEvent): Option[(UserId, RemoteInstant, GenericMessage)] = event match {
-        case GenericMessageEvent(_, time, from, msg) =>
+        case GenericMessageEvent(_, _, time, from, _, msg) =>
           msg.unpackContent match {
             case edit: MsgEdit => edit.unpack.map(_ => (from, time, msg))
             case _ => None

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -134,9 +134,9 @@ class NotificationServiceImpl(selfUserId:      UserId,
 
   override val connectionNotificationEventStage = EventScheduler.Stage[Event]({ (_, events) =>
     val toShow = events.collect {
-      case UserConnectionEvent(_, _, userId, msg, ConnectionStatus.PendingFromOther, time, _) =>
+      case UserConnectionEvent(_, _, _, userId, msg, ConnectionStatus.PendingFromOther, time, _) =>
         NotificationData(NotId(CONNECT_REQUEST, userId), msg.getOrElse(""), ConvId(userId.str), userId, CONNECT_REQUEST, time)
-      case UserConnectionEvent(_, _, userId, _, ConnectionStatus.Accepted, time, _) =>
+      case UserConnectionEvent(_, _, _, userId, _, ConnectionStatus.Accepted, time, _) =>
         NotificationData(NotId(CONNECT_ACCEPTED, userId), "", ConvId(userId.str), userId, CONNECT_ACCEPTED, time)
     }
 
@@ -307,7 +307,7 @@ class NotificationServiceImpl(selfUserId:      UserId,
   private def getReactionChanges(events: Vector[Event]) = {
     object Reacted {
       def unapply(event: GenericMessageEvent): Option[Liking] = event match {
-        case GenericMessageEvent(_, time, from, gm: GenericMessage) if from != selfUserId =>
+        case GenericMessageEvent(_, _, time, from, _, gm: GenericMessage) if from != selfUserId =>
           gm.unpackContent match {
             case r: Reaction =>
               val (msg, action) = r.unpack

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -159,7 +159,6 @@ class PushServiceImpl(selfUserId:           UserId,
   private def processDecryptedRows(): Future[Unit] = {
     def decodeRow(event: PushNotificationEvent) =
       if(event.plain.isDefined && isOtrEventJson(event.event)) {
-        verbose(l"JSN otr event: ${event.event.toString(2)}")
         verbose(l"decodeRow($event) for an otr event")
         val msg = GenericMessage(event.plain.get)
         val msgEvent = ConversationEvent.ConversationEventDecoder(event.event)

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -143,7 +143,7 @@ class PushServiceImpl(selfUserId:           UserId,
                 verbose(l"Ignoring duplicate message")
                 notificationStorage.remove(row.index)
               case Left(error) =>
-                val e = OtrErrorEvent(otrEvent.convId, otrEvent.time, otrEvent.from, error)
+                val e = OtrErrorEvent(otrEvent.convId, otrEvent.convDomain, otrEvent.time, otrEvent.from, otrEvent.fromDomain, error)
                 verbose(l"Got error when decrypting: $e")
                 tracking.msgDecryptionFailed(otrEvent.convId, this.selfUserId)
                 notificationStorage.writeError(row.index, e)
@@ -159,6 +159,7 @@ class PushServiceImpl(selfUserId:           UserId,
   private def processDecryptedRows(): Future[Unit] = {
     def decodeRow(event: PushNotificationEvent) =
       if(event.plain.isDefined && isOtrEventJson(event.event)) {
+        verbose(l"JSN otr event: ${event.event.toString(2)}")
         verbose(l"decodeRow($event) for an otr event")
         val msg = GenericMessage(event.plain.get)
         val msgEvent = ConversationEvent.ConversationEventDecoder(event.event)

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -162,7 +162,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode GenericMessageEvent") {
-      val msg = GenericMessageEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), GenericMessage.TextMessage("content"))
+      val msg = GenericMessageEvent(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, GenericMessage.TextMessage("content"))
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: GenericMessageEvent =>
           ev.convId shouldEqual msg.convId
@@ -174,7 +174,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode OtrErrorEvent(duplicate)") {
-      val msg = OtrErrorEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), Duplicate)
+      val msg = OtrErrorEvent(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, Duplicate)
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: OtrErrorEvent =>
           ev.convId shouldEqual msg.convId
@@ -186,7 +186,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode OtrErrorEvent(DecryptionError)") {
-      val msg = OtrErrorEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), DecryptionError("error", Some(100), UserId(), ClientId()))
+      val msg = OtrErrorEvent(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, DecryptionError("error", Some(100), UserId(), ClientId()))
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: OtrErrorEvent =>
           ev.convId shouldEqual msg.convId
@@ -198,7 +198,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode OtrErrorEvent(IdentityChanged)") {
-      val msg = OtrErrorEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), IdentityChangedError(UserId(), ClientId()))
+      val msg = OtrErrorEvent(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, IdentityChangedError(UserId(), ClientId()))
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: OtrErrorEvent =>
           ev.convId shouldEqual msg.convId
@@ -210,7 +210,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("encode/decode SessionReset") {
-      val msg = SessionReset(RConvId(), RemoteInstant(Instant.now()), UserId(), ClientId())
+      val msg = SessionReset(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, ClientId())
       EventDecoder(MessageEventEncoder(msg)) match {
         case ev: SessionReset =>
           ev.convId shouldEqual msg.convId

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -32,6 +32,7 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
   import MessageEvent._
 
   feature("Event parsing") {
+
     scenario("parse UserConnectionEvent") {
 
       Given("some json data")

--- a/zmessaging/src/test/scala/com/waz/service/EventSchedulerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/EventSchedulerSpec.scala
@@ -108,9 +108,9 @@ class EventSchedulerSpec extends FeatureSpec with Matchers with OptionValues wit
   }
 
   feature("Defining event processing stages") {
-    lazy val e1 = RenameConversationEvent(RConvId("R"), RemoteInstant(Instant.now()), UserId("u1"), Name("meep 1"))
+    lazy val e1 = RenameConversationEvent(RConvId("R"), None, RemoteInstant(Instant.now()), UserId("u1"), None, Name("meep 1"))
     lazy val e2 = UnknownPropertyEvent("e2", "u1")
-    lazy val e3 = RenameConversationEvent(RConvId("R"), RemoteInstant(Instant.now()), UserId("u2"), Name("meep 2"))
+    lazy val e3 = RenameConversationEvent(RConvId("R"), None, RemoteInstant(Instant.now()), UserId("u2"), None, Name("meep 2"))
     lazy val e4 = UnknownPropertyEvent("e4", "u2")
 
     scenario("Eligibility check")(withFixture { env => import env._
@@ -158,9 +158,7 @@ class EventSchedulerSpec extends FeatureSpec with Matchers with OptionValues wit
     }
 
     def E(es: Symbol*): Vector[Event] = es.zipWithIndex.map {
-      case (user, uid) => new UnknownPropertyEvent(uid.toString, user.name) {
-        override def toString = key
-      }
+      case (user, uid) => UnknownPropertyEvent(uid.toString, user.name)
     }(breakOut)
 
     implicit class RichEvents(events: Vector[Event]) {

--- a/zmessaging/src/test/scala/com/waz/service/EventSchedulerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/EventSchedulerSpec.scala
@@ -161,6 +161,11 @@ class EventSchedulerSpec extends FeatureSpec with Matchers with OptionValues wit
       case (user, uid) => UnknownPropertyEvent(uid.toString, user.name)
     }(breakOut)
 
+    def toString(event: Event): String = event match {
+      case ev: UnknownPropertyEvent => ev.key
+      case ev => ev.toString
+    }
+
     implicit class RichEvents(events: Vector[Event]) {
       def scheduledBy(stage: Stage): String = stringify(new EventScheduler(stage).createSchedule(events))
 /*      def scheduledAndExecutedBy(stage: Stage) = {
@@ -170,11 +175,12 @@ class EventSchedulerSpec extends FeatureSpec with Matchers with OptionValues wit
       }*/
     }
 
-    def stringify(es: Vector[(Stage, Vector[Event])]): String = es.map { case (stage, events) => s"$stage${events.mkString}" } .mkString(",")
+    def stringify(es: Vector[(Stage, Vector[Event])]): String =
+      es.map { case (stage, events) => s"$stage${events.mkString}" } .mkString(",")
 
     def stringify(schedule: Schedule): String = schedule match {
       case NOP => "-"
-      case Leaf(stage, events) => s"$stage${events.mkString}"
+      case Leaf(stage, events) => s"$stage${events.map(toString).mkString}"
       case Branch(strat, scheds) => s"${strat.toString.take(3).toLowerCase}(${scheds.map(stringify).mkString(",")})"
     }
 

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -816,8 +816,10 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
                     time: RemoteInstant = RemoteInstant(Instant.now())): GenericMessageEvent =
       GenericMessageEvent(
         convId,
+        None,
         time,
         UserId("senderId"),
+        None,
         message
       )
 

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -72,7 +72,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       val conv = ConversationData(ConvId("conv"), RConvId("r_conv"), None, UserId("creator"), ConversationType.OneToOne)
 
       clock.advance(5.seconds)
-      val event = GenericMessageEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, GenericMessage(Uid("uid"), Text(text)))
+      val event = GenericMessageEvent(conv.remoteId, None, RemoteInstant(clock.instant()), sender, None, GenericMessage(Uid("uid"), Text(text)))
 
       (storage.updateOrCreate _).expects(*, *, *).onCall { (_, _, creator) => Future.successful(creator)}
       (storage.get _).expects(*).once().returns(Future.successful(None))
@@ -161,9 +161,9 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
         membersAdded.map(id => QualifiedId(id) -> ConversationRole.AdminRole).toMap
       ))
       clock.advance(1.second)
-      testRound(MemberLeaveEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, membersAdded, reason = None))
+      testRound(MemberLeaveEvent(conv.remoteId, None, RemoteInstant(clock.instant()), sender, None, membersAdded, reason = None))
       clock.advance(1.second)
-      testRound(RenameConversationEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, Name("new name")))
+      testRound(RenameConversationEvent(conv.remoteId, None, RemoteInstant(clock.instant()), sender, None, Name("new name")))
     }
 
     scenario("System message events are overridden if only local version is present") {
@@ -174,7 +174,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       val localMsg = MessageData(MessageId(), conv.id, RENAME, selfUserId, time = RemoteInstant(clock.instant()), localTime = LocalInstant(clock.instant()), state = Status.PENDING)
 
       clock.advance(1.second) //some time later, we get the response from the backend
-      val event = RenameConversationEvent(conv.remoteId, RemoteInstant(clock.instant()), selfUserId, Name("new name"))
+      val event = RenameConversationEvent(conv.remoteId, None, RemoteInstant(clock.instant()), selfUserId, None, Name("new name"))
 
       (storage.hasSystemMessage _).expects(conv.id, event.time, RENAME, selfUserId).returning(Future.successful(false))
       (storage.getLastSentMessage _).expects(conv.id).anyNumberOfTimes().returning(Future.successful(None))
@@ -228,10 +228,10 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
       }
 
       clock.advance(5.seconds)
-      val originalEvent = GenericMessageEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, GenericMessage(messageId, originalAsset))
+      val originalEvent = GenericMessageEvent(conv.remoteId, None, RemoteInstant(clock.instant()), sender, None, GenericMessage(messageId, originalAsset))
 
       clock.advance(5.seconds)
-      val uploadEvent = GenericMessageEvent(conv.remoteId, RemoteInstant(clock.instant()), sender, GenericMessage(messageId, uploadAsset))
+      val uploadEvent = GenericMessageEvent(conv.remoteId, None, RemoteInstant(clock.instant()), sender, None, GenericMessage(messageId, uploadAsset))
 
       // Expectations
 
@@ -333,5 +333,5 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   }
 
   private def event(convId: RConvId, sender: UserId, uid: String, composite: Composite) =
-    GenericMessageEvent(convId, RemoteInstant(clock.instant()), sender, GenericMessage(Uid(uid), composite))
+    GenericMessageEvent(convId, None, RemoteInstant(clock.instant()), sender, None, GenericMessage(Uid(uid), composite))
 }

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -57,7 +57,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
     scenario("Handle connection events updates the last event time of the conversation") {
       val service = initConnectionService()
-      val event = UserConnectionEvent(rConvId, selfUserId, otherUserId, None, Accepted, RemoteInstant.ofEpochMilli(1))
+      val event = UserConnectionEvent(rConvId, None, selfUserId, otherUserId, None, Accepted, RemoteInstant.ofEpochMilli(1))
       val updatedConv = getUpdatedConversation(service, event)
 
       updatedConv.lastEventTime should be(event.lastUpdated)
@@ -65,7 +65,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
     scenario("Handling an accepted connection event should return a one to one conversation") {
       val service = initConnectionService()
-      val event = UserConnectionEvent(rConvId, selfUserId, otherUserId, None, Accepted, RemoteInstant.ofEpochMilli(1))
+      val event = UserConnectionEvent(rConvId, None, selfUserId, otherUserId, None, Accepted, RemoteInstant.ofEpochMilli(1))
       val updatedConv = getUpdatedConversation(service, event)
 
       updatedConv.convType should be(ConversationType.OneToOne)
@@ -73,7 +73,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
     scenario("Handling a pending from other connection event should return a wait for connection conversation") {
       val service = initConnectionService()
-      val event = UserConnectionEvent(rConvId, selfUserId, otherUserId, None, PendingFromOther, RemoteInstant.ofEpochMilli(1))
+      val event = UserConnectionEvent(rConvId, None, selfUserId, otherUserId, None, PendingFromOther, RemoteInstant.ofEpochMilli(1))
 
       (messagesService.addConnectRequestMessage _).expects(*, *, *, *, *, *).once().returns(Future.successful(MessageData.Empty))
 
@@ -84,7 +84,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
     scenario("Handling a pending from user connection event should return a incoming conversation") {
       val service = initConnectionService()
-      val event = UserConnectionEvent(rConvId, selfUserId, otherUserId, None, PendingFromUser, RemoteInstant.ofEpochMilli(1))
+      val event = UserConnectionEvent(rConvId, None, selfUserId, otherUserId, None, PendingFromUser, RemoteInstant.ofEpochMilli(1))
       val updatedConv = getUpdatedConversation(service, event)
 
       updatedConv.convType should be(WaitForConnection)
@@ -286,7 +286,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
 
       val service = createBlankService()
-      await(service.handleUserConnectionEvents(Seq(UserConnectionEvent(remoteId, selfUserId, otherUser.id, Some("Hi!"), PendingFromUser, RemoteInstant(clock.instant()), None))))
+      await(service.handleUserConnectionEvents(Seq(UserConnectionEvent(remoteId, None, selfUserId, otherUser.id, Some("Hi!"), PendingFromUser, RemoteInstant(clock.instant()), None))))
 
       previousConv.remoteId shouldEqual remoteId
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationOrderEventsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationOrderEventsServiceSpec.scala
@@ -81,7 +81,7 @@ class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLog
 
     val convId = RConvId()
     val events = (1 to 10).map { _ =>
-      RenameConversationEvent(convId, RemoteInstant(clock.instant()), UserId(), Name("blah"))
+      RenameConversationEvent(convId, None, RemoteInstant(clock.instant()), UserId(), None, Name("blah"))
     }
 
     result(pipeline.apply(events).map(_ => println(output.toString)))
@@ -181,7 +181,7 @@ class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLog
     result(storage.get(convId)).map(_.archived) shouldEqual Some(true)
 
     val events = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(1), UserId(), GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId,  None, RemoteInstant.ofEpochMilli(1), UserId(), None, GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
 
     result(service.conversationOrderEventsStage.apply(rConvId, events))
@@ -209,13 +209,13 @@ class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLog
 
     // false positive check: don't unarchive because of a standard text message
     val events1 = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(1), UserId(), GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(1), UserId(), None, GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
     result(service.conversationOrderEventsStage.apply(rConvId, events1))
     result(storage.get(convId)).map(_.archived) shouldEqual Some(true)
 
     val events2 = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(2), UserId(), GenericMessage.TextMessage("hello @user", Seq(Mention(Some(selfUserId), 6, 11)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(2), UserId(), None, GenericMessage.TextMessage("hello @user", Seq(Mention(Some(selfUserId), 6, 11)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
     result(service.conversationOrderEventsStage.apply(rConvId, events2))
     result(storage.get(convId)).map(_.archived) shouldEqual Some(false)
@@ -247,13 +247,13 @@ class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLog
 
     // false positive check: don't unarchive because of a standard text message
     val events1 = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(1), UserId(), GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(1), UserId(), None, GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
     result(service.conversationOrderEventsStage.apply(rConvId, events1))
     result(storage.get(convId)).map(_.archived) shouldEqual Some(true)
 
     val events2 = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(2), UserId(), GenericMessage.TextMessage("hello @user", Nil, Nil, Some(Quote(msgId, None)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(2), UserId(), None, GenericMessage.TextMessage("hello @user", Nil, Nil, Some(Quote(msgId, None)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
     result(service.conversationOrderEventsStage.apply(rConvId, events2))
     result(storage.get(convId)).map(_.archived) shouldEqual Some(false)
@@ -284,9 +284,9 @@ class ConversationOrderEventsServiceSpec extends AndroidFreeSpec with DerivedLog
     result(storage.get(convId)).map(_.archived) shouldEqual Some(true)
 
     val events = Seq(
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(1), UserId(), GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN)),
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(2), UserId(), GenericMessage.TextMessage("hello @user", Seq(Mention(Some(selfUserId), 6, 11)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN)),
-      GenericMessageEvent(rConvId: RConvId,  RemoteInstant.ofEpochMilli(3), UserId(), GenericMessage.TextMessage("hello @user", Nil, Nil, Some(Quote(msgId, None)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(1), UserId(), None, GenericMessage.TextMessage("hello", Nil, expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN)),
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(2), UserId(), None, GenericMessage.TextMessage("hello @user", Seq(Mention(Some(selfUserId), 6, 11)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN)),
+      GenericMessageEvent(rConvId, None, RemoteInstant.ofEpochMilli(3), UserId(), None, GenericMessage.TextMessage("hello @user", Nil, Nil, Some(Quote(msgId, None)), expectsReadConfirmation = false, LegalHoldStatus.UNKNOWN))
     )
     result(pipeline.apply(events))
     result(storage.get(convId)).map(_.archived) shouldEqual Some(true)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -150,7 +150,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val selfMember = ConversationMemberData(selfUserId, convId, ConversationRole.AdminRole)
 
       val events = Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(selfUserId), reason = None)
+        MemberLeaveEvent(rConvId, None, RemoteInstant.ofEpochSec(10000), selfUserId, None, Seq(selfUserId), reason = None)
       )
       (userService.syncIfNeeded _).expects(*, *, *).anyNumberOfTimes().returning(Future.successful(None))
 
@@ -200,7 +200,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       val removerId = UserId()
       val events = Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), removerId, Seq(selfUserId), reason = None)
+        MemberLeaveEvent(rConvId, None, RemoteInstant.ofEpochSec(10000), removerId, None, Seq(selfUserId), reason = None)
       )
 
       (userService.syncIfNeeded _).expects(*, *, *).anyNumberOfTimes().returning(Future.successful(None))
@@ -246,7 +246,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       val otherUserId = UserId()
       val events = Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(otherUserId), reason = None)
+        MemberLeaveEvent(rConvId, None, RemoteInstant.ofEpochSec(10000), selfUserId, None, Seq(otherUserId), reason = None)
       )
 
       (userService.syncIfNeeded _).expects(Set(otherUserId), *, *).anyNumberOfTimes().returning(Future.successful(None))
@@ -301,7 +301,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       val dummyUserId = UserId()
       val events = Seq(
-        DeleteConversationEvent(rConvId, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), dummyUserId)
+        DeleteConversationEvent(rConvId, None, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), dummyUserId, None)
       )
 
       // EXPECT
@@ -319,7 +319,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(Some(conversationData)))
 
       val events = Seq(
-        DeleteConversationEvent(rConvId, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId())
+        DeleteConversationEvent(rConvId, None, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId(), None)
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
@@ -349,7 +349,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(Some(conversationData)))
 
       val events = Seq(
-        DeleteConversationEvent(rConvId, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId())
+        DeleteConversationEvent(rConvId, None, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId(), None)
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
@@ -378,7 +378,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(Some(conversationData)))
 
       val events = Seq(
-        DeleteConversationEvent(rConvId, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId())
+        DeleteConversationEvent(rConvId, None, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId(), None)
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
@@ -417,7 +417,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
         .returning(Future.successful(Some(conversationData)))
 
       val events = Seq(
-        DeleteConversationEvent(rConvId, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId())
+        DeleteConversationEvent(rConvId, None, RemoteInstant.ofEpochMilli(Instant.now().toEpochMilli), UserId(), None)
       )
       (notifications.displayNotificationForDeletingConversation _).expects(*, *, *).anyNumberOfTimes()
         .returning(Future.successful(()))
@@ -934,14 +934,14 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       result(service.conversationName(convId).head) shouldEqual Name(List(user2, user3).map(_.name).mkString(", "))
 
       result(service.convStateEventProcessingStage.apply(rConvId, Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(user3.id), reason = None)
+        MemberLeaveEvent(rConvId, None, RemoteInstant.ofEpochSec(10000), selfUserId, None, Seq(user3.id), reason = None)
       )))
       awaitAllTasks
       result(members.head.map(_.size)) shouldEqual 2
       result(service.conversationName(convId).head) shouldEqual user2.name
 
       result(service.convStateEventProcessingStage.apply(rConvId, Seq(
-        MemberLeaveEvent(rConvId, RemoteInstant.ofEpochSec(10000), selfUserId, Seq(user2.id), reason = None)
+        MemberLeaveEvent(rConvId, None, RemoteInstant.ofEpochSec(10000), selfUserId, None, Seq(user2.id), reason = None)
       )))
       awaitAllTasks
       result(members.head.map(_.size)) shouldEqual 1

--- a/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/notifications/NotificationServiceSpec.scala
@@ -64,7 +64,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   private val conv       = ConversationData(remoteId = rConvId, id = convId)
   private val content    = TextMessage("abc")
   private val from       = UserId("User1")
-  private lazy val event = GenericMessageEvent(rConvId, lastEventTime, from, content)
+  private lazy val event = GenericMessageEvent(rConvId, None, lastEventTime, from, None, content)
 
   private val msg = MessageData(
     MessageId(content.unpack._1.str),
@@ -375,10 +375,10 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val originalContent = GenericMessage(Uid("messageId"), Text("abc"))
 
       val editContent1 = GenericMessage(Uid("edit-id-1"), MsgEdit(MessageId(originalContent.unpack._1.str), Text("def")))
-      val editEvent1 = GenericMessageEvent(rConvId, edit1EventTime, from, editContent1)
+      val editEvent1 = GenericMessageEvent(rConvId, None, edit1EventTime, from, None, editContent1)
 
       val editContent2 = GenericMessage(Uid("edit-id-2"), MsgEdit(MessageId(editContent1.unpack._1.str), Text("ghi")))
-      val editEvent2 = GenericMessageEvent(rConvId, edit2EventTime, from, editContent2)
+      val editEvent2 = GenericMessageEvent(rConvId, None, edit2EventTime, from, None, editContent2)
 
       val originalNotification = NotificationData(
         id               = NotId(originalContent.unpack._1.str),
@@ -432,13 +432,13 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       val from = UserId("User1")
       val msgContent = GenericMessage(Uid("messageId"), Text("abc"))
-      val msgEvent = GenericMessageEvent(rConvId, RemoteInstant(clock.instant()), from, msgContent)
+      val msgEvent = GenericMessageEvent(rConvId, None, RemoteInstant(clock.instant()), from, None, msgContent)
 
       val deleteContent1 = GenericMessage(Uid(), MsgDeleted(rConvId, MessageId(toBeDeletedNotif.id.str)))
-      val deleteEvent1 = GenericMessageEvent(rConvId, RemoteInstant.apply(clock.instant()), from, deleteContent1)
+      val deleteEvent1 = GenericMessageEvent(rConvId, None, RemoteInstant.apply(clock.instant()), from, None, deleteContent1)
 
       val deleteContent2 = GenericMessage(Uid(), MsgRecall(MessageId(msgContent.unpack._1.str)))
-      val deleteEvent2 = GenericMessageEvent(rConvId, RemoteInstant.apply(clock.instant()), from, deleteContent2)
+      val deleteEvent2 = GenericMessageEvent(rConvId, None, RemoteInstant.apply(clock.instant()), from, None, deleteContent2)
 
       setup(
         availability = Availability.Available,
@@ -476,16 +476,16 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       val likedMessageId = MessageId("message")
 
       val like1Content = GenericMessage(Uid("like1-id"), Reaction(likedMessageId, Liking.Action.Like, LegalHoldStatus.UNKNOWN))
-      val like1Event = GenericMessageEvent(rConvId, like1EventTime, from, like1Content)
+      val like1Event = GenericMessageEvent(rConvId, None, like1EventTime, from, None, like1Content)
 
       val unlikeContent = GenericMessage(Uid("unlike-id"), Reaction(likedMessageId, Liking.Action.Unlike, LegalHoldStatus.UNKNOWN))
-      val unlikeEvent = GenericMessageEvent(rConvId, unlikeEventTime, from, unlikeContent)
+      val unlikeEvent = GenericMessageEvent(rConvId, None, unlikeEventTime, from, None, unlikeContent)
 
       val like2Content = GenericMessage(Uid("like2-id"), Reaction(likedMessageId, Liking.Action.Like, LegalHoldStatus.UNKNOWN))
-      val like2Event = GenericMessageEvent(rConvId, like2EventTime, from, like2Content)
+      val like2Event = GenericMessageEvent(rConvId, None, like2EventTime, from, None, like2Content)
 
       val otherLikeContent = GenericMessage(Uid("like3-id"), Reaction(likedMessageId, Liking.Action.Like, LegalHoldStatus.UNKNOWN))
-      val otherLikeEvent = GenericMessageEvent(rConvId, otherEventTime, from2, otherLikeContent)
+      val otherLikeEvent = GenericMessageEvent(rConvId, None, otherEventTime, from2, None, otherLikeContent)
 
       val originalMessage =
         MessageData(
@@ -529,7 +529,7 @@ class NotificationServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     scenario("Group creation events") {
       val domain = "anta"
       val generatedMessageId = MessageId()
-      val event = CreateConversationEvent(rConvId, RemoteInstant(clock.instant()), from, ConversationResponse(
+      val event = CreateConversationEvent(rConvId, None, RemoteInstant(clock.instant()), from, None, ConversationResponse(
         rConvId, None, Some(Name("conv")), from, ConversationType.Group, None, MuteSet.AllAllowed,
         RemoteInstant.Epoch, archived = false, RemoteInstant.Epoch, Set.empty, None, None, None,
         Map(QualifiedId(account1Id, domain) -> MemberRole, QualifiedId(from, domain) -> AdminRole), None

--- a/zmessaging/src/test/scala/com/waz/utils/SerialProcessingQueueSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/SerialProcessingQueueSpec.scala
@@ -46,9 +46,9 @@ class SerialProcessingQueueSpec extends AndroidFreeSpec with Matchers with Scala
       val convId = RConvId()
       val future = queue.enqueue(
         Seq(
-          TypingEvent(convId, RemoteInstant(Instant.now()), UserId(), isTyping = true),
-          TypingEvent(convId, RemoteInstant(Instant.now()), UserId(), isTyping = true),
-          TypingEvent(RConvId(), RemoteInstant(Instant.now()), UserId(), isTyping = true)
+          TypingEvent(convId, None, RemoteInstant(Instant.now()), UserId(), None, isTyping = true),
+          TypingEvent(convId, None, RemoteInstant(Instant.now()), UserId(), None, isTyping = true),
+          TypingEvent(RConvId(), None, RemoteInstant(Instant.now()), UserId(), None, isTyping = true)
         )
       )
 


### PR DESCRIPTION
On new backends each conversation event will contain data about the domain its coming from:
the domain of the conversation and also the domain of the sender, if applicable.
This PR is mostly just rewriting the Event class where after adding these two fields a lot of other code
had to be changed. I wrote JSON parsing in such way that if for some reason the Android app is connected
to the old backend which sends events without domains, the event will be handled properly and
the domains will be set to None.

Changes in other classes are only side-effects, like in pattern matching where now we need to take into
account that there are more fields in the given event class.

#### APK
[Download build #3786](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3786/artifact/build/artifact/wire-dev-PR3434-3786.apk)