### PR TITLE
Federation: basic messaging

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -147,7 +147,7 @@ class UsersController(implicit injector: Injector, context: Context)
   def isFederated(user: UserData, selfDomain: String): Boolean = user.domain.exists(_ != selfDomain)
 
   def isFederated(user: UserData): Future[Boolean] =
-    userService.head.flatMap(_.isFederated(user))(Threading.Background)
+    zms.head.map(z => z.selfDomain.fold(false)(domain => isFederated(user, domain)))(Threading.Background)
 
   def isFederated(id: UserId): Future[Boolean] =
     userService.head.flatMap(_.isFederated(id))(Threading.Background)

--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     // should match okhttp3's mockserver version (see test dependencies)
     implementation BuildDependencies.libPhoneNumber
     implementation "com.wire:cryptobox-android:1.1.2"
-    implementation "com.wire:generic-message-proto:1.28.2"
+    implementation "com.wire:generic-message-proto:1.35.0"
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"

--- a/zmessaging/src/main/scala/com/waz/model/otr/MessageResponse.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/MessageResponse.scala
@@ -1,0 +1,71 @@
+package com.waz.model.otr
+
+import com.waz.model.RemoteInstant
+import com.waz.utils.JsonDecoder
+import org.json.JSONObject
+
+sealed trait MessageResponse {
+  def mismatch: ClientMismatch
+
+  def deleted: OtrClientIdMap = mismatch.deleted
+
+  def missing: OtrClientIdMap = mismatch.missing
+}
+
+object MessageResponse {
+  final case class Success(mismatch: ClientMismatch) extends MessageResponse
+  final case class Failure(mismatch: ClientMismatch) extends MessageResponse
+}
+
+final case class ClientMismatch(redundant: OtrClientIdMap = OtrClientIdMap.Empty,
+                                missing:   OtrClientIdMap = OtrClientIdMap.Empty,
+                                deleted:   OtrClientIdMap = OtrClientIdMap.Empty,
+                                time:     RemoteInstant)
+
+object ClientMismatch {
+  implicit lazy val Decoder: JsonDecoder[ClientMismatch] = new JsonDecoder[ClientMismatch] {
+    import JsonDecoder._
+    import OtrClientIdMap.decodeMap
+
+    override def apply(implicit js: JSONObject): ClientMismatch =
+      ClientMismatch(
+        decodeMap('redundant),
+        decodeMap('missing),
+        decodeMap('deleted),
+        decodeOptUtcDate('time).map(t => RemoteInstant.ofEpochMilli(t.getTime)).getOrElse(RemoteInstant.Epoch)
+      )
+  }
+}
+
+sealed trait QMessageResponse {
+  def mismatch: QClientMismatch
+
+  def deleted: QOtrClientIdMap = mismatch.deleted
+
+  def missing: QOtrClientIdMap = mismatch.missing
+}
+
+object QMessageResponse {
+  final case class Success(mismatch: QClientMismatch) extends QMessageResponse
+  final case class Failure(mismatch: QClientMismatch) extends QMessageResponse
+}
+
+final case class QClientMismatch(redundant: QOtrClientIdMap = QOtrClientIdMap.Empty,
+                                 missing:   QOtrClientIdMap = QOtrClientIdMap.Empty,
+                                 deleted:   QOtrClientIdMap = QOtrClientIdMap.Empty,
+                                 time:     RemoteInstant)
+
+object QClientMismatch {
+  implicit lazy val Decoder: JsonDecoder[QClientMismatch] = new JsonDecoder[QClientMismatch] {
+    import JsonDecoder._
+    import QOtrClientIdMap.decodeMap
+
+    override def apply(implicit js: JSONObject): QClientMismatch =
+      QClientMismatch(
+        decodeMap('redundant),
+        decodeMap('missing),
+        decodeMap('deleted),
+        decodeOptUtcDate('time).map(t => RemoteInstant.ofEpochMilli(t.getTime)).getOrElse(RemoteInstant.Epoch)
+      )
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrMessage.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrMessage.scala
@@ -1,0 +1,69 @@
+package com.waz.model.otr
+
+import java.io.ByteArrayInputStream
+
+import com.google.protobuf.ByteString
+import com.waz.model.{QualifiedId, UserId}
+import com.waz.sync.client.OtrClient
+import com.waz.sync.client.OtrClient.{ClientMismatch, EncryptedContent, QEncryptedContent}
+import com.waz.znet2.http.{MediaType, RawBody, RawBodySerializer}
+import com.wire.messages.Otr
+import com.wire.messages.Otr.ClientMismatchStrategy
+import com.wire.messages.Otr.ClientMismatchStrategy.ReportOnly
+
+import scala.collection.JavaConverters._
+
+final case class OtrMessage(sender:         ClientId,
+                            recipients:     EncryptedContent,
+                            external:       Option[Array[Byte]] = None,
+                            nativePush:     Boolean = true,
+                            report_missing: Option[Set[UserId]] = None)
+
+object OtrMessage {
+  implicit val OtrMessageSerializer: RawBodySerializer[OtrMessage] = RawBodySerializer.create { m =>
+    val builder = Otr.NewOtrMessage.newBuilder()
+      .setSender(OtrClient.clientId(m.sender))
+      .setNativePush(m.nativePush)
+      .addAllRecipients(m.recipients.userEntries.toIterable.asJava)
+
+    m.external.foreach { ext => builder.setBlob(ByteString.copyFrom(ext)) }
+    m.report_missing.foreach { missing => builder.addAllReportMissing(missing.map(OtrClient.userId).asJava) }
+
+    val bytes = builder.build.toByteArray
+    RawBody(mediaType = Some(MediaType.Protobuf), () => new ByteArrayInputStream(bytes), dataLength = Some(bytes.length))
+  }
+}
+
+final case class QualifiedOtrMessage(sender:         ClientId,
+                                     recipients:     QEncryptedContent,
+                                     external:       Option[Array[Byte]] = None,
+                                     nativePush:     Boolean = true,
+                                     reportMissing:  Option[Set[QualifiedId]] = None,
+                                     reportAll:      Boolean = true
+                                    )
+
+object QualifiedOtrMessage {
+  implicit val QualifiedOtrMessageSerializer: RawBodySerializer[QualifiedOtrMessage] = RawBodySerializer.create { m =>
+    val builder = Otr.QualifiedNewOtrMessage.newBuilder()
+      .setSender(OtrClient.clientId(m.sender))
+      .setNativePush(m.nativePush)
+      .addAllRecipients(m.recipients.entries.toIterable.asJava)
+
+    m.external.foreach { ext => builder.setBlob(ByteString.copyFrom(ext)) }
+
+    (m.reportAll, m.reportMissing) match {
+      case (true, _) =>
+        builder.setReportAll(Otr.ClientMismatchStrategy.ReportAll.getDefaultInstance)
+      case (false, None) =>
+        builder.setIgnoreAll(Otr.ClientMismatchStrategy.IgnoreAll.getDefaultInstance)
+      case (false, Some(missing)) =>
+        val reportOnlyBuilder = ReportOnly.newBuilder()
+        reportOnlyBuilder.addAllUserIds(missing.map(OtrClient.qualifiedId).asJava)
+        builder.setReportOnly(reportOnlyBuilder.build)
+    }
+
+    val bytes = builder.build.toByteArray
+    RawBody(mediaType = Some(MediaType.Protobuf), () => new ByteArrayInputStream(bytes), dataLength = Some(bytes.length))
+  }
+}
+

--- a/zmessaging/src/main/scala/com/waz/model/otr/OtrMessage.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/OtrMessage.scala
@@ -5,10 +5,9 @@ import java.io.ByteArrayInputStream
 import com.google.protobuf.ByteString
 import com.waz.model.{QualifiedId, UserId}
 import com.waz.sync.client.OtrClient
-import com.waz.sync.client.OtrClient.{ClientMismatch, EncryptedContent, QEncryptedContent}
+import com.waz.sync.client.OtrClient.{EncryptedContent, QEncryptedContent}
 import com.waz.znet2.http.{MediaType, RawBody, RawBodySerializer}
 import com.wire.messages.Otr
-import com.wire.messages.Otr.ClientMismatchStrategy
 import com.wire.messages.Otr.ClientMismatchStrategy.ReportOnly
 
 import scala.collection.JavaConverters._

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -134,19 +134,6 @@ class UserServiceImpl(selfUserId:        UserId,
     } yield ()
   }
 
-  private lazy val shouldMigrateToFederation = userPrefs.preference(UserPreferences.ShouldMigrateToFederation)
-
-  for {
-    shouldMigrate <- if (BuildConfig.FEDERATION_USER_DISCOVERY) shouldMigrateToFederation() else Future.successful(false)
-  } if (shouldMigrate && currentDomain.isDefined) {
-    verbose(l"Migrating users to federation")
-    for {
-      userIds <- usersStorage.keySet
-      _       <- usersStorage.updateAll2(userIds, { user => if (user.domain.isEmpty) user.copy(domain = currentDomain) else user })
-      _       <- shouldMigrateToFederation := false
-    } yield ()
-  }
-
   override val currentConvMembers = for {
     Some(convId) <- selectedConv.selectedConversationId
     membersIds   <- membersStorage.activeMembers(convId)

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -57,7 +57,8 @@ trait UserService {
 
   def getSelfUser: Future[Option[UserData]]
   def isFederated(id: UserId): Future[Boolean]
-  def isFederated(user: UserData): Future[Boolean]
+  def isFederated(user: UserData): Boolean
+  def isFederated(qId: QualifiedId): Boolean
   def findUser(id: UserId): Future[Option[UserData]]
   def findUsers(ids: Seq[UserId]): Future[Seq[Option[UserData]]]
   def qualifiedId(userId: UserId): Future[QualifiedId]
@@ -70,6 +71,7 @@ trait UserService {
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
   def syncRichInfoNowForUser(id: UserId): Future[Option[UserData]]
   def syncUser(userId: UserId): Future[Option[UserData]]
+  def syncUser(qId: QualifiedId): Future[Option[UserData]]
   def acceptedOrBlockedUsers: Signal[Map[UserId, UserData]]
 
   def updateSyncedUsers(users: Seq[UserInfo], timestamp: LocalInstant = LocalInstant.Now): Future[Set[UserData]]
@@ -297,7 +299,7 @@ class UserServiceImpl(selfUserId:        UserId,
       if (BuildConfig.FEDERATION_USER_DISCOVERY) {
         for {
           Some(user) <- findUser(userId)
-          federated  <- isFederated(user)
+          federated  =  isFederated(user)
           res        <- ((federated, user.qualifiedId) match {
                           case (true, Some(qId)) => usersClient.loadQualifiedUser(qId)
                           case _                 => usersClient.loadUser(userId)
@@ -311,6 +313,18 @@ class UserServiceImpl(selfUserId:        UserId,
       case Left(e)           => Future.failed(e)
       case Right(Some(info)) => updateSyncedUsers(Seq(info)).map(_.headOption)
       case Right(None)       => deleteUsers(Set(userId)).map(_ => None)
+    }
+  }
+
+  override def syncUser(qId: QualifiedId): Future[Option[UserData]] = {
+    val updateResult =
+      if (isFederated(qId)) usersClient.loadQualifiedUser(qId)
+      else usersClient.loadUser(qId.id)
+
+    updateResult.future.flatMap {
+      case Left(e)           => Future.failed(e)
+      case Right(Some(info)) => updateSyncedUsers(Seq(info)).map(_.headOption)
+      case Right(None)       => deleteUsers(Set(qId.id)).map(_ => None)
     }
   }
 
@@ -333,20 +347,20 @@ class UserServiceImpl(selfUserId:        UserId,
       case _              => syncSelfNow
     }
 
-  override def isFederated(user: UserData): Future[Boolean] =
+  override def isFederated(user: UserData): Boolean =
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      selfUser.head.map(_.domain).map {
-        case Some(selfDomain) => user.domain.exists(_ != selfDomain)
-        case _                => false
-      }
+      currentDomain.fold(false)(domain => user.domain.exists(_ != domain))
     } else
-      Future.successful(false)
+      false
+
+  override def isFederated(qId: QualifiedId): Boolean =
+    currentDomain.fold(false)(domain => qId.domain != domain)
 
   override def isFederated(id: UserId): Future[Boolean] =
     if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      findUser(id).flatMap {
+      findUser(id).map {
         case Some(user) => isFederated(user)
-        case _          => Future.successful(false)
+        case _          => false
       }
     } else
       Future.successful(false)

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -348,9 +348,9 @@ class UserServiceImpl(selfUserId:        UserId,
     }
 
   override def isFederated(user: UserData): Boolean =
-    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
-      currentDomain.fold(false)(domain => user.domain.exists(_ != domain))
-    } else
+    if (BuildConfig.FEDERATION_USER_DISCOVERY)
+      user.qualifiedId.fold(false)(isFederated)
+    else
       false
 
   override def isFederated(qId: QualifiedId): Boolean =

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -500,7 +500,7 @@ class CallingServiceImpl(val accountId:       UserId,
       }
     }
 
-  override def continueDegradedCall(forceConstantBitRate: Boolean = false) =
+  override def continueDegradedCall(forceConstantBitRate: Boolean = false): Unit =
     currentCall.head.map {
       case Some(info) =>
         (info.outstandingMsg, info.state) match {
@@ -518,7 +518,7 @@ class CallingServiceImpl(val accountId:       UserId,
 
   private def sendCallMessage(wCall: WCall, convId: ConvId, msg: GenericMessage, targetRecipients: TargetRecipients, ctx: Pointer): Unit = {
     verbose(l"Sending msg on behalf of avs: convId: $convId")
-    otrSyncHandler.postOtrMessage(convId, msg, targetRecipients, isHidden = true).map {
+    otrSyncHandler.postOtrMessage(convId, msg, isHidden = true, targetRecipients).map {
       case Right(_) =>
         updateActiveCall(_.copy(outstandingMsg = None))("sendCallMessage/verified")
         avs.onHttpResponse(wCall, 200, "", ctx)

--- a/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -62,7 +62,6 @@ class OtrClientImpl(implicit
                     urlCreator: UrlCreator,
                     httpClient: HttpClient,
                     authRequestInterceptor: AuthRequestInterceptor) extends OtrClient with DerivedLogTag {
-
   import HttpClient.AutoDerivationOld._
   import HttpClient.dsl._
   import OtrMessage.OtrMessageSerializer
@@ -223,7 +222,6 @@ class OtrClientImpl(implicit
 }
 
 object OtrClient extends DerivedLogTag {
-
   val ClientsPath = "/clients"
   val PrekeysPath = "/users/prekeys"
   val BroadcastPath = "/broadcast/otr/messages"
@@ -231,17 +229,11 @@ object OtrClient extends DerivedLogTag {
   val ListPrekeysPath = "/users/list-prekeys"
 
   def clientPath(id: ClientId) = s"/clients/$id"
-
   def clientKeyIdsPath(id: ClientId) = s"/clients/$id/prekeys"
-
   def userPreKeysPath(user: UserId) = s"/users/$user/prekeys"
-
   def userClientsPath(user: UserId) = s"/users/$user/clients"
-
   def clientPreKeyPath(user: UserId, client: ClientId) = s"/users/$user/prekeys/$client"
-
   def userPreKeysPath(qId: QualifiedId) = s"/users/${qId.domain}/${qId.id.str}/prekeys"
-
   def clientPreKeyPath(qId: QualifiedId, clientId: ClientId) = s"/users/${qId.domain}/${qId.id.str}/prekeys/$clientId"
 
   // If you change this, don't forget to set the 'ShouldPostClientCapabilities' user preference
@@ -291,9 +283,7 @@ object OtrClient extends DerivedLogTag {
 
   final case class EncryptedContent(content: Map[UserId, Map[ClientId, Array[Byte]]]) {
     lazy val estimatedSize: Int = content.valuesIterator.map { cs => 16 + cs.valuesIterator.map(_.length + 8).sum }.sum
-
-    lazy val userEntries: Array[Otr.UserEntry] =
-      content.map { case (user, cs) => userEntry(user, cs) }(breakOut)
+    lazy val userEntries: Array[Otr.UserEntry] = content.map { case (user, cs) => userEntry(user, cs) }(breakOut)
   }
 
   object EncryptedContent {
@@ -301,8 +291,8 @@ object OtrClient extends DerivedLogTag {
   }
 
   final case class QEncryptedContent(content: Map[QualifiedId, Map[ClientId, Array[Byte]]]) {
-    lazy val estimatedSize: Int = content.valuesIterator.map { cs => 16 + cs.valuesIterator.map(_.length + 8).sum }.sum
-
+    lazy val estimatedSize: Int =
+      content.valuesIterator.map { cs => 16 + cs.valuesIterator.map(_.length + 8).sum }.sum
     lazy val entries: Array[Otr.QualifiedUserEntry] =
       content.groupBy(_._1.domain).map { case (domain, userContent) =>
         val userEntries = userContent.map { case (user, cs) => userEntry(user.id, cs) }
@@ -330,7 +320,6 @@ object OtrClient extends DerivedLogTag {
   type PreKeysResponse = Seq[(UserId, Seq[ClientKey])]
 
   object PreKeysResponse {
-
     import scala.collection.JavaConverters._
 
     def unapply(content: ResponseContent): Option[PreKeysResponse] = content match {
@@ -351,9 +340,9 @@ object OtrClient extends DerivedLogTag {
   final case class ListPreKeysResponse(values: Map[QualifiedId, Map[ClientId, PreKey]])
 
   object ListPreKeysResponse {
-    val Empty: ListPreKeysResponse = ListPreKeysResponse(Map.empty)
-
     import scala.collection.JavaConverters._
+
+    val Empty: ListPreKeysResponse = ListPreKeysResponse(Map.empty)
 
     private def getPreKeys(json: JSONObject): Map[ClientId, PreKey] =
       json.keySet.asScala.toSeq.map { clientId =>
@@ -376,9 +365,7 @@ object OtrClient extends DerivedLogTag {
         if (response.nonEmpty) ListPreKeysResponse(response) else Empty
       }
     }
-
   }
-
 
   final case class ListClientsRequest(qualifiedUsers: Seq[QualifiedId]) {
     def encode: JSONObject = JsonEncoder { o =>
@@ -390,19 +377,17 @@ object OtrClient extends DerivedLogTag {
   }
 
   object ListClientsRequest {
-
     implicit object Encoder extends JsonEncoder[ListClientsRequest] {
       override def apply(request: ListClientsRequest): JSONObject = request.encode
     }
-
   }
 
   final case class ListClientsResponse(values: Map[QualifiedId, Seq[Client]])
 
   object ListClientsResponse {
-    val Empty: ListClientsResponse = ListClientsResponse(Map.empty)
-
     import scala.collection.JavaConverters._
+
+    val Empty: ListClientsResponse = ListClientsResponse(Map.empty)
 
     private def getClients(json: JSONArray): Seq[Client] =
       JsonDecoder.array(json, (arr, i) => Try(arr.getJSONObject(i)).map(ClientsResponse.Decoder(_)).toOption).flatten
@@ -426,11 +411,9 @@ object OtrClient extends DerivedLogTag {
         if (response.nonEmpty) ListClientsResponse(response) else Empty
       }
     }
-
   }
 
   object ClientsResponse {
-
     implicit object Decoder extends JsonDecoder[Client] {
       override def apply(implicit js: JSONObject): Client = {
         Client(
@@ -457,6 +440,4 @@ object OtrClient extends DerivedLogTag {
       case _ => None
     }
   }
-
 }
-

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -45,7 +45,7 @@ class LastReadSyncHandler(selfUserId: UserId,
       case Some(conv) =>
         val msg = GenericMessage(Uid(), LastRead(conv.remoteId, time))
         otrSync
-          .postOtrMessage(ConvId(selfUserId.str), msg, TargetRecipients.SpecificUsers(Set(selfUserId)), isHidden = true)
+          .postOtrMessage(ConvId(selfUserId.str), msg, isHidden = true, TargetRecipients.SpecificUsers(Set(selfUserId)))
           .map(SyncResult(_))
       case None =>
         Future.successful(Failure(s"No conversation found for id: $convId"))

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -25,17 +25,18 @@ import com.waz.service.MetaDataService
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.{Failure, Success}
 import com.waz.sync.otr.OtrSyncHandler
-import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
+import com.waz.sync.otr.OtrSyncHandler.{QTargetRecipients, TargetRecipients}
 import com.waz.utils.RichWireInstant
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.Future
 
-class LastReadSyncHandler(selfUserId: UserId,
-                          convs: ConversationStorage,
-                          metadata: MetaDataService,
-                          msgsSync: MessagesSyncHandler,
-                          otrSync: OtrSyncHandler) extends DerivedLogTag {
-
+class LastReadSyncHandler(selfUserId:    UserId,
+                          currentDomain: Option[String],
+                          convs:         ConversationStorage,
+                          metadata:      MetaDataService,
+                          msgsSync:      MessagesSyncHandler,
+                          otrSync:       OtrSyncHandler) extends DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
   def postLastRead(convId: ConvId, time: RemoteInstant): Future[SyncResult] =
@@ -44,9 +45,14 @@ class LastReadSyncHandler(selfUserId: UserId,
         Future.successful(Success)
       case Some(conv) =>
         val msg = GenericMessage(Uid(), LastRead(conv.remoteId, time))
-        otrSync
-          .postOtrMessage(ConvId(selfUserId.str), msg, isHidden = true, TargetRecipients.SpecificUsers(Set(selfUserId)))
-          .map(SyncResult(_))
+        val postMsg =
+          if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+            val qId = currentDomain.map(QualifiedId(selfUserId, _)).getOrElse(QualifiedId(selfUserId))
+            otrSync.postQualifiedOtrMessage(ConvId(selfUserId.str), msg, isHidden = true, QTargetRecipients.SpecificUsers(Set(qId)))
+          } else {
+            otrSync.postOtrMessage(ConvId(selfUserId.str), msg, isHidden = true, TargetRecipients.SpecificUsers(Set(selfUserId)))
+          }
+        postMsg.map(SyncResult(_))
       case None =>
         Future.successful(Failure(s"No conversation found for id: $convId"))
     }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -36,14 +36,15 @@ import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.otr.OtrClientsService
 import com.waz.service.tracking.TrackingService
-import com.waz.service.{ErrorsService, Timeouts}
+import com.waz.service.{ErrorsService, Timeouts, UserService}
 import com.waz.sync.SyncHandler.RequestInfo
 import com.waz.sync.SyncResult.Failure
 import com.waz.sync.client.{ErrorOr, ErrorOrResponse}
 import com.waz.sync.otr.OtrSyncHandler
-import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
+import com.waz.sync.otr.OtrSyncHandler.{QTargetRecipients, TargetRecipients}
 import com.waz.sync.{SyncResult, SyncServiceHandle}
 import com.waz.utils._
+import com.waz.zms.BuildConfig
 import com.waz.znet2.http.ResponseCode
 import com.wire.signals.CancellableFuture
 
@@ -64,18 +65,39 @@ class MessagesSyncHandler(selfUserId: UserId,
                           uploadAssetStorage: UploadAssetStorage,
                           cache:      CacheService,
                           members:    MembersStorage,
+                          users: =>   UserService,
                           tracking:   TrackingService,
                           errors:     ErrorsService,
                           timeouts: Timeouts) extends DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
+  private def postOtrMessage(convId: ConvId, gm: GenericMessage, isHidden: Boolean) =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      otrSync.postQualifiedOtrMessage(convId, gm, isHidden)
+    } else {
+      otrSync.postOtrMessage(convId, gm, isHidden)
+    }
+
+  private def postOtrMessage(convId: ConvId,
+                             gm: GenericMessage,
+                             isHidden: Boolean,
+                             specificUsers: Set[UserId],
+                             nativePush: Boolean,
+                             enforceIgnoreMissing: Boolean
+                            ) =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      users.qualifiedIds(specificUsers).flatMap { qIds =>
+        otrSync.postQualifiedOtrMessage(convId, gm, isHidden, QTargetRecipients.SpecificUsers(qIds), nativePush, enforceIgnoreMissing)
+      }
+    } else {
+      otrSync.postOtrMessage(convId, gm, isHidden, TargetRecipients.SpecificUsers(specificUsers), nativePush, enforceIgnoreMissing)
+    }
+
   def postDeleted(convId: ConvId, msgId: MessageId): Future[SyncResult] =
     convs.convById(convId).flatMap {
       case Some(conv) =>
         val msg = GenericMessage(Uid(), MsgDeleted(conv.remoteId, msgId))
-        otrSync
-          .postOtrMessage(ConvId(selfUserId.str), msg, isHidden = true)
-          .map(SyncResult(_))
+        postOtrMessage(ConvId(selfUserId.str), msg, isHidden = true).map(SyncResult(_))
       case None =>
         successful(Failure("conversation not found"))
     }
@@ -84,7 +106,7 @@ class MessagesSyncHandler(selfUserId: UserId,
     convs.convById(convId) flatMap {
       case Some(conv) =>
         val msg = GenericMessage(msgId.uid, MsgRecall(recalled))
-        otrSync.postOtrMessage(conv.id, msg, isHidden = true).flatMap {
+        postOtrMessage(conv.id, msg, isHidden = true).flatMap {
           case Left(e) => successful(SyncResult(e))
           case Right(time) =>
             msgContent
@@ -104,15 +126,15 @@ class MessagesSyncHandler(selfUserId: UserId,
           case ReceiptType.EphemeralExpired => (GenericMessage(msgs.head.uid, MsgRecall(msgs.head)), Set(selfUserId, userId))
         }
 
-        otrSync
-          .postOtrMessage(
-            conv.id,
-            msg,
-            isHidden = true,
-            TargetRecipients.SpecificUsers(recipients),
-            nativePush = false
-          )
-          .map(SyncResult(_))
+        postOtrMessage(
+          conv.id,
+          msg,
+          isHidden = true,
+          recipients,
+          nativePush = false,
+          enforceIgnoreMissing = false
+        )
+        .map(SyncResult(_))
       case None =>
         successful(Failure("conversation not found"))
     }
@@ -121,12 +143,14 @@ class MessagesSyncHandler(selfUserId: UserId,
     storage.get(messageId).flatMap {
       case None      => successful(Failure("message not found"))
       case Some(msg) => for {
-        result <- otrSync.postOtrMessage(
+        result <- postOtrMessage(
                     msg.convId,
                     GenericMessage(Uid(), ButtonAction(buttonId.str, messageId.str)),
                     isHidden = true,
-                    TargetRecipients.SpecificUsers(Set(senderId)),
-                    enforceIgnoreMissing = true)
+                    Set(senderId),
+                    nativePush = false,
+                    enforceIgnoreMissing = true
+                  )
         _      <- result.fold(_ => service.setButtonError(messageId, buttonId), _ => Future.successful(()))
       } yield SyncResult(result)
     }
@@ -205,7 +229,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         }
       }.getOrElse((TextMessage(adjustedMsg), false))
 
-      otrSync.postOtrMessage(conv.id, gm, isHidden = false).flatMap {
+      postOtrMessage(conv.id, gm, isHidden = false).flatMap {
         case Right(time) if isEdit =>
           verbose(l"postOtrMessage successful for edit")
           // delete original message and create new message with edited content
@@ -228,7 +252,7 @@ class MessagesSyncHandler(selfUserId: UserId,
       case _ if msg.isAssetMessage =>
         Cancellable(UploadTaskKey(msg.assetId.get))(uploadAsset(conv, msg)).future.map(_.map((_, msg.id)))
       case KNOCK =>
-        otrSync.postOtrMessage(conv.id, GenericMessage(msg.id.uid, msg.ephemeral, Knock(msg.expectsRead.getOrElse(false), conv.messageLegalHoldStatus)), isHidden = false).map(_.map((_, msg.id)))
+        postOtrMessage(conv.id, GenericMessage(msg.id.uid, msg.ephemeral, Knock(msg.expectsRead.getOrElse(false), conv.messageLegalHoldStatus)), isHidden = false).map(_.map((_, msg.id)))
       case TEXT | TEXT_EMOJI_ONLY =>
         postTextMessage().map(_.map(data => (data.time, data.id)))
       case RICH_MEDIA =>
@@ -241,9 +265,9 @@ class MessagesSyncHandler(selfUserId: UserId,
           m.unpack match {
             case (id, loc: Location) if msg.isEphemeral =>
               val expiry = msg.ephemeral.getOrElse(Duration.Zero)
-              otrSync.postOtrMessage(conv.id, GenericMessage(id, Ephemeral(msg.ephemeral, EphemeralLocation(loc.proto, expiry))), isHidden = false).map(_.map((_, msg.id)))
+              postOtrMessage(conv.id, GenericMessage(id, Ephemeral(msg.ephemeral, EphemeralLocation(loc.proto, expiry))), isHidden = false).map(_.map((_, msg.id)))
             case _ =>
-              otrSync.postOtrMessage(conv.id, m, isHidden = false).map(_.map((_, msg.id)))
+              postOtrMessage(conv.id, m, isHidden = false).map(_.map((_, msg.id)))
           }
         }.getOrElse {
           successful(Left(internalError(s"Unexpected location message content: $msg")))
@@ -252,7 +276,7 @@ class MessagesSyncHandler(selfUserId: UserId,
         verbose(l"post generic message")
         msg.genericMsgs.headOption match {
           case Some(proto) if !msg.isEphemeral =>
-            otrSync.postOtrMessage(conv.id, proto, isHidden = false).map(_.map((_, msg.id)))
+            postOtrMessage(conv.id, proto, isHidden = false).map(_.map((_, msg.id)))
           case Some(_) =>
             successful(Left(internalError(s"Can not send generic ephemeral message: $msg")))
           case None =>
@@ -268,7 +292,7 @@ class MessagesSyncHandler(selfUserId: UserId,
 
     def postAssetMessage(message: GenericMessage, id: GeneralAssetId): CancellableFuture[RemoteInstant] = {
       for {
-        time <- otrSync.postOtrMessage(conv.id, message, isHidden = false).flatMap { case Left(errorResponse) => Future.failed(errorResponse)
+        time <- postOtrMessage(conv.id, message, isHidden = false).flatMap { case Left(errorResponse) => Future.failed(errorResponse)
           case Right(time) => Future.successful(time)
         }.lift
         _ <- msgContent.updateMessage(msg.id)(_.copy(genericMsgs = Seq(message), time = time, assetId = Some(id))).lift
@@ -390,7 +414,7 @@ class MessagesSyncHandler(selfUserId: UserId,
           Future.failed(FailedExpectationsError(s"We expect uploaded asset status $statusToPost. Got $assetStatus."))
       }
       message = GenericMessage(mid.uid, expiration, genericAsset)
-      _ <- otrSync.postOtrMessage(conv.id, message, isHidden = false)
+      _ <- postOtrMessage(conv.id, message, isHidden = false)
       _ <- statusToPost match {
         case UploadAssetStatus.Cancelled => storage.remove(msg.id)
         case _ => Future.successful(())

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -105,7 +105,13 @@ class MessagesSyncHandler(selfUserId: UserId,
         }
 
         otrSync
-          .postOtrMessage(conv.id, msg, TargetRecipients.SpecificUsers(recipients), isHidden = true, nativePush = false)
+          .postOtrMessage(
+            conv.id,
+            msg,
+            isHidden = true,
+            TargetRecipients.SpecificUsers(recipients),
+            nativePush = false
+          )
           .map(SyncResult(_))
       case None =>
         successful(Failure("conversation not found"))
@@ -118,8 +124,8 @@ class MessagesSyncHandler(selfUserId: UserId,
         result <- otrSync.postOtrMessage(
                     msg.convId,
                     GenericMessage(Uid(), ButtonAction(buttonId.str, messageId.str)),
-                    TargetRecipients.SpecificUsers(Set(senderId)),
                     isHidden = true,
+                    TargetRecipients.SpecificUsers(Set(senderId)),
                     enforceIgnoreMissing = true)
         _      <- result.fold(_ => service.setButtonError(messageId, buttonId), _ => Future.successful(()))
       } yield SyncResult(result)

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TrackingSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TrackingSyncHandler.scala
@@ -16,8 +16,8 @@ class TrackingSyncHandler(selfUserId: UserId, otrSync: OtrSyncHandler) {
       .postOtrMessage(
         ConvId(selfUserId.str),
         GenericMessage(Uid(), DataTransfer(trackingId)),
-        TargetRecipients.SpecificUsers(Set(selfUserId)),
-        isHidden = true
+        isHidden = true,
+        TargetRecipients.SpecificUsers(Set(selfUserId))
       )
       .map(SyncResult(_))
 }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -25,29 +25,28 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
-import com.waz.model.otr.{ClientId, OtrClientIdMap, OtrMessage, QOtrClientIdMap}
+import com.waz.model.otr.{ClientId, ClientMismatch, MessageResponse, OtrClientIdMap, OtrMessage, QClientMismatch, QMessageResponse, QOtrClientIdMap, QualifiedOtrMessage}
 import com.waz.service.conversation.ConversationsService
 import com.waz.service.otr.OtrService
 import com.waz.service.push.PushService
 import com.waz.service.{ErrorsService, UserService}
 import com.waz.sync.SyncResult
 import com.waz.sync.SyncResult.Failure
-import com.waz.sync.client.OtrClient.{ClientMismatch, EncryptedContent, MessageResponse}
+import com.waz.sync.client.OtrClient.{EncryptedContent, QEncryptedContent}
 import com.waz.sync.client._
-import com.waz.sync.otr.OtrSyncHandler.MissingClientsStrategy._
-import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
-import com.waz.sync.otr.OtrSyncHandler.TargetRecipients._
+import com.waz.sync.otr.OtrSyncHandler.{QTargetRecipients, TargetRecipients}
 import com.waz.utils.crypto.AESUtils
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
 import scala.util.control.NonFatal
+import com.waz.utils.{RichEither, RichFutureEither}
 
 trait OtrSyncHandler {
   def postOtrMessage(convId:                ConvId,
                      message:               GenericMessage,
-                     targetRecipients:      TargetRecipients = ConversationParticipants,
                      isHidden:              Boolean,
+                     targetRecipients:      TargetRecipients = TargetRecipients.ConversationParticipants,
                      nativePush:            Boolean = true,
                      enforceIgnoreMissing:  Boolean = false
                     ): ErrorOr[RemoteInstant]
@@ -59,10 +58,22 @@ trait OtrSyncHandler {
                        recipients: Option[Set[UserId]] = None
                       ): ErrorOr[RemoteInstant]
   def postClientDiscoveryMessage(convId: RConvId): ErrorOr[OtrClientIdMap]
+
+
+  def postQualifiedOtrMessage(convId:                ConvId,
+                              message:               GenericMessage,
+                              isHidden:              Boolean,
+                              targetRecipients:      QTargetRecipients = QTargetRecipients.ConversationParticipants,
+                              nativePush:            Boolean = true,
+                              enforceIgnoreMissing:  Boolean = false
+                             ): ErrorOr[RemoteInstant]
+  def postSessionReset(convId: ConvId, qualifiedId: QualifiedId, client: ClientId): Future[SyncResult]
+  def postClientDiscoveryMessage(convId: RConvQualifiedId): ErrorOr[QOtrClientIdMap]
 }
 
 class OtrSyncHandlerImpl(teamId:             Option[TeamId],
                          selfClientId:       ClientId,
+                         currentDomain:      Option[String],
                          otrClient:          OtrClient,
                          msgClient:          MessagesClient,
                          service:            OtrService,
@@ -84,87 +95,21 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
    *
    * @param convId The id conversation to post the message to.
    * @param message The message being posted.
-   * @param targetRecipients Who should receive the message.
    * @param isHidden Whether the message is a hidden message. As a rule of thumb, if it doesn't
    *                 occupy a row in the message list, then it is hidden.
+   * @param targetRecipients Who should receive the message.
    * @param nativePush
    * @param enforceIgnoreMissing When missing clients should be ignored.
    * @return
    */
   override def postOtrMessage(convId:                ConvId,
                               message:               GenericMessage,
-                              targetRecipients:      TargetRecipients = ConversationParticipants,
                               isHidden:              Boolean,
+                              targetRecipients:      TargetRecipients = TargetRecipients.ConversationParticipants,
                               nativePush:            Boolean = true,
                               enforceIgnoreMissing:  Boolean = false
                              ): ErrorOr[RemoteInstant] = {
-    import com.waz.utils.{RichEither, RichFutureEither}
-
-    def encryptAndSend(msg:      GenericMessage,
-                       external: Option[Array[Byte]] = None,
-                       retries:  Int = 0,
-                       previous: EncryptedContent = EncryptedContent.Empty
-                      ): ErrorOr[MessageResponse] =
-      for {
-        _          <- push.waitProcessing
-        Some(conv) <- convStorage.get(convId)
-        _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
-        recipients <- clientsMap(targetRecipients, convId)
-        content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
-        resp       <- if (external.isDefined || content.estimatedSize < MaxContentSize) {
-                        val (shouldIgnoreMissingClients, targetUsers) = missingClientsStrategy(targetRecipients) match {
-                          case DoNotIgnoreMissingClients                    => (false, None)
-                          case IgnoreMissingClientsExceptFromUsers(userIds) => (false, Some(userIds))
-                          case IgnoreMissingClients                         => (true, None)
-                        }
-
-                        msgClient.postMessage(
-                          conv.remoteId,
-                          OtrMessage(selfClientId, content, external, nativePush, report_missing = targetUsers),
-                          ignoreMissing = shouldIgnoreMissingClients || enforceIgnoreMissing || retries > 1
-                        ).future
-                      } else {
-                        warn(l"Message content too big, will post as External. Estimated size: ${content.estimatedSize}")
-                        val key = AESKey()
-                        val (sha, data) = AESUtils.encrypt(key, msg.proto.toByteArray)
-                        val newMessage  = GenericMessage(Uid(msg.proto.getMessageId), External(key, sha))
-                        encryptAndSend(newMessage, Some(data)) //abandon retries and previous EncryptedContent
-                      }
-        _          <- resp.map(_.deleted).mapFuture(service.deleteClients)
-        _          <- resp.map(_.missing.userIds).mapFuture(convsService.addUnexpectedMembersToConv(conv.id, _))
-        retry      <- resp.flatMapFuture {
-                        case MessageResponse.Failure(ClientMismatch(_, missing, _, _)) if retries < 3 =>
-                          warn(l"a message response failure with client mismatch with $missing, self client id is: $selfClientId")
-                          for {
-                            syncResult        <- syncClients(missing.userIds)
-                            err                = SyncResult.unapply(syncResult)
-                            _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
-                            needsConfirmation <- needsLegalHoldConfirmation(conv, isHidden, missing.userIds)
-                            _                  = if (needsConfirmation) throw LegalHoldDiscoveredException
-                            result            <- encryptAndSend(msg, external, retries + 1, content)
-                          } yield result
-                        case _: MessageResponse.Failure =>
-                          successful(Left(internalError(s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries")))
-                        case resp => Future.successful(Right(resp))
-                      }
-      } yield retry
-
-    def needsLegalHoldConfirmation(conv: ConversationData,
-                                   isMessageHidden: Boolean,
-                                   usersWithMissingClients: Set[UserId]): Future[Boolean] = {
-      if (isMessageHidden || conv.isUnderLegalHold) {
-        Future.successful(false)
-      } else {
-        clientsStorage.getAll(usersWithMissingClients).map {
-          _.exists {
-            case Some(userClients) => userClients.containsLegalHoldDevice
-            case None => false
-          }
-        }
-      }
-    }
-
-    encryptAndSend(message).recover {
+    encryptAndSend(message)(convId, targetRecipients, EncryptAndSendFlags(isHidden, nativePush, enforceIgnoreMissing)).recover {
       case UnverifiedException =>
         if (!message.proto.hasCalling) errors.addConvUnverifiedError(convId, MessageId(message.proto.getMessageId))
         Left(ErrorResponse.Unverified)
@@ -176,12 +121,148 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
     }.mapRight(_.mismatch.time)
   }
 
-  private def missingClientsStrategy(targetRecipients: TargetRecipients): MissingClientsStrategy =
-    targetRecipients match {
-      case ConversationParticipants => DoNotIgnoreMissingClients
-      case SpecificUsers(userIds)   => IgnoreMissingClientsExceptFromUsers(userIds)
-      case SpecificClients(_)       => IgnoreMissingClients
-    }
+  /**
+   * Post an otr message to a conversation.
+   *
+   * @param convId The id conversation to post the message to.
+   * @param message The message being posted.
+   * @param isHidden Whether the message is a hidden message. As a rule of thumb, if it doesn't
+   *                 occupy a row in the message list, then it is hidden.
+   @param targetRecipients Who should receive the message.
+   * @param nativePush
+   * @param enforceIgnoreMissing When missing clients should be ignored.
+   * @return
+   */
+  override def postQualifiedOtrMessage(convId:                ConvId,
+                                       message:               GenericMessage,
+                                       isHidden:              Boolean,
+                                       targetRecipients:      QTargetRecipients = QTargetRecipients.ConversationParticipants,
+                                       nativePush:            Boolean = true,
+                                       enforceIgnoreMissing:  Boolean = false
+                                      ): ErrorOr[RemoteInstant] = {
+    encryptAndSendQualified(message)(convId, targetRecipients, EncryptAndSendFlags(isHidden, nativePush, enforceIgnoreMissing)).recover {
+      case UnverifiedException =>
+        if (!message.proto.hasCalling) errors.addConvUnverifiedError(convId, MessageId(message.proto.getMessageId))
+        Left(ErrorResponse.Unverified)
+      case LegalHoldDiscoveredException =>
+        errors.addUnapprovedLegalHoldStatusError(convId, MessageId(message.proto.getMessageId))
+        Left(ErrorResponse.UnapprovedLegalHold)
+      case NonFatal(e) =>
+        Left(ErrorResponse.internalError(e.getMessage))
+    }.mapRight(_.mismatch.time)
+  }
+
+  private def encryptAndSend(msg:      GenericMessage,
+                             external: Option[Array[Byte]] = None,
+                             retries:  Int = 0,
+                             previous: EncryptedContent = EncryptedContent.Empty)
+                            (implicit convId:           ConvId,
+                                      targetRecipients: TargetRecipients,
+                                      flags:            EncryptAndSendFlags): ErrorOr[MessageResponse] =
+    for {
+      _          <- push.waitProcessing
+      Some(conv) <- convStorage.get(convId)
+      _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
+      recipients <- clientsMap(targetRecipients, convId)
+      content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
+      resp       <- if (external.isDefined || content.estimatedSize < MaxContentSize) {
+                      val (shouldIgnoreMissingClients, targetUsers) = targetRecipients.missingClientsStrategy match {
+                        case MissingClientsStrategy.DoNotIgnoreMissingClients                    => (false, None)
+                        case MissingClientsStrategy.IgnoreMissingClientsExceptFromUsers(userIds) => (false, Some(userIds))
+                        case MissingClientsStrategy.IgnoreMissingClients                         => (true, None)
+                      }
+
+                      msgClient.postMessage(
+                        conv.remoteId,
+                        OtrMessage(selfClientId, content, external, flags.nativePush, report_missing = targetUsers),
+                        ignoreMissing = shouldIgnoreMissingClients || flags.enforceIgnoreMissing || retries > 1
+                      ).future
+                    } else {
+                      warn(l"Message content too big, will post as External. Estimated size: ${content.estimatedSize}")
+                      val key = AESKey()
+                      val (sha, data) = AESUtils.encrypt(key, msg.proto.toByteArray)
+                      val newMessage  = GenericMessage(Uid(msg.proto.getMessageId), External(key, sha))
+                      encryptAndSend(newMessage, external = Some(data)) //abandon retries and previous EncryptedContent
+                    }
+      _          <- resp.map(_.deleted).mapFuture(service.deleteClients)
+      _          <- resp.map(_.missing.userIds).mapFuture(convsService.addUnexpectedMembersToConv(conv.id, _))
+      retry      <- resp.flatMapFuture {
+                      case MessageResponse.Failure(ClientMismatch(_, missing, _, _)) if retries < 3 =>
+                        warn(l"a message response failure with client mismatch with $missing, self client id is: $selfClientId")
+                        for {
+                          syncResult        <- syncClients(missing.userIds)
+                          err                = SyncResult.unapply(syncResult)
+                          _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
+                          needsConfirmation <- needsLegalHoldConfirmation(conv, flags.isHidden, missing.userIds)
+                          _                  = if (needsConfirmation) throw LegalHoldDiscoveredException
+                          result            <- encryptAndSend(msg, external = external, retries = retries + 1, previous = content)
+                        } yield result
+                      case _: MessageResponse.Failure =>
+                        successful(Left(internalError(s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries")))
+                      case resp => Future.successful(Right(resp))
+                    }
+    } yield retry
+
+  private def encryptAndSendQualified(msg:      GenericMessage,
+                                      external: Option[Array[Byte]] = None,
+                                      retries:  Int = 0,
+                                      previous: QEncryptedContent = QEncryptedContent.Empty)
+                                     (implicit convId:  ConvId,
+                                      targetRecipients: QTargetRecipients,
+                                      flags:            EncryptAndSendFlags): ErrorOr[QMessageResponse] =
+    for {
+      _          <- push.waitProcessing
+      Some(conv) <- convStorage.get(convId)
+      _          =  if (conv.verified == Verification.UNVERIFIED) throw UnverifiedException
+      recipients <- clientsMap(targetRecipients, convId)
+      content    <- service.encryptMessage(msg, recipients, retries > 0, previous)
+      resp       <- if (external.isDefined || content.estimatedSize < MaxContentSize) {
+        val (reportAll, targetUsers) = targetRecipients.missingClientsStrategy match {
+          case QMissingClientsStrategy.DoNotIgnoreMissingClients                 => (!flags.enforceIgnoreMissing && retries == 0, None)
+          case QMissingClientsStrategy.IgnoreMissingClientsExceptFromUsers(qIds) => (false, if (retries == 0) Some(qIds) else None)
+          case QMissingClientsStrategy.IgnoreMissingClients                      => (false, None)
+        }
+
+        msgClient.postMessage(
+          conv.qualifiedId.getOrElse(RConvQualifiedId(conv.remoteId, currentDomain.getOrElse(""))),
+          QualifiedOtrMessage(selfClientId, content, external, flags.nativePush, reportMissing = targetUsers, reportAll = reportAll)
+        ).future
+      } else {
+        warn(l"Message content too big, will post as External. Estimated size: ${content.estimatedSize}")
+        val key = AESKey()
+        val (sha, data) = AESUtils.encrypt(key, msg.proto.toByteArray)
+        val newMessage  = GenericMessage(Uid(msg.proto.getMessageId), External(key, sha))
+        encryptAndSendQualified(newMessage, external = Some(data)) //abandon retries and previous QEncryptedContent
+      }
+      _          <- resp.map(_.deleted).mapFuture(service.deleteClients)
+      _          <- resp.map(_.missing.qualifiedIds.map(_.id)).mapFuture(convsService.addUnexpectedMembersToConv(conv.id, _))
+      retry      <- resp.flatMapFuture {
+        case QMessageResponse.Failure(QClientMismatch(_, missing, _, _)) if retries < 3 =>
+          warn(l"a message response failure with client mismatch with $missing, self client id is: $selfClientId")
+          for {
+            syncResult        <- clientsSyncHandler.syncClients(missing.qualifiedIds)
+            err                = SyncResult.unapply(syncResult)
+            _                  = err.foreach { err => error(l"syncClients for missing clients failed: $err") }
+            needsConfirmation <- needsLegalHoldConfirmation(conv, flags.isHidden, missing.qualifiedIds.map(_.id))
+            _                  = if (needsConfirmation) throw LegalHoldDiscoveredException
+            result            <- encryptAndSendQualified(msg, external = external, retries = retries + 1, previous = content)
+          } yield result
+        case _: QMessageResponse.Failure =>
+          successful(Left(internalError(s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries")))
+        case resp => Future.successful(Right(resp))
+      }
+    } yield retry
+
+
+  private def needsLegalHoldConfirmation(conv: ConversationData, isMessageHidden: Boolean, usersWithMissingClients: Set[UserId]): Future[Boolean] =
+    if (isMessageHidden || conv.isUnderLegalHold) Future.successful(false)
+    else
+      clientsStorage.getAll(usersWithMissingClients).map {
+        _.exists {
+          case Some(userClients) => userClients.containsLegalHoldDevice
+          case None              => false
+        }
+      }
 
   private def clientsMap(targetRecipients: TargetRecipients, convId: ConvId): Future[OtrClientIdMap] = {
     def clientIds(userIds: Set[UserId]): Future[OtrClientIdMap] = {
@@ -193,47 +274,63 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
     }
 
     targetRecipients match {
-      case ConversationParticipants       => members.getActiveUsers(convId).map(_.toSet).flatMap(clientIds)
-      case SpecificUsers(userIds)         => clientIds(userIds)
-      case SpecificClients(clientsByUser) => Future.successful(clientsByUser)
+      case TargetRecipients.ConversationParticipants       => members.getActiveUsers(convId).map(_.toSet).flatMap(clientIds)
+      case TargetRecipients.SpecificUsers(userIds)         => clientIds(userIds)
+      case TargetRecipients.SpecificClients(clientsByUser) => Future.successful(clientsByUser)
     }
   }
+
+  private def clientsMap(targetRecipients: QTargetRecipients, convId: ConvId): Future[QOtrClientIdMap] = {
+    def clientIds(qIds: Set[QualifiedId]): Future[QOtrClientIdMap] = {
+      Future.traverse(qIds) { qId =>
+        clientsStorage.getClients(qId.id).map { clients =>
+          qId -> clients.map(_.id).filterNot(_ == selfClientId).toSet
+        }
+      }.map(QOtrClientIdMap(_))
+    }
+
+    targetRecipients match {
+      case QTargetRecipients.ConversationParticipants       =>
+        members.getActiveUsers(convId).flatMap(ids => userService.qualifiedIds(ids.toSet)).flatMap(clientIds)
+      case QTargetRecipients.SpecificUsers(userIds)         => clientIds(userIds)
+      case QTargetRecipients.SpecificClients(clientsByUser) => Future.successful(clientsByUser)
+    }
+  }
+
+  private def getBroadcastRecipients =
+    for {
+      acceptedOrBlocked <- userService.acceptedOrBlockedUsers.head
+      myTeam            <- teamId.fold(Future.successful(Set.empty[UserData]))(id => usersStorage.getByTeam(Set(id)))
+      myTeamIds         =  myTeam.map(_.id)
+    } yield acceptedOrBlocked.keySet ++ myTeamIds
 
   override def broadcastMessage(message:    GenericMessage,
                                 retry:      Int = 0,
                                 previous:   EncryptedContent = EncryptedContent.Empty,
                                 recipients: Option[Set[UserId]] = None
-                               ): Future[Either[ErrorResponse, RemoteInstant]] =
-    push.waitProcessing.flatMap { _ =>
-      val broadcastRecipients = recipients match {
-        case Some(recp) => Future.successful(recp)
-        case None =>
-          for {
-            acceptedOrBlocked <- userService.acceptedOrBlockedUsers.head
-            myTeam            <- teamId.fold(Future.successful(Set.empty[UserData]))(id => usersStorage.getByTeam(Set(id)))
-            myTeamIds         =  myTeam.map(_.id)
-          } yield acceptedOrBlocked.keySet ++ myTeamIds
-      }
-
-      import com.waz.utils.RichEither
-
-      broadcastRecipients.flatMap { recp =>
-        for {
-          content  <- service.encryptMessageForUsers(message, recp, useFakeOnError = retry > 0, previous)
-          response <- otrClient.broadcastMessage(
-                        OtrMessage(selfClientId, content, report_missing = Some(recp)),
-                        ignoreMissing = retry > 1
-                      ).future
-          _        <- response.map(_.deleted).mapFuture(service.deleteClients)
-          res      <- loopIfMissingClients(
-                       response,
-                       retry,
-                       recp,
-                       (rs: Set[UserId]) => broadcastMessage(message, retry + 1, content, Some(rs))
-                      )
-        } yield res
-      }
+                               ): Future[Either[ErrorResponse, RemoteInstant]] = push.waitProcessing.flatMap { _ =>
+    val broadcastRecipients = recipients match {
+      case Some(recp) => Future.successful(recp)
+      case None       => getBroadcastRecipients
     }
+
+    broadcastRecipients.flatMap { recp =>
+      for {
+        content  <- service.encryptMessageForUsers(message, recp, previous, useFakeOnError = retry > 0)
+        response <- otrClient.broadcastMessage(
+                      OtrMessage(selfClientId, content, report_missing = Some(recp)),
+                      ignoreMissing = retry > 1
+                    ).future
+        _        <- response.map(_.deleted).mapFuture(service.deleteClients)
+        res      <- loopIfMissingClients(
+                     response,
+                     retry,
+                     recp,
+                     (rs: Set[UserId]) => broadcastMessage(message, retry + 1, content, Some(rs))
+                    )
+      } yield res
+    }
+  }
 
   private def loopIfMissingClients(response:          Either[ErrorResponse, MessageResponse],
                                    retry:             Int,
@@ -265,16 +362,43 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         successful(Left(err))
     }
 
-  override def postSessionReset(convId: ConvId, userId: UserId, clientId: ClientId): Future[SyncResult] = {
-
-    val msg = GenericMessage(Uid(), ClientAction.SessionReset)
-
-    val convData = convStorage.get(convId).flatMap {
-      case None => convStorage.get(ConvId(userId.str))
-      case conv => successful(conv)
+  private def loopIfMissingQualifiedClients(response:          Either[ErrorResponse, QMessageResponse],
+                                            retry:             Int,
+                                            currentRecipients: Set[QualifiedId],
+                                            onRetry:           (Set[QualifiedId]) => Future[Either[ErrorResponse, RemoteInstant]]
+                                           ): Future[Either[ErrorResponse, RemoteInstant]] =
+    response match {
+      case Right(QMessageResponse.Success(QClientMismatch(_, _, deleted, time))) =>
+        // XXX: we are ignoring redundant clients, we rely on members list to encrypt messages,
+        // so if user left the conv then we won't use his clients on next message
+        service.deleteClients(deleted).map(_ => Right(time))
+      case Right(QMessageResponse.Failure(QClientMismatch(_, missing, deleted, _))) =>
+        service.deleteClients(deleted).flatMap {
+          case _ if retry > 2 =>
+            successful(Left(internalError(
+              s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries: $missing"
+            )))
+          case _ =>
+            clientsSyncHandler.syncClients(missing.qualifiedIds).flatMap { syncResult =>
+              SyncResult.unapply(syncResult) match {
+                case None                 => onRetry(missing.qualifiedIds)
+                case Some(_) if retry < 3 => onRetry(currentRecipients)
+                case Some(err)            => successful(Left(err))
+              }
+            }
+        }
+      case Left(err) =>
+        error(l"postOtrMessage failed with error: $err")
+        successful(Left(err))
     }
 
-    def msgContent = service.encryptTargetedMessage(userId, clientId, msg).flatMap {
+  private def getConvData(convId: ConvId, userId: UserId) = convStorage.get(convId).flatMap {
+    case None => convStorage.get(ConvId(userId.str))
+    case conv => successful(conv)
+  }
+
+  private def encrypt(userId: UserId, clientId: ClientId, msg: GenericMessage) =
+    service.encryptTargetedMessage(userId, clientId, msg).flatMap {
       case Some(ct) => successful(Some(ct))
       case None =>
         for {
@@ -284,11 +408,22 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         } yield content
     }
 
-    convData.flatMap {
+  private def encrypt(qualifiedId: QualifiedId, clientId: ClientId, msg: GenericMessage) =
+    service.encryptTargetedMessage(qualifiedId, clientId, msg).flatMap {
+      case Some(ct) => successful(Some(ct))
+      case None =>
+        for {
+          _       <- clientsSyncHandler.syncSessions(QOtrClientIdMap.from(qualifiedId -> Set(clientId)))
+          content <- service.encryptTargetedMessage(qualifiedId, clientId, msg)
+        } yield content
+    }
+
+  override def postSessionReset(convId: ConvId, userId: UserId, clientId: ClientId): Future[SyncResult] =
+    getConvData(convId, userId).flatMap {
       case None =>
         successful(Failure(s"conv not found: $convId, for user: $userId in postSessionReset"))
       case Some(conv) =>
-        msgContent.flatMap {
+        encrypt(userId, clientId, GenericMessage(Uid(), ClientAction.SessionReset)).flatMap {
           case None => successful(Failure(s"session not found for $userId, $clientId"))
           case Some(content) =>
             msgClient
@@ -296,13 +431,40 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
               .map(SyncResult(_))
         }
     }
-  }
+
+  override def postSessionReset(convId: ConvId, qualifiedId: QualifiedId, clientId: ClientId): Future[SyncResult] =
+    getConvData(convId, qualifiedId.id).flatMap {
+      case None =>
+        successful(Failure(s"conv not found: $convId, for user: $qualifiedId in postSessionReset"))
+      case Some(conv) =>
+        encrypt(qualifiedId, clientId, GenericMessage(Uid(), ClientAction.SessionReset)).flatMap {
+          case None => successful(Failure(s"session not found for $qualifiedId, $clientId"))
+          case Some(content) =>
+            msgClient
+              .postMessage(
+                conv.qualifiedId.getOrElse(RConvQualifiedId(conv.remoteId, currentDomain.getOrElse(""))),
+                QualifiedOtrMessage(selfClientId, content)
+              )
+              .future
+              .map(SyncResult(_))
+        }
+    }
 
   override def postClientDiscoveryMessage(convId: RConvId): ErrorOr[OtrClientIdMap] =
     for {
       Some(conv) <- convStorage.getByRemoteId(convId)
       message    =  OtrMessage(selfClientId, EncryptedContent.Empty, nativePush = false)
       response   <- msgClient.postMessage(conv.remoteId, message, ignoreMissing = false).future
+    } yield response match {
+      case Left(error) => Left(error)
+      case Right(resp) => Right(resp.missing)
+    }
+
+  override def postClientDiscoveryMessage(convId: RConvQualifiedId): ErrorOr[QOtrClientIdMap] =
+    for {
+      Some(conv) <- convStorage.getByRemoteId(convId.id)
+      message    =  QualifiedOtrMessage(selfClientId, QEncryptedContent.Empty, nativePush = false)
+      response   <- msgClient.postMessage(convId, message).future
     } yield response match {
       case Left(error) => Left(error)
       case Right(resp) => Right(resp.missing)
@@ -320,11 +482,22 @@ object OtrSyncHandler {
   final case object UnverifiedException extends Exception
   final case object LegalHoldDiscoveredException extends Exception
 
+  final case class EncryptAndSendFlags(isHidden: Boolean, nativePush: Boolean, enforceIgnoreMissing: Boolean)
+
   val MaxInlineSize  = 10 * 1024
   val MaxContentSize = 256 * 1024 // backend accepts 256KB for otr messages, but we would prefer to send less
 
   /// Describes who should receive a message.
-  sealed trait TargetRecipients
+  sealed trait TargetRecipients {
+    import TargetRecipients._
+    import MissingClientsStrategy._
+    def missingClientsStrategy: MissingClientsStrategy =
+      this match {
+        case ConversationParticipants => DoNotIgnoreMissingClients
+        case SpecificUsers(userIds)   => IgnoreMissingClientsExceptFromUsers(userIds)
+        case SpecificClients(_)       => IgnoreMissingClients
+      }
+  }
 
   object TargetRecipients {
     /// All participants (and all their clients) should receive the message.
@@ -351,4 +524,40 @@ object OtrSyncHandler {
     final case class IgnoreMissingClientsExceptFromUsers(userIds: Set[UserId]) extends MissingClientsStrategy
   }
 
+  /// Describes who should receive a message.
+  sealed trait QTargetRecipients {
+    import QTargetRecipients._
+    import QMissingClientsStrategy._
+    def missingClientsStrategy: QMissingClientsStrategy =
+      this match {
+        case ConversationParticipants => DoNotIgnoreMissingClients
+        case SpecificUsers(userIds)   => IgnoreMissingClientsExceptFromUsers(userIds)
+        case SpecificClients(_)       => IgnoreMissingClients
+      }
+  }
+
+  object QTargetRecipients {
+    /// All participants (and all their clients) should receive the message.
+    final object ConversationParticipants extends QTargetRecipients
+
+    /// All clients of the given users should receive the message.
+    final case class SpecificUsers(qualifiedIds: Set[QualifiedId]) extends QTargetRecipients
+
+    /// These exact clients should receive the message.
+    final case class SpecificClients(clientsByUser: QOtrClientIdMap) extends QTargetRecipients
+  }
+
+  /// Describes how missing clients should be handled.
+  sealed trait QMissingClientsStrategy
+
+  object QMissingClientsStrategy {
+    /// Fetch missing clients and resend the message.
+    object DoNotIgnoreMissingClients extends QMissingClientsStrategy
+
+    /// Send the message without fetching missing clients.
+    object IgnoreMissingClients extends QMissingClientsStrategy
+
+    /// Only fetch missing clients from the given users and resend the message.
+    final case class IgnoreMissingClientsExceptFromUsers(qualifiedIds: Set[QualifiedId]) extends QMissingClientsStrategy
+  }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -460,15 +460,13 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
       case Right(resp) => Right(resp.missing)
     }
 
-  override def postClientDiscoveryMessage(convId: RConvQualifiedId): ErrorOr[QOtrClientIdMap] =
-    for {
-      Some(conv) <- convStorage.getByRemoteId(convId.id)
-      message    =  QualifiedOtrMessage(selfClientId, QEncryptedContent.Empty, nativePush = false)
-      response   <- msgClient.postMessage(convId, message).future
-    } yield response match {
+  override def postClientDiscoveryMessage(convId: RConvQualifiedId): ErrorOr[QOtrClientIdMap] = {
+    val message = QualifiedOtrMessage(selfClientId, QEncryptedContent.Empty, nativePush = false)
+    msgClient.postMessage(convId, message).future.map {
       case Left(error) => Left(error)
       case Right(resp) => Right(resp.missing)
     }
+  }
 
   private def syncClients(users: Set[UserId]): Future[SyncResult] =
     for {

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -25,7 +25,7 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE.{error, _}
 import com.waz.model.GenericContent.{ClientAction, External}
 import com.waz.model._
-import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
+import com.waz.model.otr.{ClientId, OtrClientIdMap, OtrMessage, QOtrClientIdMap}
 import com.waz.service.conversation.ConversationsService
 import com.waz.service.otr.OtrService
 import com.waz.service.push.PushService
@@ -319,12 +319,6 @@ object OtrSyncHandler {
 
   final case object UnverifiedException extends Exception
   final case object LegalHoldDiscoveredException extends Exception
-
-  final case class OtrMessage(sender:         ClientId,
-                              recipients:     EncryptedContent,
-                              external:       Option[Array[Byte]] = None,
-                              nativePush:     Boolean = true,
-                              report_missing: Option[Set[UserId]] = None)
 
   val MaxInlineSize  = 10 * 1024
   val MaxContentSize = 256 * 1024 // backend accepts 256KB for otr messages, but we would prefer to send less

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -77,7 +77,7 @@ class UserServiceSpec extends AndroidFreeSpec {
     result(userPrefs(UserPreferences.ShouldSyncUsers) := false)
 
     new UserServiceImpl(
-      users.head.id, None, None, accountsService, accountsStrg, usersStorage, membersStorage,
+      users.head.id, if (BuildConfig.FEDERATION_USER_DISCOVERY) Some(Domain) else None, None, accountsService, accountsStrg, usersStorage, membersStorage,
       userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
       selectedConv, messages
     )

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -1082,7 +1082,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
         TargetRecipients.SpecificClients(OtrClientIdMap.from(otherUser.userId -> Set(otherUser.clientId)))
 
       (otrSyncHandler.postOtrMessage _)
-        .expects(groupConv.id, *, expectedTargetRecipients, *, *, *)
+        .expects(groupConv.id, *, *, expectedTargetRecipients, *, *)
         .once()
         .returning(Future.successful(Right(RemoteInstant(Instant.now(clock)))))
 
@@ -1095,7 +1095,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     scenario("Messages are not targeted if no target recipients are specified") {
       (otrSyncHandler.postOtrMessage _)
-        .expects(groupConv.id, *, TargetRecipients.ConversationParticipants, *, *, *)
+        .expects(groupConv.id, *, *, TargetRecipients.ConversationParticipants, *, *)
         .once()
         .returning(Future.successful(Right(RemoteInstant(Instant.now(clock)))))
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -545,7 +545,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
           }
         }
       }
-      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => user.id != selfUserId }
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
@@ -595,7 +595,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
           }
         }
       }
-      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => user.id != selfUserId }
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -79,9 +79,12 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   private val convId = ConvId("conv_id1")
   private val rConvId = RConvId("r_conv_id1")
 
+  private val domain = "chala.wire.link"
+
   private lazy val service = new ConversationsServiceImpl(
     None,
     selfUserId,
+    Some(domain),
     push,
     userService,
     usersStorage,
@@ -573,7 +576,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       val convName = Name("conv")
       val conv = ConversationData(team = Some(teamId), name = Some(convName))
       val syncId = SyncId()
-      val domain = "chala.wire.link"
+
       val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
       val user1 = UserData("user1").copy(domain = Some(domain))
       val user2 = UserData("user2").copy(domain = Some(domain))

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -276,43 +276,4 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
       ConversationRole.MemberRole
     ))
   }
-
-
-  scenario("It reports missing legal hold consent error when creating a conversation with qualified members") {
-    // Given
-    val handler = createHandler
-    val convId = ConvId("convId")
-    val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
-
-    // Mock
-    (conversationsClient.postQualifiedConversation _)
-      .expects(*)
-      .once()
-      .returning(CancellableFuture.successful(Left(errorResponse)))
-
-    // Expectation
-    val errorType = ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_USER_MISSING_LEGAL_HOLD_CONSENT
-
-    (errorsService.addErrorWhenActive _)
-      .expects(where { data: ErrorData =>
-        data.errType == errorType &&
-          data.responseCode == 412 &&
-          data.responseLabel == "missing-legalhold-consent" &&
-          data.convId.contains(convId)
-      })
-      .once()
-      .returning(Future.successful(()))
-
-    // When (arguments are irrelevant)
-    result(handler.postQualifiedConversation(
-      convId,
-      Set(QualifiedId(UserId("userId"), "chala.wire.link")),
-      None,
-      None,
-      Set.empty,
-      AccessRole.TEAM,
-      None,
-      ConversationRole.MemberRole
-    ))
-  }
 }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/LegalHoldSyncHandlerSpec.scala
@@ -130,7 +130,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       )
 
       // Expectations
-      (otrSync.postClientDiscoveryMessage _)
+      (otrSync.postClientDiscoveryMessage(_ : RConvId))
         .expects(convId)
         .once()
         .returning(CancellableFuture.successful(Right(clientList)))
@@ -173,7 +173,7 @@ class LegalHoldSyncHandlerSpec extends AndroidFreeSpec {
       val errorResponse = ErrorResponse(400, "", "")
 
       // Expectations
-      (otrSync.postClientDiscoveryMessage _)
+      (otrSync.postClientDiscoveryMessage(_: RConvId))
         .expects(convId)
         .once()
         .returning(CancellableFuture.successful(Left(errorResponse)))

--- a/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
@@ -93,7 +93,7 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     val senderId = UserId()
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(Option(MessageData(messageId, convId = convId))))
-    (otrSync.postOtrMessage _).expects(convId, *, * ,true, *, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
+    (otrSync.postOtrMessage _).expects(convId, *, true, *, *, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
 
     result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Success
   }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
@@ -23,7 +23,7 @@ import com.waz.cache.CacheService
 import com.waz.content.{MembersStorage, MessagesStorage}
 import com.waz.model._
 import com.waz.service.assets.{AssetService, AssetStorage, UploadAssetStorage}
-import com.waz.service.{ErrorsService, Timeouts}
+import com.waz.service.{ErrorsService, Timeouts, UserService}
 import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.otr.OtrClientsService
@@ -32,6 +32,7 @@ import com.waz.sync.SyncHandler.RequestInfo
 import com.waz.sync.SyncResult.Failure
 import com.waz.sync.{SyncResult, SyncServiceHandle}
 import com.waz.sync.otr.OtrSyncHandler
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.Future
 
@@ -50,10 +51,16 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
   val uploads       = mock[UploadAssetStorage]
   val cache         = mock[CacheService]
   val members       = mock[MembersStorage]
+  val users         = mock[UserService]
   val timeouts      = new Timeouts()
 
+  val domain = "chala.wire.link"
+
   def getHandler: MessagesSyncHandler = {
-    new MessagesSyncHandler(account1Id, service, msgContent, clients, otrSync, convs, storage, sync, assets, assetStorage, uploads, cache, members, tracking, errors, timeouts)
+    new MessagesSyncHandler(
+      account1Id, service, msgContent, clients, otrSync, convs, storage, sync,
+      assets, assetStorage, uploads, cache, members, users, tracking, errors, timeouts
+    )
   }
 
   scenario("post invalid message should fail immediately") {
@@ -78,7 +85,11 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     (storage.getMessage _).expects(messageId).returning(Future.successful(Option(message)))
     (convs.convById _).expects(convId).returning(Future.successful(Option(ConversationData(convId))))
 
-    (otrSync.postOtrMessage _).expects(convId, *, * ,*, *, *).returning(Future.successful(Left(connectionError)))
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      (otrSync.postQualifiedOtrMessage _).expects(convId, *, *, *, *, *).returning(Future.successful(Left(connectionError)))
+    } else {
+      (otrSync.postOtrMessage _).expects(convId, *, *, *, *, *).returning(Future.successful(Left(connectionError)))
+    }
 
     (service.messageDeliveryFailed _).expects(convId, message, connectionError).returning(Future.successful(Some(message.copy(state = Message.Status.FAILED))))
 
@@ -93,8 +104,12 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     val senderId = UserId()
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(Option(MessageData(messageId, convId = convId))))
-    (otrSync.postOtrMessage _).expects(convId, *, true, *, *, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
-
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      (users.qualifiedIds _).expects(Set(senderId)).anyNumberOfTimes().returning(Future.successful(Set(QualifiedId(senderId, domain))))
+      (otrSync.postQualifiedOtrMessage _).expects(convId, *, *, *, *, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
+    } else {
+      (otrSync.postOtrMessage _).expects(convId, *, true, *, *, *).returning(Future.successful(Right(RemoteInstant.Epoch)))
+    }
     result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Success
   }
 
@@ -118,7 +133,12 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
     val errorText = "Error"
 
     (storage.get _).expects(messageId).anyNumberOfTimes().returning(Future.successful(Option(MessageData(messageId, convId = convId))))
-    (otrSync.postOtrMessage _).expects(convId, *, * ,*, *, *).returning(Future.successful(Left(internalError(errorText))))
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      (users.qualifiedIds _).expects(Set(senderId)).anyNumberOfTimes().returning(Future.successful(Set(QualifiedId(senderId, domain))))
+      (otrSync.postQualifiedOtrMessage _).expects(convId, *, *, *, *, *).returning(Future.successful(Left(internalError(errorText))))
+    } else {
+      (otrSync.postOtrMessage _).expects(convId, *, *, *, *, *).returning(Future.successful(Left(internalError(errorText))))
+    }
     (service.setButtonError _).expects(messageId, buttonId).once().returning(Future.successful({}))
 
     result(getHandler.postButtonAction(messageId, buttonId, senderId)) shouldEqual SyncResult.Failure(errorText)


### PR DESCRIPTION
This is the final PR for the Federation milestone about basic messaging. 
It's so big because of duplicated code: the new messages need to be sent through new endpoints and they need to use qualified ids instead of simple user ids (and in some case instead of remote conversation ids). In the same time we want
to still use the old code if the feature flag is off.

#### APK
[Download build #3887](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3887/artifact/build/artifact/wire-dev-PR3472-3887.apk)
[Download build #3893](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3893/artifact/build/artifact/wire-dev-PR3472-3893.apk)
[Download build #3897](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3897/artifact/build/artifact/wire-dev-PR3472-3897.apk)
[Download build #3900](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3900/artifact/build/artifact/wire-dev-PR3472-3900.apk)
[Download build #3914](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3914/artifact/build/artifact/wire-dev-PR3472-3914.apk)
[Download build #3917](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3917/artifact/build/artifact/wire-dev-PR3472-3917.apk)
[Download build #3922](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3922/artifact/build/artifact/wire-dev-PR3472-3922.apk)