### PR TITLE
[Calling]: Large conference calls - Bugfix : When the remove video is turned off, I see a frozen video instead of avatar

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/UserVideoView.scala
@@ -102,7 +102,11 @@ abstract class UserVideoView(context: Context, val participant: Participant) ext
     case _                          => View.GONE
   }.onUi(participantInfoCardView.setVisibility)
 
-  private lazy val allVideoStates =  callController.allVideoReceiveStates.map(_.getOrElse(participant, VideoState.Unknown))
+  def unMutedParticipant(participant: Participant) = participant.copy(muted = false)
+
+  private lazy val allVideoStates = if (BuildConfig.LARGE_VIDEO_CONFERENCE_CALLS)
+    callController.allVideoReceiveStates.map(_.getOrElse(unMutedParticipant(participant), VideoState.Unknown))
+  else callController.allVideoReceiveStates.map(_.getOrElse(participant, VideoState.Unknown))
 
   protected def registerHandler(view: View): Unit = {
     allVideoStates.onUi {


### PR DESCRIPTION
This PR fixes a bug for large video Conference calls : When the remove video is turned off, I see a frozen video instead of avatar.

https://wearezeta.atlassian.net/browse/SQCALL-348

#### APK
[Download build #3858](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3858/artifact/build/artifact/wire-dev-PR3463-3858.apk)