### PR TITLE
fix: live update of federation configuration FS-512

### DIFF
--- a/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/views/ConversationListRow.scala
@@ -126,6 +126,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
 
   private val subtitleText = for {
     z <- zms
+    federation <- z.backend.map { b => b.federationSupport }
     conv <- conversation
     lastMessage <- controller.lastMessage(conv.id).map(_.lastMsg)
     lastUnreadMessage = lastMessage.filter(_.userId != z.selfUserId).filter(_ => conv.unreadCount.total > 0)
@@ -152,7 +153,7 @@ class NormalConversationListRow(context: Context, attrs: AttributeSet, style: In
       isGroupConv,
       userName,
       currentDomain,
-      z.federation.isSupported
+      federation.isSupported
     )
   )
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -234,9 +234,9 @@ class AccountViewController(view: AccountView)(implicit inj: Injector, ec: Event
   self.map(_.picture).collect { case Some(pic) => pic}.onUi { id =>
     view.setPicture(id)
   }
-  Signal.zip(self, zms).onUi {
-    case(self, z) => {
-      view.setHandle(self.displayHandle(self.domain, if(z.federation.isSupported) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain))
+  Signal.zip(self, zms.flatMap {_.backend}).onUi {
+    case(self, backend) => {
+      view.setHandle(self.displayHandle(self.domain, if(backend.federationSupport.isSupported) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain))
       view.setName(self.name)
       view.setAccentDrawable(new Drawable {
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/ProfileView.scala
@@ -238,6 +238,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   lazy val zms             = inject[Signal[ZMessaging]]
   lazy val usersController = inject[UsersController]
   lazy val usersAccounts   = inject[UserAccountsController]
+  private lazy val backendConfig = zms.flatMap(_.backend)
   private lazy val userPrefs = zms.map(_.userPrefs)
 
   val currentUser = accounts.activeAccountId.collect { case Some(id) => id }
@@ -262,7 +263,7 @@ class ProfileViewController(view: ProfileView)(implicit inj: Injector, ec: Event
   } yield clients
 
   self.on(Threading.Ui) { self =>
-    val federationEnabled = zms.currentValue.exists { p => p.federation.isSupported }
+    val federationEnabled = backendConfig.currentValue.exists(_.federationSupport.isSupported)
     view.setAccentColor(AccentColor(self.accent).color)
     view.setHandle(self.displayHandle(self.domain, if(federationEnabled) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain))
     view.setUserName(self.name)

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/SettingsView.scala
@@ -119,12 +119,13 @@ class SettingsViewController(view: SettingsView)(implicit inj: Injector, ec: Eve
 
   val selfInfo = for {
     z <- zms
+    backend <- z.backend
     self <- UserSignal(z.selfUserId)
   } yield (
     self.name,
     self.displayHandle(
       self.domain,
-      if(z.federation.isSupported) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain
+      if(backend.federationSupport.isSupported) DisplayHandleDomainPolicies.AlwaysShowDomain else DisplayHandleDomainPolicies.NeverShowDomain
     )
   )
 

--- a/zmessaging/src/main/scala/com/waz/log/BasicLogging.scala
+++ b/zmessaging/src/main/scala/com/waz/log/BasicLogging.scala
@@ -67,6 +67,8 @@ object BasicLogging {
     def apply[T](implicit ct: ClassTag[T]): LogTag = new LogTag(ct.runtimeClass.getSimpleName)
   }
 
+  def unsafeLog[T](value: T): CanBeShown = new CanBeShownImpl[T](value)
+
   trait CanBeShown {
     def showSafe: String
     def showUnsafe: String

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -201,10 +201,9 @@ final class GlobalModuleImpl(val context:             AContext,
 
   lazy val httpProxy:           Option[Proxy]                    = HttpProxy(metadata, defaultProxyDetails).proxy
 
-  private def _backendConfiguration = new SourceSignal[BackendConfig](None)
+  private val _backendConfiguration = new SourceSignal[BackendConfig](Option(backend))
   override def backendConfiguration: Signal[BackendConfig] = _backendConfiguration
 
-  _backendConfiguration ! backend
 }
 
 class EmptyGlobalModule extends GlobalModule {

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -412,7 +412,7 @@ class UserServiceImpl(selfUserId:        UserId,
         qualified             =  qIds.filter(qId => newIds.contains(qId.id)) ++
                                    existing.collect { case (_, u) if u.qualifiedId.nonEmpty => u.qualifiedId.get }.toSet
         nonQualified          =  toSync -- qualified.map(_.id)
-        _                     =  verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size}) (qualified: ${qualified.size})")
+        _                     =  verbose(l"syncIfNeeded for users (qualified); new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size}) (qualified: ${qualified.size})")
         syncId1               <- if (qualified.nonEmpty)
                                    sync.syncQualifiedUsers(qualified).map(Option(_))
                                  else
@@ -430,7 +430,7 @@ class UserServiceImpl(selfUserId:        UserId,
         val offset   = LocalInstant.Now - olderThan
         val existing = found.filter(u => !u.isConnected && (u.teamId.isEmpty || u.teamId != teamId) && u.syncTimestamp.forall(_.isBefore(offset)))
         val toSync   = newIds ++ existing.map(_.id)
-        verbose(l"syncIfNeeded for users; new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
+        verbose(l"syncIfNeeded for users (unqualified); new: (${newIds.size}) + existing: (${existing.size}) = all: (${toSync.size})")
         if (toSync.nonEmpty)
           sync.syncUsers(toSync)
             .flatMap {

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -111,9 +111,7 @@ class ZMessaging(val teamId:    Option[TeamId],
   val clock = ZMessaging.clock
 
   val global     = account.global
-
-  //def federation2: FederationSupport = global.backend.federationSupport
-
+  
   lazy val selfUserId: UserId = account.userId
   lazy val selfDomain: Domain = account.domain
 

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -112,7 +112,7 @@ class ZMessaging(val teamId:    Option[TeamId],
 
   val global     = account.global
 
-  def federation: FederationSupport = global.backend.federationSupport
+  //def federation2: FederationSupport = global.backend.federationSupport
 
   lazy val selfUserId: UserId = account.userId
   lazy val selfDomain: Domain = account.domain
@@ -153,7 +153,7 @@ class ZMessaging(val teamId:    Option[TeamId],
   def metadata          = global.metadata
   def network           = global.network
   def blacklist         = global.blacklist
-  def backend           = global.backend
+  def backend           = global.backendConfiguration
   def teamsStorage      = global.teamsStorage
   def videoTranscoder   = global.videoTranscoder
   def audioTranscader   = global.audioTranscoder

--- a/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -61,7 +61,7 @@ object WSPushServiceImpl {
             networkModeService: NetworkModeService
            ): WSPushServiceImpl = {
 
-    val websocketUrl = backend.currentValue.map { b => b.websocketUrl }.getOrElse(URI.parse("")) // the first value is guaranteed to have at least the URLs
+    val websocketUrl = backend.currentValue.map { b => b.websocketUrl }.get // the first value is guaranteed to have at least the URLs
     val requestCreator = (token: AccessToken) => {
       val webSocketUri = if(websocketUrl.getPath.startsWith("/await")) websocketUrl
         else websocketUrl.buildUpon.appendPath("await").build

--- a/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -19,7 +19,6 @@ package com.waz.service.push
 
 import java.net.URL
 import java.util.concurrent.atomic.AtomicInteger
-
 import com.waz.log.LogSE._
 import com.waz.log.BasicLogging.LogTag
 import com.waz.model.UserId
@@ -34,6 +33,7 @@ import com.wire.signals._
 import com.waz.utils.{Backoff, ExponentialBackoff}
 import com.waz.sync.client.AuthenticationManager.AccessToken
 import com.waz.sync.client
+import com.waz.utils.wrappers.URI
 import com.waz.znet2.WebSocketFactory.SocketEvent
 import com.waz.znet2.http.{Body, Method, Request}
 import com.waz.znet2.{WebSocket, WebSocketFactory, http}
@@ -55,15 +55,16 @@ object WSPushServiceImpl {
 
   def apply(userId: UserId,
             clientId: ClientId,
-            backend: BackendConfig,
+            backend:  Signal[BackendConfig],
             webSocketFactory: WebSocketFactory,
             accessTokenProvider: AccessTokenProvider,
             networkModeService: NetworkModeService
            ): WSPushServiceImpl = {
 
+    val websocketUrl = backend.currentValue.map { b => b.websocketUrl }.getOrElse(URI.parse("")) // the first value is guaranteed to have at least the URLs
     val requestCreator = (token: AccessToken) => {
-      val webSocketUri = if(backend.websocketUrl.getPath.startsWith("/await")) backend.websocketUrl
-        else backend.websocketUrl.buildUpon.appendPath("await").build
+      val webSocketUri = if(websocketUrl.getPath.startsWith("/await")) websocketUrl
+        else websocketUrl.buildUpon.appendPath("await").build
 
       val uri = webSocketUri.buildUpon.appendQueryParameter("client", clientId.str).build
       // XXX: this is a hack for Backend In The Box problem: 'Accept-Encoding: gzip' header causes 500

--- a/zmessaging/src/test/scala/com/waz/service/BackendConfigSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/BackendConfigSpec.scala
@@ -20,9 +20,32 @@ package com.waz.service
 import com.waz.specs.ZSpec
 import com.waz.sync.client.SupportedApiConfig
 import com.waz.utils.wrappers.URI
+import com.wire.signals.{Signal, SourceSignal}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+
+object BackendConfigFixture {
+
+  //This information can be found in downloadable google-services.json file from the BE console.
+  val testFirebaseOptions = FirebaseOptions(
+    "21312312312",
+    "1:7213123213:android:123123213213",
+    "dsadasr3ee2ed213123eqw213")
+
+  val testBackend: BackendConfig = BackendConfig(
+    environment = "test",
+    baseUrl = "https://example.com",
+    websocketUrl = "https://example.com",
+    blacklistHost = Some("https://example.com"),
+    teamsUrl = "https://example.com",
+    accountsUrl = "https://example.com",
+    websiteUrl = "https://example.com",
+    testFirebaseOptions
+  )
+
+  val backendSignal: Signal[BackendConfig] = new SourceSignal[BackendConfig](Option(BackendConfigFixture.testBackend))
+}
 
 @RunWith(classOf[RobolectricTestRunner])
 class BackendConfigSpec extends ZSpec {

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -665,7 +665,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec with DerivedLogTag {
       selfId,
       if (inTeam) teamId else emptyTeamId,
       currentDomain,
-      FederationSupport(federationSupported),
+      BackendConfigFixture.backendSignal,
       userService,
       usersStorage,
       teamsService,

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -78,7 +78,7 @@ class UserServiceSpec extends AndroidFreeSpec {
     result(userPrefs(UserPreferences.ShouldSyncUsers) := false)
 
     new UserServiceImpl(
-      users.head.id, domain, None, FederationSupport(federationSupported), accountsService,
+      users.head.id, domain, None, BackendConfigFixture.backendSignal, accountsService,
       accountsStrg, usersStorage, membersStorage,
       userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
       selectedConv, messages, syncRequests
@@ -101,7 +101,7 @@ class UserServiceSpec extends AndroidFreeSpec {
       availability should not equal Availability.Busy
 
       val userService = new UserServiceImpl(
-        users.head.id, domain, someTeamId, FederationSupport(federationSupported), accountsService,
+        users.head.id, domain, someTeamId, BackendConfigFixture.backendSignal, accountsService,
         accountsStrg, usersStorage, membersStorage,
         userPrefs, pushService, assetService, usersClient, sync, assetsStorage, credentials,
         selectedConv, messages, syncRequests

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -35,7 +35,7 @@ import com.waz.service.call.CallingServiceSpec.CallStateCheckpoint
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService}
 import com.waz.service.messages.MessagesService
 import com.waz.service.push.PushService
-import com.waz.service.{MediaManagerService, NetworkModeService}
+import com.waz.service.{BackendConfigFixture, MediaManagerService, NetworkModeService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.otr.OtrSyncHandler
 import com.waz.sync.otr.OtrSyncHandler.TargetRecipients
@@ -1198,7 +1198,7 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (avs.registerAccount _).expects(*).once().returning(Future.successful(wCall))
 
     val s = new CallingServiceImpl(
-      selfUserId, selfClientId, domain, FederationSupport(federationSupported), null, avs, convs, convsService, members, otrSyncHandler,
+      selfUserId, selfClientId, domain, BackendConfigFixture.backendSignal, null, avs, convs, convsService, members, otrSyncHandler,
       flows, messages, media, push, network, prefs, globalPrefs, permissions, httpProxy = None
     )
     result(s.wCall)

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -346,7 +346,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
   def createBlankService() =
    new ConnectionServiceImpl(
-     selfUserId, teamId, FederationSupport(federationSupported), push, convs, convsStorage,
+     selfUserId, teamId, BackendConfigFixture.backendSignal, push, convs, convsStorage,
      members, messagesService, messagesStorage, users, usersStorage, sync
    )
 
@@ -387,7 +387,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     }
     (users.syncUsers _).expects(*, *, *).anyNumberOfTimes().returns(Future.successful(Option(SyncId())))
     new ConnectionServiceImpl(
-      selfUserId, teamId, FederationSupport(federationSupported), push, convs, convsStorage,
+      selfUserId, teamId, BackendConfigFixture.backendSignal, push, convs, convsStorage,
       members, messagesService, messagesStorage, users, usersStorage, sync
     )
   }

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsServiceSpec.scala
@@ -88,7 +88,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
     None,
     selfUserId,
     domain,
-    FederationSupport(federationSupported),
+    BackendConfigFixture.backendSignal,
     push,
     userService,
     usersStorage,
@@ -112,7 +112,7 @@ class ConversationsServiceSpec extends AndroidFreeSpec {
 
   private def createConvsUi(teamId: Option[TeamId] = Some(TeamId())): ConversationsUiService = {
     new ConversationsUiServiceImpl(
-      selfUserId, teamId, domain, FederationSupport(federationSupported), assets, userService, messages, msgStorage,
+      selfUserId, teamId, domain, BackendConfigFixture.backendSignal, assets, userService, messages, msgStorage,
       msgUpdater, membersStorage, content, convsStorage, network,
       service, sync, requests, convsClient, accounts, tracking, errors, uriHelper,
       properties

--- a/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/ConversationsUiServiceSpec.scala
@@ -23,7 +23,7 @@ import com.waz.service.BackendConfig.FederationSupport
 import com.waz.service.assets.{AssetService, UriHelper}
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.push.PushService
-import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, UserService}
+import com.waz.service.{BackendConfigFixture, ErrorsService, NetworkModeService, PropertiesService, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
@@ -62,7 +62,7 @@ class ConversationsUiServiceSpec extends AndroidFreeSpec {
   private def getService(teamId: Option[TeamId] = None): ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(
-      selfUserId, teamId, domain, FederationSupport(federationSupported), assetService, users, messages,
+      selfUserId, teamId, domain, BackendConfigFixture.backendSignal, assetService, users, messages,
       messagesStorage,
       msgContent, members, content, convsStorage, network, convsService, sync, requests, client,
       accounts, tracking, errors, uriHelper, properties)

--- a/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/conversation/TeamConversationSpec.scala
@@ -25,7 +25,7 @@ import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{ConversationMemberData, _}
 import com.waz.service.BackendConfig.FederationSupport
 import com.waz.service.assets.{AssetService, UriHelper}
-import com.waz.service.{ErrorsService, NetworkModeService, PropertiesService, SearchKey, UserService}
+import com.waz.service.{BackendConfigFixture, ErrorsService, NetworkModeService, PropertiesService, SearchKey, UserService}
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient
@@ -67,7 +67,7 @@ class TeamConversationSpec extends AndroidFreeSpec {
   def initService: ConversationsUiService = {
     val msgContent = new MessagesContentUpdater(messagesStorage, convsStorage, deletions, buttons, prefs, userPrefs)
     new ConversationsUiServiceImpl(
-      selfId, team, domain, FederationSupport(federationSupported), assetService, users, messages,
+      selfId, team, domain, BackendConfigFixture.backendSignal, assetService, users, messages,
       messagesStorage, msgContent, members, convsContent, convsStorage, network, convsService, sync,
       requests, client, accounts, tracking, errors, uriHelper, properties
     )

--- a/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/ConversationsSyncHandlerSpec.scala
@@ -8,7 +8,7 @@ import com.waz.model._
 import com.waz.service.BackendConfig.FederationSupport
 import com.waz.service.conversation.{ConversationOrderEventsService, ConversationsContentUpdater, ConversationsService}
 import com.waz.service.messages.MessagesService
-import com.waz.service.{ConversationRolesService, ErrorsService, GenericMessageService, UserService}
+import com.waz.service.{BackendConfigFixture, ConversationRolesService, ErrorsService, GenericMessageService, UserService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.ConversationsClient.{ConversationResponse, ListConversationsIdsResponse}
 import com.waz.sync.client.ConversationsClient.ConversationResponse.{ConversationsResult, QConversationsResult}
@@ -37,7 +37,7 @@ class ConversationsSyncHandlerSpec extends AndroidFreeSpec {
   private val membersStorage = mock[MembersStorage]
 
   private def createHandler: ConversationsSyncHandler = new ConversationsSyncHandler(
-    self.id, domain, Some(teamId), FederationSupport(federationSupported),userService,
+    self.id, domain, Some(teamId), BackendConfigFixture.backendSignal,userService,
     messagesStorage, messagesService,
     convService, convs, convEvents, convStorage, errorsService,
     conversationsClient, genericMessages, rolesService, membersStorage

--- a/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
@@ -24,7 +24,7 @@ import com.waz.content.{MembersStorage, MessagesStorage}
 import com.waz.model._
 import com.waz.service.BackendConfig.FederationSupport
 import com.waz.service.assets.{AssetService, AssetStorage, UploadAssetStorage}
-import com.waz.service.{ErrorsService, Timeouts, UserService}
+import com.waz.service.{BackendConfigFixture, ErrorsService, Timeouts, UserService}
 import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
 import com.waz.service.otr.OtrClientsService
@@ -59,7 +59,7 @@ class MessagesSyncHandlerSpec extends AndroidFreeSpec {
 
   def getHandler: MessagesSyncHandler = {
     new MessagesSyncHandler(
-      account1Id, FederationSupport(federationSupported), service, msgContent, clients, otrSync,
+      account1Id, BackendConfigFixture.backendSignal, service, msgContent, clients, otrSync,
       convs, storage, sync,
       assets, assetStorage, uploads, cache, members, users, tracking, errors, timeouts
     )

--- a/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
@@ -5,6 +5,7 @@ import com.waz.content.UserPreferences.ShouldPostClientCapabilities
 import com.waz.model.{Domain, QualifiedId, UserId}
 import com.waz.model.otr.{Client, ClientId, OtrClientIdMap, QOtrClientIdMap, UserClients}
 import com.waz.service.BackendConfig.FederationSupport
+import com.waz.service.BackendConfigFixture
 import com.waz.service.otr.{CryptoBoxService, CryptoSessionService, OtrClientsService}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -37,7 +38,7 @@ class OtrClientsSyncHandlerSpec extends AndroidFreeSpec {
   private def createHandler() = new OtrClientsSyncHandlerImpl(
     selfUserId,
     currentDomain,
-    FederationSupport(federationSupported),
+    BackendConfigFixture.backendSignal,
     selfClientId,
     netClient,
     otrClients,

--- a/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/UsersSyncHandlerSpec.scala
@@ -3,7 +3,7 @@ package com.waz.sync.handler
 import com.waz.content.UsersStorage
 import com.waz.model._
 import com.waz.service.BackendConfig.FederationSupport
-import com.waz.service.{UserSearchService, UserService}
+import com.waz.service.{BackendConfigFixture, UserSearchService, UserService}
 import com.waz.service.assets.AssetService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -35,7 +35,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
   val teamId = TeamId()
 
   def handler: UsersSyncHandler = new UsersSyncHandlerImpl(
-    FederationSupport(federationSupported), userService, usersStorage, assetService, searchService,
+    BackendConfigFixture.backendSignal, userService, usersStorage, assetService, searchService,
     usersClient, otrSync, Some(teamId), teamsSyncHandler
   )
 
@@ -309,7 +309,7 @@ class UsersSyncHandlerSpec extends AndroidFreeSpec {
         .once()
 
       val handler = new UsersSyncHandlerImpl(
-        FederationSupport(federationSupported), userService, usersStorage, assetService,
+        BackendConfigFixture.backendSignal, userService, usersStorage, assetService,
         searchService, usersClient, otrSync, None, teamsSyncHandler
       )
       result(handler.syncSearchResults(users.keys.toArray:_*)) shouldEqual SyncResult.Success


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-512" title="FS-512" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-512</a>  [Android] Issues with API versioning federation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Following up on https://github.com/wireapp/wire-android/pull/3686, there are still some instances in the code that, as described in the aforementioned PR, capture the value of the "federation enabled" flag at creation time, when that value might be not updated yet.

### Issues

This had many symptoms:

- Could not send connection requests to a remote user when the app is first started
- Could not place a call to the webapp
- ... other minor effects mentioned in FS-512 and FS-506

### Causes (Optional)

Often, a class constructor would be passed a `FederationSupported` instance, which is just a wrapper for a boolean initially set to false until we get the API information from the backend. 

The `FederationSupported` instance is then never modified even if we later discover that the backend supports federation.

An example of this is visible in `zmessaging/src/main/scala/com/waz/service/ConnectionService.scala`.

There were other ways in which the `FederationSupported` in `GlobalModule` was accessed, which might have had the same issue. Therefore I removed them.

### Solutions

Pass a `Signal` of the backend configuration rather than a value. When using the signal, the call site has the most updated value of the federation flag.

### Testing

I ran the app on production, staging and Anta environment. Calling the webapp worked, and the UI seemed to show the right values, with the exception of the automation issue C925125, which I will keep investigating and address in another PR.