### PR TITLE
Fix: App crashing on minified builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,15 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# For E2EE
+-keep class com.wire.cryptobox.** { *; }
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+# Gson
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}


### PR DESCRIPTION
### The issue
Minified builds are crashing when deserialising using Gson.

Also crashing when attempting to JNI + native methods.

### The fix
Added proguard rules!