### PR TITLE
fix: consider domain only for federation

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -138,9 +138,13 @@ final case class UserData(override val id:       UserId,
   }
 
   def isGuest(ourTeamId: Option[TeamId], ourDomain: Domain = Domain.Empty): Boolean = {
-    val isSameTeam = teamId == ourTeamId
-    val isSameDomain = ourDomain == domain
-    ourTeamId.isDefined && (!isSameTeam || !isSameDomain)
+    val isNotSameTeam = ourTeamId.isDefined && teamId != ourTeamId
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      val isSameDomain = ourDomain == domain
+      isNotSameTeam || !isSameDomain
+    } else {
+      isNotSameTeam
+    }
   }
 
   def isExternal(ourTeamId: Option[TeamId], ourDomain: Domain): Boolean = {


### PR DESCRIPTION
## What's new in this PR?
Jira : https://wearezeta.atlassian.net/browse/SQCORE-1164

### Issues

User is unable to create 1:1 conversation from search

### Causes

This is due to invalid response from `isGuest()`

When federation is turned off, we still do have a value for domain. So comparing the `domain` with `ourDomain` (which is Empty) invalidates the test.

### Solutions

Consider the domain only for federation 

### Testing

Manually tested
