### PR TITLE
fix: flickering in selfuser screen (AR-2338)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -79,11 +79,9 @@ class SelfUserProfileViewModel @Inject constructor(
 
     private fun observeEstablishedCall() {
         viewModelScope.launch {
-            observeEstablishedCalls()
-                .map { it.isNotEmpty() }
+            val establishedCalls = withContext(dispatchers.io()) { observeEstablishedCalls() }
+            establishedCalls.map { it.isNotEmpty() }
                 .distinctUntilChanged()
-                .flowOn(dispatchers.io())
-                .shareIn(this, SharingStarted.WhileSubscribed(1))
                 .collect {
                     userProfileState = userProfileState.copy(isUserInCall = it)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -15,7 +15,6 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.ui.common.topappbar.ConnectivityUIState
 import com.wire.android.ui.userprofile.self.dialog.StatusDialogData
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -26,7 +25,6 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
-import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
@@ -36,10 +34,13 @@ import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -78,18 +79,26 @@ class SelfUserProfileViewModel @Inject constructor(
 
     private fun observeEstablishedCall() {
         viewModelScope.launch {
-            observeEstablishedCalls().map { it.isNotEmpty() }.distinctUntilChanged().collect {
-                userProfileState = userProfileState.copy(isUserInCall = it)
-            }
+            observeEstablishedCalls()
+                .map { it.isNotEmpty() }
+                .distinctUntilChanged()
+                .flowOn(dispatchers.io())
+                .shareIn(this, SharingStarted.WhileSubscribed(1))
+                .collect {
+                    userProfileState = userProfileState.copy(isUserInCall = it)
+                }
         }
     }
 
     private suspend fun fetchSelfUser() {
         viewModelScope.launch {
+            val self = getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
+            val selfTeam = getSelfTeam().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
+            val validAccounts = observeValidAccounts().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
             combine(
-                getSelf(),
-                getSelfTeam(),
-                observeValidAccounts()
+                self,
+                selfTeam,
+                validAccounts
             ) { selfUser: SelfUser, team: Team?, list: List<Pair<SelfUser, Team?>> ->
                 Triple(
                     selfUser,
@@ -125,7 +134,6 @@ class SelfUserProfileViewModel @Inject constructor(
     }
 
     private fun updateUserAvatar(avatarAssetId: UserAssetId) {
-
         if (avatarAssetId == userProfileState.avatarAsset?.userAssetId) {
             return
         }
@@ -133,21 +141,19 @@ class SelfUserProfileViewModel @Inject constructor(
         // We try to download the user avatar on a separate thread so that we don't block the display of the user's info
         viewModelScope.launch {
             showLoadingAvatar(true)
-            withContext(dispatchers.io()) {
-                try {
-                    userProfileState = userProfileState.copy(
-                        avatarAsset = UserAvatarAsset(wireSessionImageLoader, avatarAssetId)
-                    )
-
-                    // Update avatar asset id on user data store
-                    // TODO: obtain the asset id through a useCase once we also store assets ids
-                    dataStore.updateUserAvatarAssetId(avatarAssetId.toString())
-                } catch (e: ClassCastException) {
-                    appLogger.e("There was an error while downloading the user avatar", e)
-                    // Show error snackbar if avatar download fails
-                    showErrorMessage()
-                }
+            try {
+                userProfileState = userProfileState.copy(
+                    avatarAsset = UserAvatarAsset(wireSessionImageLoader, avatarAssetId)
+                )
+                // Update avatar asset id on user data store
+                // TODO: obtain the asset id through a useCase once we also store assets ids
+                withContext(dispatchers.io()) { dataStore.updateUserAvatarAssetId(avatarAssetId.toString()) }
+            } catch (e: ClassCastException) {
+                appLogger.e("There was an error while downloading the user avatar", e)
+                // Show error snackbar if avatar download fails
+                showErrorMessage()
             }
+
             showLoadingAvatar(false)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2338" title="AR-2338" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2338</a>  [SPIKE] PoC Navigation with parameters - self user profile screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Solves flickering of userprofile screen by handling proper dispatcher for operations.
Note: This also solves the flickering when clicking on change user availability 

### Attachments (Optional)

[device-2022-09-09-101457.webm](https://user-images.githubusercontent.com/5806454/189304640-79b3411e-d2af-4f53-ba45-63883cac46c5.webm)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
