### PR TITLE
Federation: Refactoring to use qualified ids in zmessaging (part 1)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -51,9 +51,7 @@ class ClientsController(implicit inj: Injector) extends Injectable with DerivedL
 
   def client(userId: UserId, clientId: ClientId): Signal[Option[Client]] = for {
     manager <- accountManager
-    _ = verbose(l"FIX client($userId, $clientId)")
     clients <- manager.storage.otrClientsStorage.signal(userId)
-    _ = verbose(l"FIX ${clients.clients.keys}")
   } yield clients.clients.get(clientId)
 
   def selfClient(clientId: ClientId): Signal[Option[Client]] = for {

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -66,7 +66,6 @@ public enum SyncCommand {
     PostSelf("post-self"),
     SyncSelfClients("sync-clients"),   // sync user clients, register current client and update prekeys when needed
     SyncSelfPermissions("sync-self-permissions"),
-    SyncClients("sync-user-clients"),
     SyncClientsBatch("sync-user-clients-batch"),
     SyncPreKeys("sync-prekeys"),
     PostAddBot("post-add-bot"),

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -438,4 +438,6 @@ object UserPreferences {
     PrefKey[Option[LegalHoldStatus]]("legal_hold_disclosure_type", customDefault = None)
 
   lazy val ShouldPostClientCapabilities: PrefKey[Boolean] = PrefKey[Boolean]("should_post_client_capabilities", customDefault = true)
+
+  lazy val ShouldMigrateToFederation: PrefKey[Boolean] = PrefKey[Boolean]("should_migrate_to_federation", customDefault = true)
 }

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
@@ -5,7 +5,7 @@ import com.waz.utils.JsonDecoder.decodeStringSeq
 import org.json.JSONObject
 import scala.collection.JavaConverters._
 
-final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) {
+final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) extends AnyVal {
   def userIds: Set[UserId] = entries.keySet
   def isEmpty: Boolean = entries.isEmpty
   def size: Int = entries.size

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
@@ -1,0 +1,30 @@
+package com.waz.model.otr
+
+import com.waz.model.UserId
+import com.waz.utils.JsonDecoder.decodeStringSeq
+import org.json.JSONObject
+import scala.collection.JavaConverters._
+
+final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) {
+  def userIds: Set[UserId] = entries.keySet
+  def isEmpty: Boolean = entries.isEmpty
+  def size: Int = entries.size
+}
+
+object OtrClientIdMap {
+  val Empty: OtrClientIdMap = OtrClientIdMap(Map.empty)
+
+  def apply(entries: Iterable[(UserId, Set[ClientId])]): OtrClientIdMap = OtrClientIdMap(entries.toMap)
+  def from(entries: (UserId, Set[ClientId])*): OtrClientIdMap = OtrClientIdMap(entries.toMap)
+
+  def decodeMap(key: Symbol)(implicit js: JSONObject): OtrClientIdMap =
+    if (!js.has(key.name) || js.isNull(key.name)) OtrClientIdMap.Empty
+    else {
+      val mapJs = js.getJSONObject(key.name)
+      OtrClientIdMap(
+        mapJs.keys.asScala.map { key =>
+          UserId(key) -> decodeStringSeq(Symbol(key))(mapJs).map(ClientId(_)).toSet
+        }.toMap
+      )
+    }
+}

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
@@ -1,11 +1,12 @@
 package com.waz.model.otr
 
-import com.waz.model.UserId
+import com.waz.model.{QualifiedId, UserId}
 import com.waz.utils.JsonDecoder.decodeStringSeq
 import org.json.JSONObject
+
 import scala.collection.JavaConverters._
 
-final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) extends AnyVal {
+final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) {
   def userIds: Set[UserId] = entries.keySet
   def isEmpty: Boolean = entries.isEmpty
   def size: Int = entries.size
@@ -27,4 +28,17 @@ object OtrClientIdMap {
         }.toMap
       )
     }
+}
+
+final case class QOtrClientIdMap(entries: Map[QualifiedId, Set[ClientId]]) {
+  def qualifiedIds: Set[QualifiedId] = entries.keySet
+  def isEmpty: Boolean = entries.isEmpty
+  def size: Int = entries.size
+}
+
+object QOtrClientIdMap {
+  val Empty: QOtrClientIdMap = QOtrClientIdMap(Map.empty)
+
+  def apply(entries: Iterable[(QualifiedId, Set[ClientId])]): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
+  def from(entries: (QualifiedId, Set[ClientId])*): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
 }

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -299,8 +299,6 @@ object SyncRequest {
     override val mergeKey: Any = (cmd, id)
   }
 
-  final case class SyncClients(userId: UserId) extends RequestForUser(Cmd.SyncClients)
-
   final case class SyncClientsBatch(ids: Set[QualifiedId]) extends BaseRequest(Cmd.SyncClientsBatch) {
     override def merge(req: SyncRequest) = mergeHelper[SyncClientsBatch](req) { other =>
       if (other.ids.subsetOf(ids)) Merged(this)
@@ -528,7 +526,6 @@ object SyncRequest {
           case Cmd.PostSelf                  => PostSelf(JsonDecoder[UserInfo]('user))
           case Cmd.SyncSelfClients           => SyncSelfClients
           case Cmd.SyncSelfPermissions       => SyncSelfPermissions
-          case Cmd.SyncClients               => SyncClients(userId)
           case Cmd.SyncClientsBatch          => SyncClientsBatch(decodeQualifiedIds('qualified_ids).toSet)
           case Cmd.SyncPreKeys               => SyncPreKeys(userId, decodeClientIdSeq('clients).toSet)
           case Cmd.PostClientLabel           => PostClientLabel(decodeId[ClientId]('client), 'label)
@@ -685,8 +682,6 @@ object SyncRequest {
         case PostSessionReset(_, user, client) =>
           o.put("client", client.str)
           o.put("user", user)
-        case SyncClients(user) =>
-          o.put("user", user.str)
         case SyncClientsBatch(qIds) =>
           o.put("qualified_ids", qIds.map(QualifiedId.Encoder(_)))
         case SyncPreKeys(user, clients) =>

--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -134,13 +134,10 @@ class AccountManager(val userId:  UserId,
   } yield ()
 
   private def qualifiedId(userId: UserId) =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY)
-      for {
-        zms  <- zmessaging
-        user <- zms.usersStorage.get(userId)
-      } yield user.flatMap(_.qualifiedId).orElse(currentDomain.map(QualifiedId(userId, _))).getOrElse(QualifiedId(userId))
-    else
-      Future.successful(QualifiedId(userId))
+    for {
+      zms  <- zmessaging
+      qId  <- zms.users.qualifiedId(userId)
+    } yield qId
 
   def fingerprintSignal(uId: UserId, cId: ClientId): Signal[Option[Array[Byte]]] =
     for {

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -45,7 +45,9 @@ class LegalHoldServiceImpl(selfUserId: UserId,
                            membersStorage: MembersStorage,
                            cryptoSessionService: CryptoSessionService,
                            sync: SyncServiceHandle,
-                           messagesService: MessagesService) extends LegalHoldService {
+                           messagesService: MessagesService,
+                           userService: UserService
+                          ) extends LegalHoldService {
 
   import com.waz.threading.Threading.Implicits.Background
 
@@ -59,12 +61,12 @@ class LegalHoldServiceImpl(selfUserId: UserId,
 
     case LegalHoldEnableEvent(userId) =>
       if (userId == selfUserId) onLegalHoldApprovedFromAnotherDevice()
-      else sync.syncClients(userId).map(_ => ())
+      else userService.syncClients(userId).map(_ => ())
 
 
     case LegalHoldDisableEvent(userId) =>
       if (userId == selfUserId) onLegalHoldDisabled()
-      else  sync.syncClients(userId).map(_ => ())
+      else userService.syncClients(userId).map(_ => ())
 
     case _ =>
       Future.successful({})

--- a/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/LegalHoldService.scala
@@ -134,7 +134,7 @@ class LegalHoldServiceImpl(selfUserId: UserId,
   } yield ()
 
   private def deleteLegalHoldClientAndSession(clientId: ClientId): Future[Unit] = for {
-    _ <- clientsService.removeClients(selfUserId, Seq(clientId))
+    _ <- clientsService.removeClients(selfUserId, Set(clientId))
     _ <- cryptoSessionService.deleteSession(SessionId(selfUserId, None, clientId))
   } yield ()
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -460,15 +460,14 @@ class UserServiceImpl(selfUserId:        UserId,
       case _ => Future.successful({})
     })
 
-  override def syncClients(userId: UserId): Future[SyncId] =
-    sync.syncClients(userId)
+  override def syncClients(userId: UserId): Future[SyncId] = syncClients(Set(userId))
 
   override def syncClients(userIds: Set[UserId]): Future[SyncId] =
     for {
       users  <- usersStorage.listAll(userIds)
       qIds   =  users.map(user => user.qualifiedId.getOrElse(QualifiedId(user.id))).toSet
       syncId <- sync.syncClients(qIds)
-    } yield (syncId)
+    } yield syncId
 
   override def syncClients(convId: ConvId): Future[SyncId] =
     membersStorage.getActiveUsers(convId).flatMap(userIds => syncClients(userIds.toSet))

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -28,7 +28,7 @@ import com.waz.content.{GlobalPreferences, MembersStorage, UserPreferences, User
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.log.LogShow.SafeToLog
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.model.{ConvId, RConvId, UserId, _}
 import com.waz.permissions.PermissionsService
 import com.waz.service.EventScheduler.Stage
@@ -221,7 +221,7 @@ class CallingServiceImpl(val accountId:       UserId,
       sendCallMessage(wCall, conv.id, GenericMessage(Uid(), GenericContent.Calling(msg)), recipients, ctx)
     }
 
-  private def clientsMap(avsClients: Set[AvsClient]): Map[UserId, Set[ClientId]] = {
+  private def clientsMap(avsClients: Set[AvsClient]): OtrClientIdMap = OtrClientIdMap {
     avsClients
       .groupBy(_.userid)
       .mapValues(_.map(_.clientid))

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -63,7 +63,7 @@ class CryptoSessionServiceImpl(cryptoBox: CryptoBoxService)
   }
 
   private def loadSession(cb: CryptoBox, id: SessionId): Option[CryptoSession] =
-    Try(cb.tryGetSession(id.toString)).toOption.orElse {
+    Try(Option(cb.tryGetSession(id.toString))).getOrElse {
       error(l"session loading failed unexpectedly, will delete session file")
       cb.deleteSession(id.toString)
       None

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
@@ -46,7 +46,7 @@ trait OtrClientsService {
   def updateUserClients(user: UserId, clients: Seq[Client], replace: Boolean): Future[UserClients]
   def updateUserClients(ucs: Map[UserId, Seq[Client]], replace: Boolean): Future[Set[UserClients]]
   def onCurrentClientRemoved(): Future[Option[(UserClients, UserClients)]]
-  def removeClients(user: UserId, clients: Seq[ClientId]): Future[Option[(UserClients, UserClients)]]
+  def removeClients(user: UserId, clients: Set[ClientId]): Future[Option[(UserClients, UserClients)]]
   def updateClientLabel(id: ClientId, label: String): Future[Option[SyncId]]
   def selfClient: Signal[Client]
   def getSelfClient: Future[Option[Client]]
@@ -81,7 +81,7 @@ class OtrClientsServiceImpl(selfId:    UserId,
           id <- sync.syncPreKeys(selfId, Set(client.id))
         } yield id
       case OtrClientRemoveEvent(cId) =>
-        removeClients(selfId, Seq(cId))
+        removeClients(selfId, Set(cId))
     }
   }
 
@@ -122,7 +122,7 @@ class OtrClientsServiceImpl(selfId:    UserId,
 
   def onCurrentClientRemoved(): Future[Option[(UserClients, UserClients)]] = storage.update(selfId, _ - clientId)
 
-  override def removeClients(user: UserId, clients: Seq[ClientId]): Future[Option[(UserClients, UserClients)]] =
+  override def removeClients(user: UserId, clients: Set[ClientId]): Future[Option[(UserClients, UserClients)]] =
     storage.update(user, { cs =>
       cs.copy(clients = cs.clients -- clients)
     })

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -173,14 +173,12 @@ class OtrServiceImpl(selfUserId:     UserId,
       syncId <- sync.postSessionReset(conv, userId, clientId)
     } yield syncId
 
-  override def encryptTargetedMessage(userId: UserId, clientId: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]] = {
-    val msgData = msg.toByteArray
+  override def encryptTargetedMessage(userId: UserId, clientId: ClientId, msg: GenericMessage): Future[Option[OtrClient.EncryptedContent]] =
     users.qualifiedId(userId).flatMap { qId =>
       sessions.withSession(SessionId(qId, clientId, currentDomain)) { session =>
-        EncryptedContent(Map(userId -> Map(clientId -> session.encrypt(msgData))))
+        EncryptedContent(Map(userId -> Map(clientId -> session.encrypt(msg.toByteArray))))
       }
     }
-  }
 
   /**
     * @param message the message to be encrypted

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -169,7 +169,7 @@ class OtrServiceImpl(selfUserId:     UserId,
       qId    <- users.qualifiedId(userId)
       _      <- sessions.deleteSession(SessionId(qId, clientId, currentDomain)).recover { case _ => () }
       _      <- clientsStorage.updateVerified(userId, clientId, verified = false)
-      _      <- sync.syncPreKeys(userId, Set(clientId))
+      _      <- sync.syncPreKeys(qId, Set(clientId))
       syncId <- sync.postSessionReset(conv, userId, clientId)
     } yield syncId
 

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -24,7 +24,7 @@ import com.waz.content.{UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.UserData.ConnectionStatus
-import com.waz.model.otr.{ClientId, OtrClientIdMap}
+import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.model.sync._
 import com.waz.model.{AccentColor, Availability, _}
@@ -122,7 +122,7 @@ trait SyncServiceHandle {
   def syncClients(users: Set[QualifiedId]): Future[SyncId]
   def syncProperties(): Future[SyncId]
 
-  def syncPreKeys(user: UserId, clients: Set[ClientId]): Future[SyncId]
+  def syncPreKeys(qId: QualifiedId, clientIds: Set[ClientId]): Future[SyncId]
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId): Future[SyncId]
 
   def performFullSync(): Future[Unit]
@@ -239,7 +239,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postClientLabel(id: ClientId, label: String) = addRequest(PostClientLabel(id, label))
   def postClientCapabilities(): Future[SyncId] = addRequest(PostClientCapabilities)
   def syncClients(users: Set[QualifiedId]): Future[SyncId] = addRequest(SyncClientsBatch(users))
-  def syncPreKeys(user: UserId, clients: Set[ClientId]) = addRequest(SyncPreKeys(user, clients))
+  def syncPreKeys(qId: QualifiedId, clientIds: Set[ClientId]): Future[SyncId] = addRequest(SyncPreKeys(qId, clientIds))
   def syncProperties(): Future[SyncId] = addRequest(SyncProperties, forceRetry = true)
 
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId) = addRequest(PostSessionReset(conv, user, client))
@@ -301,7 +301,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
         req match {
           case SyncSelfClients                                 => zms.otrClientsSync.syncSelfClients()
           case SyncClientsBatch(users)                         => zms.otrClientsSync.syncClients(users)
-          case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(OtrClientIdMap.from(user -> clients))
+          case SyncPreKeys(qId, clientIds)                     => zms.otrClientsSync.syncPreKeys(QOtrClientIdMap.from(qId -> clientIds))
           case PostClientLabel(id, label)                      => zms.otrClientsSync.postLabel(id, label)
           case SyncConversation(convs)                         => zms.conversationSync.syncConversations(convs)
           case SyncConversations                               => zms.conversationSync.syncConversations()

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -119,7 +119,6 @@ trait SyncServiceHandle {
   def syncSelfPermissions(): Future[SyncId]
   def postClientLabel(id: ClientId, label: String): Future[SyncId]
   def postClientCapabilities(): Future[SyncId]
-  def syncClients(user: UserId): Future[SyncId]
   def syncClients(users: Set[QualifiedId]): Future[SyncId]
   def syncProperties(): Future[SyncId]
 
@@ -239,8 +238,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def syncSelfPermissions() = addRequest(SyncSelfPermissions, priority = Priority.High)
   def postClientLabel(id: ClientId, label: String) = addRequest(PostClientLabel(id, label))
   def postClientCapabilities(): Future[SyncId] = addRequest(PostClientCapabilities)
-  def syncClients(user: UserId) = addRequest(SyncClients(user))
-  def syncClients(users: Set[QualifiedId]) = addRequest(SyncClientsBatch(users))
+  def syncClients(users: Set[QualifiedId]): Future[SyncId] = addRequest(SyncClientsBatch(users))
   def syncPreKeys(user: UserId, clients: Set[ClientId]) = addRequest(SyncPreKeys(user, clients))
   def syncProperties(): Future[SyncId] = addRequest(SyncProperties, forceRetry = true)
 
@@ -301,8 +299,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
     accounts.getZms(accountId).flatMap {
       case Some(zms) =>
         req match {
-          case SyncSelfClients                                 => zms.otrClientsSync.syncClients(accountId)
-          case SyncClients(user)                               => zms.otrClientsSync.syncClients(user)
+          case SyncSelfClients                                 => zms.otrClientsSync.syncSelfClients()
           case SyncClientsBatch(users)                         => zms.otrClientsSync.syncClients(users)
           case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(Map(user -> clients.toSeq))
           case PostClientLabel(id, label)                      => zms.otrClientsSync.postLabel(id, label)

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -24,7 +24,7 @@ import com.waz.content.{UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.UserData.ConnectionStatus
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.model.sync._
 import com.waz.model.{AccentColor, Availability, _}
@@ -301,7 +301,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
         req match {
           case SyncSelfClients                                 => zms.otrClientsSync.syncSelfClients()
           case SyncClientsBatch(users)                         => zms.otrClientsSync.syncClients(users)
-          case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(Map(user -> clients.toSeq))
+          case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(OtrClientIdMap.from(user -> clients))
           case PostClientLabel(id, label)                      => zms.otrClientsSync.postLabel(id, label)
           case SyncConversation(convs)                         => zms.conversationSync.syncConversations(convs)
           case SyncConversations                               => zms.conversationSync.syncConversations()

--- a/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -43,9 +43,8 @@ import scala.collection.breakOut
 import scala.util.{Failure, Success, Try}
 
 trait OtrClient {
-  def loadPreKeys(user: UserId): ErrorOrResponse[Seq[ClientKey]]
-  def loadClientPreKey(user: UserId, client: ClientId): ErrorOrResponse[ClientKey]
   def loadPreKeys(users: OtrClientIdMap): ErrorOrResponse[Map[UserId, Seq[ClientKey]]]
+  def loadPreKeys(users: QOtrClientIdMap): ErrorOrResponse[Map[QualifiedId, Map[ClientId, PreKey]]]
   def loadClients(): ErrorOrResponse[Seq[Client]]
   def loadClients(user: UserId): ErrorOrResponse[Seq[Client]]
   def loadClients(users: Set[QualifiedId]): ErrorOrResponse[Map[QualifiedId, Seq[Client]]]
@@ -82,22 +81,11 @@ class OtrClientImpl(implicit
   private implicit val ListClientsResponseDeserializer: RawBodyDeserializer[ListClientsResponse] =
     RawBodyDeserializer[JSONObject].map(ListClientsResponse.Decoder(_))
 
+  private implicit val ListPreKeysResponseDeserializer: RawBodyDeserializer[ListPreKeysResponse] =
+    RawBodyDeserializer[JSONObject].map(ListPreKeysResponse.Decoder(_))
+
   private implicit val ClientDeserializer: RawBodyDeserializer[Client] =
     RawBodyDeserializer[JSONObject].map(ClientsResponse.Decoder(_))
-
-  override def loadPreKeys(user: UserId): ErrorOrResponse[Seq[ClientKey]] = {
-    Request.Get(relativePath = userPreKeysPath(user))
-      .withResultType[UserPreKeysResponse]
-      .withErrorType[ErrorResponse]
-      .executeSafe(_.keys)
-  }
-
-  override def loadClientPreKey(user: UserId, client: ClientId): ErrorOrResponse[ClientKey] = {
-    Request.Get(relativePath = clientPreKeyPath(user, client))
-      .withResultType[ClientKey]
-      .withErrorType[ErrorResponse]
-      .executeSafe
-  }
 
   override def loadPreKeys(users: OtrClientIdMap): ErrorOrResponse[Map[UserId, Seq[ClientKey]]] = {
     // TODO: request accepts up to 128 clients, we should make sure not to send more
@@ -107,14 +95,33 @@ class OtrClientImpl(implicit
       }
     }
 
-    Request.Post(relativePath = prekeysPath, body = data)
+    Request.Post(relativePath = PrekeysPath, body = data)
       .withResultType[PreKeysResponse]
       .withErrorType[ErrorResponse]
       .executeSafe(_.toMap)
   }
 
+  override def loadPreKeys(users: QOtrClientIdMap): ErrorOrResponse[Map[QualifiedId, Map[ClientId, PreKey]]] = {
+    val entries: Map[String, Map[QualifiedId, Set[ClientId]]] = users.entries.groupBy(_._1.domain)
+    val data = JsonEncoder { o =>
+      entries.foreach { case (domain, map) =>
+        val mapJson = JsonEncoder { js =>
+          map.foreach { case (QualifiedId(id, _), cs) =>
+            js.put(id.str, JsonEncoder.arrString(cs.map(_.str).toSeq))
+          }
+        }
+        o.put(domain, mapJson)
+      }
+    }
+
+    Request.Post(relativePath = ListPrekeysPath, body = data)
+      .withResultType[ListPreKeysResponse]
+      .withErrorType[ErrorResponse]
+      .executeSafe(_.values)
+  }
+
   override def loadClients(): ErrorOrResponse[Seq[Client]] = {
-    Request.Get(relativePath = clientsPath)
+    Request.Get(relativePath = ClientsPath)
       .withResultType[Seq[Client]]
       .withErrorType[ErrorResponse]
       .executeSafe
@@ -159,7 +166,7 @@ class OtrClientImpl(implicit
       password.map(_.str).foreach(o.put("password", _))
     }
 
-    Request.Post(relativePath = clientsPath, body = data)
+    Request.Post(relativePath = ClientsPath, body = data)
       .withResultType[Client]
       .withErrorType[ErrorResponse]
       .executeSafe(_.copy(verified = Verification.VERIFIED)) //TODO Maybe we can add description for this?
@@ -218,16 +225,20 @@ class OtrClientImpl(implicit
 
 object OtrClient extends DerivedLogTag {
 
-  val clientsPath = "/clients"
-  val prekeysPath = "/users/prekeys"
+  val ClientsPath = "/clients"
+  val PrekeysPath = "/users/prekeys"
   val BroadcastPath = "/broadcast/otr/messages"
   val ListClientsPath = "/users/list-clients/v2"
+  val ListPrekeysPath = "/users/list-prekeys"
 
   def clientPath(id: ClientId) = s"/clients/$id"
   def clientKeyIdsPath(id: ClientId) = s"/clients/$id/prekeys"
   def userPreKeysPath(user: UserId) = s"/users/$user/prekeys"
   def userClientsPath(user: UserId) = s"/users/$user/clients"
   def clientPreKeyPath(user: UserId, client: ClientId) = s"/users/$user/prekeys/$client"
+
+  def userPreKeysPath(qId: QualifiedId) = s"/users/${qId.domain}/${qId.id.str}/prekeys"
+  def clientPreKeyPath(qId: QualifiedId, clientId: ClientId) = s"/users/${qId.domain}/${qId.id.str}/prekeys/$clientId"
 
   // If you change this, don't forget to set the 'ShouldPostClientCapabilities' user preference
   // to true so that the updated client with inform the backend.
@@ -296,14 +307,6 @@ object OtrClient extends DerivedLogTag {
     (decodeId[ClientId]('client), JsonDecoder[PreKey]('prekey))
   }
 
-  case class UserPreKeysResponse(userId: UserId, keys: Seq[ClientKey])
-
-  object UserPreKeysResponse {
-    implicit def UserPreKeysResponseDecoder: JsonDecoder[UserPreKeysResponse] = JsonDecoder.lift { implicit js =>
-      UserPreKeysResponse('user: UserId, JsonDecoder.decodeSeq('clients)(js, ClientDecoder))
-    }
-  }
-
   //TODO Remove this. Introduce JSONDecoder for the Map
   type PreKeysResponse = Seq[(UserId, Seq[ClientKey])]
   object PreKeysResponse {
@@ -322,6 +325,37 @@ object OtrClient extends DerivedLogTag {
       case _ => None
     }
   }
+
+  final case class ListPreKeysResponse(values: Map[QualifiedId, Map[ClientId, PreKey]])
+
+  object ListPreKeysResponse {
+    val Empty: ListPreKeysResponse = ListPreKeysResponse(Map.empty)
+
+    import scala.collection.JavaConverters._
+
+    private def getPreKeys(json: JSONObject): Map[ClientId, PreKey] =
+      json.keySet.asScala.toSeq.map { clientId =>
+        ClientId(clientId) -> PreKeyDecoder(json.getJSONObject(clientId))
+      }.toMap
+
+    private def getUserPreKeys(domain: String, json: JSONObject): Map[QualifiedId, Map[ClientId, PreKey]] =
+      json.keySet.asScala.toSeq.flatMap { userId =>
+        Try(json.getJSONObject(userId)).map { preKeysJson =>
+          QualifiedId(UserId(userId), domain) -> getPreKeys(preKeysJson)
+        }.toOption
+      }.toMap
+
+    implicit object Decoder extends JsonDecoder[ListPreKeysResponse] {
+      override def apply(implicit jsMap: JSONObject): ListPreKeysResponse = {
+        val response =
+          jsMap.keySet.asScala.toSeq.flatMap { domain =>
+            Try(jsMap.getJSONObject(domain)).map(getUserPreKeys(domain, _)).getOrElse(Map.empty)
+          }.toMap
+        if (response.nonEmpty) ListPreKeysResponse(response) else Empty
+      }
+    }
+  }
+
 
   final case class ListClientsRequest(qualifiedUsers: Seq[QualifiedId]) {
     def encode: JSONObject = JsonEncoder { o =>

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LegalHoldSyncHandler.scala
@@ -40,14 +40,14 @@ class LegalHoldSyncHandlerImpl(teamId: Option[TeamId],
     otrSync.postClientDiscoveryMessage(convId).flatMap {
       case Left(errorResponse) =>
         Future.successful(SyncResult.Failure(errorResponse))
-      case Right(clientList) =>
-        val userIds = clientList.keys.toSet
+      case Right(clientsMap) =>
+        val userIds = clientsMap.userIds
 
         for {
-          id1            <- userService.syncIfNeeded(userIds)
-          id2            <- userService.syncClients(userIds)
-          allIds         =  Set(id1, Some(id2)).collect { case Some(id) => id }
-          _              <- syncRequestService.await(allIds)
+          id1    <- userService.syncIfNeeded(userIds)
+          id2    <- userService.syncClients(userIds)
+          allIds =  Set(id1, Some(id2)).collect { case Some(id) => id }
+          _      <- syncRequestService.await(allIds)
         } yield {
           SyncResult.Success
         }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
@@ -22,13 +22,14 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.ShouldPostClientCapabilities
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.otr.{Client, ClientId, OtrClientIdMap}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.model.{QualifiedId, UserId}
 import com.waz.service.otr.OtrService.SessionId
 import com.waz.service.otr._
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.Success
 import com.waz.sync.client.{ErrorOr, OtrClient}
+import com.waz.zms.BuildConfig
 import com.wire.cryptobox.PreKey
 
 import scala.collection.immutable.Map
@@ -39,37 +40,37 @@ trait OtrClientsSyncHandler {
   def syncSelfClients(): Future[SyncResult]
   def postLabel(id: ClientId, label: String): Future[SyncResult]
   def postCapabilities(): Future[SyncResult]
-  def syncPreKeys(clients: OtrClientIdMap): Future[SyncResult]
-  def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]]
+  def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult]
+  def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]]
 }
 
-class OtrClientsSyncHandlerImpl(selfId:     UserId,
-                                selfClient: ClientId,
-                                netClient:  OtrClient,
-                                otrClients: OtrClientsService,
-                                cryptoBox:  CryptoBoxService,
-                                userPrefs:  UserPreferences)
-  extends OtrClientsSyncHandler
-    with DerivedLogTag { self =>
-
+class OtrClientsSyncHandlerImpl(selfId:        UserId,
+                                currentDomain: Option[String],
+                                selfClient:    ClientId,
+                                netClient:     OtrClient,
+                                otrClients:    OtrClientsService,
+                                cryptoBox:     CryptoBoxService,
+                                userPrefs:     UserPreferences)
+  extends OtrClientsSyncHandler with DerivedLogTag { self =>
+  import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
   import com.waz.threading.Threading.Implicits.Background
 
   private lazy val sessions = cryptoBox.sessions
 
-  private def hasSession(user: UserId, client: ClientId) =
-    sessions.getSession(SessionId(user, None, client)).map(_.isDefined)
+  private def hasSession(qId: QualifiedId, clientId: ClientId) =
+    sessions.getSession(SessionId(qId, clientId, currentDomain)).map(_.isDefined)
 
-  private def withoutSession(userId: UserId, clients: Iterable[ClientId]) =
-    Future.traverse(clients) { client =>
-      if (selfClient == client) Future successful None
-      else hasSession(userId, client) map { if (_) None else Some(client) }
+  private def withoutSession(qId: QualifiedId, clients: Iterable[ClientId]) =
+    Future.traverse(clients) { clientId =>
+      if (selfClient == clientId) Future successful None
+      else hasSession(qId, clientId) map { if (_) None else Some(clientId) }
     } map { _.flatten.toSeq }
 
-  private def updateClients(users: Map[UserId, Seq[Client]]): Future[SyncResult] = {
-    def withoutSession(): Future[OtrClientIdMap] =
+  private def updateClients(users: Map[QualifiedId, Seq[Client]]): Future[SyncResult] = {
+    def withoutSession(): Future[QOtrClientIdMap] =
       Future.sequence(
         users.map { case (id, clients) => self.withoutSession(id, clients.map(_.id)).map(cs => id -> cs.toSet) }
-      ).map(OtrClientIdMap(_))
+      ).map(QOtrClientIdMap(_))
 
     def syncSessionsIfNeeded() =
       for {
@@ -91,14 +92,14 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
         case Left(error) => Future.successful(SyncResult(error))
       }
 
-    val (selfClients, otherClients) = users.partition(_._1 == selfId)
+    val (selfClients, otherClients) = users.partition(_._1.id == selfId)
     val userClients =
       otherClients ++ selfClients.map {
         case (id, clients) => id -> clients.map(c => if (selfClient == c.id) c.copy(verified = Verification.VERIFIED) else c)
       }
 
     for {
-      _   <- otrClients.updateUserClients(userClients, replace = true)
+      _   <- otrClients.updateUserClients(userClients.map { case (QualifiedId(id, _), c) => id -> c }, replace = true)
       res <- syncSessionsIfNeeded()
       res <- if (SyncResult.isSuccess(res)) updatePreKeys(selfClient) else Future.successful(res)
       _   <- res match {
@@ -112,7 +113,7 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
     netClient.loadClients().future
       .flatMap {
         case Left(error)    => Future.successful(SyncResult(error))
-        case Right(clients) => updateClients(Map(selfId -> clients))
+        case Right(clients) => updateClients(Map(QualifiedId(selfId, currentDomain.getOrElse("")) -> clients))
       }
 
   override def syncClients(users: Set[QualifiedId]): Future[SyncResult] = {
@@ -134,7 +135,7 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
   private def syncQualified(users: Set[QualifiedId]): Future[SyncResult] =
     netClient.loadClients(users).future.flatMap {
       case Right(response) =>
-        updateClients(response.map { case (QualifiedId(id, _), clients) => id -> clients })
+        updateClients(response)
       case Left(ErrorResponse.PageNotFound) =>
         // fallback to requesting clients per user
         syncNonQualified(users.map(_.id))
@@ -151,7 +152,9 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
           case Some(err) =>
             Future.successful(SyncResult(err))
           case None =>
-            updateClients(responses.collect { case (id, Right(clients)) => id -> clients }.toMap)
+            updateClients(responses.collect {
+              case (id, Right(clients)) => QualifiedId(id, currentDomain.getOrElse("")) -> clients
+            }.toMap)
         }
       }
 
@@ -167,19 +170,41 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
       case Left(err) => (userPrefs.preference(ShouldPostClientCapabilities) := true).map(_ => SyncResult(err))
     }
 
-  override def syncPreKeys(clients: OtrClientIdMap): Future[SyncResult] = syncSessions(clients).map {
+  override def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult] = syncSessions(clients).map {
     case Some(error) => SyncResult(error)
     case None        => Success
   }
 
-  override def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]] =
+  override def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      loadPreKeys(clients).flatMap {
+        case Left(error) => Future.successful(Some(error))
+        case Right(qs)   =>
+          for {
+            _       <- otrClients.updateUserClients(
+                         qs.map { case (QualifiedId(id, _), cs) => id -> cs.keys.map(Client(_)).toSeq },
+                         replace = false
+                       )
+            prekeys =  qs.flatMap { case (qId, cs) => cs.map { case (c, p) => (SessionId(qId, c, currentDomain), p)} }
+            _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
+            _       <- VerificationStateUpdater.awaitUpdated(selfId)
+          } yield None
+      }.recover {
+        case e: Throwable => Some(ErrorResponse.internalError(e.getMessage))
+      }
+  } else {
+      syncSessions(OtrClientIdMap(clients.entries.map { case (qId, cs) => qId.id -> cs }))
+    }
+
+  private def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]] =
     loadPreKeys(clients).flatMap {
       case Left(error) => Future.successful(Some(error))
       case Right(us)   =>
         for {
           _       <- otrClients.updateUserClients(
-                       us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } }, replace = false
-                     )
+            us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } },
+            replace = false
+          )
           prekeys =  us.flatMap { case (u, cs) => cs map { case (c, p) => (SessionId(u, None, c), p)} }
           _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
           _       <- VerificationStateUpdater.awaitUpdated(selfId)
@@ -189,8 +214,6 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
     }
 
   private def loadPreKeys(clients: OtrClientIdMap) = {
-    import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
-
     def mapSize(map: OtrClientIdMap): Int = map.entries.values.map(_.size).sum
     def load(map: OtrClientIdMap): ErrorOr[Map[UserId, Seq[(ClientId, PreKey)]]] = netClient.loadPreKeys(map).future
 
@@ -216,6 +239,38 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
               responses
                 .collect { case Right(prekeys) => prekeys }
                 .reduce[Map[UserId, Seq[(ClientId, PreKey)]]] { case (p1, p2) => p1 ++ p2 }
+            }
+          }
+        }
+    }
+  }
+
+  private def loadPreKeys(clients: QOtrClientIdMap) = {
+    def mapSize(map: QOtrClientIdMap): Int = map.entries.values.map(_.size).sum
+    def load(map: QOtrClientIdMap): ErrorOr[Map[QualifiedId, Map[ClientId, PreKey]]] = netClient.loadPreKeys(map).future
+
+    // request accepts up to 128 clients, we should make sure not to send more
+    if (mapSize(clients) < LoadPreKeysMaxClients) load(clients)
+    else {
+      // we divide the original map into a list of chunks, each with at most 127 clients
+      val chunks =
+        clients.entries.foldLeft(List(QOtrClientIdMap.Empty)) { case (acc, (qualifiedId, clientIds)) =>
+          val currentMap = acc.head
+          if (mapSize(currentMap) + clientIds.size < LoadPreKeysMaxClients)
+            QOtrClientIdMap(currentMap.entries + (qualifiedId -> clientIds)) :: acc.tail
+          else
+            QOtrClientIdMap.from(qualifiedId -> clientIds) :: acc
+        }
+
+      // for each chunk we load the prekeys separately and then add them together (unless there's an error response)
+      Future
+        .sequence(chunks.map(load))
+        .map { responses =>
+          responses.find(_.isLeft).getOrElse {
+            Right {
+              responses
+                .collect { case Right(prekeys) => prekeys }
+                .reduce[Map[QualifiedId, Map[ClientId, PreKey]]] { case (p1, p2) => p1 ++ p2 }
             }
           }
         }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -25,7 +25,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.service.conversation.ConversationsService
 import com.waz.service.otr.OtrService
 import com.waz.service.push.PushService
@@ -58,7 +58,7 @@ trait OtrSyncHandler {
                        previous:   EncryptedContent = EncryptedContent.Empty,
                        recipients: Option[Set[UserId]] = None
                       ): ErrorOr[RemoteInstant]
-  def postClientDiscoveryMessage(convId: RConvId): ErrorOr[Map[UserId, Seq[ClientId]]]
+  def postClientDiscoveryMessage(convId: RConvId): ErrorOr[OtrClientIdMap]
 }
 
 class OtrSyncHandlerImpl(teamId:             Option[TeamId],
@@ -131,15 +131,15 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
                         encryptAndSend(newMessage, Some(data)) //abandon retries and previous EncryptedContent
                       }
         _          <- resp.map(_.deleted).mapFuture(service.deleteClients)
-        _          <- resp.map(_.missing.keySet).mapFuture(convsService.addUnexpectedMembersToConv(conv.id, _))
+        _          <- resp.map(_.missing.userIds).mapFuture(convsService.addUnexpectedMembersToConv(conv.id, _))
         retry      <- resp.flatMapFuture {
                         case MessageResponse.Failure(ClientMismatch(_, missing, _, _)) if retries < 3 =>
                           warn(l"a message response failure with client mismatch with $missing, self client id is: $selfClientId")
                           for {
-                            syncResult        <- syncClients(missing.keys.toSet)
+                            syncResult        <- syncClients(missing.userIds)
                             err                = SyncResult.unapply(syncResult)
                             _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
-                            needsConfirmation <- needsLegalHoldConfirmation(conv, isHidden, missing.keys.toSet)
+                            needsConfirmation <- needsLegalHoldConfirmation(conv, isHidden, missing.userIds)
                             _                  = if (needsConfirmation) throw LegalHoldDiscoveredException
                             result            <- encryptAndSend(msg, external, retries + 1, content)
                           } yield result
@@ -183,13 +183,13 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case SpecificClients(_)       => IgnoreMissingClients
     }
 
-  private def clientsMap(targetRecipients: TargetRecipients, convId: ConvId): Future[Map[UserId, Set[ClientId]]] = {
-    def clientIds(userIds: Set[UserId]): Future[Map[UserId, Set[ClientId]]] = {
+  private def clientsMap(targetRecipients: TargetRecipients, convId: ConvId): Future[OtrClientIdMap] = {
+    def clientIds(userIds: Set[UserId]): Future[OtrClientIdMap] = {
       Future.traverse(userIds) { userId =>
         clientsStorage.getClients(userId).map { clients =>
           userId -> clients.map(_.id).filterNot(_ == selfClientId).toSet
         }
-      }.map(_.toMap)
+      }.map(OtrClientIdMap(_))
     }
 
     targetRecipients match {
@@ -252,9 +252,9 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
               s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries: $missing"
             )))
           case _ =>
-            syncClients(missing.keys.toSet).flatMap { syncResult =>
+            syncClients(missing.userIds).flatMap { syncResult =>
               SyncResult.unapply(syncResult) match {
-                case None                 => onRetry(missing.keySet)
+                case None                 => onRetry(missing.userIds)
                 case Some(_) if retry < 3 => onRetry(currentRecipients)
                 case Some(err)            => successful(Left(err))
               }
@@ -278,7 +278,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case Some(ct) => successful(Some(ct))
       case None =>
         for {
-          _       <- clientsSyncHandler.syncSessions(Map(userId -> Seq(clientId)))
+          _       <- clientsSyncHandler.syncSessions(OtrClientIdMap.from(userId -> Set(clientId)))
           content <- service.encryptTargetedMessage(userId, clientId, msg)
         } yield content
     }
@@ -297,18 +297,15 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
     }
   }
 
-  override def postClientDiscoveryMessage(convId: RConvId): Future[Either[ErrorResponse, Map[UserId, Seq[ClientId]]]] = {
+  override def postClientDiscoveryMessage(convId: RConvId): ErrorOr[OtrClientIdMap] =
     for {
       Some(conv) <- convStorage.getByRemoteId(convId)
-      message = OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
-      response <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
+      message    =  OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
+      response   <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
     } yield response match {
-      case Left(error) =>
-        Left(error)
-      case Right(messageResponse) =>
-        Right(messageResponse.missing)
+      case Left(error) => Left(error)
+      case Right(resp) => Right(resp.missing)
     }
-  }
 
   private def syncClients(users: Set[UserId]): Future[SyncResult] =
     for {
@@ -342,7 +339,7 @@ object OtrSyncHandler {
     final case class SpecificUsers(userIds: Set[UserId]) extends TargetRecipients
 
     /// These exact clients should receive the message.
-    final case class SpecificClients(clientsByUser: Map[UserId, Set[ClientId]]) extends TargetRecipients
+    final case class SpecificClients(clientsByUser: OtrClientIdMap) extends TargetRecipients
   }
 
   /// Describes how missing clients should be handled.

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -25,7 +25,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
-import com.waz.model.otr.{ClientId, OtrClientIdMap}
+import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.service.conversation.ConversationsService
 import com.waz.service.otr.OtrService
 import com.waz.service.push.PushService
@@ -278,7 +278,8 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case Some(ct) => successful(Some(ct))
       case None =>
         for {
-          _       <- clientsSyncHandler.syncSessions(OtrClientIdMap.from(userId -> Set(clientId)))
+          qId     <- userService.qualifiedId(userId)
+          _       <- clientsSyncHandler.syncSessions(QOtrClientIdMap.from(qId -> Set(clientId)))
           content <- service.encryptTargetedMessage(userId, clientId, msg)
         } yield content
     }

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -480,7 +480,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
 
       // Delete client.
       (clientsService.removeClients _ )
-        .expects(selfUserId, Seq(client.id))
+        .expects(selfUserId, Set(client.id))
         .once()
         // We don't care about the return type.
         .returning(Future.successful(None))

--- a/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/LegalHoldServiceSpec.scala
@@ -41,6 +41,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
   private val cryptoSessionService = mock[CryptoSessionService]
   private val sync = mock[SyncServiceHandle]
   private val messagesService = mock[MessagesService]
+  private val userService = mock[UserService]
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -68,7 +69,8 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       membersStorage,
       cryptoSessionService,
       sync,
-      messagesService
+      messagesService,
+      userService
     )
   }
 
@@ -350,7 +352,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
 
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(*)
         .anyNumberOfTimes()
         .returning(Future.successful(SyncId("syncId")))
@@ -379,7 +381,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
       userPrefs.setValue(UserPreferences.LegalHoldRequest, Some(legalHoldRequest))
 
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(*)
         .anyNumberOfTimes()
         .returning(Future.successful(SyncId("syncId")))
@@ -397,7 +399,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
 
       // Expectation
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
           .expects(otherUserId)
           .once()
           .returning(Future.successful(SyncId("syncId")))
@@ -412,7 +414,7 @@ class LegalHoldServiceSpec extends AndroidFreeSpec {
       val pipeline = createEventPipeline()
 
       // Expectation
-      (sync.syncClients(_: UserId))
+      (userService.syncClients(_: UserId))
         .expects(otherUserId)
         .once()
         .returning(Future.successful(SyncId("syncId")))

--- a/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
@@ -15,6 +15,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
 
   private val selfUserId = UserId("selfUserId")
   private val selfClientId = ClientId("selfClientId")
+  private val currentDomain = Some("staging.zinfra.io")
   private val userPrefs = new TestUserPreferences()
   private val storage = mock[OtrClientsStorage]
   private val sync = mock[SyncServiceHandle]
@@ -22,6 +23,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
   private def createService(): OtrClientsServiceImpl =
     new OtrClientsServiceImpl(
       selfUserId,
+      currentDomain,
       selfClientId,
       userPrefs,
       storage,

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -76,7 +76,7 @@ class UserServiceSpec extends AndroidFreeSpec {
     result(userPrefs(UserPreferences.ShouldSyncUsers) := false)
 
     new UserServiceImpl(
-      users.head.id, None, accountsService, accountsStrg, usersStorage, membersStorage,
+      users.head.id, None, None, accountsService, accountsStrg, usersStorage, membersStorage,
       userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
       selectedConv, messages
     )
@@ -98,7 +98,7 @@ class UserServiceSpec extends AndroidFreeSpec {
       availability should not equal Availability.Busy
 
       val userService = new UserServiceImpl(
-        users.head.id, someTeamId, accountsService, accountsStrg, usersStorage, membersStorage,
+        users.head.id, None, someTeamId, accountsService, accountsStrg, usersStorage, membersStorage,
         userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
         selectedConv, messages
       )

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -23,7 +23,7 @@ import com.waz.content.GlobalPreferences.SkipTerminatingState
 import com.waz.content.{MembersStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
-import com.waz.model.otr.ClientId
+import com.waz.model.otr.{ClientId, OtrClientIdMap}
 import com.waz.model.{LocalInstant, UserId, _}
 import com.waz.permissions.PermissionsService
 import com.waz.service.call.Avs.AvsClosedReason.{AnsweredElsewhere, Normal, StillOngoing}
@@ -1078,7 +1078,8 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     }
 
     scenario("Messages are targeted if target recipients are specified") {
-      val expectedTargetRecipients = TargetRecipients.SpecificClients(Map(otherUser.userId -> Set(otherUser.clientId)))
+      val expectedTargetRecipients =
+        TargetRecipients.SpecificClients(OtrClientIdMap.from(otherUser.userId -> Set(otherUser.clientId)))
 
       (otrSyncHandler.postOtrMessage _)
         .expects(groupConv.id, *, expectedTargetRecipients, *, *, *)

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -2,7 +2,7 @@ package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.OtrClientsStorage
-import com.waz.model.otr.{Client, ClientId, UserClients}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, UserClients}
 import com.waz.model.{LegalHoldRequest, RConvId, SyncId, TeamId, UserId}
 import com.waz.service.{LegalHoldService, UserService}
 import com.waz.specs.AndroidFreeSpec
@@ -124,9 +124,9 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val client1 = Client(ClientId("client1"))
       val client2 = Client(ClientId("client2"))
 
-      val clientList = Map(
-        user1 -> Seq(client1.id),
-        user2 -> Seq(client2.id)
+      val clientList = OtrClientIdMap.from(
+        user1 -> Set(client1.id),
+        user2 -> Set(client2.id)
       )
 
       // Expectations


### PR DESCRIPTION
You can follow titles of respective commits to see how the refactoring went from one stage to the other.
1. Use qualified ids only for syncing clients - I simplified a bit the code for syncing clients. I removed the old `SyncClients` command and the associated methods. Now in all cases the code for qualified ids will be used (but it still respects the federation flag - if it's off, we're only interested in `userId`s in qualified ids, not the domains. 
2. Use domains in generated qualified ids - Until now an empty string for the domain was the sign that we use the current domain. From now on, qualified ids will always carry the domain, also the domain of the current user. This is necessary, because new OTR events always carry the domain of the conversation and the sender and we need to be able to compare those domains with domains of other users. It's easier to do it if we can be sure that the domain is always there.
3. Migrate users data - There is already the "domain" field in `UserData` (also in DB) but until now it was empty for users from the current domain. Now, these will be changed to the current domain.
4. Wrap the map of user ids to client ids in `OtrClientIdMap` - In a lot of places in zmessaging we use maps of the type `Map[UserId, Set[ClientId]]` or `Map[UserId, Seq[ClientId]]`. I wrapped them into a new type, `OtrClientIdMap`. In future I want to change `UserId` in there to `QualifiedId` and it will be easier if I have this code in one place, so to say. But before I do that, I want to work on prekeys and basic messaging. So that's why refactoring stops at this point.

#### APK
[Download build #3831](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3831/artifact/build/artifact/wire-dev-PR3457-3831.apk)
[Download build #3845](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3845/artifact/build/artifact/wire-dev-PR3457-3845.apk)