### PR TITLE
fix: Creating a new conversation fails

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -283,9 +283,9 @@ class ConversationsClientImpl(implicit
   override def postConversation(state: ConversationInitState): ErrorOrResponse[ConversationResponse] = {
     verbose(l"postConversation($state): \n${ConversationInitState.Encoder(state).toString(2)}")
     Request.Post(relativePath = ConversationsPath, body = state)
-      .withResultType[ConversationsResult]
+      .withResultType[ConversationResponse]
       .withErrorType[ErrorResponse]
-      .executeSafe(_.conversations.head)
+      .executeSafe
   }
 
   override def postConversationRole(conv: RConvId, userId: UserId, role: ConversationRole): ErrorOrResponse[Unit] = {


### PR DESCRIPTION
At some point of working on federation I made a mistake in the name of the class which should be used in deserialization
of the response (a json object) returned from the backend when we create a new conversation. The faulty code not only
didn't fail at compilation but also at runtime it just ignored the error and failed at a different place, giving a wrong
error message. It took me quite a while to figure out what's actually wrong.

What's even worse, this code is written in a way that makes it really hard to unit test it. I can't think of any way
right now that wouldn't be a few days of work of preparing mocks and actually testing the tests. It was supposed
to be type-safe which would make unit tests unnecessary. As we know now, it's not.

## What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues. (Optional)_

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Testing

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

## Notes

_Specify here any other facts that you think are important for this issue. (Optional)_
