### PR TITLE
fix: crash because of null pointer exception FS-421

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SupportedApiClient.scala
@@ -21,7 +21,7 @@ final class SupportedApiClientImpl(implicit httpClient: HttpClient)
   import SupportedApiConfig._
 
   override def getSupportedApiVersions(baseUrl: URI): ErrorOrResponse[SupportedApiConfig] = {
-    if(baseUrl.getHost.isEmpty) { // this might be the case before we switch to another backend
+    if(baseUrl == null || baseUrl.getHost == null || baseUrl.getHost.isEmpty) { // this might be the case before we switch to another backend
       return CancellableFuture(Right(v0OnlyApiConfig))
     }
     val appended = baseUrl.toString.stripSuffix("/") + "/api-version"


### PR DESCRIPTION
# What's new in this PR?

### Issues

When building with a custom configuration for a customer in release mode, the app crashes due to a null pointer exception as one of the configuration values is empty. When building locally, the app does not crash, but it crashes with the configuration of the build machine.

### Solutions

We were only checking if the string was empty. Now we check if the string is null too.

### Testing

Tested manually but the real test is going to be whether the build coming out of the build machine crashes or not.