### PR TITLE
fix(calling): avoid unnecessary recomposition

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -45,7 +45,11 @@ fun GroupCallGrid(
         columns = GridCells.Fixed(NUMBER_OF_GRID_CELLS)
     ) {
 
-        items(items = participants, key = { it.id.toString() + it.clientId }) { participant ->
+        items(
+            items = participants,
+            key = { it.id.toString() + it.clientId },
+            contentType = { getContentType(it.isCameraOn, it.isSharingScreen) }
+        ) { participant ->
             // since we are getting participants by chunk of 8 items,
             // we need to check that we are on first page for self user
             val isSelfUser = pageIndex == 0 && participants.first() == participant
@@ -109,6 +113,11 @@ fun GroupCallGrid(
 private fun tilesRowsCount(participantsSize: Int): Int = with(participantsSize) {
     return@with if (this % 2 == 0) (this / 2) else ((this / 2) + 1)
 }
+
+private fun getContentType(
+    isCameraOn: Boolean,
+    isSharingScreen: Boolean
+) = if (isCameraOn || isSharingScreen) "videoRender" else null
 
 private const val NUMBER_OF_GRID_CELLS = 2
 private const val TOP_APP_BAR_AND_BOTTOM_SHEET_HEIGHT = 170


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In an ongoing call, we were recomposition tiles for every action/event happens on the screen

### Solutions

We moved some parts to separate compose functions, this way any change on a value won't will affect the container
and will skip recomposition.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
