### PR TITLE
Replace icu4j-shrunk dependency with native equivalent

### DIFF
--- a/zmessaging/build.gradle
+++ b/zmessaging/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation "io.circe:circe-core_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-generic_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
     implementation "io.circe:circe-parser_${LegacyDependencies.SCALA_MAJOR_VERSION}:$versions.circe"
-    implementation "com.wire:icu4j-shrunk:57.1"
     implementation "com.googlecode.mp4parser:isoparser:1.1.7"
     implementation BuildDependencies.wireSignals
     implementation BuildDependencies.wireSignalsExtensions

--- a/zmessaging/src/main/scala/com/waz/utils/Locales.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/Locales.scala
@@ -105,8 +105,9 @@ object Transliteration extends DerivedLogTag {
 
 object ICU4JTransliteration {
   def create(id: String)(implicit logTag: LogTag): Transliteration = new Transliteration {
-    debug(l"using ICU4J transliteration")(logTag)
-    private val delegate = com.ibm.icu.text.Transliterator.getInstance(id)
+    debug(l"using ICU transliteration")(logTag) // available since Android 7
+
+    private val delegate = android.icu.text.Transliterator.getInstance(id)
     def transliterate(s: String): String = delegate.transliterate(s)
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The dependency com.wire.icu4j-shrunk is currently blocking a F-Droid release because this dependency is nowhere uploaded to a public open source maven repository. Instead of uploading it to a repo and having to maintain it we decided to finally completely remove it.

### Solutions

Some work has already been done to remove icu4j dependencies by @makingthematrix : https://github.com/wireapp/wire-android/pull/3221

Now it was easy to exchange the only call to icu4j with the android native equivalent that is available since Android 7.

### Testing

It compiles but i did not test it on runtime.


#### APK
[Download build #3981](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3981/artifact/build/artifact/wire-dev-PR3519-3981.apk)