### PR TITLE
Feature: Enforce ephemeral messages (part 1) 

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -32,7 +32,10 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       val fileSharing = JsonDecoder.decode[FileSharingFeatureConfig](data)
       verbose(l"File sharing enabled: ${fileSharing.isEnabled}")
       storeFileSharing(fileSharing)
-
+    case FeatureConfigUpdateEvent("selfDeletingMessages", data) =>
+      val selfDeletingMessages = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](data)
+      verbose(l"Self deleting messages config: $selfDeletingMessages")
+      storeSelfDeletingMessages(selfDeletingMessages)
     case _ =>
       Future.successful(())
   }

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -93,4 +93,21 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(userPrefs(FileSharingFeatureEnabled).apply()) shouldEqual false
   }
 
+  scenario("Process update event for SelfDeletingMessages feature config") {
+    // Given
+    val service = createService
+    val pipeline = createEventPipeline(service)
+    val event = FeatureConfigUpdateEvent("selfDeletingMessages", "{ \"status\": \"true\", \"enforcedSeconds\": 60 }")
+
+    userPrefs.setValue(AreSelfDeletingMessagesEnabled, false)
+    userPrefs.setValue(SelfDeletingMessagesEnforcedTimeout, 0)
+
+    // When
+    result(pipeline.apply(Seq(event)))
+
+    // Then
+    result(userPrefs(AreSelfDeletingMessagesEnabled).apply()) shouldEqual true
+    result(userPrefs(SelfDeletingMessagesEnforcedTimeout).apply()) shouldEqual 60
+  }
+
 }


### PR DESCRIPTION
Continuation of #3445

## What's new in this PR?

Handling of SelfDeletingMessages feature flag updates events.

### Testing

* The event is correctly de-serialized
* The event is correctly processed

