### PR TITLE
Feature/version file implementation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         booleanParam(name: 'AppUnitTests', defaultValue: true, description: 'Run all app unit tests for this build')
         booleanParam(name: 'StorageUnitTests', defaultValue: true, description: 'Run all Storage unit tests for this build')
         booleanParam(name: 'ZMessageUnitTests', defaultValue: false, description: 'Run all zmessaging unit tests for this build')
+        booleanParam(name: 'CompileFDroid', defaultValue: true, description: 'Defines if the fdroid flavor should be compiled in addition')
     }
 
     stages {
@@ -77,7 +78,7 @@ pipeline {
                     load env.GROOVY_FILE_THAT_SETS_VARIABLES
                 }
                 sh "echo ConfigFile ${params.ConfigFileId} loaded successfully"
-                sh "echo Version of the client: ${usedClientVersion}${BUILD_NUMBER}"
+                sh "echo Version of the client: ${usedClientVersion}${PATCH_VERSION}"
             }
         }
 
@@ -130,6 +131,16 @@ pipeline {
             }
         }
 
+        stage('Generate version.txt') {
+            steps {
+                script {
+                    last_stage = env.STAGE_NAME
+                }
+                sh './gradlew generateVersionFile'
+                archiveArtifacts(artifacts: "app/version.txt", allowEmptyArchive: true, caseSensitive: true, onlyIfSuccessful: true)
+            }
+        }
+
         stage('App Unit Testing') {
             when {
                 expression { params.AppUnitTests }
@@ -175,9 +186,6 @@ pipeline {
         stage('Assemble/Archive/Upload') {
             parallel {
                 stage('Branch Client') {
-                    when {
-                        expression { usedFlavor != "F-Droid"}
-                    }
                     stages {
                         stage('Assemble Branch') {
                             steps {
@@ -202,7 +210,7 @@ pipeline {
                                     last_stage = env.STAGE_NAME
                                     pathToUploadTo = "megazord/android/${usedFlavor.toLowerCase()}/${usedBuildType.toLowerCase()}/"
                                     fileNameForS3 = "wire-${usedFlavor.toLowerCase()}-${usedBuildType.toLowerCase()}-${BRANCH_NAME.replaceAll('/','_')}-${usedClientVersion}${env.PATCH_VERSION}.apk"
-                                    println("Uploading wire client with version [${usedClientVersion}${env.BUILD_NUMBER}] to the the S3 Bucket [${env.S3_BUCKET_NAME}] to the folder [${pathToUploadTo}] under the name [${fileNameForS3}]")
+                                    println("Uploading wire client with version [${usedClientVersion}${env.PATCH_VERSION}] to the the S3 Bucket [${env.S3_BUCKET_NAME}] to the folder [${pathToUploadTo}] under the name [${fileNameForS3}]")
                                 }
                                 s3Upload(acl: "${env.ACL_NAME}", file: "app/build/outputs/apk/wire-${usedFlavor.toLowerCase()}-${usedBuildType.toLowerCase()}-${usedClientVersion}${env.PATCH_VERSION}.apk", bucket: "${env.S3_BUCKET_NAME}", path: "${pathToUploadTo}${fileNameForS3}")
                             }
@@ -215,9 +223,9 @@ pipeline {
                             steps {
                                 script {
                                     last_stage = env.STAGE_NAME
-                                    println("Uploading internal wire client with version [${usedClientVersion}${env.BUILD_NUMBER}] to the Track [${env.WIRE_ANDROID_INTERNAL_TRACK_NAME}]")
+                                    println("Uploading internal wire client with version [${usedClientVersion}${env.PATCH_VERSION}] to the Track [${env.WIRE_ANDROID_INTERNAL_TRACK_NAME}]")
                                 }
-                                androidApkUpload(googleCredentialsId: "${env.GOOGLE_PLAY_CREDS}", filesPattern: "app/build/outputs/apk/wire-internal-release-${usedClientVersion}${env.BUILD_NUMBER}.apk", trackName: "${env.WIRE_ANDROID_INTERNAL_TRACK_NAME}", rolloutPercentage: '100', releaseName: "Internal Release ${usedClientVersion}${env.BUILD_NUMBER}")
+                                androidApkUpload(googleCredentialsId: "${env.GOOGLE_PLAY_CREDS}", filesPattern: "app/build/outputs/apk/wire-internal-release-${usedClientVersion}${env.PATCH_VERSION}.apk", trackName: "${env.WIRE_ANDROID_INTERNAL_TRACK_NAME}", rolloutPercentage: '100', releaseName: "Internal Release ${usedClientVersion}${env.PATCH_VERSION}")
                             }
                         }
                     }
@@ -255,7 +263,7 @@ pipeline {
                                     )
                                     println("Uploading prod version of wire client with version [${usedClientVersion}${env.BUILD_NUMBER}] to the the S3 Bucket [${env.S3_BUCKET_NAME}] to the folder [megazord/android/prod/${usedBuildType.toLowerCase()}/]")
                                 }
-                                s3Upload(acl: "${env.ACL_NAME}", workingDir: "app/build/outputs/apk/", includePathPattern: "wire-*.apk", bucket: "${env.S3_BUCKET_NAME}", path: "megazord/android/prod/${usedBuildType.toLowerCase()}/")
+                                s3Upload(acl: "${env.ACL_NAME}", workingDir: "app/build/outputs/apk/", includePathPattern: "wire-prod-*.apk", bucket: "${env.S3_BUCKET_NAME}", path: "megazord/android/prod/${usedBuildType.toLowerCase()}/")
                                 wireSend secret: env.WIRE_BOT_WIRE_ANDROID_SECRET, message: "[${env.BRANCH_NAME}] Prod${usedBuildType} **[${BUILD_NUMBER}](${BUILD_URL})** - ✅ SUCCESS 🎉" +
                                                                     "\nLast 5 commits:\n```\n$lastCommits\n```"
                             }
@@ -278,7 +286,7 @@ pipeline {
 
                 stage('FDroid') {
                     when {
-                        expression { usedFlavor.equals("F-Droid") }
+                        expression { params.CompileFDroid }
                     }
                     stages {
                         stage('Assemble F-Droid') {
@@ -286,9 +294,50 @@ pipeline {
                                 script {
                                     last_stage = env.STAGE_NAME
                                 }
+                                sh "./gradlew --profile assembleFDroid${usedBuildType}"
+                                sh "ls -la app/build/outputs/apk"
+                            }
+                        }
+
+                        stage('Archive F-Droid') {
+                            steps {
+                                script {
+                                    last_stage = env.STAGE_NAME
+                                }
+                                archiveArtifacts(artifacts: "app/build/outputs/apk/wire-fdroid-${usedBuildType.toLowerCase()}-${usedClientVersion}${env.PATCH_VERSION}.apk", allowEmptyArchive: true, caseSensitive: true, onlyIfSuccessful: true)
+                            }
+                        }
+
+                        stage('Upload FDroid to S3') {
+                            steps {
+                                script {
+                                    last_stage = env.STAGE_NAME
+                                    lastCommits = sh(
+                                            script: "git log -5 --pretty=\"%h [%an] %s\" | sed \"s/^/    /\"",
+                                            returnStdout: true
+                                    )
+                                    println("Uploading fdroid version of wire client with version [${usedClientVersion}${env.BUILD_NUMBER}] to the the S3 Bucket [${env.S3_BUCKET_NAME}] to the folder [megazord/android/fdroid/${usedBuildType.toLowerCase()}/]")
+                                }
+                                s3Upload(acl: "${env.ACL_NAME}", workingDir: "app/build/outputs/apk/", includePathPattern: "wire-fdroid-*.apk", bucket: "${env.S3_BUCKET_NAME}", path: "megazord/android/fdroid/${usedBuildType.toLowerCase()}/")
+                                wireSend secret: env.WIRE_BOT_WIRE_ANDROID_SECRET, message: "[${env.BRANCH_NAME}] Prod${usedBuildType} **[${BUILD_NUMBER}](${BUILD_URL})** - ✅ SUCCESS 🎉" +
+                                                                    "\nLast 5 commits:\n```\n$lastCommits\n```"
                             }
                         }
                     }
+                }
+            }
+        }
+
+        stage('Release to Github') {
+            when {
+                expression { env.BRANCH_NAME == "release" }
+            }
+            steps {
+                script {
+                    last_stage = env.STAGE_NAME
+                    versionName = usedClientVersion =~ /(.*)\./
+                    println("Releasing version to Github under Release Tag ${versionName} automatically")
+                    println("THIS FEATURE IS NOT YET IMPLEMENTED")
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,7 +319,7 @@ pipeline {
                                     println("Uploading fdroid version of wire client with version [${usedClientVersion}${env.BUILD_NUMBER}] to the the S3 Bucket [${env.S3_BUCKET_NAME}] to the folder [megazord/android/fdroid/${usedBuildType.toLowerCase()}/]")
                                 }
                                 s3Upload(acl: "${env.ACL_NAME}", workingDir: "app/build/outputs/apk/", includePathPattern: "wire-fdroid-*.apk", bucket: "${env.S3_BUCKET_NAME}", path: "megazord/android/fdroid/${usedBuildType.toLowerCase()}/")
-                                wireSend secret: env.WIRE_BOT_WIRE_ANDROID_SECRET, message: "[${env.BRANCH_NAME}] Prod${usedBuildType} **[${BUILD_NUMBER}](${BUILD_URL})** - ✅ SUCCESS 🎉" +
+                                wireSend secret: env.WIRE_BOT_WIRE_ANDROID_SECRET, message: "[${env.BRANCH_NAME}] FDroid${usedBuildType} **[${BUILD_NUMBER}](${BUILD_URL})** - ✅ SUCCESS 🎉" +
                                                                     "\nLast 5 commits:\n```\n$lastCommits\n```"
                             }
                         }

--- a/README.md
+++ b/README.md
@@ -50,5 +50,4 @@ These steps will build only the Wire client UI, pulling in all other Wire framew
 When importing project in Android Studio **do not allow** gradle plugin update. Our build setup requires Android Plugin for Gradle version 3.2.1.
 
 ### Translations
-
-All Wire translations are crowdsourced via CrowdIn: https://crowdin.com/projects/wire
+Translation: https://crowdin.com/projects/wire

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -526,7 +526,7 @@ def readOrGenerateVersionCode() {
     //file exists, read the version code from the version.txt
     println("version.txt found, using versionCode from version.txt file")
     String versionContext = new File("$projectDir/version.txt").text
-    def matcher = versionContext =~ /^VersionCode: (.*)/
+    def matcher = versionContext =~ /VersionCode: (.*)/
     matcher.find()
     def versionCode = matcher.group(1)
     println("Found VersionCode in File: $versionCode")
@@ -543,7 +543,7 @@ def readOrGenerateVersionName() {
     //file exists, read the versionanme from the version.txt
     String versionContext = new File("$projectDir/version.txt").text
     println("$versionContext")
-    def matcher = versionContext =~ /^VersionName: (.*)/
+    def matcher = versionContext =~ /VersionName: (.*)/
     matcher.find()
     def versionName = matcher.group(1)
     println("Found VersionName found in File: $versionName")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,7 @@
+import java.text.SimpleDateFormat
+import org.ajoberstar.grgit.Grgit
+
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -58,8 +62,6 @@ task copyCustomResources(type: Copy) {
 }
 
 android {
-    def patchVersion = System.getenv("PATCH_VERSION") as Integer?: System.getenv("BUILD_NUMBER") as Integer ?: 99999
-
     //Trigger the licenseFormat task at least once in any compile phase
     applicationVariants.all { variant ->
         variant.javaCompiler.dependsOn(rootProject.licenseFormat)
@@ -73,8 +75,8 @@ android {
     defaultConfig {
         minSdkVersion Versions.MIN_SDK_VERSION
         targetSdkVersion Versions.TARGET_SDK_VERSION
-        versionCode getUnixTimestamp() as Integer
-        versionName = Versions.ANDROID_CLIENT_MAJOR_VERSION + patchVersion
+        versionCode readOrGenerateVersionCode() as Integer
+        versionName = readOrGenerateVersionName() as String
         applicationId "com.waz.zclient"
         testInstrumentationRunner "com.waz.background.TestRunner"
 
@@ -488,13 +490,67 @@ tasks.withType(ScalaCompile) {
         "UTF-8"]
 }
 
+tasks.register("generateVersionFile") {
+    //clean the repo from a probably existing version.txt
+    if(file("$projectDir/version.txt").exists()) {
+        println("deleting existing version.txt file for safety reasons")
+        delete file "$projectDir/version.txt"
+    }
+    def versionCode = readOrGenerateVersionCode()
+    def versionName = readOrGenerateVersionName()
+
+    println("VersionCode = " + versionCode)
+    println("VersionName = " + versionName)
+    doLast {
+        new File(projectDir, "version.txt").text = """VersionCode: $versionCode
+VersionName: $versionName
+Revision: ${grgit.head().abbreviatedId}
+Buildtime: ${new SimpleDateFormat("dd-MM-yyyy HH:mm:ss").format(new Date())}
+Application-name: com.wire
+    """
+    }
+}
+
 def getDate() {
     def date = new Date()
     def formattedDate = date.format('MM/dd HH:mm:ss')
     return formattedDate
 }
 
-def getUnixTimestamp() {
+def readOrGenerateVersionCode() {
+    if(!file("$projectDir/version.txt").exists()) {
+        println("No version.txt found, generating new versioncode")
+        return generateUnixTimestamp()
+    }
+
+    //file exists, read the version code from the version.txt
+    println("version.txt found, using versionCode from version.txt file")
+    String versionContext = new File("$projectDir/version.txt").text
+    def matcher = versionContext =~ /^VersionCode: (.*)/
+    matcher.find()
+    def versionCode = matcher.group(1)
+    println("Found VersionCode in File: $versionCode")
+    return versionCode
+}
+
+def readOrGenerateVersionName() {
+    if(!file("$projectDir/version.txt").exists()) {
+        println("No version.txt found, using system internal version name")
+        def patchVersion = System.getenv("PATCH_VERSION") as Integer?: System.getenv("BUILD_NUMBER") as Integer ?: 99999
+        return "$Versions.ANDROID_CLIENT_MAJOR_VERSION$patchVersion"
+    }
+
+    //file exists, read the versionanme from the version.txt
+    String versionContext = new File("$projectDir/version.txt").text
+    println("$versionContext")
+    def matcher = versionContext =~ /^VersionName: (.*)/
+    matcher.find()
+    def versionName = matcher.group(1)
+    println("Found VersionName found in File: $versionName")
+    return versionName
+}
+
+def generateUnixTimestamp() {
     def dateOffset = new Date("04/21/2021 01:00:00")
     def date = new Date()
     def dateTime = (date.getTime()/10000L)

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,8 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter() // FIXME
+        jcenter()
         maven { url "https://jitpack.io" }
-        maven {
-            name "ajoberstar-backup"
-            url "https://ajoberstar.github.io/bintray-backup/"
-        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}"

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ buildscript {
         mavenCentral()
         jcenter() // FIXME
         maven { url "https://jitpack.io" }
+        maven {
+            name "ajoberstar-backup"
+            url "https://ajoberstar.github.io/bintray-backup/"
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}"
@@ -19,6 +23,7 @@ buildscript {
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT}"
         classpath "org.jacoco:org.jacoco.core:${Versions.JACOCO}"
         classpath "com.mutualmobile.gradle.plugins:dexinfo:${Versions.DEX_INFO}"
+        classpath "org.ajoberstar.grgit:grgit-core:${Versions.GRGIT}"
 
         if (fdroidBuild) {
             println("Not including gms")
@@ -32,6 +37,7 @@ buildscript {
 plugins {
     id "com.github.hierynomus.license" version "0.13.1"
     id "io.gitlab.arturbosch.detekt" version "1.2.2"
+    id "org.ajoberstar.grgit" version "4.1.0"
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val DETEKT = "1.2.2"
     const val JACOCO = "0.8.5"
     const val DEX_INFO = "0.1.2"
-    const val GRGIT = "3.0.0"
+    const val GRGIT = "4.1.0"
 
     //build
     const val COROUTINES = "1.3.7"

--- a/scripts/custombuild.gradle
+++ b/scripts/custombuild.gradle
@@ -6,10 +6,7 @@ import org.ajoberstar.grgit.Credentials
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            name "ajoberstar-backup"
-            url "https://ajoberstar.github.io/bintray-backup/"
-        }
+        jcenter()
     }
     dependencies {
         classpath "org.ajoberstar.grgit:grgit-core:${Versions.GRGIT}"


### PR DESCRIPTION
this PR implements the first phase for the version.txt implementation which is supposed to be used for the f-droid store build and release process.

in order to make this work as flawless as possible, the version.txt will also be used now by the general build pipeline.
if no version.txt exists, the build script logic will generate the necessary variables itself over the same functions as used by the version.txt generation task.