### PR TITLE
fix: custom server deep link dialogue displaying team url instead of api

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
@@ -29,7 +29,7 @@ internal fun CustomBEDeeplinkDialog(
                 colorsScheme().onBackground,
                 colorsScheme().onBackground,
                 wireActivityViewModel.globalAppState.customBackendDialog.serverLinks.title,
-                wireActivityViewModel.globalAppState.customBackendDialog.serverLinks.teams
+                wireActivityViewModel.globalAppState.customBackendDialog.serverLinks.api
             ),
 
             buttonsHorizontalAlignment = true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

custom server deep link dialogue displaying team url instead of api

### Solutions

.team -> .api

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
