### PR TITLE
fix: add tag to logs for notification exceptions

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/otr/NotificationParser.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/NotificationParser.scala
@@ -46,7 +46,7 @@ final class NotificationParserImpl(selfId:       UserId,
       notification      <- createNotification(uid, self, conv, event, msgContent)
     } yield notification)
       .recover { case ex: Throwable =>
-        error(l"error while parsing $event, ${ex.getMessage}", ex)
+        error(l"error while parsing (1) $event, ${ex.getMessage}", ex)
         None
       }
 
@@ -93,7 +93,7 @@ final class NotificationParserImpl(selfId:       UserId,
         ))
       else None
     ).recover { case ex: Throwable =>
-      error(l"error while parsing $event, ${ex.getMessage}", ex)
+      error(l"error while parsing (2) $event, ${ex.getMessage}", ex)
       None
     }
 
@@ -111,7 +111,7 @@ final class NotificationParserImpl(selfId:       UserId,
         ))
       else None
   ).recover { case ex: Throwable =>
-    error(l"error while parsing $event, ${ex.getMessage}", ex)
+    error(l"error while parsing (3) $event, ${ex.getMessage}", ex)
     None
   }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When looking at some error logs, there is an exception with a stack trace that could be triggered in 3 different parts of the code, and we can't distinguish them.

Here is a sample log:
```
2022-03-28T09:07:53.225Z-TID:620/E/NotificationParserImpl: error while parsing GenericMessageEvent(FBww0O4bZ), String(cCCHJwYG9)
java.util.NoSuchElementException: Future.filter predicate is not satisfied
	at scala.concurrent.Future$$anonfun$filter$1.apply(Future.scala:280)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:1237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
	at com.wire.signals.LimitedDispatchQueue$Executor$.run(DispatchQueue.scala:3206)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
```

The string "error while parsing" is used in three different code paths, and since the stack trace of the exception does not contain any reference to those, I assume due to the execution being asynchronous, I can't figure out where the exception is coming from.

### Solutions

I added a simple tag to the error string ("1", "2", "3") to distinguish in the logs which part of the code generated it.

### Testing

No testing has been done on this because I can't reproduce that exception myself. However this is just a log string copy change, so I believe testing is not necessary.
