### PR TITLE
fix: team creation SQSERVICES-1437

### DIFF
--- a/zmessaging/src/main/scala/com/waz/client/RegistrationClient.scala
+++ b/zmessaging/src/main/scala/com/waz/client/RegistrationClient.scala
@@ -53,7 +53,7 @@ class RegistrationClientImpl(implicit
       credentials.addToRegistrationJson(o)
       teamName.foreach { t =>
         o.put("team", JsonEncoder { o2 =>
-          o2.put("icon", "abc") //TODO proper icon
+          o2.put("icon", "default")
           o2.put("name", t)
         })
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1437" title="SQSERVICES-1437" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1437</a>  [Android] It's not possible anymore to register a team account because password is not recognised as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Team creation was failing because the "icon" value in the request JSON was "abc" rather than "default". The request then causes a `400` because of this string.

### Testing

Tested manually by creating a team
