### PR TITLE
fix: do not crash at startup if the backend URL is not set FS-421

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/BackendConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/service/BackendConfig.scala
@@ -39,7 +39,6 @@ final class BackendConfig(private var _environment: String,
 
   def environment: String = _environment
   def baseUrl: URI = _baseUrl
-  def domain: String = if (baseUrl.getPath.contains('.')) baseUrl.getPath.substring(baseUrl.getPath.indexOf('.')) else ""
   def websocketUrl: URI = _websocketUrl
   def blacklistHost: Option[URI] = _blacklistHost
   def teamsUrl: URI = _teamsUrl
@@ -78,7 +77,6 @@ final class BackendConfig(private var _environment: String,
       |BackendConfig(
       |  environment:   $environment,
       |  baseUrl:       $baseUrl,
-      |  domain:        $domain,
       |  websocketUrl:  $websocketUrl,
       |  blacklistHost: $blacklistHost,
       |  teamsUrl:      $teamsUrl,

--- a/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
@@ -2,10 +2,12 @@ package com.waz.sync.client
 
 import java.net.URL
 import com.waz.api.impl.ErrorResponse
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.utils.JsonDecoder.intArray
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 import com.waz.utils.wrappers.URI
 import com.waz.znet2.http.{HttpClient, Method, Request}
+import com.wire.signals.CancellableFuture
 import org.json.{JSONArray, JSONObject}
 
 trait SupportedApiClient {
@@ -13,12 +15,15 @@ trait SupportedApiClient {
 }
 
 final class SupportedApiClientImpl(implicit httpClient: HttpClient)
-  extends SupportedApiClient {
+  extends SupportedApiClient with DerivedLogTag {
   import com.waz.znet2.http.HttpClient.AutoDerivationOld._
   import HttpClient.dsl._
   import SupportedApiConfig._
 
   override def getSupportedApiVersions(baseUrl: URI): ErrorOrResponse[SupportedApiConfig] = {
+    if(baseUrl.getHost.isEmpty) { // this might be the case before we switch to another backend
+      return CancellableFuture(Right(v0OnlyApiConfig))
+    }
     val appended = baseUrl.toString.stripSuffix("/") + "/api-version"
     // unfortunately, the nicer code:
     //      val appended = baseUrl.buildUpon.appendPath("api-version").build


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-421" title="FS-421" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-421</a>  [Android] Clients need to know if the backend support federated endpoints or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Some build configuration have no backend API URL set, because it will be set anyway to a custom backend later via deep link or other configuration mechanism.

The app would crash when trying to parse the URL for the `/api-version` request made at startup, because the host is null (since the backend URL is empty).

### Solutions

If the backend URL is empty, do not attempt to make a request. The request will be made later anyway when the backend is set to another value.

I also removed an unnecessary, unused field `domain` from the backend config. If we need a domain, we should NOT infer it from the backend URL but take the one from the `api-version` response.
