### PR TITLE
fix(calling): Microphone state not respected when changed on precall screen (AR-2357)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -238,7 +238,7 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             callState.isMuted?.let {
                 callState = if (it) {
-                    muteCall(conversationId)
+                    unMuteCall(conversationId)
                     callState.copy(isMuted = false)
                 } else {
                     muteCall(conversationId)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -238,8 +238,10 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             callState.isMuted?.let {
                 callState = if (it) {
+                    muteCall(conversationId)
                     callState.copy(isMuted = false)
                 } else {
+                    muteCall(conversationId)
                     callState.copy(isMuted = true)
                 }
             }

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -153,16 +153,18 @@ class SharedCallingViewModelTest {
 
         runTest { sharedCallingViewModel.toggleMute() }
 
+        coVerify(exactly = 1) { muteCall(any()) }
         sharedCallingViewModel.callState.isMuted shouldBeEqualTo true
     }
 
     @Test
     fun `given a muted call, when toggling microphone, then un-mute the call`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = true)
-        coEvery { unMuteCall(conversationId) } returns Unit
+        coEvery { unMuteCall(any()) } returns Unit
 
         runTest { sharedCallingViewModel.toggleMute() }
 
+        coVerify(exactly = 1) { unMuteCall(any()) }
         sharedCallingViewModel.callState.isMuted shouldBeEqualTo false
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2357" title="AR-2357" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2357</a>  Microphone state not respected when changed on precall screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…screen

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Microphone state not respected when changed on precall screen

### Causes (Optional)

On incoming and outgoing screens, we were not storing the state in cache to be retrieved later in the ongoing all screen

### Solutions

call use case for muting/unmuting that will store this state 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
