### PR TITLE
feat: add system messages UI [AR-1487]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -40,7 +40,6 @@ import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.MessageViewWrapper
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireColorScheme
-import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -55,8 +54,8 @@ fun MessageItem(
         Row(
             Modifier
                 .padding(
-                    end = MaterialTheme.wireDimensions.spacing16x,
-                    bottom = MaterialTheme.wireDimensions.messageItemBottomPadding
+                    end = dimensions().spacing16x,
+                    bottom = dimensions().messageItemBottomPadding - dimensions().userAvatarClickablePadding
                 )
                 .fillMaxWidth()
                 .combinedClickable(
@@ -65,15 +64,15 @@ fun MessageItem(
                     onLongClick = { onLongClicked(message) }
                 )
         ) {
-            Spacer(Modifier.padding(start = dimensions().spacing2x))
+            Spacer(Modifier.padding(start = dimensions().spacing8x - dimensions().userAvatarClickablePadding))
             UserProfileAvatar(
                 userAvatarAsset = message.user.avatarAsset,
                 status = message.user.availabilityStatus
             )
-            Spacer(Modifier.padding(start = dimensions().spacing12x))
+            Spacer(Modifier.padding(start = dimensions().spacing16x - dimensions().userAvatarClickablePadding))
             Column {
+                Spacer(modifier = Modifier.height(dimensions().userAvatarClickablePadding))
                 MessageHeader(messageHeader)
-                Spacer(modifier = Modifier.height(dimensions().spacing6x))
                 if (!isDeleted) {
                     MessageContent(messageContent,
                         onAssetClick = { onAssetMessageClicked(message.messageHeader.messageId) },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -1,0 +1,211 @@
+package com.wire.android.ui.home.conversations
+
+import android.content.res.Resources
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun SystemMessageItem(type: SystemMessageType) {
+    Row(
+        Modifier
+            .padding(
+                end = dimensions().spacing16x,
+                start = dimensions().spacing8x,
+                top = dimensions().messageItemBottomPadding / 2,
+                bottom = dimensions().messageItemBottomPadding / 2
+            )
+            .fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier.width(dimensions().userAvatarDefaultSize),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            if (type.iconResId != null)
+                Image(
+                    painter = painterResource(id = type.iconResId),
+                    contentDescription = stringResource(R.string.content_description_system_message_icon),
+                    modifier = Modifier
+                        .padding(
+                            horizontal = dimensions().spacing2x,
+                            vertical = dimensions().spacing4x
+                        )
+                        .size(dimensions().systemMessageIconSize),
+                    contentScale = ContentScale.Crop
+                )
+        }
+        Spacer(Modifier.padding(start = dimensions().spacing16x))
+        Column {
+            val context = LocalContext.current
+            val normalStyle = SpanStyle(
+                color = MaterialTheme.wireColorScheme.secondaryText,
+                fontWeight = MaterialTheme.wireTypography.body01.fontWeight,
+                fontSize = MaterialTheme.wireTypography.body01.fontSize,
+                fontFamily = MaterialTheme.wireTypography.body01.fontFamily,
+                fontStyle = MaterialTheme.wireTypography.body01.fontStyle
+            )
+            val boldStyle = SpanStyle(
+                color = MaterialTheme.wireColorScheme.onBackground,
+                fontWeight = MaterialTheme.wireTypography.body02.fontWeight,
+                fontSize = MaterialTheme.wireTypography.body02.fontSize,
+                fontFamily = MaterialTheme.wireTypography.body02.fontFamily,
+                fontStyle = MaterialTheme.wireTypography.body02.fontStyle
+            )
+            var expanded: Boolean by remember { mutableStateOf(false) }
+            Crossfade(targetState = expanded) {
+                Text(type.getAnnotatedString(context.resources, it, normalStyle, boldStyle))
+            }
+            if (type.expandable) {
+                WireSecondaryButton(
+                    onClick = { expanded = !expanded },
+                    text = stringResource(if (expanded) R.string.label_show_less else R.string.label_show_all),
+                    fillMaxWidth = false,
+                    minHeight = dimensions().spacing32x,
+                    minWidth = dimensions().spacing40x,
+                    shape = RoundedCornerShape(size = dimensions().corner12x),
+                    contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
+                    modifier = Modifier
+                        .padding(top = dimensions().spacing4x)
+                        .height(height = dimensions().spacing32x)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SystemMessageItemAdded7UsersPreview() {
+    SystemMessageItem(
+        type = SystemMessageType.Added(
+            "Barbara Cotolina",
+            listOf("Albert Lewis", "Bert Strunk", "Claudia Schiffer", "Dorothee Friedrich", "Erich Weinert", "Frieda Kahlo", "Gudrun Gut")
+        )
+    )
+}
+
+@Preview
+@Composable
+fun SystemMessageItemAdded4UsersPreview() {
+    SystemMessageItem(
+        type = SystemMessageType.Added(
+            "Barbara Cotolina",
+            listOf("Albert Lewis", "Bert Strunk", "Claudia Schiffer", "Dorothee Friedrich")
+        )
+    )
+}
+
+@Preview
+@Composable
+fun SystemMessageItemRemoved4UsersPreview() {
+    SystemMessageItem(
+        type = SystemMessageType.Removed(
+            "Barbara Cotolina",
+            listOf("Albert Lewis", "Bert Strunk", "Claudia Schiffer", "Dorothee Friedrich")
+        )
+    )
+}
+
+@Preview
+@Composable
+fun SystemMessageItemLeftPreview() {
+    SystemMessageItem(type = SystemMessageType.Left("Barbara Cotolina"))
+}
+
+sealed class SystemMessageType(@DrawableRes val iconResId: Int?, @StringRes val stringResId: Int) {
+    data class Added(
+        val author: String,
+        val userNames: List<String>
+    ) : SystemMessageType(R.drawable.ic_add, R.string.label_system_message_added)
+
+    data class Removed(
+        val author: String,
+        val userNames: List<String>
+    ) : SystemMessageType(R.drawable.ic_minus, R.string.label_system_message_removed)
+
+    data class Left(
+        val author: String
+    ) : SystemMessageType(R.drawable.ic_minus, R.string.label_system_message_left_the_conversation)
+}
+
+val SystemMessageType.expandable
+    get() = when (this) {
+        is SystemMessageType.Added -> this.userNames.size > EXPANDABLE_THRESHOLD
+        is SystemMessageType.Removed -> this.userNames.size > EXPANDABLE_THRESHOLD
+        is SystemMessageType.Left -> false
+    }
+
+private fun String.bold() = STYLE_SEPARATOR + this + STYLE_SEPARATOR
+
+private fun List<String>.toUserNamesListString(res: Resources) = when {
+    this.isEmpty() -> ""
+    this.size == 1 -> this[0].bold()
+    else -> res.getString(R.string.label_system_message_and, this.dropLast(1).joinToString(", ").bold(), this.last().bold())
+}
+
+private fun List<String>.limitUserNamesList(res: Resources, threshold: Int) =
+    if (this.size <= threshold) this
+    else {
+        val moreCount = this.size - (threshold - 1) // the last visible place is taken by "and X more"
+        this.take(threshold - 1)
+            .plus(res.getQuantityString(R.plurals.label_system_message_x_more, moreCount, moreCount))
+    }
+
+fun SystemMessageType.getAnnotatedString(res: Resources, expanded: Boolean, normalStyle: SpanStyle, boldStyle: SpanStyle): AnnotatedString {
+    val string = when (this) {
+        is SystemMessageType.Added -> res.getString(
+            stringResId,
+            author.bold(),
+            userNames.limitUserNamesList(res, if (expanded) userNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
+        )
+        is SystemMessageType.Removed -> res.getString(
+            stringResId,
+            author.bold(),
+            userNames.limitUserNamesList(res, if (expanded) userNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
+        )
+        is SystemMessageType.Left -> res.getString(stringResId, author.bold())
+    }
+    return buildAnnotatedString {
+        string.split(STYLE_SEPARATOR).forEachIndexed { index, text ->
+            withStyle(if (index % 2 == 0) normalStyle else boldStyle) { append(text) }
+        }
+    }
+}
+
+private const val EXPANDABLE_THRESHOLD = 4
+private const val STYLE_SEPARATOR: String = "\u0000"

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -122,6 +122,7 @@ internal fun MessageAsset(
     val assetDescription = provideAssetDescription(assetExtension, assetSizeInBytes)
     Box(
         modifier = Modifier
+            .padding(top = dimensions().spacing4x)
             .background(
                 color = MaterialTheme.wireColorScheme.onPrimary,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -57,6 +57,7 @@ data class WireDimensions(
     val messageComposerActiveInputMaxHeight: Dp,
     val attachmentButtonSize: Dp,
     val messageComposerPaddingEnd: Dp,
+    val systemMessageIconSize: Dp,
     // TextFields
     val textFieldMinHeight: Dp,
     val textFieldCornerSize: Dp,
@@ -248,6 +249,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     defaultSearchLazyColumnHeight = 320.dp,
     showAllCollapseButtonMinHeight = 32.dp,
     messageComposerPaddingEnd = 82.dp,
+    systemMessageIconSize = 12.dp,
     groupButtonHeight = 82.dp,
     defaultCallingControlsSize = 66.dp,
     defaultSheetPeekHeight = 95.dp,

--- a/app/src/main/res/drawable/ic_minus.xml
+++ b/app/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:viewportWidth="16"
+        android:viewportHeight="16">
+    <path
+            android:pathData="M0,7H16V9H0Z"
+            android:fillColor="#000000"
+            android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_try_again">Try again</string>
     <string name="label_federated_membership">Federated</string>
+    <string name="label_show_all">Show All</string>
+    <string name="label_show_less">Show Less</string>
 
     <!-- Content descriptions -->
     <string name="content_description_search_back">Search back icon</string>
@@ -62,6 +64,7 @@
     <string name="content_description_image_message">Image message</string>
     <string name="content_description_file_message">File message</string>
     <string name="content_description_ping_everyone">Ping everyone</string>
+    <string name="content_description_system_message_icon">System message icon</string>
 
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
@@ -265,6 +268,15 @@
     <string name="label_edit">Edit</string>
     <string name="label_delete">Delete</string>
     <string name="info_message_copied">Message copied</string>
+
+    <!-- System messages -->
+    <string name="label_system_message_added">%1$s added %2$s to the conversation</string>
+    <string name="label_system_message_removed">%1$s removed %2$s from the conversation</string>
+    <string name="label_system_message_left_the_conversation">%1$s left the conversation</string>
+    <string name="label_system_message_and">%1$s and %2$s</string>
+    <plurals name="label_system_message_x_more">
+        <item quantity="other">%1$d more</item>
+    </plurals>
 
     <!--Search Contact-->
     <string name="label_contacts">CONTACTS</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1487" title="AR-1487" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1487</a>  (UI) implement system message UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we don't see system messages in conversations (user added, user removed, user left).

### Solutions

Implemented UI for system messages as the first part of a task to add support for them.

### Testing

#### How to Test

Right now only by checking composable previews.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
