### PR TITLE
[Calling]: Large conference calls - Feature  : Video participants moved to the top of the list and order tiles alphabetically

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -169,8 +169,9 @@ class CallingGridFragment extends FragmentHelper {
         }.sortWith {
           case (_: SelfVideoView, _) => true
           case (_, _: SelfVideoView) => false
-          case (v1, v2) =>
-            infoMap(v1.participant.userId).displayName.toLowerCase < infoMap(v2.participant.userId).displayName.toLowerCase
+          case (v1, v2) if isVideoUser(infoMap(v1.participant.userId)) && !isVideoUser(infoMap(v2.participant.userId)) => true
+          case (v1, v2) if !isVideoUser(infoMap(v1.participant.userId)) && isVideoUser(infoMap(v2.participant.userId)) => false
+          case (v1, v2) => infoMap(v1.participant.userId).displayName.toLowerCase < infoMap(v2.participant.userId).displayName.toLowerCase
         }.take(MaxAllVideoPreviews)
 
     gridViews.zipWithIndex.foreach { case (userVideoView, index) =>
@@ -213,6 +214,8 @@ class CallingGridFragment extends FragmentHelper {
 
     viewMap = viewMap.filter { case (participant, _) => participantsToShow.contains(participant) }
   }
+
+  def isVideoUser(callParticipantInfo: CallParticipantInfo): Boolean = callParticipantInfo.isVideoEnabled || callParticipantInfo.isScreenShareEnabled
 
   private def refreshViews(participantsToShow: Seq[Participant], selfUserId: UserId, selfClientId: ClientId): Seq[UserVideoView] = {
 


### PR DESCRIPTION
## What's new in this PR?

This PR introduce a new feature for large video calls. The main request is to sort participant tiles using the follow order:

- Self user (always on the top, with or without the camera on)
- participants with video ON, ordered by alphabet
- participants with video OFF, ordered by alphabet

https://wearezeta.atlassian.net/browse/SQCALL-389

#### APK
[Download build #3855](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3855/artifact/build/artifact/wire-dev-PR3461-3855.apk)