### PR TITLE
fix: long delays when updating version AN-7156

### DIFF
--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/UserDatabase.kt
@@ -97,7 +97,7 @@ abstract class UserDatabase : RoomDatabase() {
     abstract fun buttonsDao(): ButtonsDao
 
     companion object {
-        const val VERSION = 139
+        const val VERSION = 140
 
         @JvmStatic
         val migrations = arrayOf(
@@ -112,7 +112,8 @@ abstract class UserDatabase : RoomDatabase() {
             USER_DATABASE_MIGRATION_135_TO_136,
             USER_DATABASE_MIGRATION_136_TO_137,
             USER_DATABASE_MIGRATION_137_TO_138,
-            USER_DATABASE_MIGRATION_138_TO_139
+            USER_DATABASE_MIGRATION_138_TO_139,
+            USER_DATABASE_MIGRATION_139_TO_140
         )
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
@@ -11,8 +11,8 @@ val USER_DATABASE_MIGRATION_139_TO_140 = object : Migration(139, 140) {
             execSQL("DELETE FROM EncryptedPushNotificationEvents")
             // Deleting decrypted events is tricky: they can not be decrypted again. Deleting a
             // message that was not processed yet causes the message to be lost forever.
-            // Distinguishing which event was already processed and is still (wrongfully) in this
-            // table will add a lot of complexity. It would be possible for some message types,
+            // We can't distinguishing which events are already processed but are still
+            // (wrongfully) in this table. It would be possible for some message types,
             // but it will be impossible for other. At the cost of losing some encrypted messages, the
             // easiest solution is to just delete the entire table.
             execSQL("DELETE FROM DecryptedPushNotificationEvents")

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
@@ -9,13 +9,6 @@ val USER_DATABASE_MIGRATION_139_TO_140 = object : Migration(139, 140) {
         with(database) {
             // Deleting encrypted events is safe: they can be re-fetched and decrypted again
             execSQL("DELETE FROM EncryptedPushNotificationEvents")
-            // Deleting decrypted events is tricky: they can not be decrypted again. Deleting a
-            // message that was not processed yet causes the message to be lost forever.
-            // We can't distinguishing which events are already processed but are still
-            // (wrongfully) in this table. It would be possible for some message types,
-            // but it will be impossible for other. At the cost of losing some encrypted messages, the
-            // easiest solution is to just delete the entire table.
-            execSQL("DELETE FROM DecryptedPushNotificationEvents")
         }
     }
 }

--- a/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
+++ b/storage/src/main/kotlin/com/waz/zclient/storage/db/users/migration/UserDatabase139To140Migration.kt
@@ -1,0 +1,21 @@
+@file:Suppress("MagicNumber")
+package com.waz.zclient.storage.db.users.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val USER_DATABASE_MIGRATION_139_TO_140 = object : Migration(139, 140) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        with(database) {
+            // Deleting encrypted events is safe: they can be re-fetched and decrypted again
+            execSQL("DELETE FROM EncryptedPushNotificationEvents")
+            // Deleting decrypted events is tricky: they can not be decrypted again. Deleting a
+            // message that was not processed yet causes the message to be lost forever.
+            // Distinguishing which event was already processed and is still (wrongfully) in this
+            // table will add a lot of complexity. It would be possible for some message types,
+            // but it will be impossible for other. At the cost of losing some encrypted messages, the
+            // easiest solution is to just delete the entire table.
+            execSQL("DELETE FROM DecryptedPushNotificationEvents")
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AN-7156" title="AN-7156" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AN-7156</a>  App stuck on syncing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

This is a follow up to https://github.com/wireapp/wire-android/pull/3730.

### Issues

As mentioned in #3730 

> It may be possible that there are users who have accumulated so many rows in the `EncryptedPushNotificationEvents` table that the application will hang before the above fix has a chance to start deleting events after they are decrypted (and then processed).

The app might take a long time to recover after migrating to a new version. This looks to the user like the app is stuck (while it is in fact processing a LOT of messages in the background).

### Causes

This happens when a LOT of messages have accumulated over time in the `EncryptedPushNotificationEvents` table. This is because before #3730 those events were never discarded, they kept accumulating over time.

### Solutions

This PR introduces a DB migration that simply deletes the content of `EncryptedPushNotificationEvents`. The migration is run only once, upon update. There is no data loss: if the events are still in `EncryptedPushNotificationEvents`, they have either:

- (correctly) not been processed
- have been processed but are (incorrectly) still in the table due to the bug addressed in #3730

If they have not been processed, then the ID of the last event that was processed has not been updated to include those. This means that the next time the app is opened, it will use an older last event ID to fetch new events, causing those events to be fetched again. Therefore deleting them is no problem.

If the event have been processed already, then deleting them is no problem.

The PR leaves the content of `DecryptedPushNotificationEvents` as is. This table might also have grown substantially due to the `EncryptedPushNotificationEvents` being copied over, however deleting messages from this table might result in them being lost forever (since they can't be decrypted again). Therefore we will wipe this table only if it turns out that deleting the encrypted table is not enough to reduce the delay.

### Testing

Pending. We want to see how this PR affects the performance of devices that are affected by the issue, which we can't easily reproduce in a test setup. Therefore we will test on real devices.

#### How to Test

Install this build as a replacement of a build that was showing symptoms of taking a long time to synchronize on start.
