### PR TITLE
Federation: Use qualified ids for encrypting, decrypting, and fingerprints

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -51,9 +51,7 @@ class ClientsController(implicit inj: Injector) extends Injectable with DerivedL
 
   def client(userId: UserId, clientId: ClientId): Signal[Option[Client]] = for {
     manager <- accountManager
-    _ = verbose(l"FIX client($userId, $clientId)")
     clients <- manager.storage.otrClientsStorage.signal(userId)
-    _ = verbose(l"FIX ${clients.clients.keys}")
   } yield clients.clients.get(clientId)
 
   def selfClient(clientId: ClientId): Signal[Option[Client]] = for {

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -66,7 +66,6 @@ public enum SyncCommand {
     PostSelf("post-self"),
     SyncSelfClients("sync-clients"),   // sync user clients, register current client and update prekeys when needed
     SyncSelfPermissions("sync-self-permissions"),
-    SyncClients("sync-user-clients"),
     SyncClientsBatch("sync-user-clients-batch"),
     SyncPreKeys("sync-prekeys"),
     PostAddBot("post-add-bot"),

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -438,4 +438,6 @@ object UserPreferences {
     PrefKey[Option[LegalHoldStatus]]("legal_hold_disclosure_type", customDefault = None)
 
   lazy val ShouldPostClientCapabilities: PrefKey[Boolean] = PrefKey[Boolean]("should_post_client_capabilities", customDefault = true)
+
+  lazy val ShouldMigrateToFederation: PrefKey[Boolean] = PrefKey[Boolean]("should_migrate_to_federation", customDefault = true)
 }

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
@@ -1,0 +1,44 @@
+package com.waz.model.otr
+
+import com.waz.model.{QualifiedId, UserId}
+import com.waz.utils.JsonDecoder.decodeStringSeq
+import org.json.JSONObject
+
+import scala.collection.JavaConverters._
+
+final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) {
+  def userIds: Set[UserId] = entries.keySet
+  def isEmpty: Boolean = entries.isEmpty
+  def size: Int = entries.size
+}
+
+object OtrClientIdMap {
+  val Empty: OtrClientIdMap = OtrClientIdMap(Map.empty)
+
+  def apply(entries: Iterable[(UserId, Set[ClientId])]): OtrClientIdMap = OtrClientIdMap(entries.toMap)
+  def from(entries: (UserId, Set[ClientId])*): OtrClientIdMap = OtrClientIdMap(entries.toMap)
+
+  def decodeMap(key: Symbol)(implicit js: JSONObject): OtrClientIdMap =
+    if (!js.has(key.name) || js.isNull(key.name)) OtrClientIdMap.Empty
+    else {
+      val mapJs = js.getJSONObject(key.name)
+      OtrClientIdMap(
+        mapJs.keys.asScala.map { key =>
+          UserId(key) -> decodeStringSeq(Symbol(key))(mapJs).map(ClientId(_)).toSet
+        }.toMap
+      )
+    }
+}
+
+final case class QOtrClientIdMap(entries: Map[QualifiedId, Set[ClientId]]) {
+  def qualifiedIds: Set[QualifiedId] = entries.keySet
+  def isEmpty: Boolean = entries.isEmpty
+  def size: Int = entries.size
+}
+
+object QOtrClientIdMap {
+  val Empty: QOtrClientIdMap = QOtrClientIdMap(Map.empty)
+
+  def apply(entries: Iterable[(QualifiedId, Set[ClientId])]): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
+  def from(entries: (QualifiedId, Set[ClientId])*): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
+}

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -134,13 +134,10 @@ class AccountManager(val userId:  UserId,
   } yield ()
 
   private def qualifiedId(userId: UserId) =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY)
-      for {
-        zms  <- zmessaging
-        user <- zms.usersStorage.get(userId)
-      } yield user.flatMap(_.qualifiedId).orElse(currentDomain.map(QualifiedId(userId, _))).getOrElse(QualifiedId(userId))
-    else
-      Future.successful(QualifiedId(userId))
+    for {
+      zms  <- zmessaging
+      qId  <- zms.users.qualifiedId(userId)
+    } yield qId
 
   def fingerprintSignal(uId: UserId, cId: ClientId): Signal[Option[Array[Byte]]] =
     for {

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -35,6 +35,7 @@ import com.waz.sync.client.InvitationClient.ConfirmedTeamInvitation
 import com.waz.sync.client.{ErrorOr, ErrorOrResponse, InvitationClientImpl, OtrClientImpl}
 import com.wire.signals.CancellableFuture
 import com.waz.utils._
+import com.waz.zms.BuildConfig
 import com.wire.signals._
 import com.waz.znet2.http.ResponseCode
 import com.waz.znet2.{AuthRequestInterceptor, AuthRequestInterceptorImpl}
@@ -45,7 +46,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Right, Success}
 
 class AccountManager(val userId:  UserId,
-                     val domain:  Option[String],
+                     val currentDomain:  Option[String],
                      val teamId:  Option[TeamId],
                      val global:  GlobalModule,
                      accounts:    AccountsService,
@@ -132,14 +133,26 @@ class AccountManager(val userId:  UserId,
     _        <- zms.users.updateSelfPicture(content)
   } yield ()
 
+  private def qualifiedId(userId: UserId) =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY)
+      for {
+        zms  <- zmessaging
+        user <- zms.usersStorage.get(userId)
+      } yield user.flatMap(_.qualifiedId).orElse(currentDomain.map(QualifiedId(userId, _))).getOrElse(QualifiedId(userId))
+    else
+      Future.successful(QualifiedId(userId))
+
   def fingerprintSignal(uId: UserId, cId: ClientId): Signal[Option[Array[Byte]]] =
     for {
       selfClientId <- clientId
       fingerprint  <-
         if (userId == uId && selfClientId.contains(cId))
           Signal.from(cryptoBox(Future successful _.getLocalFingerprint))
-        else
-          cryptoBox.sessions.remoteFingerprint(SessionId(uId, None, cId))
+        else {
+          Signal.from(qualifiedId(uId)).flatMap { qId =>
+            cryptoBox.sessions.remoteFingerprint(SessionId(qId, cId, currentDomain))
+          }
+        }
     } yield fingerprint
 
   def getOrRegisterClient(): ErrorOr[ClientRegistrationState] = {

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -45,7 +45,9 @@ class LegalHoldServiceImpl(selfUserId: UserId,
                            membersStorage: MembersStorage,
                            cryptoSessionService: CryptoSessionService,
                            sync: SyncServiceHandle,
-                           messagesService: MessagesService) extends LegalHoldService {
+                           messagesService: MessagesService,
+                           userService: UserService
+                          ) extends LegalHoldService {
 
   import com.waz.threading.Threading.Implicits.Background
 
@@ -59,12 +61,12 @@ class LegalHoldServiceImpl(selfUserId: UserId,
 
     case LegalHoldEnableEvent(userId) =>
       if (userId == selfUserId) onLegalHoldApprovedFromAnotherDevice()
-      else sync.syncClients(userId).map(_ => ())
+      else userService.syncClients(userId).map(_ => ())
 
 
     case LegalHoldDisableEvent(userId) =>
       if (userId == selfUserId) onLegalHoldDisabled()
-      else  sync.syncClients(userId).map(_ => ())
+      else userService.syncClients(userId).map(_ => ())
 
     case _ =>
       Future.successful({})
@@ -132,7 +134,7 @@ class LegalHoldServiceImpl(selfUserId: UserId,
   } yield ()
 
   private def deleteLegalHoldClientAndSession(clientId: ClientId): Future[Unit] = for {
-    _ <- clientsService.removeClients(selfUserId, Seq(clientId))
+    _ <- clientsService.removeClients(selfUserId, Set(clientId))
     _ <- cryptoSessionService.deleteSession(SessionId(selfUserId, None, clientId))
   } yield ()
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -60,6 +60,7 @@ trait UserService {
   def findUser(id: UserId): Future[Option[UserData]]
   def findUsers(ids: Seq[UserId]): Future[Seq[Option[UserData]]]
   def qualifiedId(userId: UserId): Future[QualifiedId]
+  def qualifiedIds(userIds: Set[UserId]): Future[Set[QualifiedId]]
   def getOrCreateUser(id: UserId): Future[UserData]
   def updateUserData(id: UserId, updater: UserData => UserData): Future[Option[(UserData, UserData)]]
   def syncIfNeeded(userIds: Set[UserId], olderThan: FiniteDuration = SyncIfOlderThan, qIds: Set[QualifiedId] = Set.empty): Future[Option[SyncId]]
@@ -98,6 +99,7 @@ trait UserService {
 }
 
 class UserServiceImpl(selfUserId:        UserId,
+                      currentDomain:     Option[String],
                       teamId:            Option[TeamId],
                       accounts:          AccountsService,
                       accsStorage:       AccountStorage,
@@ -126,6 +128,19 @@ class UserServiceImpl(selfUserId:        UserId,
       users <- usersStorage.keySet
       _     <- syncUsers(users)
       _     <- shouldSyncUsers := false
+    } yield ()
+  }
+
+  private lazy val shouldMigrateToFederation = userPrefs.preference(UserPreferences.ShouldMigrateToFederation)
+
+  for {
+    shouldMigrate <- if (BuildConfig.FEDERATION_USER_DISCOVERY) shouldMigrateToFederation() else Future.successful(false)
+  } if (shouldMigrate && currentDomain.isDefined) {
+    verbose(l"Migrating users to federation")
+    for {
+      userIds <- usersStorage.keySet
+      _       <- usersStorage.updateAll2(userIds, { user => if (user.domain.isEmpty) user.copy(domain = currentDomain) else user })
+      _       <- shouldMigrateToFederation := false
     } yield ()
   }
 
@@ -213,8 +228,37 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def findUsers(ids: Seq[UserId]): Future[Seq[Option[UserData]]] = usersStorage.getAll(ids)
 
+  private def getOrCreateQualifiedId(userId: UserId, qualifiedId: Option[QualifiedId]) =
+    (qualifiedId, currentDomain) match {
+      case (Some(qId), _) if qId.hasDomain => qId
+      case (_, Some(domain)) =>
+        warn(l"qualifiedId($userId): Unable to find the user for the given id or the user has no specified domain - generating a new qId")
+        QualifiedId(userId, domain)
+      case _ =>
+        warn(l"qualifiedId($userId): Unable to find the user for the given id and there is no current domain")
+        QualifiedId(userId)
+    }
+
   override def qualifiedId(userId: UserId): Future[QualifiedId] =
-    findUser(userId).map(_.flatMap(_.qualifiedId).getOrElse(QualifiedId(userId)))
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      for {
+        user        <- findUser(userId)
+        qualifiedId =  user.flatMap(_.qualifiedId)
+      } yield getOrCreateQualifiedId(userId, qualifiedId)
+    } else {
+      Future.successful(QualifiedId(userId))
+    }
+
+  override def qualifiedIds(userIds: Set[UserId]): Future[Set[QualifiedId]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      findUsers(userIds.toSeq).map {
+        _.zip(userIds).map {
+          case (user, userId) => getOrCreateQualifiedId(userId, user.flatMap(_.qualifiedId))
+        }.toSet
+      }
+    } else {
+      Future.successful(userIds.map(QualifiedId(_)))
+    }
 
   override def getOrCreateUser(id: UserId): Future[UserData] =
     usersStorage.getOrCreate(id, {
@@ -460,15 +504,13 @@ class UserServiceImpl(selfUserId:        UserId,
       case _ => Future.successful({})
     })
 
-  override def syncClients(userId: UserId): Future[SyncId] =
-    sync.syncClients(userId)
+  override def syncClients(userId: UserId): Future[SyncId] = syncClients(Set(userId))
 
   override def syncClients(userIds: Set[UserId]): Future[SyncId] =
     for {
-      users  <- usersStorage.listAll(userIds)
-      qIds   =  users.map(user => user.qualifiedId.getOrElse(QualifiedId(user.id))).toSet
+      qIds  <- qualifiedIds(userIds)
       syncId <- sync.syncClients(qIds)
-    } yield (syncId)
+    } yield syncId
 
   override def syncClients(convId: ConvId): Future[SyncId] =
     membersStorage.getActiveUsers(convId).flatMap(userIds => syncClients(userIds.toSet))

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -110,7 +110,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
 
   val global     = account.global
   val selfUserId: UserId = account.userId
-  val selfDomain: Option[String] = if (BuildConfig.FEDERATION_USER_DISCOVERY) account.domain else None
+  val selfDomain: Option[String] = if (BuildConfig.FEDERATION_USER_DISCOVERY) account.currentDomain else None
 
   val auth       = account.auth
   val urlCreator = global.urlCreator

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -28,7 +28,7 @@ import com.waz.content.{GlobalPreferences, MembersStorage, UserPreferences, User
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.log.LogShow.SafeToLog
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.model.{ConvId, RConvId, UserId, _}
 import com.waz.permissions.PermissionsService
 import com.waz.service.EventScheduler.Stage
@@ -221,7 +221,7 @@ class CallingServiceImpl(val accountId:       UserId,
       sendCallMessage(wCall, conv.id, GenericMessage(Uid(), GenericContent.Calling(msg)), recipients, ctx)
     }
 
-  private def clientsMap(avsClients: Set[AvsClient]): Map[UserId, Set[ClientId]] = {
+  private def clientsMap(avsClients: Set[AvsClient]): OtrClientIdMap = OtrClientIdMap {
     avsClients
       .groupBy(_.userid)
       .mapValues(_.map(_.clientid))

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -62,7 +62,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
       loadSession(cb, id).orElse(Option(createSession()))
   }
 
-  private def loadSession(cb: CryptoBox, id: SessionId): Option[CryptoSession] = 
+  private def loadSession(cb: CryptoBox, id: SessionId): Option[CryptoSession] =
     Try(cb.tryGetSession(id.toString)).toOption.orElse {
       error(l"session loading failed unexpectedly, will delete session file")
       cb.deleteSession(id.toString)

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -63,7 +63,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
   }
 
   private def loadSession(cb: CryptoBox, id: SessionId): Option[CryptoSession] =
-    Try(cb.tryGetSession(id.toString)).toOption.orElse {
+    Try(Option(cb.tryGetSession(id.toString))).getOrElse {
       error(l"session loading failed unexpectedly, will delete session file")
       cb.deleteSession(id.toString)
       None

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -50,7 +50,7 @@ trait OtrService {
 
   def resetSession(conv: ConvId, user: UserId, client: ClientId): Future[SyncId]
   def encryptTargetedMessage(user: UserId, client: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]]
-  def deleteClients(userMap: Map[UserId, Seq[ClientId]]): Future[Any]
+  def deleteClients(userMap: OtrClientIdMap): Future[Any]
 
   def encryptMessageForUsers(message:        GenericMessage,
                              users:          Set[UserId],
@@ -58,7 +58,7 @@ trait OtrService {
                              partialResult:  EncryptedContent): Future[EncryptedContent]
 
   def encryptMessage(message:         GenericMessage,
-                     recipients:      Map[UserId, Set[ClientId]],
+                     recipients:      OtrClientIdMap,
                      userFakeOnError: Boolean = false,
                      partialResult:   EncryptedContent): Future[EncryptedContent]
 
@@ -166,21 +166,19 @@ class OtrServiceImpl(selfUserId:     UserId,
 
   override def resetSession(conv: ConvId, userId: UserId, clientId: ClientId): Future[SyncId] =
     for {
-      qId    <- qualifiedId(userId)
+      qId    <- users.qualifiedId(userId)
       _      <- sessions.deleteSession(SessionId(qId, clientId, currentDomain)).recover { case _ => () }
       _      <- clientsStorage.updateVerified(userId, clientId, verified = false)
-      _      <- sync.syncPreKeys(userId, Set(clientId))
+      _      <- sync.syncPreKeys(qId, Set(clientId))
       syncId <- sync.postSessionReset(conv, userId, clientId)
     } yield syncId
 
-  override def encryptTargetedMessage(userId: UserId, clientId: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]] = {
-    val msgData = msg.toByteArray
-    qualifiedId(userId).flatMap { qId =>
+  override def encryptTargetedMessage(userId: UserId, clientId: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]] =
+    users.qualifiedId(userId).flatMap { qId =>
       sessions.withSession(SessionId(qId, clientId, currentDomain)) { session =>
-        EncryptedContent(Map(userId -> Map(clientId -> session.encrypt(msgData))))
+        EncryptedContent(Map(userId -> Map(clientId -> session.encrypt(msg.toByteArray))))
       }
     }
-  }
 
   /**
     * @param message the message to be encrypted
@@ -199,12 +197,12 @@ class OtrServiceImpl(selfUserId:     UserId,
     } yield encryptedContent
   }
 
-  private def clientsMap(userIds: Set[UserId]): Future[Map[UserId, Set[ClientId]]] =
+  private def clientsMap(userIds: Set[UserId]): Future[OtrClientIdMap] =
     Future.traverse(userIds) { userId =>
       getClients(userId).map { clientIds =>
         userId -> clientIds
       }
-    }.map(_.toMap)
+    }.map(OtrClientIdMap(_))
 
   private def getClients(userId: UserId): Future[Set[ClientId]] =
     clientsStorage.getClients(userId).map { clients =>
@@ -219,14 +217,14 @@ class OtrServiceImpl(selfUserId:     UserId,
     * @param partialResult partial content encrypted in previous run, we will use that instead of encrypting again when available
     */
   override def encryptMessage(message:         GenericMessage,
-                              recipients:      Map[UserId, Set[ClientId]],
+                              recipients:      OtrClientIdMap,
                               useFakeOnError:  Boolean = false,
                               partialResult:   EncryptedContent): Future[EncryptedContent] = {
 
     val msgData = message.toByteArray
 
     for {
-      payloads <- Future.traverse(recipients) { case (userId, clientIds) =>
+      payloads <- Future.traverse(recipients.entries) { case (userId, clientIds) =>
                     val partialResultForUser = partialResult.content.getOrElse(userId, Map.empty)
                     encryptForClients(userId, clientIds, msgData, useFakeOnError, partialResultForUser)
                   }
@@ -240,7 +238,7 @@ class OtrServiceImpl(selfUserId:     UserId,
                                 useFakeOnError: Boolean,
                                 partialResult:  Map[ClientId, Array[Byte]]
                                ): Future[(UserId, Map[ClientId, Array[Byte]])] =
-    qualifiedId(userId).flatMap { qId =>
+    users.qualifiedId(userId).flatMap { qId =>
       Future.traverse(clients) { clientId =>
         val previous = partialResult.get(clientId)
           .filter(arr => arr.nonEmpty && arr.sameElements(EncryptionFailedMsg))
@@ -259,11 +257,11 @@ class OtrServiceImpl(selfUserId:     UserId,
       }.map(ms => userId -> ms.flatten.toMap)
     }
 
-  override def deleteClients(userMap: Map[UserId, Seq[ClientId]]): Future[Any] = Future.traverse(userMap) {
+  override def deleteClients(userMap: OtrClientIdMap): Future[Any] = Future.traverse(userMap.entries) {
     case (userId, cs) =>
       for {
         removalResult <- clients.removeClients(userId, cs)
-        qId           <- qualifiedId(userId)
+        qId           <- users.qualifiedId(userId)
         _             <- Future.traverse(cs) { c => sessions.deleteSession(SessionId(qId, c, currentDomain)) }
         _             <- if (removalResult.exists(_._2.clients.isEmpty))
                            users.syncUser(userId)
@@ -305,15 +303,6 @@ class OtrServiceImpl(selfUserId:     UserId,
 
   override def decryptAssetData(assetId: AssetId, otrKey: Option[AESKey], sha: Option[Sha256], data: Option[Array[Byte]]): Option[Array[Byte]] =
     decryptAssetDataCBC(assetId, otrKey, sha, data)
-
-  private def qualifiedId(userId: UserId) =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY)
-      for {
-        user <- users.findUser(userId)
-        qId  =  user.flatMap(_.qualifiedId)
-      } yield qId.orElse(currentDomain.map(QualifiedId(userId, _))).getOrElse(QualifiedId(userId))
-    else
-      Future.successful(QualifiedId(userId))
 }
 
 object OtrService {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
@@ -40,14 +40,14 @@ class LegalHoldSyncHandlerImpl(teamId: Option[TeamId],
     otrSync.postClientDiscoveryMessage(convId).flatMap {
       case Left(errorResponse) =>
         Future.successful(SyncResult.Failure(errorResponse))
-      case Right(clientList) =>
-        val userIds = clientList.keys.toSet
+      case Right(clientsMap) =>
+        val userIds = clientsMap.userIds
 
         for {
-          id1            <- userService.syncIfNeeded(userIds)
-          id2            <- userService.syncClients(userIds)
-          allIds         =  Set(id1, Some(id2)).collect { case Some(id) => id }
-          _              <- syncRequestService.await(allIds)
+          id1    <- userService.syncIfNeeded(userIds)
+          id2    <- userService.syncClients(userIds)
+          allIds =  Set(id1, Some(id2)).collect { case Some(id) => id }
+          _      <- syncRequestService.await(allIds)
         } yield {
           SyncResult.Success
         }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
@@ -22,13 +22,14 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.ShouldPostClientCapabilities
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.otr.{Client, ClientId}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.model.{QualifiedId, UserId}
 import com.waz.service.otr.OtrService.SessionId
 import com.waz.service.otr._
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.Success
 import com.waz.sync.client.{ErrorOr, OtrClient}
+import com.waz.zms.BuildConfig
 import com.wire.cryptobox.PreKey
 
 import scala.collection.immutable.Map
@@ -36,40 +37,40 @@ import scala.concurrent.Future
 
 trait OtrClientsSyncHandler {
   def syncClients(users: Set[QualifiedId]): Future[SyncResult]
-  def syncClients(user: UserId): Future[SyncResult]
+  def syncSelfClients(): Future[SyncResult]
   def postLabel(id: ClientId, label: String): Future[SyncResult]
   def postCapabilities(): Future[SyncResult]
-  def syncPreKeys(clients: Map[UserId, Seq[ClientId]]): Future[SyncResult]
-  def syncSessions(clients: Map[UserId, Seq[ClientId]]): Future[Option[ErrorResponse]]
+  def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult]
+  def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]]
 }
 
-class OtrClientsSyncHandlerImpl(selfId:     UserId,
-                                selfClient: ClientId,
-                                netClient:  OtrClient,
-                                otrClients: OtrClientsService,
-                                cryptoBox:  CryptoBoxService,
-                                userPrefs:  UserPreferences)
-  extends OtrClientsSyncHandler
-    with DerivedLogTag { self =>
-
+class OtrClientsSyncHandlerImpl(selfId:        UserId,
+                                currentDomain: Option[String],
+                                selfClient:    ClientId,
+                                netClient:     OtrClient,
+                                otrClients:    OtrClientsService,
+                                cryptoBox:     CryptoBoxService,
+                                userPrefs:     UserPreferences)
+  extends OtrClientsSyncHandler with DerivedLogTag { self =>
+  import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
   import com.waz.threading.Threading.Implicits.Background
 
   private lazy val sessions = cryptoBox.sessions
 
-  private def hasSession(user: UserId, client: ClientId) =
-    sessions.getSession(SessionId(user, None, client)).map(_.isDefined)
+  private def hasSession(qId: QualifiedId, clientId: ClientId) =
+    sessions.getSession(SessionId(qId, clientId, currentDomain)).map(_.isDefined)
 
-  private def withoutSession(userId: UserId, clients: Iterable[ClientId]) =
-    Future.traverse(clients) { client =>
-      if (selfClient == client) Future successful None
-      else hasSession(userId, client) map { if (_) None else Some(client) }
+  private def withoutSession(qId: QualifiedId, clients: Iterable[ClientId]) =
+    Future.traverse(clients) { clientId =>
+      if (selfClient == clientId) Future successful None
+      else hasSession(qId, clientId) map { if (_) None else Some(clientId) }
     } map { _.flatten.toSeq }
 
-  private def updateClients(users: Map[UserId, Seq[Client]]): Future[SyncResult] = {
-    def withoutSession(): Future[Map[UserId, Seq[ClientId]]] =
+  private def updateClients(users: Map[QualifiedId, Seq[Client]]): Future[SyncResult] = {
+    def withoutSession(): Future[QOtrClientIdMap] =
       Future.sequence(
-        users.map { case (id, clients) => self.withoutSession(id, clients.map(_.id)).map(cs => id -> cs) }
-      ).map(_.toMap)
+        users.map { case (id, clients) => self.withoutSession(id, clients.map(_.id)).map(cs => id -> cs.toSet) }
+      ).map(QOtrClientIdMap(_))
 
     def syncSessionsIfNeeded() =
       for {
@@ -91,14 +92,14 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
         case Left(error) => Future.successful(SyncResult(error))
       }
 
-    val (selfClients, otherClients) = users.partition(_._1 == selfId)
+    val (selfClients, otherClients) = users.partition(_._1.id == selfId)
     val userClients =
       otherClients ++ selfClients.map {
         case (id, clients) => id -> clients.map(c => if (selfClient == c.id) c.copy(verified = Verification.VERIFIED) else c)
       }
 
     for {
-      _   <- otrClients.updateUserClients(userClients, replace = true)
+      _   <- otrClients.updateUserClients(userClients.map { case (QualifiedId(id, _), c) => id -> c }, replace = true)
       res <- syncSessionsIfNeeded()
       res <- if (SyncResult.isSuccess(res)) updatePreKeys(selfClient) else Future.successful(res)
       _   <- res match {
@@ -108,21 +109,21 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
     } yield res
   }
 
-  override def syncClients(userId: UserId): Future[SyncResult] =
-    ((if (userId == selfId) netClient.loadClients() else netClient.loadClients(userId)).future)
+  override def syncSelfClients(): Future[SyncResult] =
+    netClient.loadClients().future
       .flatMap {
         case Left(error)    => Future.successful(SyncResult(error))
-        case Right(clients) => updateClients(Map(userId -> clients))
+        case Right(clients) => updateClients(Map(QualifiedId(selfId, currentDomain.getOrElse("")) -> clients))
       }
 
   override def syncClients(users: Set[QualifiedId]): Future[SyncResult] = {
-    val (qualified, unqualified) = users.partition(_.hasDomain)
+    val (qualified, nonQualified) = users.partition(_.hasDomain)
 
     val qualifiedSync =
       if (qualified.nonEmpty) syncQualified(qualified)
       else Future.successful(SyncResult.Success)
     val unqualifiedSync =
-      if (unqualified.nonEmpty) syncUnqualified(unqualified.map(_.id))
+      if (nonQualified.nonEmpty) syncNonQualified(nonQualified.map(_.id))
       else Future.successful(SyncResult.Success)
 
     qualifiedSync.flatMap {
@@ -134,15 +135,15 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
   private def syncQualified(users: Set[QualifiedId]): Future[SyncResult] =
     netClient.loadClients(users).future.flatMap {
       case Right(response) =>
-        updateClients(response.map { case (QualifiedId(id, _), clients) => id -> clients })
+        updateClients(response)
       case Left(ErrorResponse.PageNotFound) =>
         // fallback to requesting clients per user
-        syncUnqualified(users.map(_.id))
+        syncNonQualified(users.map(_.id))
       case Left(error)=>
         Future.successful(SyncResult(error))
     }
 
-  private def syncUnqualified(users: Set[UserId]): Future[SyncResult] =
+  private def syncNonQualified(users: Set[UserId]): Future[SyncResult] =
     Future
       .sequence(users.map { id => netClient.loadClients(id).future.map(id -> _) })
       .flatMap { responses =>
@@ -151,7 +152,9 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
           case Some(err) =>
             Future.successful(SyncResult(err))
           case None =>
-            updateClients(responses.collect { case (id, Right(clients)) => id -> clients }.toMap)
+            updateClients(responses.collect {
+              case (id, Right(clients)) => QualifiedId(id, currentDomain.getOrElse("")) -> clients
+            }.toMap)
         }
       }
 
@@ -167,19 +170,41 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
       case Left(err) => (userPrefs.preference(ShouldPostClientCapabilities) := true).map(_ => SyncResult(err))
     }
 
-  override def syncPreKeys(clients: Map[UserId, Seq[ClientId]]): Future[SyncResult] = syncSessions(clients).map {
+  override def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult] = syncSessions(clients).map {
     case Some(error) => SyncResult(error)
     case None        => Success
   }
 
-  override def syncSessions(clients: Map[UserId, Seq[ClientId]]): Future[Option[ErrorResponse]] =
+  override def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      loadPreKeys(clients).flatMap {
+        case Left(error) => Future.successful(Some(error))
+        case Right(qs)   =>
+          for {
+            _       <- otrClients.updateUserClients(
+                         qs.map { case (QualifiedId(id, _), cs) => id -> cs.keys.map(Client(_)).toSeq },
+                         replace = false
+                       )
+            prekeys =  qs.flatMap { case (qId, cs) => cs.map { case (c, p) => (SessionId(qId, c, currentDomain), p)} }
+            _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
+            _       <- VerificationStateUpdater.awaitUpdated(selfId)
+          } yield None
+      }.recover {
+        case e: Throwable => Some(ErrorResponse.internalError(e.getMessage))
+      }
+  } else {
+      syncSessions(OtrClientIdMap(clients.entries.map { case (qId, cs) => qId.id -> cs }))
+    }
+
+  private def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]] =
     loadPreKeys(clients).flatMap {
       case Left(error) => Future.successful(Some(error))
       case Right(us)   =>
         for {
           _       <- otrClients.updateUserClients(
-                       us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } }, replace = false
-                     )
+            us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } },
+            replace = false
+          )
           prekeys =  us.flatMap { case (u, cs) => cs map { case (c, p) => (SessionId(u, None, c), p)} }
           _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
           _       <- VerificationStateUpdater.awaitUpdated(selfId)
@@ -188,23 +213,21 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
       case e: Throwable => Some(ErrorResponse.internalError(e.getMessage))
     }
 
-  private def loadPreKeys(clients: Map[UserId, Seq[ClientId]]) = {
-    import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
-
-    def mapSize(map: Map[UserId, Seq[ClientId]]): Int = map.values.map(_.size).sum
-    def load(map: Map[UserId, Seq[ClientId]]): ErrorOr[Map[UserId, Seq[(ClientId, PreKey)]]] = netClient.loadPreKeys(map).future
+  private def loadPreKeys(clients: OtrClientIdMap) = {
+    def mapSize(map: OtrClientIdMap): Int = map.entries.values.map(_.size).sum
+    def load(map: OtrClientIdMap): ErrorOr[Map[UserId, Seq[(ClientId, PreKey)]]] = netClient.loadPreKeys(map).future
 
     // request accepts up to 128 clients, we should make sure not to send more
     if (mapSize(clients) < LoadPreKeysMaxClients) load(clients)
     else {
       // we divide the original map into a list of chunks, each with at most 127 clients
       val chunks =
-        clients.foldLeft(List(Map.empty[UserId, Seq[ClientId]])) { case (acc, (userId, clientIds)) =>
+        clients.entries.foldLeft(List(OtrClientIdMap.Empty)) { case (acc, (userId, clientIds)) =>
           val currentMap = acc.head
           if (mapSize(currentMap) + clientIds.size < LoadPreKeysMaxClients)
-            (currentMap + (userId -> clientIds)) :: acc.tail
+            OtrClientIdMap(currentMap.entries + (userId -> clientIds)) :: acc.tail
           else
-            Map(userId -> clientIds) :: acc
+            OtrClientIdMap.from(userId -> clientIds) :: acc
         }
 
       // for each chunk we load the prekeys separately and then add them together (unless there's an error response)
@@ -216,6 +239,38 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
               responses
                 .collect { case Right(prekeys) => prekeys }
                 .reduce[Map[UserId, Seq[(ClientId, PreKey)]]] { case (p1, p2) => p1 ++ p2 }
+            }
+          }
+        }
+    }
+  }
+
+  private def loadPreKeys(clients: QOtrClientIdMap) = {
+    def mapSize(map: QOtrClientIdMap): Int = map.entries.values.map(_.size).sum
+    def load(map: QOtrClientIdMap): ErrorOr[Map[QualifiedId, Map[ClientId, PreKey]]] = netClient.loadPreKeys(map).future
+
+    // request accepts up to 128 clients, we should make sure not to send more
+    if (mapSize(clients) < LoadPreKeysMaxClients) load(clients)
+    else {
+      // we divide the original map into a list of chunks, each with at most 127 clients
+      val chunks =
+        clients.entries.foldLeft(List(QOtrClientIdMap.Empty)) { case (acc, (qualifiedId, clientIds)) =>
+          val currentMap = acc.head
+          if (mapSize(currentMap) + clientIds.size < LoadPreKeysMaxClients)
+            QOtrClientIdMap(currentMap.entries + (qualifiedId -> clientIds)) :: acc.tail
+          else
+            QOtrClientIdMap.from(qualifiedId -> clientIds) :: acc
+        }
+
+      // for each chunk we load the prekeys separately and then add them together (unless there's an error response)
+      Future
+        .sequence(chunks.map(load))
+        .map { responses =>
+          responses.find(_.isLeft).getOrElse {
+            Right {
+              responses
+                .collect { case Right(prekeys) => prekeys }
+                .reduce[Map[QualifiedId, Map[ClientId, PreKey]]] { case (p1, p2) => p1 ++ p2 }
             }
           }
         }

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -41,6 +41,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
   private val cryptoSessionService = mock[CryptoSessionService]
   private val sync = mock[SyncServiceHandle]
   private val messagesService = mock[MessagesService]
+  private val userService = mock[UserService]
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -68,7 +69,8 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       membersStorage,
       cryptoSessionService,
       sync,
-      messagesService
+      messagesService,
+      userService
     )
   }
 
@@ -350,7 +352,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
 
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(*)
         .anyNumberOfTimes()
         .returning(Future.successful(SyncId("syncId")))
@@ -379,7 +381,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
 
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(*)
         .anyNumberOfTimes()
         .returning(Future.successful(SyncId("syncId")))
@@ -397,7 +399,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
 
       // Expectation
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
           .expects(otherUserId)
           .once()
           .returning(Future.successful(SyncId("syncId")))
@@ -412,7 +414,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
 
       // Expectation
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(otherUserId)
         .once()
         .returning(Future.successful(SyncId("syncId")))
@@ -478,7 +480,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
 
       // Delete client.
       (clientsService.removeClients _ )
-        .expects(selfUserId, Seq(client.id))
+        .expects(selfUserId, Set(client.id))
         .once()
         // We don't care about the return type.
         .returning(Future.successful(None))

--- a/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
@@ -15,6 +15,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
 
   private val selfUserId = UserId("selfUserId")
   private val selfClientId = ClientId("selfClientId")
+  private val currentDomain = Some("staging.zinfra.io")
   private val userPrefs = new TestUserPreferences()
   private val storage = mock[OtrClientsStorage]
   private val sync = mock[SyncServiceHandle]
@@ -22,6 +23,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
   private def createService(): OtrClientsServiceImpl =
     new OtrClientsServiceImpl(
       selfUserId,
+      currentDomain,
       selfClientId,
       userPrefs,
       storage,

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -76,7 +76,7 @@ class UserServiceSpec extends AndroidFreeSpec {
     result(userPrefs(UserPreferences.ShouldSyncUsers) := false)
 
     new UserServiceImpl(
-      users.head.id, None, accountsService, accountsStrg, usersStorage, membersStorage,
+      users.head.id, None, None, accountsService, accountsStrg, usersStorage, membersStorage,
       userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
       selectedConv, messages
     )
@@ -98,7 +98,7 @@ class UserServiceSpec extends AndroidFreeSpec {
       availability should not equal Availability.Busy
 
       val userService = new UserServiceImpl(
-        users.head.id, someTeamId, accountsService, accountsStrg, usersStorage, membersStorage,
+        users.head.id, None, someTeamId, accountsService, accountsStrg, usersStorage, membersStorage,
         userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
         selectedConv, messages
       )

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -23,7 +23,7 @@ import com.waz.content.GlobalPreferences.SkipTerminatingState
 import com.waz.content.{MembersStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.model.{LocalInstant, UserId, _}
 import com.waz.permissions.PermissionsService
 import com.waz.service.call.Avs.AvsClosedReason.{AnsweredElsewhere, Normal, StillOngoing}
@@ -1078,7 +1078,8 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     }
 
     scenario("Messages are targeted if target recipients are specified") {
-      val expectedTargetRecipients = TargetRecipients.SpecificClients(Map(otherUser.userId -> Set(otherUser.clientId)))
+      val expectedTargetRecipients =
+        TargetRecipients.SpecificClients(OtrClientIdMap.from(otherUser.userId -> Set(otherUser.clientId)))
 
       (otrSyncHandler.postOtrMessage _)
         .expects(groupConv.id, *, expectedTargetRecipients, *, *, *)

--- a/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
@@ -22,7 +22,7 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.content.{ConversationStorage, MembersStorage, OtrClientsStorage, UsersStorage}
 import com.waz.model.ConversationData.LegalHoldStatus
 import com.waz.model.GenericMessage.TextMessage
-import com.waz.model.otr.{Client, ClientId, UserClients}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, UserClients}
 import com.waz.model._
 import com.waz.model.otr.Client.DeviceClass
 import com.waz.service.conversation.ConversationsService
@@ -87,7 +87,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
 
       val otherUser = UserId("other-user-id")
       val otherUsersClient = ClientId("other-user-client-id")
-      val recipients = Map(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUsersClient))
+      val recipients = OtrClientIdMap.from(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUsersClient))
 
       val content = "content".getBytes
       val encryptedContent = EncryptedContent(Map(otherUser -> Map(otherUsersClient -> content)))
@@ -120,7 +120,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .returning(CancellableFuture.successful(Right(MessageResponse.Success(ClientMismatch(time = RemoteInstant.Epoch)))))
 
       (service.deleteClients _)
-        .expects(Map.empty[UserId, Seq[ClientId]])
+        .expects(OtrClientIdMap.Empty)
         .returning(Future.successful({}))
 
       (convsService.addUnexpectedMembersToConv _)
@@ -149,15 +149,16 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       val msg = createTextMessage("content")
 
       val selfClient       = Client(selfClientId)
+      val currentDomain    = "domain"
 
       val otherUser        = UserId("other-user-id")
       val otherUserClient  = Client(ClientId("other-user-client-1"))
       val encryptedContent1 = EncryptedContent(Map(otherUser -> Map(otherUserClient.id -> "content".getBytes)))
 
       val missingUser       = UserId("missing-user-id")
-      val missingUserData   = UserData(missingUser, domain = Some("domain"), name = Name("missing user"), searchKey = SearchKey.simple("missing user"))
+      val missingUserData   = UserData(missingUser, domain = Some(currentDomain), name = Name("missing user"), searchKey = SearchKey.simple("missing user"))
       val missingUserClient = Client(ClientId("missing-user-client-1"), deviceClass = DeviceClass.LegalHold)
-      val missing           = Map(missingUser -> Seq(missingUserClient.id))
+      val missing           = OtrClientIdMap.from(missingUser -> Set(missingUserClient.id))
 
       // Expectations for missing clients
       (convStorage.get _)
@@ -191,7 +192,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .returning(CancellableFuture.successful(Right(MessageResponse.Failure(ClientMismatch(missing = missing, time = RemoteInstant.Max)))))
 
       (service.deleteClients _)
-        .expects(Map.empty[UserId, Seq[ClientId]])
+        .expects(OtrClientIdMap.Empty)
         .once()
         .returning(Future.successful({}))
 
@@ -203,7 +204,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       // Expectations for handling missing clients
       (usersStorage.listAll _)
         .expects(Set(missingUser))
-        .once()
+        .anyNumberOfTimes()
         .returning(Future.successful(Vector(missingUserData)))
 
       (clientsSyncHandler.syncClients(_ : Set[QualifiedId]))
@@ -220,6 +221,9 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .once()
         .returning(Future.successful(ErrorData(Uid(), ErrorType.CANNOT_SEND_MESSAGE_TO_UNAPPROVED_LEGAL_HOLD_CONVERSATION)))
 
+      (users.qualifiedIds _).expects(*).anyNumberOfTimes().onCall { userIds: Set[UserId] =>
+        Future.successful(userIds.map(QualifiedId(_, currentDomain)))
+      }
       // When
       val actualResult = result(syncHandler.postOtrMessage(conv.id, msg, isHidden = false))
 
@@ -271,6 +275,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
     def setUpExpectationsForReencryptAndSend(conv: ConversationData,
                                              message: GenericMessage): Unit = {
       val selfClient       = Client(selfClientId)
+      val currentDomain    = "domain"
 
       val otherUser        = UserId("other-user-id")
       val otherUserClient  = Client(ClientId("other-user-client-1"))
@@ -279,10 +284,10 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       val encryptedContent1 = EncryptedContent(Map(otherUser -> Map(otherUserClient.id -> content)))
 
       val missingUser       = UserId("missing-user-id")
-      val missingUserData   = UserData(missingUser, domain = Some("domain"), name = Name("missing user"), searchKey = SearchKey.simple("missing user"))
+      val missingUserData   = UserData(missingUser, domain = Some(currentDomain), name = Name("missing user"), searchKey = SearchKey.simple("missing user"))
       val missingUserClient = Client(ClientId("missing-user-client-1"))
       val contentForMissing = "content".getBytes
-      val missing           = Map(missingUser -> Seq(missingUserClient.id))
+      val missing           = OtrClientIdMap.from(missingUser -> Set(missingUserClient.id))
 
       val encryptedContent2 = EncryptedContent(
         encryptedContent1.content ++
@@ -335,11 +340,11 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
           callsToEncrypt += 1
           callsToEncrypt match {
             case 1 =>
-              recipients shouldEqual Map(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUserClient.id))
+              recipients shouldEqual OtrClientIdMap.from(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUserClient.id))
               previous shouldEqual EncryptedContent.Empty
               Future.successful(encryptedContent1)
             case 2 =>
-              recipients shouldEqual Map(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUserClient.id), missingUser -> Set(missingUserClient.id))
+              recipients shouldEqual OtrClientIdMap.from(account1Id -> Set.empty[ClientId], otherUser -> Set(otherUserClient.id), missingUser -> Set(missingUserClient.id))
               previous shouldEqual encryptedContent1
               Future.successful(encryptedContent2)
           }
@@ -367,7 +372,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         }
 
       (service.deleteClients _)
-        .expects(Map.empty[UserId, Seq[ClientId]])
+        .expects(OtrClientIdMap.Empty)
         .twice()
         .returning(Future.successful({}))
 
@@ -387,7 +392,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
 
       (usersStorage.listAll _)
         .expects(Set(missingUser))
-        .once()
+        .anyNumberOfTimes()
         .returning(Future.successful(Vector(missingUserData)))
 
       (clientsSyncHandler.syncClients(_ : Set[QualifiedId]))
@@ -398,6 +403,10 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .expects(Set(missingUser))
         .noMoreThanOnce()
         .returning(Future.successful(Seq(Some(UserClients(missingUser, Map(missingUserClient.id -> missingUserClient))))))
+
+      (users.qualifiedIds _).expects(*).anyNumberOfTimes().onCall { userIds: Set[UserId] =>
+        Future.successful(userIds.map(QualifiedId(_, currentDomain)))
+      }
     }
 
     scenario("Target message to specific clients") {
@@ -415,7 +424,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       val content = "content".getBytes
       val encryptedContent = EncryptedContent(Map(otherUser1 -> Map(otherClient1 -> content, otherClient2 -> content)))
 
-      val targetRecipients = Map(otherUser1 -> Set(otherClient1), otherUser2 -> Set(otherClient2))
+      val targetRecipients = OtrClientIdMap.from(otherUser1 -> Set(otherClient1), otherUser2 -> Set(otherClient2))
 
       // Expectations
       (convStorage.get _)
@@ -423,7 +432,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .returning(Future.successful(Some(conv)))
 
       (service.encryptMessage _)
-        .expects(msg, Map(otherUser1 -> Set(otherClient1), otherUser2 -> Set(otherClient2)), *, EncryptedContent.Empty)
+        .expects(msg, OtrClientIdMap.from(otherUser1 -> Set(otherClient1), otherUser2 -> Set(otherClient2)), *, EncryptedContent.Empty)
         .returning(Future.successful(encryptedContent))
 
       (msgClient.postMessage _)
@@ -431,7 +440,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
         .returning(CancellableFuture.successful(Right(MessageResponse.Success(ClientMismatch(time = RemoteInstant.Epoch)))))
 
       (service.deleteClients _)
-        .expects(Map.empty[UserId, Seq[ClientId]])
+        .expects(OtrClientIdMap.Empty)
         .returning(Future.successful({}))
 
       (convsService.addUnexpectedMembersToConv _)
@@ -451,9 +460,9 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
       val conv = ConversationData(ConvId("conv-id"), RConvId("r-conv-id"))
       val encryptedContent = EncryptedContent.Empty
 
-      val missingClients: Map[UserId, Seq[ClientId]] = Map(
-        UserId("user1") -> Seq(ClientId("client1"), ClientId("client2")),
-        UserId("user2") -> Seq(ClientId("client1"), ClientId("client2"))
+      val missingClients: OtrClientIdMap = OtrClientIdMap.from(
+        UserId("user1") -> Set(ClientId("client1"), ClientId("client2")),
+        UserId("user2") -> Set(ClientId("client1"), ClientId("client2"))
       )
 
       // Expectations

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -2,7 +2,7 @@ package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.OtrClientsStorage
-import com.waz.model.otr.{Client, ClientId, UserClients}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, UserClients}
 import com.waz.model.{LegalHoldRequest, RConvId, SyncId, TeamId, UserId}
 import com.waz.service.{LegalHoldService, UserService}
 import com.waz.specs.AndroidFreeSpec
@@ -124,9 +124,9 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val client1 = Client(ClientId("client1"))
       val client2 = Client(ClientId("client2"))
 
-      val clientList = Map(
-        user1 -> Seq(client1.id),
-        user2 -> Seq(client2.id)
+      val clientList = OtrClientIdMap.from(
+        user1 -> Set(client1.id),
+        user2 -> Set(client2.id)
       )
 
       // Expectations

--- a/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
@@ -2,8 +2,8 @@ package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences.ShouldPostClientCapabilities
-import com.waz.model.UserId
-import com.waz.model.otr.{Client, ClientId, UserClients}
+import com.waz.model.{QualifiedId, UserId}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, QOtrClientIdMap, UserClients}
 import com.waz.service.otr.{CryptoBoxService, CryptoSessionService, OtrClientsService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -20,6 +20,7 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
 
   private val selfUserId = UserId("selfUserId")
   private val selfClientId = ClientId("selfClientId")
+  private val currentDomain = Some("staging.zinfra.io")
   private val netClient = mock[OtrClient]
   private val otrClients = mock[OtrClientsService]
   private val cryptoBox =  mock[CryptoBoxService]
@@ -27,10 +28,12 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
   private val userPrefs = new TestUserPreferences()
 
   private val otherUserId = UserId("otherUserId")
+  private val otherQualifiedId = QualifiedId(otherUserId, currentDomain.get)
   private val otherClientId = ClientId("otherClientId")
 
   private def createHandler() = new OtrClientsSyncHandlerImpl(
     selfUserId,
+    currentDomain,
     selfClientId,
     netClient,
     otrClients,
@@ -82,13 +85,13 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
     scenario("sync one client") {
       // Given
       val handler = createHandler()
-      val clients = Map(otherUserId -> Seq(otherClientId))
+      val clients = QOtrClientIdMap.from(otherQualifiedId -> Set(otherClientId))
       val responsePreKey = new PreKey(0, Array[Byte](0))
-      val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] =
-        Right(Map(otherUserId -> Seq((otherClientId, responsePreKey))))
+      val response: Either[ErrorResponse, Map[QualifiedId, Map[ClientId, PreKey]]] =
+        Right(Map(otherQualifiedId -> Map(otherClientId -> responsePreKey)))
       val responseUserClients = UserClients(otherUserId, Map(otherClientId -> Client(otherClientId)))
 
-      (netClient.loadPreKeys(_ : Map[UserId, Seq[ClientId]])).expects(clients).once().returning(
+      (netClient.loadPreKeys(_ : QOtrClientIdMap)).expects(clients).once().returning(
         CancellableFuture.successful(response)
       )
       (otrClients.updateUserClients(_: Map[UserId, Seq[Client]], _: Boolean)).expects(*, *).once().returning(
@@ -106,18 +109,21 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
   scenario("sync more clients than the request limit") {
     // Given
     val handler = createHandler()
-    val clients = (0 to (OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients/4 + 1)).map { _ =>
-      UserId() -> Seq(ClientId(), ClientId(), ClientId(), ClientId())
-    }.toMap
+    val clients =
+      QOtrClientIdMap(
+        (0 to (OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients/4 + 1)).map { _ =>
+          QualifiedId(UserId(), currentDomain.get) -> Set(ClientId(), ClientId(), ClientId(), ClientId())
+        }.toMap
+      )
     val responsePreKey = new PreKey(0, Array[Byte](0))
     val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] =
       Right(Map(otherUserId -> Seq((otherClientId, responsePreKey))))
     val responseUserClients = UserClients(otherUserId, Map(otherClientId -> Client(otherClientId)))
 
-    (netClient.loadPreKeys(_ : Map[UserId, Seq[ClientId]])).expects(*).twice().onCall { cs: Map[UserId, Seq[ClientId]] =>
+    (netClient.loadPreKeys(_ : QOtrClientIdMap)).expects(*).twice().onCall { cs: QOtrClientIdMap =>
       (cs.size <  OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients) shouldBe true
-      val result = cs.map { case (userId, clientIds) => userId -> clientIds.map(cId => (cId, responsePreKey)) }
-      val response: Either[ErrorResponse, Map[UserId, Seq[(ClientId, PreKey)]]] = Right(result)
+      val result = cs.entries.map { case (qId, clientIds) => qId -> clientIds.map(_ -> responsePreKey).toMap }
+      val response: Either[ErrorResponse, Map[QualifiedId, Map[ClientId, PreKey]]] = Right(result)
       CancellableFuture.successful(response)
     }
     (otrClients.updateUserClients(_: Map[UserId, Seq[Client]], _: Boolean)).expects(*, *).once().returning(


### PR DESCRIPTION
In this PR we start to use the domain in encrypting and decrypting messages.
We do it only if the domain of the other user is different from the current domain,
which means that on non-federated backends nothing will change even if the feature flag is on.

#### APK
[Download build #3821](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3821/artifact/build/artifact/wire-dev-PR3451-3821.apk)