### PR TITLE
feat: Assets in Federation (FS-293)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/ClientsController.scala
@@ -37,7 +37,7 @@ import com.waz.zclient.BuildConfig
 
 import scala.concurrent.Future
 
-class ClientsController(implicit inj: Injector) extends Injectable with DerivedLogTag {
+final class ClientsController(implicit inj: Injector) extends Injectable with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Background
 

--- a/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
@@ -151,10 +151,10 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
 object ChatHeadView {
   private val pendingConnectionStatuses = Set(ConnectionStatus.PendingFromUser, ConnectionStatus.PendingFromOther)
 
-  case class Attributes(isRound: Boolean,
-                        showWaiting: Boolean,
-                        greyScaleOnConnected: Boolean,
-                        defaultBackground: Int)
+  final case class Attributes(isRound: Boolean,
+                              showWaiting: Boolean,
+                              greyScaleOnConnected: Boolean,
+                              defaultBackground: Int)
 
   object OverlayIcon extends Enumeration {
     val Waiting, Blocked = Value
@@ -166,12 +166,12 @@ object ChatHeadView {
   }
   type CropShape = CropShape.Value
 
-  case class ChatHeadViewOptions(picture: Option[Picture],
-                                 backgroundColor: Int,
-                                 grayScale: Boolean,
-                                 initials: String,
-                                 cropShape: Option[CropShape],
-                                 icon: Option[OverlayIcon])(implicit context: Context) extends DerivedLogTag {
+  final case class ChatHeadViewOptions(picture: Option[Picture],
+                                       backgroundColor: Int,
+                                       grayScale: Boolean,
+                                       initials: String,
+                                       cropShape: Option[CropShape],
+                                       icon: Option[OverlayIcon])(implicit context: Context) extends DerivedLogTag {
     lazy val placeholder = ChatHeadViewPlaceholder(backgroundColor, initials, cropShape = cropShape, reversedColors = cropShape.isEmpty)
 
     def glideRequest(implicit context: Context): RequestBuilder[Drawable] = {
@@ -208,10 +208,10 @@ object ChatHeadView {
     }
   }
 
-  case class ChatHeadViewPlaceholder(color: Int,
-                                     text: String,
-                                     cropShape: Option[CropShape],
-                                     reversedColors: Boolean = false)(implicit context: Context) extends Drawable {
+  final case class ChatHeadViewPlaceholder(color: Int,
+                                           text: String,
+                                           cropShape: Option[CropShape],
+                                           reversedColors: Boolean = false)(implicit context: Context) extends Drawable {
     private val textPaint = returning(new Paint(Paint.ANTI_ALIAS_FLAG)) { p =>
       p.setTextAlign(Paint.Align.CENTER)
       val tf = TypefaceUtils.getTypeface(getString(if (reversedColors) R.string.wire__typeface__medium else R.string.wire__typeface__light))

--- a/app/src/main/scala/com/waz/zclient/glide/AssetRequest.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/AssetRequest.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.zclient.glide
 
-import com.waz.model.{AssetId, GeneralAssetId, Picture, PictureNotUploaded, PictureUploaded, UploadAssetId}
+import com.waz.model.{AssetId, GeneralAssetId, UploadAssetId}
 import com.waz.api.MessageContent.Location
 
 sealed trait AssetRequest {
@@ -30,26 +30,21 @@ object AssetRequest {
     case a: AssetId       => AssetIdRequest(a)
     case _                => EmptyRequest
   }
-
-  def apply(picture: Picture): AssetRequest = picture match {
-    case PictureUploaded(assetId)    => PublicAssetIdRequest(assetId)
-    case PictureNotUploaded(assetId) => UploadAssetIdRequest(assetId)
-  }
 }
 
-case class AssetIdRequest(assetId: AssetId) extends AssetRequest {
+final case class AssetIdRequest(assetId: AssetId) extends AssetRequest {
   override val key: String = assetId.str
 }
 
-case class PublicAssetIdRequest(assetId: AssetId) extends AssetRequest {
+final case class PublicAssetIdRequest(assetId: AssetId) extends AssetRequest {
   override val key: String = assetId.str
 }
 
-case class UploadAssetIdRequest(assetId: UploadAssetId) extends AssetRequest {
+final case class UploadAssetIdRequest(assetId: UploadAssetId) extends AssetRequest {
   override val key: String = assetId.str
 }
 
-case class MapRequest(location: Location) extends AssetRequest {
+final case class MapRequest(location: Location) extends AssetRequest {
   override val key: String = location.toString
 }
 

--- a/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
+final class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
   extends DataFetcher[InputStream] with DerivedLogTag {
 
   import com.waz.threading.Threading.Implicits.Background
@@ -42,15 +42,13 @@ class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
   private var currentData: Option[CancellableFuture[AssetInput]] = None
 
   override def loadData(priority: Priority, callback: DataFetcher.DataCallback[_ >: InputStream]): Unit = {
-
     val data = CancellableFuture.lift(zms.head).flatMap { zms =>
       request match {
         case AssetIdRequest(assetId)             => zms.assetService.loadContentById(assetId)
         case PublicAssetIdRequest(assetId)       => zms.assetService.loadPublicContentById(assetId, None)
         case UploadAssetIdRequest(uploadAssetId) => zms.assetService.loadUploadContentById(uploadAssetId, None)
         case MapRequest(location)                => zms.mapsMediaService.loadMapPreview(location)
-        case _ =>
-          CancellableFuture.failed(NotSupportedError("Unsupported image request"))
+        case _                                   => CancellableFuture.failed(NotSupportedError("Unsupported image request"))
       }
     }
 

--- a/app/src/main/scala/com/waz/zclient/glide/loaders/AssetModelLoader.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/loaders/AssetModelLoader.scala
@@ -32,7 +32,7 @@ import com.waz.zclient.glide.{AssetRequest, ImageAssetFetcher}
 import com.waz.zclient.log.LogUI._
 import com.waz.zclient.{Injectable, Injector, WireContext}
 
-class AssetModelLoader(zms: Signal[ZMessaging]) extends ModelLoader[GeneralAssetId, InputStream]
+final class AssetModelLoader(zms: Signal[ZMessaging]) extends ModelLoader[GeneralAssetId, InputStream]
   with DerivedLogTag {
 
   override def buildLoadData(model: GeneralAssetId, width: Int, height: Int, options: Options): ModelLoader.LoadData[InputStream] = {

--- a/app/src/main/scala/com/waz/zclient/glide/loaders/MapModelLoader.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/loaders/MapModelLoader.scala
@@ -32,7 +32,7 @@ import com.waz.zclient.{Injectable, Injector, WireContext}
 import com.waz.zclient.glide.{MapRequest, ImageAssetFetcher}
 import com.waz.zclient.log.LogUI._
 
-class MapModelLoader(zms: Signal[ZMessaging]) extends ModelLoader[Location, InputStream]
+final class MapModelLoader(zms: Signal[ZMessaging]) extends ModelLoader[Location, InputStream]
   with DerivedLogTag {
 
   override def buildLoadData(model: Location, width: Int, height: Int, options: Options): ModelLoader.LoadData[InputStream] = {

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/accountdata/ActiveAccountsDaoTest.kt
@@ -164,6 +164,7 @@ class ActiveAccountsDaoTest : IntegrationTest() {
             refreshToken: String = TEST_ACTIVE_ACCOUNT_COOKIE
         ) = ActiveAccountsEntity(
             id = userId,
+            domain = null,
             teamId = TEST_ACTIVE_ACCOUNT_TEAM_ID,
             refreshToken = refreshToken,
             accessToken = accessToken,

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetsDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/assets/AssetsDaoTest.kt
@@ -41,8 +41,6 @@ class AssetsDaoTest : IntegrationTest() {
             assetsDao.insert(assetsEntity())
         }
         val storedMessages = assetsDao.allAssets()
-        assertEquals(storedMessages.first().conversationId, data.first().conversationId)
-        assertEquals(storedMessages.last().conversationId, data.last().conversationId)
         assertEquals(storedMessages.size, numberOfItems)
     }
 
@@ -77,6 +75,7 @@ class AssetsDaoTest : IntegrationTest() {
         val data = AssetsTestDataProvider.provideDummyTestData()
         return AssetsEntity(
             id = id,
+            domain = null,
             token = data.token,
             name = data.name,
             encryption = data.encryption,
@@ -85,8 +84,7 @@ class AssetsDaoTest : IntegrationTest() {
             size = data.size,
             source = data.source,
             preview = data.preview,
-            details = data.details,
-            conversationId = data.conversationId
+            details = data.details
         )
     }
 }

--- a/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UsersDaoTest.kt
+++ b/storage/src/androidTest/kotlin/com/waz/zclient/storage/userdatabase/users/UsersDaoTest.kt
@@ -92,7 +92,8 @@ class UsersDaoTest : IntegrationTest() {
             selfPermission = data.selfPermission,
             copyPermission = data.copyPermission,
             createdBy = data.createdBy,
-            domain = data.domain
+            domain = data.domain,
+            conversationDomain = data.conversationDomain
         )
     }
 

--- a/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/UsersStorage.scala
@@ -19,10 +19,10 @@ package com.waz.content
 
 import android.content.Context
 import com.waz.log.BasicLogging.LogTag
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model._
 import com.waz.service.{SearchKey, SearchQuery}
-import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils._
 import com.wire.signals._
 
@@ -38,6 +38,8 @@ trait UsersStorage extends CachedStorage[UserId, UserData] {
   def listAcceptedOrPendingUsers: Future[Map[UserId, UserData]]
 
   def findUsersForService(id: IntegrationId): Future[Set[UserData]]
+
+  def findByPicture(assetId: GeneralAssetId): Future[Option[UserData]]
 }
 
 final class UsersStorageImpl(context: Context, storage: ZmsDatabase)
@@ -73,4 +75,7 @@ final class UsersStorageImpl(context: Context, storage: ZmsDatabase)
 
   override def searchByTeam(team: TeamId, query: SearchQuery): Future[Set[UserData]] =
     storage(UserDataDao.search(SearchKey(query.query), query.domain, query.handleOnly, Some(team))(_)).future
+
+  override def findByPicture(assetId: GeneralAssetId): Future[Option[UserData]] =
+    values.map(_.find(_.picture.exists(_.id == assetId)))
 }

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -99,6 +99,8 @@ trait UserService {
   def syncClients(userId: UserId): Future[SyncId]
   def syncClients(userIds: Set[UserId]): Future[SyncId]
   def syncClients(convId: ConvId): Future[SyncId]
+
+  def findUserByPicture(assetId: GeneralAssetId): Future[Option[UserData]]
 }
 
 class UserServiceImpl(selfUserId:        UserId,
@@ -527,6 +529,9 @@ class UserServiceImpl(selfUserId:        UserId,
 
   override def syncClients(convId: ConvId): Future[SyncId] =
     membersStorage.getActiveUsers(convId).flatMap(userIds => syncClients(userIds.toSet))
+
+  override def findUserByPicture(assetId: GeneralAssetId): Future[Option[UserData]] =
+    usersStorage.findByPicture(assetId)
 }
 
 object UserService {

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -309,7 +309,8 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
       )(Threading.IO),
       new UploadAssetContentCacheImpl(rawCacheDirectory)(Threading.IO),
       assetClient,
-      sync
+      sync,
+      users
     )
   }
 

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -29,6 +29,7 @@ import com.waz.testutils.TestUserPreferences
 import com.waz.utils.Managed
 import com.wire.signals.{EventStream, Signal, SourceSignal}
 import com.waz.utils.wrappers.DB
+import com.waz.zms.BuildConfig
 
 import scala.collection.breakOut
 import scala.collection.generic.CanBuild
@@ -55,81 +56,88 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val timeouts          = new Timeouts
   val userPrefs         = new TestUserPreferences
 
+  private def userWithName(idSymbol: Symbol, name: String): UserData =
+    if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+      UserData.withName(id(idSymbol), name).copy(domain = currentDomain)
+    } else {
+      UserData.withName(id(idSymbol), name)
+    }
+
   lazy val users = Map(
-    id('me) -> UserData.withName(id('me), "A user"),
-    id('a) -> UserData.withName(id('a), "other user 1"),
-    id('b) -> UserData.withName(id('b), "other user 2"),
-    id('c) -> UserData.withName(id('c), "some name"),
-    id('d) -> UserData.withName(id('d), "related user 1").copy(relation = Relation.Second), // TODO: relation does not exists anymore, can be removed!
-    id('e) -> UserData.withName(id('e), "related user 2").copy(relation = Relation.Second),
-    id('f) -> UserData.withName(id('f), "other related").copy(relation = Relation.Third),
-    id('g) -> UserData.withName(id('g), "friend user 1").copy(connection = ConnectionStatus.ACCEPTED),
-    id('h) -> UserData.withName(id('h), "friend user 2").copy(connection = ConnectionStatus.ACCEPTED),
-    id('i) -> UserData.withName(id('i), "some other friend").copy(connection = ConnectionStatus.ACCEPTED),
-    id('j) -> UserData.withName(id('j), "meep moop").copy(email = Some(EmailAddress("moop@meep.me"))),
-    id('k) -> UserData.withName(id('k), "unconnected user").copy(connection = ConnectionStatus.UNCONNECTED),
-    id('l) -> UserData.withName(id('l), "Bjorn-Rodrigo Smith"),
-    id('m) -> UserData.withName(id('m), "John Smith"),
-    id('n) -> UserData.withName(id('n), "Jason-John Mercier"),
-    id('o) -> UserData.withName(id('o), "Captain Crunch").copy(handle = Some(Handle.from("john"))),
-    id('p) -> UserData.withName(id('p), "Peter Pan").copy(handle = Some(Handle.from("john"))),
-    id('q) -> UserData.withName(id('q), "James gjohnjones"),
-    id('r) -> UserData.withName(id('r), "Liv Boeree").copy(handle = Some(Handle.from("testjohntest"))),
-    id('s) -> UserData.withName(id('s), "blah").copy(handle = Some(Handle.from("mores"))),
-    id('t) -> UserData.withName(id('t), "test handle").copy(handle = Some(Handle.from("smoresare"))),
-    id('u) -> UserData.withName(id('u), "Wireless").copy(expiresAt = Some(RemoteInstant.ofEpochMilli(12345L))),
-    id('v) -> UserData.withName(id('v), "Wireful"),
-    id('z) -> UserData.withName(id('z), "Francois francois"),
-    id('pp1) -> UserData.withName(id('pp1), "External 1").copy(
+    id('me) -> userWithName('me, "A user"),
+    id('a) -> userWithName('a, "other user 1"),
+    id('b) -> userWithName('b, "other user 2"),
+    id('c) -> userWithName('c, "some name"),
+    id('d) -> userWithName('d, "related user 1").copy(relation = Relation.Second), // TODO: relation does not exists anymore, can be removed!
+    id('e) -> userWithName('e, "related user 2").copy(relation = Relation.Second),
+    id('f) -> userWithName('f, "other related").copy(relation = Relation.Third),
+    id('g) -> userWithName('g, "friend user 1").copy(connection = ConnectionStatus.ACCEPTED),
+    id('h) -> userWithName('h, "friend user 2").copy(connection = ConnectionStatus.ACCEPTED),
+    id('i) -> userWithName('i, "some other friend").copy(connection = ConnectionStatus.ACCEPTED),
+    id('j) -> userWithName('j, "meep moop").copy(email = Some(EmailAddress("moop@meep.me"))),
+    id('k) -> userWithName('k, "unconnected user").copy(connection = ConnectionStatus.UNCONNECTED),
+    id('l) -> userWithName('l, "Bjorn-Rodrigo Smith"),
+    id('m) -> userWithName('m, "John Smith"),
+    id('n) -> userWithName('n, "Jason-John Mercier"),
+    id('o) -> userWithName('o, "Captain Crunch").copy(handle = Some(Handle.from("john"))),
+    id('p) -> userWithName('p, "Peter Pan").copy(handle = Some(Handle.from("john"))),
+    id('q) -> userWithName('q, "James gjohnjones"),
+    id('r) -> userWithName('r, "Liv Boeree").copy(handle = Some(Handle.from("testjohntest"))),
+    id('s) -> userWithName('s, "blah").copy(handle = Some(Handle.from("mores"))),
+    id('t) -> userWithName('t, "test handle").copy(handle = Some(Handle.from("smoresare"))),
+    id('u) -> userWithName('u, "Wireless").copy(expiresAt = Some(RemoteInstant.ofEpochMilli(12345L))),
+    id('v) -> userWithName('v, "Wireful"),
+    id('z) -> userWithName('z, "Francois francois"),
+    id('pp1) -> userWithName('pp1, "External 1").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
       handle = Some(Handle.from("pp1")),
       createdBy = Some(id('aa1))
     ),
-    id('pp2) -> UserData.withName(id('pp2), "External 2").copy(
+    id('pp2) -> userWithName('pp2, "External 2").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
       handle = Some(Handle.from("pp2")),
       createdBy = Some(id('aa2))
     ),
-    id('pp3) -> UserData.withName(id('pp3), "External 3").copy(
+    id('pp3) -> userWithName('pp3, "External 3").copy(
       permissions = (externalPermissions, externalPermissions),
       teamId = teamId,
       handle = Some(Handle.from("pp3"))
     ),
-    id('mm1) -> UserData.withName(id('mm1), "Member 1").copy(
+    id('mm1) -> userWithName('mm1, "Member 1").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
       handle = Some(Handle.from("mm1")),
       createdBy = Some(id('aa1))
     ),
-    id('mm2) -> UserData.withName(id('mm2), "Member 2").copy(
+    id('mm2) -> userWithName('mm2, "Member 2").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
       handle = Some(Handle.from("mm2")),
       createdBy = Some(id('aa1))
     ),
-    id('mm3) -> UserData.withName(id('mm3), "Member 3").copy(
+    id('mm3) -> userWithName('mm3, "Member 3").copy(
       permissions = (memberPermissions, memberPermissions),
       teamId = teamId,
       handle = Some(Handle.from("mm3")),
       createdBy = Some(id('aa1))
     ),
-    id('aa1) -> UserData.withName(id('aa1), "Admin 1").copy(
+    id('aa1) -> userWithName('aa1, "Admin 1").copy(
       permissions = (adminPermissions, adminPermissions),
       teamId = teamId,
       handle = Some(Handle.from("aa1"))
     ),
-    id('aa2) -> UserData.withName(id('aa2), "Admin 2").copy(
+    id('aa2) -> userWithName('aa2, "Admin 2").copy(
       permissions = (adminPermissions, adminPermissions),
       teamId = teamId,
       handle = Some(Handle.from("aa2"))
     ),
-    id('me1) -> UserData.withName(id('me1), "Team Member With Email").copy(
+    id('me1) -> userWithName('me1, "Team Member With Email").copy(
       email = Some(EmailAddress("a_member@wire.com")),
       teamId = teamId
     ),
-    id('pe1) -> UserData.withName(id('pe1), "Person With Email").copy(
+    id('pe1) -> userWithName('pe1, "Person With Email").copy(
       email = Some(EmailAddress("a_person@wire.com"))
     )
   )
@@ -252,11 +260,21 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (convsStorage.findGroupConversations _).expects(*, *, *, *).returns(Future.successful(IndexedSeq.empty[ConversationData]))
 
-      (sync.syncSearchQuery _).expects(query).once().onCall { _: SearchQuery =>
-        Future.successful[SyncId] {
-          querySignal ! Some(queryResults)
-          result(querySignal.filter(_.contains(queryResults)).head)
-          SyncId()
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        (sync.syncSearchQuery _).expects(query.withDomain(currentDomain.str)).once().onCall { _: SearchQuery =>
+          Future.successful[SyncId] {
+            querySignal ! Some(queryResults)
+            result(querySignal.filter(_.contains(queryResults)).head)
+            SyncId()
+          }
+        }
+      } else {
+        (sync.syncSearchQuery _).expects(query).once().onCall { _: SearchQuery =>
+          Future.successful[SyncId] {
+            querySignal ! Some(queryResults)
+            result(querySignal.filter(_.contains(queryResults)).head)
+            SyncId()
+          }
         }
       }
 
@@ -280,11 +298,21 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
 
       (convsStorage.findGroupConversations _).expects(*, *, *, *).returns(Future.successful(IndexedSeq.empty[ConversationData]))
 
-      (sync.syncSearchQuery _).expects(query).once().onCall { _: SearchQuery =>
-        Future.successful[SyncId] {
-          querySignal ! Some(queryResults)
-          result(querySignal.filter(_.contains(queryResults)).head)
-          SyncId()
+      if (BuildConfig.FEDERATION_USER_DISCOVERY) {
+        (sync.syncSearchQuery _).expects(query.withDomain(currentDomain.str)).once().onCall { _: SearchQuery =>
+          Future.successful[SyncId] {
+            querySignal ! Some(queryResults)
+            result(querySignal.filter(_.contains(queryResults)).head)
+            SyncId()
+          }
+        }
+      } else {
+        (sync.syncSearchQuery _).expects(query).once().onCall { _: SearchQuery =>
+          Future.successful[SyncId] {
+            querySignal ! Some(queryResults)
+            result(querySignal.filter(_.contains(queryResults)).head)
+            SyncId()
+          }
         }
       }
 
@@ -562,6 +590,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       // THEN
       res shouldBe ids()
     }
+
 
     scenario("as an admin, search the externals that I invited") {
 

--- a/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
@@ -27,7 +27,7 @@ import com.waz.log.LogSE.{debug, _}
 import com.waz.log.LogShow
 import com.waz.model.errors.NotFoundLocal
 import com.waz.model._
-import com.waz.service.AccountsService
+import com.waz.service.{AccountsService, UserService}
 import com.waz.service.assets._
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.AssetClient
@@ -58,6 +58,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with Auth
   private val client              = mock[AssetClient]
   private val uriHelperMock       = mock[UriHelper]
   private val syncHandle          = mock[SyncServiceHandle]
+  private val userService         = mock[UserService]
 
   override val accountsService: AccountsService = mock[AccountsService]
   override val accountStorage: AccountStorage = mock[AccountStorage]
@@ -93,7 +94,8 @@ class AssetServiceSpec extends ZIntegrationMockSpec with DerivedLogTag with Auth
       cache,
       rawCache,
       client,
-      syncHandle
+      syncHandle,
+      userService
     )
 
   feature("Assets") {

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -28,7 +28,8 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
   private val otrSync          = mock[OtrSyncHandler]
   private val teamsSyncHandler = mock[TeamsSyncHandler]
 
-  val self = UserData("self")
+  val domain = if (BuildConfig.FEDERATION_USER_DISCOVERY) Domain("chala.wire.link") else Domain.Empty
+  val self = UserData("self").copy(domain = domain)
   val teamId = TeamId()
 
   def handler: UsersSyncHandler = new UsersSyncHandlerImpl(
@@ -49,10 +50,10 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
         Future.successful(Some(self))
       )
 
-      val user1 = UserData("user1").copy(connection = Accepted)
-      val user2 = UserData("user2").copy(connection = Blocked)
-      val user3 = UserData("user3").copy(connection = Unconnected)
-      val user4 = UserData("user4").copy(connection = PendingFromOther)
+      val user1 = UserData("user1").copy(connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(connection = Blocked, domain = domain)
+      val user3 = UserData("user3").copy(connection = Unconnected, domain = domain)
+      val user4 = UserData("user4").copy(connection = PendingFromOther, domain = domain)
       (usersStorage.values _).expects().anyNumberOfTimes().returning(
         Future.successful(Vector(user1, user2, user3, user4))
       )
@@ -72,15 +73,15 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
 
     scenario("Post to all team users (also unconnected) if self is in the team") {
       // given
-      val self = UserData("self").copy(teamId = Some(teamId))
+      val self = UserData("self").copy(teamId = Some(teamId), domain = domain)
       (userService.getSelfUser _).expects().anyNumberOfTimes().returning(
         Future.successful(Some(self))
       )
 
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Blocked)
-      val user3 = UserData("user3").copy(teamId = Some(teamId), connection = Unconnected)
-      val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Blocked, domain = domain)
+      val user3 = UserData("user3").copy(teamId = Some(teamId), connection = Unconnected, domain = domain)
+      val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther, domain = domain)
       (usersStorage.values _).expects().anyNumberOfTimes().returning(
         Future.successful(Vector(user1, user2, user3, user4))
       )
@@ -134,17 +135,17 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
 
     scenario("Post to to all team users and only connected non-team users") {
       // given
-      val self = UserData("self").copy(teamId = Some(teamId))
+      val self = UserData("self").copy(teamId = Some(teamId), domain = domain)
       (userService.getSelfUser _).expects().anyNumberOfTimes().returning(
         Future.successful(Some(self))
       )
 
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Blocked)
-      val user3 = UserData("user3").copy(teamId = Some(teamId), connection = Unconnected)
-      val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther)
-      val user5 = UserData("user5").copy(connection = Accepted)
-      val user6 = UserData("user6").copy(connection = Unconnected)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Blocked, domain = domain)
+      val user3 = UserData("user3").copy(teamId = Some(teamId), connection = Unconnected, domain = domain)
+      val user4 = UserData("user4").copy(teamId = Some(teamId), connection = PendingFromOther, domain = domain)
+      val user5 = UserData("user5").copy(connection = Accepted, domain = domain)
+      val user6 = UserData("user6").copy(connection = Unconnected, domain = domain)
       (usersStorage.values _).expects().anyNumberOfTimes().returning(
         Future.successful(Vector(user1, user2, user3, user4, user5, user6))
       )
@@ -164,15 +165,15 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
 
     scenario("Cut off some non-team users if limit is reached") {
       // given
-      val self = UserData("self").copy(teamId = Some(teamId))
+      val self = UserData("self").copy(teamId = Some(teamId), domain = domain)
       (userService.getSelfUser _).expects().anyNumberOfTimes().returning(
         Future.successful(Some(self))
       )
 
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
-      val user3 = UserData("user3").copy(connection = Accepted)
-      val user4 = UserData("user4").copy(connection = Accepted)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user3 = UserData("user3").copy(connection = Accepted, domain = domain)
+      val user4 = UserData("user4").copy(connection = Accepted, domain = domain)
       (usersStorage.values _).expects().anyNumberOfTimes().returning(
         Future.successful(Vector(user1, user2, user3, user4))
       )
@@ -193,15 +194,15 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
 
     scenario("Cut off all non-team users and then some team users if limit is reached") {
       // given
-      val self = UserData("self").copy(teamId = Some(teamId))
+      val self = UserData("self").copy(teamId = Some(teamId), domain = domain)
       (userService.getSelfUser _).expects().anyNumberOfTimes().returning(
         Future.successful(Some(self))
       )
 
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
-      val user3 = UserData("user3").copy(connection = Accepted)
-      val user4 = UserData("user4").copy(connection = Accepted)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user3 = UserData("user3").copy(connection = Accepted, domain = domain)
+      val user4 = UserData("user4").copy(connection = Accepted, domain = domain)
       (usersStorage.values _).expects().anyNumberOfTimes().returning(
         Future.successful(Vector(user1, user2, user3, user4))
       )
@@ -227,10 +228,10 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
     def toTeamMember(user: UserData): TeamMember = TeamMember(user.id, None, None)
 
     scenario("Update search results when in a team") {
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
-      val user3 = UserData("user3").copy(connection = Accepted)
-      val user4 = UserData("user4").copy(connection = Accepted)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user3 = UserData("user3").copy(connection = Accepted, domain = domain)
+      val user4 = UserData("user4").copy(connection = Accepted, domain = domain)
       val users = Seq(user1, user2, user3, user4).toIdMap
 
       (usersClient.loadUsers _)
@@ -271,10 +272,10 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
     }
 
     scenario("Update search results when NOT in a team") {
-      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted)
-      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted)
-      val user3 = UserData("user3").copy(connection = Accepted)
-      val user4 = UserData("user4").copy(connection = Accepted)
+      val user1 = UserData("user1").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user2 = UserData("user2").copy(teamId = Some(teamId), connection = Accepted, domain = domain)
+      val user3 = UserData("user3").copy(connection = Accepted, domain = domain)
+      val user4 = UserData("user4").copy(connection = Accepted, domain = domain)
       val users = Seq(user1, user2, user3, user4).toIdMap
 
       (usersClient.loadUsers _)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-293" title="FS-293" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-293</a>  [Android] As a user, I like to share pictures with members from federated backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/FS-293

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implements downloading assets through the v4 endpoints and handling the information about the domain
where the backend should search for the given asset. Works for files, pictures, profile pictures,
audio and video. (Locations still don't display previews).

The PR also fixes unit tests which failed before when the federation flag was on.

There is one significant change to how the user search works which applies also to non-federation
environments. Until now the results of a search were not stored in the database. It was actually
a change from an earlier implementation where we did that, and with more complicated handling of
profile pictures I decided to go back to this idea. I think it shouldn't make the search more heavy,
or heavier that we can tolerate. I will test it some more.


### Testing

Unit tests and manually


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.

