### PR TITLE
Fix: self-deleting asset messages were not being deleted by receiver

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -150,16 +150,12 @@ class EphemeralMessagesService(selfUserId: UserId,
     else if (msg.isAssetMessage)
       // check if asset was fully uploaded
       msg.genericMsgs.exists(_.unpackContent match {
-        case eph: Ephemeral =>
-          eph.unpackContent match {
-            case asset: Asset =>
-              val status = asset.unpack._1.status
-              status == UploadDone || status == UploadFailed
-            case image: ImageAsset =>
-              val status = image.unpack.status
-              status == UploadDone || status == UploadFailed
-            case _ => false
-          }
+        case asset: Asset =>
+          val status = asset.unpack._1.status
+          status == UploadDone || status == UploadFailed
+        case image: ImageAsset =>
+          val status = image.unpack.status
+          status == UploadDone || status == UploadFailed
         case _ => false
       })
     else true


### PR DESCRIPTION
## What's new in this PR?

### Issues

As reported in [SQSERVICES-974](https://wearezeta.atlassian.net/browse/SQSERVICES-974). Android Client was **not** deleting self-deleting messages with assets after the user reads them.

### Causes

Checking for ephemeral as content, instead of directly checking for the content type. in `EphemeralMessagesService#153`.

### Solutions

Deleted extra-checking for ephemeral messages. As it's already being checked in `EphemeralMessagesService#149`.

### Testing

Manually tested
