### PR TITLE
Federation: Display the domain in the handle

### DIFF
--- a/app/src/main/res/layout/preferences_account_layout.xml
+++ b/app/src/main/res/layout/preferences_account_layout.xml
@@ -73,6 +73,20 @@
                 app:subtitle="@string/pref_account_phone_title"
                 />
 
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_account_team"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:subtitle="@string/pref_account_team_title"
+                />
+
+            <com.waz.zclient.preferences.views.TextButton
+                android:id="@+id/preferences_account_domain"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/preference_button_height"
+                app:subtitle="@string/pref_account_domain_title"
+                />
+
             <com.waz.zclient.ui.text.TypefaceTextView
                 android:id="@+id/preferences_account_appearance_header"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,8 @@
     <string name="pref_account_conversations_category_title">History</string>
     <string name="pref_account_username_title">Username</string>
     <string name="pref_account_phone_title">Phone</string>
+    <string name="pref_account_team_title">Team</string>
+    <string name="pref_account_domain_title">Domain</string>
     <string name="pref_account_add_phone_title">Add phone number</string>
     <string name="pref_account_email_title">Email</string>
     <string name="pref_account_add_email_title">Add email</string>

--- a/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/SetHandleFragment.scala
@@ -103,7 +103,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
     keepButton.foreach { keepButton =>
       keepButton.setIsFilled(false)
       keepButton.onClick {
-        zms.head.map(_.users.updateHandle(Handle(suggestedUsername))).map { _ =>
+        zms.head.map(_.users.updateHandle(Handle.from(suggestedUsername))).map { _ =>
           getContainer.onUsernameSet()
         }
       }
@@ -117,8 +117,8 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
     self.head.foreach { self =>
       self.handle.foreach{ handle =>
-        suggestedUsername = handle.string
-        usernameTextView.foreach(_.setText(StringUtils.formatHandle(handle.string)))
+        suggestedUsername = handle.toString
+        usernameTextView.foreach(_.setText(StringUtils.formatHandle(handle.toString)))
       }
       startUsernameGenerator(self.name)
     }
@@ -173,7 +173,7 @@ class SetHandleFragment extends BaseFragment[SetHandleFragment.Container] with F
 
   private def getAttempts(base: String, attempts: Int): Seq[Handle] =
     (0 until attempts).map(getTrailingNumber).map { tN =>
-      Handle(StringUtils.truncate(base, HandleLength.HandleMaxLength - tN.length) + tN)
+      Handle.from(StringUtils.truncate(base, HandleLength.HandleMaxLength - tN.length) + tN)
     }
 
   private def getTrailingNumber(attempt: Int): String = {

--- a/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/SingleUserRowView.scala
@@ -41,7 +41,7 @@ import com.waz.zclient.paintcode.{ForwardNavigationIcon, GuestIcon}
 import com.waz.zclient.ui.animation.interpolators.penner.Quad.EaseOut
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.{GuestUtils, StringUtils, _}
+import com.waz.zclient.utils.{GuestUtils, _}
 import com.waz.zclient.views.AvailabilityView
 import com.waz.zclient.{R, ViewHelper}
 import com.wire.signals.{EventStream, Signal, SourceStream}
@@ -263,9 +263,7 @@ class SingleUserRowView(context: Context, attrs: AttributeSet, style: Int)
 
 object SingleUserRowView {
   def defaultSubtitle(user: UserData, isFederated: Boolean)(implicit context: Context): String = {
-    lazy val handle: String =
-      user.handle.fold("")(h => StringUtils.formatHandle(h.string)) +
-        (if (isFederated) "@" + user.domain.getOrElse("") else "")
+    lazy val handle: String = user.displayHandle.getOrElse("")
     val expiration = user.expiresAt.map(ea => GuestUtils.timeRemainingString(ea.instant, Instant.now))
     expiration.getOrElse(handle)
   }

--- a/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
@@ -24,7 +24,6 @@ import android.widget.{LinearLayout, TextView}
 import com.waz.model.UserId
 import com.wire.signals.Signal
 import com.waz.zclient.messages.UsersController
-import com.waz.zclient.utils.StringUtils
 import com.waz.zclient.{R, ViewHelper}
 import com.waz.threading.Threading._
 
@@ -39,11 +38,7 @@ class UserDetailsView(val context: Context, val attrs: AttributeSet, val defStyl
   val users = inject[UsersController]
   val userId = Signal[UserId]()
 
-  userId.flatMap(users.userHandle).map {
-    case Some(h) => StringUtils.formatHandle(h.string)
-    case None => ""
-  }.onUi(userNameTextView.setText(_))
-
+  userId.flatMap(users.user).map(_.displayHandle.getOrElse("")).onUi(userNameTextView.setText(_))
   userId.flatMap(users.user).map(_.name).onUi(userInfoTextView.setText(_))
 
   def setUserId(id: UserId): Unit =

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -49,7 +49,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.ui.utils.TextViewUtils
 import com.waz.zclient.ui.views.properties.MoveToAnimateable
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.{ConversationSignal, StringUtils, UiStorage, UserSetSignal, UserSignal, ViewUtils}
+import com.waz.zclient.utils.{ConversationSignal, UiStorage, UserSetSignal, UserSignal, ViewUtils}
 import com.waz.zclient.views.AvailabilityView
 import com.waz.zclient.{R, ViewHelper}
 
@@ -411,7 +411,7 @@ object ConversationListRow {
         case Message.Type.KNOCK =>
           formatSubtitle(getString(R.string.conversation_list__pinged), senderName, isGroup, quotePrefix = isQuote)
         case Message.Type.CONNECT_ACCEPTED | Message.Type.MEMBER_JOIN if !isGroup =>
-          members.headOption.flatMap(_.handle).map(_.string).fold("")(StringUtils.formatHandle)
+          members.headOption.flatMap(_.displayHandle).getOrElse("")
         case Message.Type.MEMBER_JOIN if members.exists(_.id == selfId) =>
           getString(R.string.conversation_list__added_you, senderName)
         case Message.Type.MEMBER_JOIN if members.length > 1 =>
@@ -443,7 +443,7 @@ object ConversationListRow {
                                     userName:                 Option[Name])
                                    (implicit context: Context): String = {
     if (conv.convType == ConversationType.WaitForConnection || (lastMessage.exists(_.msgType == Message.Type.MEMBER_JOIN) && !isGroupConv)) {
-      otherMember.flatMap(_.handle.map(_.string)).fold("")(StringUtils.formatHandle)
+      otherMember.flatMap(_.displayHandle).getOrElse("")
     } else if (memberIds.count(_ != selfId) == 0 && conv.convType == ConversationType.Group) {
       ""
     } else if (conv.unreadCount.total == 0 && !conv.isActive) {

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -136,8 +136,6 @@ class UsersController(implicit injector: Injector, context: Context)
       strings.mkString(itemSeparator + " ")
   }
 
-  def userHandle(id: UserId): Signal[Option[Handle]] = user(id).map(_.handle)
-
   def user(id: UserId): Signal[UserData] = zms.flatMap(_.usersStorage.signal(id))
   def userOpt(id: UserId): Signal[Option[UserData]] = zms.flatMap(_.usersStorage.optSignal(id))
   def users(ids: Iterable[UserId]): Signal[Vector[UserData]] = zms.flatMap(_.usersStorage.listSignal(ids))

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -37,7 +37,7 @@ import com.waz.zclient.conversation.creation.CreateConversationController
 import com.waz.zclient.pages.main.MainPhoneFragment
 import com.waz.zclient.pages.main.conversation.controller.IConversationScreenController
 import com.waz.zclient.participants.{ParticipantOtrDeviceAdapter, ParticipantsController}
-import com.waz.zclient.utils.{ContextUtils, GuestUtils, RichView, StringUtils}
+import com.waz.zclient.utils.{ContextUtils, GuestUtils, RichView}
 import com.waz.zclient.views.menus.{FooterMenu, FooterMenuCallback}
 import com.waz.zclient.{FragmentHelper, R}
 import org.threeten.bp.Instant
@@ -181,10 +181,10 @@ class SingleParticipantFragment extends FragmentHelper {
   }
 
   private def initUserHandle(): Unit = returning(view[TextView](R.id.user_handle)) { vh =>
-    subs += participantsController.otherParticipant.map(_.handle.map(_.string)).onUi {
+    subs += participantsController.otherParticipant.map(_.displayHandle).onUi {
       case Some(h) =>
         vh.foreach { view =>
-          view.setText(StringUtils.formatHandle(h))
+          view.setText(h)
           view.setVisible(true)
         }
       case None =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -14,7 +14,6 @@ import com.waz.zclient.common.controllers.ThemeController
 import com.waz.zclient.controllers.navigation.Page
 import com.waz.zclient.pages.main.pickuser.controller.IPickUserController
 import com.waz.zclient.participants.UserRequester
-import com.waz.zclient.utils.StringUtils
 
 import scala.concurrent.duration._
 import com.waz.threading.Threading._
@@ -57,7 +56,7 @@ abstract class UntabbedRequestFragment extends SingleParticipantFragment {
         linkedText    <- linkedText(user)
       } yield (user, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isFederated, linkedText)).foreach {
         case (user, isGuest, isExternal, isDarkTheme, isGroup, isWireless, isFederated, linkedText) =>
-          val formattedHandle = StringUtils.formatHandle(user.handle.map(_.string).getOrElse(""))
+          val formattedHandle = user.displayHandle.getOrElse("")
           val participantRole = participantsController.participants.map(_.get(userToConnectId))
           val selfRole =
             if (fromParticipants)

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
@@ -56,7 +56,7 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
 
   lazy val zms = inject[Signal[ZMessaging]]
   lazy val users = zms.map(_.users)
-  lazy val currentHandle = users.flatMap(_.selfUser.map(_.handle))
+  lazy val currentHandle = users.flatMap(_.selfUser.map(_.displayHandle))
 
   private val handleTextWatcher = new TextWatcher() {
     private var lastText: String = ""
@@ -82,8 +82,8 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
             for {
               z         <- zms.head
               curHandle <- currentHandle.head
-              if !curHandle.map(_.string).contains(normalText)
-              _ <- z.handlesClient.isUserHandleAvailable(Handle(normalText)).map {
+              if !curHandle.contains(normalText)
+              _ <- z.handlesClient.isUserHandleAvailable(Handle.from(normalText)).map {
                 case Right(true) =>
                   setErrorMessage("")
                   okButton.setEnabled(editingEnabled)
@@ -115,7 +115,7 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
 
       Option(inputHandle).filter(_.nonEmpty).foreach { input =>
         currentHandle.head.map {
-          case Some(h) if h.string == input => dismiss()
+          case Some(h) if h == input => dismiss()
           case _ =>
             import ValidationError._
             validateUsername(input) match {
@@ -235,7 +235,7 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
     handleEditText.startAnimation(AnimationUtils.loadAnimation(getContext, R.anim.shake_animation))
 
   private def updateHandle(handle: String) =
-    users.head.flatMap(_.updateHandle(Handle(handle)))
+    users.head.flatMap(_.updateHandle(Handle.from(handle)))
 }
 
 object ChangeHandleFragment {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/BackupExportView.scala
@@ -84,7 +84,7 @@ class BackupExportView(context: Context, attrs: AttributeSet, style: Int)
     for {
       users          <- inject[Signal[UserService]].head
       self           <- users.selfUser.head
-      userHandle     =  self.handle.fold("")(_.string)
+      userHandle     =  self.handle.map(_.toString).getOrElse("")
       Some(clientId) <- inject[Signal[AccountManager]].flatMap(_.clientId).head
       _              <- lifecycle.uiActive.collect { case true => () }.head
       _              <- Future {

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -43,7 +43,7 @@ import com.waz.zclient.preferences.views.TextButton
 import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.utils.Time.TimeStamp
-import com.waz.zclient.utils.{BackStackKey, BackStackNavigator, RichView, StringUtils, UiStorage, UserSignal}
+import com.waz.zclient.utils.{BackStackKey, BackStackNavigator, RichView, UiStorage, UserSignal}
 import com.waz.zclient.views.AvailabilityView
 import com.waz.threading.Threading._
 
@@ -264,7 +264,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
 
   self.on(Threading.Ui) { self =>
     view.setAccentColor(AccentColor(self.accent).color)
-    self.handle.foreach(handle => view.setHandle(StringUtils.formatHandle(handle.string)))
+    self.displayHandle.foreach(view.setHandle)
     view.setUserName(self.name)
   }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -119,7 +119,7 @@ class SettingsViewController(view: SettingsView)(implicit inj: Injector, ec: Eve
   val selfInfo = for {
     z <- zms
     self <- UserSignal(z.selfUserId)
-  } yield (self.name, self.handle.fold("")(_.string))
+  } yield (self.name, self.displayHandle.getOrElse(""))
 
   val team = zms.flatMap(_.teams.selfTeam)
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -60,7 +60,7 @@ import com.waz.zclient.ui.text.TypefaceTextView
 import com.waz.zclient.usersearch.domain.RetrieveSearchResults
 import com.waz.zclient.usersearch.views.SearchEditText
 import com.waz.zclient.utils.ContextUtils._
-import com.waz.zclient.utils.{IntentUtils, ResColor, RichView, StringUtils, UiStorage, UserSignal}
+import com.waz.zclient.utils.{IntentUtils, ResColor, RichView, UiStorage, UserSignal}
 import com.waz.zclient.views._
 
 import scala.concurrent.Future
@@ -486,7 +486,8 @@ class SearchUIFragment extends BaseFragment[Container]
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
         getString(R.string.people_picker__invite__share_text__header, self.name.str),
-        getString(R.string.people_picker__invite__share_text__body, StringUtils.formatHandle(self.handle.map(_.string).getOrElse(""))))
+        getString(R.string.people_picker__invite__share_text__body,self.displayHandle.getOrElse(""))
+      )
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }
 

--- a/zmessaging/src/main/scala/com/waz/api/Credentials.scala
+++ b/zmessaging/src/main/scala/com/waz/api/Credentials.scala
@@ -61,7 +61,7 @@ case class HandleCredentials(handle: Handle, password: Password) extends Credent
   override val autoLogin = false
 
   override def addToRegistrationJson(o: JSONObject): Unit = {
-    o.put("email", handle.string)
+    o.put("email", handle.toString)
     o.put("password", password)
   }
 

--- a/zmessaging/src/main/scala/com/waz/db/DbTranslator.scala
+++ b/zmessaging/src/main/scala/com/waz/db/DbTranslator.scala
@@ -121,10 +121,10 @@ object DbTranslator {
     override def literal(value: EmailAddress): String = value.str
   }
   implicit object HandleTranslator extends DbTranslator[Handle] {
-    override def load(cursor: DBCursor, index: Int): Handle = Handle(cursor.getString(index))
+    override def load(cursor: DBCursor, index: Int): Handle = Handle.from(cursor.getString(index))
     override def save(value: Handle, name: String, values: DBContentValues): Unit = values.put(name, literal(value))
     override def bind(value: Handle, index: Int, stmt: DBProgram): Unit = stmt.bindString(index, literal(value))
-    override def literal(value: Handle): String = value.string
+    override def literal(value: Handle): String = value.toString
   }
   implicit def optionTranslator[A](implicit trans: DbTranslator[A]): DbTranslator[Option[A]] = new DbTranslator[Option[A]] {
     override def load(cursor: DBCursor, index: Int): Option[A] = if (cursor.isNull(index)) None else Some(trans.load(cursor, index))

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 
 import com.waz.utils.Locales
 
-case class Handle(string: String) extends AnyVal {
+final case class Handle(private val string: String) extends AnyVal {
   override def toString : String = string
 
   def startsWithQuery(query: String): Boolean =
@@ -31,11 +31,18 @@ case class Handle(string: String) extends AnyVal {
     string == Handle.stripSymbol(query).toLowerCase
 
   def withSymbol: String = if (string.startsWith("@")) string else s"@$string"
+
+  def nonEmpty: Boolean = string.nonEmpty
 }
 
 object Handle extends (String => Handle){
   val Empty: Handle = Handle("")
-  def apply(): Handle = Empty
+
+  def from(string: String): Handle = {
+    val h = string.trim
+    if (h.nonEmpty) Handle(h) else Empty
+  }
+
   def random: Handle = Handle(UUID.randomUUID().toString)
   private val handlePattern = """@(.*)""".r
   def transliterated(s: String): String = Locales.transliterate(s)

--- a/zmessaging/src/main/scala/com/waz/model/UserInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserInfo.scala
@@ -152,7 +152,7 @@ object UserInfo {
       info.phone.foreach(p => o.put("phone", p.str))
       info.email.foreach(e => o.put("email", e.str))
       info.accentId.foreach(o.put("accent_id", _))
-      info.handle.foreach(h => o.put("handle", h.string))
+      info.handle.foreach(h => o.put("handle", h.toString))
       info.trackingId.foreach(id => o.put("tracking_id", id.str))
       info.picture.foreach(ps => o.put("assets", encodeAsset(ps)))
       info.managedBy.foreach(m => o.put("managed_by", m.toString))

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -136,7 +136,7 @@ class UserSearchServiceImpl(selfUserId:           UserId,
 
       def cmpHandle(u: UserData, fn: String => Boolean) = u.handle match {
         case None => false
-        case Some(h) => fn(h.string)
+        case Some(h) => fn(h.toString)
       }
 
       val rules: Seq[UserData => Boolean] = Seq(
@@ -328,7 +328,7 @@ object UserSearchService {
       UserSearchEntry(qualified_id,
                       Name(name),
                       accent_id,
-                      handle.fold(Handle.Empty)(Handle(_)),
+                      handle.fold(Handle.Empty)(Handle.from),
                       team.map(TeamId.apply))
     }
   }

--- a/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
@@ -91,7 +91,7 @@ object HandlesClient {
   val CheckMultipleAvailabilityPath = "/users/handles"
   val MaxHandlesToPost = 50
 
-  def checkSingleAvailabilityPath(handle: Handle): String = s"/users/handles/${handle.string}"
+  def checkSingleAvailabilityPath(handle: Handle): String = s"/users/handles/${handle.toString}"
 
   case class UsernameValidation(username: String, reason: UsernameValidationError) {
     def isValid: Boolean = reason == UsernameValidationError.NONE

--- a/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
@@ -174,8 +174,8 @@ object JsonDecoder {
   implicit def decodeOptEmailAddress(s: Symbol)(implicit js: JSONObject): Option[EmailAddress] = opt(s, js => EmailAddress(js.getString(s.name)))
   implicit def decodePhoneNumber(s: Symbol)(implicit js: JSONObject): PhoneNumber = PhoneNumber(js.getString(s.name))
   implicit def decodeOptPhoneNumber(s: Symbol)(implicit js: JSONObject): Option[PhoneNumber] = opt(s, js => PhoneNumber(js.getString(s.name)))
-  implicit def decodeOptHandle(s: Symbol)(implicit js: JSONObject): Option[Handle] = opt(s, js => Handle(js.getString(s.name)))
-  implicit def decodeHandleSeq(s: Symbol)(implicit js: JSONObject): Seq[Handle] = array[Handle](s)({ (arr, i) => Handle(arr.getString(i)) })
+  implicit def decodeOptHandle(s: Symbol)(implicit js: JSONObject): Option[Handle] = opt(s, js => Handle.from(js.getString(s.name)))
+  implicit def decodeHandleSeq(s: Symbol)(implicit js: JSONObject): Seq[Handle] = array[Handle](s)({ (arr, i) => Handle.from(arr.getString(i)) })
 
   implicit def decodePushToken(s: Symbol)(implicit js: JSONObject): PushToken = PushToken(js.getString(s.name))
 
@@ -200,7 +200,7 @@ object JsonDecoder {
   implicit def decodeUploadAssetId(s: Symbol)(implicit js: JSONObject): UploadAssetId = UploadAssetId(js.getString(s.name))
   implicit def decodeRAssetId(s: Symbol)(implicit js: JSONObject): RAssetId = RAssetId(js.getString(s.name))
   implicit def decodeMessageId(s: Symbol)(implicit js: JSONObject): MessageId = MessageId(js.getString(s.name))
-  implicit def decodeHandle(s: Symbol)(implicit js: JSONObject): Handle = Handle(js.getString(s.name))
+  implicit def decodeHandle(s: Symbol)(implicit js: JSONObject): Handle = Handle.from(js.getString(s.name))
   implicit def decodeInvitationId(s: Symbol)(implicit js: JSONObject): InvitationId = InvitationId(js.getString(s.name))
   implicit def decodeMessage(s: Symbol)(implicit js: JSONObject): GenericMessage = GenericMessage(AESUtils.base64(decodeString(s)))
   implicit def decodeMessageIdSeq(s: Symbol)(implicit js: JSONObject): Seq[MessageId] = array[MessageId](s)({ (arr, i) => MessageId(arr.getString(i)) })

--- a/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
@@ -32,7 +32,7 @@ class UserDataSpec extends AndroidFreeSpec {
     None, // ignoring pictures for now
     Some(TrackingId("123454fsdf")),
     false,
-    Some(Handle("atticus")),
+    Some(Handle.from("atticus")),
     Some(false),
     Some(Service(
       IntegrationId("f0f83af0-c7d3-42b7-ab8b-7fc137ee7173"),

--- a/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
@@ -19,6 +19,7 @@ package com.waz.model
 
 import com.waz.model.UserInfo.Service
 import com.waz.specs.AndroidFreeSpec
+import com.waz.zms.BuildConfig
 
 class UserDataSpec extends AndroidFreeSpec {
 
@@ -54,7 +55,11 @@ class UserDataSpec extends AndroidFreeSpec {
 
       // THEN
       data.id.shouldEqual(referenceInfo.id)
-      data.domain.shouldEqual(referenceInfo.domain)
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        data.domain.shouldEqual(referenceInfo.domain)
+      } else {
+        data.domain.shouldEqual(None)
+      }
       data.name.shouldEqual(referenceInfo.name.get)
       data.accent.shouldEqual(referenceInfo.accentId.get)
       data.email.shouldEqual(referenceInfo.email)

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -70,59 +70,59 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     id('l) -> UserData.withName(id('l), "Bjorn-Rodrigo Smith"),
     id('m) -> UserData.withName(id('m), "John Smith"),
     id('n) -> UserData.withName(id('n), "Jason-John Mercier"),
-    id('o) -> UserData.withName(id('o), "Captain Crunch").copy(handle = Some(Handle("john"))),
-    id('p) -> UserData.withName(id('p), "Peter Pan").copy(handle = Some(Handle("john"))),
+    id('o) -> UserData.withName(id('o), "Captain Crunch").copy(handle = Some(Handle.from("john"))),
+    id('p) -> UserData.withName(id('p), "Peter Pan").copy(handle = Some(Handle.from("john"))),
     id('q) -> UserData.withName(id('q), "James gjohnjones"),
-    id('r) -> UserData.withName(id('r), "Liv Boeree").copy(handle = Some(Handle("testjohntest"))),
-    id('s) -> UserData.withName(id('s), "blah").copy(handle = Some(Handle("mores"))),
-    id('t) -> UserData.withName(id('t), "test handle").copy(handle = Some(Handle("smoresare"))),
+    id('r) -> UserData.withName(id('r), "Liv Boeree").copy(handle = Some(Handle.from("testjohntest"))),
+    id('s) -> UserData.withName(id('s), "blah").copy(handle = Some(Handle.from("mores"))),
+    id('t) -> UserData.withName(id('t), "test handle").copy(handle = Some(Handle.from("smoresare"))),
     id('u) -> UserData.withName(id('u), "Wireless").copy(expiresAt = Some(RemoteInstant.ofEpochMilli(12345L))),
     id('v) -> UserData.withName(id('v), "Wireful"),
     id('z) -> UserData.withName(id('z), "Francois francois"),
     id('pp1) -> UserData.withName(id('pp1), "External 1").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
-      handle = Some(Handle("pp1")),
+      handle = Some(Handle.from("pp1")),
       createdBy = Some(id('aa1))
     ),
     id('pp2) -> UserData.withName(id('pp2), "External 2").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
-      handle = Some(Handle("pp2")),
+      handle = Some(Handle.from("pp2")),
       createdBy = Some(id('aa2))
     ),
     id('pp3) -> UserData.withName(id('pp3), "External 3").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
-      handle = Some(Handle("pp3"))
+      handle = Some(Handle.from("pp3"))
     ),
     id('mm1) -> UserData.withName(id('mm1), "Member 1").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
-      handle = Some(Handle("mm1")),
+      handle = Some(Handle.from("mm1")),
       createdBy = Some(id('aa1))
     ),
     id('mm2) -> UserData.withName(id('mm2), "Member 2").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
-      handle = Some(Handle("mm2")),
+      handle = Some(Handle.from("mm2")),
       createdBy = Some(id('aa1))
     ),
     id('mm3) -> UserData.withName(id('mm3), "Member 3").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
-      handle = Some(Handle("mm3")),
+      handle = Some(Handle.from("mm3")),
       createdBy = Some(id('aa1))
     ),
     id('aa1) -> UserData.withName(id('aa1), "Admin 1").copy(
       permissions = (adminPermissions, adminPermissions),
       teamId = teamId,
-      handle = Some(Handle("aa1"))
+      handle = Some(Handle.from("aa1"))
     ),
     id('aa2) -> UserData.withName(id('aa2), "Admin 2").copy(
       permissions = (adminPermissions, adminPermissions),
       teamId = teamId,
-      handle = Some(Handle("aa2"))
+      handle = Some(Handle.from("aa2"))
     ),
     id('me1) -> UserData.withName(id('me1), "Team Member With Email").copy(
       email = Some(EmailAddress("a_member@wire.com")),

--- a/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -68,11 +68,11 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
     val initialTeamMembers = Set(
-      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
-      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty),
+      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
     )
 
-    val newTeamMember = UserData(UserId(), None, teamId, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val newTeamMember = UserData(UserId(), None, teamId, Name("user3"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
 
     (userStorage.getByTeam _).expects(Set(teamId).flatten).once().returning(Future.successful(initialTeamMembers))
 
@@ -100,8 +100,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
 
-    val member1 = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.simple("user1"))
-    val member2 = UserData(UserId(), None, teamId, Name("rick2"), handle = Some(Handle()), searchKey = SearchKey.simple("rick2"))
+    val member1 = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle.Empty), searchKey = SearchKey.simple("user1"))
+    val member2 = UserData(UserId(), None, teamId, Name("rick2"), handle = Some(Handle.Empty), searchKey = SearchKey.simple("rick2"))
     val member2Updated = member2.copy(name = Name("user2"), searchKey = SearchKey.simple("user2"))
 
     val query = SearchQuery("user")
@@ -132,11 +132,11 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
     val initialTeamMembers = Set(
-      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty),
-      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+      UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty),
+      UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
     )
 
-    val newTeamMember = UserData(UserId(), None, None, Name("user3"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val newTeamMember = UserData(UserId(), None, None, Name("user3"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
 
     (userStorage.getByTeam _).expects(Set(teamId).flatten).once().returning(Future.successful(initialTeamMembers))
 
@@ -163,8 +163,8 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (userStorage.onUpdated _).expects().once().returning(userStorageOnUpdated)
     (userStorage.onDeleted _).expects().once().returning(userStorageOnDeleted)
 
-    val constUser = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
-    val teamMemberToUpdate = UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val constUser = UserData(UserId(), None, teamId, Name("user1"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
+    val teamMemberToUpdate = UserData(UserId(), None, teamId, Name("user2"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
     val updatedTeamMember = teamMemberToUpdate.copy(name = Name("user3"))
 
     val initialTeamMembers = Set(constUser, teamMemberToUpdate)
@@ -186,7 +186,7 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     // GIVEN
     val createdBy = id('creator)
     val permissions = TeamsClient.Permissions(123, 890)
-    val userData = UserData(selfUser, None, teamId, Name("user1"), handle = Some(Handle()), searchKey = SearchKey.Empty)
+    val userData = UserData(selfUser, None, teamId, Name("user1"), handle = Some(Handle.Empty), searchKey = SearchKey.Empty)
     val service = createService
     val teamMember = TeamMember(selfUser, Some(permissions), Some(createdBy))
 


### PR DESCRIPTION
If the user data contains the domain, the handle (or "username") of that user should look like this: `@personalhandle@domain` instead of just `@personalhandle`. But editing the handle is still possible only for the personal handle. I also added "Domain" and "Team" fields to the Account view. They're not editable. (the "Team" does not belong to the Federation feature, but it was missing, while the design docs show it just next to "Domain").

Still needs testing.
#### APK
[Download build #3964](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3964/artifact/build/artifact/wire-dev-PR3507-3964.apk)
[Download build #3965](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3965/artifact/build/artifact/wire-dev-PR3507-3965.apk)