### PR TITLE
Federation: Simplify post conversation

### DIFF
--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -37,7 +37,6 @@ public enum SyncCommand {
     SyncQualifiedSearchResults("sync-qualified-search-results"),
     SyncProperties("sync-properties"),
     PostConv("post-conv"),
-    PostQualifiedConv("post-qualified-conv"),
     PostConvReceiptMode("post-conv-receipt-mode"),
     PostConvName("post-conv-name"),
     PostConvState("post-conv-state"),

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -83,7 +83,7 @@ trait SyncServiceHandle {
   def postConversationMemberLeave(id: ConvId, member: QualifiedId): Future[SyncId]
   def postConversationState(id: ConvId, state: ConversationState): Future[SyncId]
   def postConversation(id:          ConvId,
-                       users:       Set[UserId],
+                       otherUser:   Option[UserId],
                        name:        Option[Name],
                        team:        Option[TeamId],
                        access:      Set[Access],
@@ -91,15 +91,6 @@ trait SyncServiceHandle {
                        receiptMode: Option[Int],
                        defaultRole: ConversationRole
                       ): Future[SyncId]
-  def postQualifiedConversation(id:          ConvId,
-                                users:       Set[QualifiedId],
-                                name:        Option[Name],
-                                team:        Option[TeamId],
-                                access:      Set[Access],
-                                accessRole:  AccessRole,
-                                receiptMode: Option[Int],
-                                defaultRole: ConversationRole
-                               ): Future[SyncId]
   def postConversationRole(id: ConvId, member: UserId, newRole: ConversationRole, origRole: ConversationRole): Future[SyncId]
   def postLastRead(id: ConvId, time: RemoteInstant): Future[SyncId]
   def postCleared(id: ConvId, time: RemoteInstant): Future[SyncId]
@@ -200,23 +191,14 @@ class AndroidSyncServiceHandle(account:         UserId,
   def postConversationMemberLeave(id: ConvId, member: UserId): Future[SyncId] = addRequest(PostConvLeave(id, member))
   def postConversationMemberLeave(id: ConvId, member: QualifiedId): Future[SyncId] = addRequest(PostQualifiedConvLeave(id, member))
   def postConversation(id: ConvId,
-                       users: Set[UserId],
+                       otherUser: Option[UserId],
                        name: Option[Name],
                        team: Option[TeamId],
                        access: Set[Access],
                        accessRole: AccessRole,
                        receiptMode: Option[Int],
                        defaultRole: ConversationRole): Future[SyncId] =
-    addRequest(PostConv(id, users, name, team, access, accessRole, receiptMode, defaultRole))
-  def postQualifiedConversation(id: ConvId,
-                                users: Set[QualifiedId],
-                                name: Option[Name],
-                                team: Option[TeamId],
-                                access: Set[Access],
-                                accessRole: AccessRole,
-                                receiptMode: Option[Int],
-                                defaultRole: ConversationRole): Future[SyncId] =
-    addRequest(PostQualifiedConv(id, users, name, team, access, accessRole, receiptMode, defaultRole))
+    addRequest(PostConv(id, otherUser, name, team, access, accessRole, receiptMode, defaultRole))
   def postReceiptMode(id: ConvId, receiptMode: Int): Future[SyncId] = addRequest(PostConvReceiptMode(id, receiptMode))
   def postConversationRole(id: ConvId, member: UserId, newRole: ConversationRole, origRole: ConversationRole): Future[SyncId] = addRequest(PostConvRole(id, member, newRole, origRole))
   def postLiking(id: ConvId, liking: Liking): Future[SyncId] = addRequest(PostLiking(id, liking))
@@ -351,8 +333,6 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case PostQualifiedConvLeave(convId, qId)             => zms.conversationSync.postConversationMemberLeave(convId, qId)
           case PostConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>
             zms.conversationSync.postConversation(convId, u, name, team, access, accessRole, receiptMode, defRole)
-          case PostQualifiedConv(convId, u, name, team, access, accessRole, receiptMode, defRole) =>
-            zms.conversationSync.postQualifiedConversation(convId, u, name, team, access, accessRole, receiptMode, defRole)
           case PostConvName(convId, name)                      => zms.conversationSync.postConversationName(convId, name)
           case PostConvReceiptMode(convId, receiptMode)        => zms.conversationSync.postConversationReceiptMode(convId, receiptMode)
           case PostConvState(convId, state)                    => zms.conversationSync.postConversationState(convId, state)

--- a/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
@@ -150,6 +150,7 @@ object JsonDecoder {
   implicit def decodeOptAssetId(s: Symbol)(implicit js: JSONObject): Option[AssetId] = opt(s, js => AssetId(js.getString(s.name)))
   implicit def decodeOptUploadAssetId(s: Symbol)(implicit js: JSONObject): Option[UploadAssetId] = opt(s, js => UploadAssetId(js.getString(s.name)))
   implicit def decodeOptClientId(s: Symbol)(implicit js: JSONObject): Option[ClientId] = opt(s, js => ClientId(js.getString(s.name)))
+  implicit def decodeOptUserId(s: Symbol)(implicit js: JSONObject): Option[UserId] = opt(s, js => UserId(js.getString(s.name)))
   implicit def decodeOptTeamId(s: Symbol)(implicit js: JSONObject): Option[TeamId] = opt(s, js => TeamId(js.getString(s.name)))
   implicit def decodeOptRAssetId(s: Symbol)(implicit js: JSONObject): Option[RAssetId] = opt(s, js => RAssetId(js.getString(s.name)))
   implicit def decodeOptRConvId(s: Symbol)(implicit js: JSONObject): Option[RConvId] = opt(s, js => RConvId(js.getString(s.name)))

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -468,7 +468,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       (content.createConversation _).expects(*, *, ConversationType.Group, selfUserId, *, *, *, *, *, *).once().returning(Future.successful(conv))
       (messages.addConversationStartMessage _).expects(*, selfUserId, *, *, *, *).once().returning(Future.successful(()))
-      (sync.postConversation _).expects(*, Set.empty[UserId], Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
+      (sync.postConversation _).expects(*, Option.empty[UserId], Some(convName), Some(teamId), *, *, *, *).once().returning(Future.successful(syncId))
       (requests.await(_: SyncId)).expects(*).anyNumberOfTimes().returning(Future.successful(SyncResult.Success))
       (userService.findUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
       (membersStorage.isActiveMember _).expects(conv.id, *).anyNumberOfTimes().returning(Future.successful(true))

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -201,7 +201,7 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
     val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
 
     // Mock
-    (convs.convById _)
+    (convStorage.get _)
       .expects(convId)
       .once()
       .returning(Future.successful(Some(ConversationData(convId))))
@@ -231,7 +231,7 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
       val errorResponse = ErrorResponse(412, "", "missing-legalhold-consent")
 
       // Mock
-      (convs.convById _)
+      (convStorage.get _)
         .expects(convId)
         .once()
         .returning(Future.successful(Some(ConversationData(convId))))
@@ -281,7 +281,7 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
     // When (arguments are irrelevant)
     result(handler.postConversation(
       convId,
-      Set(UserId("userId")),
+      Some(UserId("userId")),
       None,
       None,
       Set.empty,


### PR DESCRIPTION
I realized that the post conversation endpoint stays the same in federation and non-federation.
A new conversation is always created on the backend of the creator so there's no need to provide
the qualified conversation id. This lets me simplify the code.

On top of that, the fact that now we create new group conversations without members and only add members later - that also let me simplify the code a bit.
#### APK
[Download build #3962](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3962/artifact/build/artifact/wire-dev-PR3508-3962.apk)
[Download build #3975](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3975/artifact/build/artifact/wire-dev-PR3508-3975.apk)