### PR TITLE
fix: User sees enterprise alert when starting 1:1 call in a non paying team

### DIFF
--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -382,12 +382,12 @@ class ConversationFragment extends FragmentHelper {
 
     def performCall(item: MenuItem): Unit = {
       for {
-        conversationType <- convController.currentConvType.head
-        isTeam <- accountsController.isTeam.head
-        isAdmin <- accountsController.isAdmin.head
+        isGroup        <- convController.currentConvIsGroup.head
+        isTeam         <- accountsController.isTeam.head
+        isAdmin        <- accountsController.isAdmin.head
         callRestricted <- isConferenceCallingRestricted
       } yield
-        if (conversationType == ConversationType.Group && callRestricted && BuildConfig.CONFERENCE_CALLING_RESTRICTION)
+        if (isGroup && callRestricted && BuildConfig.CONFERENCE_CALLING_RESTRICTION)
           displayWarningDialogs(isAdmin, isTeam)
         else {
           callStartController.startCallInCurrentConv(withVideo = item.getItemId == R.id.action_video_call, forceOption = true)


### PR DESCRIPTION
fixes https://wearezeta.atlassian.net/browse/SQSERVICES-842

The alert should be visible only for real group conversations, that is, if there are more than two participants
or if the name of the conversation is customized, indicating that even though there are only two people in,
it's still considered a group conv, not a fake 1-to-1.
The bug was because we checked explicitely if the conversation type is GROUP, but this is not enough.
#### APK
[Download build #3982](http://10.10.124.11:8080/job/Pull%20Request%20Builder/3982/artifact/build/artifact/wire-dev-PR3520-3982.apk)