### PR TITLE
chore: use new message by id usecase to fetch asset content (AR-1882)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -40,10 +40,10 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusU
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
-import com.wire.kalium.logic.feature.publicuser.search.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchPublicUsersUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
@@ -77,7 +77,6 @@ annotation class KaliumCoreLogic
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class CurrentSessionFlowService
-
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -420,6 +419,13 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): GetMessageAssetUseCase = coreLogic.getSessionScope(currentAccount).messages.getAssetMessage
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetMessageByIdUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): GetMessageByIdUseCase = coreLogic.getSessionScope(currentAccount).messages.getMessageById
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.util.isGreaterThan
 import javax.inject.Inject
-import com.wire.android.ui.home.conversations.model.UIMessageContent as UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 
 // TODO: splits mapping into more classes
 class MessageContentMapper @Inject constructor(

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.util.isGreaterThan
 import javax.inject.Inject
-import com.wire.android.ui.home.conversations.model.MessageContent as UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent as UIMessageContent
 
 // TODO: splits mapping into more classes
 class MessageContentMapper @Inject constructor(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -57,7 +57,7 @@ import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewM
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewState
 import com.wire.android.ui.home.conversations.mock.getMockedMessages
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
-import com.wire.android.ui.home.conversations.model.MessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.messagecomposer.KeyboardHeight
@@ -447,7 +447,7 @@ fun MessageList(
         items(messages, key = {
             it.messageHeader.messageId
         }) { message ->
-            if (message.messageContent is MessageContent.SystemMessage) {
+            if (message.messageContent is UIMessageContent.SystemMessage) {
                 SystemMessageItem(message = message.messageContent)
             } else {
                 MessageItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.UIMessage
-import com.wire.android.ui.home.conversations.model.MessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.MessageSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -70,7 +70,7 @@ class ConversationScreenState(
 
     fun copyMessage() {
         selectedMessage?.messageContent.let { messageContent ->
-            if (messageContent is MessageContent.TextMessage) {
+            if (messageContent is UIMessageContent.TextMessage) {
                 clipboardManager.setText(AnnotatedString(messageContent.messageBody.message.asString(context.resources)))
                 coroutineScope.launch {
                     modalBottomSheetState.animateTo(ModalBottomSheetValue.Hidden)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -38,7 +38,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.model.ImageMessageParams
 import com.wire.android.ui.home.conversations.model.MessageAsset
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageImage
 import com.wire.android.ui.home.conversations.model.MessageSource
@@ -201,32 +201,32 @@ private fun Username(username: String, modifier: Modifier = Modifier) {
 
 @Composable
 private fun MessageContent(
-    messageContent: MessageContent?,
+    messageContent: UIMessageContent?,
     onAssetClick: Clickable,
     onImageClick: Clickable,
     onLongClick: (() -> Unit)? = null
 ) {
     when (messageContent) {
-        is MessageContent.ImageMessage -> MessageImage(
+        is UIMessageContent.ImageMessage -> MessageImage(
             rawImgData = messageContent.imgData,
             imgParams = ImageMessageParams(messageContent.width, messageContent.height),
             onImageClick = onImageClick
         )
-        is MessageContent.TextMessage -> MessageBody(
+        is UIMessageContent.TextMessage -> MessageBody(
             messageBody = messageContent.messageBody,
             onLongClick = onLongClick
         )
-        is MessageContent.AssetMessage -> MessageAsset(
+        is UIMessageContent.AssetMessage -> MessageAsset(
             assetName = messageContent.assetName,
             assetExtension = messageContent.assetExtension,
             assetSizeInBytes = messageContent.assetSizeInBytes,
             assetDownloadStatus = messageContent.downloadStatus,
             onAssetClick = onAssetClick
         )
-        is MessageContent.SystemMessage.MemberAdded -> {}
-        is MessageContent.SystemMessage.MemberLeft -> {}
-        is MessageContent.SystemMessage.MemberRemoved -> {}
-        is MessageContent.RestrictedAsset -> {
+        is UIMessageContent.SystemMessage.MemberAdded -> {}
+        is UIMessageContent.SystemMessage.MemberLeft -> {}
+        is UIMessageContent.SystemMessage.MemberRemoved -> {}
+        is UIMessageContent.RestrictedAsset -> {
             when {
                 messageContent.mimeType.contains("image/") -> {
                     RestrictedAssetMessage(R.drawable.ic_gallery, stringResource(id = R.string.prohibited_images_message))

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.home.conversations.model.MessageContent.SystemMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.SystemMessage
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -11,7 +11,6 @@ import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.home.conversations.ConversationAvatar
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
-import com.wire.android.ui.home.conversations.model.MessageContent
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
@@ -20,10 +19,12 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
@@ -40,6 +41,7 @@ class ConversationMessagesViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val getMessageAsset: GetMessageAssetUseCase,
+    private val getMessageByIdUseCase: GetMessageByIdUseCase,
     private val updateAssetMessageDownloadStatus: UpdateAssetMessageDownloadStatusUseCase,
     private val fileManager: FileManager,
     private val dispatchers: DispatcherProvider,
@@ -111,20 +113,26 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     private suspend fun attemptDownloadOfAsset(messageId: String) {
-        val assetMessage = conversationViewState.messages.firstOrNull {
-            it.messageHeader.messageId == messageId && it.messageContent is MessageContent.AssetMessage
+        val messageDataResult = getMessageByIdUseCase(conversationId, messageId)
+        if (messageDataResult !is GetMessageByIdUseCase.Result.Success) {
+            appLogger.w("Failed when fetching details of message to download asset: $messageDataResult")
+            return
         }
+        val message = messageDataResult.message
+        val messageContent = message.content
 
-        val messageContent = assetMessage?.messageContent
-        val (isAssetDownloadedInternally, assetName, assetSize) = (messageContent as MessageContent.AssetMessage).run {
-            Triple(
-                (downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY || downloadStatus == Message.DownloadStatus.IN_PROGRESS),
-                assetName,
-                assetSizeInBytes
-            )
+        if (messageContent !is MessageContent.Asset) {
+            // This _should_ not even happen, tho. Unless UI is buggy. So... do we crash?! Better not.
+            appLogger.w("Attempting to download assets of a non-asset message. Ignoring user input.")
+            return
         }
+        val assetContent = messageContent.value
+        val downloadStatus = assetContent.downloadStatus
+        val isAssetDownloadedInternally = downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY ||
+                downloadStatus == Message.DownloadStatus.IN_PROGRESS
 
         if (!isAssetDownloadedInternally)
+            // TODO: Refactor. UseCase responsible for downloading should update to IN_PROGRESS status.
             updateAssetMessageDownloadStatus(Message.DownloadStatus.IN_PROGRESS, conversationId, messageId)
 
         val resultData = assetDataPath(conversationId, messageId)
@@ -135,7 +143,7 @@ class ConversationMessagesViewModel @Inject constructor(
         )
 
         if (resultData != null) {
-            showOnAssetDownloadedDialog(assetName, resultData, assetSize, messageId)
+            showOnAssetDownloadedDialog(assetContent.name ?: "", resultData, assetContent.sizeInBytes, messageId)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.withContext
 import okio.Path
 import javax.inject.Inject
 
-
 @HiltViewModel
 @Suppress("LongParameterList")
 class ConversationMessagesViewModel @Inject constructor(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -11,7 +11,7 @@ import coil.request.ImageResult
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
@@ -36,7 +36,7 @@ val mockMessageWithText = UIMessage(
         messageId = "",
         connectionState = ConnectionState.ACCEPTED
     ),
-    messageContent = MessageContent.TextMessage(
+    messageContent = UIMessageContent.TextMessage(
         messageBody = MessageBody(
             UIText.DynamicString(
                 "This is some test message that is very very" +
@@ -74,7 +74,7 @@ val mockAssetMessage = UIMessage(
         messageId = "",
         connectionState = ConnectionState.ACCEPTED
     ),
-    messageContent = MessageContent.AssetMessage(
+    messageContent = UIMessageContent.AssetMessage(
         assetName = "This is some test asset message",
         assetExtension = "ZIP",
         assetId = UserAssetId("asset", "domain"),
@@ -85,7 +85,7 @@ val mockAssetMessage = UIMessage(
 )
 
 @Suppress("MagicNumber")
-val mockedImg = MessageContent.ImageMessage(UserAssetId("a", "domain"), ByteArray(16), 0, 0)
+val mockedImg = UIMessageContent.ImageMessage(UserAssetId("a", "domain"), ByteArray(16), 0, 0)
 
 @Suppress("LongMethod", "MagicNumber")
 fun getMockedMessages(): List<UIMessage> = listOf(
@@ -100,7 +100,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageId = "1",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = MessageContent.TextMessage(
+        messageContent = UIMessageContent.TextMessage(
             messageBody = MessageBody(
                 UIText.DynamicString(
                     "This is some test message that is very very" +
@@ -165,7 +165,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageId = "5",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = MessageContent.TextMessage(
+        messageContent = UIMessageContent.TextMessage(
             messageBody = MessageBody(
                 UIText.DynamicString(
                     "This is some test message that is very very" +
@@ -202,7 +202,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageId = "7",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = MessageContent.TextMessage(
+        messageContent = UIMessageContent.TextMessage(
             messageBody = MessageBody(
                 UIText.DynamicString(
                     "This is some test message that is very very" +

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -64,9 +64,9 @@ fun PreviewMessageWithSystemMessage() {
             onAssetMessageClicked = {},
             onImageMessageClicked = { _, _ -> },
             onAvatarClicked = { _, _ -> })
-        SystemMessageItem(MessageContent.SystemMessage.MissedCall.YouCalled(UIText.DynamicString("You")))
+        SystemMessageItem(UIMessageContent.SystemMessage.MissedCall.YouCalled(UIText.DynamicString("You")))
         SystemMessageItem(
-            MessageContent.SystemMessage.MemberAdded(
+            UIMessageContent.SystemMessage.MemberAdded(
                 UIText.DynamicString("You"),
                 listOf(UIText.DynamicString("Adam Smith"))
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -21,7 +21,7 @@ data class UIMessage(
     val userAvatarData: UserAvatarData,
     val messageSource: MessageSource,
     val messageHeader: MessageHeader,
-    val messageContent: MessageContent?,
+    val messageContent: UIMessageContent?,
 ) {
     val isDeleted: Boolean = messageHeader.messageStatus == Deleted
     val sendingFailed: Boolean = messageHeader.messageStatus == SendFailure
@@ -52,9 +52,9 @@ sealed class MessageStatus(val text: UIText) {
     object DecryptionFailure : MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
 }
 
-sealed class MessageContent {
+sealed class UIMessageContent {
 
-    sealed class ClientMessage : MessageContent()
+    sealed class ClientMessage : UIMessageContent()
 
     data class TextMessage(val messageBody: MessageBody) : ClientMessage()
 
@@ -73,7 +73,7 @@ sealed class MessageContent {
         val downloadStatus: Message.DownloadStatus
     ) : ClientMessage()
 
-    data class ImageMessage(val assetId: AssetId, val imgData: ByteArray?, val width: Int, val height: Int) : MessageContent() {
+    data class ImageMessage(val assetId: AssetId, val imgData: ByteArray?, val width: Int, val height: Int) : UIMessageContent() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -92,7 +92,7 @@ sealed class MessageContent {
         @DrawableRes val iconResId: Int?,
         @StringRes open val stringResId: Int,
         val isSmallIcon: Boolean = true
-    ) : MessageContent() {
+    ) : UIMessageContent() {
 
         data class MemberAdded(
             val author: UIText,

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -2,7 +2,7 @@ package com.wire.android.framework
 
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent.TextMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.TextMessage
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
@@ -40,6 +40,16 @@ object TestMessage {
     )
     val ASSET_IMAGE_CONTENT = AssetContent(
         0L, "name", "image/jpg", AssetContent.AssetMetadata.Image(100, 100), DUMMY_ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
+    )
+    val ASSET_MESSAGE = Message.Regular(
+        id = "messageID",
+        content = MessageContent.Asset(ASSET_IMAGE_CONTENT),
+        conversationId = ConversationId("convo-id", "convo.domain"),
+        date = "some-date",
+        senderUserId = UserId("user-id", "domain"),
+        senderClientId = ClientId("client-id"),
+        status = Message.Status.SENT,
+        editStatus = Message.EditStatus.NotEdited
     )
     val MEMBER_REMOVED_MESSAGE = Message.System(
         id = "messageID",

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -5,9 +5,9 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestUser
-import com.wire.android.ui.home.conversations.model.MessageContent.AssetMessage
-import com.wire.android.ui.home.conversations.model.MessageContent.ImageMessage
-import com.wire.android.ui.home.conversations.model.MessageContent.SystemMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.AssetMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.ImageMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.SystemMessage
 import com.wire.android.ui.home.conversations.name
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Conversation.Member

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -5,7 +5,7 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent.TextMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent.TextMessage
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/GetMessageForConversationsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/GetMessageForConversationsUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.mapper.MessageMapper
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
@@ -97,7 +97,7 @@ class GetMessageForConversationsUseCaseTest {
                 with(onlyMessage) {
                     assertEquals(expectedUserName, (messageHeader.username as UIText.DynamicString).value)
 
-                    val messageBody = (messageContent as MessageContent.TextMessage).messageBody
+                    val messageBody = (messageContent as UIMessageContent.TextMessage).messageBody
                     assertEquals(expectedMessageBody, ((messageBody.message as UIText.DynamicString).value))
                 }
             }
@@ -138,7 +138,7 @@ class GetMessageForConversationsUseCaseTest {
                 every { it.messageTime } returns MessageTime("")
                 every { it.messageStatus } returns MessageStatus.Untouched
             }
-            every { it.messageContent } returns MessageContent.TextMessage(MessageBody(UIText.DynamicString(messageBody)))
+            every { it.messageContent } returns UIMessageContent.TextMessage(MessageBody(UIText.DynamicString(messageBody)))
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -12,9 +12,13 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
+import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -43,6 +47,9 @@ class ConversationMessagesViewModelArrangement {
     lateinit var getMessagesForConversationUseCase: GetMessagesForConversationUseCase
 
     @MockK
+    lateinit var getMessageById: GetMessageByIdUseCase
+
+    @MockK
     lateinit var observeConversationDetails: ObserveConversationDetailsUseCase
 
     @MockK
@@ -66,6 +73,7 @@ class ConversationMessagesViewModelArrangement {
             savedStateHandle,
             observeConversationDetails,
             getMessageAsset,
+            getMessageById,
             updateAssetMessageDownloadStatus,
             fileManager,
             TestDispatcherProvider(),
@@ -83,6 +91,7 @@ class ConversationMessagesViewModelArrangement {
         } returns QualifiedID("some-dummy-value", "some.dummy.domain")
         coEvery { observeConversationDetails(any()) } returns flowOf()
         coEvery { getMessagesForConversationUseCase(any()) } returns flowOf(listOf())
+        coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
     }
 
     suspend fun withSuccessfulViewModelInit() = apply {
@@ -99,6 +108,14 @@ class ConversationMessagesViewModelArrangement {
         every { fileManager.openWithExternalApp(any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
         }
+    }
+
+    fun withGetMessageByIdReturning(message: Message) = apply {
+        coEvery { getMessageById(any(), any()) } returns GetMessageByIdUseCase.Result.Success(message)
+    }
+
+    fun withGetMessageAssetUseCaseReturning(decodedAssetPath: Path, assetSize: Long) = apply {
+        coEvery { getMessageAsset(any(), any()) } returns MessageAssetResult.Success(decodedAssetPath, assetSize)
     }
 
     suspend fun withMessagesUpdate(messages: List<UIMessage>) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.home.conversations.messages
 
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.framework.TestMessage
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
 import com.wire.android.ui.home.conversations.mockConversationDetailsGroup
 import com.wire.android.ui.home.conversations.mockUITextMessage
@@ -24,6 +25,19 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(CoroutineTestExtension::class)
 class ConversationMessagesViewModelTest {
 
+    @Test
+    fun `given an message ID, when downloading or fetching into internal storage, then should get message details by ID`() = runTest {
+        val message = TestMessage.ASSET_MESSAGE
+        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withGetMessageAssetUseCaseReturning("path".toPath(), 42L)
+            .withGetMessageByIdReturning(message)
+            .arrange()
+
+        viewModel.downloadOrFetchAssetToInternalStorage(message.id)
+
+        coVerify(exactly = 1) { arrangement.getMessageById(arrangement.conversationId, message.id) }
+    }
 
     @Test
     fun `given an asset message, when opening it, then the file manager open function gets invoked and closes the dialog`() = runTest {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1882" title="AR-1882" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-1882</a>  Paginate Messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we're iterating through the list of UI messages in order to get asset information to start downloading assets.
With pagination, we don't have always a list of messages we can simply fetch details from. Also, it is not very performant iterating through messages once the user scrolls a lot and the list of messages become huge.

### Solutions

- Use the new `GetMessageByIdUseCase` added into Kalium recently instead of iterating through a list.
- Rename Reloaded's `MessageContent` to `UIMessageContent`, so it doesn't conflict with Kalium's `MessageContent`

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

- Go to a conversation
- Receive an Asset message
- Click on it

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
