### PR TITLE
fix: enable picture and color change on all accounts

### DIFF
--- a/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
+++ b/app/src/main/scala/com/waz/zclient/preferences/pages/AccountView.scala
@@ -178,11 +178,6 @@ class AccountViewImpl(context: Context, attrs: AttributeSet, style: Int) extends
     handleButton.setEnabled(!locked)
     emailButton.setEnabled(!locked)
     phoneButton.setEnabled(!locked)
-    pictureButton.setEnabled(!locked)
-    colorButton.setEnabled(!locked)
-    appearanceHeader.setVisible(!locked)
-    pictureButton.setVisible(!locked)
-    colorButton.setVisible(!locked)
   }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users can't change their accent colour or profile picture.

### Causes

When account is not managed by Wire, we call `setAccountLocked`, which hides these options.

### Solutions

Account locking should not interefere with these cosmetic changes.

### Testing

Manually tested 

#### How to Test

Log-in with an account managed by SCIM for example.
Go to Account Details

Colour and Profile pictures should be enabled.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
