### PR TITLE
fix: random crash when opening conversation list

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -56,6 +56,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Date
@@ -90,9 +91,10 @@ class ConversationListViewModel @Inject constructor(
         startObservingConversationsAndConnections()
     }
 
-    private fun startObservingConversationsAndConnections() = viewModelScope.launch(dispatcher.io()) {
-        observeConversationsAndConnections() // TODO AR-1736
+    private fun startObservingConversationsAndConnections() = viewModelScope.launch {
+        observeConversationsAndConnections()
             .combine(observeSelfUser(), ::Pair)
+            .flowOn(dispatcher.io())
             .collect { (conversationListDetails, selfUser) ->
                 with(conversationListDetails) {
                     selfUserId = selfUser.id


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Random crash happening some times when opening the Conversation List

### Causes

We're updating the `state` outside the `main` thread.

### Solutions

We can flow on the IO Dispatcher but collect the Flow items in the Main thread.

### Testing

Manually tested on my device.
Went from around 50% crash rate to 0%.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
