### PR TITLE
 fix: Conference calling user preference and the enterprise alert SQSERVICES-906

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         string(name: 'PatchVersion', defaultValue: '', description: 'PatchVersion for the build as a numeric value (e.g. 1337)')
         booleanParam(name: 'AppUnitTests', defaultValue: true, description: 'Run all app unit tests for this build')
         booleanParam(name: 'StorageUnitTests', defaultValue: true, description: 'Run all Storage unit tests for this build')
-        booleanParam(name: 'ZMessageUnitTests', defaultValue: false, description: 'Run all zmessaging unit tests for this build')
+        booleanParam(name: 'ZMessageUnitTests', defaultValue: true, description: 'Run all zmessaging unit tests for this build')
         booleanParam(name: 'CompileFDroid', defaultValue: true, description: 'Defines if the fdroid flavor should be compiled in addition')
     }
 
@@ -177,7 +177,7 @@ pipeline {
                 script {
                     last_stage = env.STAGE_NAME
                 }
-                sh "./gradlew :zmessaging:test${usedBuildType}UnitTest -PwireDeflakeTests=1"
+                sh "./gradlew :zmessaging:test${usedBuildType}UnitTest -PwireDeflakeTests=3"
                 publishHTML(allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: "zmessaging/build/reports/tests/test${usedBuildType}UnitTest/", reportFiles: 'index.html', reportName: 'ZMessaging Unit Test Report', reportTitles: 'ZMessaging Unit Test')
                 junit "zmessaging/build/test-results/**/*.xml"
             }

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -421,7 +421,7 @@ class ConversationFragment extends FragmentHelper {
     def isConferenceCallingRestricted: Future[Boolean] =
       userPreferences.head
         .flatMap(_.preference(UserPreferences.ConferenceCallingFeatureEnabled).apply())
-        .map(isEnabled => !isEnabled.get)
+        .map(!_)
 
     def displayConferenceCallingUpgradeDialog(): Unit = {
       accentColorController.accentColor.head.foreach { accentColor =>

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -446,7 +446,7 @@ object UserPreferences {
   lazy val SelfDeletingMessagesEnforcedTimeout: PrefKey[Int] = PrefKey[Int]("self_deleting_messages_enforced_timeout", customDefault = 0)
   lazy val ShouldInformSelfDeletingMessagesChanged: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enforced_changed", customDefault = false)
 
-  lazy val ConferenceCallingFeatureEnabled: PrefKey[Option[Boolean]] = PrefKey[Option[Boolean]]("conference_calling_feature_enabled", customDefault = Some(true))
+  lazy val ConferenceCallingFeatureEnabled: PrefKey[Option[Boolean]] = PrefKey[Option[Boolean]]("conference_calling_feature_enabled_1", customDefault = Some(true))
   lazy val ShouldInformPlanUpgradedToEnterprise: PrefKey[Boolean] = PrefKey[Boolean]("should_inform_plan_upgraded_to_enterprise", customDefault = false)
 
   lazy val ShouldMigrateToFederation: PrefKey[Boolean] = PrefKey[Boolean]("should_migrate_to_federation_2", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -446,7 +446,7 @@ object UserPreferences {
   lazy val SelfDeletingMessagesEnforcedTimeout: PrefKey[Int] = PrefKey[Int]("self_deleting_messages_enforced_timeout", customDefault = 0)
   lazy val ShouldInformSelfDeletingMessagesChanged: PrefKey[Boolean] = PrefKey[Boolean]("self_deleting_messages_enforced_changed", customDefault = false)
 
-  lazy val ConferenceCallingFeatureEnabled: PrefKey[Option[Boolean]] = PrefKey[Option[Boolean]]("conference_calling_feature_enabled_1", customDefault = Some(true))
+  lazy val ConferenceCallingFeatureEnabled: PrefKey[Boolean] = PrefKey[Boolean]("conference_calling_feature_enabled_1", customDefault = true)
   lazy val ShouldInformPlanUpgradedToEnterprise: PrefKey[Boolean] = PrefKey[Boolean]("should_inform_plan_upgraded_to_enterprise", customDefault = false)
 
   lazy val ShouldMigrateToFederation: PrefKey[Boolean] = PrefKey[Boolean]("should_migrate_to_federation_2", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/model/ConferenceCallingFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConferenceCallingFeatureConfig.scala
@@ -9,7 +9,7 @@ final case class ConferenceCallingFeatureConfig(status: String) {
 
 object ConferenceCallingFeatureConfig {
 
-  val Default: ConferenceCallingFeatureConfig = ConferenceCallingFeatureConfig(status = "disabled")
+  val Default: ConferenceCallingFeatureConfig = ConferenceCallingFeatureConfig(status = "enabled")
 
   implicit object Decoder extends JsonDecoder[ConferenceCallingFeatureConfig] {
     override def apply(implicit js: JSONObject): ConferenceCallingFeatureConfig =

--- a/zmessaging/src/main/scala/com/waz/model/FileSharingFeatureConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/model/FileSharingFeatureConfig.scala
@@ -18,5 +18,4 @@ object FileSharingFeatureConfig {
       if (!js.has("status")) Default
       else FileSharingFeatureConfig(js.getString("status"))
   }
-
 }

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -63,9 +63,9 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
 
   override def updateFileSharing(): Future[Unit] =
     for {
-      fileSharing <- syncHandler.fetchFileSharing()
-      _           =  verbose(l"FileSharing feature config : $fileSharing")
-      _           <- storeFileSharing(fileSharing)
+      Some(fileSharing) <- syncHandler.fetchFileSharing() // if the handler returns None, we don't store anything
+      _                 =  verbose(l"FileSharing feature config : $fileSharing")
+      _                 <- storeFileSharing(fileSharing)
     } yield ()
 
   private def storeFileSharing(fileSharing: FileSharingFeatureConfig): Future[Unit] = {

--- a/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/FeatureConfigsService.scala
@@ -88,15 +88,11 @@ class FeatureConfigsServiceImpl(syncHandler: FeatureConfigsSyncHandler,
 
   private def storeConferenceCallingConfig(conferenceCallingFeatureConfig: ConferenceCallingFeatureConfig): Future[Unit] = {
     for {
-      existingValue <- userPrefs (ConferenceCallingFeatureEnabled).apply()
+      existingValue <- userPrefs(ConferenceCallingFeatureEnabled).apply()
       newValue      =  conferenceCallingFeatureConfig.isEnabled
-      _             <- userPrefs(ConferenceCallingFeatureEnabled) := Some(newValue)
-                    // Inform of plan upgraded.
-      _             <- if (existingValue != None && !existingValue.get && newValue)
-                          userPrefs(ShouldInformPlanUpgradedToEnterprise) := true
-                       // Don't inform
-                       else if (!newValue) userPrefs(ShouldInformPlanUpgradedToEnterprise) := false
-                       else Future.successful(())
+      _             <- userPrefs(ConferenceCallingFeatureEnabled) := newValue
+                       // inform if we didn't have conference calls and now we do
+      _             <- userPrefs(ShouldInformPlanUpgradedToEnterprise) := !existingValue && newValue
     } yield ()
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/FeatureConfigsClient.scala
@@ -9,9 +9,9 @@ import org.json.JSONObject
 
 trait FeatureConfigsClient {
   def getAppLock(teamId: TeamId): ErrorOrResponse[AppLockFeatureConfig]
-  def getFileSharing(): ErrorOrResponse[FileSharingFeatureConfig]
-  def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig]
-  def getConferenceCalling(): ErrorOrResponse[ConferenceCallingFeatureConfig]
+  def getFileSharing: ErrorOrResponse[FileSharingFeatureConfig]
+  def getSelfDeletingMessages: ErrorOrResponse[SelfDeletingMessagesFeatureConfig]
+  def getConferenceCalling: ErrorOrResponse[ConferenceCallingFeatureConfig]
 }
 
 class FeatureConfigsClientImpl(implicit
@@ -31,19 +31,19 @@ class FeatureConfigsClientImpl(implicit
       .withErrorType[ErrorResponse]
       .executeSafe
 
-  override def getFileSharing(): ErrorOrResponse[FileSharingFeatureConfig] =
+  override def getFileSharing: ErrorOrResponse[FileSharingFeatureConfig] =
     Request.Get(relativePath =  fileSharingPath)
     .withResultType[FileSharingFeatureConfig]
     .withErrorType[ErrorResponse]
     .executeSafe
 
-  override def getSelfDeletingMessages(): ErrorOrResponse[SelfDeletingMessagesFeatureConfig] =
+  override def getSelfDeletingMessages: ErrorOrResponse[SelfDeletingMessagesFeatureConfig] =
     Request.Get(relativePath =  selfDeletingMessages)
     .withResultType[SelfDeletingMessagesFeatureConfig]
     .withErrorType[ErrorResponse]
     .executeSafe
 
-  override def getConferenceCalling(): ErrorOrResponse[ConferenceCallingFeatureConfig] =
+  override def getConferenceCalling: ErrorOrResponse[ConferenceCallingFeatureConfig] =
     Request.Get(relativePath =  conferenceCallingPath)
       .withResultType[ConferenceCallingFeatureConfig]
       .withErrorType[ErrorResponse]

--- a/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 trait FeatureConfigsSyncHandler {
   def fetchAppLock(): Future[AppLockFeatureConfig]
-  def fetchFileSharing(): Future[FileSharingFeatureConfig]
+  def fetchFileSharing(): Future[Option[FileSharingFeatureConfig]]
   def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig]
   def fetchConferenceCalling(): Future[ConferenceCallingFeatureConfig]
 }
@@ -31,13 +31,13 @@ class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfi
       }
   }
 
-  override def fetchFileSharing(): Future[FileSharingFeatureConfig] =
+  override def fetchFileSharing(): Future[Option[FileSharingFeatureConfig]] =
     client.getFileSharing().map {
       case Left(err) =>
         error(l"Unable to fetch FileSharing feature flag: $err")
-        FileSharingFeatureConfig.Default
+        None
       case Right(fileSharing) =>
-        fileSharing
+        Some(fileSharing)
     }
 
   override def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig] =

--- a/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/FeatureConfigsSyncHandler.scala
@@ -3,58 +3,44 @@ package com.waz.sync.handler
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.{AppLockFeatureConfig, ConferenceCallingFeatureConfig, FileSharingFeatureConfig, SelfDeletingMessagesFeatureConfig, TeamId}
-import com.waz.sync.client.FeatureConfigsClient
+import com.waz.sync.client.{ErrorOrResponse, FeatureConfigsClient}
 
 import scala.concurrent.Future
 
 trait FeatureConfigsSyncHandler {
-  def fetchAppLock(): Future[AppLockFeatureConfig]
-  def fetchFileSharing(): Future[Option[FileSharingFeatureConfig]]
-  def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig]
-  def fetchConferenceCalling(): Future[ConferenceCallingFeatureConfig]
+  def fetchAppLock: Future[Option[AppLockFeatureConfig]]
+  def fetchFileSharing: Future[Option[FileSharingFeatureConfig]]
+  def fetchSelfDeletingMessages: Future[Option[SelfDeletingMessagesFeatureConfig]]
+  def fetchConferenceCalling: Future[Option[ConferenceCallingFeatureConfig]]
 }
 
 class FeatureConfigsSyncHandlerImpl(teamId: Option[TeamId], client: FeatureConfigsClient)
   extends FeatureConfigsSyncHandler with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
-  override def fetchAppLock(): Future[AppLockFeatureConfig] = teamId match {
+  override def fetchAppLock: Future[Option[AppLockFeatureConfig]] = teamId match {
     case None =>
-      Future.successful(AppLockFeatureConfig.Default)
+      Future.successful(Some(AppLockFeatureConfig.Default))
     case Some(tId) =>
-      client.getAppLock(tId).future.map {
-        case Left(err) =>
-          error(l"Unable to fetch AppLock feature flag: $err")
-          AppLockFeatureConfig.Default
-        case Right(appLock) =>
-          appLock
-      }
+      fetchFeatureFlag(() => client.getAppLock(tId), "AppLock")
   }
 
-  override def fetchFileSharing(): Future[Option[FileSharingFeatureConfig]] =
-    client.getFileSharing().map {
+  override def fetchFileSharing: Future[Option[FileSharingFeatureConfig]] =
+    fetchFeatureFlag(client.getFileSharing _, "FileSharing")
+
+  override def fetchSelfDeletingMessages: Future[Option[SelfDeletingMessagesFeatureConfig]] =
+    fetchFeatureFlag(client.getSelfDeletingMessages _, "SelfDeletingMessages")
+
+  override def fetchConferenceCalling: Future[Option[ConferenceCallingFeatureConfig]] =
+    fetchFeatureFlag(client.getConferenceCalling _, "ConferenceCalling")
+
+  @inline
+  private def fetchFeatureFlag[T](clientFunc: () => ErrorOrResponse[T], name: String): Future[Option[T]] =
+    clientFunc().map {
       case Left(err) =>
-        error(l"Unable to fetch FileSharing feature flag: $err")
+        error(l"Unable to fetch $name feature flag: $err")
         None
-      case Right(fileSharing) =>
-        Some(fileSharing)
-    }
-
-  override def fetchSelfDeletingMessages(): Future[SelfDeletingMessagesFeatureConfig] =
-    client.getSelfDeletingMessages().map {
-      case Left(err) =>
-        error(l"Unable to fetch SelfDeletingMessages feature flag: $err")
-        SelfDeletingMessagesFeatureConfig.Default
-      case Right(selfDeletingMessages) =>
-        selfDeletingMessages
-    }
-
-  override def fetchConferenceCalling(): Future[ConferenceCallingFeatureConfig] =
-    client.getConferenceCalling().map {
-      case Left(err) =>
-        error(l"Unable to fetch ConferenceCalling feature flag: $err")
-        ConferenceCallingFeatureConfig.Default
-      case Right(conferenceCalling) =>
-        conferenceCalling
+      case Right(value) =>
+        Some(value)
     }
 }

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -41,6 +41,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val externalPermissions: Long = 1025
   val memberPermissions: Long = 1587
   val adminPermissions: Long = 5951
+  val currentDomain: Domain = Domain("staging.zinfra.io")
 
   val userService       = mock[UserService]
   val usersStorage      = mock[UsersStorage]
@@ -633,6 +634,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     new UserSearchServiceImpl(
       selfId,
       if (inTeam) teamId else emptyTeamId,
+      currentDomain,
       userService,
       usersStorage,
       teamsService,

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -111,7 +111,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private def createConvsUi(teamId: Option[TeamId] = Some(TeamId())): ConversationsUiService = {
     new ConversationsUiServiceImpl(
-      selfUserId, teamId, assets, userService, messages, msgStorage,
+      selfUserId, teamId, domain, assets, userService, messages, msgStorage,
       msgUpdater, membersStorage, content, convsStorage, network,
       service, sync, requests, convsClient, accounts, tracking, errors, uriHelper,
       properties
@@ -1038,7 +1038,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
       val teamsService: TeamsService =
         new TeamsServiceImpl(
-          selfUserId, Some(teamId), teamsStorage, userService, usersStorage, convsStorage, membersStorage,
+          selfUserId, Some(teamId), domain, teamsStorage, userService, usersStorage, convsStorage, membersStorage,
           content, service, sync, requests, userPrefs, errorsService, rolesService
         )
 

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -27,6 +27,7 @@ import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.testutils.{TestGlobalPreferences, TestUserPreferences}
+import com.waz.zms.BuildConfig
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -34,6 +35,7 @@ import scala.concurrent.{Await, Future}
 class ConversationsUiServiceSpec extends AndroidFreeSpec {
 
   val selfUserId = UserId()
+  val domain = Domain("chala.wire.link")
   val push =            mock[PushService]
   val users =           mock[UserService]
   val convsStorage =    mock[ConversationStorage]
@@ -57,7 +59,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   val userPrefs = new TestUserPreferences()
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
-    new ConversationsUiServiceImpl(selfUserId, teamId, assetService, users, messages, messagesStorage,
+    new ConversationsUiServiceImpl(selfUserId, teamId, domain, assetService, users, messages, messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)
   }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -64,7 +64,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
 
   def initService: ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
-    new ConversationsUiServiceImpl(selfId, team, assetService, users, messages, messagesStorage,
+    new ConversationsUiServiceImpl(selfId, team, domain, assetService, users, messages, messagesStorage,
       msgContent, members, convsContent, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)
   }

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -68,7 +68,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     // Mock
     (syncHandler.fetchFileSharing _).expects().anyNumberOfTimes().returning(
-      Future.successful(FileSharingFeatureConfig("disabled"))
+      Future.successful(Some(FileSharingFeatureConfig("disabled")))
     )
 
     // When

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -30,7 +30,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     userPrefs.setValue(AppLockTimeout, Some(30.seconds))
 
     (syncHandler.fetchAppLock _).expects().anyNumberOfTimes().returning(
-      Future.successful(AppLockFeatureConfig(enabled = true, forced = true, timeout = Some(10.seconds)))
+      Future.successful(Some(AppLockFeatureConfig(enabled = true, forced = true, timeout = Some(10.seconds))))
     )
 
     val service = createService
@@ -50,7 +50,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     userPrefs.setValue(AppLockTimeout, Some(30.seconds))
 
     (syncHandler.fetchAppLock _).expects().anyNumberOfTimes().returning(
-      Future.successful(AppLockFeatureConfig.Disabled)
+      Future.successful(Some(AppLockFeatureConfig.Disabled))
     )
 
     val service = createService
@@ -86,7 +86,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     // Mock
     (syncHandler.fetchSelfDeletingMessages _).expects().anyNumberOfTimes().returning(
-      Future.successful(SelfDeletingMessagesFeatureConfig(isEnabled = true, 60))
+      Future.successful(Some(SelfDeletingMessagesFeatureConfig(isEnabled = true, 60)))
     )
 
     // When
@@ -136,7 +136,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     // Mock
     (syncHandler.fetchConferenceCalling _).expects().anyNumberOfTimes().returning(
-      Future.successful(ConferenceCallingFeatureConfig("disabled"))
+      Future.successful(Some(ConferenceCallingFeatureConfig("disabled")))
     )
 
     // When
@@ -146,4 +146,20 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(userPrefs(ConferenceCallingFeatureEnabled).apply()) shouldEqual false
   }
 
+  scenario("Don't update the feature flag if the fetching fails") {
+    // Given
+    val service = createService
+    userPrefs.setValue(ConferenceCallingFeatureEnabled, true)
+
+    // Mock
+    (syncHandler.fetchConferenceCalling _).expects().anyNumberOfTimes().returning(
+      Future.successful(None)
+    )
+
+    // When
+    result(service.updateConferenceCalling())
+
+    // Then
+    result(userPrefs(ConferenceCallingFeatureEnabled).apply()) shouldEqual true
+  }
 }

--- a/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/FeatureConfigsServiceSpec.scala
@@ -132,7 +132,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   scenario("Fetch the ConferenceCalling feature config and set properties") {
     // Given
     val service = createService
-    userPrefs.setValue(ConferenceCallingFeatureEnabled, Some(true))
+    userPrefs.setValue(ConferenceCallingFeatureEnabled, true)
 
     // Mock
     (syncHandler.fetchConferenceCalling _).expects().anyNumberOfTimes().returning(
@@ -143,7 +143,7 @@ class FeatureConfigsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     result(service.updateConferenceCalling())
 
     // Then
-    result(userPrefs(ConferenceCallingFeatureEnabled).apply()) shouldEqual Some(false)
+    result(userPrefs(ConferenceCallingFeatureEnabled).apply()) shouldEqual false
   }
 
 }

--- a/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/teams/TeamsServiceSpec.scala
@@ -294,7 +294,7 @@ class TeamsServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
   def createService: TeamsService =
     new TeamsServiceImpl(
-      selfUser, teamId, teamStorage, userService, userStorage, convsStorage, convMembers,
+      selfUser, teamId, domain, teamStorage, userService, userStorage, convsStorage, convMembers,
       convsContent, convsService, sync, syncRequests, userPrefs, errorsService, rolesService
     )
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-906

A change in how we handle the conference calling user preference.
This should fix both that on on-premise installation with older backends conference calling should stil be enabled
and that the user for whom conference calling is disabled should see the enterprise alert only when it becomes
enabled by a change on the backend.

Also this commit contains fixes to unit tests, broken recently by some other changes.
