### PR TITLE
fix: stuck on sync'ing and repeating system messages - AN-7156

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
@@ -78,6 +78,7 @@ final class PushNotificationEventsStorageImpl(context: Context, storage: Databas
     for {
       event <- encryptedStorage.get(index)
       _ <- decryptedStorage.insert(event.get)
+      _ <- encryptedStorage.remove(event.get.id)
     } yield()
   }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

System messages ("USER left", Profile name / username changes, etc) are repeated every time notifications are processed. Additionally the application can hang while while syncing if too many system messages are being reprocessed. This can cause erratic behavior (ie: hanging application, delay in sending or receiving messages, etc)

### Causes (Optional)

This bug appears to have been introduced in #3715 / AN-7154.  When system events are decrypted by `PushNotificationEventsStorage.setAsDecrypted(index)` they are copied into the `DecryptedPushNotificationEvents` table but they are never removed from the `EncryptedPushNotificationEvents` table. This causes the application to reschedule and process system events forever. Closing the application will not clear this table.

According to #3715 these events should be deleted from the `EncryptedPushNotificationEvents` table after they are inserted into the `DecryptedPushNotificationEvents` table.

The behavior described above appears to be what causes (potentially) the "stuck on sync" bug where a client can freeze or deliverer/receive messages in a seemingly erratic pattern. Because the table does not delete system messages after decrypting them the client will reprocess every system message sent to the client since upgrading to any version containing the PR #3715 / AN-7154 fix. The more system messages the user has, the longer the delay.

### Solutions

Remove encrypted messages from the database after they are decrypted and copied the decrypted table in the database. This will fix the bug for most users after upgrading (see step 2 for exceptions).

This is accomplished by updating the method `PushNotificationEventsStorage.setAsDecrypted(index)` to include a call to `remove()` the event from the `EncryptedPushNotificationEvents` table after it has been copied to the `DecryptedPushNotificationEvents` table.

The `setAsDecrypted()` method could potentially be renamed `moveDecryptedEvent()` as it moves the entry from one table to the other. This PR does not make this change as it is optional.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Using `ADB` inspect the application to ensure the `EncryptedPushNotificationEvents` is empty after receiving system events (another user leaves a group, changes name, etc)

### Notes (Optional)

It may be possible that there are users who have accumulated so many rows in the `EncryptedPushNotificationEvents` table that the application will hang before the above fix has a chance to start deleting events after they are decrypted (and then processed). 

#### Strategy 1: Delete excessive rows on startup

Delete all rows in the `EncryptedPushNotificationEvents` table since the users' last session. This would be a one time operation and should be safe except in some edge cases such as the application was interrupted or closed unexpectedly, since the last run. This operation should only be performed one time.

This is the most easy strategy. 

#### Strategy 2: Detect duplicate events

Modify methods in `EventScheduler` to detect duplicate system events and delete them when the scheduler attempts to schedule the event for process a second time. 

This strategy is of moderate complexity and time as different types of system events may need different methods detect if they are a duplicate. For example the method used for detecting duplicate "Profile name" changes is most likely different then detecting duplicate "USER left" system messages.


### Attachments (Optional)


_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
