### PR TITLE
[Fix] Alert button not working

### DIFF
--- a/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
+++ b/app/src/main/java/com/waz/zclient/views/menus/ConfirmationMenu.java
@@ -344,12 +344,13 @@ public class ConfirmationMenu extends LinearLayout {
         positiveButton.setOnClickListener(onClickListener);
 
         negativeButton = ViewUtils.getView(this, R.id.negative);
+        negativeButton.setOnClickListener(onClickListener);
+
         if (negativeButtonText == null || negativeButtonText.isEmpty()) {
             negativeButton.setVisibility(GONE);
         } else {
             negativeButton.setVisibility(VISIBLE);
             negativeButton.setText(negativeButtonText);
-            negativeButton.setOnClickListener(onClickListener);
         }
 
         neutralButton = ViewUtils.getView(this, R.id.neutral);


### PR DESCRIPTION
## What's new in this PR?

**Jira:** https://wearezeta.atlassian.net/browse/SQCORE-853

### Issues

Tapping the alert button "show device" in the conversation degradation alert doesn't do anything.

### Causes

Some refactoring done as part of https://github.com/wireapp/wire-android/pull/3441 moved setting the click listener of the negative button only when there exists some negative button text. Although this should be the case here, it seems to have broken the button.

### Solutions

Always set the click listener for the negative button.

### Testing

Manually tested.


#### APK
[Download build #3830](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3830/artifact/build/artifact/wire-dev-PR3456-3830.apk)