### PR TITLE
fix: Change in the copy of the classified conversation banner (FS-468)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1362,7 +1362,7 @@
     <string name="federated_externals_guests_and_services_are_present">Federated users, externals, guests, and services are present</string>
 
     <string name="conversation_is_classified">SECURITY LEVEL: VS-NfD</string>
-    <string name="conversation_is_not_classified">SECURITY LEVEL: NOT CLASSIFIED</string>
+    <string name="conversation_is_unclassified">SECURITY LEVEL: UNCLASSIFIED</string>
 
     <string name="participants_details_header_title">DETAILS</string>
     <string name="invitation_link_description">Anyone with the link can join the conversation, even if they don\'t have Wire</string>

--- a/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
+++ b/app/src/main/scala/com/waz/zclient/calling/views/CallingHeader.scala
@@ -73,7 +73,7 @@ class CallingHeader(val context: Context, val attrs: AttributeSet, val defStyleA
       classifiedBannerText.setTextColor(getColor(R.color.background_dark))
       classifiedBannerText.setVisible(true)
     case ClassifiedConversation.NotClassified =>
-      classifiedBannerText.setTransformedText(getString(R.string.conversation_is_not_classified))
+      classifiedBannerText.setTransformedText(getString(R.string.conversation_is_unclassified))
       classifiedBannerText.setTextColor(getColor(R.color.background_light))
       classifiedBannerText.setVisible(true)
     case ClassifiedConversation.None =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -225,7 +225,7 @@ class SingleParticipantFragment extends FragmentHelper {
         }
       case ClassifiedConversation.NotClassified =>
         vh.foreach { view =>
-          view.setTransformedText(getString(R.string.conversation_is_not_classified))
+          view.setTransformedText(getString(R.string.conversation_is_unclassified))
           view.setTextColor(getColor(R.color.background_light))
           view.setVisible(true)
         }

--- a/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/views/ConversationFragment.scala
@@ -190,7 +190,7 @@ class ConversationFragment extends FragmentHelper {
         }
       case ClassifiedConversation.NotClassified =>
         vh.foreach { view =>
-          view.setTransformedText(getString(R.string.conversation_is_not_classified))
+          view.setTransformedText(getString(R.string.conversation_is_unclassified))
           view.setTextColor(getColor(R.color.background_light))
           view.setVisible(true)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-468" title="FS-468" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-468</a>  [Web] User from not classified domain has label "unclassified" instead "not classified"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/FS-468

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

An error in the copy for unclassified conversations banner (it's "not classified", should be "unclassified")

### Solutions

A change in the banner text from "NOT CLASSIFIED" to "UNCLASSIFIED"

### Testing

 Manually 


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.

---