### PR TITLE
fix(calling): speaker state is not respecting camera state

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -1,6 +1,5 @@
 package com.wire.android.ui.calling
 
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallStatus
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipantsUseCase
@@ -39,9 +40,13 @@ import com.wire.kalium.logic.feature.conversation.SecurityClassificationTypeResu
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -79,11 +84,16 @@ class SharedCallingViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            val allCallsSharedFlow = allCalls().shareIn(this, started = SharingStarted.Lazily)
+
             launch {
                 observeConversationDetails()
             }
             launch {
-                observeCallState()
+                initCallState(allCallsSharedFlow)
+            }
+            launch {
+                observeParticipants(allCallsSharedFlow)
             }
             launch {
                 observeOnSpeaker()
@@ -148,14 +158,14 @@ class SharedCallingViewModel @Inject constructor(
     }
 
     private suspend fun observeOnSpeaker() {
-        observeSpeaker().collect {
+        observeSpeaker().collectLatest {
             callState = callState.copy(isSpeakerOn = it)
         }
     }
 
     private suspend fun observeOnMute() {
         //We should only mute established calls
-          snapshotFlow { callState.isMuted to callState.callStatus }.collectLatest { (isMuted, callStatus) ->
+        snapshotFlow { callState.isMuted to callState.callStatus }.collectLatest { (isMuted, callStatus) ->
             if (callStatus == CallStatus.ESTABLISHED) {
                 isMuted?.let {
                     if (it) {
@@ -168,8 +178,8 @@ class SharedCallingViewModel @Inject constructor(
         }
     }
 
-    private suspend fun observeCallState() {
-        allCalls().collect { calls ->
+    private suspend fun initCallState(sharedFlow: SharedFlow<List<Call>>) {
+        sharedFlow.first { calls ->
             calls.find { call ->
                 call.conversationId == conversationId &&
                         call.status != CallStatus.CLOSED &&
@@ -178,8 +188,24 @@ class SharedCallingViewModel @Inject constructor(
                 callState = callState.copy(
                     callStatus = call.status,
                     callerName = call.callerName,
-                    isMuted = call.isMuted,
                     isCameraOn = call.isCameraOn,
+                    isMuted = call.isMuted
+                )
+            }
+            true
+        }
+    }
+
+    private suspend fun observeParticipants(sharedFlow: SharedFlow<List<Call>>) {
+        sharedFlow.collect { calls ->
+            calls.find { call ->
+                call.conversationId == conversationId &&
+                        call.status != CallStatus.CLOSED &&
+                        call.status != CallStatus.MISSED
+            }?.let { call ->
+                callState = callState.copy(
+                    callStatus = call.status,
+                    callerName = call.callerName,
                     participants = call.participants.map { uiCallParticipantMapper.toUICallParticipant(it) }
                 )
             }
@@ -229,13 +255,11 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             callState.isCameraOn?.let {
                 callState = if (it) {
-                    turnLoudSpeakerOff()
                     callState.copy(
                         isCameraOn = false,
                         isSpeakerOn = false
                     )
                 } else {
-                    turnLoudSpeakerOn()
                     callState.copy(
                         isCameraOn = true,
                         isSpeakerOn = true

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -180,11 +180,9 @@ class SharedCallingViewModelTest {
     fun `given camera is turned on, when toggling video, then turn off video and speaker`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = true)
         coEvery { updateVideoState(any(), any()) } returns Unit
-        every { turnLoudSpeakerOff() } returns Unit
 
         runTest { sharedCallingViewModel.toggleVideo() }
 
-        verify(exactly = 1) { turnLoudSpeakerOff() }
         sharedCallingViewModel.callState.isCameraOn shouldBeEqualTo false
         sharedCallingViewModel.callState.isSpeakerOn shouldBeEqualTo false
     }
@@ -193,11 +191,9 @@ class SharedCallingViewModelTest {
     fun `given camera is turned off, when toggling video, then turn on video and speaker`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = false)
         coEvery { updateVideoState(any(), any()) } returns Unit
-        every { turnLoudSpeakerOn() } returns Unit
 
         runTest { sharedCallingViewModel.toggleVideo() }
 
-        verify(exactly = 1) { turnLoudSpeakerOn() }
         sharedCallingViewModel.callState.isCameraOn shouldBeEqualTo true
         sharedCallingViewModel.callState.isSpeakerOn shouldBeEqualTo true
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On a call, tapping many times on camera button, to activate you camera, makes the speaker button behaves wrongly(switched on to off by itself)

### Causes (Optional)

We were getting initial screen state along side participants list mapping, which take some to be done.

### Solutions

Separate screen state init from updating participants list by collecting a sharedFlow

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

In a call, tap many times on camera button 

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
