### PR TITLE
fix: display domain in handle if federation is enabled FS-506

### DIFF
--- a/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/common/views/UserDetailsView.scala
@@ -21,7 +21,8 @@ package com.waz.zclient.common.views
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.{LinearLayout, TextView}
-import com.waz.model.UserId
+import com.waz.model.{DisplayHandleDomainPolicies, UserId}
+import com.waz.service.BackendConfig.FederationSupport
 import com.wire.signals.Signal
 import com.waz.zclient.messages.UsersController
 import com.waz.zclient.{R, ViewHelper}
@@ -37,8 +38,11 @@ class UserDetailsView(val context: Context, val attrs: AttributeSet, val defStyl
 
   val users = inject[UsersController]
   val userId = Signal[UserId]()
+  val federation = inject[FederationSupport]
 
-  userId.flatMap(id => Signal.from(users.displayHandle(id))).onUi(userNameTextView.setText(_))
+  val policy = if (federation.isSupported) { DisplayHandleDomainPolicies.AlwaysShowDomain } else { DisplayHandleDomainPolicies.ShowIfNotSame }
+
+  userId.flatMap(id => Signal.from(users.displayHandle(id, policy))).onUi(userNameTextView.setText(_))
   userId.flatMap(users.user).map(_.name).onUi(userInfoTextView.setText(_))
 
   def setUserId(id: UserId): Unit =

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -430,7 +430,7 @@ object ConversationListRow {
         case Message.Type.KNOCK =>
           formatSubtitle(getString(R.string.conversation_list__pinged), senderName, isGroup, quotePrefix = isQuote)
         case Message.Type.CONNECT_ACCEPTED | Message.Type.MEMBER_JOIN if !isGroup =>
-          members.headOption.map(_.displayHandle(currentDomain)).getOrElse("")
+          members.headOption.map(_.displayHandle(currentDomain, federationEnabled = false)).getOrElse("")
         case Message.Type.MEMBER_JOIN if members.exists(_.id == selfId) =>
           getString(R.string.conversation_list__added_you, senderName)
         case Message.Type.MEMBER_JOIN if members.length > 1 =>
@@ -463,7 +463,7 @@ object ConversationListRow {
                                     currentDomain:            Domain)
                                    (implicit context: Context): String = {
     if (conv.convType == ConversationType.WaitForConnection || (lastMessage.exists(_.msgType == Message.Type.MEMBER_JOIN) && !isGroupConv)) {
-      otherMember.map(_.displayHandle(currentDomain)).getOrElse("")
+      otherMember.map(_.displayHandle(currentDomain, federationEnabled = false)).getOrElse("")
     } else if (memberIds.count(_ != selfId) == 0 && conv.convType == ConversationType.Group) {
       ""
     } else if (conv.unreadCount.total == 0 && !conv.isActive) {

--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -151,7 +151,8 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
       z.selfUserId,
       isGroupConv,
       userName,
-      currentDomain
+      currentDomain,
+      z.federation.isSupported
     )
   )
 
@@ -397,10 +398,13 @@ object ConversationListRow {
                                            isGroup:       Boolean,
                                            selfId:        UserId,
                                            isQuote:       Boolean,
-                                           currentDomain: Domain
+                                           currentDomain: Domain,
+                                           federationEnabled: Boolean
                                   )(implicit context: Context): String = {
     lazy val senderName = user.map(_.name).getOrElse(Name(getString(R.string.conversation_list__someone)))
     lazy val memberName = members.headOption.map(_.name).getOrElse(Name(getString(R.string.conversation_list__someone)))
+
+    val showDomainInLabel = if(federationEnabled) DisplayHandleDomainPolicies.ShowIfNotSame else DisplayHandleDomainPolicies.NeverShowDomain
 
     if (messageData.isEphemeral) {
       if (messageData.hasMentionOf(selfId)) {
@@ -430,7 +434,7 @@ object ConversationListRow {
         case Message.Type.KNOCK =>
           formatSubtitle(getString(R.string.conversation_list__pinged), senderName, isGroup, quotePrefix = isQuote)
         case Message.Type.CONNECT_ACCEPTED | Message.Type.MEMBER_JOIN if !isGroup =>
-          members.headOption.map(_.displayHandle(currentDomain, federationEnabled = false)).getOrElse("")
+          members.headOption.map(_.displayHandle(currentDomain, showDomainInLabel)).getOrElse("")
         case Message.Type.MEMBER_JOIN if members.exists(_.id == selfId) =>
           getString(R.string.conversation_list__added_you, senderName)
         case Message.Type.MEMBER_JOIN if members.length > 1 =>
@@ -460,10 +464,12 @@ object ConversationListRow {
                                     selfId:                   UserId,
                                     isGroupConv:              Boolean,
                                     userName:                 Option[Name],
-                                    currentDomain:            Domain)
+                                    currentDomain:            Domain,
+                                    federationEnabled:        Boolean
+                                   )
                                    (implicit context: Context): String = {
     if (conv.convType == ConversationType.WaitForConnection || (lastMessage.exists(_.msgType == Message.Type.MEMBER_JOIN) && !isGroupConv)) {
-      otherMember.map(_.displayHandle(currentDomain, federationEnabled = false)).getOrElse("")
+      otherMember.map(_.displayHandle(currentDomain, DisplayHandleDomainPolicies.ShowIfNotSame)).getOrElse("")
     } else if (memberIds.count(_ != selfId) == 0 && conv.convType == ConversationType.Group) {
       ""
     } else if (conv.unreadCount.total == 0 && !conv.isActive) {
@@ -535,7 +541,8 @@ object ConversationListRow {
             isGroupConv,
             selfId,
             conv.unreadCount.quotes > 0,
-            currentDomain
+            currentDomain,
+            federationEnabled
           )
         }
       } { usr =>

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -77,7 +77,7 @@ class UsersController(implicit injector: Injector, context: Context)
     } yield displayHandle(user)
   }
 
-  def displayHandle(user: UserData): String = user.displayHandle(selfDomain)
+  def displayHandle(user: UserData): String = user.displayHandle(selfDomain, federationEnabled = false)
 
   def syncUserAndCheckIfDeleted(userId: UserId): Future[(Option[UserData], Option[UserData])] = {
     import Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/UsersController.scala
@@ -69,15 +69,15 @@ class UsersController(implicit injector: Injector, context: Context)
       userService.flatMap(_.userNames.map(_.getOrElse(id, DefaultDeletedName)).map(Other(_)))
   }
 
-  def displayHandle(id: UserId): Future[String] = {
+  def displayHandle(id: UserId, domainPolicy: DisplayHandleDomainPolicies.Policy): Future[String] = {
     import Threading.Implicits.Background
     for {
+      z <- zms.head
       service    <- userService.head
       Some(user) <- service.findUser(id)
-    } yield displayHandle(user)
+    } yield displayHandle(user, domainPolicy)
   }
-
-  def displayHandle(user: UserData): String = user.displayHandle(selfDomain, federationEnabled = false)
+  def displayHandle(user: UserData, domainPolicy: DisplayHandleDomainPolicies.Policy): String = user.displayHandle(selfDomain, domainPolicy)
 
   def syncUserAndCheckIfDeleted(userId: UserId): Future[(Option[UserData], Option[UserData])] = {
     import Threading.Implicits.Background

--- a/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/ParticipantsAdapter.scala
@@ -57,7 +57,7 @@ class ParticipantsAdapter(participants:    Signal[Map[UserId, ConversationRole]]
                           maxParticipants: Option[Int] = None,
                           showPeopleOnly:  Boolean = false,
                           showArrow:       Boolean = true,
-                          createSubtitle:  Option[(UserData, Boolean) => String] = None
+                          createSubtitle:  Option[(UserData, DisplayHandleDomainPolicies.Policy) => String] = None
                          )(implicit context: Context, injector: Injector, eventContext: EventContext)
   extends RecyclerView.Adapter[ViewHolder] with Injectable with DerivedLogTag {
   import ParticipantsAdapter._
@@ -372,7 +372,7 @@ object ParticipantsAdapter {
 
     def bind(participant:    ParticipantData,
              lastRow:        Boolean,
-             createSubtitle: Option[(UserData, Boolean) => String],
+             createSubtitle: Option[(UserData, DisplayHandleDomainPolicies.Policy) => String],
              showArrow:      Boolean): Unit = {
       if (participant.isSelf) {
         view.showArrow(false)
@@ -381,10 +381,7 @@ object ParticipantsAdapter {
         view.showArrow(showArrow)
         userId = Some(participant.userData.id)
       }
-      createSubtitle match {
-        case Some(f) => view.setUserData(participant.userData, createSubtitle = f)
-        case None    => view.setUserData(participant.userData)
-      }
+      view.setUserData(participant.userData, createSubtitle)
       view.setSeparatorVisible(!lastRow)
       view.setContentDescription(s"${if (participant.isAdmin) "Admin" else "Member"}: ${participant.userData.name}")
     }
@@ -500,7 +497,7 @@ object ParticipantsAdapter {
 
 final class LikesAndReadsAdapter(userIds: Signal[Set[UserId]], createSubtitle: Option[UserData => String] = None)
                                 (implicit context: Context, injector: Injector, eventContext: EventContext)
-  extends ParticipantsAdapter(Signal.empty, None, true, false, createSubtitle.map(f => { (u: UserData, _: Boolean) => f(u) })) {
+  extends ParticipantsAdapter(Signal.empty, None, true, false, createSubtitle.map(f => { (u: UserData, _: DisplayHandleDomainPolicies.Policy) => f(u) })) {
   import ParticipantsAdapter._
 
   override protected lazy val users: Signal[Vector[ParticipantData]] = for {

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/SingleParticipantFragment.scala
@@ -24,7 +24,7 @@ import android.widget.{FrameLayout, TextView}
 import androidx.annotation.Nullable
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
 import com.google.android.material.tabs.TabLayout
-import com.waz.model.{ConversationRole, UserField, UserId}
+import com.waz.model.{ConversationRole, DisplayHandleDomainPolicies, UserField, UserId}
 import com.wire.signals.{CancellableFuture, Signal, SourceSignal, Subscription}
 import com.waz.service.{BackendConfig, ZMessaging}
 import com.waz.threading.Threading
@@ -186,7 +186,7 @@ class SingleParticipantFragment extends FragmentHelper {
   private def initUserHandle(): Unit = returning(view[TextView](R.id.user_handle)) { vh =>
     subs += (for {
       otherUser <- participantsController.otherParticipant
-      handle    =  usersController.displayHandle(otherUser)
+      handle    =  usersController.displayHandle(otherUser, DisplayHandleDomainPolicies.ShowIfNotSame)
     } yield handle).onUi {
       case handle if handle.nonEmpty =>
         vh.foreach { view =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/UntabbedRequestFragment.scala
@@ -3,7 +3,7 @@ package com.waz.zclient.participants.fragments
 import android.os.Bundle
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.{LinearLayoutManager, RecyclerView}
-import com.waz.model.{ConversationRole, UserData, UserId}
+import com.waz.model.{ConversationRole, DisplayHandleDomainPolicies, UserData, UserId}
 import com.waz.service.{BackendConfig, ZMessaging}
 import com.wire.signals.CancellableFuture
 import com.waz.threading.Threading
@@ -57,7 +57,7 @@ abstract class UntabbedRequestFragment extends SingleParticipantFragment {
         Some(user)    <- userToConnect
         isGroup       <- participantsController.isGroup.head
         isFederated   =  usersController.isFederated(user)
-        handle        =  usersController.displayHandle(user)
+        handle        =  usersController.displayHandle(user, DisplayHandleDomainPolicies.ShowIfNotSame)
         isGuest       =  !user.isWireBot && user.isGuest(zms.teamId, zms.selfDomain)
         isExternal    =  !user.isWireBot && user.isExternal(zms.teamId, zms.selfDomain)
         isDarkTheme   <- inject[ThemeController].darkThemeSet.head

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ChangeHandleFragment.scala
@@ -18,7 +18,6 @@
 package com.waz.zclient.preferences.dialogs
 
 import java.util.Locale
-
 import android.os.Bundle
 import android.text.{Editable, TextWatcher}
 import android.view.View.OnClickListener
@@ -27,7 +26,7 @@ import android.view.{LayoutInflater, View, ViewGroup}
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.textfield.TextInputLayout
-import com.waz.model.Handle
+import com.waz.model.{DisplayHandleDomainPolicies, Domain, Handle}
 import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.wire.signals.Signal
@@ -56,7 +55,7 @@ class ChangeHandleFragment extends DialogFragment with FragmentHelper {
 
   lazy val zms = inject[Signal[ZMessaging]]
   lazy val users = zms.map(_.users)
-  private lazy val currentHandle = users.flatMap(_.selfUser.map(_.displayHandle()))
+  private lazy val currentHandle = users.flatMap(_.selfUser.map(_.displayHandle(Domain.Empty, DisplayHandleDomainPolicies.NeverShowDomain)))
 
   private val handleTextWatcher = new TextWatcher() {
     private var lastText: String = ""

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -27,7 +27,7 @@ import android.widget.{ImageView, LinearLayout}
 import com.bumptech.glide.request.RequestOptions
 import com.waz.content.UserPreferences
 import com.waz.model.otr.Client
-import com.waz.model.{AccentColor, Availability, Picture, TeamData, UserPermissions}
+import com.waz.model.{AccentColor, Availability, DisplayHandleDomainPolicies, Picture, TeamData, UserPermissions}
 import com.waz.service.teams.TeamsService
 import com.waz.service.{AccountsService, ZMessaging}
 import com.waz.threading.Threading
@@ -262,9 +262,9 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   } yield clients
 
   self.on(Threading.Ui) { self =>
-    val federationSupported = zms.currentValue.map { p => p.federation.isSupported }.getOrElse(false)
+    val federationEnabled = zms.currentValue.exists { p => p.federation.isSupported }
     view.setAccentColor(AccentColor(self.accent).color)
-    view.setHandle(self.displayHandle(federationEnabled = federationSupported))
+    view.setHandle(self.displayHandle(self.domain, if(federationEnabled) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain))
     view.setUserName(self.name)
   }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -262,8 +262,9 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   } yield clients
 
   self.on(Threading.Ui) { self =>
+    val federationSupported = zms.currentValue.map { p => p.federation.isSupported }.getOrElse(false)
     view.setAccentColor(AccentColor(self.accent).color)
-    view.setHandle(self.displayHandle(forceDomain = true))
+    view.setHandle(self.displayHandle(federationEnabled = federationSupported))
     view.setUserName(self.name)
   }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -23,6 +23,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.model.DisplayHandleDomainPolicies
 import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.wire.signals.{EventContext, EventStream, Signal}
@@ -119,7 +120,13 @@ class SettingsViewController(view: SettingsView)(implicit inj: Injector, ec: Eve
   val selfInfo = for {
     z <- zms
     self <- UserSignal(z.selfUserId)
-  } yield (self.name, self.displayHandle())
+  } yield (
+    self.name,
+    self.displayHandle(
+      self.domain,
+      if(z.federation.isSupported) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain
+    )
+  )
 
   val team = zms.flatMap(_.teams.selfTeam)
 

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -482,7 +482,7 @@ final class SearchUIFragment extends BaseFragment[Container]
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
         getString(R.string.people_picker__invite__share_text__header, self.name.str),
-        getString(R.string.people_picker__invite__share_text__body,self.displayHandle())
+        getString(R.string.people_picker__invite__share_text__body,self.displayHandle(federationEnabled = false))
       )
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }

--- a/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/usersearch/SearchUIFragment.scala
@@ -482,7 +482,7 @@ final class SearchUIFragment extends BaseFragment[Container]
     self.head.map { self =>
       val sharingIntent = IntentUtils.getInviteIntent(
         getString(R.string.people_picker__invite__share_text__header, self.name.str),
-        getString(R.string.people_picker__invite__share_text__body,self.displayHandle(federationEnabled = false))
+        getString(R.string.people_picker__invite__share_text__body,self.displayHandle(self.domain, DisplayHandleDomainPolicies.ShowIfNotSame))
       )
       startActivity(Intent.createChooser(sharingIntent, getString(R.string.people_picker__invite__share_details_dialog)))
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-506" title="FS-506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-506</a>  [Android] Issues with API versioning staging
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was an automation failure: 
`C352687 - We do also see [xyz@staging.zinfra.io](mailto:xyz@staging.zinfra.io) in settings/account`

The @handle in the profile screen contained the domain even for backends where the federation was not enabled. This is because the code was checking if the domain of the user displayed is the same as the domain of the user logged in. However, sometimes (probably when the federation is disabled?) the domain of the logged in user is empty, which is of course not equal to any domain that is not empty. So users with a domain would always display a domain, even if it's in theory the same domain as the user and federation is disabled.

### Solutions

There is a function to compute the display handle (`displayHandle`) with a boolean parameter `forceDomain` . I replaced it with a policy enumeration:

- `NeverShowDomain`
- `AlwaysShowDomain`
- `ShowIfNotSame`

The `displayHandle` function was called in various parts of the code. I followed this strategy:
- When federation is not enabled, I will pass in `NeverShowDomain`. Users are guaranteed to be from the same backend anyway.
- When federation is enabled, if it's a UI component that is supposed to show the domain only if it's not the same as the logged in user (e.g. conversations, search results), I pass `ShowIfNotSame`. Hopefully in this case, the logged in user has a domain as federation is enabled.
- When federation is enabled, if it's a UI component that is always supposed to show the domain (e.g. profile view), I pass `AlwaysShowDomain`

I'm not 100% sure that I got all the specs right on where we should display the domain even if it's the same as the logged in user. So after we merge this PR we should be on the lookout for QA automation breaking in other places for @handles. Good news is that now the code is more clear (at least to me :D ) so I can fix it easily if it breaks somewhere else.

### Testing

I did some manual testing of the UI, as it's not possible to automate UI testing with the current setup. Nightly QA automation will tell us if anything else is broken.