### PR TITLE
fix: log negotiated API version after updating supported versions (FS-421)

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -424,11 +424,11 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
     inject[SupportedApiClient].getSupportedApiVersions(backend.baseUrl).foreach {
       case Right(supportedApiConfig) => {
         verbose(l"change in supported API versions: $supportedApiConfig")
+        backend.updateSupportedAPIConfig(supportedApiConfig)
         backend.agreedApiVersion match {
           case Some(version) => verbose(l"Agreed on API version: $version")
           case None => error(l"Can't agree on API version: backend: ${supportedApiConfig.supported}, app: ${SupportedApiConfig.supportedBackendAPIVersions}")
         }
-        backend.updateSupportedAPIConfig(supportedApiConfig)
         ZMessaging.setBackend(backend)
         inject[BackendController].storeSupportedApiConfig(supportedApiConfig)
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-421" title="FS-421" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-421</a>  [Android] Clients need to know if the backend support federated endpoints or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Move the log that prints the negotiated client-server API version to after the version is updated from the backend. 

### Issues

Before this change, it would log the negotiated version before it was updated from the backend, which resulted in logging that there was no common version.

### Testing

Tested manually against staging backend