### PR TITLE
Notifications: Refactoring to make initialization lighter when it's triggered by a notification (SQCORE-1146)

### DIFF
--- a/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
+++ b/app/src/main/scala/com/waz/services/websocket/WebSocketService.scala
@@ -38,7 +38,7 @@ import com.waz.zclient._
 import com.waz.zclient.log.LogUI._
 import com.wire.signals.Signal
 
-class WebSocketController(implicit inj: Injector) extends Injectable with DerivedLogTag {
+final class WebSocketController(implicit inj: Injector) extends Injectable with DerivedLogTag {
   private lazy val global = inject[GlobalModule]
   private lazy val accounts = inject[AccountsService]
 
@@ -60,6 +60,7 @@ class WebSocketController(implicit inj: Injector) extends Injectable with Derive
   lazy val serviceInForeground: Signal[Boolean] =
     for {
       uiActive       <- global.lifecycle.uiActive
+      _ = verbose(l"uiActive: $uiActive")
       (zmsWithWS, _) <- accountWebsocketStates
     } yield !uiActive && zmsWithWS.nonEmpty
 
@@ -133,7 +134,7 @@ class OnBootAndUpdateBroadcastReceiver extends BroadcastReceiver with DerivedLog
 /**
   * Service keeping the process running as long as web socket should be connected.
   */
-class WebSocketService extends ServiceHelper with DerivedLogTag {
+final class WebSocketService extends ServiceHelper with DerivedLogTag {
   private implicit def context: Context = getApplicationContext
 
   private lazy val launchIntent        = PendingIntent.getActivity(context, 1, Intents.ShowAdvancedSettingsIntent, 0)

--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -44,6 +44,7 @@ import com.waz.service.assets._
 import com.waz.service.call.GlobalCallingService
 import com.waz.service.conversation._
 import com.waz.service.messages.MessagesService
+import com.waz.service.push.PushService.{ForceSync, SyncHistory}
 import com.waz.service.teams.{FeatureConfigsService, TeamsService}
 import com.waz.service.tracking.TrackingService
 import com.waz.services.fcm.FetchJob
@@ -453,6 +454,11 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     inject[ImageNotificationsController]
     inject[CallingNotificationsController]
     inject[MessageNotificationsController].initialize()
+    activityLifecycleCallback.appInBackground.map(!_._1).foreach {
+      case true =>
+        inject[Signal[ZMessaging]].head.foreach(_.push.syncNotifications(SyncHistory(ForceSync)))
+      case false =>
+    }
 
 //    //TODO [AN-4942] - is this early enough for app launch events?
     inject[GlobalTrackingController]

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -87,9 +87,7 @@ final class MessagesStorageImpl(context:     Context,
                                 selfUserId:  UserId,
                                 convs:       ConversationStorage,
                                 users:       UsersStorage,
-                                msgAndLikes: => MessageAndLikesStorage,
-                                timeouts:    Timeouts,
-                                tracking:    TrackingService)
+                                msgAndLikes: => MessageAndLikesStorage)
   extends CachedStorageImpl[MessageId, MessageData](
     new TrimmingLruCache[MessageId, Option[MessageData]](context, Fixed(MessagesStorage.cacheSize)),
     storage
@@ -326,7 +324,9 @@ trait MessageAndLikesStorage {
   def sortedLikes(likes: Likes, selfUserId: UserId): (IndexedSeq[UserId], Boolean)
 }
 
-class MessageAndLikesStorageImpl(selfUserId: UserId, messages: => MessagesStorage, likings: ReactionsStorage) extends MessageAndLikesStorage {
+final class MessageAndLikesStorageImpl(selfUserId: UserId,
+                                       messages:   => MessagesStorage,
+                                       likings:    ReactionsStorage) extends MessageAndLikesStorage {
   import com.waz.threading.Threading.Implicits.Background
 
   val onUpdate = EventStream[MessageId]() // TODO: use batching, maybe report new message data instead of just id

--- a/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountContext.scala
@@ -24,8 +24,7 @@ import com.waz.service.AccountsService.LoggedOut
 import com.waz.service.ZMessaging.accountTag
 import com.wire.signals.{BaseEventContext, SerialDispatchQueue}
 
-class AccountContext(userId: UserId, accounts: AccountsService) extends BaseEventContext {
-
+final class AccountContext(userId: UserId, accounts: AccountsService) extends BaseEventContext {
   implicit val logTag: LogTag = accountTag[AccountContext](userId)
   private implicit val dispatcher = SerialDispatchQueue(name = "AccountContext")
 

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -58,8 +58,7 @@ trait Avs {
   * Facilitates synchronous communication with AVS and also provides a wrapper around the native code which can be easily
   * mocked for testing the CallingService
   */
-class AvsImpl() extends Avs with DerivedLogTag {
-
+final class AvsImpl() extends Avs with DerivedLogTag {
   private implicit val dispatcher = SerialDispatchQueue(name = "AvsWrapper")
 
   import Avs._

--- a/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
@@ -29,11 +29,11 @@ import com.waz.utils.RichWireInstant
 import com.wire.signals.EventContext
 import org.threeten.bp.Duration
 
-class CallLoggingService(selfUserId:  UserId,
-                         calling:     CallingService,
-                         messages:    MessagesService,
-                         pushService: PushService,
-                         tracking:    TrackingService)(implicit eventContext: EventContext) extends DerivedLogTag {
+final class CallLoggingService(selfUserId:  UserId,
+                               calling:     CallingService,
+                               messages:    MessagesService,
+                               pushService: PushService,
+                               tracking:    TrackingService)(implicit eventContext: EventContext) extends DerivedLogTag {
 
   private var subscribedConvs = Set.empty[ConvId]
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -57,8 +57,7 @@ import scala.concurrent.{Future, Promise}
 import scala.util.Success
 import scala.util.control.NonFatal
 
-class GlobalCallingService extends DerivedLogTag {
-
+final class GlobalCallingService extends DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
 
   lazy val globalCallProfile: Signal[GlobalCallProfile] =
@@ -173,11 +172,9 @@ final class CallingServiceImpl(val accountId:       UserId,
                                mediaManagerService: MediaManagerService,
                                pushService:         PushService,
                                network:             NetworkModeService,
-                               errors:              ErrorsService,
                                userPrefs:           UserPreferences,
                                globalPrefs:         GlobalPreferences,
                                permissions:         PermissionsService,
-                               userStorage:         UsersStorage,
                                httpProxy:           Option[Proxy])
                               (implicit accountContext: AccountContext)
   extends CallingService with DerivedLogTag with SafeToLog { self =>

--- a/zmessaging/src/main/scala/com/waz/service/otr/EventDecrypter.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/EventDecrypter.scala
@@ -20,7 +20,7 @@ class EventDecrypterImpl(selfId:        UserId,
                          storage:       PushNotificationEventsStorage,
                          clients:       OtrClientsService,
                          sessions:      CryptoSessionService,
-                         tracking:      => TrackingService) extends EventDecrypter with DerivedLogTag {
+                         tracking:      () => TrackingService) extends EventDecrypter with DerivedLogTag {
   import com.waz.threading.Threading.Implicits.Background
   import EventDecrypter._
 
@@ -38,7 +38,7 @@ class EventDecrypterImpl(selfId:        UserId,
       case Left(err) =>
         val e = OtrErrorEvent(otrEvent.convId, otrEvent.convDomain, otrEvent.time, otrEvent.from, otrEvent.fromDomain, err)
         error(l"Got error when decrypting: $e")
-        tracking.msgDecryptionFailed(otrEvent.convId, selfId)
+        tracking().msgDecryptionFailed(otrEvent.convId, selfId)
         storage.writeError(index, e)
       case Right(_) =>
         Future.successful(())
@@ -82,6 +82,6 @@ object EventDecrypter {
             storage:       PushNotificationEventsStorage,
             clients:       OtrClientsService,
             sessions:      CryptoSessionService,
-            tracking:      => TrackingService): EventDecrypter =
+            tracking:      () => TrackingService): EventDecrypter =
     new EventDecrypterImpl(selfId, currentDomain, storage, clients, sessions, tracking)
 }

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
@@ -88,7 +88,7 @@ class OtrClientsServiceImpl(selfId:        UserId,
 
   override def requestSyncIfNeeded(retryInterval: FiniteDuration = 7.days): Unit =
     getSelfClient.zip(lastSelfClientsSyncPref()) flatMap {
-      case (Some(c), t) if t > System.currentTimeMillis() - retryInterval.toMillis => Future.successful(())
+      case (Some(_), t) if t > System.currentTimeMillis() - retryInterval.toMillis => Future.successful(())
       case _ =>
         sync.syncSelfClients() flatMap { _ =>
           lastSelfClientsSyncPref := System.currentTimeMillis()
@@ -142,7 +142,7 @@ class OtrClientsServiceImpl(selfId:        UserId,
         Future.successful(Option.empty[SyncId])
     }
 
-  override def selfClient: Signal[Client] = for {
+  override lazy val selfClient: Signal[Client] = for {
     uc <- storage.signal(selfId)
     res <- Signal.const(uc.clients.get(clientId)).collect { case Some(c) => c }
   } yield res

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrEventDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrEventDecoder.scala
@@ -13,7 +13,7 @@ trait OtrEventDecoder {
   def decode(event: PushNotificationEvent): Option[Event]
 }
 
-final class OtrEventDecoderImpl(selfUserId:    UserId, currentDomain: Domain)
+final class OtrEventDecoderImpl(selfUserId: UserId, currentDomain: Domain)
   extends OtrEventDecoder with DerivedLogTag {
   import OtrEventDecoder._
 

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -82,13 +82,8 @@ final class PushServiceImpl(selfUserId:        UserId,
                             otrEventDecrypter: EventDecrypter,
                             otrEventDecoder:   OtrEventDecoder,
                             wsPushService:     WSPushService,
-                            accounts:          AccountsService,
-                            pushTokenService:  PushTokenService,
-                            network:           NetworkModeService,
-                            lifeCycle:         UiLifeCycle,
-                            tracking:          TrackingService,
-                            sync:              SyncServiceHandle,
-                            timeouts:          Timeouts)
+                            network:           => NetworkModeService,
+                            sync:              => SyncServiceHandle)
                            (implicit ev: AccountContext) extends PushService { self =>
   import PushService._
 

--- a/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -87,12 +87,12 @@ object WSPushServiceImpl {
   }
 }
 
-class WSPushServiceImpl(userId:              UserId,
-                        accessTokenProvider: AccessTokenProvider,
-                        requestCreator:      RequestCreator,
-                        webSocketFactory:    WebSocketFactory,
-                        networkModeService:  NetworkModeService,
-                        backoff:             Backoff = ExponentialBackoff.standardBackoff) extends WSPushService {
+final class WSPushServiceImpl(userId:              UserId,
+                              accessTokenProvider: AccessTokenProvider,
+                              requestCreator:      RequestCreator,
+                              webSocketFactory:    WebSocketFactory,
+                              networkModeService:  NetworkModeService,
+                              backoff:             Backoff = ExponentialBackoff.standardBackoff) extends WSPushService {
 
   private implicit val logTag: LogTag = accountTag[WSPushServiceImpl](userId)
   private implicit val dispatcher = SerialDispatchQueue(name = "WSPushServiceImpl")

--- a/zmessaging/src/test/scala/com/waz/service/EventDecrypterSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/EventDecrypterSpec.scala
@@ -18,7 +18,7 @@ class EventDecrypterSpec extends AndroidFreeSpec {
   private val clients = mock[OtrClientsService]
   private val sessions = mock[CryptoSessionService]
 
-  def decrypter: EventDecrypter = EventDecrypter(userId, domain, storage, clients, sessions, tracking)
+  def decrypter: EventDecrypter = EventDecrypter(userId, domain, storage, clients, sessions, () => tracking)
 
   scenario("decrypt a valid otr event") {
     val from = UserId()

--- a/zmessaging/src/test/scala/com/waz/service/NotificationParserSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/NotificationParserSpec.scala
@@ -24,12 +24,12 @@ class NotificationParserSpec extends AndroidFreeSpec {
   private val self = UserData.withName(selfId, "self").copy(availability = Availability.Available, domain = domain)
   private val conv = ConversationData(convId, rConvId, Some("conv"), selfId, lastRead = before, domain = domain, muted = MuteSet.AllAllowed)
 
-  private lazy val convStorage = mock[ConversationStorage]
-  private lazy val usersStorage = mock[UsersStorage]
-  private lazy val mlStorage = mock[MessageAndLikesStorage]
-  private lazy val calling = mock[CallingService]
+  private val convStorage = mock[ConversationStorage]
+  private val usersStorage = mock[UsersStorage]
+  private val mlStorage = mock[MessageAndLikesStorage]
+  private val calling = mock[CallingService]
 
-  private def parser = NotificationParser(selfId, convStorage, usersStorage, mlStorage, calling)
+  private def parser = NotificationParser(selfId, convStorage, usersStorage, () => mlStorage, () => calling)
 
   scenario("show a notification on the event of deleting a conversation") {
     val senderId = UserId("sender")

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -62,7 +62,6 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val messages       = mock[MessagesService]
   val permissions    = mock[PermissionsService]
   val push           = mock[PushService]
-  val usersStorage   = mock[UsersStorage]
   val otrSyncHandler = mock[OtrSyncHandler]
   val globalPrefs    = new TestGlobalPreferences
 
@@ -1190,11 +1189,9 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
     (avs.registerAccount _).expects(*).once().returning(Future.successful(wCall))
 
-    (usersStorage.get _).expects(selfUserId).anyNumberOfTimes().returning(Future.successful(Some(selfUserData)))
-
     val s = new CallingServiceImpl(
       selfUserId, selfClientId, null, avs, convs, convsService, members, otrSyncHandler,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, httpProxy = None
+      flows, messages, media, push, network, prefs, globalPrefs, permissions, httpProxy = None
     )
     result(s.wCall)
     s


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQCORE-1146

When the app starts, either because the user clicked on the icon, or because of an incoming notification, the method `WireApplication.ensureInitialized()` is called.

The original idea was to split the initialization into two parts - one with the all necessary components that need to be initialized immediately, the other with components that are needed only when the app goes to the front and can be initialized as a response to that. 
But it turns out the initialization is too complicated. Components depend on each other in a non-trivial way, and this ticket shouldn't try to untangle and fix it all. So instead I looked into logs to learn what happens when the app is initialized through a notification and tried to minimize what I saw there while not risking that one of the components will stop working because I turned off something it depended on.

I also included a small fix in `NotificationHandlerService` for when a notification is cancelled by swiping it out from the screen. When the bug was there, it was possible that a specific notification was removed but the "bundle" notification wrapped around it stayed in the tray, displayed as an empty rectangle.