### PR TITLE
fix: GroupConversationDetails flickering

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/Extensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/Extensions.kt
@@ -10,18 +10,28 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.Role
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.placeholder
 import com.google.accompanist.placeholder.shimmer
 import com.wire.android.model.Clickable
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Composable
 fun Modifier.selectableBackground(isSelected: Boolean, onClick: () -> Unit): Modifier =
@@ -64,3 +74,28 @@ fun Modifier.clickable(clickable: Clickable?) = clickable?.let {
         onLongClick = clickable.onLongClick
     )
 } ?: this
+
+@Composable
+fun <T> rememberFlow(
+    flow: Flow<T>,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+): Flow<T> {
+    return remember(key1 = flow, key2 = lifecycleOwner) { flow.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED) }
+}
+
+// TODO replace by collectAsStateWithLifecycle() after updating lifecycle version to 2.6.0-alpha01 or newer
+@Composable
+fun <T : R, R> Flow<T>.collectAsStateLifecycleAware(
+    initial: R,
+    context: CoroutineContext = EmptyCoroutineContext
+): State<R> {
+    val lifecycleAwareFlow = rememberFlow(flow = this)
+    return lifecycleAwareFlow.collectAsState(initial = initial, context = context)
+}
+
+// TODO replace by collectAsStateWithLifecycle() after updating lifecycle version to 2.6.0-alpha01 or newer
+@Suppress("StateFlowValueCalledInComposition")
+@Composable
+fun <T> StateFlow<T>.collectAsStateLifecycleAware(
+    context: CoroutineContext = EmptyCoroutineContext
+): State<T> = collectAsStateLifecycleAware(value, context)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +41,7 @@ import com.wire.android.ui.common.TabItem
 import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.calculateCurrentTab
+import com.wire.android.ui.common.collectAsStateLifecycleAware
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
@@ -105,8 +105,7 @@ private fun GroupConversationDetailsContent(
     context: Context = LocalContext.current
 ) {
     val scope = rememberCoroutineScope()
-    // TODO convert to asStateWithLifeCycle
-    val groupOptionsState by groupOptionsStateFlow.collectAsState()
+    val groupOptionsState by groupOptionsStateFlow.collectAsStateLifecycleAware()
     val lazyListStates: List<LazyListState> = GroupConversationDetailsTabItem.values().map { rememberLazyListState() }
     val initialPageIndex = GroupConversationDetailsTabItem.OPTIONS.ordinal
     val pagerState = rememberPagerState(initialPage = initialPageIndex)
@@ -237,10 +236,12 @@ private fun GroupConversationDetailsPreview() {
             onAddParticipantsPressed = {},
             onLeaveGroup = {},
             onDeleteGroup = {},
-            groupOptionsStateFlow = MutableStateFlow(GroupConversationOptionsState(
-                conversationId = ConversationId("someValue", "someDomain"),
-                groupName = "Group name"
-            )),
+            groupOptionsStateFlow = MutableStateFlow(
+                GroupConversationOptionsState(
+                    conversationId = ConversationId("someValue", "someDomain"),
+                    groupName = "Group name"
+                )
+            ),
             groupParticipantsState = GroupConversationParticipantsState.PREVIEW,
             isLoading = false,
             messages = MutableSharedFlow(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -106,7 +106,7 @@ private fun GroupConversationDetailsContent(
 ) {
     val scope = rememberCoroutineScope()
     // TODO convert to asStateWithLifeCycle
-    val groupOptionsState = groupOptionsStateFlow.collectAsState()
+    val groupOptionsState by groupOptionsStateFlow.collectAsState()
     val lazyListStates: List<LazyListState> = GroupConversationDetailsTabItem.values().map { rememberLazyListState() }
     val initialPageIndex = GroupConversationDetailsTabItem.OPTIONS.ordinal
     val pagerState = rememberPagerState(initialPage = initialPageIndex)
@@ -135,7 +135,7 @@ private fun GroupConversationDetailsContent(
         coroutineScope = rememberCoroutineScope(),
         sheetContent = {
             ConversationGroupDetailsBottomSheet(
-                conversationOptionsState = groupOptionsState.value,
+                conversationOptionsState = groupOptionsState,
                 closeBottomSheet = closeBottomSheet,
                 onDeleteGroup = deleteGroupDialogState::show,
                 onLeaveGroup = leaveGroupDialogState::show

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -66,10 +66,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
     qualifiedIdMapper
 ) {
 
-    init {
-        println("cyka init")
-    }
-
     override val maxNumberOfItems: Int get() = MAX_NUMBER_OF_PARTICIPANTS
 
     private val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
@@ -102,7 +98,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 groupDetailsFlow
                     .collect { groupDetails ->
                         with(groupDetails) {
-                            println("cyka update 1")
                             updateState(
                                 groupOptionsState.copy(
                                     groupName = conversation.name.orEmpty(),
@@ -130,7 +125,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     val isAbleToRemoveGroup = (selfUser.teamId != null
                             && groupDetails.conversation.creatorId.value == selfUser.id.value)
 
-                    println("cyka update 2")
                     updateState(
                         groupOptionsState.copy(
                             isUpdatingAllowed = isSelfAnAdmin,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -94,7 +94,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 .map { it.isSelfAnAdmin }
                 .distinctUntilChanged()
 
-            viewModelScope.launch(dispatcher.io()) {
+            launch {
                 groupDetailsFlow
                     .collect { groupDetails ->
                         with(groupDetails) {
@@ -111,7 +111,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     }
             }
 
-            viewModelScope.launch(dispatcher.io()) {
+            launch {
                 combine(
                     observerSelfUser().take(1),
                     groupDetailsFlow,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -24,6 +23,7 @@ import com.wire.android.model.Clickable
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.collectAsStateLifecycleAware
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.theme.wireColorScheme
@@ -36,7 +36,7 @@ fun GroupConversationOptions(
     viewModel: GroupConversationDetailsViewModel = hiltViewModel(),
     lazyListState: LazyListState
 ) {
-    val state by viewModel.groupOptionsState.collectAsState()
+    val state by viewModel.groupOptionsState.collectAsStateLifecycleAware()
 
     GroupConversationSettings(
         state = state,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,20 +35,22 @@ fun GroupConversationOptions(
     viewModel: GroupConversationDetailsViewModel = hiltViewModel(),
     lazyListState: LazyListState
 ) {
+    val state = viewModel.groupOptionsState.collectAsState()
+
     GroupConversationSettings(
-        state = viewModel.groupOptionsState,
+        state = state.value,
         onGuestSwitchClicked = viewModel::onGuestUpdate,
         onServiceSwitchClicked = viewModel::onServicesUpdate,
         lazyListState = lazyListState
     )
-    if (viewModel.groupOptionsState.changeGuestOptionConfirmationRequired) {
+    if (state.value.changeGuestOptionConfirmationRequired) {
         DisableGuestConfirmationDialog(
             onConfirm = viewModel::onGuestDialogConfirm,
             onDialogDismiss = viewModel::onGuestDialogDismiss
         )
     }
 
-    if (viewModel.groupOptionsState.changeServiceOptionConfirmationRequired) {
+    if (state.value.changeServiceOptionConfirmationRequired) {
         DisableServicesConfirmationDialog(
             onConfirm = viewModel::onServiceDialogConfirm,
             onDialogDismiss = viewModel::onServiceDialogDismiss

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,22 +36,22 @@ fun GroupConversationOptions(
     viewModel: GroupConversationDetailsViewModel = hiltViewModel(),
     lazyListState: LazyListState
 ) {
-    val state = viewModel.groupOptionsState.collectAsState()
+    val state by viewModel.groupOptionsState.collectAsState()
 
     GroupConversationSettings(
-        state = state.value,
+        state = state,
         onGuestSwitchClicked = viewModel::onGuestUpdate,
         onServiceSwitchClicked = viewModel::onServicesUpdate,
         lazyListState = lazyListState
     )
-    if (state.value.changeGuestOptionConfirmationRequired) {
+    if (state.changeGuestOptionConfirmationRequired) {
         DisableGuestConfirmationDialog(
             onConfirm = viewModel::onGuestDialogConfirm,
             onDialogDismiss = viewModel::onGuestDialogDismiss
         )
     }
 
-    if (state.value.changeServiceOptionConfirmationRequired) {
+    if (state.changeServiceOptionConfirmationRequired) {
         DisableServicesConfirmationDialog(
             onConfirm = viewModel::onServiceDialogConfirm,
             onDialogDismiss = viewModel::onServiceDialogDismiss

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -66,7 +66,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(details.conversation.name, viewModel.groupOptionsState.groupName)
+        assertEquals(details.conversation.name,  viewModel.groupOptionsState.value.groupName)
     }
 
     @Test
@@ -90,10 +90,10 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(details1.conversation.name, viewModel.groupOptionsState.groupName)
+        assertEquals(details1.conversation.name,  viewModel.groupOptionsState.value.groupName)
         // When - Then
         arrangement.withConversationDetailUpdate(details2)
-        assertEquals(details2.conversation.name, viewModel.groupOptionsState.groupName)
+        assertEquals(details2.conversation.name,  viewModel.groupOptionsState.value.groupName)
     }
 
     @Test
@@ -130,17 +130,17 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(details.conversation.name, viewModel.groupOptionsState.groupName)
-        assertEquals(conversationParticipantsData.isSelfAnAdmin, viewModel.groupOptionsState.isUpdatingAllowed)
-        assertEquals(details.conversation.name, viewModel.groupOptionsState.groupName)
-        assertEquals(details.conversation.isTeamGroup(), viewModel.groupOptionsState.areAccessOptionsAvailable)
+        assertEquals(details.conversation.name,  viewModel.groupOptionsState.value.groupName)
+        assertEquals(conversationParticipantsData.isSelfAnAdmin,  viewModel.groupOptionsState.value.isUpdatingAllowed)
+        assertEquals(details.conversation.name,  viewModel.groupOptionsState.value.groupName)
+        assertEquals(details.conversation.isTeamGroup(),  viewModel.groupOptionsState.value.areAccessOptionsAvailable)
         assertEquals(
             (details.conversation.isGuestAllowed() || details.conversation.isNonTeamMemberAllowed()),
-            viewModel.groupOptionsState.isGuestAllowed
+             viewModel.groupOptionsState.value.isGuestAllowed
         )
         assertEquals(
             conversationParticipantsData.isSelfAnAdmin && details.conversation.teamId?.value == selfTeam.id,
-            viewModel.groupOptionsState.isUpdatingGuestAllowed
+             viewModel.groupOptionsState.value.isUpdatingGuestAllowed
         )
     }
 
@@ -202,7 +202,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onGuestUpdate(false)
-        assertEquals(true, viewModel.groupOptionsState.changeGuestOptionConfirmationRequired)
+        assertEquals(true,  viewModel.groupOptionsState.value.changeGuestOptionConfirmationRequired)
     }
 
     @Test
@@ -229,7 +229,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onGuestDialogConfirm()
-        assertEquals(false, viewModel.groupOptionsState.changeGuestOptionConfirmationRequired)
+        assertEquals(false,  viewModel.groupOptionsState.value.changeGuestOptionConfirmationRequired)
         coVerify(exactly = 1) {
             arrangement.updateConversationAccessRoleUseCase(
                 conversationId = details.conversation.id,
@@ -264,7 +264,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onServicesUpdate(false)
-        assertEquals(true, viewModel.groupOptionsState.changeServiceOptionConfirmationRequired)
+        assertEquals(true,  viewModel.groupOptionsState.value.changeServiceOptionConfirmationRequired)
     }
 
     @Test
@@ -325,7 +325,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onServiceDialogConfirm()
-        assertEquals(false, viewModel.groupOptionsState.changeServiceOptionConfirmationRequired)
+        assertEquals(false,  viewModel.groupOptionsState.value.changeServiceOptionConfirmationRequired)
         coVerify(exactly = 1) {
             arrangement.updateConversationAccessRoleUseCase(
                 conversationId = details.conversation.id,
@@ -349,7 +349,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(true, viewModel.groupOptionsState.isUpdatingGuestAllowed)
+        assertEquals(true,  viewModel.groupOptionsState.value.isUpdatingGuestAllowed)
     }
 
     @Test
@@ -365,7 +365,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(false, viewModel.groupOptionsState.isUpdatingGuestAllowed)
+        assertEquals(false,  viewModel.groupOptionsState.value.isUpdatingGuestAllowed)
     }
 
     companion object {


### PR DESCRIPTION
# What's new in this PR?

### Issues

GroupConversationDetails was flickering (loading to much time)

### Causes (Optional)

- getting all the necessary data in UI dispatcher
- waiting for all Flows to emit at least once and display the data only after that

### Solutions

- move all DB operations into IO dispatcher
- update ScreenState in portions when some part of the data is got - display it. Do not wait for all data to display all at once.
- change `groupOptionsState` from `State` to `StateFlow` so we can update in from any dispatcher without any risc 

### Attachments (Optional)

#### Was before: 

https://user-images.githubusercontent.com/6539347/189315897-ede082e8-4412-45b2-8cfa-3277e9c0a4ed.mp4

#### Become:

https://user-images.githubusercontent.com/6539347/189316137-e0397602-0c06-4cb5-ba56-6be378290ca4.mp4



