### PR TITLE
fix: black screen after failing to register clients in some SSO accounts [WCB-73] [WCB-57]

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountManager.scala
@@ -189,7 +189,7 @@ class AccountManager(val userId:  UserId,
   def registerNewClient(password: Option[Password] = None): ErrorOr[ClientRegistrationState] = {
     for {
       account <- global.accountsStorage.signal(userId).head
-      pwd     = password.orElse(if (account.ssoId.isEmpty) account.password else None)
+      pwd     = password.orElse(account.password)
       client  <- cryptoBox.createClient()
       resp    <- client match {
         case None => Future.successful(Left(internalError("CryptoBox missing")))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WCB-73" title="WCB-73" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WCB-73</a>  Wire not working on Android
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On SSO accounts with password, the screen would just stay black after logging in.

### Causes

The app never sends the password when registering the client if the account has SSO.
However, it's necessary to send it in case the account has a password.

### Solutions

Send the password, if available.

### Testing

Manually tested

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
