### PR TITLE
fix: migration for missing messages  - AN-7154

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -48,17 +48,7 @@ import com.waz.zclient.storage.db.sync.SyncJobsDao
 import com.waz.zclient.storage.db.sync.SyncJobsEntity
 import com.waz.zclient.storage.db.userclients.UserClientDao
 import com.waz.zclient.storage.db.userclients.UserClientsEntity
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_127_TO_128
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_128_TO_129
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_129_TO_130
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_130_TO_131
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_131_TO_132
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_132_TO_133
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_133_TO_134
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_134_TO_135
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_135_TO_136
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_136_TO_137
-import com.waz.zclient.storage.db.users.migration.USER_DATABASE_MIGRATION_137_TO_138
+import com.waz.zclient.storage.db.users.migration.*
 import com.waz.zclient.storage.db.users.model.UsersEntity
 import com.waz.zclient.storage.db.users.service.UsersDao
 
@@ -107,7 +97,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 138
+        const val VERSION = 139
 
         @JvmStatic
         val migrations = arrayOf(
@@ -121,7 +111,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_134_TO_135,
             USER_DATABASE_MIGRATION_135_TO_136,
             USER_DATABASE_MIGRATION_136_TO_137,
-            USER_DATABASE_MIGRATION_137_TO_138
+            USER_DATABASE_MIGRATION_137_TO_138,
+            USER_DATABASE_MIGRATION_138_TO_139
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase138To139Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase138To139Migration.kt
@@ -7,7 +7,6 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 val USER_DATABASE_MIGRATION_138_TO_139 = object : Migration(138, 139) {
     override fun migrate(database: SupportSQLiteDatabase) {
 
-        println("NOW MIGRATING FROM 138 TO 139")
         val previousTableName = "PushNotificationEvents"
         val createTableEncrypted = """
           CREATE TABLE IF NOT EXISTS EncryptedPushNotificationEvents(

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase138To139Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase138To139Migration.kt
@@ -1,0 +1,49 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import java.io.Console
+
+val USER_DATABASE_MIGRATION_138_TO_139 = object : Migration(138, 139) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+
+        println("NOW MIGRATING FROM 138 TO 139")
+        val previousTableName = "PushNotificationEvents"
+        val createTable = """
+          CREATE TABLE IF NOT EXISTS EncryptedPushNotificationEvents(
+             pushId TEXT,
+             event_index INTEGER,
+             event TEXT,
+             PRIMARY KEY (pushId, event_index))"
+          """.trimIndent()
+        val copyFromPreviousTable = """
+            INSERT INTO DecryptedPushNotificationEvents(
+            pushId,
+            event_index,
+            event,
+            plain
+            )
+            SELECT
+            pushId,
+            event_index,
+            event,
+            plain
+            FROM $previousTableName
+            WHERE decrypted = 1
+        """.trimIndent()
+
+        with(database) {
+            kotlin.io.println("NOW MIGRATING: create table")
+            //execSQL(createTable)
+            kotlin.io.println("NOW MIGRATING: check table exists")
+            if (com.waz.zclient.storage.db.MigrationUtils.tableExists(database, previousTableName)) {
+                kotlin.io.println("NOW MIGRATING: copy previous table")
+                //execSQL(copyFromPreviousTable)
+                kotlin.io.println("NOW MIGRATING: deleting table")
+                execSQL("DROP TABLE $previousTableName")
+            }
+            kotlin.io.println("NOW MIGRATING: done!")
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AN-7154" title="AN-7154" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AN-7154</a>  Android ::: Missing messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This is a follow up to https://github.com/wireapp/wire-android/pull/3715

In https://github.com/wireapp/wire-android/pull/3715, in order to address an issue, we created two new database tables. That PR did not include the proper database migration, which would cause updating the app to that version to freeze the app.

This PR addresses the DB migration by:
- manually creating the two new tables introduced by [#3715](https://github.com/wireapp/wire-android/pull/3715): `DecryptedPushNotificationEvents` and `EncryptedPushNotificationEvents`
- migrating the *decrypted* payloads in the old `PushNotificationEvents` table to `DecryptedPushNotificationEvents`
- migrating the *encrypted* payloads in the old `PushNotificationEvents` table to `EncryptedPushNotificationEvents`
- deleting the old table