### PR TITLE
feat: Security clearance on the call view (FS-385)

### DIFF
--- a/app/src/main/res/layout/calling_header.xml
+++ b/app/src/main/res/layout/calling_header.xml
@@ -82,4 +82,23 @@
         android:textSize="@dimen/wire__text_size__smaller"
         app:themedColor="Secondary"
         app:w_font="@string/wire__typeface__medium" />
+
+    <FrameLayout
+        android:id="@+id/call_classified_banner"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/classified_toolbar_height"
+        android:background="@color/white"
+        android:layout_gravity="bottom"
+        android:visibility="gone">
+
+        <com.waz.zclient.ui.text.TypefaceTextView
+            android:id="@+id/call_classified_banner_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:textSize="@dimen/wire__text_size__smaller"
+            app:w_font="@string/wire__typeface__medium"/>
+    </FrameLayout>
 </merge>

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -20,25 +20,27 @@ package com.waz.zclient.calling.views
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.{LinearLayout, TextView}
-import com.waz.content.UserPreferences
+import android.widget.{FrameLayout, LinearLayout, TextView}
 import com.waz.threading.Threading._
 import com.waz.zclient.calling.controllers.CallController
 import com.waz.zclient.common.views.GlyphButton
-import com.waz.zclient.utils.ContextUtils.getString
+import com.waz.zclient.participants.ParticipantsController.ClassifiedConversation
+import com.waz.zclient.ui.text.TypefaceTextView
+import com.waz.zclient.utils.ContextUtils.{getColor, getString}
 import com.waz.zclient.{R, ViewHelper}
 import com.wire.signals.Signal
+import com.waz.zclient.utils._
 
-class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleAttr: Int) extends LinearLayout(context, attrs, defStyleAttr) with ViewHelper {
+class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleAttr: Int)
+  extends LinearLayout(context, attrs, defStyleAttr) with ViewHelper {
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
   def this(context: Context) =  this(context, null)
 
-  private val controller              = inject[CallController]
-  private lazy val vbrSettingsEnabled = inject[Signal[UserPreferences]].flatMap(_.preference(UserPreferences.VBREnabled).signal)
+  private val controller  = inject[CallController]
 
-  private lazy val nameView               = findById[TextView](R.id.ttv__calling__header__name)
-  private lazy val subtitleView           = findById[TextView](R.id.ttv__calling__header__subtitle)
-  private lazy val bitRateModeView        = findById[TextView](R.id.ttv__calling__header__bitrate)
+  private lazy val nameView        = findById[TextView](R.id.ttv__calling__header__name)
+  private lazy val subtitleView    = findById[TextView](R.id.ttv__calling__header__subtitle)
+  private lazy val bitRateModeView = findById[TextView](R.id.ttv__calling__header__bitrate)
 
   lazy val closeButton: GlyphButton = findById[GlyphButton](R.id.calling_header_close)
 
@@ -51,4 +53,30 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
     case (true, false, Some(true)) => getString(R.string.audio_message_constant_bit_rate)
     case _ => ""
   }.onUi(bitRateModeView.setText)
+
+  private lazy val classifiedBanner = findById[FrameLayout](R.id.call_classified_banner)
+  controller.isCurrentConvClassified.onUi {
+    case ClassifiedConversation.Classified =>
+      classifiedBanner.setBackgroundColor(getColor(R.color.background_light))
+      classifiedBanner.setVisible(true)
+    case ClassifiedConversation.NotClassified =>
+      classifiedBanner.setBackgroundColor(getColor(R.color.background_dark))
+      classifiedBanner.setVisible(true)
+    case ClassifiedConversation.None =>
+      classifiedBanner.setVisible(false)
+  }
+
+  private lazy val classifiedBannerText = findById[TypefaceTextView](R.id.call_classified_banner_text)
+  controller.isCurrentConvClassified.onUi {
+    case ClassifiedConversation.Classified =>
+      classifiedBannerText.setTransformedText(getString(R.string.conversation_is_classified))
+      classifiedBannerText.setTextColor(getColor(R.color.background_dark))
+      classifiedBannerText.setVisible(true)
+    case ClassifiedConversation.NotClassified =>
+      classifiedBannerText.setTransformedText(getString(R.string.conversation_is_not_classified))
+      classifiedBannerText.setTextColor(getColor(R.color.background_light))
+      classifiedBannerText.setVisible(true)
+    case ClassifiedConversation.None =>
+      classifiedBannerText.setVisible(false)
+  }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-385" title="FS-385" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />FS-385</a>  [Android] As a user, I like to be aware of the security clearance of a conversation (only for BUND at this point).
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/FS-385

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds the security clearance banner on the call view, as designed in the JIRA ticket.
The banner responds to the securpty clearance of participants of the conversation, not those only in the call.
The banner changes in real time.

The calling functionality is separated from the text-based conversations functionality so I had to copy-paste some of the code. I would prefer to leave it like this instead of making some complex connections between classes only to avoid duplication.

### Testing

Manually 


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.