### PR TITLE
fix: Notifications: Calls and missed calls notifications should be ignored when the user is Away (SQCORE-1180)

### DIFF
--- a/app/src/nonfree/scala/com/waz/services/fcm/FCMNotificationWorker.scala
+++ b/app/src/nonfree/scala/com/waz/services/fcm/FCMNotificationWorker.scala
@@ -65,7 +65,10 @@ final class FCMNotificationWorker(context: Context, params: WorkerParameters)
       parser     =  zms.notificationParser
       controller = WireApplication.APP_INSTANCE.messageNotificationsController
     } yield
-      FCMPushHandler(userId, clientId, client,  storage, decrypter, decoder, parser, controller, () => zms.calling, global.prefs, zms.userPrefs)
+      FCMPushHandler(
+        userId, clientId, client,  storage, decrypter, decoder, parser, controller,
+        () => zms.calling, () => zms.usersStorage, global.prefs, zms.userPrefs
+      )
     handler.foreach(_.syncNotifications())
   }
 }

--- a/app/src/test/scala/com/waz/services/fcm/FCMPushHandlerSpec.scala
+++ b/app/src/test/scala/com/waz/services/fcm/FCMPushHandlerSpec.scala
@@ -19,6 +19,7 @@ package com.waz.services.fcm
 
 import com.waz.content.GlobalPreferences.BackendDrift
 import com.waz.content.UserPreferences.LastStableNotification
+import com.waz.content.UsersStorage
 import com.waz.model.otr.ClientId
 import com.waz.model._
 import com.waz.service.call.CallingService
@@ -49,18 +50,20 @@ class FCMPushHandlerSpec extends FeatureSpec
     Threading.setAsDefault(dispatcher)
   }
 
-  private val client      = mock[PushNotificationsClient]
-  private val storage     = mock[PushNotificationEventsStorage]
-  private val decrypter   = mock[EventDecrypter]
-  private val decoder     = mock[OtrEventDecoder]
-  private val parser      = mock[NotificationParser]
-  private val calling     = mock[CallingService]
-  private val controller  = mock[NotificationUiController]
-  private val globalPrefs = new TestGlobalPreferences
-  private val userPrefs   = new TestUserPreferences
+  private val client       = mock[PushNotificationsClient]
+  private val storage      = mock[PushNotificationEventsStorage]
+  private val decrypter    = mock[EventDecrypter]
+  private val decoder      = mock[OtrEventDecoder]
+  private val parser       = mock[NotificationParser]
+  private val calling      = mock[CallingService]
+  private val usersStorage = mock[UsersStorage]
+  private val controller   = mock[NotificationUiController]
+  private val globalPrefs  = new TestGlobalPreferences
+  private val userPrefs    = new TestUserPreferences
 
   private def handler = FCMPushHandler(
-    userId, clientId, client, storage, decrypter, decoder, parser, controller, () => calling, globalPrefs, userPrefs
+    userId, clientId, client, storage, decrypter, decoder, parser,
+    controller, () => calling, () => usersStorage, globalPrefs, userPrefs
   )
 
   private def result[T](scenario: Future[T]): T = Await.result(scenario, 5.seconds)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1180" title="SQCORE-1180" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQCORE-1180</a>  [Android] The missed call notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


https://wearezeta.atlassian.net/browse/SQCORE-1180

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we have an inconsistent behaviour when a call comes in while the availability status of the user is Away.
The call is ignored, but the "missed call" notification appears.

### Solutions

This PR fixes it by ensuring that any call notification will be ignored when the user is Away, including missed calls.


### Testing

Unit tests  and manually


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.