### PR TITLE
fix: A back frame is displayed after accepting video call (SQCALL-426)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/calling/AllParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/AllParticipantsAdapter.scala
@@ -49,7 +49,7 @@ class AllParticipantsAdapter(implicit context: Context, eventContext: EventConte
   override def createFragment(position: Int): Fragment = CallingGridFragment.newInstance(position)
 
   private def getPagesCount(): Int =
-    if (numberOfParticipants == 0) 0
+    if (numberOfParticipants == 0) 1
     else if (numberOfParticipants % MAX_PARTICIPANTS_PER_PAGE == 0) numberOfParticipants / MAX_PARTICIPANTS_PER_PAGE
     else (numberOfParticipants / MAX_PARTICIPANTS_PER_PAGE) + 1
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-426" title="SQCALL-426" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-426</a>  [Android] Random: Video caller sees only avatar and callee sees black screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user B accepts a video call received from A, a full black screen is displayed preventing the user from seeing A video.

### Causes 

CallingGridFragment, which is responsible for displaying users's video, is not being created due to invalid returned value from `getItemCount()`.

### Solutions

Return 1 as item count of `AllParticipantsAdapter` in case of  number of participants equal to 0.
This way, we ensure that CallingGridFragment is created and it will be updated once new participants join the call

### Testing

Manually tested

### Notes 

This PR also fixes FS-351

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
