### PR TITLE
fix: Automatically rejoined conference call after leaving (SQCORE-1242)

### DIFF
--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -4,7 +4,7 @@ final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
 final String AVS_GROUP = "com.wire"
 final String AVS_NAME = "avs"
 
-String avsVersion = "8.0.12"
+String avsVersion = "8.0.13"
 
 ext {
     avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_GROUP

--- a/scripts/avs.gradle
+++ b/scripts/avs.gradle
@@ -4,7 +4,7 @@ final String AVS_VERSION_ENV_VAR = "AVS_VERSION"
 final String AVS_GROUP = "com.wire"
 final String AVS_NAME = "avs"
 
-String avsVersion = "8.0.13"
+String avsVersion = "8.0.14"
 
 ext {
     avsGroup = System.getenv(AVS_GROUP_ENV_VAR) ?: AVS_GROUP


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1242" title="SQCORE-1242" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1242</a>  [Wrapper] Automatically rejoined conference call after leaving
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Automatically rejoined conference call after leaving

### Solutions

fixed in AVS 8.0.13

### Testing

Manually tested

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
