### PR TITLE
[Calling] : Bump AVS version to 7.2.95

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -4,7 +4,7 @@ final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
 final String AVS_GROUP = "com.wire"
 final String AVS_NAME = "avs"
 
-String avsVersion = "7.2.87"
+String avsVersion = "7.2.95"
 
 ext {
     avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_GROUP


### PR DESCRIPTION
## What's new in this PR?

Bump AVS to the latest version 7.2.95

#### APK
[Download build #3976](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3976/artifact/build/artifact/wire-dev-PR3515-3976.apk)