### PR TITLE
chore: speed up other user profile loading, one query instead of two for get convo (part 1)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -67,9 +67,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -260,7 +260,7 @@ class UseCaseModule {
     @ViewModelScoped
     @Provides
     fun provideObserveConversationUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
-        coreLogic.getSessionScope(currentAccount).conversations.getConversationDetails
+        coreLogic.getSessionScope(currentAccount).conversations.getOneToOneConversation
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -39,8 +39,8 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUs
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
-import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.getPaginatedFlowOfMessagesByConversation
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
@@ -67,9 +67,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -256,6 +256,11 @@ class UseCaseModule {
     @Provides
     fun provideObserveConversationListDetailsUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).conversations.observeConversationListDetails
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveConversationUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).conversations.getConversationDetails
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -7,8 +7,8 @@ import androidx.annotation.ArrayRes
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -255,6 +255,8 @@ private fun WelcomeFooter(modifier: Modifier, onPrivateAccountClick: () -> Unit)
                     interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onPrivateAccountClick
                 )
         )
+
+        Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.welcomeVerticalPadding))
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -3,7 +3,7 @@ package com.wire.android.ui.calling
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
-import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,9 +16,12 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -52,18 +55,8 @@ fun ParticipantTile(
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit
 ) {
-    var updatedModifier = modifier
-    if (participantTitleState.isSpeaking) {
-        updatedModifier = modifier
-            .border(
-                width = dimensions().spacing4x,
-                color = MaterialTheme.wireColorScheme.primary,
-                shape = RoundedCornerShape(dimensions().corner8x)
-            )
-            .padding(dimensions().spacing6x)
-    }
     Surface(
-        modifier = updatedModifier.padding(top = 0.dp),
+        modifier = modifier,
         color = MaterialTheme.wireColorScheme.ongoingCallBackground,
         shape = RoundedCornerShape(dimensions().corner6x)
     ) {
@@ -88,9 +81,8 @@ fun ParticipantTile(
             } else {
                 val context = LocalContext.current
                 if (participantTitleState.isCameraOn || participantTitleState.isSharingScreen) {
-
-                    AndroidView(factory = {
-                        val videoRenderer = VideoRenderer(
+                    val videoRenderer = remember {
+                        VideoRenderer(
                             context,
                             participantTitleState.id.toString(),
                             participantTitleState.clientId,
@@ -98,6 +90,8 @@ fun ParticipantTile(
                         ).apply {
                             layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
                         }
+                    }
+                    AndroidView(factory = {
                         val frameLayout = FrameLayout(it)
                         frameLayout.addView(videoRenderer)
                         frameLayout
@@ -107,17 +101,7 @@ fun ParticipantTile(
                                 // Needed to disconnect renderer from container, skipping this will lead to some issues like video freezing
                                 it.removeAllViews()
 
-
-                                val videoRenderer = VideoRenderer(
-                                    context,
-                                    participantTitleState.id.toString(),
-                                    participantTitleState.clientId,
-                                    false
-                                ).apply {
-                                    layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-                                }
                                 it.addView(videoRenderer)
-
                             }
                         }
                     )
@@ -147,9 +131,31 @@ fun ParticipantTile(
                     }
                     .widthIn(max = onGoingCallTileUsernameMaxWidth),
                 name = participantTitleState.name,
-                color = if (participantTitleState.isSpeaking) MaterialTheme.wireColorScheme.primary else Color.Black
+                isSpeaking = participantTitleState.isSpeaking
             )
+        }
+        TileBorder(participantTitleState.isSpeaking)
+    }
+}
 
+@Composable
+fun TileBorder(isSpeaking: Boolean) {
+    if (isSpeaking) {
+        val color = MaterialTheme.wireColorScheme.primary
+        val strokeWidth = dimensions().corner8x
+        val cornerRadius = dimensions().corner10x
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val canvasQuadrantSize = size
+            drawRoundRect(
+                color = color,
+                size = canvasQuadrantSize,
+                style = Stroke(width = strokeWidth.toPx()),
+                cornerRadius = CornerRadius(
+                    x = cornerRadius.toPx(),
+                    y = cornerRadius.toPx()
+                )
+            )
         }
     }
 }
@@ -193,8 +199,10 @@ private fun AvatarTile(
 private fun UsernameTile(
     modifier: Modifier,
     name: String,
-    color: Color
+    isSpeaking: Boolean
 ) {
+    val color = if (isSpeaking) MaterialTheme.wireColorScheme.primary else Color.Black
+
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(dimensions().corner4x),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileInfoMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileInfoMessageType.kt
@@ -1,0 +1,35 @@
+package com.wire.android.ui.userprofile.other
+
+import com.wire.android.R
+import com.wire.android.model.SnackBarMessage
+import com.wire.android.util.ui.UIText
+
+sealed class OtherUserProfileInfoMessageType(override val uiText: UIText) : SnackBarMessage {
+    // connection
+    object SuccessConnectionSentRequest : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_sent))
+    object ConnectionRequestError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_sent_error))
+    object SuccessConnectionAcceptRequest : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_accepted))
+    object ConnectionAcceptError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_accept_error))
+    object SuccessConnectionCancelRequest : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_canceled))
+    object ConnectionCancelError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_cancel_error))
+    object ConnectionIgnoreError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.connection_request_ignore_error))
+
+    object LoadUserInformationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_unknown_message))
+    object LoadDirectConversationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_unknown_message))
+
+    // change group role
+    object ChangeGroupRoleError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.user_profile_role_change_error))
+
+    // remove conversation member
+    object RemoveConversationMemberError :
+        OtherUserProfileInfoMessageType(UIText.StringResource(R.string.dialog_remove_conversation_member_error))
+
+    // Conversation BottomSheet
+    object BlockingUserOperationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_blocking_user))
+    class BlockingUserOperationSuccess(val name: String) :
+        OtherUserProfileInfoMessageType(UIText.StringResource(R.string.blocking_user_success, name))
+
+    object MutingOperationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_updating_muting_setting))
+
+    object UnblockingUserOperationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_unblocking_user))
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -68,7 +68,7 @@ import com.wire.kalium.logic.feature.connection.UnblockUserResult
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
-import com.wire.kalium.logic.feature.conversation.GetConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -78,13 +78,12 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.Date
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Date
+import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -97,7 +96,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val blockUser: BlockUserUseCase,
     private val unblockUser: UnblockUserUseCase,
     private val getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase,
-    private val getConversation: GetConversationUseCase,
+    private val getConversation: GetOneToOneConversationUseCase,
     private val observeUserInfo: ObserveUserInfoUseCase,
     private val sendConnectionRequest: SendConnectionRequestUseCase,
     private val cancelConnectionRequest: CancelConnectionRequestUseCase,
@@ -181,12 +180,12 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         if (otherUser.connectionStatus != ConnectionState.ACCEPTED) return
 
         viewModelScope.launch {
-            when (val conversationResult = getConversation(userId).first()) {
-                is GetConversationUseCase.Result.Failure -> {
+            when (val conversationResult = getConversation(userId)) {
+                is GetOneToOneConversationUseCase.Result.Failure -> {
                     appLogger.d("Couldn't not getOrCreateOneToOneConversation for user id: $userId")
                     showInfoMessage(LoadDirectConversationError)
                 }
-                is GetConversationUseCase.Result.Success -> {
+                is GetOneToOneConversationUseCase.Result.Success -> {
                     observeSelfUser().collect { selfUser ->
                         state = state.copy(
                             conversationSheetContent = ConversationSheetContent(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -150,7 +150,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                             ?.let { pic -> ImageAsset.UserAvatarAsset(wireSessionImageLoader, pic) }
 
                         // TODO yamil: remove this block from here. we should loaded on user click
-                        // observeConversationSheetContentIfNeeded(otherUser, userAvatarAsset)
+                        observeConversationSheetContentIfNeeded(otherUser, userAvatarAsset)
                         observeGroupStateIfNeeded()
 
                         state = state.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.model.ImageAsset
@@ -25,6 +24,21 @@ import com.wire.android.ui.home.conversationslist.bottomsheet.ConversationTypeDe
 import com.wire.android.ui.home.conversationslist.model.getBlockingState
 import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
 import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationSuccess
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ChangeGroupRoleError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ConnectionAcceptError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ConnectionCancelError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ConnectionIgnoreError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ConnectionRequestError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.LoadDirectConversationError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.LoadUserInformationError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.MutingOperationError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.RemoveConversationMemberError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.SuccessConnectionAcceptRequest
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.SuccessConnectionCancelRequest
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.SuccessConnectionSentRequest
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.UnblockingUserOperationError
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -54,6 +68,7 @@ import com.wire.kalium.logic.feature.connection.UnblockUserResult
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
+import com.wire.kalium.logic.feature.conversation.GetConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -63,12 +78,13 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -81,6 +97,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val blockUser: BlockUserUseCase,
     private val unblockUser: UnblockUserUseCase,
     private val getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase,
+    private val getConversation: GetConversationUseCase,
     private val observeUserInfo: ObserveUserInfoUseCase,
     private val sendConnectionRequest: SendConnectionRequestUseCase,
     private val cancelConnectionRequest: CancelConnectionRequestUseCase,
@@ -106,36 +123,39 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     val infoMessage = _infoMessage.asSharedFlow()
 
     init {
-        state = state.copy(isDataLoading = true)
+        state = state.copy(isDataLoading = true, isAvatarLoading = true)
 
         observeUserInfoAndUpdateViewState()
         persistClients()
     }
 
     private fun persistClients() {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.io()) {
             persistOtherUserClients(userId)
         }
     }
 
     private fun observeUserInfoAndUpdateViewState() {
         viewModelScope.launch {
-            observeUserInfo(userId).collect { getInfoResult ->
+            val userInfoResult = withContext(dispatchers.io()) { observeUserInfo(userId) }
+            userInfoResult.collect { getInfoResult ->
                 when (getInfoResult) {
                     is GetUserInfoResult.Failure -> {
                         appLogger.d("Couldn't not find the user with provided id: $userId")
-                        showInfoMessage(InfoMessageType.LoadUserInformationError)
+                        showInfoMessage(LoadUserInformationError)
                     }
                     is GetUserInfoResult.Success -> {
                         val otherUser = getInfoResult.otherUser
                         val userAvatarAsset = otherUser.completePicture
                             ?.let { pic -> ImageAsset.UserAvatarAsset(wireSessionImageLoader, pic) }
 
-                        observeConversationSheetContentIfNeeded(otherUser, userAvatarAsset)
+                        // TODO yamil: remove this block from here. we should loaded on user click
+                        // observeConversationSheetContentIfNeeded(otherUser, userAvatarAsset)
                         observeGroupStateIfNeeded()
 
                         state = state.copy(
                             isDataLoading = false,
+                            isAvatarLoading = false,
                             userAvatarAsset = userAvatarAsset,
                             fullName = otherUser.name.orEmpty(),
                             userName = mapUserLabel(otherUser),
@@ -152,19 +172,21 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         }
     }
 
+    /**
+     * This should be loaded on demand not on init.
+     */
     private fun observeConversationSheetContentIfNeeded(otherUser: OtherUser, userAvatarAsset: ImageAsset.UserAvatarAsset?) {
-
         // if we are not connected with that user -> we don't have a direct conversation ->
         // -> no need to load data for ConversationBottomSheet
         if (otherUser.connectionStatus != ConnectionState.ACCEPTED) return
 
         viewModelScope.launch {
-            when (val conversationResult = getOrCreateOneToOneConversation(userId)) {
-                is CreateConversationResult.Failure -> {
+            when (val conversationResult = getConversation(userId).first()) {
+                is GetConversationUseCase.Result.Failure -> {
                     appLogger.d("Couldn't not getOrCreateOneToOneConversation for user id: $userId")
-                    showInfoMessage(InfoMessageType.LoadDirectConversationError)
+                    showInfoMessage(LoadDirectConversationError)
                 }
-                is CreateConversationResult.Success -> {
+                is GetConversationUseCase.Result.Success -> {
                     observeSelfUser().collect { selfUser ->
                         state = state.copy(
                             conversationSheetContent = ConversationSheetContent(
@@ -187,7 +209,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private fun observeGroupStateIfNeeded() {
         conversationId?.let {
             viewModelScope.launch {
-                observeConversationRoleForUser(it, userId).collect { conversationRoleData ->
+                val result = withContext(dispatchers.io()) { observeConversationRoleForUser(it, userId) }
+                result.collect { conversationRoleData ->
                     state = state.copy(
                         groupState = conversationRoleData.userRole?.let { userRole ->
                             OtherUserProfileGroupState(
@@ -205,7 +228,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     override fun onOpenConversation() {
         viewModelScope.launch {
-            when (val result = getOrCreateOneToOneConversation(userId)) {
+            when (val result = withContext(dispatchers.io()) { getOrCreateOneToOneConversation(userId) }) {
                 is CreateConversationResult.Failure -> appLogger.d(("Couldn't retrieve or create the conversation"))
                 is CreateConversationResult.Success ->
                     navigationManager.navigate(
@@ -223,11 +246,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (sendConnectionRequest(userId)) {
                 is SendConnectionRequestResult.Failure -> {
                     appLogger.d(("Couldn't send a connect request to user $userId"))
-                    showInfoMessage(InfoMessageType.ConnectionRequestError)
+                    showInfoMessage(ConnectionRequestError)
                 }
                 is SendConnectionRequestResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.SENT)
-                    showInfoMessage(InfoMessageType.SuccessConnectionSentRequest)
+                    showInfoMessage(SuccessConnectionSentRequest)
                 }
             }
         }
@@ -238,11 +261,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (cancelConnectionRequest(userId)) {
                 is CancelConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't cancel a connect request to user $userId"))
-                    showInfoMessage(InfoMessageType.ConnectionCancelError)
+                    showInfoMessage(ConnectionCancelError)
                 }
                 is CancelConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.NOT_CONNECTED)
-                    showInfoMessage(InfoMessageType.SuccessConnectionCancelRequest)
+                    showInfoMessage(SuccessConnectionCancelRequest)
                 }
             }
         }
@@ -253,11 +276,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (acceptConnectionRequest(userId)) {
                 is AcceptConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't accept a connect request to user $userId"))
-                    showInfoMessage(InfoMessageType.ConnectionAcceptError)
+                    showInfoMessage(ConnectionAcceptError)
                 }
                 is AcceptConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.ACCEPTED)
-                    showInfoMessage(InfoMessageType.SuccessConnectionAcceptRequest)
+                    showInfoMessage(SuccessConnectionAcceptRequest)
                 }
             }
         }
@@ -268,7 +291,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (ignoreConnectionRequest(userId)) {
                 is IgnoreConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't ignore a connect request to user $userId"))
-                    showInfoMessage(InfoMessageType.ConnectionIgnoreError)
+                    showInfoMessage(ConnectionIgnoreError)
                 }
                 is IgnoreConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.IGNORED)
@@ -287,7 +310,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             if (conversationId != null) {
                 updateMemberRole(conversationId, userId, role).also {
                     if (it is UpdateConversationMemberRoleResult.Failure)
-                        showInfoMessage(InfoMessageType.ChangeGroupRoleError)
+                        showInfoMessage(ChangeGroupRoleError)
                 }
             }
         }
@@ -308,7 +331,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             }
 
             if (response is RemoveMemberFromConversationUseCase.Result.Failure)
-                showInfoMessage(InfoMessageType.RemoveConversationMemberError)
+                showInfoMessage(RemoveConversationMemberError)
 
             requestInProgress = false
         }
@@ -318,7 +341,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         conversationId?.let {
             viewModelScope.launch {
                 when (updateConversationMutedStatus(conversationId, status, Date().time)) {
-                    ConversationUpdateStatusResult.Failure -> showInfoMessage(InfoMessageType.MutingOperationError)
+                    ConversationUpdateStatusResult.Failure -> showInfoMessage(MutingOperationError)
                     ConversationUpdateStatusResult.Success -> {
                         state = state.updateMuteStatus(status)
                         appLogger.i("MutedStatus changed for conversation: $conversationId to $status")
@@ -334,11 +357,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (val result = blockUser(userId)) {
                 BlockUserResult.Success -> {
                     appLogger.i("User $userId was blocked")
-                    showInfoMessage(InfoMessageType.BlockingUserOperationSuccess(blockUserState.userName))
+                    showInfoMessage(BlockingUserOperationSuccess(blockUserState.userName))
                 }
                 is BlockUserResult.Failure -> {
                     appLogger.e("Error while blocking user $userId ; Error ${result.coreFailure}")
-                    showInfoMessage(InfoMessageType.BlockingUserOperationError)
+                    showInfoMessage(BlockingUserOperationError)
                 }
             }
             requestInProgress = false
@@ -354,7 +377,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 }
                 is UnblockUserResult.Failure -> {
                     appLogger.e("Error while unblocking user $userId ; Error ${result.coreFailure}")
-                    showInfoMessage(InfoMessageType.UnblockingUserOperationError)
+                    showInfoMessage(UnblockingUserOperationError)
                 }
             }
             requestInProgress = false
@@ -395,7 +418,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     override fun getOtherUserClients() {
         viewModelScope.launch {
-            getOtherUserClients(userId).let {
+            val result = withContext(dispatchers.io()) { getOtherUserClients(userId) }
+            result.let {
                 when (it) {
                     is GetOtherUserClientsResult.Failure.UserNotFound -> {
                         appLogger.e("User or Domain not found while fetching user clients ")
@@ -412,34 +436,4 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     }
 
     override fun navigateBack() = viewModelScope.launch { navigationManager.navigateBack() }
-
-}
-
-sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
-    // connection
-    object SuccessConnectionSentRequest : InfoMessageType(UIText.StringResource(R.string.connection_request_sent))
-    object ConnectionRequestError : InfoMessageType(UIText.StringResource(R.string.connection_request_sent_error))
-    object SuccessConnectionAcceptRequest : InfoMessageType(UIText.StringResource(R.string.connection_request_accepted))
-    object ConnectionAcceptError : InfoMessageType(UIText.StringResource(R.string.connection_request_accept_error))
-    object SuccessConnectionCancelRequest : InfoMessageType(UIText.StringResource(R.string.connection_request_canceled))
-    object ConnectionCancelError : InfoMessageType(UIText.StringResource(R.string.connection_request_cancel_error))
-    object ConnectionIgnoreError : InfoMessageType(UIText.StringResource(R.string.connection_request_ignore_error))
-
-    object LoadUserInformationError : InfoMessageType(UIText.StringResource(R.string.error_unknown_message))
-    object LoadDirectConversationError : InfoMessageType(UIText.StringResource(R.string.error_unknown_message))
-
-    // change group role
-    object ChangeGroupRoleError : InfoMessageType(UIText.StringResource(R.string.user_profile_role_change_error))
-
-    // remove conversation member
-    object RemoveConversationMemberError : InfoMessageType(UIText.StringResource(R.string.dialog_remove_conversation_member_error))
-
-    // Conversation BottomSheet
-    object BlockingUserOperationError : InfoMessageType(UIText.StringResource(R.string.error_blocking_user))
-    class BlockingUserOperationSuccess(val name: String) :
-        InfoMessageType(UIText.StringResource(R.string.blocking_user_success, name))
-
-    object MutingOperationError : InfoMessageType(UIText.StringResource(R.string.error_updating_muting_setting))
-
-    object UnblockingUserOperationError : InfoMessageType(UIText.StringResource(R.string.error_unblocking_user))
 }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -365,6 +365,7 @@ class OtherUserProfileScreenViewModelTest {
         // then
         coVerify {
             arrangement.getConversationUseCase(USER_ID)
+            arrangement.getOrCreateOneToOneConversation(USER_ID) wasNot Called
         }
 
         assertEquals(false, viewModel.state.isDataLoading)

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCaseRe
 import com.wire.kalium.logic.feature.connection.IgnoreConnectionRequestUseCaseResult
 import com.wire.kalium.logic.feature.connection.SendConnectionRequestResult
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
+import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import io.mockk.Called
@@ -341,11 +342,12 @@ class OtherUserProfileScreenViewModelTest {
             .withUserInfo(
                 GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)
             )
+            .withGetConversationDetails(GetOneToOneConversationUseCase.Result.Success(CONVERSATION))
             .arrange()
 
         // then
         coVerify {
-            arrangement.getOrCreateOneToOneConversation(USER_ID)
+            arrangement.getConversationUseCase(USER_ID)
         }
     }
 
@@ -357,11 +359,12 @@ class OtherUserProfileScreenViewModelTest {
                 GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)
             )
             .withGetOneToOneConversation(CreateConversationResult.Failure(Unknown(RuntimeException("some error"))))
+            .withGetConversationDetails(GetOneToOneConversationUseCase.Result.Failure)
             .arrange()
 
         // then
         coVerify {
-            arrangement.getOrCreateOneToOneConversation(USER_ID)
+            arrangement.getConversationUseCase(USER_ID)
         }
 
         assertEquals(false, viewModel.state.isDataLoading)

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -54,7 +54,7 @@ class OtherUserProfileScreenViewModelTest {
                 // then
                 coVerify { arrangement.sendConnectionRequest(eq(USER_ID)) }
                 assertEquals(ConnectionState.SENT, viewModel.state.connectionState)
-                assertEquals(InfoMessageType.SuccessConnectionSentRequest.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.SuccessConnectionSentRequest.uiText, awaitItem())
             }
         }
 
@@ -77,7 +77,7 @@ class OtherUserProfileScreenViewModelTest {
                     arrangement.sendConnectionRequest(eq(USER_ID))
                     arrangement.navigationManager wasNot Called
                 }
-                assertEquals(InfoMessageType.ConnectionRequestError.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.ConnectionRequestError.uiText, awaitItem())
             }
         }
 
@@ -113,7 +113,7 @@ class OtherUserProfileScreenViewModelTest {
                 // then
                 coVerify { arrangement.cancelConnectionRequest(eq(USER_ID)) }
                 assertEquals(ConnectionState.NOT_CONNECTED, viewModel.state.connectionState)
-                assertEquals(InfoMessageType.SuccessConnectionCancelRequest.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.SuccessConnectionCancelRequest.uiText, awaitItem())
             }
         }
 
@@ -133,7 +133,7 @@ class OtherUserProfileScreenViewModelTest {
                 // then
                 coVerify { arrangement.acceptConnectionRequest(eq(USER_ID)) }
                 assertEquals(ConnectionState.ACCEPTED, viewModel.state.connectionState)
-                assertEquals(InfoMessageType.SuccessConnectionAcceptRequest.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.SuccessConnectionAcceptRequest.uiText, awaitItem())
             }
         }
 
@@ -265,7 +265,7 @@ class OtherUserProfileScreenViewModelTest {
                     arrangement.updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, newRole)
                     arrangement.navigationManager wasNot Called
                 }
-                assertEquals(InfoMessageType.ChangeGroupRoleError.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.ChangeGroupRoleError.uiText, awaitItem())
             }
         }
 
@@ -288,7 +288,7 @@ class OtherUserProfileScreenViewModelTest {
                 )
                 // then
                 coVerify { arrangement.blockUser(eq(USER_ID)) }
-                assertEquals(InfoMessageType.BlockingUserOperationError.uiText, awaitItem())
+                assertEquals(OtherUserProfileInfoMessageType.BlockingUserOperationError.uiText, awaitItem())
                 assertEquals(false, viewModel.requestInProgress)
             }
         }
@@ -316,7 +316,7 @@ class OtherUserProfileScreenViewModelTest {
                 coVerify { arrangement.blockUser(eq(USER_ID)) }
                 assertEquals(
                     (awaitItem() as UIText.StringResource).resId,
-                    (InfoMessageType.BlockingUserOperationSuccess(userName).uiText as UIText.StringResource).resId
+                    (OtherUserProfileInfoMessageType.BlockingUserOperationSuccess(userName).uiText as UIText.StringResource).resId
                 )
                 assertEquals(false, viewModel.requestInProgress)
             }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.feature.connection.SendConnectionRequestResult
 import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
-import com.wire.kalium.logic.feature.conversation.GetConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -104,7 +104,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var persistOtherUserClientsUseCase: PersistOtherUserClientsUseCase
 
     @MockK
-    lateinit var getConversationUseCase: GetConversationUseCase
+    lateinit var getConversationUseCase: GetOneToOneConversationUseCase
 
     private val viewModel by lazy {
         OtherUserProfileScreenViewModel(
@@ -193,6 +193,10 @@ internal class OtherUserProfileViewModelArrangement {
 
     suspend fun withUserInfo(result: GetUserInfoResult) = apply {
         coEvery { observeUserInfo(any()) } returns flowOf(result)
+    }
+
+    fun withGetConversationDetails(result: GetOneToOneConversationUseCase.Result) = apply {
+        coEvery { getConversationUseCase(any()) } returns result
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.connection.SendConnectionRequestResult
 import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
+import com.wire.kalium.logic.feature.conversation.GetConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -102,6 +103,9 @@ internal class OtherUserProfileViewModelArrangement {
     @MockK
     lateinit var persistOtherUserClientsUseCase: PersistOtherUserClientsUseCase
 
+    @MockK
+    lateinit var getConversationUseCase: GetConversationUseCase
+
     private val viewModel by lazy {
         OtherUserProfileScreenViewModel(
             savedStateHandle,
@@ -112,6 +116,7 @@ internal class OtherUserProfileViewModelArrangement {
             blockUser,
             unblockUser,
             getOrCreateOneToOneConversation,
+            getConversationUseCase,
             observeUserInfo,
             sendConnectionRequest,
             cancelConnectionRequest,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On other user profile screen, we are creating always (or getting) a new conversation on init block. 
You can test now in the current build with any user with who you didn't have a conversation before, and you will see automatically added to conversations list, even without clicking open conversation.

What this does is: 

- Change, some dispatchers to offload init process
- Activate the loader to the avatar image
- Kalium update to exec 1 query instead of 2 to the conversation info

Note: On upcoming PRs we will move this logic to being on demand, as we only need this info when we display the bottom sheet.

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
