### PR TITLE
Chore: change URL to prod environment on release build type

### DIFF
--- a/buildSrc/src/main/kotlin/ClientConfig.kt
+++ b/buildSrc/src/main/kotlin/ClientConfig.kt
@@ -4,9 +4,9 @@ import scripts.Variants_gradle.BuildTypes
  * Config fields with DEFAULT values per Build Type.
  */
 enum class ConfigFields(val defaultValue: String) {
-    API_BASE_URL("\"https://staging-nginz-https.zinfra.io\""),
-    ACCOUNTS_URL("\"https://wire-account-staging.zinfra.io\""),
-    WEB_SOCKET_URL("\"https://staging-nginz-ssl.zinfra.io/await?client=\"")
+    API_BASE_URL(""""https://staging-nginz-https.zinfra.io""""),
+    ACCOUNTS_URL(""""https://wire-account-staging.zinfra.io""""),
+    WEB_SOCKET_URL(""""https://staging-nginz-ssl.zinfra.io/await?client="""")
 }
 
 /**
@@ -22,10 +22,11 @@ object ClientConfig {
             ConfigFields.WEB_SOCKET_URL to ConfigFields.WEB_SOCKET_URL.defaultValue
         ),
         //Config field values for RELEASE Build Type
+        //TODO: Certificate pinning, change backend based on flavour
         BuildTypes.RELEASE to mapOf(
-            ConfigFields.API_BASE_URL to ConfigFields.API_BASE_URL.defaultValue,
-            ConfigFields.ACCOUNTS_URL to ConfigFields.ACCOUNTS_URL.defaultValue,
-            ConfigFields.WEB_SOCKET_URL to ConfigFields.WEB_SOCKET_URL.defaultValue
+            ConfigFields.API_BASE_URL to """"https://prod-nginz-https.wire.com"""",
+            ConfigFields.ACCOUNTS_URL to """"https://account.wire.com"""",
+            ConfigFields.WEB_SOCKET_URL to """"https://prod-nginz-ssl.wire.com""""
         )
     )
 }


### PR DESCRIPTION
In order for internal users to test the application with useful content, the URL for releases should targe the production backend.