### PR TITLE
fix: configuration for espresso tests setup

### DIFF
--- a/app/src/androidTest/java/com/wire/android/ui/ConversationScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/ConversationScreenTest.kt
@@ -1,14 +1,18 @@
 package com.wire.android.ui
 
+import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.home.conversations.ConversationScreen
 import com.wire.android.ui.home.conversations.ConversationViewModel
 import com.wire.android.ui.theme.WireTheme
@@ -38,16 +42,21 @@ class ConversationScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                ConversationScreen(composeTestRule.getViewModel(ConversationViewModel::class))
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    ConversationScreen(getViewModel(activity, ConversationViewModel::class))
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/CreateTeamScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/CreateTeamScreenTest.kt
@@ -1,36 +1,32 @@
 package com.wire.android.ui
 
 import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import com.wire.android.ui.authentication.create.team.CreateTeamScreen
-import com.wire.android.ui.authentication.login.email.LoginEmailScreen
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.utils.EMAIL
-import com.wire.android.utils.PASSWORD
 import com.wire.android.utils.WorkManagerTestRule
-import com.wire.android.utils.waitForExecution
 import com.wire.kalium.logic.configuration.ServerConfig
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.amshove.kluent.shouldNotBeEqualTo
 import org.hamcrest.core.AllOf.allOf
 import org.junit.After
 import org.junit.Before
@@ -58,7 +54,9 @@ class CreateTeamScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
@@ -66,9 +64,12 @@ class CreateTeamScreenTest {
         Intents.init()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                CreateTeamScreen(serverConfig = ServerConfig.STAGING)
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    CreateTeamScreen(serverConfig = ServerConfig.STAGING)
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/LoginEmailScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/LoginEmailScreenTest.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui
 
 import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,12 +11,14 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
@@ -55,7 +58,9 @@ class LoginEmailScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
@@ -63,9 +68,12 @@ class LoginEmailScreenTest {
         Intents.init()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                LoginEmailScreen(serverConfig = ServerConfig.STAGING)
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    LoginEmailScreen(serverConfig = ServerConfig.STAGING)
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/MainScreenTest.kt
@@ -1,24 +1,27 @@
 package com.wire.android.ui
 
+import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.authentication.welcome.WelcomeScreen
 import com.wire.android.ui.authentication.welcome.WelcomeViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.utils.WorkManagerTestRule
 import com.wire.android.utils.getViewModel
-import com.wire.android.utils.waitForExecution
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -44,16 +47,21 @@ class MainScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                WelcomeScreen(composeTestRule.getViewModel(WelcomeViewModel::class))
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    WelcomeScreen(getViewModel(activity, WelcomeViewModel::class))
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/RegisterDeviceTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/RegisterDeviceTest.kt
@@ -1,5 +1,7 @@
 package com.wire.android.ui
 
+import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,11 +11,13 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.authentication.devices.register.RegisterDeviceScreen
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.utils.PASSWORD
@@ -45,16 +49,21 @@ class RegisterDeviceTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                RegisterDeviceScreen()
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    RegisterDeviceScreen()
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/RemoveDeviceScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/RemoveDeviceScreenTest.kt
@@ -1,26 +1,26 @@
 package com.wire.android.ui
 
+import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.test.assertAll
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasAnyChild
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onChildren
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceScreen
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.utils.PASSWORD
@@ -50,15 +50,20 @@ class RemoveDeviceScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
-        composeTestRule.setContent {
-            WireTheme {
-                RemoveDeviceScreen()
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    RemoveDeviceScreen()
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/wire/android/ui/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/UserProfileScreenTest.kt
@@ -1,5 +1,7 @@
 package com.wire.android.ui
 
+import android.content.Intent
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,12 +11,13 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onSibling
 import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.userprofile.self.SelfUserProfileScreen
 import com.wire.android.ui.userprofile.self.SelfUserProfileViewModel
@@ -45,16 +48,21 @@ class UserProfileScreenTest {
 
     // Third, we create the compose rule using an AndroidComposeRule, as we are depending on instrumented environment ie: Hilt, WorkManager
     @get:Rule(order = 2)
-    val composeTestRule = createAndroidComposeRule<WireActivity>()
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var scenario: ActivityScenario<WireActivity>
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
         // Start the app
-        composeTestRule.setContent {
-            WireTheme {
-                SelfUserProfileScreen(composeTestRule.getViewModel(SelfUserProfileViewModel::class))
+        scenario = ActivityScenario.launch(Intent(ApplicationProvider.getApplicationContext(), WireActivity::class.java))
+        scenario.onActivity { activity ->
+            activity.setContent {
+                WireTheme {
+                    SelfUserProfileScreen(getViewModel(activity, SelfUserProfileViewModel::class))
+                }
             }
         }
     }
@@ -81,8 +89,10 @@ class UserProfileScreenTest {
         composeTestRule.waitForExecution {
             busyText.assertIsDisplayed()
         }
-        busyText.onSiblings()[0].assertTextContains("You will appear as Busy to other people. You will only receive notifications " +
-                "for mentions, replies, and calls in conversations that are not muted.")
+        busyText.onSiblings()[0].assertTextContains(
+            "You will appear as Busy to other people. You will only receive notifications " +
+                "for mentions, replies, and calls in conversations that are not muted."
+        )
         busyText.onSiblings()[1].performClick().assertIsOn()
         busyText.onSiblings()[1].performClick().assertIsOff().assertTextContains("Do not display this information again")
         okButton.performClick()
@@ -93,7 +103,7 @@ class UserProfileScreenTest {
     fun userProfile_change_status_available() {
         title.assertIsDisplayed()
         availableButton.onSibling().performClick()
-       val availableText = composeTestRule.onNodeWithText("Set yourself to Available")
+        val availableText = composeTestRule.onNodeWithText("Set yourself to Available")
         availableText.assertDoesNotExist()
     }
 
@@ -105,8 +115,10 @@ class UserProfileScreenTest {
         composeTestRule.waitForExecution {
             awayText.assertIsDisplayed()
         }
-        awayText.onSiblings()[1].performClick().assertIsOn().performClick().assertIsOff().assertTextContains("Do not display this" +
-                " information again")
+        awayText.onSiblings()[1].performClick().assertIsOn().performClick().assertIsOff().assertTextContains(
+            "Do not display this" +
+                " information again"
+        )
         okButton.performClick()
         awayText.assertDoesNotExist()
     }
@@ -122,7 +134,7 @@ class UserProfileScreenTest {
         }
         okButton.performClick()
         noneText.assertDoesNotExist()
-        noneButton.onSibling().performClick()  // check status is set
+        noneButton.onSibling().performClick() // check status is set
         noneText.assertDoesNotExist()
     }
 
@@ -132,8 +144,10 @@ class UserProfileScreenTest {
         awayButton.onSibling().performClick()
         val awayText = composeTestRule.onNodeWithText("Set yourself to Away")
         composeTestRule.waitForExecution {
-            awayText.assertIsDisplayed().onSiblings()[1].performClick().assertIsOn().assertTextContains("Do not display this " +
-                    "information again")
+            awayText.assertIsDisplayed().onSiblings()[1].performClick().assertIsOn().assertTextContains(
+                "Do not display this " +
+                    "information again"
+            )
         }
         okButton.performClick()
         awayText.assertDoesNotExist()
@@ -149,8 +163,10 @@ class UserProfileScreenTest {
         awayButton.onSibling().performClick()
         val awayText = composeTestRule.onNodeWithText("Set yourself to Away")
         composeTestRule.waitForExecution {
-            awayText.assertIsDisplayed().onSiblings()[1].performClick().assertIsOn().assertTextContains("Do not " +
-                    "display this information again")
+            awayText.assertIsDisplayed().onSiblings()[1].performClick().assertIsOn().assertTextContains(
+                "Do not " +
+                    "display this information again"
+            )
         }
         cancelButton.performClick()
         awayText.assertDoesNotExist()

--- a/app/src/androidTest/java/com/wire/android/utils/Extensions.kt
+++ b/app/src/androidTest/java/com/wire/android/utils/Extensions.kt
@@ -17,6 +17,11 @@ AndroidComposeTestRule<R, A>.getViewModel(viewModel: KClass<VM>): VM {
     return this.activity.viewModels<VM>().value
 }
 
+inline fun <reified VM : ViewModel> getViewModel(activity: ComponentActivity, viewModel: KClass<VM>): VM {
+    println("Getting test instance of ViewModel: $viewModel")
+    return activity.viewModels<VM>().value
+}
+
 fun ComposeTestRule.waitForExecution(timeoutMillis: Long = WAIT_TIMEOUT, block: () -> Unit) {
     waitUntil(timeoutMillis) {
         try {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes the configuration for launching a screen for testing with espresso tests rules.
Replaces `composeAndroidTestRule` with an `createEmptyComposeRule` to manually handle the setContent block for the views.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
