### PR TITLE
fix: Make profile pictures more responsive to changes (SQCORE-1227)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/ChatHeadView.scala
@@ -53,7 +53,6 @@ import com.waz.utils.{NameParts, returning}
 import com.waz.zclient.common.views.ChatHeadView._
 import com.waz.zclient.glide.WireGlide
 import com.waz.zclient.glide.transformations.{GlyphOverlayTransformation, GreyScaleTransformation, IntegrationBackgroundCrop}
-import com.waz.zclient.log.LogUI._
 import com.waz.zclient.ui.utils.TypefaceUtils
 import com.waz.zclient.utils.ContextUtils.{getColor, getString}
 import com.waz.zclient.{R, ViewHelper}
@@ -92,8 +91,10 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
   def loadUser(userId: UserId): Unit =
     this.userId ! Some(userId)
 
-  def setUserData(userData: UserData, belongsToSelfTeam: Boolean): Unit =
+  def setUserData(userData: UserData, belongsToSelfTeam: Boolean): Unit = {
     setInfo(optionsForUser(userData, belongsToSelfTeam, attributes))
+    loadUser(userData.id)
+  }
 
   def clearImage(): Unit = {
     WireGlide(context).clear(this)
@@ -114,7 +115,6 @@ class ChatHeadView(val context: Context, val attrs: AttributeSet, val defStyleAt
       setImageDrawable(options.placeholder)
     } else
       options.glideRequest.into(this)
-
 
   private def optionsForIntegration(integration: IntegrationData, attributes: Attributes): ChatHeadViewOptions =
     ChatHeadViewOptions(
@@ -176,12 +176,8 @@ object ChatHeadView {
 
     def glideRequest(implicit context: Context): RequestBuilder[Drawable] = {
       val request = picture match {
-        case Some(p) =>
-          verbose(l"picture is $p")
-          WireGlide(context).load(p)
-        case _ =>
-          verbose(l"picture is None, loading a placeholder")
-          WireGlide(context).load(placeholder)
+        case Some(p) => WireGlide(context).load(p)
+        case _       => WireGlide(context).load(placeholder)
       }
       val requestOptions = new RequestOptions()
 

--- a/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
+++ b/app/src/main/scala/com/waz/zclient/glide/ImageAssetFetcher.scala
@@ -22,7 +22,6 @@ import java.io.InputStream
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.data.DataFetcher
-import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.errors.NotSupportedError
 import com.waz.service.ZMessaging
 import com.waz.service.assets.AssetInput
@@ -34,7 +33,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 final class ImageAssetFetcher(request: AssetRequest, zms: Signal[ZMessaging])
-  extends DataFetcher[InputStream] with DerivedLogTag {
+  extends DataFetcher[InputStream] {
 
   import com.waz.threading.Threading.Implicits.Background
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
@@ -91,7 +91,7 @@ final class AssetClientImpl(implicit
                                       callback: Option[ProgressCallback],
                                       domain: Domain = Domain.Empty): ErrorOrResponse[InputStream] =
     Request
-      .Get(relativePath = assetPath(assetId, domain))
+      .Get(relativePath = assetPath(assetId, domain), headers = AssetClient.PublicAssetHeaders)
       .withDownloadCallback(callback)
       .withResultType[InputStream]
       .withErrorType[ErrorResponse]
@@ -140,6 +140,8 @@ object AssetClient {
 
   val AssetsV3Path = "/assets/v3"
   val AssetsV4Path = "/assets/v4"
+
+  val PublicAssetHeaders: Headers = Headers(("Content-Type", "application/json"), ("Accept", "application/json"))
 
   def assetPath(assetId: AssetId, domain: Domain = Domain.Empty): String =
     if (BuildConfig.FEDERATION_USER_DISCOVERY && domain.isDefined) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1227" title="SQCORE-1227" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQCORE-1227</a>  Make profile pictures more responsive to changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/SQCORE-1227

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
My recent work on assets in Federation exposed a small issue in how profile pictures are being updated.
Sometimes when another user changes their profile picture, or even when the current user requests
the profile picture of another user, the new picture is not displayed in all places, for example
in little icons next to messages.

### Solutions


This consists of two changes
1. Every "chathead" listens now to update events.
2. I added headers for "content type" and "accept" to a request for the profile picture
(without the headers it is possible that the backend will refuse).


### Testing

Unit tests / Manually


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.

---