### PR TITLE
fix: The "reply" notification should be used only for replies to the current user (SQCORE-1249)

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -46,30 +46,30 @@ import org.threeten.bp.Instant.now
 import scala.collection.breakOut
 import scala.concurrent.duration._
 
-case class MessageData(override val id:   MessageId              = MessageId(),
-                       convId:            ConvId                 = ConvId(),
-                       msgType:           Message.Type           = Message.Type.TEXT,
-                       userId:            UserId                 = UserId(),
-                       error:             Option[ErrorContent]   = None,
-                       content:           Seq[MessageContent]    = Seq.empty,
-                       genericMsgs:       Seq[GenericMessage]    = Seq.empty,
-                       firstMessage:      Boolean                = false,
-                       members:           Set[UserId]            = Set.empty[UserId],
-                       recipient:         Option[UserId]         = None,
-                       email:             Option[String]         = None,
-                       name:              Option[Name]           = None,
-                       state:             MessageState           = Message.Status.SENT,
-                       time:              RemoteInstant          = RemoteInstant(now(clock)), //TODO: now is local...
-                       localTime:         LocalInstant           = LocalInstant.Epoch,
-                       editTime:          RemoteInstant          = RemoteInstant.Epoch,
-                       ephemeral:         Option[FiniteDuration] = None,
-                       expiryTime:        Option[LocalInstant]   = None, // local expiration time
-                       expired:           Boolean                = false,
-                       duration:          Option[FiniteDuration] = None, //for successful calls and message_timer changes
-                       assetId:           Option[GeneralAssetId] = None,
-                       quote:             Option[QuoteContent]   = None,
-                       forceReadReceipts: Option[Int]            = None
-                      ) extends Identifiable[MessageId] with DerivedLogTag {
+final case class MessageData(override val id:   MessageId              = MessageId(),
+                             convId:            ConvId                 = ConvId(),
+                             msgType:           Message.Type           = Message.Type.TEXT,
+                             userId:            UserId                 = UserId(),
+                             error:             Option[ErrorContent]   = None,
+                             content:           Seq[MessageContent]    = Seq.empty,
+                             genericMsgs:       Seq[GenericMessage]    = Seq.empty,
+                             firstMessage:      Boolean                = false,
+                             members:           Set[UserId]            = Set.empty[UserId],
+                             recipient:         Option[UserId]         = None,
+                             email:             Option[String]         = None,
+                             name:              Option[Name]           = None,
+                             state:             MessageState           = Message.Status.SENT,
+                             time:              RemoteInstant          = RemoteInstant(now(clock)), //TODO: now is local...
+                             localTime:         LocalInstant           = LocalInstant.Epoch,
+                             editTime:          RemoteInstant          = RemoteInstant.Epoch,
+                             ephemeral:         Option[FiniteDuration] = None,
+                             expiryTime:        Option[LocalInstant]   = None, // local expiration time
+                             expired:           Boolean                = false,
+                             duration:          Option[FiniteDuration] = None, //for successful calls and message_timer changes
+                             assetId:           Option[GeneralAssetId] = None,
+                             quote:             Option[QuoteContent]   = None,
+                             forceReadReceipts: Option[Int]            = None
+                            ) extends Identifiable[MessageId] with DerivedLogTag {
   lazy val contentString: String = genericMsgs.lastOption match {
     case Some(TextMessage(ct, _, _, _, _)) => ct
     case _ if msgType == api.Message.Type.RICH_MEDIA => content.map(_.content).mkString(" ")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1249" title="SQCORE-1249" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1249</a>  [Android] User sees replies in the push notification for replies that are for different message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/SQCORE-1249

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently this form of notification is used for any reply, also when another participant of a group conversation
replies to yet another participant.

### Solutions

To check if the reply is the reply to the current user we need to look for the original message (the one that is
replied to) and then check if the author of that message is the current participant.


### Testing

 Manually


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
