### PR TITLE
Feature: Enforce ephemeral messages

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1646,8 +1646,10 @@
     <string name="join_conversation_invalid_link_error_message">The conversation link is invalid.</string>
     <string name="join_conversation_member_limit_reached_error_message">The conversation is full.</string>
 
+    <!-- Feature Config Changes -->
+    <string name="feature_config_changed_info_dialog_title">There has been a change in Wire</string>
+
     <!-- File sharing feature config -->
-    <string name="file_sharing_restriction_info_dialog_title">There has been a change in Wire</string>
     <string name="file_sharing_restriction_info_dialog_message">Sharing and receiving files of any type is now disabled.</string>
 
     <string name="file_sharing_restriction_info_image">RECEIVING IMAGES RESTRICTED</string>
@@ -1655,6 +1657,11 @@
     <string name="file_sharing_restriction_info_audio">RECEIVING AUDIO FILES RESTRICTED</string>
     <string name="file_sharing_restriction_info_file">RECEIVING FILES RESTRICTED</string>
     <string name="file_sharing_restriction_info_generic">FILE SHARING RESTRICTED</string>
+
+    <!-- Self Deleting Messages feature config -->
+    <string name="self_deleting_messages_change_info_dialog_message_enabled">Sending of self deleting messages is enabled.</string>
+    <string name="self_deleting_messages_change_info_dialog_message_enabled_enforced">Sending of self deleting messages is mandatory. The enforced timeout for deletion is %s seconds.</string>
+    <string name="self_deleting_messages_change_info_dialog_message_disabled">Sending of self deleting messages is disabled.</string>
 
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -245,6 +245,20 @@ class MainActivity extends BaseActivity
         }
       }
     }
+    userPreferences.flatMap(_.preference(UserPreferences.ShouldInformSelfDeletingMessagesChanged).signal).onUi { shouldInform =>
+      if (!shouldInform) {}
+      else for {
+        prefs                     <- userPreferences.head
+        isFeatureEnabled          <- prefs.preference(AreSelfDeletingMessagesEnabled).apply()
+        enforcedTimeoutInSeconds  <- prefs.preference(SelfDeletingMessagesEnforcedTimeout).apply()
+      } yield {
+        showSelfDeletingMessagesConfigsChangeInfoDialog(isFeatureEnabled, enforcedTimeoutInSeconds) { _ =>
+          userPreferences.head.foreach { prefs =>
+            prefs(UserPreferences.ShouldInformSelfDeletingMessagesChanged) := false
+          }
+        }
+      }
+    }
 
     featureConfigsController.startUpdatingFlagsWhenEnteringForeground()
   }
@@ -291,7 +305,6 @@ class MainActivity extends BaseActivity
     super.onResume()
     Option(ZMessaging.currentGlobal).foreach(_.googleApi.checkGooglePlayServicesAvailable(this))
   }
-
 
   override def onDestroy(): Unit = {
     verbose(l"[BE]: onDestroy")

--- a/app/src/main/scala/com/waz/zclient/common/controllers/FeatureConfigsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/FeatureConfigsController.scala
@@ -14,9 +14,14 @@ class FeatureConfigsController(implicit inj: Injector) extends Injectable with D
   private lazy val featureConfigs = inject[Signal[FeatureConfigsService]]
 
   def startUpdatingFlagsWhenEnteringForeground(): Unit =
-    inject[ActivityLifecycleCallback].appInBackground.map(_._1).foreach {
-      case false => featureConfigs.head.foreach(_.updateFileSharing())
-      case true  => ()
+    inject[ActivityLifecycleCallback].appInBackground.map(_._1).foreach { isInBackground =>
+      if(!isInBackground){
+        featureConfigs.head.foreach(updateFlags)
+      }
     }
 
+  private def updateFlags(configsService: FeatureConfigsService): Unit = {
+    configsService.updateFileSharing()
+    configsService.updateSelfDeletingMessages()
+  }
 }

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -27,6 +27,7 @@ import com.google.android.gms.common.{ConnectionResult, GoogleApiAvailability}
 import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
 import com.waz.content.UserPreferences.AreSelfDeletingMessagesEnabled
+import com.waz.content.UserPreferences.SelfDeletingMessagesEnforcedTimeout
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.model._
 import com.waz.permissions.PermissionsService
@@ -92,8 +93,12 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   val isEditingMessage = editingMsg.map(_.isDefined)
 
   val areSelfDeletingMessagesEnabled = userPrefs.flatMap { prefs => prefs(AreSelfDeletingMessagesEnabled).signal }
+  val enforcedSelfDeletingMessagesTimeout = userPrefs.flatMap { prefs => prefs(SelfDeletingMessagesEnforcedTimeout).signal}
 
-  val ephemeralExp = conv.map(_.ephemeralExpiration)
+  val ephemeralExp = Signal.zip(conv.map(_.ephemeralExpiration), (enforcedSelfDeletingMessagesTimeout)).map {
+      case (_, enforcedTimeout) if enforcedTimeout > 0 => Some(ConvExpiry(enforcedTimeout.seconds))
+      case (timeout, _ ) => timeout
+  }
   val isEphemeral  = ephemeralExp.map(_.isDefined)
 
   val emojiKeyboardVisible = extendedCursor.map(_ == ExtendedCursorContainer.Type.EMOJIS)

--- a/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorController.scala
@@ -26,6 +26,7 @@ import android.widget.Toast
 import com.google.android.gms.common.{ConnectionResult, GoogleApiAvailability}
 import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.IncognitoKeyboardEnabled
+import com.waz.content.UserPreferences.AreSelfDeletingMessagesEnabled
 import com.waz.content.{GlobalPreferences, UserPreferences}
 import com.waz.model._
 import com.waz.permissions.PermissionsService
@@ -90,6 +91,8 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   }
   val isEditingMessage = editingMsg.map(_.isDefined)
 
+  val areSelfDeletingMessagesEnabled = userPrefs.flatMap { prefs => prefs(AreSelfDeletingMessagesEnabled).signal }
+
   val ephemeralExp = conv.map(_.ephemeralExpiration)
   val isEphemeral  = ephemeralExp.map(_.isDefined)
 
@@ -125,8 +128,9 @@ class CursorController(implicit inj: Injector, ctx: Context, evc: EventContext) 
   val sendButtonVisible = Signal.zip(emojiKeyboardVisible, enteredTextEmpty, sendButtonEnabled, isEditingMessage).map {
     case (emoji, empty, enabled, editing) => enabled && (emoji || !empty) && !editing
   }
-  val ephemeralBtnVisible = Signal.zip(isEditingMessage, convIsActive).flatMap {
-    case (false, true) =>
+  val ephemeralBtnVisible = Signal.zip(areSelfDeletingMessagesEnabled, isEditingMessage, convIsActive).flatMap {
+    case (false, _, _ ) => Signal.const(false)
+    case (true, false, true) =>
       isEphemeral.flatMap {
         case true => Signal.const(true)
         case _ => sendButtonVisible.map(!_)

--- a/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
@@ -33,6 +33,8 @@ import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import com.waz.api.impl.ContentUriAssetForUpload
+import com.waz.content.UserPreferences
+import com.waz.content.UserPreferences.AreSelfDeletingMessagesEnabled
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{MessageContent => _, _}
@@ -43,6 +45,7 @@ import com.wire.signals._
 import com.waz.utils.wrappers.URI
 import com.waz.utils.{RichWireInstant, returning}
 import com.waz.zclient._
+import com.waz.zclient.R
 import com.waz.zclient.common.controllers.SharingController
 import com.waz.zclient.common.controllers.SharingController.{FileContent, ImageContent, NewContent, TextContent}
 import com.waz.zclient.common.controllers.global.AccentColorController
@@ -92,6 +95,10 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
   private lazy val accountTabs = view[AccountTabsView](R.id.account_tabs)
   private lazy val bottomContainer = view[AnimatedBottomContainer](R.id.ephemeral_container)
   private lazy val ephemeralIcon = view[EphemeralTimerButton](R.id.ephemeral_toggle)
+
+  private lazy val userPrefs = inject[Signal[UserPreferences]]
+  private lazy val areSelfDeletingMessagesEnabled = userPrefs.flatMap { prefs => prefs(AreSelfDeletingMessagesEnabled).signal }
+  private lazy val isEphemeralButtonVisible = areSelfDeletingMessagesEnabled
 
   private lazy val sendButton = returning(view[CursorIconButton](R.id.cib__send_button)) { vh =>
     (for {
@@ -208,26 +215,31 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
       }
     })
 
-    ephemeralIcon.foreach(icon => icon.onClick {
-      bottomContainer.foreach { bc =>
-        bc.isExpanded.currentValue match {
-          case Some(true) =>
-            bc.closedAnimated()
-          case Some(false) =>
-            returning(getLayoutInflater.inflate(R.layout.ephemeral_keyboard_layout, null, false).asInstanceOf[EphemeralLayout]) { l =>
-              sharingController.ephemeralExpiration.foreach(l.setSelectedExpiration)
-              l.expirationSelected.onUi { case (exp, close) =>
-                icon.ephemeralExpiration ! exp.map(MessageExpiry)
-                sharingController.ephemeralExpiration ! exp
-                if (close) bc.closedAnimated()
+    ephemeralIcon.foreach(icon =>
+      isEphemeralButtonVisible.onUi(icon.setVisible)
+    )
+    ephemeralIcon.foreach(icon =>
+      icon.onClick {
+        bottomContainer.foreach { bc =>
+          bc.isExpanded.currentValue match {
+            case Some(true) =>
+              bc.closedAnimated()
+            case Some(false) =>
+              returning(getLayoutInflater.inflate(R.layout.ephemeral_keyboard_layout, null, false).asInstanceOf[EphemeralLayout]) { l =>
+                sharingController.ephemeralExpiration.foreach(l.setSelectedExpiration)
+                l.expirationSelected.onUi { case (exp, close) =>
+                  icon.ephemeralExpiration ! exp.map(MessageExpiry)
+                  sharingController.ephemeralExpiration ! exp
+                  if (close) bc.closedAnimated()
+                }
+                bc.addView(l)
               }
-              bc.addView(l)
-            }
-            bc.openAnimated()
-          case _ =>
+              bc.openAnimated()
+            case _ =>
+          }
         }
       }
-    })
+    )
 
     searchBox.foreach { box =>
       box.setCallback(new PickerSpannableEditText.Callback {

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -356,8 +356,21 @@ object ContextUtils {
 
   def showFileSharingRestrictionInfoDialog(onConfirm: Boolean => Unit)(implicit ex: ExecutionContext, context: Context): Unit = {
     showInfoDialog(
-      title = getString(R.string.file_sharing_restriction_info_dialog_title),
+      title = getString(R.string.feature_config_changed_info_dialog_title),
       msg = getString(R.string.file_sharing_restriction_info_dialog_message)
+    ).foreach(onConfirm)
+  }
+
+  def showSelfDeletingMessagesConfigsChangeInfoDialog(isEnabled: Boolean, enforcedTimeoutInSeconds: Int)(onConfirm: Boolean => Unit)(implicit ex: ExecutionContext, context: Context): Unit = {
+    val message = (isEnabled, enforcedTimeoutInSeconds) match {
+      case (true, 0 )       => getString(R.string.self_deleting_messages_change_info_dialog_message_enabled)
+      case (true, seconds)  => getString(R.string.self_deleting_messages_change_info_dialog_message_enabled_enforced, seconds.toString)
+      case (false, _)       => getString(R.string.self_deleting_messages_change_info_dialog_message_disabled)
+    }
+
+    showInfoDialog(
+      title = getString(R.string.feature_config_changed_info_dialog_title),
+      msg = message
     ).foreach(onConfirm)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -441,4 +441,8 @@ object UserPreferences {
 
   lazy val FileSharingFeatureEnabled: PrefKey[Boolean] = PrefKey[Boolean]("file_sharing_feature_enabled", customDefault = true)
   lazy val ShouldInformFileSharingRestriction: PrefKey[Boolean] = PrefKey[Boolean]("should_inform_file_sharing_restriction", customDefault = false)
+
+  lazy val AreSelfDeletingMessagesEnabled: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enabled", customDefault = true)
+  lazy val SelfDeletingMessagesEnforcedTimeout: PrefKey[Int] = PrefKey[Int]("self_deleting_messages_enforced_timeout", customDefault = 0)
+  lazy val ShouldInformSelfDeletingMessagesChanged: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enforced_changed", customDefault = false)
 }

--- a/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/SelfDeletingMessagesFeatureConfig.scala
@@ -1,0 +1,28 @@
+package com.waz.model
+
+import com.waz.utils.JsonDecoder
+import org.json.JSONObject
+
+final case class SelfDeletingMessagesFeatureConfig(isEnabled: Boolean, private val seconds: Int) {
+
+  def enforcedTimeoutInSeconds: Int = Math.max(0, seconds)
+
+}
+
+object SelfDeletingMessagesFeatureConfig {
+
+  val Default: SelfDeletingMessagesFeatureConfig = SelfDeletingMessagesFeatureConfig(isEnabled = true, 0)
+
+  implicit object Decoder extends JsonDecoder[SelfDeletingMessagesFeatureConfig] {
+    override def apply(implicit js: JSONObject): SelfDeletingMessagesFeatureConfig =
+      if (!js.has("status")) Default
+      else if (js.getString("status") != "enabled") SelfDeletingMessagesFeatureConfig(isEnabled = false, 0)
+      else {
+        val config = js.optJSONObject("config")
+        val enforcedTimeoutSeconds = if (config != null && config.has("enforcedTimeoutSeconds"))
+          config.getInt("enforcedTimeoutSeconds")
+        else Default.enforcedTimeoutInSeconds
+        SelfDeletingMessagesFeatureConfig(isEnabled = true, enforcedTimeoutSeconds)
+      }
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -27,7 +27,7 @@ import com.waz.model._
 import com.waz.service.ZMessaging.clock
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.wire.signals.Serialized
+import com.wire.signals.{Serialized, Signal}
 import org.threeten.bp.Instant.now
 
 import scala.collection.breakOut
@@ -38,7 +38,8 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
                              convs:           ConversationStorage,
                              deletions:       MsgDeletionStorage,
                              buttonsStorage:  ButtonsStorage,
-                             prefs:           GlobalPreferences) extends DerivedLogTag {
+                             prefs:           GlobalPreferences,
+                             userPrefs:       UserPreferences) extends DerivedLogTag {
   import Threading.Implicits.Background
 
   def getMessage(msgId: MessageId) = messagesStorage.getMessage(msgId)
@@ -91,18 +92,28 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
     buttonsStorage.updateOrCreateAll2(newButtons.keys, { (id, _) => newButtons(id) }).map(_ => ())
   }
   /**
-    * @param exp ConvExpiry takes precedence over one-time expiry (exp), which takes precedence over the MessageExpiry
-    */
+    * @param exp Message Expiration precedence order:
+   *            1. Team self-deleting messages feature config
+   *            2. ConvExpiry: Conversation-specific timer setting
+   *            3. One-time expiry (parameter exp),
+   *            4. Which takes precedence over the MessageExpiry
+   */
   def addLocalMessage(msg: MessageData, state: Status = Status.PENDING, exp: Option[Option[FiniteDuration]] = None, localTime: LocalInstant = LocalInstant.Now) =
     Serialized.future(s"add local message ${msg.convId}") {
 
       def expiration =
-        if (MessageData.EphemeralMessageTypes(msg.msgType))
-          convs.get(msg.convId).map(_.fold(Option.empty[EphemeralDuration])(_.ephemeralExpiration)).map {
-            case Some(ConvExpiry(d))    => Some(d)
-            case Some(MessageExpiry(d)) => exp.getOrElse(Some(d))
-            case _                      => exp.flatten
-          }
+        if (MessageData.EphemeralMessageTypes(msg.msgType)) {
+          def doesTeamEnablesExpiration = userPrefs(UserPreferences.AreSelfDeletingMessagesEnabled).signal
+          val conversationExpiration = Signal.from(convs.get(msg.convId).map(_.fold(Option.empty[EphemeralDuration])(_.ephemeralExpiration)))
+          def teamExpiration = userPrefs(UserPreferences.SelfDeletingMessagesEnforcedTimeout).signal
+          Signal.zip(doesTeamEnablesExpiration, conversationExpiration, teamExpiration).map {
+            case (false, _, _)                                    => None
+            case (_, _, enforcedDuration) if enforcedDuration > 0 => Some(enforcedDuration.seconds)
+            case (_, Some(ConvExpiry(d)), _)                      => Some(d)
+            case (_, Some(MessageExpiry(d)), _)                   => exp.getOrElse(Some(d))
+            case _ => exp.flatten
+          }.future
+        }
         else Future.successful(None)
 
       (for {

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -33,7 +33,10 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
       val fileSharing = JsonDecoder.decode[FileSharingFeatureConfig](data)
       verbose(l"File sharing enabled: ${fileSharing.isEnabled}")
       storeFileSharing(fileSharing)
-
+    case FeatureConfigUpdateEvent("selfDeletingMessages", data) =>
+      val selfDeletingMessages = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](data)
+      verbose(l"Self deleting messages config: $selfDeletingMessages")
+      storeSelfDeletingMessages(selfDeletingMessages)
     case _ =>
       Future.successful(())
   }

--- a/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
@@ -1,7 +1,7 @@
 package com.waz.sync.client
 
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, TeamId}
+import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig, TeamId}
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http.{HttpClient, RawBodyDeserializer, Request}
@@ -10,6 +10,7 @@ import org.json.JSONObject
 trait FeatureConfigsClient {
   def getAppLock(teamId: TeamId): ErrorOrResponse[AppLockFeatureConfig]
   def getFileSharing(): ErrorOrResponse[FileSharingFeatureConfig]
+  def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig]
 }
 
 class FeatureConfigsClientImpl(implicit
@@ -34,6 +35,12 @@ class FeatureConfigsClientImpl(implicit
     .withResultType[FileSharingFeatureConfig]
     .withErrorType[ErrorResponse]
     .executeSafe
+
+  override def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig] =
+    Request.Get(relativePath =  selfDeletingMessages)
+    .withResultType[SelfDeletingMessagesFeatureConfig]
+    .withErrorType[ErrorResponse]
+    .executeSafe
 }
 
 object FeatureConfigsClient {
@@ -41,5 +48,6 @@ object FeatureConfigsClient {
 
   val basePath: String = "/feature-configs"
   val fileSharingPath: String = s"$basePath/fileSharing"
+  val selfDeletingMessages: String = s"$basePath/selfDeletingMessages"
 
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
@@ -2,7 +2,7 @@ package com.waz.sync.handler
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, TeamId}
+import com.waz.model.{AppLockFeatureConfig, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig, TeamId}
 import com.waz.sync.client.FeatureConfigsClient
 
 import scala.concurrent.Future
@@ -10,6 +10,7 @@ import scala.concurrent.Future
 trait FeatureConfigsSyncHandler {
   def fetchAppLock(): Future[AppLockFeatureConfig]
   def fetchFileSharing(): Future[FileSharingFeatureConfig]
+  def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig]
 }
 
 class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfigsClient)
@@ -36,5 +37,14 @@ class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfi
         FileSharingFeatureConfig.Default
       case Right(fileSharing) =>
         fileSharing
+    }
+
+  override def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig] =
+    client.getSelfDeletingMessages().map {
+      case Left(err) =>
+        error(l"Unable to fetch SelfDeletingMessages feature flag: $err")
+        SelfDeletingMessagesFeatureConfig.Default
+      case Right(selfDeletingMessages) =>
+        selfDeletingMessages
     }
 }

--- a/zmessaging/src/test/scala/com/waz/model/SelfDeletingMessagesFeatureConfigSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/SelfDeletingMessagesFeatureConfigSpec.scala
@@ -1,0 +1,78 @@
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.JsonDecoder
+
+class SelfDeletingMessagesFeatureConfigSpec extends AndroidFreeSpec {
+
+  feature("Deserialization form JSON") {
+
+    scenario("Deserializing an enabled config with enforced timeout") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "enabled",
+          |  "config":{
+          |    "enforcedTimeoutSeconds": 30
+          |  }
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual true
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 30
+    }
+    scenario("Deserializing an enabled config without enforced timeout") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "enabled",
+          |  "config":{
+          |    "enforcedTimeoutSeconds": 0
+          |  }
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual true
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 0
+    }
+
+    scenario("Deserializing a disabled config") {
+      // Given
+      val json =
+        """
+          |{
+          |  "status": "disabled"
+          |}
+          |""".stripMargin
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig.isEnabled shouldEqual false
+      selfDeletingMessagesFeatureConfig.enforcedTimeoutInSeconds shouldEqual 0
+    }
+
+    scenario("Deserializing an error (empty json object)") {
+      // Given
+      val json = "{}"
+
+      // When
+      val selfDeletingMessagesFeatureConfig: SelfDeletingMessagesFeatureConfig = JsonDecoder.decode[SelfDeletingMessagesFeatureConfig](json)
+
+      // Then
+      selfDeletingMessagesFeatureConfig shouldEqual SelfDeletingMessagesFeatureConfig.Default
+    }
+  }
+
+}

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -31,6 +31,7 @@ import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsS
 import com.waz.service.messages.{MessageEventProcessor, MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.TestUserPreferences
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ReplyHashing
 import com.wire.signals.{EventStream, Signal}
@@ -54,6 +55,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   val downloadStorage   = mock[DownloadAssetStorage]
   val buttonsStorage    = mock[ButtonsStorage]
   val prefs             = new TestGlobalPreferences()
+  val userPrefs         = new TestUserPreferences()
 
   val messagesInStorage = Signal[Seq[MessageData]](Seq.empty)
   (storage.getMessages _).expects(*).atLeastOnce.onCall { ids: Traversable[MessageId] =>
@@ -301,7 +303,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   }
 
   def getProcessor = {
-    val content = new MessagesContentUpdater(storage, convsStorage, deletions, buttonsStorage, prefs)
+    val content = new MessagesContentUpdater(storage, convsStorage, deletions, buttonsStorage, prefs, userPrefs)
 
     //TODO make VerificationStateUpdater mockable
     (otrClientsStorage.onAdded _).expects().anyNumberOfTimes().returning(EventStream[Seq[UserClients]]())

--- a/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessagesServiceSpec.scala
@@ -29,7 +29,7 @@ import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesServiceImpl}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ReplyHashing
 import com.wire.signals.{EventStream, Signal}
@@ -51,10 +51,11 @@ class MessagesServiceSpec extends AndroidFreeSpec {
   val buttons =       mock[ButtonsStorage]
   val users =         mock[UsersStorage]
   val replyHashing =  mock[ReplyHashing]
-  lazy val prefs =         new TestGlobalPreferences()
+  lazy val prefs      = new TestGlobalPreferences()
+  lazy val userPrefs  = new TestUserPreferences()
 
   def getService = {
-    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs)
+    val updater = new MessagesContentUpdater(storage, convsStorage, deletions, buttons, prefs, userPrefs)
     new MessagesServiceImpl(selfUserId, None, replyHashing, storage, updater, edits, convs, network, members, users, buttons, sync)
   }
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -70,7 +70,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private lazy val globalPrefs    = new TestGlobalPreferences()
   private lazy val userPrefs      = new TestUserPreferences()
-  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, buttons, globalPrefs)
+  private lazy val msgUpdater     = new MessagesContentUpdater(msgStorage, convsStorage, deletions, buttons, globalPrefs, userPrefs)
 
   val teamsStorage                = mock[TeamsStorage]
   val errorsService               = mock[ErrorsService]

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -26,7 +26,7 @@ import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, Us
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -53,11 +53,10 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   val properties =      mock[PropertiesService]
   val buttons =         mock[ButtonsStorage]
 
-
-  val prefs = new TestGlobalPreferences()
-
+  val prefs     = new TestGlobalPreferences()
+  val userPrefs = new TestUserPreferences()
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
-    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -29,7 +29,7 @@ import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncResult, SyncServiceHandle}
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
 
 import scala.concurrent.Future
 
@@ -57,10 +57,11 @@ class TeamConversationSpec extends AndroidFreeSpec {
   val errors          = mock[ErrorsService]
   val uriHelper       = mock[UriHelper]
 
-  val prefs = new TestGlobalPreferences()
+  val prefs       = new TestGlobalPreferences()
+  val userPrefs   = new TestUserPreferences()
 
   def initService: ConversationsUiService = {
-    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs)
+    val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(selfId, team, assetService, users, messages, messagesStorage,
       msgContent, members, convsContent, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -112,4 +112,21 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(userPrefs(FileSharingFeatureEnabled).apply()) shouldEqual false
   }
 
+  scenario("Process update event for SelfDeletingMessages feature config") {
+    // Given
+    val service = createService
+    val pipeline = createEventPipeline(service)
+    val event = FeatureConfigUpdateEvent("selfDeletingMessages", "{ \"status\": \"enabled\", \"config\": {\"enforcedTimeoutSeconds\": 60} }")
+
+    userPrefs.setValue(AreSelfDeletingMessagesEnabled, false)
+    userPrefs.setValue(SelfDeletingMessagesEnforcedTimeout, 0)
+
+    // When
+    result(pipeline.apply(Seq(event)))
+
+    // Then
+    result(userPrefs(AreSelfDeletingMessagesEnabled).apply()) shouldEqual true
+    result(userPrefs(SelfDeletingMessagesEnforcedTimeout).apply()) shouldEqual 60
+  }
+
 }


### PR DESCRIPTION
Sanity check.
The sum of all of the following + conflict solving.

#3445
#3446
#3447 
#3470 
#3478 
#3481 

## What's new

Jira: https://wearezeta.atlassian.net/browse/SQSERVICES-572

A mechanism that allows team admins to disable or disable the self-deleting messages (ephemeral messages) and optionally enforce a timeout in seconds for them.

The team settings will override any other ephemeral messages settings set by the user or set in a group conversation. The value will be visible in the usual timer button, without option to alter its value.

When the team settings change, a alert dialog will inform the users about it.
#### APK
[Download build #3907](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3907/artifact/build/artifact/wire-dev-PR3482-3907.apk)