### PR TITLE
fix(config): Change default of conference calling enabled to true JCT-70

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -446,7 +446,7 @@ object UserPreferences {
   lazy val SelfDeletingMessagesEnforcedTimeout: PrefKey[Int] = PrefKey[Int]("self_deleting_messages_enforced_timeout", customDefault = 0)
   lazy val ShouldInformSelfDeletingMessagesChanged: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enforced_changed", customDefault = false)
 
-  lazy val ConferenceCallingFeatureEnabled: PrefKey[Option[Boolean]] = PrefKey[Option[Boolean]]("conference_calling_feature_enabled", customDefault = None)
+  lazy val ConferenceCallingFeatureEnabled: PrefKey[Option[Boolean]] = PrefKey[Option[Boolean]]("conference_calling_feature_enabled", customDefault = Some(true))
   lazy val ShouldInformPlanUpgradedToEnterprise: PrefKey[Boolean] = PrefKey[Boolean]("should_inform_plan_upgraded_to_enterprise", customDefault = false)
 
   lazy val ShouldMigrateToFederation: PrefKey[Boolean] = PrefKey[Boolean]("should_migrate_to_federation_2", customDefault = true)


### PR DESCRIPTION
For on-prem installations conference calls should always be possible (unless deliberately configured otherwise). Therefore, the default value should be true.

## What's new in this PR?

### Issues

Conference calling is at the moment disabled by default on the client. It should instead be enabled by default.

### Causes

A missing endpoint on an older on-prem installation can trigger the client to behave in such fashion that conference calling is disabled.

### Solutions

Change the client default to be true, thus enabling conference calling for older on-prem installations.

### Testing

GIVEN: An older backend
WHEN: Using the android client
THEN: I am able to make conference calls
