### PR TITLE
Feature: Enforce ephemeral messages (part 5)

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -88,7 +88,7 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       isNowEnabled      =  config.isEnabled
       newTimeout        =  config.enforcedTimeoutInSeconds
       _                 <- userPrefs(AreSelfDeletingMessagesEnabled) := isNowEnabled
-      _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := newTimeout
+      _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := 300
       // Inform of new restrictions.
       _                 <- userPrefs(ShouldInformSelfDeletingMessagesChanged) :=
         (wasEnabled != isNowEnabled || lastKnownTimeout != newTimeout)

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -88,7 +88,7 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       isNowEnabled      =  config.isEnabled
       newTimeout        =  config.enforcedTimeoutInSeconds
       _                 <- userPrefs(AreSelfDeletingMessagesEnabled) := isNowEnabled
-      _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := 300
+      _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := newTimeout
       // Inform of new restrictions.
       _                 <- userPrefs(ShouldInformSelfDeletingMessagesChanged) :=
         (wasEnabled != isNowEnabled || lastKnownTimeout != newTimeout)

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -31,6 +31,7 @@ import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsS
 import com.waz.service.messages.{MessageEventProcessor, MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.TestUserPreferences
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ReplyHashing
 import com.wire.signals.{EventStream, Signal}
@@ -54,6 +55,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   val downloadStorage   = mock[DownloadAssetStorage]
   val buttonsStorage    = mock[ButtonsStorage]
   val prefs             = new TestGlobalPreferences()
+  val userPrefs         = new TestUserPreferences()
 
   val messagesInStorage = Signal[Seq[MessageData]](Seq.empty)
   (storage.getMessages _).expects(*).atLeastOnce.onCall { ids: Traversable[MessageId] =>
@@ -301,7 +303,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   }
 
   def getProcessor = {
-    val content = new MessagesContentUpdater(storage, convsStorage, deletions, buttonsStorage, prefs)
+    val content = new MessagesContentUpdater(storage, convsStorage, deletions, buttonsStorage, prefs, userPrefs)
 
     //TODO make VerificationStateUpdater mockable
     (otrClientsStorage.onAdded _).expects().anyNumberOfTimes().returning(EventStream[Seq[UserClients]]())

--- a/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
@@ -29,7 +29,7 @@ import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesServiceImpl}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ReplyHashing
 import com.wire.signals.{EventStream, Signal}
@@ -51,10 +51,11 @@ class MessagesServiceSpec extends AndroidFreeSpec {
   val buttons =       mock[ButtonsStorage]
   val users =         mock[UsersStorage]
   val replyHashing =  mock[ReplyHashing]
-  lazy val prefs =         new TestGlobalPreferences()
+  lazy val prefs      = new TestGlobalPreferences()
+  lazy val userPrefs  = new TestUserPreferences()
 
   def getService = {
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs, userPrefs)
     new MessagesServiceImpl(selfUserId, None, replyHashing, storage, updater, edits, convs, network, members, users, buttons, sync)
   }
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -70,7 +70,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private lazy val globalPrefs    = new TestGlobalPreferences()
   private lazy val userPrefs      = new TestUserPreferences()
-  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, buttons, globalPrefs)
+  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, buttons, globalPrefs, userPrefs)
 
   val teamsStorage                = mock[TeamsStorage]
   val errorsService               = mock[ErrorsService]

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -26,7 +26,7 @@ import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, Us
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -53,11 +53,10 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   val properties =      mock[PropertiesService]
   val buttons =         mock[ButtonsStorage]
 
-
-  val prefs = new TestGlobalPreferences()
-
+  val prefs     = new TestGlobalPreferences()
+  val userPrefs = new TestUserPreferences()
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
-    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -29,7 +29,7 @@ import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncResult, SyncServiceHandle}
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 
 import scala.concurrent.Future
 
@@ -57,10 +57,11 @@ class TeamConversationSpec extends AndroidFreeSpec {
   val errors          = mock[ErrorsService]
   val uriHelper       = mock[UriHelper]
 
-  val prefs = new TestGlobalPreferences()
+  val prefs       = new TestGlobalPreferences()
+  val userPrefs   = new TestUserPreferences()
 
   def initService: ConversationsUiService = {
-    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(selfId, team, assetService, users, messages, messagesStorage,
       msgContent, members, convsContent, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)

--- a/zmessaging/src/test/scala/com/waz/service/messages/MessagesContentUpdaterSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/messages/MessagesContentUpdaterSpec.scala
@@ -3,7 +3,7 @@ package com.waz.service.messages
 import com.waz.content.{ButtonsStorage, ConversationStorage, MessagesStorage, MsgDeletionStorage}
 import com.waz.model.{ButtonData, ButtonId, MessageId}
 import com.waz.specs.AndroidFreeSpec
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 
 import scala.concurrent.Future
 
@@ -14,6 +14,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
   private lazy val deletions    =  mock[MsgDeletionStorage]
   private lazy val buttons      =  mock[ButtonsStorage]
   private lazy val prefs        =  new TestGlobalPreferences()
+  private lazy val userPrefs    =  new TestUserPreferences()
 
   scenario("Confirm a button action") {
     val messageId = MessageId()
@@ -25,7 +26,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
     (buttons.findByMessage _).expects(messageId).atLeastOnce().returning(Future.successful(Seq(buttonData)))
     (buttons.updateAll2 _).expects(Seq((messageId, buttonId)), *).atLeastOnce().returning(Future.successful(Nil))
 
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs, userPrefs)
 
     result(updater.updateButtonConfirmations(confirmation))
   }
@@ -44,7 +45,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
     (buttons.findByMessage _).expects(messageId).atLeastOnce().returning(Future.successful(Seq(buttonData1, buttonData2)))
     (buttons.updateAll2 _).expects(ids, *).atLeastOnce().returning(Future.successful(Nil))
 
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs, userPrefs)
 
     result(updater.updateButtonConfirmations(confirmation))
   }
@@ -63,7 +64,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
     (buttons.findByMessage _).expects(messageId).atLeastOnce().returning(Future.successful(Seq(buttonData1, buttonData2)))
     (buttons.updateAll2 _).expects(ids, *).atLeastOnce().returning(Future.successful(Nil))
 
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs, userPrefs)
 
     result(updater.updateButtonConfirmations(confirmation))
   }

--- a/zmessaging/src/test/scala/com/waz/service/messages/MessagesContentUpdaterSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/messages/MessagesContentUpdaterSpec.scala
@@ -72,7 +72,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
 
   scenario(
     """Given self deleting messages are disabled by the team,
-      | and a conversation has a global and local expiration settings
+      | and a conversation has global and local expiration settings
       |When adding new local message to a conversation with a specified expiration parameter
       |Then no expiration should be used""".stripMargin){
 
@@ -97,7 +97,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
 
   scenario(
     """Given self deleting messages are enforced by the team,
-      | and a conversation has a global and local expiration settings
+      | and a conversation has global and local expiration settings
       |When adding new local message to a conversation with a specified expiration parameter
       |Then the team enforced expiration should be used""".stripMargin){
     val conversationId = ConvId("ABC")
@@ -121,7 +121,7 @@ class MessagesContentUpdaterSpec extends AndroidFreeSpec {
 
   scenario(
     """Given self deleting messages are enabled by the team,
-      | and a conversation has a global and local expiration settings
+      | and a conversation has global and local expiration settings
       |When adding new local message to a conversation with a specified expiration parameter
       |Then the conversation timer expiration should be used""".stripMargin){
     val conversationId = ConvId("ABC")


### PR DESCRIPTION
Continuation of #3445

## What's new in this PR?

Put in place the team settings enforcing. When the feature is disabled, the messages will not be self deleting. When the feature is enabled and there's and enforced timeout, this timeout will be considered above all else.


## Testing

Covered the altered logic inside the method `MessagesContentUpdater$addLocalMessage` with tests in `MessagesContentUpdaterSpec`.


#### APK
[Download build #3896](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3896/artifact/build/artifact/wire-dev-PR3478-3896.apk)
[Download build #3901](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3901/artifact/build/artifact/wire-dev-PR3478-3901.apk)
[Download build #3905](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3905/artifact/build/artifact/wire-dev-PR3478-3905.apk)