### PR TITLE
feat: remove phone registration SQCORE-1281

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
@@ -82,7 +82,6 @@ class OpenGraphSyncHandler(backend:         Signal[BackendConfig],
                     Future successful SyncResult.Success
                   case Right(proto) =>
                     verbose(l"updated link previews: $proto")
-                    val m = proto.unpack._2.proto 
                     val postMsg = if (federationSupported) {
                       otrSync.postQualifiedOtrMessage(conv.id, proto, isHidden = false)
                     } else {
@@ -143,24 +142,21 @@ class OpenGraphSyncHandler(backend:         Signal[BackendConfig],
       }
     }
 
-    verbose(l"Updating Link preview...")
     msg.genericMsgs.lastOption match {
       case Some(TextMessage(content, mentions, ps, quote, rr)) =>
-
         val previews = if (ps.isEmpty) createEmptyPreviews(content) else ps
-        verbose(l"Updating Link preview for message ${content}: previews ${previews}")
-        RichFuture.traverseSequential(links zip previews)
-          { case (link, preview) => generatePreview(msg.id, link.openGraph.get, preview, retention) } flatMap { res =>
-            val errors = res collect { case Left(err) => err }
-            val updated = (res zip previews) collect {
-              case (Right(p), _) => p._2
-              case (_, p) => p
-            }
 
-            val gm = GenericMessage(msg.id.uid, msg.ephemeral, Text(content, mentions, updated, quote, rr, msg.protoLegalHoldStatus))
-            verbose(l"Update generic message with previews: ${updated}")
-            updateIfNotEdited(msg, _.copy(genericMsgs = Seq(gm))) map { _ => if (errors.isEmpty) Right(gm) else Left(errors) }
+        RichFuture.traverseSequential(links zip previews) { case (link, preview) => generatePreview(msg.id, link.openGraph.get, preview, retention) } flatMap { res =>
+          val errors = res collect { case Left(err) => err }
+          val updated = (res zip previews) collect {
+            case (Right(p), _) => p._2
+            case (_, p) => p
           }
+
+          val gm = GenericMessage(msg.id.uid, msg.ephemeral, Text(content, mentions, updated, quote, rr, msg.protoLegalHoldStatus))
+
+          updateIfNotEdited(msg, _.copy(genericMsgs = Seq(gm))) map { _ => if (errors.isEmpty) Right(gm) else Left(errors) }
+        }
 
       case _ =>
         Future successful Left(Seq(ErrorResponse.internalError(s"Unexpected message protos in: $msg")))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1281" title="SQCORE-1281" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQCORE-1281</a>  [Android] As a user, I should not be able to register with phone number
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We decided to disable registration by phone number due to the high costs caused by scammers abusing the SMS needed for registration. This is already disabled on the backend side, but the UI still shows this option. Since the backend already does not allow to complete the registration, the user experience is broken.

This PR hides the button to switch to phone number registration during the registration process.

### Testing

Tested manually by opening the registration flow
