### PR TITLE
Automation help : Increase the display duration for the calling overlay in internal builds

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -268,8 +268,11 @@ class CallController(implicit inj: Injector, cxt: WireContext)
     (for {
       Some(est)    <- currentCall.map(_.estabTime)
       (show, last) <- lastControlsClick.orElse(Signal.const((true, clock.instant())))
-      display      <- if (show) ClockSignal(3.seconds).map(c => last.max(est.instant).until(c).asScala <= 3.seconds)
-      else Signal.const(false)
+      display      <-
+        if (show) {
+           if (BuildConfig.FLAVOR.equals("internal")) ClockSignal(8.seconds).map(c => last.max(est.instant).until(c).asScala <= 8.seconds)
+           else ClockSignal(3.seconds).map(c => last.max(est.instant).until(c).asScala <= 3.seconds)
+        } else Signal.const(false)
     } yield display).orElse(Signal.const(true))
   else
     (for {


### PR DESCRIPTION
## What's new in this PR?

This PR intends to help automation to detect the call overlay. The display time is increased from 3 to 8 in internal builds only.

#### APK
[Download build #3966](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3966/artifact/build/artifact/wire-dev-PR3510-3966.apk)