### PR TITLE
Federation: Use old code when the federation feature flag is off

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -33,6 +33,7 @@ import com.waz.znet2.http.Request.UrlCreator
 import com.waz.znet2.http._
 import org.json
 import org.json.JSONObject
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration


### PR DESCRIPTION
This commit introduces more careful separation of the federation feature.
In the last release we changed the way group conversations are created. The list of participant ids is no longer sent in `ConversationInitState`. The group conversation starts empty (only with the creator) and the all other participants are added in a "member join" event. It simplifies handling situations when some users cannot be added to a conversation for various reasons. The json for `ConversationInitState` was also changed, because of work on Federation - if the list of users is empty (as it always is now for groups) then we skip the field. On the backend used by one of our customers this fails with `ErrorResponse(code: 400, message: Error in $: key "users" not found, label: invalid-payload)`.

This PR reverts the change: If the federation feature flag is off, we will still add the "users" field to the json, even if it's empty. Also, it reverts to using the old code and endpoints in a few cases.

The amount of code changed is mostly due to indentation - the previous code is now wrapped in if/else-s.

This is a version of https://github.com/wireapp/wire-android/pull/3485 and https://github.com/wireapp/wire-android/pull/3486 - those PRs are a hotfix on top of the release branch. This PR here introduces the same changes to the federation feature.
#### APK
[Download build #3913](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3913/artifact/build/artifact/wire-dev-PR3488-3913.apk)
[Download build #3918](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3918/artifact/build/artifact/wire-dev-PR3488-3918.apk)
[Download build #3925](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3925/artifact/build/artifact/wire-dev-PR3488-3925.apk)