### PR TITLE
fix: calling on federation has no audio FS-639

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
+++ b/zmessaging/src/main/scala/com/waz/model/QualifiedId.scala
@@ -13,6 +13,7 @@ final case class QualifiedId(id: UserId, domain: String) {
 object QualifiedId {
   def apply(userId: UserId): QualifiedId = QualifiedId(userId, "")
   def apply(userId: UserId, domain: Domain): QualifiedId = QualifiedId(userId, domain.str)
+  def apply(userId: UserId, domain: Domain, federationSupported: Boolean): QualifiedId = if(federationSupported) QualifiedId(userId, domain.str) else QualifiedId(userId)
 
   private val IdFieldName = "id"
   private val DomainFieldName  = "domain"

--- a/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/Avs.scala
@@ -98,7 +98,7 @@ final class AvsImpl(backendConfiguration: Signal[BackendConfig]) extends Avs wit
   override def registerAccount(cs: CallingServiceImpl) = available.flatMap { _ =>
     verbose(l"Initialising calling for: ${cs.accountId} and current client: ${cs.clientId}")
 
-    val qualifiedId = if(federationSupported) QualifiedId.apply(cs.accountId, cs.domain) else QualifiedId.apply(cs.accountId)
+    val qualifiedId = QualifiedId.apply(cs.accountId, cs.domain, federationSupported)
 
     val callingReady = Promise[Unit]()
 
@@ -206,7 +206,7 @@ final class AvsImpl(backendConfiguration: Signal[BackendConfig]) extends Avs wit
             val participants = participantsChange.members.map(m => {
               val userIdString = DomainUtils.removeDomain(m.userid.str)
               val userDomain = DomainUtils.getDomainFromString(m.userid.str)
-              val qualifiedId = QualifiedId.apply(UserId(userIdString), Domain(userDomain))
+              val qualifiedId = QualifiedId.apply(UserId(userIdString), Domain(userDomain), federationSupported)
               Participant(qualifiedId, m.clientid, m.muted == 1)
             }).toSet
             cs.onParticipantsChanged(RConvId(convId), participants)
@@ -233,7 +233,7 @@ final class AvsImpl(backendConfiguration: Signal[BackendConfig]) extends Avs wit
                                              arg: Pointer): Unit = {
           val userIdString = DomainUtils.removeDomain(userId)
           val userDomain = DomainUtils.getDomainFromString(userId)
-          val qualifiedId = QualifiedId(UserId(userIdString), Domain(userDomain))
+          val qualifiedId = QualifiedId(UserId(userIdString), Domain(userDomain), federationSupported)
           val participant = Participant(qualifiedId, ClientId(clientId))
 
           cs.onNetworkQualityChanged(ConvId(convId), participant, NetworkQuality(quality))

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -299,7 +299,7 @@ final class CallingServiceImpl(val accountId:       UserId,
 
       val newCall = CallInfo(
         conv.id,
-        selfParticipant = Participant(QualifiedId(accountId, domain), clientId),
+        selfParticipant = Participant(QualifiedId(accountId, domain, federationSupported), clientId),
         isGroup,
         userId,
         OtherCalling,
@@ -432,7 +432,7 @@ final class CallingServiceImpl(val accountId:       UserId,
   def onVideoStateChanged(userId: String, clientId: String, videoReceiveState: VideoState, userDomain: String): Future[Unit] =
     updateActiveCallAsync { (_, _, call) =>
       verbose(l"video state changed: $videoReceiveState")
-      val qualifiedId = QualifiedId(UserId(userId), Domain(userDomain))
+      val qualifiedId = QualifiedId(UserId(userId), Domain(userDomain), federationSupported)
       call.updateVideoState(Participant(qualifiedId, ClientId(clientId)), videoReceiveState)
     }("onVideoStateChanged")
 
@@ -540,7 +540,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                       //Assume that when a video call starts, sendingVideo will be true. From here on, we can then listen to state handler
                       val newCall = CallInfo(
                         conv.id,
-                        selfParticipant = Participant(QualifiedId(accountId, domain), clientId),
+                        selfParticipant = Participant(QualifiedId(accountId, domain, federationSupported), clientId),
                         isGroup,
                         accountId,
                         SelfCalling,
@@ -639,7 +639,7 @@ final class CallingServiceImpl(val accountId:       UserId,
       val rConvQualifiedId = RConvQualifiedId.apply(conv.remoteId, conv.domain, federationSupported)
 
       if (state != NoCameraPermission && shouldUpdateVideoState) avs.setVideoSendState(w, rConvQualifiedId, targetSt)
-      call.updateVideoState(Participant(QualifiedId(accountId, domain), clientId), targetSt)
+      call.updateVideoState(Participant(QualifiedId(accountId, domain, federationSupported), clientId), targetSt)
     }("setVideoSendState")
 
   override val callMessagesStage: Stage.Atomic = EventScheduler.Stage[CallMessageEvent] {
@@ -647,7 +647,7 @@ final class CallingServiceImpl(val accountId:       UserId,
       Future.successful(events.sortBy(_.time).foreach { e =>
 
         val rConvQualifiedId = RConvQualifiedId.apply(e.convId, e.convDomain, federationSupported)
-        val qualifiedId = QualifiedId.apply(e.from, e.fromDomain)
+        val qualifiedId = QualifiedId.apply(e.from, e.fromDomain, federationSupported)
 
         receiveCallEvent(e.content, e.time, rConvQualifiedId, qualifiedId, e.sender)
       })
@@ -658,7 +658,7 @@ final class CallingServiceImpl(val accountId:       UserId,
                                 convId: RConvId,
                                 from: UserId,
                                 sender: ClientId): Unit =
-    receiveCallEvent(msg, msgTime, RConvQualifiedId(convId, domain, federationSupported), QualifiedId(from, domain), sender)
+    receiveCallEvent(msg, msgTime, RConvQualifiedId(convId, domain, federationSupported), QualifiedId(from, domain, federationSupported), sender)
 
   private var lastCallEventTime = Option.empty[LocalInstant]
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-639" title="FS-639" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-639</a>  [Android] No audio in current internal and dev version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

This is a follow up to https://github.com/wireapp/wire-android/pull/3698.
There are still some calls to AVS that are using fully qualified identifiers even when federation is disabled. 

This caused video calls to have working video but not working audio on non-federated environments.

### Solutions

Use qualified IDs only when federation is on.

### Testing

Tested manually and QA will re-test