### PR TITLE
Add new list to either operator

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
+++ b/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
@@ -116,3 +116,14 @@ fun <L, R> Either<L, R>.getOrElse(value: R): R =
         is Either.Left -> value
         is Either.Right -> b
     }
+
+/**
+ * Folds a list into an Either while it doesn't go Left.
+ * Allows for accumulation of value through iterations.
+ * @return the final accumulated value if there are NO Left results, or the first Left result otherwise.
+ */
+fun <T, L, R> Iterable<T>.foldToEitherWhileRight(initialValue: R, fn: (item: T, accumulated: R) -> Either<L, R>): Either<L, R> {
+    return this.fold<T, Either<L, R>>(Either.Right(initialValue)) { acc, item ->
+        acc.flatMap { accumulatedValue -> fn(item, accumulatedValue) }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/core/functional/SuspendableEitherScope.kt
+++ b/app/src/main/kotlin/com/wire/android/core/functional/SuspendableEitherScope.kt
@@ -58,6 +58,20 @@ class SuspendableEitherScope {
             is Left -> Left(a)
             is Right -> Right(fn(b))
         }
+
+    /**
+     * Folds a list into an Either while it doesn't go Left.
+     * Allows for accumulation of value through iterations.
+     * @return the final accumulated value if there are NO Left results, or the first Left result otherwise.
+     */
+    suspend fun <T, L, R> Iterable<T>.foldToEitherWhileRight(
+        initialValue: R,
+        fn: suspend (item: T, accumulated: R) -> Either<L, R>
+    ): Either<L, R> {
+        return this.fold<T, Either<L, R>>(Right(initialValue)) { acc, item ->
+            acc.flatMap { accumulatedValue -> fn(item, accumulatedValue) }
+        }
+    }
 }
 
 suspend fun <T> suspending(block: suspend SuspendableEitherScope.() -> T): T = SuspendableEitherScope().block()


### PR DESCRIPTION
## New

`foldToEitherWhileRight` operator.

Folds a list into an Either while it it continues to produce Right values.
Allows for accumulation of value through iterations.
Returns the final accumulated value if there are no Left results, or the first Left result otherwise.

This is super useful when you have a list of things to process, they are processed one-at-a-time, but you want to stop once one fails.

For example, a establish a crypto session for a list of clients, stopping at the first failure.