### PR TITLE
fix(build): remove 'null' from F-Droid build version strings.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,7 +242,6 @@ android {
 
         fdroid {
             applicationId buildtimeConfiguration.configuration.fdroid.applicationId
-            versionName android.defaultConfig.versionName + buildtimeConfiguration.configuration.fdroid.version_name_postfix
             manifestPlaceholders = [applicationLabel       : buildtimeConfiguration.configuration.fdroid.appName,
                                     applicationIcon        : "@mipmap/$buildtimeConfiguration.configuration.fdroid.launcherIcon",
                                     sharedUserId           : buildtimeConfiguration.configuration.fdroid.userId]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The version string embedded in the F-Droid flavoured APK's contains a trailing "null", which does not match with the versions which are published on GitHub. This causes the F-Droid project's automated builds to fail on a lint pass which checks whether the versions match -- see [this F-Droid merge request](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/10237) for more context.

### Causes

The build configuration for the F-Droid flavour uses a `version_name_postfix` field which is uninitialised in the build configuration, which is then converted into "null" due to a string type conversion.

### Solutions

Removing the `version_name_postfix` from the F-Droid build, as this field is unused for this flavour.

### Testing

I've disassembled an APK built with and without this change applied to inspect the embedded version metadata, and the trailing "null" is no longer present after this change.

### Notes

Thanks to @Gardosen for helping to find the cause of this bug.
