### PR TITLE
Federation: prekeys

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrClientIdMap.scala
@@ -1,11 +1,12 @@
 package com.waz.model.otr
 
-import com.waz.model.UserId
+import com.waz.model.{QualifiedId, UserId}
 import com.waz.utils.JsonDecoder.decodeStringSeq
 import org.json.JSONObject
+
 import scala.collection.JavaConverters._
 
-final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) extends AnyVal {
+final case class OtrClientIdMap(entries: Map[UserId, Set[ClientId]]) {
   def userIds: Set[UserId] = entries.keySet
   def isEmpty: Boolean = entries.isEmpty
   def size: Int = entries.size
@@ -27,4 +28,17 @@ object OtrClientIdMap {
         }.toMap
       )
     }
+}
+
+final case class QOtrClientIdMap(entries: Map[QualifiedId, Set[ClientId]]) {
+  def qualifiedIds: Set[QualifiedId] = entries.keySet
+  def isEmpty: Boolean = entries.isEmpty
+  def size: Int = entries.size
+}
+
+object QOtrClientIdMap {
+  val Empty: QOtrClientIdMap = QOtrClientIdMap(Map.empty)
+
+  def apply(entries: Iterable[(QualifiedId, Set[ClientId])]): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
+  def from(entries: (QualifiedId, Set[ClientId])*): QOtrClientIdMap = QOtrClientIdMap(entries.toMap)
 }

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -169,7 +169,7 @@ class OtrServiceImpl(selfUserId:     UserId,
       qId    <- users.qualifiedId(userId)
       _      <- sessions.deleteSession(SessionId(qId, clientId, currentDomain)).recover { case _ => () }
       _      <- clientsStorage.updateVerified(userId, clientId, verified = false)
-      _      <- sync.syncPreKeys(userId, Set(clientId))
+      _      <- sync.syncPreKeys(qId, Set(clientId))
       syncId <- sync.postSessionReset(conv, userId, clientId)
     } yield syncId
 

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -24,7 +24,7 @@ import com.waz.content.{UserPreferences, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.UserData.ConnectionStatus
-import com.waz.model.otr.{ClientId, OtrClientIdMap}
+import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.model.sync._
 import com.waz.model.{AccentColor, Availability, _}
@@ -122,7 +122,7 @@ trait SyncServiceHandle {
   def syncClients(users: Set[QualifiedId]): Future[SyncId]
   def syncProperties(): Future[SyncId]
 
-  def syncPreKeys(user: UserId, clients: Set[ClientId]): Future[SyncId]
+  def syncPreKeys(qId: QualifiedId, clientIds: Set[ClientId]): Future[SyncId]
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId): Future[SyncId]
 
   def performFullSync(): Future[Unit]
@@ -239,7 +239,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postClientLabel(id: ClientId, label: String) = addRequest(PostClientLabel(id, label))
   def postClientCapabilities(): Future[SyncId] = addRequest(PostClientCapabilities)
   def syncClients(users: Set[QualifiedId]): Future[SyncId] = addRequest(SyncClientsBatch(users))
-  def syncPreKeys(user: UserId, clients: Set[ClientId]) = addRequest(SyncPreKeys(user, clients))
+  def syncPreKeys(qId: QualifiedId, clientIds: Set[ClientId]): Future[SyncId] = addRequest(SyncPreKeys(qId, clientIds))
   def syncProperties(): Future[SyncId] = addRequest(SyncProperties, forceRetry = true)
 
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId) = addRequest(PostSessionReset(conv, user, client))
@@ -301,7 +301,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
         req match {
           case SyncSelfClients                                 => zms.otrClientsSync.syncSelfClients()
           case SyncClientsBatch(users)                         => zms.otrClientsSync.syncClients(users)
-          case SyncPreKeys(user, clients)                      => zms.otrClientsSync.syncPreKeys(OtrClientIdMap.from(user -> clients))
+          case SyncPreKeys(qId, clientIds)                     => zms.otrClientsSync.syncPreKeys(QOtrClientIdMap.from(qId -> clientIds))
           case PostClientLabel(id, label)                      => zms.otrClientsSync.postLabel(id, label)
           case SyncConversation(convs)                         => zms.conversationSync.syncConversations(convs)
           case SyncConversations                               => zms.conversationSync.syncConversations()

--- a/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -43,9 +43,8 @@ import scala.collection.breakOut
 import scala.util.{Failure, Success, Try}
 
 trait OtrClient {
-  def loadPreKeys(user: UserId): ErrorOrResponse[Seq[ClientKey]]
-  def loadClientPreKey(user: UserId, client: ClientId): ErrorOrResponse[ClientKey]
   def loadPreKeys(users: OtrClientIdMap): ErrorOrResponse[Map[UserId, Seq[ClientKey]]]
+  def loadPreKeys(users: QOtrClientIdMap): ErrorOrResponse[Map[QualifiedId, Map[ClientId, PreKey]]]
   def loadClients(): ErrorOrResponse[Seq[Client]]
   def loadClients(user: UserId): ErrorOrResponse[Seq[Client]]
   def loadClients(users: Set[QualifiedId]): ErrorOrResponse[Map[QualifiedId, Seq[Client]]]
@@ -82,22 +81,11 @@ class OtrClientImpl(implicit
   private implicit val ListClientsResponseDeserializer: RawBodyDeserializer[ListClientsResponse] =
     RawBodyDeserializer[JSONObject].map(ListClientsResponse.Decoder(_))
 
+  private implicit val ListPreKeysResponseDeserializer: RawBodyDeserializer[ListPreKeysResponse] =
+    RawBodyDeserializer[JSONObject].map(ListPreKeysResponse.Decoder(_))
+
   private implicit val ClientDeserializer: RawBodyDeserializer[Client] =
     RawBodyDeserializer[JSONObject].map(ClientsResponse.Decoder(_))
-
-  override def loadPreKeys(user: UserId): ErrorOrResponse[Seq[ClientKey]] = {
-    Request.Get(relativePath = userPreKeysPath(user))
-      .withResultType[UserPreKeysResponse]
-      .withErrorType[ErrorResponse]
-      .executeSafe(_.keys)
-  }
-
-  override def loadClientPreKey(user: UserId, client: ClientId): ErrorOrResponse[ClientKey] = {
-    Request.Get(relativePath = clientPreKeyPath(user, client))
-      .withResultType[ClientKey]
-      .withErrorType[ErrorResponse]
-      .executeSafe
-  }
 
   override def loadPreKeys(users: OtrClientIdMap): ErrorOrResponse[Map[UserId, Seq[ClientKey]]] = {
     // TODO: request accepts up to 128 clients, we should make sure not to send more
@@ -107,14 +95,33 @@ class OtrClientImpl(implicit
       }
     }
 
-    Request.Post(relativePath = prekeysPath, body = data)
+    Request.Post(relativePath = PrekeysPath, body = data)
       .withResultType[PreKeysResponse]
       .withErrorType[ErrorResponse]
       .executeSafe(_.toMap)
   }
 
+  override def loadPreKeys(users: QOtrClientIdMap): ErrorOrResponse[Map[QualifiedId, Map[ClientId, PreKey]]] = {
+    val entries: Map[String, Map[QualifiedId, Set[ClientId]]] = users.entries.groupBy(_._1.domain)
+    val data = JsonEncoder { o =>
+      entries.foreach { case (domain, map) =>
+        val mapJson = JsonEncoder { js =>
+          map.foreach { case (QualifiedId(id, _), cs) =>
+            js.put(id.str, JsonEncoder.arrString(cs.map(_.str).toSeq))
+          }
+        }
+        o.put(domain, mapJson)
+      }
+    }
+
+    Request.Post(relativePath = ListPrekeysPath, body = data)
+      .withResultType[ListPreKeysResponse]
+      .withErrorType[ErrorResponse]
+      .executeSafe(_.values)
+  }
+
   override def loadClients(): ErrorOrResponse[Seq[Client]] = {
-    Request.Get(relativePath = clientsPath)
+    Request.Get(relativePath = ClientsPath)
       .withResultType[Seq[Client]]
       .withErrorType[ErrorResponse]
       .executeSafe
@@ -159,7 +166,7 @@ class OtrClientImpl(implicit
       password.map(_.str).foreach(o.put("password", _))
     }
 
-    Request.Post(relativePath = clientsPath, body = data)
+    Request.Post(relativePath = ClientsPath, body = data)
       .withResultType[Client]
       .withErrorType[ErrorResponse]
       .executeSafe(_.copy(verified = Verification.VERIFIED)) //TODO Maybe we can add description for this?
@@ -218,16 +225,20 @@ class OtrClientImpl(implicit
 
 object OtrClient extends DerivedLogTag {
 
-  val clientsPath = "/clients"
-  val prekeysPath = "/users/prekeys"
+  val ClientsPath = "/clients"
+  val PrekeysPath = "/users/prekeys"
   val BroadcastPath = "/broadcast/otr/messages"
   val ListClientsPath = "/users/list-clients/v2"
+  val ListPrekeysPath = "/users/list-prekeys"
 
   def clientPath(id: ClientId) = s"/clients/$id"
   def clientKeyIdsPath(id: ClientId) = s"/clients/$id/prekeys"
   def userPreKeysPath(user: UserId) = s"/users/$user/prekeys"
   def userClientsPath(user: UserId) = s"/users/$user/clients"
   def clientPreKeyPath(user: UserId, client: ClientId) = s"/users/$user/prekeys/$client"
+
+  def userPreKeysPath(qId: QualifiedId) = s"/users/${qId.domain}/${qId.id.str}/prekeys"
+  def clientPreKeyPath(qId: QualifiedId, clientId: ClientId) = s"/users/${qId.domain}/${qId.id.str}/prekeys/$clientId"
 
   // If you change this, don't forget to set the 'ShouldPostClientCapabilities' user preference
   // to true so that the updated client with inform the backend.
@@ -296,14 +307,6 @@ object OtrClient extends DerivedLogTag {
     (decodeId[ClientId]('client), JsonDecoder[PreKey]('prekey))
   }
 
-  case class UserPreKeysResponse(userId: UserId, keys: Seq[ClientKey])
-
-  object UserPreKeysResponse {
-    implicit def UserPreKeysResponseDecoder: JsonDecoder[UserPreKeysResponse] = JsonDecoder.lift { implicit js =>
-      UserPreKeysResponse('user: UserId, JsonDecoder.decodeSeq('clients)(js, ClientDecoder))
-    }
-  }
-
   //TODO Remove this. Introduce JSONDecoder for the Map
   type PreKeysResponse = Seq[(UserId, Seq[ClientKey])]
   object PreKeysResponse {
@@ -322,6 +325,37 @@ object OtrClient extends DerivedLogTag {
       case _ => None
     }
   }
+
+  final case class ListPreKeysResponse(values: Map[QualifiedId, Map[ClientId, PreKey]])
+
+  object ListPreKeysResponse {
+    val Empty: ListPreKeysResponse = ListPreKeysResponse(Map.empty)
+
+    import scala.collection.JavaConverters._
+
+    private def getPreKeys(json: JSONObject): Map[ClientId, PreKey] =
+      json.keySet.asScala.toSeq.map { clientId =>
+        ClientId(clientId) -> PreKeyDecoder(json.getJSONObject(clientId))
+      }.toMap
+
+    private def getUserPreKeys(domain: String, json: JSONObject): Map[QualifiedId, Map[ClientId, PreKey]] =
+      json.keySet.asScala.toSeq.flatMap { userId =>
+        Try(json.getJSONObject(userId)).map { preKeysJson =>
+          QualifiedId(UserId(userId), domain) -> getPreKeys(preKeysJson)
+        }.toOption
+      }.toMap
+
+    implicit object Decoder extends JsonDecoder[ListPreKeysResponse] {
+      override def apply(implicit jsMap: JSONObject): ListPreKeysResponse = {
+        val response =
+          jsMap.keySet.asScala.toSeq.flatMap { domain =>
+            Try(jsMap.getJSONObject(domain)).map(getUserPreKeys(domain, _)).getOrElse(Map.empty)
+          }.toMap
+        if (response.nonEmpty) ListPreKeysResponse(response) else Empty
+      }
+    }
+  }
+
 
   final case class ListClientsRequest(qualifiedUsers: Seq[QualifiedId]) {
     def encode: JSONObject = JsonEncoder { o =>

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
@@ -22,13 +22,14 @@ import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.ShouldPostClientCapabilities
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.otr.{Client, ClientId, OtrClientIdMap}
+import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.model.{QualifiedId, UserId}
 import com.waz.service.otr.OtrService.SessionId
 import com.waz.service.otr._
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.Success
 import com.waz.sync.client.{ErrorOr, OtrClient}
+import com.waz.zms.BuildConfig
 import com.wire.cryptobox.PreKey
 
 import scala.collection.immutable.Map
@@ -39,37 +40,37 @@ trait OtrClientsSyncHandler {
   def syncSelfClients(): Future[SyncResult]
   def postLabel(id: ClientId, label: String): Future[SyncResult]
   def postCapabilities(): Future[SyncResult]
-  def syncPreKeys(clients: OtrClientIdMap): Future[SyncResult]
-  def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]]
+  def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult]
+  def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]]
 }
 
-class OtrClientsSyncHandlerImpl(selfId:     UserId,
-                                selfClient: ClientId,
-                                netClient:  OtrClient,
-                                otrClients: OtrClientsService,
-                                cryptoBox:  CryptoBoxService,
-                                userPrefs:  UserPreferences)
-  extends OtrClientsSyncHandler
-    with DerivedLogTag { self =>
-
+class OtrClientsSyncHandlerImpl(selfId:        UserId,
+                                currentDomain: Option[String],
+                                selfClient:    ClientId,
+                                netClient:     OtrClient,
+                                otrClients:    OtrClientsService,
+                                cryptoBox:     CryptoBoxService,
+                                userPrefs:     UserPreferences)
+  extends OtrClientsSyncHandler with DerivedLogTag { self =>
+  import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
   import com.waz.threading.Threading.Implicits.Background
 
   private lazy val sessions = cryptoBox.sessions
 
-  private def hasSession(user: UserId, client: ClientId) =
-    sessions.getSession(SessionId(user, None, client)).map(_.isDefined)
+  private def hasSession(qId: QualifiedId, clientId: ClientId) =
+    sessions.getSession(SessionId(qId, clientId, currentDomain)).map(_.isDefined)
 
-  private def withoutSession(userId: UserId, clients: Iterable[ClientId]) =
-    Future.traverse(clients) { client =>
-      if (selfClient == client) Future successful None
-      else hasSession(userId, client) map { if (_) None else Some(client) }
+  private def withoutSession(qId: QualifiedId, clients: Iterable[ClientId]) =
+    Future.traverse(clients) { clientId =>
+      if (selfClient == clientId) Future successful None
+      else hasSession(qId, clientId) map { if (_) None else Some(clientId) }
     } map { _.flatten.toSeq }
 
-  private def updateClients(users: Map[UserId, Seq[Client]]): Future[SyncResult] = {
-    def withoutSession(): Future[OtrClientIdMap] =
+  private def updateClients(users: Map[QualifiedId, Seq[Client]]): Future[SyncResult] = {
+    def withoutSession(): Future[QOtrClientIdMap] =
       Future.sequence(
         users.map { case (id, clients) => self.withoutSession(id, clients.map(_.id)).map(cs => id -> cs.toSet) }
-      ).map(OtrClientIdMap(_))
+      ).map(QOtrClientIdMap(_))
 
     def syncSessionsIfNeeded() =
       for {
@@ -91,14 +92,14 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
         case Left(error) => Future.successful(SyncResult(error))
       }
 
-    val (selfClients, otherClients) = users.partition(_._1 == selfId)
+    val (selfClients, otherClients) = users.partition(_._1.id == selfId)
     val userClients =
       otherClients ++ selfClients.map {
         case (id, clients) => id -> clients.map(c => if (selfClient == c.id) c.copy(verified = Verification.VERIFIED) else c)
       }
 
     for {
-      _   <- otrClients.updateUserClients(userClients, replace = true)
+      _   <- otrClients.updateUserClients(userClients.map { case (QualifiedId(id, _), c) => id -> c }, replace = true)
       res <- syncSessionsIfNeeded()
       res <- if (SyncResult.isSuccess(res)) updatePreKeys(selfClient) else Future.successful(res)
       _   <- res match {
@@ -112,7 +113,7 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
     netClient.loadClients().future
       .flatMap {
         case Left(error)    => Future.successful(SyncResult(error))
-        case Right(clients) => updateClients(Map(selfId -> clients))
+        case Right(clients) => updateClients(Map(QualifiedId(selfId, currentDomain.getOrElse("")) -> clients))
       }
 
   override def syncClients(users: Set[QualifiedId]): Future[SyncResult] = {
@@ -134,7 +135,7 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
   private def syncQualified(users: Set[QualifiedId]): Future[SyncResult] =
     netClient.loadClients(users).future.flatMap {
       case Right(response) =>
-        updateClients(response.map { case (QualifiedId(id, _), clients) => id -> clients })
+        updateClients(response)
       case Left(ErrorResponse.PageNotFound) =>
         // fallback to requesting clients per user
         syncNonQualified(users.map(_.id))
@@ -151,7 +152,9 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
           case Some(err) =>
             Future.successful(SyncResult(err))
           case None =>
-            updateClients(responses.collect { case (id, Right(clients)) => id -> clients }.toMap)
+            updateClients(responses.collect {
+              case (id, Right(clients)) => QualifiedId(id, currentDomain.getOrElse("")) -> clients
+            }.toMap)
         }
       }
 
@@ -167,19 +170,41 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
       case Left(err) => (userPrefs.preference(ShouldPostClientCapabilities) := true).map(_ => SyncResult(err))
     }
 
-  override def syncPreKeys(clients: OtrClientIdMap): Future[SyncResult] = syncSessions(clients).map {
+  override def syncPreKeys(clients: QOtrClientIdMap): Future[SyncResult] = syncSessions(clients).map {
     case Some(error) => SyncResult(error)
     case None        => Success
   }
 
-  override def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]] =
+  override def syncSessions(clients: QOtrClientIdMap): Future[Option[ErrorResponse]] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      loadPreKeys(clients).flatMap {
+        case Left(error) => Future.successful(Some(error))
+        case Right(qs)   =>
+          for {
+            _       <- otrClients.updateUserClients(
+                         qs.map { case (QualifiedId(id, _), cs) => id -> cs.keys.map(Client(_)).toSeq },
+                         replace = false
+                       )
+            prekeys =  qs.flatMap { case (qId, cs) => cs.map { case (c, p) => (SessionId(qId, c, currentDomain), p)} }
+            _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
+            _       <- VerificationStateUpdater.awaitUpdated(selfId)
+          } yield None
+      }.recover {
+        case e: Throwable => Some(ErrorResponse.internalError(e.getMessage))
+      }
+  } else {
+      syncSessions(OtrClientIdMap(clients.entries.map { case (qId, cs) => qId.id -> cs }))
+    }
+
+  private def syncSessions(clients: OtrClientIdMap): Future[Option[ErrorResponse]] =
     loadPreKeys(clients).flatMap {
       case Left(error) => Future.successful(Some(error))
       case Right(us)   =>
         for {
           _       <- otrClients.updateUserClients(
-                       us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } }, replace = false
-                     )
+            us.map { case (uId, cs) => uId -> cs.map { case (id, _) => Client(id) } },
+            replace = false
+          )
           prekeys =  us.flatMap { case (u, cs) => cs map { case (c, p) => (SessionId(u, None, c), p)} }
           _       <- Future.traverse(prekeys) { case (id, p) => sessions.getOrCreateSession(id, p) }
           _       <- VerificationStateUpdater.awaitUpdated(selfId)
@@ -189,8 +214,6 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
     }
 
   private def loadPreKeys(clients: OtrClientIdMap) = {
-    import OtrClientsSyncHandlerImpl.LoadPreKeysMaxClients
-
     def mapSize(map: OtrClientIdMap): Int = map.entries.values.map(_.size).sum
     def load(map: OtrClientIdMap): ErrorOr[Map[UserId, Seq[(ClientId, PreKey)]]] = netClient.loadPreKeys(map).future
 
@@ -216,6 +239,38 @@ class OtrClientsSyncHandlerImpl(selfId:     UserId,
               responses
                 .collect { case Right(prekeys) => prekeys }
                 .reduce[Map[UserId, Seq[(ClientId, PreKey)]]] { case (p1, p2) => p1 ++ p2 }
+            }
+          }
+        }
+    }
+  }
+
+  private def loadPreKeys(clients: QOtrClientIdMap) = {
+    def mapSize(map: QOtrClientIdMap): Int = map.entries.values.map(_.size).sum
+    def load(map: QOtrClientIdMap): ErrorOr[Map[QualifiedId, Map[ClientId, PreKey]]] = netClient.loadPreKeys(map).future
+
+    // request accepts up to 128 clients, we should make sure not to send more
+    if (mapSize(clients) < LoadPreKeysMaxClients) load(clients)
+    else {
+      // we divide the original map into a list of chunks, each with at most 127 clients
+      val chunks =
+        clients.entries.foldLeft(List(QOtrClientIdMap.Empty)) { case (acc, (qualifiedId, clientIds)) =>
+          val currentMap = acc.head
+          if (mapSize(currentMap) + clientIds.size < LoadPreKeysMaxClients)
+            QOtrClientIdMap(currentMap.entries + (qualifiedId -> clientIds)) :: acc.tail
+          else
+            QOtrClientIdMap.from(qualifiedId -> clientIds) :: acc
+        }
+
+      // for each chunk we load the prekeys separately and then add them together (unless there's an error response)
+      Future
+        .sequence(chunks.map(load))
+        .map { responses =>
+          responses.find(_.isLeft).getOrElse {
+            Right {
+              responses
+                .collect { case Right(prekeys) => prekeys }
+                .reduce[Map[QualifiedId, Map[ClientId, PreKey]]] { case (p1, p2) => p1 ++ p2 }
             }
           }
         }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -25,7 +25,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
-import com.waz.model.otr.{ClientId, OtrClientIdMap}
+import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
 import com.waz.service.conversation.ConversationsService
 import com.waz.service.otr.OtrService
 import com.waz.service.push.PushService
@@ -278,7 +278,8 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case Some(ct) => successful(Some(ct))
       case None =>
         for {
-          _       <- clientsSyncHandler.syncSessions(OtrClientIdMap.from(userId -> Set(clientId)))
+          qId     <- userService.qualifiedId(userId)
+          _       <- clientsSyncHandler.syncSessions(QOtrClientIdMap.from(qId -> Set(clientId)))
           content <- service.encryptTargetedMessage(userId, clientId, msg)
         } yield content
     }

--- a/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/OtrClientsServiceSpec.scala
@@ -15,6 +15,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
 
   private val selfUserId = UserId("selfUserId")
   private val selfClientId = ClientId("selfClientId")
+  private val currentDomain = Some("staging.zinfra.io")
   private val userPrefs = new TestUserPreferences()
   private val storage = mock[OtrClientsStorage]
   private val sync = mock[SyncServiceHandle]
@@ -22,6 +23,7 @@ class OtrClientsServiceSpec extends AndroidFreeSpec {
   private def createService(): OtrClientsServiceImpl =
     new OtrClientsServiceImpl(
       selfUserId,
+      currentDomain,
       selfClientId,
       userPrefs,
       storage,


### PR DESCRIPTION
This PR implements usage of qualified ids for fetching prekeys. The idea is simple but since we need to still handle non-federation backends at the same time, it involves a lot of code duplication where the only change to the new version of a given method is that it works with qualified ids. A few changes not directly conneted to prekeys were made in preparation for basic messaging, which is in the next PR. It's all work in progress until we all switch to federated backends eventually, and then another huge PR will delete all the obsolete code. 

#### APK
[Download build #3864](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3864/artifact/build/artifact/wire-dev-PR3467-3864.apk)