### PR TITLE
fix: not marking messages as read (AR-2436)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -438,7 +438,7 @@ fun MessageList(
 
             // TODO: This IF condition should be in the UseCase
             //       If there are no unread messages, then use distant future and don't update read date
-            if (lastVisibleMessageInstant > (lastUnreadMessageInstant ?: Instant.DISTANT_FUTURE)) {
+            if (lastVisibleMessageInstant >= (lastUnreadMessageInstant ?: Instant.DISTANT_FUTURE)) {
                 onUpdateConversationReadDate(lastVisibleMessage.messageHeader.messageTime.utcISO)
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2436" title="AR-2436" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2436</a>  Not marking messages as read
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some messages are not being marked as read by the app.

### Causes

When the user stops scrolling, we check the most recent message visible and compare its time with the `lastUnreadMessage`.
We need to check if the the latest visible message is more recent than the last unread. And if it is the case, we should update the conversation last read date.

Unfortunatelly this logic was originally implemented on the Composable itself, instead of being on the `ViewModel` or ideally in a `UseCase` inside Kalium.

And I ended-up changing the comparison yesterday with #979, introducing a bug.

### Solutions

Revert the comparison operator between `lastVisibleMessageDateTime` and `lastUnreadDateTime` back to `>=` from `>`.

### Testing

Not easily testable without further rewrite. This logic should not be in the Composable.

#### How to Test

Open a conversation.
Receive messages.
Scroll down to the latest message.
Going out the conversation, seeing the conversation list, it should have no unread messages.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
