### PR TITLE
chore: No syntax highlighting in build messages for performance (SQPIT-926)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -442,7 +442,7 @@ pipeline {
                 }
             }
             wireSend secret: env.WIRE_BOT_WIRE_ANDROID_SECRET, message: "[${env.BRANCH_NAME}] ${usedFlavor}${usedBuildType} **[${BUILD_NUMBER}](${BUILD_URL})** - ✅ SUCCESS 🎉" +
-                    "\nLast 5 commits:\n```\n$lastCommits\n```"
+                    "\nLast 5 commits:\n```text\n$lastCommits\n```"
         }
         aborted {
             script {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-926" title="SQPIT-926" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQPIT-926</a>  Android build chats are slow to open on desktop/webapp
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

## Issue

The build jobs sends messages into the build chat on success which contain code tags ```. The chat is very slow to open.

## Causes

Every time when opening this chat with the webapp/desktop app the syntax highlighter tries to parse and guess which language the code has.

## Solutions

With the term text we disable the highlighting.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
