### PR TITLE
fix: properly handle SSO types where the user has a password [SQSERVICES-1565]

### DIFF
--- a/app/src/main/scala/com/waz/zclient/MainActivity.scala
+++ b/app/src/main/scala/com/waz/zclient/MainActivity.scala
@@ -354,10 +354,10 @@ class MainActivity extends BaseActivity
               isNewClient <- z.userPrefs(IsNewClient).apply()
               pendingPw <- z.userPrefs(PendingPassword).apply()
               pendingEmail <- z.userPrefs(PendingEmail).apply()
-              ssoLogin <- accountsService.activeAccount.map(_.exists(_.ssoId.isDefined)).head
+              passwordManagedBySSO <- accountsService.activeAccountHasCompanyManagedPassword.head
             } yield {
               val (f, t) =
-                if (ssoLogin) {
+                if (passwordManagedBySSO) {
                   if (self.handle.isEmpty) (SetHandleFragment(), SetHandleFragment.Tag)
                   else (new MainPhoneFragment, MainPhoneFragment.Tag)
                 }
@@ -375,10 +375,10 @@ class MainActivity extends BaseActivity
               self <- am.getSelf
               pendingPw <- am.storage.userPrefs(PendingPassword).apply()
               pendingEmail <- am.storage.userPrefs(PendingEmail).apply()
-              ssoLogin <- accountsService.activeAccount.map(_.exists(_.ssoId.isDefined)).head
+              passwordManagedBySSO <- accountsService.activeAccountHasCompanyManagedPassword.head
             } yield {
               val (f, t) =
-                if (ssoLogin) (OtrDeviceLimitFragment.newInstance, OtrDeviceLimitFragment.Tag)
+                if (passwordManagedBySSO) (OtrDeviceLimitFragment.newInstance, OtrDeviceLimitFragment.Tag)
                 else if (self.email.isDefined && pendingPw) (SetOrRequestPasswordFragment(self.email.get), SetOrRequestPasswordFragment.Tag)
                 else if (pendingEmail.isDefined) (VerifyEmailFragment(pendingEmail.get), VerifyEmailFragment.Tag)
                 else if (self.email.isEmpty) (AddEmailFragment(), AddEmailFragment.Tag)
@@ -390,10 +390,10 @@ class MainActivity extends BaseActivity
             for {
               self <- am.getSelf
               pendingEmail <- am.storage.userPrefs(PendingEmail).apply()
-              ssoLogin <- accountsService.activeAccount.map(_.exists(_.ssoId.isDefined)).head
+              passwordManagedBySSO <- accountsService.activeAccountHasCompanyManagedPassword.head
             } {
               val (f, t) =
-                if (ssoLogin) {
+                if (passwordManagedBySSO) {
                   if (self.handle.isEmpty) (SetHandleFragment(), SetHandleFragment.Tag)
                   else (new MainPhoneFragment, MainPhoneFragment.Tag)
                 }

--- a/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
+++ b/app/src/main/scala/com/waz/zclient/common/controllers/global/PasswordController.scala
@@ -55,7 +55,7 @@ class PasswordController(implicit inj: Injector) extends Injectable with Derived
       }
   }
 
-  val ssoEnabled:            Signal[Boolean] = accounts.isActiveAccountSSO
+  val ssoManagedPassword:    Signal[Boolean] = accounts.activeAccountHasCompanyManagedPassword
   val customPasswordEmpty:   Signal[Boolean] = customPassword.flatMap(_.signal.map(_.isEmpty))
   val appLockEnabled:        Signal[Boolean] = prefs.flatMap(_.preference(AppLockEnabled).signal)
   val appLockFeatureEnabled: Signal[Boolean] = prefs.flatMap(_.preference(AppLockFeatureEnabled).signal)

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldApprovalHandler.scala
@@ -42,11 +42,11 @@ class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
 
   private def showLegalHoldRequestDialog(showError: Boolean = false): Unit = {
     def showDialog(activity: FragmentActivity,
-                   isSso: Boolean,
+                   isPassManagedByCompany: Boolean,
                    fingerprint: String): Unit = {
       val fingerprintText = DevicesPreferencesUtil.getFormattedFingerprint(activity, fingerprint).toString
 
-      returning(LegalHoldRequestDialog.newInstance(isSso = isSso, fingerprintText, showError = showError)) { dialog =>
+      returning(LegalHoldRequestDialog.newInstance(isPasswordManagedByCompany = isPassManagedByCompany, fingerprintText, showError = showError)) { dialog =>
         dialog.onAccept.onUi(onLegalHoldAccepted)
         dialog.onDecline.onUi(_ => setFinished())
       }.show(activity.getSupportFragmentManager, LegalHoldRequestDialog.TAG)
@@ -56,14 +56,14 @@ class LegalHoldApprovalHandler(implicit injector: Injector) extends Injectable {
       if (!isShowingLegalHoldRequestDialog(activity)) {
 
         for {
-          request     <- legalHoldController.legalHoldRequest.head
-          isSso       <- accountsService.isActiveAccountSSO.head
-          fingerprint <- request match {
+          request               <- legalHoldController.legalHoldRequest.head
+          companyManagedPassword  <- accountsService.activeAccountHasCompanyManagedPassword.head
+          fingerprint           <- request match {
                            case Some(r) => legalHoldController.getFingerprint(r)
                            case None    => Future.successful(Option.empty)
                          }
-        } yield (request, isSso, fingerprint) match {
-          case (_, sso, Some(fp)) => showDialog(activity, sso, fp)
+        } yield (request, companyManagedPassword, fingerprint) match {
+          case (_, passwordManagedByCompany, Some(fp)) => showDialog(activity, passwordManagedByCompany, fp)
           case (Some(_), _, None) => showGeneralError()
           case _ =>
         }

--- a/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/legalhold/LegalHoldRequestDialog.scala
@@ -9,7 +9,7 @@ import com.waz.zclient.R
 class LegalHoldRequestDialog extends ConfirmationWithPasswordDialog {
   import LegalHoldRequestDialog._
 
-  override lazy val isSSO: Boolean = getArguments.getBoolean(ARG_IS_SSO)
+  override lazy val isPasswordManagedByCompany: Boolean = getArguments.getBoolean(ARG_IS_PASSWORD_COMPANY_MANAGED)
 
   override lazy val errorMessage: Option[String] =
     if (getArguments.getBoolean(ARG_SHOW_ERROR))
@@ -20,7 +20,7 @@ class LegalHoldRequestDialog extends ConfirmationWithPasswordDialog {
 
   override lazy val message: String = {
     val stringRes =
-      if (isSSO) R.string.legal_hold_request_dialog_message_for_sso
+      if (isPasswordManagedByCompany) R.string.legal_hold_request_dialog_message_for_sso
       else R.string.legal_hold_request_dialog_message
     getString(stringRes, getArguments.getString(ARG_CLIENT_FINGERPRINT))
   }
@@ -39,15 +39,15 @@ class LegalHoldRequestDialog extends ConfirmationWithPasswordDialog {
 object LegalHoldRequestDialog {
   val TAG = "LegalHoldRequestDialog"
 
-  private val ARG_IS_SSO = "LegalHold_arg_isSso"
+  private val ARG_IS_PASSWORD_COMPANY_MANAGED = "LegalHold_arg_isPasswordCompanyManaged"
   private val ARG_CLIENT_FINGERPRINT = "LegalHold_arg_fingerprint"
   private val ARG_SHOW_ERROR = "LegalHold_arg_showError"
 
-  def newInstance(isSso: Boolean, fingerprint: String, showError: Boolean) : LegalHoldRequestDialog =
+  def newInstance(isPasswordManagedByCompany: Boolean, fingerprint: String, showError: Boolean) : LegalHoldRequestDialog =
     returning(new LegalHoldRequestDialog) {
       _.setArguments(returning(new Bundle()) { args =>
         args.putString(ARG_CLIENT_FINGERPRINT, fingerprint)
-        args.putBoolean(ARG_IS_SSO, isSso)
+        args.putBoolean(ARG_IS_PASSWORD_COMPANY_MANAGED, isPasswordManagedByCompany)
         args.putBoolean(ARG_SHOW_ERROR, showError)
       })
     }

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/ConfirmationWithPasswordDialog.scala
@@ -57,13 +57,13 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
 
   private lazy val dialogClickListener = new DialogInterface.OnClickListener {
     override def onClick(dialog: DialogInterface, which: Int): Unit = which match {
-      case DialogInterface.BUTTON_POSITIVE => providePassword(if (isSSO) None else Some(Password(passwordEditText.getText.toString)))
+      case DialogInterface.BUTTON_POSITIVE => providePassword(if (isPasswordManagedByCompany) None else Some(Password(passwordEditText.getText.toString)))
       case DialogInterface.BUTTON_NEGATIVE => onNegativeClick()
       case _ =>
     }
   }
 
-  def isSSO: Boolean
+  def isPasswordManagedByCompany: Boolean
   def errorMessage: Option[String]
   def title: String
   def message: String
@@ -71,9 +71,9 @@ abstract class ConfirmationWithPasswordDialog extends DialogFragment with Fragme
   def negativeButtonText: Int
 
   override def onCreateDialog(savedInstanceState: Bundle): Dialog = {
-    passwordEditText.setVisible(!isSSO)
-    textInputLayout.setVisible(!isSSO)
-    forgotPasswordButton.setVisible(!isSSO)
+    passwordEditText.setVisible(!isPasswordManagedByCompany)
+    textInputLayout.setVisible(!isPasswordManagedByCompany)
+    forgotPasswordButton.setVisible(!isPasswordManagedByCompany)
     messageTextView.setText(message)
     errorMessage.foreach(textInputLayout.setError)
     new AlertDialog.Builder(getActivity)

--- a/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/dialogs/RemoveDeviceDialog.scala
@@ -24,7 +24,7 @@ import com.waz.zclient.R
 class RemoveDeviceDialog extends ConfirmationWithPasswordDialog {
   import RemoveDeviceDialog._
 
-  override lazy val isSSO: Boolean = getArguments.getBoolean(IsSSOARG)
+  override lazy val isPasswordManagedByCompany: Boolean = getArguments.getBoolean(IsSSOARG)
 
   override lazy val errorMessage: Option[String] = Option(getArguments.getString(ErrorArg))
 
@@ -34,7 +34,7 @@ class RemoveDeviceDialog extends ConfirmationWithPasswordDialog {
   )
 
   override lazy val message: String = {
-    val resId = if (isSSO) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message
+    val resId = if (isPasswordManagedByCompany) R.string.otr__remove_device__are_you_sure else R.string.otr__remove_device__message
     getString(resId)
   }
 

--- a/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/DeviceDetailsView.scala
@@ -277,7 +277,7 @@ final case class DeviceDetailsViewController(view: DeviceDetailsView, clientId: 
   }
 
   private def showRemoveDeviceDialog(error: Option[String] = None): Unit =
-    Signal.zip(inject[PasswordController].ssoEnabled, client.map(deviceName)).head.foreach { case (isSSO, name) =>
+    Signal.zip(inject[PasswordController].ssoManagedPassword, client.map(deviceName)).head.foreach { case (isSSO, name) =>
       val fragment = returning(RemoveDeviceDialog.newInstance(name, error, isSSO))(_.onAccept.onUi(removeDevice))
       context.asInstanceOf[BaseActivity]
         .getSupportFragmentManager

--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -94,11 +94,24 @@ trait AccountsService {
 
   def accountState(userId: UserId): Signal[AccountState]
 
-  def activeAccountId:      Signal[Option[UserId]]
-  def activeAccount:        Signal[Option[AccountData]]
-  def isActiveAccountSSO:   Signal[Boolean] = activeAccount.map(_.exists(_.ssoId.isDefined))
-  def activeAccountManager: Signal[Option[AccountManager]]
-  def activeZms:            Signal[Option[ZMessaging]]
+  def activeAccountId:                Signal[Option[UserId]]
+  def activeAccount:                  Signal[Option[AccountData]]
+
+  /**
+   * @return a Signal of Boolean that informs if the active account has a SSO Subject (i.e. the
+   *         account's password is managed by SSO and we should never ask the user for password confirmation).
+   *         It doesn't mean that the account isn't managed by SSO at all. For that, see [[activeAccountUsesCompanyLogin]].
+   */
+  def activeAccountHasCompanyManagedPassword: Signal[Boolean] = activeAccount.map(_.exists(_.ssoId.exists(_.subject.nonEmpty)))
+
+  /**
+   * @return a Signal of Boolean that informs if the active account is managed by SSO. It doesn't mean
+   *         that the account doesn't have a password. For that, see [[activeAccountHasCompanyManagedPassword]].
+   */
+  def activeAccountUsesCompanyLogin: Signal[Boolean] = activeAccount.map(_.exists(_.ssoId.isDefined))
+
+  def activeAccountManager:           Signal[Option[AccountManager]]
+  def activeZms:                      Signal[Option[ZMessaging]]
 
   def loginClient: LoginClient
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- App asks for passwords and when it shouldn't, for example when removing devices.

### Causes

App was only using one check (`isSSO`, or `ssoId.isDefined`) in order to make this kind of decisions.
But some kinds of SSO don't have SAML-based credentials, for example when the email is whitelisted by some external entity, but the password is managed within wire.

### Solutions

Instead of only checking `isSSO`, we need two different checks:
- `sso.id != null` to know if the account is managed by a 3rd party
- `sso.subject != null && sso.subject.isNotEmpty` to know if the password is also managed by a 3rd party

The first condition is to be used on things like Delete account or change e-mail (we don't want any SSOO users to be able to do that).

The second one is for password-related stuff. Making it mandatory or not when removing clients, showing or not the option to reset the password, etc.

### Testing

Manually tested

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Log-in with a different accounts:
* SCIM-managed (SSO with password)
* SAML-managed (SSO without password)
* Regular account (non-SSO)

Attempt to do the following on each:
- Remove another device
- Reset your password
- Delete your account
- Logout

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
