### PR TITLE
fix: Video freezes on a group video call (AR-2316)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -1,5 +1,6 @@
 package com.wire.android.ui.calling
 
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
@@ -85,12 +86,37 @@ fun ParticipantTile(
                     onClearSelfUserVideoPreview = onClearSelfUserVideoPreview
                 )
             } else {
-                OthersVideo(
-                    isCameraOn = participantTitleState.isCameraOn,
-                    isSharingScreen = participantTitleState.isSharingScreen,
-                    userId = participantTitleState.id.toString(),
-                    clientId = participantTitleState.clientId
+
+                val context = LocalContext.current
+                AndroidView(factory = {
+                    FrameLayout(it)
+                },
+                    update = {
+                        it.removeAllViews()
+
+                        if (participantTitleState.isCameraOn || participantTitleState.isSharingScreen) {
+
+                            val videoRenderer = VideoRenderer(
+                                context,
+                                participantTitleState.id.toString(),
+                                participantTitleState.clientId,
+                                false
+                            ).apply {
+                                layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+                            }
+                            it.addView(videoRenderer)
+                        }
+
+
+                    }
                 )
+
+//                OthersVideo(
+//                    isCameraOn = participantTitleState.isCameraOn,
+//                    isSharingScreen = participantTitleState.isSharingScreen,
+//                    userId = participantTitleState.id.toString(),
+//                    clientId = participantTitleState.clientId
+//                )
             }
 
             MicrophoneTile(
@@ -123,6 +149,8 @@ fun ParticipantTile(
     }
 }
 
+val views = mutableMapOf<String, VideoRenderer>()
+
 @Composable
 private fun OthersVideo(
     isCameraOn: Boolean,
@@ -130,14 +158,25 @@ private fun OthersVideo(
     userId: String,
     clientId: String
 ) {
-    if (isCameraOn || isSharingScreen) {
-        val context = LocalContext.current
-        AndroidView(factory = {
-            VideoRenderer(context, userId, clientId, false).apply {
-                layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+    val context = LocalContext.current
+    val frameLayout = FrameLayout(context)
+    Log.d("parent", "OthersVideo: ")
+    AndroidView(factory =
+    {
+        frameLayout
+    },
+        update = {
+            it.removeAllViews()
+
+            if (isCameraOn || isSharingScreen) {
+
+                val view2 = VideoRenderer(context, userId, clientId, false).apply {
+                    layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+                }
+                it.addView(view2)
             }
-        })
-    }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -103,7 +103,7 @@ fun ParticipantTile(
                 },
                     update = {
                         if (shouldRecomposeVideoRenderer) {
-                            // Needed to disconnect renderer from container, skip this will lead to same issues like video freezing
+                            // Needed to disconnect renderer from container, skipping this will lead to some issues like video freezing
                             it.removeAllViews()
 
                             if (participantTitleState.isCameraOn || participantTitleState.isSharingScreen) {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -25,6 +25,8 @@ import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.QualifiedID
 
+val lastParticipants = mutableListOf<UICallParticipant>()
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun GroupCallGrid(
@@ -37,6 +39,8 @@ fun GroupCallGrid(
 ) {
     val config = LocalConfiguration.current
 
+    // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
+    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants)
     LazyVerticalGrid(
         userScrollEnabled = false,
         contentPadding = PaddingValues(MaterialTheme.wireDimensions.spacing4x),
@@ -101,10 +105,22 @@ fun GroupCallGrid(
                     if (isSelfUser) {
                         onSelfClearVideoPreview()
                     }
-                }
+                },
+                shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
             )
         }
+        lastParticipants.clear()
+        lastParticipants.addAll(participants)
     }
+}
+
+fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>): Boolean {
+    if (lastParticipants.isEmpty())
+        return true
+    lastParticipants.zip(newParticipants).forEach { pair ->
+        if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isCameraOn != pair.second.isCameraOn)) return true
+    }
+    return false
 }
 
 /**

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -114,11 +114,13 @@ fun GroupCallGrid(
     }
 }
 
-fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>): Boolean {
+@Suppress("ReturnCount")
+fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>) : Boolean {
     if (lastParticipants.isEmpty())
         return true
     lastParticipants.zip(newParticipants).forEach { pair ->
-        if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isCameraOn != pair.second.isCameraOn)) return true
+        if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isCameraOn != pair.second.isCameraOn))
+            return true
     }
     return false
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
@@ -34,6 +34,9 @@ fun OneOnOneCallView(
 ) {
     val config = LocalConfiguration.current
 
+    // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
+    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants)
+
     LazyColumn(
         modifier = Modifier.padding(dimensions().spacing4x),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.wireDimensions.spacing2x)
@@ -78,8 +81,11 @@ fun OneOnOneCallView(
                 onClearSelfUserVideoPreview = {
                     if (isSelfUser)
                         onSelfClearVideoPreview()
-                }
+                },
+                shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
             )
+            lastParticipants.clear()
+            lastParticipants.addAll(participants)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2316" title="AR-2316" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2316</a>  Video is freezing on Android client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In a video group call, some videos becomes freezed when someone join/left the call or someone else turned on his camera

### Causes (Optional)

Every video renderer created should be disconnected from the container(parent view) before creating new ones.

### Solutions

Every time the screen is recomposed due to camera state change, I  disconnect old renderers by calling `removeAllViews() `from parent view 
Removing old renders and creating new ones should be only done when there is a change on camera, that's why I am using `shouldRecomposeVideoRenderer`

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

You can test it after merging the PR for ordering the participants wireapp/kalium#840

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
