### PR TITLE
fix: make sure AVS calls use qualified/non-qualified identifiers based on federation FS-506

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -13,7 +13,7 @@ final case class RConvQualifiedId(id: RConvId, domain: String) {
 object RConvQualifiedId {
   def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
   def apply(id: RConvId, domain: Domain): RConvQualifiedId = RConvQualifiedId(id, domain.str)
-  def apply(id: RConvId, domain: Domain, useDomain: Boolean): RConvQualifiedId = if(useDomain) apply(id) else apply(id, domain)
+  def apply(id: RConvId, domain: Domain, federationSupported: Boolean): RConvQualifiedId = if(federationSupported) apply(id, domain) else apply(id)
 
   private val IdFieldName = "id"
   private val DomainFieldName  = "domain"

--- a/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/RConvQualifiedId.scala
@@ -13,6 +13,7 @@ final case class RConvQualifiedId(id: RConvId, domain: String) {
 object RConvQualifiedId {
   def apply(id: RConvId): RConvQualifiedId = RConvQualifiedId(id, "")
   def apply(id: RConvId, domain: Domain): RConvQualifiedId = RConvQualifiedId(id, domain.str)
+  def apply(id: RConvId, domain: Domain, useDomain: Boolean): RConvQualifiedId = if(useDomain) apply(id) else apply(id, domain)
 
   private val IdFieldName = "id"
   private val DomainFieldName  = "domain"

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -59,7 +59,6 @@ trait GlobalModule {
 
   def context:                  AContext
   def backend:                  BackendConfig
-  def federationSupport:       FederationSupport
 
   def syncRequests:             SyncRequestService
   def syncHandler:              SyncHandler
@@ -130,7 +129,6 @@ final class GlobalModuleImpl(val context:             AContext,
   }
 
   def backend:                 BackendConfig                    = _backend
-  def federationSupport:       FederationSupport                = _backend.federationSupport
 
   //trigger initialization of Firebase in onCreate - should prevent problems with Firebase setup
   val lifecycle:                UiLifeCycle                      = new UiLifeCycleImpl()
@@ -156,7 +154,7 @@ final class GlobalModuleImpl(val context:             AContext,
   lazy val phoneNumbers:        PhoneNumberService               = wire[PhoneNumberServiceImpl]
   lazy val timeouts                                              = wire[Timeouts]
   lazy val permissions:         PermissionsService               = new PermissionsService
-  lazy val avs:                 Avs                              = wire[AvsImpl]
+  lazy val avs:                 Avs                              = new AvsImpl(backendConfiguration)
 
   lazy val reporting                                             = wire[GlobalReportingService]
 
@@ -208,8 +206,6 @@ final class GlobalModuleImpl(val context:             AContext,
 
 class EmptyGlobalModule extends GlobalModule {
   override def setBackend(newBackend: BackendConfig): Unit                                   = ???
-
-  override def federationSupport: FederationSupport                                          = ???
 
   override def accountsService:          AccountsService                                     = ???
   override def trackingService:          TrackingService                                     = ???

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -23,13 +23,14 @@ import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model._
 import com.waz.model.otr.{ClientId, OtrClientIdMap, QOtrClientIdMap}
+import com.waz.service.BackendConfig
 import com.waz.service.BackendConfig.FederationSupport
 import com.waz.service.call.CallInfo.{ActiveSpeaker, Participant}
 import com.waz.service.call.Calling.{ActiveSpeakersHandler, Handle, _}
 import com.waz.utils.jna.{Size_t, Uint32_t}
 import com.waz.utils.{CirceJSONSupport, returning}
 import com.waz.zms.BuildConfig
-import com.wire.signals.{DispatchQueue, SerialDispatchQueue}
+import com.wire.signals.{DispatchQueue, SerialDispatchQueue, Signal}
 import org.threeten.bp.Instant
 
 import scala.concurrent.{Future, Promise}
@@ -59,7 +60,7 @@ trait Avs {
   * Facilitates synchronous communication with AVS and also provides a wrapper around the native code which can be easily
   * mocked for testing the CallingService
   */
-final class AvsImpl(federation: FederationSupport) extends Avs with DerivedLogTag {
+final class AvsImpl(backendConfiguration: Signal[BackendConfig]) extends Avs with DerivedLogTag {
   private implicit val dispatcher: DispatchQueue = SerialDispatchQueue(name = "AvsWrapper")
 
   import Avs._
@@ -91,6 +92,8 @@ final class AvsImpl(federation: FederationSupport) extends Avs with DerivedLogTa
   override def libraryVersion: Future[String] = {
     withAvsReturning(wcall_library_version(), "Unknown AVS version")
   }
+
+  private def federationSupported: Boolean = backendConfiguration.currentValue.exists { b => b.federationSupport.isSupported }
 
   override def registerAccount(cs: CallingServiceImpl) = available.flatMap { _ =>
     verbose(l"Initialising calling for: ${cs.accountId} and current client: ${cs.clientId}")
@@ -133,7 +136,7 @@ final class AvsImpl(federation: FederationSupport) extends Avs with DerivedLogTa
               AvsClientList.decode(json).fold({ throw _ }, identity)
             }
 
-            if (federation.isSupported) {
+            if (federationSupported) {
               cs.onQSend(ctx, message, rConvId, targetRecipients)
             } else {
               cs.onSend(ctx, message, rConvId, targetRecipients)

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -98,7 +98,7 @@ final class AvsImpl(backendConfiguration: Signal[BackendConfig]) extends Avs wit
   override def registerAccount(cs: CallingServiceImpl) = available.flatMap { _ =>
     verbose(l"Initialising calling for: ${cs.accountId} and current client: ${cs.clientId}")
 
-    val qualifiedId = QualifiedId.apply(cs.accountId, cs.domain)
+    val qualifiedId = if(federationSupported) QualifiedId.apply(cs.accountId, cs.domain) else QualifiedId.apply(cs.accountId)
 
     val callingReady = Promise[Unit]()
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -534,6 +534,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                   }
                 case _ =>
                   val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
+                  verbose(l"Start call with qualified Id ${rConvQualifiedId}, federation supported: ${federationSupported}")
                   avs.startCall(w, rConvQualifiedId, callType, convType, useConstantBitRate).map {
                     case 0 =>
                       //Assume that when a video call starts, sendingVideo will be true. From here on, we can then listen to state handler

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -362,7 +362,7 @@ final class CallingServiceImpl(val accountId:       UserId,
           val updatedCall = p.calls.get(conv.id).map { call =>
             verbose(l"endCall: $convId, skipTerminating (ultimate): $skipTerminatingUltimate. Active call in state: ${call.state}")
             //avs reject and end call will always trigger the onClosedCall callback - there we handle the end of the call
-            val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+            val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
 
             if (call.state == OtherCalling) avs.rejectCall(w, rConvQualifiedId) else avs.endCall(w, rConvQualifiedId)
             //if there is another incoming call - skip the terminating state
@@ -461,19 +461,16 @@ final class CallingServiceImpl(val accountId:       UserId,
   def onNetworkQualityChanged(convId: ConvId, participant: Participant, quality: NetworkQuality): Future[Unit] =
     Future.successful(())
 
-  def onClientsRequest(convId: RConvQualifiedId): Future[Unit] =
-    if (federationSupported) {
-      withConv(convId.id) { (wCall, conv) =>
+  def onClientsRequest(convId: RConvQualifiedId): Future[Unit] = {
+    withConv(convId.id) { (wCall, conv) =>
+      if (federationSupported) {
         otrSyncHandler.postClientDiscoveryMessage(convId).map {
           case Right(clients) =>
-            val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
-            avs.onQualifiedClientsRequest(wCall, rConvQualifiedId, clients)
+            avs.onQualifiedClientsRequest(wCall, RConvQualifiedId.apply(conv.remoteId, conv.domain), clients)
           case Left(errorResponse) =>
             warn(l"Could not post client discovery message: $errorResponse")
         }
-      }
-    } else {
-      withConv(convId.id) { (wCall, conv) =>
+      } else {
         otrSyncHandler.postClientDiscoveryMessage(convId.id).map {
           case Right(clients) =>
             avs.onClientsRequest(wCall, conv.remoteId, clients)
@@ -482,6 +479,7 @@ final class CallingServiceImpl(val accountId:       UserId,
         }
       }
     }
+  }
 
   override def startCall(convId: ConvId,
                          isVideo: Boolean = false,
@@ -510,7 +508,7 @@ final class CallingServiceImpl(val accountId:       UserId,
               Future.successful {
                 call.state match {
                   case OtherCalling =>
-                    val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+                    val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
                     avs.answerCall(w, rConvQualifiedId, callType, useConstantBitRate)
                     updateActiveCall(_.updateCallState(SelfJoining))("startCall/OtherCalling")
                     if (forceOption)
@@ -526,7 +524,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                 case Some(call) if !Set[CallState](Ended, Terminating)(call.state) =>
                   Future.successful {
                     verbose(l"Joining an ongoing background call")
-                    val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+                    val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
                     avs.answerCall(w, rConvQualifiedId, callType, useConstantBitRate)
                     val active = call.updateCallState(SelfJoining).copy(joinedTime = None, estabTime = None) // reset previous call state if exists
                     callProfile.mutate(_.copy(calls = profile.calls + (convId -> active)))
@@ -535,7 +533,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                       setVideoSendState(convId, if (isVideo)  Avs.VideoState.Started else Avs.VideoState.Stopped)
                   }
                 case _ =>
-                  val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+                  val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
                   avs.startCall(w, rConvQualifiedId, callType, convType, useConstantBitRate).map {
                     case 0 =>
                       //Assume that when a video call starts, sendingVideo will be true. From here on, we can then listen to state handler
@@ -613,7 +611,7 @@ final class CallingServiceImpl(val accountId:       UserId,
     updateActiveCallAsync { (w, conv, call) =>
       verbose(l"onInterrupted - gsm call received")
       //Ensure that conversation state is only performed INSIDE withConv
-      val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+      val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
       avs.endCall(w, rConvQualifiedId)
       call
     } ("onInterrupted")
@@ -637,7 +635,7 @@ final class CallingServiceImpl(val accountId:       UserId,
         case c => c
       }
       verbose(l"setVideoSendActive: $convId, providedState: $state, targetState: $targetSt")
-      val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain)
+      val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
 
       if (state != NoCameraPermission && shouldUpdateVideoState) avs.setVideoSendState(w, rConvQualifiedId, targetSt)
       call.updateVideoState(Participant(QualifiedId(accountId, domain), clientId), targetSt)
@@ -647,7 +645,7 @@ final class CallingServiceImpl(val accountId:       UserId,
     case (_, events) =>
       Future.successful(events.sortBy(_.time).foreach { e =>
 
-        val rConvQualifiedId = RConvQualifiedId.apply(e.convId, e.convDomain)
+        val rConvQualifiedId = RConvQualifiedId.apply(e.convId, e.convDomain, federationSupported)
         val qualifiedId = QualifiedId.apply(e.from, e.fromDomain)
 
         receiveCallEvent(e.content, e.time, rConvQualifiedId, qualifiedId, e.sender)
@@ -659,7 +657,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                                 convId: RConvId,
                                 from: UserId,
                                 sender: ClientId): Unit =
-    receiveCallEvent(msg, msgTime, RConvQualifiedId(convId, domain), QualifiedId(from, domain), sender)
+    receiveCallEvent(msg, msgTime, RConvQualifiedId(convId, domain, federationSupported), QualifiedId(from, domain), sender)
 
   private var lastCallEventTime = Option.empty[LocalInstant]
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-506" title="FS-506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-506</a>  [Android] Issues with API versioning staging
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With https://github.com/wireapp/wire-android/pull/3695 I fixed the fact that calling was not working on federation-enabled environments. However, it was still not working on non-federation environments when calling from Android to any other platform.

### Causes

The Android code was always using fully qualified identifiers even if the environment is non federated. Other platforms correctly do not use fully qualified identifiers in these environments, therefore Android was not able to establish call with other platforms.

### Solutions

There is a lot of code related to calling. I hope I captured all the points where we define qualified identifiers (conversation and clients) and added a check for federation support based on up-to-date federation support status.

### Testing

I manually tested by calling in 1:1 from Android to Web on both staging (non-federated) and Anta (federated). It worked.