### PR TITLE
[Calling] fix : Mute status is switched once the call is established

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -263,7 +263,9 @@ class CallingServiceImpl(val accountId:       UserId,
         isConferenceCall,
         startedAsVideoCall = videoCall,
         videoSendState = VideoState.NoCameraPermission,
-        shouldRing = !conv.muted.isAllMuted && shouldRing)
+        shouldRing = !conv.muted.isAllMuted && shouldRing,
+        muted = isGroup
+      )
 
       callProfile.mutate { p =>
         // If we have a call in the profile with the same id, this incoming call should be just a GROUPCHECK
@@ -454,7 +456,6 @@ class CallingServiceImpl(val accountId:       UserId,
                     verbose(l"Answering call")
                     avs.answerCall(w, conv.remoteId, callType, useConstantBitRate)
                     updateActiveCall(_.updateCallState(SelfJoining))("startCall/OtherCalling")
-                    setCallMuted(muted = isGroup)
                     if (forceOption)
                       setVideoSendState(convId, if (isVideo)  Avs.VideoState.Started else Avs.VideoState.Stopped)
                   case _ =>


### PR DESCRIPTION
## What's new in this PR?

This PR fixes an issue for mute button : the status is enabled after establishing the call although it was disabled on pre-call.

https://wearezeta.atlassian.net/browse/SQCALL-403

#### APK
[Download build #3955](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3955/artifact/build/artifact/wire-dev-PR3506-3955.apk)