### PR TITLE
Feature: Enforce ephemeral messages (part 6 - Final)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -27,6 +27,7 @@ import com.google.android.gms.common.{ConnectionResult, GoogleApiAvailability}
 import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
 import com.waz.content.UserPreferences.AreSelfDeletingMessagesEnabled
+import com.waz.content.UserPreferences.SelfDeletingMessagesEnforcedTimeout
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.model._
 import com.waz.permissions.PermissionsService
@@ -92,8 +93,12 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   val isEditingMessage = editingMsg.map(_.isDefined)
 
   val areSelfDeletingMessagesEnabled = userPrefs.flatMap { prefs => prefs(AreSelfDeletingMessagesEnabled).signal }
+  val enforcedSelfDeletingMessagesTimeout = userPrefs.flatMap { prefs => prefs(SelfDeletingMessagesEnforcedTimeout).signal}
 
-  val ephemeralExp = conv.map(_.ephemeralExpiration)
+  val ephemeralExp = Signal.zip(conv.map(_.ephemeralExpiration), (enforcedSelfDeletingMessagesTimeout)).map {
+      case (_, enforcedTimeout) if enforcedTimeout > 0 => Some(ConvExpiry(enforcedTimeout.seconds))
+      case (timeout, _ ) => timeout
+  }
   val isEphemeral  = ephemeralExp.map(_.isDefined)
 
   val emojiKeyboardVisible = extendedCursor.map(_ == ExtendedCursorContainer.Type.EMOJIS)

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -86,7 +86,7 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       wasEnabled        <- userPrefs(AreSelfDeletingMessagesEnabled).apply()
       lastKnownTimeout  <- userPrefs(SelfDeletingMessagesEnforcedTimeout).apply()
       isNowEnabled      =  config.isEnabled
-      newTimeout        =  15
+      newTimeout        =  config.enforcedTimeoutInSeconds
       _                 <- userPrefs(AreSelfDeletingMessagesEnabled) := isNowEnabled
       _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := newTimeout
       // Inform of new restrictions.

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -86,7 +86,7 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       wasEnabled        <- userPrefs(AreSelfDeletingMessagesEnabled).apply()
       lastKnownTimeout  <- userPrefs(SelfDeletingMessagesEnforcedTimeout).apply()
       isNowEnabled      =  config.isEnabled
-      newTimeout        =  config.enforcedTimeoutInSeconds
+      newTimeout        =  15
       _                 <- userPrefs(AreSelfDeletingMessagesEnabled) := isNowEnabled
       _                 <- userPrefs(SelfDeletingMessagesEnforcedTimeout) := newTimeout
       // Inform of new restrictions.


### PR DESCRIPTION
Continuation of #3445

## What's new in this PR?

Display the enforced timeout (when the feature is not disabled) to the user, both when using `ShareActivity` (sharing content via Intent) or in regular chats inside the app.
When there's an enforced timeout, the user is now unable to open the "Ephemeral Menu" to change the UI.

## Testing

Manual testing
#### APK
[Download build #3904](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3904/artifact/build/artifact/wire-dev-PR3481-3904.apk)