### PR TITLE
fix: Enterprise alert is displayed when personal user tries to share a file

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/ConferenceCallingFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConferenceCallingFeatureConfig.scala
@@ -9,7 +9,7 @@ final case class ConferenceCallingFeatureConfig(status: String) {
 
 object ConferenceCallingFeatureConfig {
 
-  val Default: ConferenceCallingFeatureConfig = ConferenceCallingFeatureConfig(status = "enabled")
+  val Default: ConferenceCallingFeatureConfig = ConferenceCallingFeatureConfig(status = "disabled")
 
   implicit object Decoder extends JsonDecoder[ConferenceCallingFeatureConfig] {
     override def apply(implicit js: JSONObject): ConferenceCallingFeatureConfig =


### PR DESCRIPTION
## What's new in this PR?

### Issues
Jira: https://wearezeta.atlassian.net/browse/SQSERVICES-769

When a personal user in a conversation , goes offline, then tries to share a file/photo and closes that window, he sees the enteprise alert which says "Your team was upgraded to Wire..."

### Causes

At the moment of leaving the screen of "file browser", the app is getting the default value, which is enabled(true), as a new value to check with the current value(false) if an upgrade as been done. This will lead to display the enterprise dialog.

### Solutions

Changed the default value to `disabled`

### Testing

Manually tested

#### APK
[Download build #3947](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3947/artifact/build/artifact/wire-dev-PR3501-3947.apk)