### PR TITLE
chore: upgrade android build tools to 7.2.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 private object Dependencies {
-    const val androidBuildTools = "com.android.tools.build:gradle:7.0.4"
+    const val androidBuildTools = "com.android.tools.build:gradle:7.2.2"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have plenty of warnings when building the app, as we're targeting an Android version that is newer than the build plugin.

```
We recommend using a newer Android Gradle plugin to use compileSdk = 32

This Android Gradle plugin (7.0.4) was tested up to compileSdk = 31

This warning can be suppressed by adding
    android.suppressUnsupportedCompileSdk=32
to this project's gradle.properties

The build will continue, but you are strongly encouraged to update your project to
use a newer Android Gradle Plugin that has been tested with compileSdk = 32
```

### Solutions

Upgrade it to the newest stable version (7.2.2)

### Dependencies

Needs releases with the Kalium counter-part:

- https://github.com/wireapp/kalium/pull/883

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
