### PR TITLE
fix: A change in the "Maintain connection to the server" copy (SQCORE-1196)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -585,8 +585,11 @@
     <string name="debug_report__title">Wire debug report - %1$s</string>
     <string name="debug_report__body">Please describe the steps required to reproduce the issue, provide screenshots if possible and send this email.\n\n</string>
     <string name="pref_advanced_ws_foreground_title">Maintain connection to server</string>
-    <string name="pref_advanced_ws_foreground_summary">Wire will try to keep a connection with the server open to receive notifications while the application is not in the foreground.
-        Turning this setting off may improve battery performance, but you will no longer receive notifications when Wire is in the background. This applies to all accounts on this device.</string>
+    <string name="pref_advanced_ws_foreground_summary">
+        Wire will try to keep a connection with the server open to receive notifications while the application is not in the foreground.
+        Turning this setting off may improve battery performance, but receiving notifications might be less reliable.
+        This applies to all accounts on this device.
+    </string>
     <string name="pref_advanced_full_sync_title">Perform full synchronization</string>
     <string name="pref_advanced_full_sync_summary">This performs a full synchronization with the server.</string>
     <string name="pref_advanced_full_sync_popup">Are you sure? The full synchronization may take a while.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1196" title="SQCORE-1196" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQCORE-1196</a>  [Android] Rewrite info message what “maintain connection to server” does
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


https://wearezeta.atlassian.net/browse/SQCORE-1196

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The current description of this option is invalid. When the option is off, it doesn't mean that notification won't come
(as the text suggests). It only means we switch to another way of receiving notification which might be less reliable.


### Solutions

The text has been changed.


### Testing

Manually 


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configu