### PR TITLE
fix: remove autoconnection label FS-506

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/parts/ConnectRequestPartView.scala
@@ -27,7 +27,6 @@ import com.wire.signals.Signal
 import com.waz.zclient.common.controllers.BrowserController
 import com.waz.zclient.common.views._
 import com.waz.zclient.messages.{MessageViewPart, MsgPart, UsersController}
-import com.waz.zclient.ui.utils.TextViewUtils
 import com.waz.zclient.utils.ContextUtils._
 import com.waz.zclient.{R, ViewHelper}
 
@@ -80,16 +79,11 @@ class ConnectRequestPartView(context: Context, attrs: AttributeSet, style: Int) 
 
   user.map(_.id).foreach(userDetails.setUserId)
 
-  user.map(u => (u.isAutoConnect, u.isWireBot)).onUi {
-    case (true, _) =>
-      label.setText(R.string.content__message__connect_request__auto_connect__footer)
-      TextViewUtils.linkifyText(label, getStyledColor(R.attr.wirePrimaryTextColor), true, true, new Runnable() {
-        override def run() = browser.openHelp()
-      })
-    case (false, false) =>
+  user.map(u => u.isWireBot).onUi {
+    case false =>
       label.setTextColor(getStyledColor(R.attr.wirePrimaryTextColor))
       label.setText(R.string.content__message__connect_request__footer)
-    case (_, true) =>
+    case true =>
       label.setTextColor(getColor(R.color.accent_red))
       label.setText(R.string.generic_service_warning)
   }

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -68,7 +68,6 @@ final case class UserData(override val id:       UserId,
   lazy val isSelf: Boolean              = connection == ConnectionStatus.Self
   lazy val isAcceptedOrPending: Boolean = connection == ConnectionStatus.Accepted || connection == ConnectionStatus.PendingFromOther || connection == ConnectionStatus.PendingFromUser
   lazy val isVerified: Boolean          = verified == Verification.VERIFIED
-  lazy val isAutoConnect: Boolean       = isConnected && ! isSelf && connectionMessage.isEmpty
   lazy val isReadOnlyProfile: Boolean   = managedBy.exists(_ != ManagedBy.Wire) //if none or "Wire", then it's not read only.
   lazy val isWireBot: Boolean           = integrationId.nonEmpty
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-506" title="FS-506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-506</a>  [Android] Issues with API versioning staging
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app was showing an "Auto-connected" label at the beginning of a 1:1 conversation. Autoconnection of users using address book have been removed a long time ago (probably more than 4 years?) but somehow the code to show this label was still there AND it was triggered by the recent changes to federation. 

### Solutions

Instead of figuring out what was triggering the code to show the "autoconnect" label, I just removed the code as the feature doesn't exist anymore.

### Testing

Tested manually