### PR TITLE
Feature: display conference calling restrictions dialogs based on user type

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1666,8 +1666,8 @@
 
     <!-- Conference Calling Restriction feature config -->
     <string name="conference_calling_restriction_dialog_title">Upgrade to enterprise</string>
-    <string name="conference_calling_restriction_dialog_description">Your team is currently on the free Basic plan. Upgrade to Enterprise for access to  features such as starting conferences and more.
-    &lt;br /&gt; <![CDATA[ <a href="https://wire.com/en/pricing/">Learn more about Wires pricing</a>]]></string>
+    <string name="conference_calling_restriction_dialog_description">Your team is currently on the free Basic plan. Upgrade to Enterprise for access to features such as starting conferences and more.
+    &lt;br /&gt; <![CDATA[ <a href="https://wire.com/en/pricing/">Learn more about Wire\'s pricing</a>]]></string>
     <string name="conference_calling_restriction_dialog_positive_button">UPGRADE NOW</string>
     <string name="conference_calling_restriction_dialog_negative_button">CANCEL</string>
 
@@ -1675,8 +1675,9 @@
     <string name="upgraded_plan_dialog_description">Your team was upgraded to Wire Enterprise, which gives you access to features such as conference calls and more.
         &lt;br /&gt; <![CDATA[ <a href="https://wire.com/en/products/enterprise-collaboration/">Learn more about Wire Enterprise</a>]]></string>
 
-    <string name="feature_not_accessible_dialog_title">Feature not accessible</string>
-    <string name="feature_not_accessible_dialog_description">To use the conferencing feature your team admin needs to upgrade Wire</string>
+    <string name="conference_calling_unavailable_dialog_title">Feature unavailable</string>
+    <string name="conference_calling_unavailable_dialog_description_personal_user">The option to initiate a conference call is only available in the paid version of Wire.</string>
+    <string name="conference_calling_unavailable_dialog_description_team_member_user">To start a conference call, your team needs to upgrade to the Enterprise plan.</string>
 
 </resources>
 

--- a/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
+++ b/app/src/main/scala/com/waz/zclient/utils/ContextUtils.scala
@@ -397,10 +397,17 @@ object ContextUtils {
     ).foreach(onConfirm)
   }
 
-  def showConferenceCallingNotAccessibleDialog()(implicit ex: ExecutionContext, context: Context): Unit = {
+  def showConferenceCallingUnavailableDialogForPersonal()(implicit ex: ExecutionContext, context: Context): Unit = {
     showInfoDialog(
-      title = getString(R.string.feature_not_accessible_dialog_title),
-      msg = getString(R.string.feature_not_accessible_dialog_description)
+      title = getString(R.string.conference_calling_unavailable_dialog_title),
+      msg = getString(R.string.conference_calling_unavailable_dialog_description_personal_user)
+    )
+  }
+
+  def showConferenceCallingUnavailableDialogForMember()(implicit ex: ExecutionContext, context: Context): Unit = {
+    showInfoDialog(
+      title = getString(R.string.conference_calling_unavailable_dialog_title),
+      msg = getString(R.string.conference_calling_unavailable_dialog_description_team_member_user)
     )
   }
 


### PR DESCRIPTION
## What's new in this PR?

Jira: https://wearezeta.atlassian.net/browse/SQSERVICES-560

This PR aims to dispaly conference calling restrictions dialogs based on the current user type.

| Admin's Dialog| Regular team member's dialog | Personal user's dialog|
| --- | --- | --- |
| ![upgrade](https://user-images.githubusercontent.com/18124919/133304051-8f2c9eb9-c88c-4589-87d3-f2a307644b86.PNG) | ![member](https://user-images.githubusercontent.com/18124919/133304118-48464449-0e84-45f5-98d6-e056678db6af.PNG) | ![personal](https://user-images.githubusercontent.com/18124919/133304174-8ff7fef0-f849-4634-a6ad-692b9d616a5c.PNG) |



#### APK
[Download build #3950](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3950/artifact/build/artifact/wire-dev-PR3503-3950.apk)