### PR TITLE
fix: Add build config ALLOW_ONLY_EMAIL_LOGIN

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,7 @@ android {
         buildConfigField 'String',  'BACKEND_URL',                   "\"$buildtimeConfiguration.configuration.backendUrl\""
         buildConfigField 'String',  'WEBSOCKET_URL',                 "\"$buildtimeConfiguration.configuration.websocketUrl\""
         buildConfigField 'boolean', 'ACCOUNT_CREATION_ENABLED',      "$buildtimeConfiguration.configuration.allow_account_creation"
+        buildConfigField 'boolean', 'ALLOW_ONLY_EMAIL_LOGIN',        "$buildtimeConfiguration.configuration.allow_only_email_login"
         buildConfigField 'boolean', 'ALLOW_SSO',                     "$buildtimeConfiguration.configuration.allowSSO"
         buildConfigField 'String',  'SUPPORT_EMAIL',                 "\"$buildtimeConfiguration.configuration.supportEmail\""
         buildConfigField 'String',  'FIREBASE_PUSH_SENDER_ID',       "\"$buildtimeConfiguration.configuration.firebasePushSenderId\""

--- a/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
+++ b/app/src/main/scala/com/waz/zclient/appentry/fragments/SignInFragment.scala
@@ -30,6 +30,7 @@ import com.waz.service.AccountsService
 import com.waz.threading.Threading
 import com.wire.signals.Signal
 import com.waz.utils.{returning, PasswordValidator => StrongValidator}
+import com.waz.zclient.BuildConfig.ALLOW_ONLY_EMAIL_LOGIN
 import com.waz.zclient._
 import com.waz.zclient.appentry.DialogErrorMessage.{EmailError, PhoneError}
 import com.waz.zclient.appentry.fragments.SignInFragment._
@@ -147,7 +148,7 @@ class SignInFragment extends FragmentHelper with View.OnClickListener with Count
 
     tabSelector.foreach(_.setVisible(!onlyLogin))
     emailButton.foreach(_.setVisible(!onlyLogin))
-    phoneButton.foreach(_.setVisible(!onlyLogin && !registration))
+    phoneButton.foreach(_.setVisible(!onlyLogin && !registration && !ALLOW_ONLY_EMAIL_LOGIN))
 
     emailField.foreach { field =>
       field.setValidator(emailValidator)

--- a/default.json
+++ b/default.json
@@ -67,6 +67,7 @@
     "backendUrl": "https://prod-nginz-https.wire.com",
     "websocketUrl": "https://prod-nginz-ssl.wire.com",
     "allow_account_creation": true,
+    "allow_only_email_login": false,
     "allowSSO": true,
     "supportEmail": "support@wire.com",
     "firebasePushSenderId": "782078216207",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Phone login should be configurable to be able to disable it for some customers. Unfortunately has no build flag ALLOW_ONLY_EMAIL_LOGIN like iOS.

### Solutions

This PR adds a build flag ALLOW_ONLY_EMAIL_LOGIN that makes the phone button disappear on the sign in page.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

### Testing

#### How to Test

This can only be tested with special builds and a new setting `"allow_only_email_login": true` to override the default value.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
