### PR TITLE
[Calling] Large Conference calls - Bugfix : tiles are ordered per page but not globally

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/CallingGridFragment.scala
@@ -109,7 +109,7 @@ class CallingGridFragment extends FragmentHelper {
           val startIndex = pageNumber * MAX_PARTICIPANTS_PER_PAGE
           val endIndex = startIndex + MAX_PARTICIPANTS_PER_PAGE
 
-          val participantsToShow = (orderedParticipants(participants, participantsInfo.toIdMap, selfClientId).slice(startIndex, endIndex), size) match {
+          val participantsToShow = (orderedParticipants(participants, participantsInfo.toIdMap, selfUserId, selfClientId).slice(startIndex, endIndex), size) match {
             case (ps, 2) => ps.filter(_.clientId != selfClientId)
             case (ps, _) => ps
           }
@@ -120,10 +120,12 @@ class CallingGridFragment extends FragmentHelper {
     }
   }
 
-  private def orderedParticipants(participants : Set[Participant], infoMap : Map[UserId, CallParticipantInfo], selfClientId : ClientId): Seq[Participant] =
+  private def orderedParticipants(participants: Set[Participant], infoMap: Map[UserId, CallParticipantInfo], selfUserId: UserId, selfClientId: ClientId): Seq[Participant] =
     participants.toSeq.sortWith {
-      case (p, _) if p.clientId == selfClientId => true
-      case (_, p) if p.clientId == selfClientId => false
+      case (p, _) if p.userId == selfUserId && p.clientId == selfClientId => true
+      case (_, p) if p.userId == selfUserId && p.clientId == selfClientId => false
+      case (p, _) if p.userId == selfUserId => true
+      case (_, p) if p.userId == selfUserId => false
       case (p1, p2) if isVideoUser(infoMap(p1.userId)) && !isVideoUser(infoMap(p2.userId)) => true
       case (p1, p2) if !isVideoUser(infoMap(p1.userId)) && isVideoUser(infoMap(p2.userId)) => false
       case (p1, p2) => infoMap(p1.userId).displayName.toLowerCase < infoMap(p2.userId).displayName.toLowerCase


### PR DESCRIPTION
## What's new in this PR?

### Issues

During the latest internal test for large conference calls, I realised that logic of ordering the tiles was applied per page which is different from the following acceptance criteria: 

Participants in the conference call should appear in the following order:
- me, myself & I (always, with or without the camera on)
- participants with video ON, ordered by alphabet
- participants with video OFF, ordered by alphabet

https://wearezeta.atlassian.net/browse/SQCALL-389

### Solution

Apply the order earlier before passing the list of participants to show in every page.

#### APK
[Download build #3970](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3970/artifact/build/artifact/wire-dev-PR3514-3970.apk)
[Download build #3974](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3974/artifact/build/artifact/wire-dev-PR3514-3974.apk)