### PR TITLE
Feature: Enforce ephemeral messages (part 2)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1646,8 +1646,10 @@
     <string name="join_conversation_invalid_link_error_message">The conversation link is invalid.</string>
     <string name="join_conversation_member_limit_reached_error_message">The conversation is full.</string>
 
+    <!-- Feature Config Changes -->
+    <string name="feature_config_changed_info_dialog_title">There has been a change in Wire</string>
+
     <!-- File sharing feature config -->
-    <string name="file_sharing_restriction_info_dialog_title">There has been a change in Wire</string>
     <string name="file_sharing_restriction_info_dialog_message">Sharing and receiving files of any type is now disabled.</string>
 
     <string name="file_sharing_restriction_info_image">RECEIVING IMAGES RESTRICTED</string>
@@ -1657,7 +1659,6 @@
     <string name="file_sharing_restriction_info_generic">FILE SHARING RESTRICTED</string>
 
     <!-- Self Deleting Messages feature config -->
-    <string name="self_deleting_messages_change_info_dialog_title">Self-deleting messages restrictions</string>
     <string name="self_deleting_messages_change_info_dialog_message_enabled">Sending of self deleting messages is enabled.</string>
     <string name="self_deleting_messages_change_info_dialog_message_enabled_enforced">Sending of self deleting messages is mandatory. The enforced timeout for deletion is %s seconds.</string>
     <string name="self_deleting_messages_change_info_dialog_message_disabled">Sending of self deleting messages is disabled.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1657,7 +1657,7 @@
     <string name="file_sharing_restriction_info_generic">FILE SHARING RESTRICTED</string>
 
     <!-- Self Deleting Messages feature config -->
-    <string name="self_deleting_messages_change_info_dialog_title">There has been a change in Wire</string>
+    <string name="self_deleting_messages_change_info_dialog_title">Self-deleting messages restrictions</string>
     <string name="self_deleting_messages_change_info_dialog_message_enabled">Sending of self deleting messages is enabled.</string>
     <string name="self_deleting_messages_change_info_dialog_message_enabled_enforced">Sending of self deleting messages is mandatory. The enforced timeout for deletion is %s seconds.</string>
     <string name="self_deleting_messages_change_info_dialog_message_disabled">Sending of self deleting messages is disabled.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1656,5 +1656,11 @@
     <string name="file_sharing_restriction_info_file">RECEIVING FILES RESTRICTED</string>
     <string name="file_sharing_restriction_info_generic">FILE SHARING RESTRICTED</string>
 
+    <!-- Self Deleting Messages feature config -->
+    <string name="self_deleting_messages_change_info_dialog_title">There has been a change in Wire</string>
+    <string name="self_deleting_messages_change_info_dialog_message_enabled">Sending of self deleting messages is enabled.</string>
+    <string name="self_deleting_messages_change_info_dialog_message_enabled_enforced">Sending of self deleting messages is mandatory. The enforced timeout for deletion is %s seconds.</string>
+    <string name="self_deleting_messages_change_info_dialog_message_disabled">Sending of self deleting messages is disabled.</string>
+
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -246,8 +246,8 @@ class MainActivity extends BaseActivity
       }
     }
     userPreferences.flatMap(_.preference(UserPreferences.ShouldInformSelfDeletingMessagesChanged).signal).onUi { shouldInform =>
-      if (!shouldInform) return
-      for {
+      if (!shouldInform) {}
+      else for {
         prefs                     <- userPreferences.head
         isFeatureEnabled          <- prefs.preference(AreSelfDeletingMessagesEnabled).apply()
         enforcedTimeoutInSeconds  <- prefs.preference(SelfDeletingMessagesEnforcedTimeout).apply()

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -356,7 +356,7 @@ object ContextUtils {
 
   def showFileSharingRestrictionInfoDialog(onConfirm: Boolean => Unit)(implicit ex: ExecutionContext, context: Context): Unit = {
     showInfoDialog(
-      title = getString(R.string.file_sharing_restriction_info_dialog_title),
+      title = getString(R.string.feature_config_changed_info_dialog_title),
       msg = getString(R.string.file_sharing_restriction_info_dialog_message)
     ).foreach(onConfirm)
   }
@@ -369,7 +369,7 @@ object ContextUtils {
     }
 
     showInfoDialog(
-      title = getString(R.string.self_deleting_messages_change_info_dialog_title),
+      title = getString(R.string.feature_config_changed_info_dialog_title),
       msg = message
     ).foreach(onConfirm)
   }

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -360,4 +360,17 @@ object ContextUtils {
       msg = getString(R.string.file_sharing_restriction_info_dialog_message)
     ).foreach(onConfirm)
   }
+
+  def showSelfDeletingMessagesConfigsChangeInfoDialog(isEnabled: Boolean, enforcedTimeoutInSeconds: Int)(onConfirm: Boolean => Unit)(implicit ex: ExecutionContext, context: Context): Unit = {
+    val message = (isEnabled, enforcedTimeoutInSeconds) match {
+      case (true, 0 )       => getString(R.string.self_deleting_messages_change_info_dialog_message_enabled)
+      case (true, seconds)  => getString(R.string.self_deleting_messages_change_info_dialog_message_enabled_enforced, seconds.toString)
+      case (false, _)       => getString(R.string.self_deleting_messages_change_info_dialog_message_disabled)
+    }
+
+    showInfoDialog(
+      title = getString(R.string.self_deleting_messages_change_info_dialog_title),
+      msg = message
+    ).foreach(onConfirm)
+  }
 }


### PR DESCRIPTION
Continuation of #3445

## What's new in this PR?

Display a dialog to the user informing changes in the SelfDeletingMessages feature config.

### Testing
 Tested manually

![Screenshot_1629446853](https://user-images.githubusercontent.com/9389043/130202553-8eb02b4e-b7ad-4f25-a62f-26a1070d9ac4.png)
![Screenshot_1629447221](https://user-images.githubusercontent.com/9389043/130202573-c36eae10-52d7-42e9-bccd-289b2f891e75.png)

#### APK
[Download build #3876](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3876/artifact/build/artifact/wire-dev-PR3447-3876.apk)
[Download build #3894](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3894/artifact/build/artifact/wire-dev-PR3447-3894.apk)