### PR TITLE
fix(synchronization): always consider the account domain (FS-421)

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -115,13 +115,7 @@ class ZMessaging(val teamId:    Option[TeamId],
   def federation: FederationSupport = global.backend.federationSupport
 
   lazy val selfUserId: UserId = account.userId
-  lazy val selfDomain: Domain =
-    if (federation.isSupported) {
-      account.domain
-    } else {
-      Domain.Empty
-    }
-
+  lazy val selfDomain: Domain = account.domain
 
   val auth       = account.auth
   val urlCreator: UrlCreator = global.urlCreator


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Plenty of things were broken in the QA automation (see FS-506 and FS-512) after merging https://github.com/wireapp/wire-android/pull/3665. 

That PR changed all parts of the code that were using a compile-time constant that indicated whether federation is enabled or not, to use a runtime configuration provided by querying the `GET /api-version` endpoint.

The problem is that the compile-time constant, being constant, was always available, while the runtime configuration is fetched **after** many classes have been instantiated. This results in some objects being instantiated with no domain because federation support is off (the default state) at startup, and even if later we discover that federation support is on, those objects will not be updated to reflect that.

One example of this is `ConversationUIServiceImpl`. The domain passed in to the constructor in `ZMessaging.scala` (via the *MacWire* constructor) is `Domain.Empty` because the expression `federation.isSupported` returns false at startup, as the runtime configuration is not yet fetched. `ConversationUIServiceImpl` is created with no domain, which is wrong and leads to errors down the line (e.g. when trying to determine if a user is a guest or not, it compares the domain of that user with the current domain).

### Solutions

Use the account value for domain even if the federation is turned off, rather than artificially considering the user as not having a domain.

This will make it so that objects have the right domain value from the start. In environments where federation is enabled, this creates no problem. 

In environments where federation is not enabled, we will need to verify in all the relevant code paths if federation is not enabled, rather than relying on having an empty domain.

### Testing

I'm merging this PR so that full QA automation can run on it and see which of the 20ish issues identified in the tickets mentioned above are still relevant. We can then go back to fix only those that are still relevant.

Note that we should also run the app against the multidomain test environment as that would probably be the most susceptible to break due to this change.
