### PR TITLE
fix: Only call setAllowBubbles() on Android Q and higher

### DIFF
--- a/app/src/main/scala/com/waz/zclient/notifications/controllers/AndroidNotificationsManager.scala
+++ b/app/src/main/scala/com/waz/zclient/notifications/controllers/AndroidNotificationsManager.scala
@@ -121,7 +121,8 @@ final class AndroidNotificationsManager(notificationManager: NotificationManager
       ch.enableLights(true)
       ch.setGroup(WireNotificationsChannelGroupId)
       ch.setBypassDnd(true)
-      ch.setAllowBubbles(true)
+      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+        ch.setAllowBubbles(true)
       sound.foreach(uri => ch.setSound(uri, Notification.AUDIO_ATTRIBUTES_DEFAULT))
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes #3664.

### Causes (Optional)

The `setAllowBubbles` function only exists on Android Q and higher. On Android Pie devices, this prevents the notification channel from being built, and causes notifications to not be displayed.

### Solutions

`setAllowBubbles` is only called if the device is running Android Q or higher.

### Testing

I tested this change on my Samsung SM-T380 and confirmed that notifications are now displayed. When the change is reverted, notification channels are not built and no notifications are seen.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.