### PR TITLE
Federation: Remove a federated user from the group conversation

### DIFF
--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -58,6 +58,7 @@ public enum SyncCommand {
     PostConvJoin("post-conv-join"),
     PostQualifiedConvJoin("post-qualified-conv-join"),
     PostConvLeave("post-conv-leave"),
+    PostQualifiedConvLeave("post-qualified-conv-leave"),
     PostConnection("post-connection"),
     PostQualifiedConnection("post-qualified-connection"),
     DeletePushToken("delete-push-token"),

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -447,6 +447,10 @@ object SyncRequest {
     override val mergeKey: Any = (cmd, convId, user)
   }
 
+  final case class PostQualifiedConvLeave(convId: ConvId, qId: QualifiedId) extends RequestForConversation(Cmd.PostQualifiedConvLeave) with Serialized {
+    override val mergeKey: Any = (cmd, convId, qId)
+  }
+
   final case class PostStringProperty(key: PropertyKey, value: String) extends BaseRequest(Cmd.PostStringProperty) {
     override def mergeKey: Any = (cmd, key)
   }
@@ -619,7 +623,9 @@ object SyncRequest {
         case PostQualifiedConvJoin(_, users, conversationRole) =>
           o.put("users", users.map(QualifiedId.Encoder(_)))
           o.put("conversation_role", conversationRole.label)
-        case PostConvLeave(_, user)           => putId("user", user)
+        case PostConvLeave(_, user)  => putId("user", user)
+        case PostQualifiedConvLeave(_, qId)  =>
+          o.put("qualifiedId", QualifiedId.Encoder(qId))
         case PostOpenGraphMeta(_, messageId, time) =>
           putId("message", messageId)
           o.put("time", time.toEpochMilli)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -81,6 +81,8 @@ trait ConversationsService {
   def onlyFake1To1ConvUsers: Signal[Seq[UserData]]
 
   def generateTempConversationId(users: Set[UserId]): RConvId
+
+  def rConvQualifiedId(conv: ConversationData): RConvQualifiedId
 }
 
 class ConversationsServiceImpl(teamId:          Option[TeamId],
@@ -186,6 +188,16 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
         _ <- usersStorage.remove(userId)
       } yield ()
   }
+
+  override def rConvQualifiedId(conv: ConversationData): RConvQualifiedId =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      conv
+        .qualifiedId
+        .orElse(currentDomain.map(RConvQualifiedId(conv.remoteId, _)))
+        .getOrElse(RConvQualifiedId(conv.remoteId, ""))
+    } else {
+      RConvQualifiedId(conv.remoteId)
+    }
 
   /**
    *

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -114,13 +114,14 @@ class PushServiceImpl(selfUserId:           UserId,
 
   notificationStorage.registerEventHandler { () =>
     Serialized.future(PipelineKey) {
+      verbose(l"processing new added events")
+      val offset = System.currentTimeMillis()
       for {
         _ <- Future.successful(processing ! true)
-        t =  System.currentTimeMillis()
         _ <- processEncryptedRows()
         _ <- processDecryptedRows()
-        _ = verbose(l"events processing finished, time: ${System.currentTimeMillis() - t}ms")
         _ <- Future.successful(processing ! false)
+        _ = verbose(l"events processing finished, time: ${System.currentTimeMillis() - offset}ms")
       } yield {}
     }.recover {
       case ex =>

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -80,6 +80,7 @@ trait SyncServiceHandle {
   def postConversationMemberJoin(id: ConvId, members: Set[UserId], defaultRole: ConversationRole): Future[SyncId]
   def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId]
   def postConversationMemberLeave(id: ConvId, member: UserId): Future[SyncId]
+  def postConversationMemberLeave(id: ConvId, member: QualifiedId): Future[SyncId]
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncId]
   def postConversation(id:          ConvId,
                        users:       Set[UserId],
@@ -196,7 +197,8 @@ class AndroidSyncServiceHandle(account:         UserId,
     addRequest(PostConvJoin(id, members, defaultRole))
   def postQualifiedConversationMemberJoin(id: ConvId, members: Set[QualifiedId], defaultRole: ConversationRole): Future[SyncId] =
     addRequest(PostQualifiedConvJoin(id, members, defaultRole))
-  def postConversationMemberLeave(id: ConvId, member: UserId) = addRequest(PostConvLeave(id, member))
+  def postConversationMemberLeave(id: ConvId, member: UserId): Future[SyncId] = addRequest(PostConvLeave(id, member))
+  def postConversationMemberLeave(id: ConvId, member: QualifiedId): Future[SyncId] = addRequest(PostQualifiedConvLeave(id, member))
   def postConversation(id: ConvId,
                        users: Set[UserId],
                        name: Option[Name],
@@ -346,6 +348,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostConvJoin(convId, u, role)                   => zms.conversationSync.postConversationMemberJoin(convId, u, role)
           case PostQualifiedConvJoin(convId, u, role)          => zms.conversationSync.postQualifiedConversationMemberJoin(convId, u, role)
           case PostConvLeave(convId, u)                        => zms.conversationSync.postConversationMemberLeave(convId, u)
+          case PostQualifiedConvLeave(convId, qId)             => zms.conversationSync.postConversationMemberLeave(convId, qId)
           case PostConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>
             zms.conversationSync.postConversation(convId, u, name, team, access, accessRole, receiptMode, defRole)
           case PostQualifiedConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>

--- a/zmessaging/src/main/scala/com/waz/sync/client/PushNotificationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/PushNotificationsClient.scala
@@ -132,9 +132,9 @@ object PushNotificationsClient {
   }
 }
 
-case class PushNotificationEncoded(id: Uid, events: JSONArray, transient: Boolean = false)
+final case class PushNotificationEncoded(id: Uid, events: JSONArray, transient: Boolean = false)
 
-case class PushNotification(id: Uid, events: Seq[Event], transient: Boolean = false) {
+final case class PushNotification(id: Uid, events: Seq[Event], transient: Boolean = false) {
 
   /**
     * Check if notification contains events intended for current client. In some (rare) cases it may happen that

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -224,7 +224,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
         }
 
         msgClient.postMessage(
-          conv.qualifiedId.getOrElse(RConvQualifiedId(conv.remoteId, currentDomain.getOrElse(""))),
+          convsService.rConvQualifiedId(conv),
           QualifiedOtrMessage(selfClientId, content, external, flags.nativePush, reportMissing = targetUsers, reportAll = reportAll)
         ).future
       } else {
@@ -442,7 +442,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
           case Some(content) =>
             msgClient
               .postMessage(
-                conv.qualifiedId.getOrElse(RConvQualifiedId(conv.remoteId, currentDomain.getOrElse(""))),
+                convsService.rConvQualifiedId(conv),
                 QualifiedOtrMessage(selfClientId, content)
               )
               .future

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -21,7 +21,8 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
 
   private val self = UserData("self")
   private val teamId = TeamId()
-  private val userService      = mock[UserService]
+  private val domain = "chala.wire.link"
+  private val userService = mock[UserService]
   private val messagesStorage = mock[MessagesStorage]
   private val messagesService = mock[MessagesService]
   private val convService = mock[ConversationsService]
@@ -35,7 +36,7 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
   private val membersStorage = mock[MembersStorage]
 
   private def createHandler: ConversationsSyncHandler = new ConversationsSyncHandler(
-    self.id, Some(teamId), userService, messagesStorage, messagesService,
+    self.id, Some(domain), Some(teamId), userService, messagesStorage, messagesService,
     convService, convs, convEvents, convStorage, errorsService,
     conversationsClient, genericMessages, rolesService, membersStorage
   )


### PR DESCRIPTION
Uses a new endpoint for removal of a user on federated backends and for self-removal from a group conversation.
During testing I experienced a few "glitches" when join/remove events were not processed until a subsequent event came (e.g. a message). I tried to debug it but it stopped happening after I added a few log statements. I decided to keep the new log statement should the issue happen again.

#### APK
[Download build #3945](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3945/artifact/build/artifact/wire-dev-PR3500-3945.apk)