### PR TITLE
fix: App crashes when trying to open group conversation details

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -169,7 +169,6 @@ object WireApplication extends DerivedLogTag {
     // but technically we can't guarantee it, hence every time it's used we need to check its value
     // (so, `toProvider`, not `to`)
     bind[Domain] toProvider inject[Signal[ZMessaging]].map(_.selfDomain).currentValue.getOrElse(Domain.Empty)
-    bind [Signal[Domain]] to inject[Signal[ZMessaging]].map(_.selfDomain)
 
     // services  and storages of the current zms
     bind [Signal[ConversationsService]]          to inject[Signal[ZMessaging]].map(_.conversations)

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -169,6 +169,7 @@ object WireApplication extends DerivedLogTag {
     // but technically we can't guarantee it, hence every time it's used we need to check its value
     // (so, `toProvider`, not `to`)
     bind[Domain] toProvider inject[Signal[ZMessaging]].map(_.selfDomain).currentValue.getOrElse(Domain.Empty)
+    bind [Signal[Domain]] to inject[Signal[ZMessaging]].map(_.selfDomain)
 
     // services  and storages of the current zms
     bind [Signal[ConversationsService]]          to inject[Signal[ZMessaging]].map(_.conversations)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldUsersAdapter.scala
@@ -18,7 +18,6 @@ class LegalHoldUsersAdapter(userIds: Signal[Set[UserId]], maxParticipants: Optio
     selfId       <- selfId
     usersStorage <- usersStorage
     teamId       <- team
-    domain       <- domain
     userIds      <- userIds
     users        <- usersStorage.listSignal(userIds.toList)
     filter       <- filter

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -64,7 +64,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
 
   protected lazy val usersStorage           = inject[Signal[UsersStorage]]
   protected lazy val team                   = inject[Signal[Option[TeamId]]]
-  protected lazy val domain                 = inject[Signal[Domain]]
+  protected lazy val domain                 = inject[Domain]
   protected lazy val participantsController = inject[ParticipantsController]
   protected lazy val convController         = inject[ConversationController]
   protected lazy val themeController        = inject[ThemeController]
@@ -93,7 +93,6 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
     selfId       <- selfId
     usersStorage <- usersStorage
     tId          <- team
-    domain       <- domain
     participants <- participants
     users        <- usersStorage.listSignal(participants.keys)
     f            <- filter.throttle(FilterThrottleMs)
@@ -507,7 +506,6 @@ final class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle: O
     selfId       <- selfId
     usersStorage <- usersStorage
     tId          <- team
-    domain       <- domain
     userIds      <- userIds
     users        <- usersStorage.listSignal(userIds.toList)
   } yield


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when trying to open group conversation details

### Causes

Missing bind statement in WireApplication

### Solutions

Inject Domain instead for Signal[Domain] in ParticipantsAdapter

### Testing

Manually tested

