### PR TITLE
Federation: Display the "federated users are present" in the conversation banner

### DIFF
--- a/app/src/main/res/layout/fragment_conversation.xml
+++ b/app/src/main/res/layout/fragment_conversation.xml
@@ -162,7 +162,7 @@
                 android:visibility="visible">
 
                 <com.waz.zclient.ui.text.TypefaceTextView
-                    android:id="@+id/banner_text"
+                    android:id="@+id/guests_banner_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
@@ -171,9 +171,7 @@
                     android:textSize="@dimen/wire__text_size__smaller"
                     app:w_font="@string/wire__typeface__medium"
                     android:text="@string/guests_are_present"/>
-
             </FrameLayout>
-
         </FrameLayout>
 
         <com.waz.zclient.cursor.CursorView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1336,9 +1336,28 @@
     <string name="allow_guests_error_body">Could not allow guests nor services. Please try again.</string>
     <string name="allow_guests_warning_body">Current guests and services will be removed from the conversation. New guests and services will not be allowed.</string>
     <string name="allow_guests_warning_confirm">Remove</string>
-    <string name="guests_are_present">GUESTS ARE PRESENT</string>
-    <string name="services_are_present">SERVICES ARE ACTIVE</string>
-    <string name="guests_and_services_are_present">GUESTS AND SERVICES ARE PRESENT</string>
+
+    <string name="guests_are_present">Guests are present</string>
+    <string name="services_are_present">Services are active</string>
+    <string name="externals_are_present">Externals are present</string>
+    <string name="federated_are_present">Federated users are present</string>
+
+    <string name="guests_and_services_are_present">Guests and services are present</string>
+    <string name="externals_and_services_are_present">Externals and services are present</string>
+    <string name="federated_and_services_are_present">Federated users and services are present</string>
+
+    <string name="externals_and_guests_are_present">Externals and guests are present</string>
+    <string name="federated_and_guests_are_present">Federated users and guests are present</string>
+
+    <string name="federated_and_externals_are_present">Federated users and externals are present</string>
+
+    <string name="federated_externals_and_guests_are_present">Federated users, externals, and guests are present</string>
+    <string name="federated_externals_and_services_are_present">Federated users, externals, and services are present</string>
+    <string name="federated_guests_and_services_are_present">Federated users, guests, and services are present</string>
+    <string name="externals_guests_and_services_are_present">Externals, guests, and services are present</string>
+
+    <string name="federated_externals_guests_and_services_are_present">Federated users, externals, guests, and services are present</string>
+
     <string name="participants_details_header_title">DETAILS</string>
     <string name="invitation_link_description">Anyone with the link can join the conversation, even if they don\'t have Wire</string>
     <string name="create_link_button">Create Link</string>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -99,8 +99,8 @@ class ParticipantFragment extends ManagerFragment with ConversationScreenControl
           case Some(LegalHoldInfoFragment.Tag) =>
             createLegalHoldInfoFragment.map((_, LegalHoldInfoFragment.Tag))
           case _ =>
-            participantsController.isGroupOrBot.head.map {
-              case true if getStringArg(UserToOpenArg).isEmpty =>
+            participantsController.flags.head.map {
+              case flags if (flags.isGroup || flags.hasBot) && getStringArg(UserToOpenArg).isEmpty =>
                 (GroupParticipantsFragment.newInstance(), GroupParticipantsFragment.Tag)
               case _ =>
                 (SingleParticipantFragment.newInstance(fromDeepLink = getBooleanArg(FromDeepLinkArg)), SingleParticipantFragment.Tag)

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -223,11 +223,12 @@ class SingleParticipantFragment extends FragmentHelper {
       }
   }
 
-  protected lazy val leftActionStrings = for {
-    isWireless     <- participantsController.otherParticipant.map(_.expiresAt.isDefined)
-    isGroupOrBot   <- participantsController.isGroupOrBot
-    canCreateConv  <- userAccountsController.hasCreateConvPermission
-    isExternal     <- userAccountsController.isExternal
+  protected lazy val leftActionStrings: Signal[(Int, Int)] = for {
+    isWireless    <- participantsController.otherParticipant.map(_.expiresAt.isDefined)
+    flags         <- participantsController.flags
+    isGroupOrBot  =  flags.isGroup || flags.hasBot
+    canCreateConv <- userAccountsController.hasCreateConvPermission
+    isExternal    <- userAccountsController.isExternal
   } yield if (isWireless) {
     (R.string.empty_string, R.string.empty_string)
   } else if (fromDeepLink) {


### PR DESCRIPTION
Just as we already have banners in conversations that say "guests are present" and "services are active",
we want to display information about federated users in the conversation, and about special users - "externals".
Also, all the combinations of those four categories should be displayed accordingly.

"Federated users" is the new category but "externals" were also missing from the banner so I added them now.

The commit contains also some refactoring.