### PR TITLE
fix: visual bugs in account switching UI

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightSubtTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightSubtTitle.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 fun HighlightSubtitle(
     subTitle: String,
     searchQuery: String = "",
+    suffix: String = "@"
 ) {
     val scope = rememberCoroutineScope()
 
@@ -39,7 +40,6 @@ fun HighlightSubtitle(
             )
         }
     }
-
     if (highlightIndexes.isNotEmpty()) {
         Text(
             buildAnnotatedString {
@@ -52,7 +52,7 @@ fun HighlightSubtitle(
                         fontStyle = MaterialTheme.wireTypography.subline01.fontStyle
                     )
                 ) {
-                    append("@$subTitle")
+                    append("$suffix$subTitle")
                 }
 
                 highlightIndexes
@@ -62,8 +62,8 @@ fun HighlightSubtitle(
                                 background = MaterialTheme.wireColorScheme.highLight.copy(alpha = 0.5f),
                             ),
                             // add 1 because of the "@" prefix
-                            start = highLightIndexes.startIndex + 1,
-                            end = highLightIndexes.endIndex + 1
+                            start = highLightIndexes.startIndex + suffix.length,
+                            end = highLightIndexes.endIndex + suffix.length
                         )
                     }
             },
@@ -72,7 +72,7 @@ fun HighlightSubtitle(
         )
     } else {
         Text(
-            text = "@$subTitle",
+            text = "$suffix$subTitle",
             style = MaterialTheme.wireTypography.subline01,
             color = MaterialTheme.wireColorScheme.secondaryText,
             maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -55,6 +55,7 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.search.HighlightName
 import com.wire.android.ui.home.conversations.search.HighlightSubtitle
+import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.ui.userprofile.common.EditableState
@@ -325,18 +326,7 @@ private fun ProfileStatusButton(
 
 @Composable
 private fun OtherAccountsHeader() {
-    Text(
-        modifier = Modifier
-            .padding(
-                top = dimensions().spacing16x,
-                start = dimensions().spacing16x,
-                bottom = dimensions().spacing4x
-            ),
-        text = stringResource(id = R.string.user_profile_other_accs).uppercase(),
-        style = MaterialTheme.wireTypography.title03,
-        color = MaterialTheme.colorScheme.onBackground,
-        textAlign = TextAlign.Start
-    )
+    FolderHeader(stringResource(id = R.string.user_profile_other_accs))
 }
 
 @Composable
@@ -371,9 +361,7 @@ private fun OtherAccountItem(
         },
         subtitle = {
             if (account.teamName != null)
-                HighlightSubtitle(
-                    subTitle = account.teamName
-                )
+                HighlightSubtitle(subTitle = account.teamName, suffix = "")
         },
         actions = {
             Box(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

visual issues related to 

1. the `YOUR OTHER ACCOUNTS` header have wrong color
2. @ is added before the team name 

### Solutions

1. use `FolderHeader` for the YOUR OTHER ACCOUNTS`  header
2. Modify `HighlightSubtitle` composable to take suffix parameter instead of hard codded @ suffix

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
