### PR TITLE
Feature: display local notification - Part 0

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/shared/notification/datasources/local/NotificationDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/shared/notification/datasources/local/NotificationDaoTest.kt
@@ -1,0 +1,62 @@
+package com.wire.android.shared.notification.datasources.local
+
+import com.wire.android.InstrumentationTest
+import com.wire.android.core.storage.db.user.UserDatabase
+import com.wire.android.feature.conversation.data.local.ConversationDao
+import com.wire.android.feature.conversation.data.local.ConversationEntity
+import com.wire.android.framework.storage.db.DatabaseTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldContainSame
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class NotificationDaoTest : InstrumentationTest() {
+
+    @get:Rule
+    val databaseTestRule = DatabaseTestRule.create<UserDatabase>(appContext)
+
+    private lateinit var userDatabase: UserDatabase
+    private lateinit var notificationDao: NotificationDao
+    private lateinit var conversationDao: ConversationDao
+
+    @Before
+    fun setUp() {
+        userDatabase = databaseTestRule.database
+        notificationDao = userDatabase.notificationDao()
+        conversationDao = userDatabase.conversationDao()
+    }
+
+    @Test
+    fun insertNotification_readNotification_containsInsertedItems() = databaseTestRule.runTest {
+        populateDatabaseWithConversation()
+        val notification = NotificationEntity("1254-1", "message", TEST_CONVERSATION_ID)
+        notificationDao.insert(notification)
+
+        val result = notificationDao.notificationsByConversationId(TEST_CONVERSATION_ID)
+
+        result shouldContainSame arrayOf(notification)
+    }
+
+    @Test
+    fun deleteEntity_readNotifications_doesNotContainDeletedItem() = databaseTestRule.runTest {
+        populateDatabaseWithConversation()
+        val notification = NotificationEntity("1254-1", "message", TEST_CONVERSATION_ID)
+        notificationDao.insert(notification)
+
+        notificationDao.deleteNotificationsByConversationId(TEST_CONVERSATION_ID)
+
+        notificationDao.notificationsByConversationId(TEST_CONVERSATION_ID).isEmpty() shouldBe true
+    }
+
+    private suspend fun populateDatabaseWithConversation() {
+        val conversationEntity = ConversationEntity(TEST_CONVERSATION_ID, "Test", 0)
+        conversationDao.insert(conversationEntity)
+    }
+
+    companion object {
+        private const val TEST_CONVERSATION_ID = "1234"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/core/di/Injector.kt
+++ b/app/src/main/kotlin/com/wire/android/core/di/Injector.kt
@@ -14,6 +14,7 @@ import com.wire.android.feature.profile.di.profileModule
 import com.wire.android.feature.sync.di.syncModule
 import com.wire.android.feature.welcome.di.welcomeModule
 import com.wire.android.shared.asset.di.assetModule
+import com.wire.android.shared.notification.di.notificationModule
 import com.wire.android.shared.prekey.di.prekeyModule
 import com.wire.android.shared.session.di.sessionModule
 import com.wire.android.shared.team.di.teamModule
@@ -47,7 +48,7 @@ object Injector {
      * Shared modules should contain dependencies that can
      * build up multiple features
      */
-    private val sharedModules: List<Module> = listOf(userModule, sessionModule, teamModule, assetModule, prekeyModule)
+    private val sharedModules: List<Module> = listOf(userModule, sessionModule, teamModule, assetModule, prekeyModule, notificationModule)
 
     /**
      * Feature modules should contain dependencies that build up specific

--- a/app/src/main/kotlin/com/wire/android/core/storage/db/user/UserDatabase.kt
+++ b/app/src/main/kotlin/com/wire/android/core/storage/db/user/UserDatabase.kt
@@ -15,6 +15,8 @@ import com.wire.android.feature.conversation.members.datasources.local.Conversat
 import com.wire.android.feature.conversation.members.datasources.local.ConversationMembersDao
 import com.wire.android.shared.asset.datasources.local.AssetDao
 import com.wire.android.shared.asset.datasources.local.AssetEntity
+import com.wire.android.shared.notification.datasources.local.NotificationDao
+import com.wire.android.shared.notification.datasources.local.NotificationEntity
 
 @Database(
     entities = [ConversationEntity::class,
@@ -22,7 +24,9 @@ import com.wire.android.shared.asset.datasources.local.AssetEntity
         ConversationMemberEntity::class,
         AssetEntity::class,
         ClientEntity::class,
-        MessageEntity::class],
+        MessageEntity::class,
+        NotificationEntity::class
+    ],
     version = UserDatabase.VERSION
 )
 abstract class UserDatabase : RoomDatabase() {
@@ -40,6 +44,8 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun clientDao(): ClientDao
 
     abstract fun messageDao(): MessageDao
+
+    abstract fun notificationDao(): NotificationDao
 
     companion object {
         const val VERSION = 1

--- a/app/src/main/kotlin/com/wire/android/shared/notification/datasources/local/NotificationDao.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/notification/datasources/local/NotificationDao.kt
@@ -1,0 +1,20 @@
+package com.wire.android.shared.notification.datasources.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface NotificationDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(notification: NotificationEntity)
+
+    @Query("SELECT * FROM notification WHERE conversation_id = :conversationId")
+    suspend fun notificationsByConversationId(conversationId: String) : List<NotificationEntity>
+
+    @Query("DELETE FROM notification WHERE conversation_id = :conversationId")
+    suspend fun deleteNotificationsByConversationId(conversationId: String)
+
+}

--- a/app/src/main/kotlin/com/wire/android/shared/notification/datasources/local/NotificationEntity.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/notification/datasources/local/NotificationEntity.kt
@@ -1,0 +1,24 @@
+package com.wire.android.shared.notification.datasources.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+import com.wire.android.feature.conversation.data.local.ConversationEntity
+
+@Entity(
+    tableName = "notification",
+    foreignKeys = [
+        ForeignKey(
+            entity = ConversationEntity::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("conversation_id"),
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class NotificationEntity(
+    @PrimaryKey @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "message") val message: String,
+    @ColumnInfo(name = "conversation_id") val conversationId: String
+)

--- a/app/src/main/kotlin/com/wire/android/shared/notification/di/NotificationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/notification/di/NotificationModule.kt
@@ -1,0 +1,8 @@
+package com.wire.android.shared.notification.di
+
+import com.wire.android.core.storage.db.user.UserDatabase
+import org.koin.dsl.module
+
+val notificationModule = module {
+    factory { get<UserDatabase>().notificationDao() }
+}


### PR DESCRIPTION
## What's new in this PR?
Jira US : https://wearezeta.atlassian.net/browse/AR-438

In this PR, I added a new table to user database called `notification`. 
Also I prepared some methods that will be used in next PRs.

We need to store messages (that have to be displayed in notification) in order to group notifications by conversation name.
If we don't store messages somewhere, older notifications will be erased once a newer one is received.

![image](https://user-images.githubusercontent.com/18124919/131325888-17432c3d-d0f6-4543-a207-144ccf8fed3f.png)
