### PR TITLE
fix: call being dropped when receiving a 1:1 video call (FS-382)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/controllers/CallController.scala
@@ -280,7 +280,7 @@ class CallController(implicit inj: Injector, cxt: WireContext)
     verbose(l"toggleVideo")
     updateCall { case (call, cs) =>
       import VideoState._
-      cs.setVideoSendState(call.convId, if (call.videoSendState != Started) Started else Stopped)
+      cs.setVideoSendState(call.convId, if (call.videoSendState != Started) Started else Stopped, shouldUpdateVideoState = true)
     }
   }
 
@@ -290,8 +290,8 @@ class CallController(implicit inj: Injector, cxt: WireContext)
       import VideoState._
       if (call.isVideoCall) {
         call.videoSendState match {
-          case Started if pause => cs.setVideoSendState(call.convId, Paused)
-          case Paused if !pause => cs.setVideoSendState(call.convId, Started)
+          case Started if pause => cs.setVideoSendState(call.convId, Paused, shouldUpdateVideoState = true)
+          case Paused if !pause => cs.setVideoSendState(call.convId, Started, shouldUpdateVideoState = true)
           case _ =>
         }
       }

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -108,7 +108,7 @@ trait CallingService {
 
   def setCallMuted(muted: Boolean): Unit
 
-  def setVideoSendState(convId: ConvId, state: VideoState.Value): Unit
+  def setVideoSendState(convId: ConvId, state: VideoState.Value, shouldUpdateVideoState: Boolean = false): Unit
 }
 
 object CallingService {
@@ -608,7 +608,7 @@ class CallingServiceImpl(val accountId:       UserId,
     * This method should NOT be called before we have permissions AND while the call is still incoming. Once established,
     * we do call this to convert NoCameraPermission to state Stopped.
     */
-  override def setVideoSendState(convId: ConvId, state: VideoState.Value): Unit =
+  override def setVideoSendState(convId: ConvId, state: VideoState.Value, shouldUpdateVideoState: Boolean = false): Unit =
     updateCallIfActive(convId) { (w, conv, call) =>
       val targetSt = state match {
         case NoCameraPermission => Stopped //NoCameraPermission is only valid for incoming
@@ -617,7 +617,7 @@ class CallingServiceImpl(val accountId:       UserId,
       verbose(l"setVideoSendActive: $convId, providedState: $state, targetState: $targetSt")
       val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
 
-      if (state != NoCameraPermission) avs.setVideoSendState(w, rConvQualifiedId, targetSt)
+      if (state != NoCameraPermission && shouldUpdateVideoState) avs.setVideoSendState(w, rConvQualifiedId, targetSt)
       call.updateVideoState(Participant(QualifiedId(accountId, domain), clientId), targetSt)
     }("setVideoSendState")
 

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -1031,7 +1031,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       (permissions.ensurePermissions _).expects(*).atLeastOnce().returning(Future.successful(()))
 
       (avs.startCall _).expects(*, *, *, *, *).once().returning(Future(0))
-      (avs.setVideoSendState _).expects(*, *, *).twice()
+      (avs.setVideoSendState _).expects(*, *, *).once()
 
       service.startCall(_1to1Conv.id)
       awaitCP(checkpoint1)
@@ -1042,7 +1042,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       service.onEstablishedCall(_1to1Conv.remoteId, otherUserId)
       awaitCP(checkpoint3)
 
-      service.setVideoSendState(_1to1Conv.id, VideoState.Started)
+      service.setVideoSendState(_1to1Conv.id, VideoState.Started, shouldUpdateVideoState = true)
       awaitCP(checkpoint4)
 
       (avs.endCall _).expects(*, *).once().onCall { (_: WCall, rConvQualifiedId: RConvQualifiedId) =>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-382" title="FS-382" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-382</a>  [Web] Call being dropped when receiving a 1:1 video call from android
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Call dropped when Android client running VBR makes a video call to a client on CBR

### Causes (Optional)

`set_video_send_state()`from AVS is being called every time the call is established.

### Solutions

Call `set_video_send_state` when toggling the video state

### Testing

Manually tested 

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
