### PR TITLE
Send Messages - Part 9: Add self user to list of conversation members

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/ConversationMapper.kt
@@ -14,7 +14,8 @@ class ConversationMapper(private val conversationTypeMapper: ConversationTypeMap
 
     fun fromConversationResponseListToConversationMembers(responseList: List<ConversationResponse>): List<ConversationMemberEntity> =
         responseList.flatMap { conversation ->
-            val memberIds = conversation.members.otherMembers.map { it.userId }.filter { it.isNotEmpty() }
+            val memberIds = (conversation.members.otherMembers + conversation.members.self)
+                .map { it.userId }.filter { it.isNotEmpty() }
             memberIds.map {
                 ConversationMemberEntity(conversationId = conversation.id, contactId = it)
             }

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsResponse.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/data/remote/ConversationsResponse.kt
@@ -52,7 +52,7 @@ data class ConversationSelfMemberResponse(
     val hidden: Boolean?,
 
     @SerializedName("id")
-    val userId: String,
+    override val userId: String,
 
     @SerializedName("otr_archived")
     val otrArchived: Boolean?,
@@ -62,15 +62,19 @@ data class ConversationSelfMemberResponse(
 
     @SerializedName("otr_archived_ref")
     val otrArchiveReference: String?
-)
+) : ConversationMemberResponse
 
 data class ConversationOtherMembersResponse(
     @SerializedName("service")
     val service: ServiceReferenceResponse?,
 
     @SerializedName("id")
-    val userId: String,
-)
+    override val userId: String,
+) : ConversationMemberResponse
+
+interface ConversationMemberResponse {
+    val userId: String
+}
 
 data class ServiceReferenceResponse(
     @SerializedName("id")

--- a/app/src/main/kotlin/com/wire/android/feature/sync/di/SyncModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/sync/di/SyncModule.kt
@@ -26,5 +26,5 @@ val syncModule = module {
 
     factory { SyncConversationsUseCase(get()) }
     factory { SyncAllConversationMembersUseCase(get(), get()) }
-    factory { RefineConversationNamesUseCase(get(), get()) }
+    factory { RefineConversationNamesUseCase(get(), get(), get()) }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/data/ConversationMapperTest.kt
@@ -9,6 +9,7 @@ import com.wire.android.feature.conversation.data.local.ConversationEntity
 import com.wire.android.feature.conversation.data.remote.ConversationMembersResponse
 import com.wire.android.feature.conversation.data.remote.ConversationOtherMembersResponse
 import com.wire.android.feature.conversation.data.remote.ConversationResponse
+import com.wire.android.feature.conversation.data.remote.ConversationSelfMemberResponse
 import com.wire.android.feature.conversation.members.datasources.local.ConversationMemberEntity
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -60,8 +61,7 @@ class ConversationMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given a list of ConvResponse, when fromConversationResponseListToConversationMembers is called, then returns list of members`() {
-
+    fun `given a list of ConvResponse, when mapping conversation response, then returns list of members including self user ID`() {
         val conversation1 = mockConversationResponseWithMembers("conv-1", "member-1-1", "member-1-2", "member-1-3")
         val conversation2 = mockConversationResponseWithMembers("conv-2", "member-2-1", "")
         val conversation3 = mockConversationResponseWithMembers("conv-3")
@@ -77,7 +77,11 @@ class ConversationMapperTest : UnitTest() {
             ConversationMemberEntity("conv-1", "member-1-2"),
             ConversationMemberEntity("conv-1", "member-1-3"),
             ConversationMemberEntity("conv-2", "member-2-1"),
-            ConversationMemberEntity("conv-4", "member-4-1")
+            ConversationMemberEntity("conv-4", "member-4-1"),
+            ConversationMemberEntity("conv-1", SELF_USER_ID),
+            ConversationMemberEntity("conv-2", SELF_USER_ID),
+            ConversationMemberEntity("conv-3", SELF_USER_ID),
+            ConversationMemberEntity("conv-4", SELF_USER_ID)
         )
     }
 
@@ -126,10 +130,12 @@ class ConversationMapperTest : UnitTest() {
     companion object {
         private const val TEST_CONVERSATION_ID = "test-id-123"
         private const val TEST_CONVERSATION_NAME = "test-name"
+        private const val SELF_USER_ID = "self_user_id"
 
         private fun mockConversationResponseWithMembers(conversationId: String, vararg memberIds: String): ConversationResponse =
             mockk<ConversationResponse>().also {
                 every { it.id } returns conversationId
+
 
                 val membersResponse = mockk<ConversationMembersResponse>()
                 every { it.members } returns membersResponse
@@ -138,6 +144,11 @@ class ConversationMapperTest : UnitTest() {
                     mockk<ConversationOtherMembersResponse>().also { every { it.userId } returns memberId }
                 }
                 every { membersResponse.otherMembers } returns otherMembers
+
+                val selfResponse = mockk<ConversationSelfMemberResponse>()
+                every { selfResponse.userId } returns SELF_USER_ID
+
+                every { membersResponse.self } returns selfResponse
             }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncAllConversationMembersUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/sync/conversation/usecase/SyncAllConversationMembersUseCaseTest.kt
@@ -36,7 +36,7 @@ class SyncAllConversationMembersUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given run is called, when convRepo fails to retrieve all member ids, then directly propagates failure`() {
+    fun `given convRepo fails to retrieve all member ids, when run is called, then directly propagates failure`() {
         val failure = mockk<Failure>()
         coEvery { conversationRepository.allConversationMemberIds() } returns Either.Left(failure)
 
@@ -48,7 +48,7 @@ class SyncAllConversationMembersUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given run is called, when convRepo retrieves all member ids, then calls contactRepo to fetch contact info`() {
+    fun `given convRepo retrieves all member ids, when run is called, then calls contactRepo to fetch contact info`() {
         coEvery { conversationRepository.allConversationMemberIds() } returns Either.Right(TEST_MEMBER_IDS)
         coEvery { contactRepository.fetchContactsById(any()) } returns Either.Left(mockk())
 
@@ -61,7 +61,7 @@ class SyncAllConversationMembersUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given run is called and convRepo retrieved all member ids, when contactRepo fails to fetch contacts, then propagates failure`() {
+    fun `given contactRepo fails to fetch contacts and convRepo retrieved all member ids, when run is called , then propagates failure`() {
         coEvery { conversationRepository.allConversationMemberIds() } returns Either.Right(TEST_MEMBER_IDS)
         val failure = mockk<Failure>()
         coEvery { contactRepository.fetchContactsById(any()) } returns Either.Left(failure)
@@ -72,7 +72,7 @@ class SyncAllConversationMembersUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `given run is called and convRepo retrieved all member ids, when contactRepo fetches contacts, then propagates success`() {
+    fun `given contactRepo fetches contacts and convRepo retrieved all member ids, when run is called, then propagates success`() {
         coEvery { conversationRepository.allConversationMemberIds() } returns Either.Right(TEST_MEMBER_IDS)
         coEvery { contactRepository.fetchContactsById(any()) } returns Either.Right(mockk())
 


### PR DESCRIPTION
## The problem

When getting the members of conversation, the `self` user is not included.
This is needed both when displaying the list in the UI, and when sending messages. We need to send messages to all of the members, including `self`'s other clients.

## Possible approaches
There were two possible approaches here:
1. Don't ever add `self` to the list of conversation members directly, but get the current session and go from there when needed.
2. (Chosen approach) Add `self` to the list, and filter it out when necessary.

## Chosen approach

The second one felt more natural, and seems to reduce development and edge-cases handling.

At this point in time, the only place where we need to filter-out `self` from members, is when building a name for the conversation, so I also took care of it.

I do hope it doesn't come back to hunt me in the future 😅 