### PR TITLE
fix: bottom navigation bar not working after switching account on some devices

### DIFF
--- a/app/src/main/java/com/waz/zclient/utils/extensions/BottomNavigationExtensions.kt
+++ b/app/src/main/java/com/waz/zclient/utils/extensions/BottomNavigationExtensions.kt
@@ -1,4 +1,5 @@
 @file:JvmName("BottomNavigationUtil")
+
 /**
  * Wire
  * Copyright (C) 2019 Wire Swiss GmbH
@@ -18,12 +19,9 @@
  */
 package com.waz.zclient.utils.extensions
 
-import android.view.View
 import androidx.annotation.IdRes
-import com.google.android.material.bottomnavigation.BottomNavigationMenuView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 fun BottomNavigationView.setItemVisible(@IdRes id: Int, visible: Boolean) {
-    val menuView: BottomNavigationMenuView = getChildAt(0) as BottomNavigationMenuView
-    menuView.findViewById<View>(id).visibility = if (visible) View.VISIBLE else View.GONE
+    menu.findItem(id).isVisible = visible
 }

--- a/app/src/main/scala/com/waz/zclient/WireContext.scala
+++ b/app/src/main/scala/com/waz/zclient/WireContext.scala
@@ -268,6 +268,11 @@ trait FragmentHelper
     super.onPause()
   }
 
+  override def onViewCreated(view: View, savedInstanceState: Bundle): Unit = {
+    super.onViewCreated(view, savedInstanceState)
+    views.foreach(_.clear())
+  }
+
   override def onDestroyView(): Unit = {
     views foreach(_.clear())
     super.onDestroyView()

--- a/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/conversationlist/ConversationListManagerFragment.scala
@@ -92,11 +92,7 @@ class ConversationListManagerFragment extends Fragment
 
   protected var subs = Set.empty[Subscription]
 
-  private lazy val bottomNavigationView = returning(view[BottomNavigationView](R.id.fragment_conversation_list_manager_bottom_navigation)) { vh =>
-    subs += convListController.hasConversationsAndArchive.onUi { case (_, hasArchive) =>
-      vh.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, hasArchive))
-    }
-  }
+  private lazy val bottomNavigationView = view[BottomNavigationView](R.id.fragment_conversation_list_manager_bottom_navigation)
 
   lazy val zms = inject[Signal[ZMessaging]]
 
@@ -178,6 +174,10 @@ class ConversationListManagerFragment extends Fragment
         animateOnIncomingCall()
 
       case _ => //
+    }
+
+    subs += convListController.hasConversationsAndArchive.onUi { case (_, hasArchive) =>
+      bottomNavigationView.foreach(view => BottomNavigationUtil.setItemVisible(view, R.id.navigation_archive, hasArchive))
     }
 
     subs += inject[AccentColorController].accentColor.map(_.color).onUi { c =>

--- a/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/participants/fragments/ParticipantFragment.scala
@@ -86,6 +86,7 @@ final class ParticipantFragment extends ManagerFragment with ConversationScreenC
     }
 
   override def onViewCreated(view: View, @Nullable savedInstanceState: Bundle): Unit = {
+    super.onViewCreated(view, savedInstanceState)
     verbose(l"onViewCreated.")
 
     withChildFragmentOpt(R.id.fl__participant__container) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WCB-73" title="WCB-73" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WCB-73</a>  Wire not working on Android
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On a Samsung S21 Enterprise, when switching from one user to another:

- BottomNavigationBar now has wrong colours (white selected and black unselected) 
- BottomNavigationBar stops working (items are selectable, but don't do anything once clicked).


### Causes

It seems that `onDestroyView` is not called as expected and because of that, the `views` collection of `ViewHolder`s isn't cleared properly.

This means that "dead" views that are no longer in the screen are still being hold and changed by the app, while new views show up empty/naked.

### Solutions

Make sure the view holders are cleared when going through `onViewCreated`.

This solution exposed a bug where the `archives` icon was not being properly updated. The view of the archives was being hidden, instead of the menu item that it represents.
So when touching the icon, at least on this Samsung device, the `BottomNavigationBar` would redraw and show the archive view again.

So, now, the menu item visibility is changed instead.

### Testing

Manually tested.

#### How to Test

On a Samsung S21 Enterprise Edition by doing the following:
- Log in with two accounts
- Switch from one to the other

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
