### PR TITLE
fix: disable leave group option for non member group users [AR-1552]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -255,7 +255,8 @@ private fun ConversationScreen(
                                 onPhoneButtonClick = onStartCall,
                                 hasOngoingCall = conversationCallViewState.hasOngoingCall,
                                 onJoinCallButtonClick = onJoinCall,
-                                isUserBlocked = connectionStateOrNull == ConnectionState.BLOCKED
+                                isUserBlocked = connectionStateOrNull == ConnectionState.BLOCKED,
+                                isCallingEnabled = isSendingMessagesAllowed
                             )
                         }
                     },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -51,7 +50,8 @@ fun ConversationScreenTopAppBar(
     onPhoneButtonClick: () -> Unit,
     hasOngoingCall: Boolean,
     isUserBlocked: Boolean,
-    onJoinCallButtonClick: () -> Unit
+    onJoinCallButtonClick: () -> Unit,
+    isCallingEnabled: Boolean = true
 ) {
     SmallTopAppBar(
         title = {
@@ -101,7 +101,8 @@ fun ConversationScreenTopAppBar(
                 hasOngoingCall = hasOngoingCall,
                 onJoinCallButtonClick = onJoinCallButtonClick,
                 onPhoneButtonClick = onPhoneButtonClick,
-                isUserBlocked = isUserBlocked
+                isUserBlocked = isUserBlocked,
+                isCallingEnabled = isCallingEnabled
             )
             Spacer(Modifier.width(MaterialTheme.wireDimensions.spacing6x))
         }, colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
@@ -141,14 +142,15 @@ private fun callControlButton(
     hasOngoingCall: Boolean,
     isUserBlocked: Boolean,
     onJoinCallButtonClick: () -> Unit,
-    onPhoneButtonClick: () -> Unit
+    onPhoneButtonClick: () -> Unit,
+    isCallingEnabled: Boolean
 ) {
     if (hasOngoingCall) {
         JoinButton(
             buttonClick = onJoinCallButtonClick,
             minHeight = MaterialTheme.wireDimensions.spacing28x
         )
-    } else {
+    } else if (isCallingEnabled) {
         WireSecondaryButton(
             onClick = onPhoneButtonClick,
             leadingIcon = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -105,13 +105,12 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     private fun observeIfSelfIsConversationMember() = viewModelScope.launch {
-        observeIsSelfConversationMember(conversationId)
-            .collect { result ->
-                when (result) {
-                    is IsSelfUserMemberResult.Failure -> isSendingMessagesAllowed = false
-                    is IsSelfUserMemberResult.Success -> isSendingMessagesAllowed = result.isMember
-                }
+        observeIsSelfConversationMember(conversationId).collect { result ->
+            when (result) {
+                is IsSelfUserMemberResult.Failure -> isSendingMessagesAllowed = false
+                is IsSelfUserMemberResult.Success -> isSendingMessagesAllowed = result.isMember
             }
+        }
     }
 
     private fun fetchSelfUserTeam() = viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/ConversationGroupDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/ConversationGroupDetailsBottomSheet.kt
@@ -38,17 +38,18 @@ fun ConversationGroupDetailsBottomSheet(
                 )
             }),
         menuItems = listOf {
-            LeaveGroupItem(
-                onLeaveGroup = {
-                    onLeaveGroup(
-                        GroupDialogState(
-                            conversationOptionsState.conversationId,
-                            conversationOptionsState.groupName
+            if (conversationOptionsState.isSelfUserMember)
+                LeaveGroupItem(
+                    onLeaveGroup = {
+                        onLeaveGroup(
+                            GroupDialogState(
+                                conversationOptionsState.conversationId,
+                                conversationOptionsState.groupName
+                            )
                         )
-                    )
-                },
-                closeBottomSheet = closeBottomSheet
-            )
+                    },
+                    closeBottomSheet = closeBottomSheet
+                )
             if (conversationOptionsState.isAbleToRemoveGroup)
                 DeleteGroupItem(
                     onDeleteGroup = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.home.conversations.details.options
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.conversation.ObserveIsSelfUserMemberUseCase
 
 data class GroupConversationOptionsState(
     val conversationId: ConversationId,
@@ -18,6 +19,7 @@ data class GroupConversationOptionsState(
     val changeServiceOptionConfirmationRequired: Boolean = false,
     val loadingGuestOption: Boolean = false,
     val loadingServicesOption: Boolean = false,
+    val isSelfUserMember: Boolean = true,
     val error: Error = Error.None
 ) {
     sealed interface Error {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
@@ -73,7 +73,9 @@ private fun AllConversationContent(
                     is ConversationFolder.Predefined -> context.getString(conversationFolder.folderNameResId)
                     is ConversationFolder.Custom -> conversationFolder.folderName
                 },
-                items = conversationList.associateBy { it.conversationId.toString() }
+                items = conversationList.associateBy {
+                    it.conversationId.toString()
+                }
             ) { generalConversation ->
                 ConversationItemFactory(
                     conversation = generalConversation,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -75,8 +75,7 @@ class ConversationListViewModel @Inject constructor(
     private val observeSelfUser: GetSelfUserUseCase,
     private val blockUserUseCase: BlockUserUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
-    private val userTypeMapper: UserTypeMapper,
-    private val observeIsSelfUserMember: ObserveIsSelfUserMemberUseCase
+    private val userTypeMapper: UserTypeMapper
 ) : ViewModel() {
 
     var state by mutableStateOf(ConversationListState())

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -44,7 +44,9 @@ import com.wire.kalium.logic.feature.call.AnswerCallUseCase
 import com.wire.kalium.logic.feature.connection.BlockUserResult
 import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
+import com.wire.kalium.logic.feature.conversation.IsSelfUserMemberResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationsAndConnectionsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveIsSelfUserMemberUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
@@ -74,6 +76,7 @@ class ConversationListViewModel @Inject constructor(
     private val blockUserUseCase: BlockUserUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
+    private val observeIsSelfUserMember: ObserveIsSelfUserMemberUseCase
 ) : ViewModel() {
 
     var state by mutableStateOf(ConversationListState())
@@ -261,7 +264,8 @@ class ConversationListViewModel @Inject constructor(
 
     private fun List<ConversationDetails>.toConversationItemList(selfUser: SelfUser?): List<ConversationItem> =
         filter { it is Group || it is OneOne || it is Connection }
-            .map { it.toConversationItem(wireSessionImageLoader, selfUser, userTypeMapper) }
+            .map {
+                it.toConversationItem(wireSessionImageLoader, selfUser, userTypeMapper) }
 }
 
 private fun LegalHoldStatus.showLegalHoldIndicator() = this == LegalHoldStatus.ENABLED
@@ -282,7 +286,8 @@ private fun ConversationDetails.toConversationItem(
             badgeEventType = parseConversationEventType(conversation.mutedStatus, unreadMentionsCount, unreadMessagesCount),
             hasOnGoingCall = hasOngoingCall,
             isCreator = selfUser?.teamId != null
-                    && conversation.creatorId.value == selfUser.id.value
+                    && conversation.creatorId.value == selfUser.id.value,
+            isSelfUserMember = isSelfUserMember
         )
     }
     is OneOne -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetContent.kt
@@ -71,4 +71,5 @@ data class ConversationSheetContent(
     val conversationId: ConversationId,
     val mutingConversationState: MutedConversationStatus,
     val conversationTypeDetail: ConversationTypeDetail,
+    val isSelfUserMember: Boolean = true
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetState.kt
@@ -51,7 +51,8 @@ fun rememberConversationSheetState(
                     conversationTypeDetail = ConversationTypeDetail.Group(
                         conversationId = conversationId,
                         isCreator = isCreator
-                    )
+                    ),
+                    isSelfUserMember = conversationItem.isSelfUserMember
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
@@ -49,7 +49,7 @@ internal fun ConversationMainSheetContent(
         header = MenuModalSheetHeader.Visible(
             title = conversationSheetContent.title,
             leadingIcon = {
-                if (conversationSheetContent.conversationTypeDetail is ConversationTypeDetail.Group) {
+                    if (conversationSheetContent.conversationTypeDetail is ConversationTypeDetail.Group) {
                     GroupConversationAvatar(
                         color = colorsScheme()
                             .conversationColor(id = conversationSheetContent.conversationTypeDetail.conversationId)
@@ -70,17 +70,18 @@ internal fun ConversationMainSheetContent(
         ),
         menuItems = listOf(
             {
-                MenuBottomSheetItem(
-                    title = stringResource(R.string.label_notifications),
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_mute,
-                            contentDescription = stringResource(R.string.content_description_muted_conversation),
-                        )
-                    },
-                    action = { NotificationsOptionsItemAction(conversationSheetContent.mutingConversationState) },
-                    onItemClick = navigateToNotification
-                )
+                if (conversationSheetContent.isSelfUserMember)
+                    MenuBottomSheetItem(
+                        title = stringResource(R.string.label_notifications),
+                        icon = {
+                            MenuItemIcon(
+                                id = R.drawable.ic_mute,
+                                contentDescription = stringResource(R.string.content_description_muted_conversation),
+                            )
+                        },
+                        action = { NotificationsOptionsItemAction(conversationSheetContent.mutingConversationState) },
+                        onItemClick = navigateToNotification
+                    )
             },
             {
                 MenuBottomSheetItem(
@@ -153,7 +154,7 @@ internal fun ConversationMainSheetContent(
                             )
                         }
                     }
-                } else {
+                } else if (conversationSheetContent.isSelfUserMember) {
                     CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
                         MenuBottomSheetItem(
                             icon = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -24,7 +24,8 @@ sealed class ConversationItem {
         override val lastEvent: ConversationLastEvent,
         override val badgeEventType: BadgeEventType,
         val hasOnGoingCall: Boolean = false,
-        val isCreator: Boolean = false
+        val isCreator: Boolean = false,
+        val isSelfUserMember: Boolean = true
     ) : ConversationItem()
 
     data class PrivateConversation(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -19,7 +19,9 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.feature.conversation.IsSelfUserMemberResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveIsSelfUserMemberUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
@@ -421,6 +423,9 @@ internal class GroupConversationDetailsViewModelArrangement {
     lateinit var getSelfTeamUseCase: GetSelfTeamUseCase
 
     @MockK
+    lateinit var observeIsSelfUserMember: ObserveIsSelfUserMemberUseCase
+
+    @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     private val conversationDetailsChannel = Channel<ConversationDetails>(capacity = Channel.UNLIMITED)
@@ -439,7 +444,8 @@ internal class GroupConversationDetailsViewModelArrangement {
             updateConversationAccessRole = updateConversationAccessRoleUseCase,
             getSelfTeam = getSelfTeamUseCase,
             savedStateHandle = savedStateHandle,
-            qualifiedIdMapper = qualifiedIdMapper
+            qualifiedIdMapper = qualifiedIdMapper,
+            observeIsSelfUserMember = observeIsSelfUserMember
         )
     }
 
@@ -459,6 +465,7 @@ internal class GroupConversationDetailsViewModelArrangement {
         coEvery {
             qualifiedIdMapper.fromStringToQualifiedID("conv_id@domain")
         } returns QualifiedID("conv_id", "domain")
+        coEvery { observeIsSelfUserMember(any()) } returns (flowOf(IsSelfUserMemberResult.Success(true)))
     }
 
     fun withSavedStateConversationId(conversationId: ConversationId) = apply {
@@ -466,7 +473,7 @@ internal class GroupConversationDetailsViewModelArrangement {
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
-        coEvery { observeConversationDetails(any()) }returns conversationDetailsChannel.consumeAsFlow()
+        coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow()
             .map { ObserveConversationDetailsUseCase.Result.Success(it) }
         conversationDetailsChannel.send(conversationDetails)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1552" title="AR-1552" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-1552</a>  Group member/ Admin leaving a group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Users that had left a group were still able to see the `Leave group` option on the conversation menu options as well as other non applying settings (notifications, calling...). This PR fixes that by checking a new field `isSelfUserMember` added on the `Conversation` object and propagated accordingly to the needed UI elements.


### Dependencies (Optional)

This will need to be merged after the Kalium counterpart [PR](https://github.com/wireapp/kalium/pull/870) has been also merged 

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Leave a group and then check if you can leave it again, or make calls from inside the `ConversationScreen`.


### Attachments (Optional)

<img width="417" alt="Captura de Pantalla 2022-09-07 a las 12 30 14" src="https://user-images.githubusercontent.com/2468164/188869758-4fae72f1-6b02-4221-bb62-649186d4e3fc.png">

https://user-images.githubusercontent.com/2468164/188869773-26fdf17d-de8b-4115-a79c-3af42b93f0d7.mov


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
