### PR TITLE
chore: Remove PinEditTextField

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -409,7 +409,6 @@ dependencies {
     implementation BuildDependencies.rebound
     implementation BuildDependencies.commonMark
     implementation BuildDependencies.jna
-    implementation BuildDependencies.pinEditText
     implementation BuildDependencies.countly
 
     implementation BuildDependencies.wireSignals

--- a/app/src/main/res/values/styles_edittext.xml
+++ b/app/src/main/res/values/styles_edittext.xml
@@ -32,17 +32,4 @@
         <item name="errorTextAppearance">@style/TextView.Authentication.Error</item>
     </style>
 
-    <style name="EditText.Pin" parent="@style/EditText.RobotoRegular">
-        <item name="android:inputType">number</item>
-        <item name="android:padding">@dimen/pin_code_digit_padding</item>
-        <item name="android:textSize">@dimen/pin_code_digit_text_size</item>
-        <item name="android:background">@color/white</item>
-        <item name="fieldColor">@color/white</item>
-        <item name="fieldBgColor">@color/white</item>
-        <item name="highlightColor">@color/white</item>
-        <item name="noOfFields">6</item>
-        <item name="lineThickness">0dp</item>
-        <item name="cornerRadius">@dimen/pin_code_digit_corner_radius</item>
-    </style>
-
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven { url 'https://jitpack.io' } // for PinEditTextField
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-        maven { url 'https://jitpack.io' } // for PinEditTextField
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -66,7 +66,6 @@ object Versions {
     const val COMMON_MARK = "0.11.0"
     const val JNA = "4.4.0@aar"
     const val LIB_PHONE_NUMBER = "7.1.1" // 7.2.x breaks protobuf
-    const val PIN_EDITTEXT = "1.2.3"
     const val LIB_SODIUM = "2.0.2"
     const val COUNTLY = "20.04.2"
     const val ZOOMING = "1.1.0"
@@ -149,7 +148,6 @@ object BuildDependencies {
     val commonMark = "com.atlassian.commonmark:commonmark:${Versions.COMMON_MARK}"
     val jna = "net.java.dev.jna:jna:${Versions.JNA}"
     val libPhoneNumber = "com.googlecode.libphonenumber:libphonenumber:${Versions.LIB_PHONE_NUMBER}"
-    val pinEditText = "com.github.poovamraj:PinEditTextField:${Versions.PIN_EDITTEXT}"
     val libSodium = "com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:${Versions.LIB_SODIUM}"
     val countly = "ly.count.android:sdk:${Versions.COUNTLY}"
     val zooming = "com.wire.zoom:zoomlayout:${Versions.ZOOMING}"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -66,7 +66,7 @@ object Versions {
     const val COMMON_MARK = "0.11.0"
     const val JNA = "4.4.0@aar"
     const val LIB_PHONE_NUMBER = "7.1.1" // 7.2.x breaks protobuf
-    const val PIN_EDITTEXT = "1.2.1"
+    const val PIN_EDITTEXT = "1.2.3"
     const val LIB_SODIUM = "2.0.2"
     const val COUNTLY = "20.04.2"
     const val ZOOMING = "1.1.0"
@@ -149,7 +149,7 @@ object BuildDependencies {
     val commonMark = "com.atlassian.commonmark:commonmark:${Versions.COMMON_MARK}"
     val jna = "net.java.dev.jna:jna:${Versions.JNA}"
     val libPhoneNumber = "com.googlecode.libphonenumber:libphonenumber:${Versions.LIB_PHONE_NUMBER}"
-    val pinEditText = "com.poovam:pin-edittext-field:${Versions.PIN_EDITTEXT}"
+    val pinEditText = "com.github.poovamraj:PinEditTextField:${Versions.PIN_EDITTEXT}"
     val libSodium = "com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:${Versions.LIB_SODIUM}"
     val countly = "ly.count.android:sdk:${Versions.COUNTLY}"
     val zooming = "com.wire.zoom:zoomlayout:${Versions.ZOOMING}"


### PR DESCRIPTION
We no longer use PinEditTextField so we can remove the dependency.
The update is motivated by the strive to make us F-droid compliant.

#### APK
[Download build #3908](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3908/artifact/build/artifact/wire-dev-PR3483-3908.apk)
[Download build #3919](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3919/artifact/build/artifact/wire-dev-PR3483-3919.apk)
[Download build #3920](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3920/artifact/build/artifact/wire-dev-PR3483-3920.apk)