### PR TITLE
fix: The pending connect request view was blank (FS-385)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ConnectRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ConnectRequestFragment.scala
@@ -75,8 +75,7 @@ final class ConnectRequestFragment extends UntabbedRequestFragment {
   }
 
   override protected def initViews(savedInstanceState: Bundle): Unit = {
-    initDetailsView()
-    initFooterMenu()
+    super.initViews(savedInstanceState)
     initIgnoreButton()
     initAcceptButton()
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-385" title="FS-385" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-385</a>  [Android] As a user, I like to be aware of the security clearance of a conversation (only for BUND at this point).
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/FS-385

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In the new implementation of the view the user id of the other user is kept in a signal (previously it was a constant).
A signal needed initialization before it can be used and the pending connection request view didn't do it,
because it overwrote the method that was doing the initialization without calling `super` (i.e. the original one).

### Solutions

I added the call to the original initialization method.

### Testing

 Manually 


#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.