### PR TITLE
fix(SSO): SSO webview refreshed every time the user leaves the app #SQSERVICES-1209

### DIFF
--- a/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/SSOWebViewFragment.scala
@@ -54,6 +54,8 @@ class SSOWebViewFragment extends FragmentHelper {
     toolbar.setNavigationOnClickListener(new OnClickListener {
       override def onClick(v: View): Unit = onBackPressed()
     })
+
+    loadWebView()
   }
 
   private def ssoResponse(loginResult: SSOResponse) = loginResult match {
@@ -89,11 +91,6 @@ class SSOWebViewFragment extends FragmentHelper {
     activity.showWelcomeScreen()
     inject[UserAccountsController].ssoToken ! None
     true
-  }
-
-  override def onResume(): Unit = {
-    super.onResume()
-    loadWebView()
   }
 
   override def onPause(): Unit = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1209" title="SQSERVICES-1209" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1209</a>  [Android] Air Liquide Android SSO Problem
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if during SSO authentication the user leaves the Wire Android app momentarily (e.g. to fetch a one-time-password), then the webview of the IdP login page gets refreshed when the user returns to the Wire Android app.

### Causes (Optional)

The app is loading the webview in on `onStart()` which is called every time the user returns to the app.

### Solutions

Load the webview once in the `onViewCreated()`

### Testing

Manually tested

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
