### PR TITLE
Feature: Enforce ephemeral messages (part 0)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/FeatureConfigsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/FeatureConfigsController.scala
@@ -15,8 +15,12 @@ class FeatureConfigsController(implicit inj: Injector) extends Injectable with D
 
   def startUpdatingFlagsWhenEnteringForeground(): Unit =
     inject[ActivityLifecycleCallback].appInBackground.map(_._1).foreach {
-      case false => featureConfigs.head.foreach(_.updateFileSharing())
-      case true  => ()
+      case false => featureConfigs.head.foreach(updateFlags)
+      case true => ()
     }
 
+  private def updateFlags(configsService: FeatureConfigsService)() {
+    configsService.updateFileSharing()
+    configsService.updateSelfDeletingMessages()
+  }
 }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -441,4 +441,8 @@ object UserPreferences {
 
   lazy val FileSharingFeatureEnabled: PrefKey[Boolean] = PrefKey[Boolean]("file_sharing_feature_enabled", customDefault = true)
   lazy val ShouldInformFileSharingRestriction: PrefKey[Boolean] = PrefKey[Boolean]("should_inform_file_sharing_restriction", customDefault = false)
+
+  lazy val AreSelfDeletingMessagesEnabled: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enabled", customDefault = true)
+  lazy val SelfDeletingMessagesEnforcedTimeout: PrefKey[Int] = PrefKey[Int]("self_deleting_messages_enforced_timeout", customDefault = 0)
+  lazy val ShouldInformSelfDeletingMessagesChanged: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enforced_changed", customDefault = false)
 }

--- a/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
@@ -1,0 +1,26 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder
+import org.json.JSONObject
+
+
+final case class SelfDeletingMessagesFeatureConfig(status: String, seconds: Int) {
+
+
+  def isEnabled: Boolean = status == "enabled"
+
+  def enforcedTimeoutInSeconds: Int = Math.max(0, seconds)
+
+}
+
+object SelfDeletingMessagesFeatureConfig {
+
+  val Default: SelfDeletingMessagesFeatureConfig = SelfDeletingMessagesFeatureConfig(status = "enabled", 0)
+
+  implicit object Decoder extends JsonDecoder[SelfDeletingMessagesFeatureConfig] {
+    override def apply(implicit js: JSONObject): SelfDeletingMessagesFeatureConfig =
+      if (!js.has("status") || !js.has("enforcedTimeoutSeconds")) Default
+      else SelfDeletingMessagesFeatureConfig(js.getString("status"), js.getInt("enforcedTimeoutSeconds"))
+  }
+
+}

--- a/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
@@ -3,9 +3,7 @@ package com.waz.model
 import com.waz.utils.JsonDecoder
 import org.json.JSONObject
 
-
 final case class SelfDeletingMessagesFeatureConfig(status: String, seconds: Int) {
-
 
   def isEnabled: Boolean = status == "enabled"
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
@@ -1,7 +1,7 @@
 package com.waz.sync.client
 
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, TeamId}
+import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig, TeamId}
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http.{HttpClient, RawBodyDeserializer, Request}
@@ -10,6 +10,7 @@ import org.json.JSONObject
 trait FeatureConfigsClient {
   def getAppLock(teamId: TeamId): ErrorOrResponse[AppLockFeatureConfig]
   def getFileSharing(): ErrorOrResponse[FileSharingFeatureConfig]
+  def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig]
 }
 
 class FeatureConfigsClientImpl(implicit
@@ -34,6 +35,12 @@ class FeatureConfigsClientImpl(implicit
     .withResultType[FileSharingFeatureConfig]
     .withErrorType[ErrorResponse]
     .executeSafe
+
+  override def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig] =
+    Request.Get(relativePath =  fileSharingPath)
+    .withResultType[SelfDeletingMessagesFeatureConfig]
+    .withErrorType[ErrorResponse]
+    .executeSafe
 }
 
 object FeatureConfigsClient {
@@ -41,5 +48,6 @@ object FeatureConfigsClient {
 
   val basePath: String = "/feature-configs"
   val fileSharingPath: String = s"$basePath/fileSharing"
+  val selfDeletingMessages: String = s"$basePath/selfDeletingMessages"
 
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
@@ -2,7 +2,7 @@ package com.waz.sync.handler
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, TeamId}
+import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig, TeamId}
 import com.waz.sync.client.FeatureConfigsClient
 
 import scala.concurrent.Future
@@ -10,6 +10,7 @@ import scala.concurrent.Future
 trait FeatureConfigsSyncHandler {
   def fetchAppLock(): Future[AppLockFeatureConfig]
   def fetchFileSharing(): Future[FileSharingFeatureConfig]
+  def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig]
 }
 
 class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfigsClient)
@@ -36,5 +37,14 @@ class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfi
         FileSharingFeatureConfig.Default
       case Right(fileSharing) =>
         fileSharing
+    }
+
+  override def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig] =
+    client.getSelfDeletingMessages().map {
+      case Left(err) =>
+        error(l"Unable to fetch SelfDeletingMessages feature flag: $err")
+        SelfDeletingMessagesFeatureConfig.Default
+      case Right(selfDeletingMessages) =>
+        selfDeletingMessages
     }
 }

--- a/zmessaging/src/test/scala/com/waz/model/SelfDeletingMessagesFeatureConfigSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/SelfDeletingMessagesFeatureConfigSpec.scala
@@ -1,0 +1,75 @@
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.JsonDecoder
+
+class SelfDeletingMessagesFeatureConfigSpec extends AndroidFreeSpec {
+
+  feature("Deserialization form JSON") {
+
+    scenario("Deserializing an enabled config with enforced timeout") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "enabled",
+          |  "enforcedTimeoutSeconds": 30
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual true
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 30
+    }
+    scenario("Deserializing an enabled config without enforced timeout") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "enabled",
+          |  "enforcedTimeoutSeconds": 0
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual true
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 0
+    }
+
+    scenario("Deserializing a disabled config") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "disabled",
+          |  "enforcedTimeoutSeconds": 0
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual false
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 0
+    }
+
+    scenario("Deserializing an error (empty json object)") {
+      // Given
+      val json = "{}"
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig shouldEqual SelfDeletingMessagesFeatureConfig.Default
+    }
+  }
+
+}

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -2,7 +2,7 @@ package com.waz.service.teams
 
 import com.waz.content.UserPreferences._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.{AppLockFeatureConfig, FeatureConfigUpdateEvent, FileSharingFeatureConfig}
+import com.waz.model.{AppLockFeatureConfig, FeatureConfigUpdateEvent, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig}
 import com.waz.service.{EventPipeline, EventPipelineImpl, EventScheduler}
 import com.waz.service.EventScheduler.{Sequential, Stage}
 import com.waz.specs.AndroidFreeSpec
@@ -76,6 +76,25 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     // Then
     result(userPrefs(FileSharingFeatureEnabled).apply()) shouldEqual false
+  }
+
+  scenario("Fetch the SelfDeletingMessage feature config and set properties") {
+    // Given
+    val service = createService
+    userPrefs.setValue(AreSelfDeletingMessagesEnabled, true)
+    userPrefs.setValue(SelfDeletingMessagesEnforcedTimeout, 0)
+
+    // Mock
+    (syncHandler.fetchSelfDeletingMessages _).expects().anyNumberOfTimes().returning(
+      Future.successful(SelfDeletingMessagesFeatureConfig("disabled", 20))
+    )
+
+    // When
+    result(service.updateSelfDeletingMessages())
+
+    // Then
+    result(userPrefs(AreSelfDeletingMessagesEnabled).apply()) shouldEqual false
+    result(userPrefs(SelfDeletingMessagesEnforcedTimeout).apply()) shouldEqual 20
   }
 
   scenario("Process update event for FileSharing feature config") {


### PR DESCRIPTION
## What's new

Jira: https://wearezeta.atlassian.net/browse/SQSERVICES-572

A mechanism that allows team admins to disable or disable the self-deleting messages (ephemeral messages) and optionaly enforce a timeout in seconds for them.

This first PR aims to fetch and update the new flag together with the file sharing restrictions flag recently put in place by @johnxnguyen.

In the next PRs I will tackle the receiving of flag updates via notifications and the actual usage of this flag.