### PR TITLE
chore: GRGIT update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 plugins {
     id "com.github.hierynomus.license" version "0.13.1"
     id "io.gitlab.arturbosch.detekt" version "1.2.2"
-    id "org.ajoberstar.grgit" version "4.1.0"
+    id "org.ajoberstar.grgit" version "4.1.1"
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val DETEKT = "1.2.2"
     const val JACOCO = "0.8.5"
     const val DEX_INFO = "0.1.2"
-    const val GRGIT = "4.1.0"
+    const val GRGIT = "4.1.1"
 
     //build
     const val COROUTINES = "1.3.7"


### PR DESCRIPTION
This commit fixes a bug that appears in compilation:
```
org/eclipse/jgit/storage/file/FileRepositoryBuilder has been compiled by a more recent version of the Java Runtime
(class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

The solution is to simply update GRGIT to 4.1.1.