### PR TITLE
fix: Users unable to send messages in some conversations

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -251,7 +251,7 @@ object ConversationData {
     val UnreadQuotesCount   = int('unread_quote_count)(_.unreadCount.quotes)
     val ReceiptMode         = opt(int('receipt_mode))(_.receiptMode)
     val LegalHoldStatus     = int[LegalHoldStatus]('legal_hold_status, _.value, ConversationData.LegalHoldStatus.apply)(_.legalHoldStatus)
-    val Domain              = text[model.Domain]('domain, _.str, model.Domain(_))(_.domain)
+    val Domain              = opt(text[model.Domain]('domain, _.str, model.Domain(_)))(c => Some(c.domain))
 
     private def getVerification(name: String): Verification =
       Try(Verification.valueOf(name)).getOrElse(Verification.UNKNOWN)
@@ -296,7 +296,8 @@ object ConversationData {
       Domain
     )
 
-    override def apply(implicit cursor: DBCursor): ConversationData =
+    override def apply(implicit cursor: DBCursor): ConversationData = {
+      def orEmpty(domain: Option[model.Domain]): model.Domain = domain.getOrElse(model.Domain.Empty)
       ConversationData(
         Id,
         RemoteId,
@@ -327,8 +328,9 @@ object ConversationData {
         Link,
         ReceiptMode,
         LegalHoldStatus,
-        Domain
+        orEmpty(Domain)
       )
+    }
 
     import com.waz.model.ConversationData.ConversationType._
 

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -218,7 +218,7 @@ object UserData {
 
   implicit object UserDataDao extends Dao[UserData, UserId] with StorageCodecs {
     val Id = id[UserId]('_id, "PRIMARY KEY").apply(_.id)
-    val Domain = text[model.Domain]('domain, _.str, model.Domain(_))(_.domain)
+    val Domain = opt(text[model.Domain]('domain, _.str, model.Domain(_)))(u => Some(u.domain))
     val TeamId = opt(id[TeamId]('teamId))(_.teamId)
     val Name = text[model.Name]('name, _.str, model.Name(_))(_.name)
     val Email = opt(emailAddress('email))(_.email)
@@ -265,10 +265,14 @@ object UserData {
         case _                   => None
       }
 
+      def orEmpty(domain: Option[model.Domain]): model.Domain = domain.getOrElse(model.Domain.Empty)
+
       new UserData(
-        Id, Domain, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
-        rConvQualifiedId(Conversation, ConversationDomain), Rel, Timestamp, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed,
-        Seq.empty, (SelfPermissions, CopyPermissions), CreatedBy
+        Id, orEmpty(Domain), TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn,
+        RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
+        rConvQualifiedId(Conversation, ConversationDomain), Rel, Timestamp, Verified, Deleted,
+        AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed, Seq.empty,
+        (SelfPermissions, CopyPermissions), CreatedBy
       )
     }
 


### PR DESCRIPTION
This is a hotfix and it's based on manual tests results and code review.
With the Federation feature we added fields for "domains" to the Conversations and to the Users table in db. In the db schema we allow the fields to be null, but when deserializing conversations and users we expect them to be empty strings at least, or to have the actual domain string, but we don't expect null. This might cause the bug and it might also explain why it's not 100% reproducible - the problem would appear only for old conversations and users (which now got those fields initialized to null), and in non-federated environments.

The fix introduces checks if the fields are null and if yes then they return an empty string instead.
This way we avoid another migration. If this is indeed the cause of the bug then after the update the affected apps should start working again.