### PR TITLE
fix: re-fetch API information when switching backend with a deep link FS-512

### DIFF
--- a/app/src/main/scala/com/waz/zclient/WireApplication.scala
+++ b/app/src/main/scala/com/waz/zclient/WireApplication.scala
@@ -420,7 +420,7 @@ class WireApplication extends MultiDexApplication with WireContext with Injectab
           false
       }
 
-  private def updateSupportedApiVersions(backend: BackendConfig): Unit =
+  def updateSupportedApiVersions(backend: BackendConfig): Unit =
     inject[SupportedApiClient].getSupportedApiVersions(backend.baseUrl).foreach {
       case Right(supportedApiConfig) => {
         verbose(l"change in supported API versions: $supportedApiConfig")

--- a/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/AppEntryActivity.scala
@@ -224,7 +224,9 @@ final class AppEntryActivity extends BaseActivity with SSOFragmentHandler {
 
       case Right(config) =>
         enableProgress(false)
-        backendController.switchBackend(inject[GlobalModule], config, configUrl)
+        val global = inject[GlobalModule]
+        backendController.switchBackend(global, config, configUrl)
+        WireApplication.APP_INSTANCE.updateSupportedApiVersions(global.backend)
 
         // re-present fragment for updated ui.
         getSupportFragmentManager.popBackStackImmediate(StartSSOFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-512" title="FS-512" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-512</a>  [Android] Issues with API versioning federation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the app is opened the first time, it fetches the API version from the backend (`GET /api-version`). It uses this information to know if federation is enabled.

If the app is later configured with a configuration link (a.k.a. deep link) to connect to another backend, this information is not fetched again. 

If the initial backend did not support federation, and the new does, the app will still behave as if the new backend does not support federation, generating all kind of issues when interacting with that backend.

### Solutions

Make sure that the API version information is fetched again when switching backend

### Testing

Manually tested switching from the `staging` backend to `anta` backend
