### PR TITLE
chore: bump AVS version to 8.0.5 (FS-11)

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -4,7 +4,7 @@ final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
 final String AVS_GROUP = "com.wire"
 final String AVS_NAME = "avs"
 
-String avsVersion = "7.2.105"
+String avsVersion = "8.0.5"
 
 ext {
     avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_GROUP


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-11" title="FS-11" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />FS-11</a>  [Android] As a user, I can place a call with a user in my contact list who is part of a federated backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The current AVS version does not federated conference calls

### Solutions

By updating to AVS 8.0.5 we will be able to make federated conference calls

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

Manually tested

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
