### PR TITLE
fix(synchronization): add missing `\` to `api-version` request (FS-421)

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
@@ -19,11 +19,11 @@ final class SupportedApiClientImpl(implicit httpClient: HttpClient)
   import SupportedApiConfig._
 
   override def getSupportedApiVersions(baseUrl: URI): ErrorOrResponse[SupportedApiConfig] = {
-    val appended = baseUrl.toString + "api-version"
+    val appended = baseUrl.toString.stripSuffix("/") + "/api-version"
     // unfortunately, the nicer code:
     //      val appended = baseUrl.buildUpon.appendPath("api-version").build
     // causes a `NoSuchMethodException` when run in tests
-    Request.create(Method.Get, new URL(appended.toString))
+    Request.create(Method.Get, new URL(appended))
       .withResultType[SupportedApiConfig]
       .withErrorType[ErrorResponse]
       .executeSafe

--- a/zmessaging/src/test/scala/com/waz/sync/client/SupportedApiClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/SupportedApiClientSpec.scala
@@ -53,6 +53,8 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
 
   private var mockServer: MockWebServer = _
 
+  private def mockServerPath: String = mockServer.url("").toString.stripSuffix("/")
+
   private implicit val urlCreator: UrlCreator = UrlCreator.create(relativeUrl => mockServer.url(relativeUrl).url())
 
   before {
@@ -82,7 +84,7 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
       )
 
       // WHEN
-      val future = sut.getSupportedApiVersions(URI.parse(mockServer.url("").url().toString))
+      val future = sut.getSupportedApiVersions(URI.parse(mockServerPath))
 
       // THEN
       val result = Await.result(future, 5.seconds)
@@ -106,7 +108,7 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
       )
 
       // WHEN
-      val future = sut.getSupportedApiVersions(URI.parse(mockServer.url("").url().toString))
+      val future = sut.getSupportedApiVersions(URI.parse(mockServerPath))
 
       // THEN
       val result = Await.result(future, 5.seconds)
@@ -127,7 +129,7 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
       )
 
       // WHEN
-      val future = sut.getSupportedApiVersions(URI.parse(mockServer.url("").url().toString))
+      val future = sut.getSupportedApiVersions(URI.parse(mockServerPath))
 
       // THEN
       val result = Await.result(future, 5.seconds)
@@ -151,7 +153,7 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
       )
 
       // WHEN
-      val future = sut.getSupportedApiVersions(URI.parse(mockServer.url("").url().toString))
+      val future = sut.getSupportedApiVersions(URI.parse(mockServerPath))
 
       // THEN
       val result = Await.result(future, 5.seconds)
@@ -167,7 +169,7 @@ class SupportedApiClientSpec extends FeatureSpec with Matchers with BeforeAndAft
       val sut = new SupportedApiClientImpl()(client)
 
       // WHEN
-      val future = sut.getSupportedApiVersions(URI.parse(mockServer.url("").url().toString))
+      val future = sut.getSupportedApiVersions(URI.parse(mockServerPath))
 
       // THEN
       val req = mockServer.takeRequest()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-421" title="FS-421" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-421</a>  [Android] Clients need to know if the backend support federated endpoints or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Requests to the `api-version` endpoint where missing a `\` between the host and the path.

### Causes (Optional)

The implementation of URL building used in unit tests differs from the one used at runtime, due to some mismatch of test libraries vs. runtime libraries. The unit tests were all passing but the requests to the real backend at runtime were missing the `\`

### Solutions

Added the `\` if needed

### Testing

Unit test updated to match the runtime host format, and manually tested with the real backend