### PR TITLE
fix: stuck on sync - AN-7156

### DIFF
--- a/app/src/main/scala/com/waz/zclient/messages/MessageViewLayout.scala
+++ b/app/src/main/scala/com/waz/zclient/messages/MessageViewLayout.scala
@@ -49,8 +49,7 @@ abstract class MessageViewLayout(context: Context, attrs: AttributeSet, style: I
   setClipChildren(false)
 
   protected def setParts(msg: MessageAndLikes, parts: Seq[PartDesc], opts: MsgBindOptions, adapter: MessagesPagedListAdapter)(implicit ec: EventContext): Unit = {
-    verbose(l"setParts: opts: $opts, parts: ${parts.map(_.tpe)}")
-
+    
     // recycle views in reverse order, recycled views are stored in a Stack, this way we will get the same views back if parts are the same
     // XXX: once views get bigger, we may need to optimise this, we don't need to remove views that will get reused, currently this seems to be fast enough
     (0 until getChildCount).reverseIterator.map(getChildAt) foreach {

--- a/zmessaging/src/main/scala/com/waz/service/otr/NotificationParser.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/NotificationParser.scala
@@ -31,10 +31,10 @@ final class NotificationParserImpl(selfId:       UserId,
 
   override def parse(events: Iterable[Event]): Future[Set[NotificationData]] =
     Future.traverse(events){
-      case ev: GenericMessageEvent     => parse(ev)
-      case ev: UserConnectionEvent     => parse(ev)
-      case ev: RenameConversationEvent => parse(ev)
-      case ev: DeleteConversationEvent => parse(ev)
+      case ev: GenericMessageEvent     => parse(ev).recover { case _ => None }
+      case ev: UserConnectionEvent     => parse(ev).recover { case _ => None }
+      case ev: RenameConversationEvent => parse(ev).recover { case _ => None }
+      case ev: DeleteConversationEvent => parse(ev).recover { case _ => None }
       case _                           => Future.successful(None)
     }.map(_.flatten.toSet)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AN-7156" title="AN-7156" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AN-7156</a>  App stuck on syncing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Upon opening the app, the app shows the “syncing” bar on top. No new messages come in, and it’s not possible to send messages.

When this happens, the app is unusable until it’s uninstalled and re-installed.


### Causes

From the logs:
```
2022-07-26T07:03:42.420Z-TID:4007/E/NotificationParserImpl: error while parsing (1) GenericMessageEvent(TMbQ1pe+b), String(cCCHJwYG9)
java.util.NoSuchElementException: Future.filter predicate is not satisfied
	at scala.concurrent.Future$$anonfun$filter$1.apply(Future.scala:280)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:1237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
	at com.wire.signals.LimitedDispatchQueue$Executor$.run(DispatchQueue.scala:3206)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
```
There is an error while parsing events from the backend. There is an encrypted message (GenericMessage) that references a conversation ID that does not exist locally (java.util.NoSuchElementException) and this causes an exception, aborting the processing of notifications. However, the app tries to parse the same batch of notifications again and again, resulting in an endless loop.

The reason why we don't have a local conversation with that ID is not clear, but there are legit cases in which this could happen (e.g. a conversation is deleted, a full synchronization is performed, removing the conversation from the local database, and after we process the messages that arrived in the past days, including some referring to that conversation) and also potential bugs that will delete/overwrite the local ID.

### Solutions

If one notification payload fail to parse, instead of logging the exception and then do nothing (and later try to parse it again, with the same result), discard this payload and continue to parse the rest.
