### PR TITLE
feat: flowable search users (AR-2293)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
-import com.wire.kalium.logic.feature.publicuser.search.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchPublicUsersUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import com.wire.kalium.logic.feature.publicuser.search.Result as KnownUserSearchResult
+import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult as KnownUserSearchResult
 
 @Suppress("LongParameterList")
 @HiltViewModel

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
@@ -94,14 +94,13 @@ class AddMembersToConversationViewModel @Inject constructor(
                 selfUserIncluded = false
             )
         )
-            .flowOn(dispatchers.io())
             .map { result ->
                 when (result) {
                     is KnownUserSearchResult.Failure.Generic -> ContactSearchResult.InternalContact(
                         SearchResultState.Failure(R.string.label_general_error)
                     )
                     KnownUserSearchResult.Failure.InvalidQuery -> ContactSearchResult.InternalContact(
-                        SearchResultState.Failure(R.string.label_general_error)
+                        SearchResultState.Failure(R.string.label_no_results_found)
                     )
                     KnownUserSearchResult.Failure.InvalidRequest -> ContactSearchResult.InternalContact(
                         SearchResultState.Failure(R.string.label_general_error)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/AddMembersToConversationViewModel.kt
@@ -26,7 +26,10 @@ import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversatio
 import com.wire.kalium.logic.feature.conversation.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -83,35 +86,35 @@ class AddMembersToConversationViewModel @Inject constructor(
             }
         }
 
-    override suspend fun searchKnownPeople(searchTerm: String): ContactSearchResult.InternalContact {
-        val result = withContext(dispatchers.io()) {
-            searchKnownUsers(
-                searchQuery = searchTerm,
-                searchUsersOptions = SearchUsersOptions(
-                    conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(conversationId),
-                    selfUserIncluded = false
-                )
+    override suspend fun searchKnownPeople(searchTerm: String): Flow<ContactSearchResult.InternalContact> {
+       return searchKnownUsers(
+            searchQuery = searchTerm,
+            searchUsersOptions = SearchUsersOptions(
+                conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(conversationId),
+                selfUserIncluded = false
             )
-        }
-
-        return when (result) {
-            is KnownUserSearchResult.Failure.Generic -> ContactSearchResult.InternalContact(
-                SearchResultState.Failure(R.string.label_general_error)
-            )
-            KnownUserSearchResult.Failure.InvalidQuery -> ContactSearchResult.InternalContact(
-                SearchResultState.Failure(R.string.label_general_error)
-            )
-            KnownUserSearchResult.Failure.InvalidRequest -> ContactSearchResult.InternalContact(
-                SearchResultState.Failure(R.string.label_general_error)
-            )
-            is KnownUserSearchResult.Success -> ContactSearchResult.InternalContact(
-                SearchResultState.Success(
-                    result.userSearchResult.result.map(
-                        contactMapper::fromOtherUser
+        )
+            .flowOn(dispatchers.io())
+            .map { result ->
+                when (result) {
+                    is KnownUserSearchResult.Failure.Generic -> ContactSearchResult.InternalContact(
+                        SearchResultState.Failure(R.string.label_general_error)
                     )
-                )
-            )
-        }
+                    KnownUserSearchResult.Failure.InvalidQuery -> ContactSearchResult.InternalContact(
+                        SearchResultState.Failure(R.string.label_general_error)
+                    )
+                    KnownUserSearchResult.Failure.InvalidRequest -> ContactSearchResult.InternalContact(
+                        SearchResultState.Failure(R.string.label_general_error)
+                    )
+                    is KnownUserSearchResult.Success -> ContactSearchResult.InternalContact(
+                        SearchResultState.Success(
+                            result.userSearchResult.result.map(
+                                contactMapper::fromOtherUser
+                            )
+                        )
+                    )
+                }
+            }
     }
 
     fun addMembersToConversation() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -55,13 +54,6 @@ fun SearchPeopleRouter(
     onGroupSelectionSubmitAction: () -> Unit,
     searchAllPeopleViewModel: SearchAllPeopleViewModel,
 ) {
-
-    LaunchedEffect(searchAllPeopleViewModel.savedStateHandle) {
-        // to have an updated result if something changed
-        // after user came back from some other screen
-        searchAllPeopleViewModel.refreshResult()
-    }
-
     SearchPeopleContent(
         searchPeopleState = searchAllPeopleViewModel.state,
         searchTitle = stringResource(id = R.string.label_new_conversation),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
@@ -146,18 +146,11 @@ abstract class PublicWithKnownPeopleSearchViewModel(
     navigationManager = navigationManager
 ) {
 
-    private val refreshPublicResult: MutableSharedFlow<PublicRefresh> = MutableSharedFlow(0)
-
     protected val publicPeopleSearchQueryFlow = mutableSearchQueryFlow
-        .combine(refreshPublicResult.onSubscription { emit(PublicRefresh()) })
-        { searchTerm, publicRefresh ->
-            searchTerm to publicRefresh
-        }.flatMapLatest { (searchTerm, publicRefresh) ->
+        .flatMapLatest { searchTerm ->
             searchPublicPeople(searchTerm)
                 .onStart {
-                    if (publicRefresh.withProgress) {
-                        emit(ContactSearchResult.ExternalContact(SearchResultState.InProgress))
-                    }
+                    emit(ContactSearchResult.ExternalContact(SearchResultState.InProgress))
                 }
         }
 
@@ -170,7 +163,6 @@ abstract class PublicWithKnownPeopleSearchViewModel(
                     appLogger.d(("Couldn't send a connect request to user $userId"))
                 }
                 is SendConnectionRequestResult.Success -> {
-                    refreshPublicResult.emit(PublicRefresh(withProgress = false))
                     snackbarMessageState = NewConversationSnackbarState.SuccessSendConnectionRequest
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.mapper.ContactMapper
@@ -33,7 +32,6 @@ import javax.inject.Inject
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
 class NewConversationViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
     private val createGroupConversation: CreateGroupConversationUseCase,
     getAllKnownUsers: GetAllContactsUseCase,
     searchKnownUsers: SearchKnownUsersUseCase,
@@ -44,7 +42,6 @@ class NewConversationViewModel @Inject constructor(
     sendConnectionRequest: SendConnectionRequestUseCase,
     navigationManager: NavigationManager
 ) : SearchAllPeopleViewModel(
-    savedStateHandle = savedStateHandle,
     getAllKnownUsers = getAllKnownUsers,
     sendConnectionRequest = sendConnectionRequest,
     searchKnownUsers = searchKnownUsers,

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -43,8 +43,12 @@ internal class NewConversationViewModelArrangement {
 
         // Default empty values
         coEvery { isMLSEnabledUseCase() } returns true
-        coEvery { searchPublicUsers(any()) } returns flowOf(SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER))))
-        coEvery { searchKnownUsers(any()) } returns SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
+        coEvery { searchPublicUsers(any()) } returns flowOf(
+            SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER)))
+        )
+        coEvery { searchKnownUsers(any()) } returns flowOf(
+            SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
+        )
         coEvery { getAllKnownUsers() } returns GetAllContactsResult.Success(listOf())
         coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.Success(CONVERSATION)
         coEvery { contactMapper.fromOtherUser(PUBLIC_USER) } returns Contact(
@@ -159,7 +163,6 @@ internal class NewConversationViewModelArrangement {
 
     private val viewModel by lazy {
         NewConversationViewModel(
-            savedStateHandle = savedStateHandle,
             navigationManager = navigationManager,
             searchPublicUsers = searchPublicUsers,
             searchKnownUsers = searchKnownUsers,
@@ -173,7 +176,7 @@ internal class NewConversationViewModelArrangement {
     }
 
     fun withFailureKnownSearchResponse() = apply {
-        coEvery { searchKnownUsers(any()) } returns SearchUsersResult.Failure.InvalidRequest
+        coEvery { searchKnownUsers(any()) } returns flowOf(SearchUsersResult.Failure.InvalidRequest)
     }
 
     fun withFailurePublicSearchResponse() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -27,14 +27,13 @@ import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
-import com.wire.kalium.logic.feature.publicuser.search.Result
+import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchPublicUsersUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
 internal class NewConversationViewModelArrangement {
@@ -44,8 +43,8 @@ internal class NewConversationViewModelArrangement {
 
         // Default empty values
         coEvery { isMLSEnabledUseCase() } returns true
-        coEvery { searchPublicUsers(any()) } returns flowOf(Result.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER))))
-        coEvery { searchKnownUsers(any()) } returns Result.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
+        coEvery { searchPublicUsers(any()) } returns flowOf(SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER))))
+        coEvery { searchKnownUsers(any()) } returns SearchUsersResult.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
         coEvery { getAllKnownUsers() } returns GetAllContactsResult.Success(listOf())
         coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.Success(CONVERSATION)
         coEvery { contactMapper.fromOtherUser(PUBLIC_USER) } returns Contact(
@@ -174,11 +173,11 @@ internal class NewConversationViewModelArrangement {
     }
 
     fun withFailureKnownSearchResponse() = apply {
-        coEvery { searchKnownUsers(any()) } returns Result.Failure.InvalidRequest
+        coEvery { searchKnownUsers(any()) } returns SearchUsersResult.Failure.InvalidRequest
     }
 
     fun withFailurePublicSearchResponse() = apply {
-        coEvery { searchPublicUsers(any()) } returns flowOf(Result.Failure.InvalidRequest)
+        coEvery { searchPublicUsers(any()) } returns flowOf(SearchUsersResult.Failure.InvalidRequest)
     }
 
     fun withSyncFailureOnCreatingGroup() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2293" title="AR-2293" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2293</a>  While there is a pending connection request between two users, the receiver should not be able to send a new one
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Searching users (public and internal) was static (we were not listening to any changes in our contact's DB). 
Now we are listening in search to any changes in DB so if there are some changes in the contacts list, the search will refresh and show those changes. For example after changing the connection status to the accepted, user in search should be moved from public search to internal search (attached video).

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

https://user-images.githubusercontent.com/13151239/189639870-68368700-82fe-4a75-b37e-a7a034465c08.mov


 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
