### PR TITLE
feat(build-config): add development_api_enabled switch to configs

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -51,7 +51,8 @@ class KaliumConfigsModule {
             // we use upsert, available from SQL3.24, which is supported from Android API30, so for older APIs we have to use SQLCipher
             shouldEncryptData = !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R,
             lowerKeyPackageLimits = BuildConfig.PRIVATE_BUILD,
-            lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD
+            lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD,
+            developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED
         )
     }
 

--- a/buildSrc/src/main/kotlin/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/FeatureConfigs.kt
@@ -70,6 +70,7 @@ enum class FlavourConfigs(val value: String, val configType: ConfigType) {
     LOGGING_ENABLED("logging_enabled", ConfigType.BOOLEAN),
     SAFE_LOGGING("safe_logging", ConfigType.BOOLEAN),
     PRIVATE_BUILD("private_build", ConfigType.BOOLEAN),
+    DEVELOPMENT_API_ENABLED("development_api_enabled", ConfigType.BOOLEAN),
     USER_ID("userId", ConfigType.STRING);
 
 }

--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
         "developer_features_enabled": false,
         "logging_enabled": false,
         "safe_logging": false,
-        "private_build": false
+        "private_build": false,
+        "development_api_enabled": false
     },
     "dev": {
         "applicationId": "com.waz.zclient.dev",
@@ -20,7 +21,8 @@
         "developer_features_enabled": true,
         "logging_enabled": true,
         "safe_logging": false,
-        "private_build": true
+        "private_build": true,
+        "development_api_enabled": false
     },
     "candidate": {
         "applicationId": "com.wire.candidate",
@@ -31,7 +33,8 @@
         "developer_features_enabled": true,
         "logging_enabled": true,
         "safe_logging": true,
-        "private_build": false
+        "private_build": false,
+        "development_api_enabled": false
     },
     "internal": {
         "applicationId": "com.wire.internal",
@@ -43,7 +46,8 @@
         "developer_features_enabled": true,
         "logging_enabled": true,
         "safe_logging": true,
-        "private_build": true
+        "private_build": true,
+        "development_api_enabled": false
     },
     "experimental": {
         "applicationId": "com.wire.x",
@@ -55,7 +59,8 @@
         "developer_features_enabled": true,
         "logging_enabled": true,
         "safe_logging": true,
-        "private_build": true
+        "private_build": true,
+        "development_api_enabled": false
     },
     "fdroid": {
         "applicationId": "com.wire",
@@ -67,7 +72,8 @@
         "logging_enabled": false,
         "safe_logging": true,
         "keep_websocket_on": true,
-        "private_build": false
+        "private_build": false,
+        "development_api_enabled": false
     },
     "maxAccounts": 3,
     "backendUrl": "https://prod-nginz-https.wire.com",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Add `development_api_enabled` to kalium configs. It's disabled by default for all build types, this switch will enable [if you want] switching to development apis if there is any available in the VersionAPI api.
### Issues

to manage api switching manually.



### Solutions

With this switch we force kalium to consider or to not consider development apis.

Needs releases with:

- [x] GitHub link to other pull request
need to be merged after https://github.com/wireapp/kalium/pull/869

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test
not needed! only build configs changed.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
