### PR TITLE
Federation: Use qualified target in conversation events

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -292,8 +292,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
       for {
         _      <- content.updateConversationState(conv.id, state)
         _      <- (state.target, state.conversationRole) match {
-                    case (Some(id), Some(role)) => membersStorage.updateOrCreate(conv.id, id, role)
-                    case _                      => Future.successful(())
+                    case (Some(qId), Some(role)) => membersStorage.updateOrCreate(conv.id, qId.id, role)
+                    case _                       => Future.successful(())
                   }
         syncId <- users.syncIfNeeded(Set(userId))
         _      <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -413,8 +413,8 @@ object ConversationsClient {
         val members = js.getJSONObject("members")
         val state = ConversationState.Decoder(members.getJSONObject("self"))
         val selfRole: Map[QualifiedId, ConversationRole] = (state.target, state.conversationRole) match {
-          case (Some(id), Some(role)) => Map(QualifiedId(id) -> role)
-          case _                      => Map.empty
+          case (Some(qId), Some(role)) => Map(qId -> role)
+          case _                       => Map.empty
         }
 
         val (id, domain) =

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -222,7 +222,6 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       }
     }
 
-
     scenario("Parse MemberUpdateEvent") {
       val rConvId = RConvId("bbe1053c-4999-4324-8a2a-851ce48c56c5")
       val userId = UserId("b937e85e-3611-4e29-9bda-6fe39dfd4bd0")
@@ -243,11 +242,40 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
         case ev: MemberUpdateEvent =>
           ev.convId shouldEqual rConvId
           ev.from shouldEqual senderId
-          ev.state.target shouldEqual Some(userId)
+          ev.state.target.map(_.id) shouldEqual Some(userId)
           ev.state.conversationRole shouldEqual Some(ConversationRole.AdminRole)
         case e => fail(s"unexpected event: $e")
       }
+    }
 
+    scenario("Parse MemberUpdateEvent with a qualified target") {
+      val rConvId = RConvId("bbe1053c-4999-4324-8a2a-851ce48c56c5")
+      val userId = UserId("b937e85e-3611-4e29-9bda-6fe39dfd4bd0")
+      val senderId = UserId("bea00721-4af0-4204-82a7-e152c9722ddc")
+      val domain = "chala.wire.link"
+      val jsonStr =
+        s"""
+           |{
+           |  "conversation": "${rConvId.str}",
+           |  "time": "2019-12-11T12:40:38.426Z",
+           |  "data": { "conversation_role":"${ConversationRole.AdminRole.label}",
+           |            "target": "${userId.str}",
+           |            "qualified_target": { "id": "${userId.str}", "domain": "$domain" }
+           |          },
+           |  "from": "${senderId.str}",
+           |  "type":"conversation.member-update"
+           |}
+         """.stripMargin
+
+      val jsonObject = new JSONObject(jsonStr)
+      EventDecoder(jsonObject) match {
+        case ev: MemberUpdateEvent =>
+          ev.convId shouldEqual rConvId
+          ev.from shouldEqual senderId
+          ev.state.target shouldEqual Some(QualifiedId(userId, domain))
+          ev.state.conversationRole shouldEqual Some(ConversationRole.AdminRole)
+        case e => fail(s"unexpected event: $e")
+      }
     }
 
     scenario("Parse MemberLeaveEvent with reason") {


### PR DESCRIPTION
Conversation event will now carry "qualified_target" - a qualified id of the user associated with the event (e.g. the conversation member that should be updated). The old "target" field will be eventually removed.
#### APK
[Download build #3968](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3968/artifact/build/artifact/wire-dev-PR3512-3968.apk)