### PR TITLE
chore: turn on constant bitrate calls with federation (FS-138)

### DIFF
--- a/default.json
+++ b/default.json
@@ -100,8 +100,8 @@
     "file_restriction_list":  "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
     "countly_server_url": "https://countly.wire.com",
     "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
-    "force_constant_bitrate_calls": false,
+    "force_constant_bitrate_calls": true,
     "web_link_preview": true,
-    "federation_user_discovery": false,
+    "federation_user_discovery": true,
     "keep_websocket_on": false
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-138" title="FS-138" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-138</a>  [Android] As the organizer of a conference call I like to place a conference call in a conversation with users who are part of different federated backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

N/A

### Solutions

Enabling the federation flag and constant bitrate flag for testing purpose

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
