### PR TITLE
Send messages: Part 5 - Add mapping and encryption of message content

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/conversation/content/MessageRepository.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/content/MessageRepository.kt
@@ -1,5 +1,6 @@
 package com.wire.android.feature.conversation.content
 
+import com.wire.android.core.crypto.model.EncryptedMessage
 import com.wire.android.core.crypto.model.PreKey
 import com.wire.android.core.exception.Failure
 import com.wire.android.core.functional.Either
@@ -18,6 +19,14 @@ interface MessageRepository {
         contactClientId: String,
         preKey: PreKey
     ): Either<Failure, Unit>
+
+    suspend fun encryptMessageContent(
+        senderUserId: String,
+        receiverUserId: String,
+        receiverClientId: String,
+        messageId: String,
+        content: Content
+    ): Either<Failure, EncryptedMessage>
 
     suspend fun storeOutgoingMessage(message: Message): Either<Failure, Unit>
 

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/content/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/content/mapper/MessageContentMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.android.feature.conversation.content.mapper
 
 import com.waz.model.Messages
+import com.wire.android.core.crypto.model.PlainMessage
 import com.wire.android.feature.conversation.content.Content
 
 class MessageContentMapper {
@@ -14,6 +15,21 @@ class MessageContentMapper {
         } else {
             Content.Text("This message content is UNKNOWN")
         }
+    }
+
+    fun fromContentToPlainMessage(messageUid: String, content: Content): PlainMessage {
+        val builder = Messages.GenericMessage.newBuilder()
+            .setMessageId(messageUid)
+
+        when (content) {
+            is Content.Text -> {
+                val text = Messages.Text.newBuilder()
+                    .setContent(content.value)
+                    .build()
+                builder.text = text
+            }
+        }
+        return PlainMessage(builder.build().toByteArray())
     }
 
     fun fromStringToContent(type: String, rawContent: String): Content = when (type) {

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/di/ConversationsModule.kt
@@ -102,7 +102,7 @@ val conversationContentModule = module {
     factory<SendMessageWorkerScheduler> { AndroidSendMessageWorkerScheduler(get()) }
     factory { MessageStateMapper() }
     factory { MessageMapper(get(), get(), get()) }
-    factory<MessageRepository> { MessageDataSource(get(), get(), get(), get()) }
+    factory<MessageRepository> { MessageDataSource(get(), get(), get(), get(), get()) }
     single { ConversationNavigator() }
     factory { GetConversationUseCase(get()) }
     viewModel { ConversationViewModel(get(), get(), get()) }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/content/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/content/mapper/MessageContentMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.android.feature.conversation.content.mapper
 
+import com.waz.model.Messages
 import com.wire.android.UnitTest
 import com.wire.android.feature.conversation.content.Content
 import org.amshove.kluent.shouldBeEqualTo
@@ -28,6 +29,34 @@ class MessageContentMapperTest : UnitTest() {
     @Test
     fun `given a text type and raw content, when calling fromStringToContent, then returns proper Content`() {
         messageContentMapper.fromStringToContent(TEST_MESSAGE_TYPE_TEXT, "Hello") shouldBeEqualTo Content.Text("Hello")
+    }
+
+    @Test
+    fun `given a messageUid and a text content, when calling fromContentToPlainMessage, then should add Uid to the message`() {
+        val messageId = "some cool id"
+        val content = Content.Text("Servus")
+
+        val genericMessage = getGenericMessageFromMappedContent(messageId, content)
+
+        genericMessage.messageId shouldBeEqualTo messageId
+    }
+
+    @Test
+    fun `given a messageUid and a text content, when calling fromContentToPlainMessage, then should add text to the message`() {
+        val messageId = "some cool id v2"
+        val content = Content.Text("Servus")
+
+        val genericMessage = getGenericMessageFromMappedContent(messageId, content)
+
+        genericMessage.text.content shouldBeEqualTo content.value
+    }
+
+    private fun getGenericMessageFromMappedContent(
+        messageId: String,
+        content: Content.Text
+    ): Messages.GenericMessage {
+        val result = messageContentMapper.fromContentToPlainMessage(messageId, content)
+        return Messages.GenericMessage.parseFrom(result.data)
     }
 
     companion object {


### PR DESCRIPTION
## New

1. Map the content of a message to a ByteArray that can be understood by the message receiver;
2. Encrypt this data

