### PR TITLE
[Fix] File sharing automation issues 

### DIFF
--- a/app/src/main/res/layout/collection_message_image_content.xml
+++ b/app/src/main/res/layout/collection_message_image_content.xml
@@ -36,10 +36,24 @@
         android:cropToPadding="true"
         />
 
-    <!-- Icon -->
+    <!-- Ephemeral icon -->
 
     <com.waz.zclient.ui.text.GlyphTextView
-        android:id="@+id/icon"
+        android:id="@+id/ephemeral_icon"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:text="@string/glyph__picture"
+        android:textColor="?wirePrimaryTextColor"
+        android:textSize="@dimen/wire__icon_button__text_size"
+        android:visibility="invisible"
+        />
+
+    <!-- Restricted icon -->
+
+    <com.waz.zclient.ui.text.GlyphTextView
+        android:id="@+id/restricted_icon"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/app/src/main/res/layout/row_collection_header.xml
+++ b/app/src/main/res/layout/row_collection_header.xml
@@ -20,6 +20,7 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:app="http://schemas.android.com/apk/res-auto"
+       android:id="@+id/header_container"
        android:layout_width="match_parent"
        android:layout_height="@dimen/collections__header_height"
        android:orientation="horizontal"

--- a/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
+++ b/app/src/main/scala/com/waz/zclient/collection/views/CollectionItemView.scala
@@ -123,7 +123,8 @@ class CollectionImageView(context: Context, attrs: AttributeSet, style: Int)
   override val tpe: MsgPart = MsgPart.Image
 
   private lazy val imageView = findById[ImageView](R.id.image)
-  private lazy val iconView = findById[View](R.id.icon)
+  private lazy val ephemeralIcon = findById[View](R.id.ephemeral_icon)
+  private lazy val restrictedIcon = findById[View](R.id.restricted_icon)
 
   val onClicked = EventStream[Unit]()
 
@@ -134,24 +135,26 @@ class CollectionImageView(context: Context, attrs: AttributeSet, style: Int)
   Signal.zip(messageData.map(_.assetId), ephemeralColorDrawable, restricted).onUi {
     case (Some(id: AssetId), None, false) =>
       verbose(l"Set image asset $id")
-      iconView.setVisible(false)
+      ephemeralIcon.setVisible(false)
+      restrictedIcon.setVisible(false)
       WireGlide(context)
         .load(id)
         .apply(new RequestOptions().transform(new CenterCrop(), new RoundedCorners(CornerRadius)).placeholder(new ColorDrawable(Color.TRANSPARENT)))
         .transition(DrawableTransitionOptions.withCrossFade())
         .into(target)
     case (_, _, true) =>
-      iconView.setVisible(true)
+      ephemeralIcon.setVisible(false)
+      restrictedIcon.setVisible(true)
       WireGlide(context).clear(imageView)
     case (_, Some(ephemeralDrawable), _) =>
       verbose(l"Set ephemeral drawable")
-      iconView.setVisible(true)
+      ephemeralIcon.setVisible(true)
+      restrictedIcon.setVisible(false)
       WireGlide(context).clear(imageView)
       imageView.setImageDrawable(ephemeralDrawable)
     case _ =>
       verbose(l"Set nothing")
       WireGlide(context).clear(imageView)
-
   }
 
   this.onClick {


### PR DESCRIPTION
## What's new in this PR?

This PR includes fixes for the following automation issues:
- The header views in the collection screen can't be located, so an id has been added to this view.
- In the collection image view, automation can't tell when the image is restricted. The icon view that is displayed for the cases when the image is expired or restricted has be replaced with two icon views, one for expired images, and one for restricted images. This allows automation to know when the image is restricted.
#### APK
[Download build #3826](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3826/artifact/build/artifact/wire-dev-PR3453-3826.apk)