### PR TITLE
fix: revert to old way of adding users to conversations if the federation flag is off

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -161,7 +161,7 @@ class AndroidSyncServiceHandle(account:         UserId,
   def syncQualifiedSearchResults(qIds: Set[QualifiedId]) = addRequest(SyncQualifiedSearchResults(qIds))
   def syncSearchQuery(query: SearchQuery) = addRequest(SyncSearchQuery(query), priority = Priority.High)
   def syncUsers(ids: Set[UserId]): Future[SyncId] = addRequest(SyncUser(ids))
-  def syncQualifiedUsers(qIds: Set[QualifiedId]) = addRequest(SyncQualifiedUsers(qIds))
+  def syncQualifiedUsers(qIds: Set[QualifiedId]): Future[SyncId] = addRequest(SyncQualifiedUsers(qIds))
   def syncSelfUser() = addRequest(SyncSelf, priority = Priority.High)
   def deleteAccount() = addRequest(DeleteAccount)
   def syncConversations(ids: Set[ConvId], dependsOn: Option[SyncId]) =

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -141,21 +141,25 @@ class ConversationsSyncHandler(selfUserId:      UserId,
     }
 
   private def syncQualifiedConversations(start: Option[RConvQualifiedId], rIdsFromBackend: Set[RConvQualifiedId]): Future[SyncResult] =
-    convClient.loadQualifiedConversations(start).future.flatMap {
-      case Right(ConversationsResult(responses, hasMore)) =>
-        loadConversationRoles(responses).flatMap { roles =>
-          convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
-            if (hasMore)
-              syncQualifiedConversations(
-                responses.lastOption.flatMap(_.qualifiedId),
-                rIdsFromBackend ++ responses.flatMap(_.qualifiedId)
-              )
-            else
-              removeConvsMissingOnBackend(rIdsFromBackend.map(_.id) ++ responses.map(_.id)).map(_ => Success)
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      convClient.loadQualifiedConversations(start).future.flatMap {
+        case Right(ConversationsResult(responses, hasMore)) =>
+          loadConversationRoles(responses).flatMap { roles =>
+            convService.updateConversationsWithDeviceStartMessage(responses, roles).flatMap { _ =>
+              if (hasMore)
+                syncQualifiedConversations(
+                  responses.lastOption.flatMap(_.qualifiedId),
+                  rIdsFromBackend ++ responses.flatMap(_.qualifiedId)
+                )
+              else
+                removeConvsMissingOnBackend(rIdsFromBackend.map(_.id) ++ responses.map(_.id)).map(_ => Success)
+            }
           }
-        }
-      case Left(error) =>
-        Future.successful(SyncResult(error))
+        case Left(error) =>
+          Future.successful(SyncResult(error))
+      }
+    } else {
+      syncConversations(start.map(_.id), rIdsFromBackend.map(_.id))
     }
 
   private def removeConvsMissingOnBackend(rIdsFromBackend: Set[RConvId]) =
@@ -210,12 +214,16 @@ class ConversationsSyncHandler(selfUserId:      UserId,
     }
 
   def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncResult] =
-    withConversation(id) { conv =>
-      val grouped = members.grouped(PostMembersLimit)
-      for {
-        responses   <- Future.traverse(grouped)(convClient.postQualifiedMemberJoin(conv.remoteId, _, defaultRole).future)
-        syncResults <- Future.traverse(responses)(handleMemberJoinResponse(id, members.map(_.id), _))
-      } yield syncResults.find(_ != Success).getOrElse(Success)
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      withConversation(id) { conv =>
+        val grouped = members.grouped(PostMembersLimit)
+        for {
+          responses   <- Future.traverse(grouped)(convClient.postQualifiedMemberJoin(conv.remoteId, _, defaultRole).future)
+          syncResults <- Future.traverse(responses)(handleMemberJoinResponse(id, members.map(_.id), _))
+        } yield syncResults.find(_ != Success).getOrElse(Success)
+      }
+    } else {
+      postConversationMemberJoin(id, members.map(_.id), defaultRole)
     }
 
   def postConversationMemberLeave(id: ConvId, user: UserId): Future[SyncResult] =
@@ -308,49 +316,52 @@ class ConversationsSyncHandler(selfUserId:      UserId,
                                 accessRole:  AccessRole,
                                 receiptMode: Option[Int],
                                 defaultRole: ConversationRole
-                               ): Future[SyncResult] = {
-    debug(l"postQualifiedConversation($convId, $users, $name, $defaultRole)")
+                               ): Future[SyncResult] =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      debug(l"postQualifiedConversation($convId, $users, $name, $defaultRole)")
 
-    val initState = ConversationInitState(
-      users            = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
-      qualifiedUsers   = users,
-      name             = name,
-      team             = team,
-      access           = access,
-      accessRole       = accessRole,
-      receiptMode      = receiptMode,
-      conversationRole = defaultRole
-    )
+      val initState = ConversationInitState(
+        users            = Set.empty, // TODO: for now we add all users after we created the conv, it will change in the future
+        qualifiedUsers   = users,
+        name             = name,
+        team             = team,
+        access           = access,
+        accessRole       = accessRole,
+        receiptMode      = receiptMode,
+        conversationRole = defaultRole
+      )
 
-    convClient.postQualifiedConversation(initState).future.flatMap {
-      case Right(response) =>
-        convService.updateRemoteId(convId, response.id).flatMap { _ =>
-          loadConversationRoles(Seq(response)).flatMap { roles =>
-            convService.updateConversationsWithDeviceStartMessage(Seq(response), roles).flatMap { _ =>
-              postQualifiedConversationMemberJoin(convId, users, defaultRole)
+      convClient.postQualifiedConversation(initState).future.flatMap {
+        case Right(response) =>
+          convService.updateRemoteId(convId, response.id).flatMap { _ =>
+            loadConversationRoles(Seq(response)).flatMap { roles =>
+              convService.updateConversationsWithDeviceStartMessage(Seq(response), roles).flatMap { _ =>
+                postQualifiedConversationMemberJoin(convId, users, defaultRole)
+              }
             }
           }
-        }
 
-      case Left(resp@ErrorResponse(status, _, label)) =>
-        warn(l"got error: $resp")
+        case Left(resp@ErrorResponse(status, _, label)) =>
+          warn(l"got error: $resp")
 
-        val errorType = (status, label) match {
-          case (403, "not-connected") =>
-            Some(ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_UNCONNECTED_USER)
-          case (412, "missing-legalhold-consent") =>
-            Some(ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_USER_MISSING_LEGAL_HOLD_CONSENT)
-          case _ =>
-            None
-        }
+          val errorType = (status, label) match {
+            case (403, "not-connected") =>
+              Some(ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_UNCONNECTED_USER)
+            case (412, "missing-legalhold-consent") =>
+              Some(ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_USER_MISSING_LEGAL_HOLD_CONSENT)
+            case _ =>
+              None
+          }
 
-        errorType.fold(Future.successful(SyncResult(resp))) { errorType =>
-          errorsService
-            .addErrorWhenActive(ErrorData(errorType, resp, convId))
-            .map(_ => SyncResult(resp))
-        }
+          errorType.fold(Future.successful(SyncResult(resp))) { errorType =>
+            errorsService
+              .addErrorWhenActive(ErrorData(errorType, resp, convId))
+              .map(_ => SyncResult(resp))
+          }
+      }
+    } else {
+      postConversation(convId, users.map(_.id), name, team, access, accessRole, receiptMode, defaultRole)
     }
-  }
 
   def syncConvLink(convId: ConvId): Future[SyncResult] = {
     (for {

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -34,6 +34,7 @@ import com.waz.sync.client.{ConversationsClient, ErrorOr, ErrorOrResponse}
 import com.waz.sync.client.ConversationsClient.{ConversationOverviewResponse, ConversationResponse}
 import com.waz.sync.{SyncRequestService, SyncResult, SyncServiceHandle}
 import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
+import com.waz.zms.BuildConfig
 import com.wire.signals.{CancellableFuture, EventStream, Signal, SourceSignal}
 import org.json.JSONObject
 import org.threeten.bp.Instant
@@ -468,6 +469,9 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
       (userService.findUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+      (membersStorage.getByUsers _).expects(Set.empty[UserId]).anyNumberOfTimes().returning(
+        Future.successful(IndexedSeq.empty[ConversationMemberData])
+      )
 
       val convsUi = createConvsUi(Some(teamId))
       val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), defaultRole = ConversationRole.MemberRole))
@@ -493,7 +497,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
       (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
       (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
       (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
-      (userService.findUsers _).expects(Seq(user1.id, user2.id)).once().returning(Future.successful(Seq(Some(user1), Some(user2))))
+      (userService.findUsers _).expects(Seq(user1.id, user2.id)).anyNumberOfTimes().returning(Future.successful(Seq(Some(user1), Some(user2))))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
       (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
       (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
@@ -519,103 +523,107 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
   feature("Create a group conversation with qualified users") {
 
     scenario("Create a group conversation with the creator and two users, both contacted") {
-      val teamId = TeamId()
-      val convName = Name("conv")
-      val conv = ConversationData(team = Some(teamId), name = Some(convName))
-      val syncId = SyncId()
-      val domain = "chala.wire.link"
-      val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
-      val user1 = UserData("user1").copy(domain = Some(domain))
-      val user2 = UserData("user2").copy(domain = Some(domain))
-      val users = Set(self, user1, user2)
-      val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
-      val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        val teamId = TeamId()
+        val convName = Name("conv")
+        val conv = ConversationData(team = Some(teamId), name = Some(convName))
+        val syncId = SyncId()
+        val domain = "chala.wire.link"
+        val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
+        val user1 = UserData("user1").copy(domain = Some(domain))
+        val user2 = UserData("user2").copy(domain = Some(domain))
+        val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+        val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
-      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
-      (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
-        Future.successful {
-          userIds.map { id =>
-            if (id == selfUserId) Some(self)
-            else if (id == user1.id) Some(user1)
-            else if (id == user2.id) Some(user2)
-            else None
+        (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
+        (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
+        (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+        (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
+        (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
+          Future.successful {
+            userIds.map { id =>
+              if (id == selfUserId) Some(self)
+              else if (id == user1.id) Some(user1)
+              else if (id == user2.id) Some(user2)
+              else None
+            }
           }
         }
-      }
-      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
-      (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
-      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
-      (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-      (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
-        .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
-        .once()
-        .returning(Future.successful(Set(member1, member2)))
-      (messages.addMemberJoinMessage _)
-        .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
-        .once()
-        .returning(Future.successful(None))
-      (sync.postQualifiedConversationMemberJoin _)
-        .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
-        .once()
-        .returning(Future.successful(SyncId()))
+        (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+        (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1, member2)))
+        (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+        (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
+        (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
+          .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
+          .once()
+          .returning(Future.successful(Set(member1, member2)))
+        (messages.addMemberJoinMessage _)
+          .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
+          .once()
+          .returning(Future.successful(None))
+        (sync.postQualifiedConversationMemberJoin _)
+          .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
+          .once()
+          .returning(Future.successful(SyncId()))
 
-      val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
-      data shouldEqual conv
-      sId shouldEqual syncId
+        val convsUi = createConvsUi(Some(teamId))
+        val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
+        data shouldEqual conv
+        sId shouldEqual syncId
+      }
     }
 
     scenario("Create a group conversation with the creator and two users, one uncontacted") {
-      val teamId = TeamId()
-      val convName = Name("conv")
-      val conv = ConversationData(team = Some(teamId), name = Some(convName))
-      val syncId = SyncId()
-      val domain = "chala.wire.link"
-      val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
-      val user1 = UserData("user1").copy(domain = Some(domain))
-      val user2 = UserData("user2").copy(domain = Some(domain))
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        val teamId = TeamId()
+        val convName = Name("conv")
+        val conv = ConversationData(team = Some(teamId), name = Some(convName))
+        val syncId = SyncId()
+        val domain = "chala.wire.link"
+        val self = UserData.withName(selfUserId, "self").copy(domain = Some(domain))
+        val user1 = UserData("user1").copy(domain = Some(domain))
+        val user2 = UserData("user2").copy(domain = Some(domain))
 
-      val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
-      val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
+        val member1 = ConversationMemberData(user1.id, conv.id, ConversationRole.MemberRole)
+        val member2 = ConversationMemberData(user2.id, conv.id, ConversationRole.MemberRole)
 
-      (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
-      (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
-      (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
-      (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
-        Future.successful {
-          userIds.map { id =>
-            if (id == selfUserId) Some(self)
-            else if (id == user1.id) Some(user1)
-            else if (id == user2.id) Some(user2)
-            else None
+        (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
+        (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
+        (sync.postConversation _).expects(*, *, Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+        (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
+        (userService.findUsers _).expects(*).anyNumberOfTimes().onCall { userIds: Seq[UserId] =>
+          Future.successful {
+            userIds.map { id =>
+              if (id == selfUserId) Some(self)
+              else if (id == user1.id) Some(user1)
+              else if (id == user2.id) Some(user2)
+              else None
+            }
           }
         }
-      }
-      (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
-      (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
-      (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
-      (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
-      (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
-        .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
-        .once()
-        .returning(Future.successful(Set(member1, member2)))
-      (messages.addMemberJoinMessage _)
-        .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
-        .once()
-        .returning(Future.successful(None))
-      (sync.postQualifiedConversationMemberJoin _)
-        .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
-        .once()
-        .returning(Future.successful(SyncId()))
+        (userService.isFederated(_: UserData)).expects(*).anyNumberOfTimes().onCall { user: UserData => Future.successful(user.id != selfUserId) }
+        (membersStorage.getByUsers _).expects(Set(user1.id, user2.id)).once().returning(Future.successful(IndexedSeq(member1)))
+        (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))
+        (convsStorage.optSignal _).expects(conv.id).anyNumberOfTimes().returning(Signal.const(Some(conv)))
+        (membersStorage.updateOrCreateAll(_: ConvId, _: Map[UserId, ConversationRole]))
+          .expects(conv.id, Map(user1.id -> ConversationRole.MemberRole, user2.id -> ConversationRole.MemberRole))
+          .once()
+          .returning(Future.successful(Set(member1, member2)))
+        (messages.addMemberJoinMessage _)
+          .expects(conv.id, selfUserId, Set(user1.id, user2.id), *, *)
+          .once()
+          .returning(Future.successful(None))
 
-      val convsUi = createConvsUi(Some(teamId))
-      val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
-      data shouldEqual conv
-      sId shouldEqual syncId
+        (sync.postQualifiedConversationMemberJoin _)
+          .expects(conv.id, Set(user1.qualifiedId.get, user2.qualifiedId.get), *)
+          .once()
+          .returning(Future.successful(SyncId()))
+
+        val convsUi = createConvsUi(Some(teamId))
+        val (data, sId) = result(convsUi.createGroupConversation(name = Some(convName), members = Set(user1.id, user2.id), defaultRole = ConversationRole.MemberRole))
+        data shouldEqual conv
+        sId shouldEqual syncId
+      }
     }
   }
 

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -211,32 +211,34 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
   }
 
   scenario("It reports missing legal hold consent error when adding qualified participants") {
-    // Given
-    val handler = createHandler
-    val convId = ConvId("convId")
-    val members = Set(QualifiedId(UserId("userId"), "chala.wire.link"))
-    val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      // Given
+      val handler = createHandler
+      val convId = ConvId("convId")
+      val members = Set(QualifiedId(UserId("userId"), "chala.wire.link"))
+      val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
 
-    // Mock
-    (convs.convById _)
-      .expects(convId)
-      .once()
-      .returning(Future.successful(Some(ConversationData(convId))))
+      // Mock
+      (convs.convById _)
+        .expects(convId)
+        .once()
+        .returning(Future.successful(Some(ConversationData(convId))))
 
-    (conversationsClient.postQualifiedMemberJoin _)
-      .expects(*, *, *)
-      .once()
-      .returning(CancellableFuture.successful(Left(errorResponse)))
+      (conversationsClient.postQualifiedMemberJoin _)
+        .expects(*, *, *)
+        .once()
+        .returning(CancellableFuture.successful(Left(errorResponse)))
 
-    // Expectation
-    val errorType = ErrorType.CANNOT_ADD_PARTICIPANT_WITH_MISSING_LEGAL_HOLD_CONSENT
-    (convService.onMemberAddFailed _)
-      .expects(convId, members.map(_.id), Some(errorType), errorResponse)
-      .once()
-      .returning(Future.successful(()))
+      // Expectation
+      val errorType = ErrorType.CANNOT_ADD_PARTICIPANT_WITH_MISSING_LEGAL_HOLD_CONSENT
+      (convService.onMemberAddFailed _)
+        .expects(convId, members.map(_.id), Some(errorType), errorResponse)
+        .once()
+        .returning(Future.successful(()))
 
-    // When
-    result(handler.postQualifiedConversationMemberJoin(convId, members, ConversationRole.MemberRole))
+      // When
+      result(handler.postQualifiedConversationMemberJoin(convId, members, ConversationRole.MemberRole))
+    }
   }
 
   scenario("It reports missing legal hold consent error when creating conversation") {
@@ -279,40 +281,42 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
 
 
   scenario("It reports missing legal hold consent error when creating a conversation with qualified members") {
-    // Given
-    val handler = createHandler
-    val convId = ConvId("convId")
-    val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      // Given
+      val handler = createHandler
+      val convId = ConvId("convId")
+      val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
 
-    // Mock
-    (conversationsClient.postQualifiedConversation _)
-      .expects(*)
-      .once()
-      .returning(CancellableFuture.successful(Left(errorResponse)))
+      // Mock
+      (conversationsClient.postQualifiedConversation _)
+        .expects(*)
+        .once()
+        .returning(CancellableFuture.successful(Left(errorResponse)))
 
-    // Expectation
-    val errorType = ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_USER_MISSING_LEGAL_HOLD_CONSENT
+      // Expectation
+      val errorType = ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_USER_MISSING_LEGAL_HOLD_CONSENT
 
-    (errorsService.addErrorWhenActive _)
-      .expects(where { data: ErrorData =>
-        data.errType == errorType &&
-          data.responseCode == 412 &&
-          data.responseLabel == "missing-legalhold-consent" &&
-          data.convId.contains(convId)
-      })
-      .once()
-      .returning(Future.successful(()))
+      (errorsService.addErrorWhenActive _)
+        .expects(where { data: ErrorData =>
+          data.errType == errorType &&
+            data.responseCode == 412 &&
+            data.responseLabel == "missing-legalhold-consent" &&
+            data.convId.contains(convId)
+        })
+        .once()
+        .returning(Future.successful(()))
 
-    // When (arguments are irrelevant)
-    result(handler.postQualifiedConversation(
-      convId,
-      Set(QualifiedId(UserId("userId"), "chala.wire.link")),
-      None,
-      None,
-      Set.empty,
-      AccessRole.TEAM,
-      None,
-      ConversationRole.MemberRole
-    ))
+      // When (arguments are irrelevant)
+      result(handler.postQualifiedConversation(
+        convId,
+        Set(QualifiedId(UserId("userId"), "chala.wire.link")),
+        None,
+        None,
+        Set.empty,
+        AccessRole.TEAM,
+        None,
+        ConversationRole.MemberRole
+      ))
+    }
   }
 }


### PR DESCRIPTION
The customer is still not able to create a new conversation. Another possibility is that we try to add members to
the conversation in a way that works only with new endpoints. This commit adds a check for the federation flag
in a few places and if the federation is off, it reverts to old methods.

The amount of code changed is mostly due to indentation - the previous code is now wrapped in if/else-s.

**NOTE** : This is a hotfix. The PR is based on the release branch. Please review but do not merge.

#### APK
[Download build #3911](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3911/artifact/build/artifact/wire-dev-PR3486-3911.apk)