### PR TITLE
Fix: Timer selection still enabled when configuration is enforced by team

### DIFF
--- a/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/CursorView.scala
@@ -92,6 +92,8 @@ class CursorView(val context: Context, val attrs: AttributeSet, val defStyleAttr
   val ephemeralButton = returning(findById[EphemeralTimerButton](R.id.cib__ephemeral)) { v =>
     controller.ephemeralBtnVisible.onUi(v.setVisible)
 
+    controller.enforcedSelfDeletingMessagesTimeout.map(_ > 0)
+      .pipeTo(v.hasEnforcedTimeout)
     controller.ephemeralExp.pipeTo(v.ephemeralExpiration)
     inject[ThemeController].darkThemeSet.pipeTo(v.darkTheme)
 

--- a/app/src/main/scala/com/waz/zclient/cursor/EphemeralTimerButton.scala
+++ b/app/src/main/scala/com/waz/zclient/cursor/EphemeralTimerButton.scala
@@ -39,6 +39,7 @@ class EphemeralTimerButton(context: Context, attrs: AttributeSet, defStyleAttr: 
 
   val accentColor         = inject[Signal[AccentColor]]
 
+  val hasEnforcedTimeout  = Signal[Boolean](false)
   val ephemeralExpiration = Signal[Option[EphemeralDuration]](None)
   val darkTheme           = Signal(true) //sharing controller is always in "dark" theme
 
@@ -87,7 +88,9 @@ class EphemeralTimerButton(context: Context, attrs: AttributeSet, defStyleAttr: 
     setGravity(Gravity.CENTER)
 
     display.onUi(setText)
-
+    hasEnforcedTimeout.onUi{ isEnforced =>
+      setEnabled(!isEnforced)
+    }
     drawable.onUi(setBackgroundDrawable)
     contentDescription.onUi(setContentDescription)
 

--- a/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/sharing/ConversationSelectorFragment.scala
@@ -219,11 +219,14 @@ class ConversationSelectorFragment extends FragmentHelper with OnBackPressedList
       }
     })
 
-    ephemeralIcon.foreach(icon =>
-      enforcedSelfDeletingMessagesTimeout.filter(_ > 0)
-        .map { timeoutInSeconds => Some(ConvExpiry(timeoutInSeconds.seconds)).asInstanceOf[Option[EphemeralDuration]] }
-        .pipeTo(icon.ephemeralExpiration)
-    )
+    ephemeralIcon.foreach { icon =>
+        enforcedSelfDeletingMessagesTimeout.map(_ > 0)
+          .pipeTo(icon.hasEnforcedTimeout)
+
+        enforcedSelfDeletingMessagesTimeout.filter(_ > 0)
+          .map { timeoutInSeconds => Some(ConvExpiry(timeoutInSeconds.seconds)).asInstanceOf[Option[EphemeralDuration]] }
+          .pipeTo(icon.ephemeralExpiration)
+    }
     ephemeralIcon.foreach(icon =>
       isEphemeralButtonVisible.onUi(icon.setVisible)
     )

--- a/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -150,16 +150,12 @@ class EphemeralMessagesService(selfUserId: UserId,
     else if (msg.isAssetMessage)
       // check if asset was fully uploaded
       msg.genericMsgs.exists(_.unpackContent match {
-        case eph: Ephemeral =>
-          eph.unpackContent match {
-            case asset: Asset =>
-              val status = asset.unpack._1.status
-              status == UploadDone || status == UploadFailed
-            case image: ImageAsset =>
-              val status = image.unpack.status
-              status == UploadDone || status == UploadFailed
-            case _ => false
-          }
+        case asset: Asset =>
+          val status = asset.unpack._1.status
+          status == UploadDone || status == UploadFailed
+        case image: ImageAsset =>
+          val status = image.unpack.status
+          status == UploadDone || status == UploadFailed
         case _ => false
       })
     else true


### PR DESCRIPTION
## What's new in this PR?
Fix for [SQSERVICES-973](https://wearezeta.atlassian.net/browse/SQSERVICES-973).

### Issues

As reported in [SQSERVICES-973](https://wearezeta.atlassian.net/browse/SQSERVICES-973). When the team has an enforced self deleting timeout, the timer button is still enabled and allows selection (even though the selection is ignored).

### Causes

Oversight on my end. Completely forgot about this last part!

### Solutions

Based on the enforcing by the team, the button gets disabled.

### Testing

Manually tested