### PR TITLE
fix(calling): flickering when someone starts speaking in group video call

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,17 +42,19 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.id.QualifiedID
 
-// used to display the blue border around the tile to mention that someone is talking
 @Composable
-fun TileModifier(modifier: Modifier, isSpeaking: Boolean) = if (isSpeaking) {
-    modifier.border(
-        width = dimensions().spacing4x,
-        color = MaterialTheme.wireColorScheme.primary,
-        shape = RoundedCornerShape(dimensions().corner8x)
-    )
-        .padding(dimensions().spacing6x)
-} else {
-    modifier
+fun TileModifier(modifier: Modifier, isSpeaking: Boolean): Modifier {
+    var updatedModifier = modifier
+    if (isSpeaking) {
+        updatedModifier = modifier
+            .border(
+                width = dimensions().spacing4x,
+                color = MaterialTheme.wireColorScheme.primary,
+                shape = RoundedCornerShape(dimensions().corner8x)
+            )
+            .padding(dimensions().spacing6x)
+    }
+    return updatedModifier
 }
 
 @Composable
@@ -91,9 +94,8 @@ fun ParticipantTile(
             } else {
                 val context = LocalContext.current
                 if (participantTitleState.isCameraOn || participantTitleState.isSharingScreen) {
-
-                    AndroidView(factory = {
-                        val videoRenderer = VideoRenderer(
+                    val videoRenderer = remember {
+                        VideoRenderer(
                             context,
                             participantTitleState.id.toString(),
                             participantTitleState.clientId,
@@ -101,6 +103,8 @@ fun ParticipantTile(
                         ).apply {
                             layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
                         }
+                    }
+                    AndroidView(factory = {
                         val frameLayout = FrameLayout(it)
                         frameLayout.addView(videoRenderer)
                         frameLayout
@@ -110,17 +114,7 @@ fun ParticipantTile(
                                 // Needed to disconnect renderer from container, skipping this will lead to some issues like video freezing
                                 it.removeAllViews()
 
-
-                                val videoRenderer = VideoRenderer(
-                                    context,
-                                    participantTitleState.id.toString(),
-                                    participantTitleState.clientId,
-                                    false
-                                ).apply {
-                                    layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-                                }
                                 it.addView(videoRenderer)
-
                             }
                         }
                     )
@@ -152,7 +146,6 @@ fun ParticipantTile(
                 name = participantTitleState.name,
                 isSpeaking = participantTitleState.isSpeaking
             )
-
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -3,7 +3,7 @@ package com.wire.android.ui.calling
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
-import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +19,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -43,21 +45,6 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.id.QualifiedID
 
 @Composable
-fun TileModifier(modifier: Modifier, isSpeaking: Boolean): Modifier {
-    var updatedModifier = modifier
-    if (isSpeaking) {
-        updatedModifier = modifier
-            .border(
-                width = dimensions().spacing4x,
-                color = MaterialTheme.wireColorScheme.primary,
-                shape = RoundedCornerShape(dimensions().corner8x)
-            )
-            .padding(dimensions().spacing6x)
-    }
-    return updatedModifier
-}
-
-@Composable
 fun ParticipantTile(
     modifier: Modifier,
     participantTitleState: UICallParticipant,
@@ -69,7 +56,7 @@ fun ParticipantTile(
     onClearSelfUserVideoPreview: () -> Unit
 ) {
     Surface(
-        modifier = TileModifier(modifier, participantTitleState.isSpeaking),
+        modifier = modifier,
         color = MaterialTheme.wireColorScheme.ongoingCallBackground,
         shape = RoundedCornerShape(dimensions().corner6x)
     ) {
@@ -145,6 +132,29 @@ fun ParticipantTile(
                     .widthIn(max = onGoingCallTileUsernameMaxWidth),
                 name = participantTitleState.name,
                 isSpeaking = participantTitleState.isSpeaking
+            )
+        }
+        TileBorder(participantTitleState.isSpeaking)
+    }
+}
+
+@Composable
+fun TileBorder(isSpeaking: Boolean) {
+    if (isSpeaking) {
+        val color = MaterialTheme.wireColorScheme.primary
+        val strokeWidth = dimensions().corner8x
+        val cornerRadius = dimensions().corner10x
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val canvasQuadrantSize = size
+            drawRoundRect(
+                color = color,
+                size = canvasQuadrantSize,
+                style = Stroke(width = strokeWidth.toPx()),
+                cornerRadius = CornerRadius(
+                    x = cornerRadius.toPx(),
+                    y = cornerRadius.toPx()
+                )
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -43,18 +43,15 @@ import com.wire.kalium.logic.data.id.QualifiedID
 
 // used to display the blue border around the tile to mention that someone is talking
 @Composable
-fun TileModifier(modifier: Modifier, isSpeaking: Boolean): Modifier {
-    var updatedModifier = modifier
-    if (isSpeaking) {
-        updatedModifier = modifier
-            .border(
-                width = dimensions().spacing4x,
-                color = MaterialTheme.wireColorScheme.primary,
-                shape = RoundedCornerShape(dimensions().corner8x)
-            )
-            .padding(dimensions().spacing6x)
-    }
-    return updatedModifier
+fun TileModifier(modifier: Modifier, isSpeaking: Boolean) = if (isSpeaking) {
+    modifier.border(
+        width = dimensions().spacing4x,
+        color = MaterialTheme.wireColorScheme.primary,
+        shape = RoundedCornerShape(dimensions().corner8x)
+    )
+        .padding(dimensions().spacing6x)
+} else {
+    modifier
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -41,7 +41,7 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.id.QualifiedID
 
-// used to display the blue border around the tile to mention taht someone is talking
+// used to display the blue border around the tile to mention that someone is talking
 @Composable
 fun TileModifier(modifier: Modifier, isSpeaking: Boolean): Modifier {
     var updatedModifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -41,6 +41,22 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.id.QualifiedID
 
+// used to display the blue border around the tile to mention taht someone is talking
+@Composable
+fun TileModifier(modifier: Modifier, isSpeaking: Boolean): Modifier {
+    var updatedModifier = modifier
+    if (isSpeaking) {
+        updatedModifier = modifier
+            .border(
+                width = dimensions().spacing4x,
+                color = MaterialTheme.wireColorScheme.primary,
+                shape = RoundedCornerShape(dimensions().corner8x)
+            )
+            .padding(dimensions().spacing6x)
+    }
+    return updatedModifier
+}
+
 @Composable
 fun ParticipantTile(
     modifier: Modifier,
@@ -52,18 +68,8 @@ fun ParticipantTile(
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit
 ) {
-    var updatedModifier = modifier
-    if (participantTitleState.isSpeaking) {
-        updatedModifier = modifier
-            .border(
-                width = dimensions().spacing4x,
-                color = MaterialTheme.wireColorScheme.primary,
-                shape = RoundedCornerShape(dimensions().corner8x)
-            )
-            .padding(dimensions().spacing6x)
-    }
     Surface(
-        modifier = updatedModifier.padding(top = 0.dp),
+        modifier = TileModifier(modifier, participantTitleState.isSpeaking),
         color = MaterialTheme.wireColorScheme.ongoingCallBackground,
         shape = RoundedCornerShape(dimensions().corner6x)
     ) {
@@ -147,7 +153,7 @@ fun ParticipantTile(
                     }
                     .widthIn(max = onGoingCallTileUsernameMaxWidth),
                 name = participantTitleState.name,
-                color = if (participantTitleState.isSpeaking) MaterialTheme.wireColorScheme.primary else Color.Black
+                isSpeaking = participantTitleState.isSpeaking
             )
 
         }
@@ -193,8 +199,10 @@ private fun AvatarTile(
 private fun UsernameTile(
     modifier: Modifier,
     name: String,
-    color: Color
+    isSpeaking: Boolean
 ) {
+    val color = if (isSpeaking) MaterialTheme.wireColorScheme.primary else Color.Black
+
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(dimensions().corner4x),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In a group video call, if someone starts speaking then the screen start flickering 

### Causes (Optional)

When the `isSpeaking` state is changed, it affect the parent container to be recomposed ( which is the tile)

### Solutions

Extract the speaking handling into a separate  composable, this way if the state changes then only that composable will be recomposed and not all the container
 
### Update
I replaced adding the border to show current speaker indicator by drawing a rectangle around the tile.
The main reason behind this is that the first approach (with border) is causing the container to recompose

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
