### PR TITLE
fix: white screen ongoing call while joining (AR-2411)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -17,6 +17,7 @@ import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.VideoState
@@ -39,15 +40,18 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationTypeResult
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -72,6 +76,7 @@ class SharedCallingViewModel @Inject constructor(
     private val userTypeMapper: UserTypeMapper,
     private val currentScreenManager: CurrentScreenManager,
     private val getConversationClassifiedType: GetSecurityClassificationTypeUseCase,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
 
     var callState by mutableStateOf(CallState())
@@ -90,10 +95,10 @@ class SharedCallingViewModel @Inject constructor(
                             call.status != CallStatus.CLOSED &&
                             call.status != CallStatus.MISSED
                 }
-            }.shareIn(this, started = SharingStarted.Lazily)
+            }.flowOn(dispatchers.io()).shareIn(this, started = SharingStarted.Lazily)
 
             launch {
-                observeConversationDetails()
+                observeConversationDetails(this)
             }
             launch {
                 initCallState(allCallsSharedFlow)
@@ -102,7 +107,7 @@ class SharedCallingViewModel @Inject constructor(
                 observeParticipants(allCallsSharedFlow)
             }
             launch {
-                observeOnSpeaker()
+                observeOnSpeaker(this)
             }
             launch {
                 observeOnMute()
@@ -136,10 +141,12 @@ class SharedCallingViewModel @Inject constructor(
         }
     }
 
-    private suspend fun observeConversationDetails() {
+    private suspend fun observeConversationDetails(coroutineScope: CoroutineScope) {
         conversationDetails(conversationId = conversationId)
             .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>() // TODO handle StorageFailure
             .map { it.conversationDetails }
+            .flowOn(dispatchers.io())
+            .shareIn(coroutineScope, SharingStarted.WhileSubscribed(1))
             .collect { details ->
                 callState = when (details) {
                     is ConversationDetails.Group -> {
@@ -163,10 +170,13 @@ class SharedCallingViewModel @Inject constructor(
             }
     }
 
-    private suspend fun observeOnSpeaker() {
-        observeSpeaker().collectLatest {
-            callState = callState.copy(isSpeakerOn = it)
-        }
+    private suspend fun observeOnSpeaker(coroutineScope: CoroutineScope) {
+        observeSpeaker()
+            .flowOn(dispatchers.io())
+            .shareIn(coroutineScope, SharingStarted.WhileSubscribed(1))
+            .collectLatest {
+                callState = callState.copy(isSpeakerOn = it)
+            }
     }
 
     private suspend fun observeOnMute() {
@@ -273,9 +283,11 @@ class SharedCallingViewModel @Inject constructor(
 
     fun setVideoPreview(view: View?) {
         viewModelScope.launch {
-            setVideoPreview(conversationId, PlatformView(null))
-            setVideoPreview(conversationId, PlatformView(view))
-            updateVideoState(conversationId, VideoState.STARTED)
+            withContext(dispatchers.default()) {
+                setVideoPreview(conversationId, PlatformView(null))
+                setVideoPreview(conversationId, PlatformView(view))
+                updateVideoState(conversationId, VideoState.STARTED)
+            }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.calling
 
 import android.view.View
 import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.media.CallRinger
@@ -132,7 +133,8 @@ class SharedCallingViewModelTest {
             userTypeMapper = userTypeMapper,
             currentScreenManager = currentScreenManager,
             qualifiedIdMapper = qualifiedIdMapper,
-            getConversationClassifiedType = getConversationClassifiedType
+            getConversationClassifiedType = getConversationClassifiedType,
+            dispatchers = TestDispatcherProvider()
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2411" title="AR-2411" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2411</a>  White screen on active call group conv
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR aims to solve the white screen when you are connecting to an ongoing call.
- Some operations were moved from main thread to io dispatchers
- Now we have a dynamic loader that will show in case we have a delay connecting to the call, How? Obtaining the participants lists may take some time under load, so in this case only we display this loader.

### Attachments (Optional)

[progressindicator-on-calling.webm](https://user-images.githubusercontent.com/5806454/190488325-1525b72e-5904-47c7-a0a8-961ebb420932.webm)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
