### PR TITLE
[Fix] Failing test due to feature flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ allprojects {
 }
 
 ext {
-    largeVideoConferenceCalls = true
+    largeVideoConferenceCalls = false
     callingUiButtons = true
-    federationUserDiscovery = true
+    federationUserDiscovery = false
 }
 
 apply from: "./scripts/avs.gradle"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ import org.gradle.api.JavaVersion
 
 object Versions {
     //wire android client
-    const val ANDROID_CLIENT_MAJOR_VERSION = "3.71."
+    const val ANDROID_CLIENT_MAJOR_VERSION = "3.72."
     const val COMPILE_SDK_VERSION = 30
     const val TARGET_SDK_VERSION = 30
     const val MIN_SDK_VERSION = 24


### PR DESCRIPTION
## What's new in this PR?

### Issues

A test related to federation if failing on the release branch.

### Causes

The test encounters an unexpected method call on a mock, which is called because a compile time feature flag `fedatationUserDiscovery` is `false`. The test depends on this flag being `true` to succeed.

### Solutions

Put the test behind the feature flag.

### Testing

Tested manually