### PR TITLE
chore: hash device id

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -117,7 +117,7 @@ class WireApplication : Application(), Configuration.Provider {
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
-        Datadog.setUserInfo(id = getDeviceId(this)
+        Datadog.setUserInfo(id = getDeviceId(this))
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -95,8 +95,7 @@ class WireApplication : Application(), Configuration.Provider {
         logFileWriter.start()
         appLogger.i("Logger enabled")
     }
-    
-    @Suppress("MagicNumber")
+
     private fun enableDatadog() {
 
         val clientToken = "pub98ad02250435b6082337bb79f66cbc19"
@@ -117,7 +116,7 @@ class WireApplication : Application(), Configuration.Provider {
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
-        Datadog.setUserInfo(id = getDeviceId(this))
+        Datadog.setUserInfo(id = getDeviceId(this)?.sha256())
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -95,7 +95,8 @@ class WireApplication : Application(), Configuration.Provider {
         logFileWriter.start()
         appLogger.i("Logger enabled")
     }
-
+    
+    @Suppress("MagicNumber")
     private fun enableDatadog() {
 
         val clientToken = "pub98ad02250435b6082337bb79f66cbc19"

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -17,6 +17,7 @@ import com.wire.android.util.DataDogLogger
 import com.wire.android.util.LogFileWriter
 import com.wire.android.util.extension.isGoogleServicesAvailable
 import com.wire.android.util.getDeviceId
+import com.wire.android.util.sha256
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -116,7 +116,11 @@ class WireApplication : Application(), Configuration.Provider {
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
-        Datadog.setUserInfo(id = getDeviceId(this))
+        
+        if (android.os.Build.VERSION.SDK_INT >= 26) {
+            Datadog.setUserInfo(id = getDeviceId(this).sha256())
+        }
+        
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -119,7 +119,7 @@ class WireApplication : Application(), Configuration.Provider {
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
         
         if (android.os.Build.VERSION.SDK_INT >= 26) {
-            Datadog.setUserInfo(id = getDeviceId(this).sha256())
+            Datadog.setUserInfo(id = getDeviceId(this)?.sha256())
         }
         
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -117,11 +117,7 @@ class WireApplication : Application(), Configuration.Provider {
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
-        
-        if (android.os.Build.VERSION.SDK_INT >= 26) {
-            Datadog.setUserInfo(id = getDeviceId(this)?.sha256())
-        }
-        
+        Datadog.setUserInfo(id = getDeviceId(this)
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -222,6 +222,7 @@ fun openAssetFileWithExternalApp(assetDataPath: Path, context: Context, assetExt
 }
 
 
+@Suppress("MagicNumber")
 fun getDeviceId(context: Context): String? {
     
     if (android.os.Build.VERSION.SDK_INT >= 26) {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -223,7 +223,12 @@ fun openAssetFileWithExternalApp(assetDataPath: Path, context: Context, assetExt
 
 
 fun getDeviceId(context: Context): String? {
-    return Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+    
+    if (android.os.Build.VERSION.SDK_INT >= 26) {
+        return Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+    }
+    
+    return null
 }
 
 fun Context.getProviderAuthority() = "${packageName}.provider"

--- a/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
@@ -9,6 +9,7 @@ fun String?.orDefault(default: String) = this ?: default
 
 public inline fun String.ifNotEmpty(transform: () -> String): String = if (!isEmpty()) transform() else this
 
+@Suppress("MagicNumber")
 fun String.sha256(): String {
     val md = MessageDigest.getInstance("SHA-256")
     return BigInteger(1, md.digest(toByteArray())).toString(16).padStart(32, '0')

--- a/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
@@ -1,7 +1,15 @@
 package com.wire.android.util
 
+import java.math.BigInteger
+import java.security.MessageDigest
+
 val String.Companion.EMPTY get() = ""
 
 fun String?.orDefault(default: String) = this ?: default
 
 public inline fun String.ifNotEmpty(transform: () -> String): String = if (!isEmpty()) transform() else this
+
+fun String.sha256(): String {
+    val md = MessageDigest.getInstance("SHA-256")
+    return BigInteger(1, md.digest(toByteArray())).toString(16).padStart(32, '0')
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Device id can be sensitive and we would like to be a little more resilient to accidents

### Solutions

Limit device id collection to device running API lvl 26 or more and hash it before associating it with DataDog

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
