### PR TITLE
fix: no details or slow conversation details access (AR-2380)

### DIFF
--- a/app/src/test/kotlin/com/wire/android/config/TestDispatcherProvider.kt
+++ b/app/src/test/kotlin/com/wire/android/config/TestDispatcherProvider.kt
@@ -3,7 +3,6 @@ package com.wire.android.config
 import com.wire.android.util.dispatchers.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
@@ -11,15 +10,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TestDispatcherProvider(private val dispatcher: CoroutineDispatcher = UnconfinedTestDispatcher()) : DispatcherProvider {
-    override fun main() = dispatcher
-    override fun io() = dispatcher
-    override fun default() = dispatcher
-    override fun unconfined() = dispatcher
-}
-
-
-@OptIn(ExperimentalCoroutinesApi::class)
-class TestDispatcherProvider2(private val dispatcher: CoroutineDispatcher = StandardTestDispatcher()) : DispatcherProvider {
     override fun main() = dispatcher
     override fun io() = dispatcher
     override fun default() = dispatcher

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.home.conversations.info
 
 import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -45,7 +46,8 @@ class ConversationInfoViewModelArrangement {
             savedStateHandle,
             navigationManager,
             observeConversationDetails,
-            wireSessionImageLoader
+            wireSessionImageLoader,
+            TestDispatcherProvider()
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2380" title="AR-2380" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2380</a>  Can't access group details anymore or it takes very long to be able to access it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We can't load immediately the conversation details access and navigate, only this become available after some recomposition triggered by user actions.

### Solutions

Load the Conversation Details Data (compute if the current user can have access to edit, or click in top header) before assigning new state data

### Testing

Manually tested, a video is attached to show the fixed behavior.

### Attachments (Optional)

[device-2022-09-12-155943.webm](https://user-images.githubusercontent.com/5806454/189673538-fddf94b9-c13b-405e-a9c2-90854df6f907.webm)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
