### PR TITLE
feat: Display asset upload progress [AR-1671]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -137,7 +137,6 @@ class MessageContentMapper @Inject constructor(
 
     suspend fun toUIMessageContent(assetMessageData: AssetMessageData, message: Message, scope: CoroutineScope) =
         with(assetMessageData.assetMessageContent) {
-
             when {
                 // If it's an image, we download it right away
                 assetMessageData.isValidImage() -> {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -25,8 +25,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.util.isGreaterThan
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -14,7 +14,6 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.android.util.uiMessageDateTime
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.OtherUser
@@ -22,11 +21,11 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class MessageMapper @Inject constructor(
-    private val dispatcherProvider: DispatcherProvider,
     private val userTypeMapper: UserTypeMapper,
     private val messageContentMapper: MessageContentMapper,
     private val isoFormatter: ISOFormatter,
@@ -45,8 +44,8 @@ class MessageMapper @Inject constructor(
     suspend fun toUIMessages(
         userList: List<User>,
         messages: List<Message>
-    ): List<UIMessage> = withContext(dispatcherProvider.io()) {
-        messages.map { message ->
+    ): List<UIMessage> {
+        return messages.map { message ->
             val sender = userList.findUser(message.senderUserId)
             val content = messageContentMapper.fromMessage(
                 message = message,

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class MessageMapper @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
     private val userTypeMapper: UserTypeMapper,
     private val messageContentMapper: MessageContentMapper,
     private val isoFormatter: ISOFormatter,
@@ -44,8 +45,8 @@ class MessageMapper @Inject constructor(
     suspend fun toUIMessages(
         userList: List<User>,
         messages: List<Message>
-    ): List<UIMessage> {
-        return messages.map { message ->
+    ): List<UIMessage> = withContext(dispatcherProvider.io()) {
+        messages.mapNotNull { message ->
             val sender = userList.findUser(message.senderUserId)
             val content = messageContentMapper.fromMessage(
                 message = message,
@@ -60,7 +61,7 @@ class MessageMapper @Inject constructor(
                     messageHeader = provideMessageHeader(sender, message),
                     userAvatarData = getUserAvatarData(sender)
                 )
-        }.filterNotNull()
+        }
     }
 
     private fun provideMessageHeader(sender: User?, message: Message): MessageHeader = MessageHeader(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -210,6 +210,7 @@ private fun MessageContent(
         is UIMessageContent.ImageMessage -> MessageImage(
             rawImgData = messageContent.imgData,
             imgParams = ImageMessageParams(messageContent.width, messageContent.height),
+            assetUploadStatus = messageContent.uploadStatus,
             onImageClick = onImageClick
         )
         is UIMessageContent.TextMessage -> MessageBody(
@@ -220,6 +221,7 @@ private fun MessageContent(
             assetName = messageContent.assetName,
             assetExtension = messageContent.assetExtension,
             assetSizeInBytes = messageContent.assetSizeInBytes,
+            assetUploadStatus = messageContent.uploadStatus,
             assetDownloadStatus = messageContent.downloadStatus,
             onAssetClick = onAssetClick
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -91,7 +91,7 @@ class ConversationMessagesViewModel @Inject constructor(
             } catch (e: OutOfMemoryError) {
                 appLogger.e("There was an OutOfMemory error while downloading the asset")
                 onSnackbarMessage(ConversationSnackbarMessages.ErrorDownloadingAsset)
-                updateAssetMessageDownloadStatus(Message.DownloadStatus.FAILED, conversationId, messageId)
+                updateAssetMessageDownloadStatus(Message.DownloadStatus.FAILED_DOWNLOAD, conversationId, messageId)
             }
         }
     }
@@ -113,15 +113,15 @@ class ConversationMessagesViewModel @Inject constructor(
         val assetContent = messageContent.value
         val downloadStatus = assetContent.downloadStatus
         val isAssetDownloadedInternally = downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY ||
-                downloadStatus == Message.DownloadStatus.IN_PROGRESS
+                downloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS
 
         if (!isAssetDownloadedInternally)
         // TODO: Refactor. UseCase responsible for downloading should update to IN_PROGRESS status.
-            updateAssetMessageDownloadStatus(Message.DownloadStatus.IN_PROGRESS, conversationId, messageId)
+            updateAssetMessageDownloadStatus(Message.DownloadStatus.DOWNLOAD_IN_PROGRESS, conversationId, messageId)
 
         val resultData = assetDataPath(conversationId, messageId)
         updateAssetMessageDownloadStatus(
-            if (resultData != null) Message.DownloadStatus.SAVED_INTERNALLY else Message.DownloadStatus.FAILED,
+            if (resultData != null) Message.DownloadStatus.SAVED_INTERNALLY else Message.DownloadStatus.FAILED_DOWNLOAD,
             conversationId,
             messageId
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -60,7 +60,7 @@ val mockImageLoader = WireSessionImageLoader(object : ImageLoader {
     override fun shutdown() = TODO("Not yet implemented")
 })
 
-val mockAssetMessage = UIMessage(
+fun mockAssetMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED) = UIMessage(
     userAvatarData = UserAvatarData(
         UserAvatarAsset(mockImageLoader, UserAssetId("a", "domain")),
         UserAvailabilityStatus.AVAILABLE
@@ -69,7 +69,7 @@ val mockAssetMessage = UIMessage(
         username = UIText.DynamicString("John Doe"),
         membership = Membership.Guest,
         isLegalHold = true,
-        messageTime = MessageTime( "12.23pm"),
+        messageTime = MessageTime("12.23pm"),
         messageStatus = MessageStatus.Untouched,
         messageId = "",
         connectionState = ConnectionState.ACCEPTED
@@ -79,13 +79,31 @@ val mockAssetMessage = UIMessage(
         assetExtension = "ZIP",
         assetId = UserAssetId("asset", "domain"),
         assetSizeInBytes = 21957335,
+        uploadStatus = uploadStatus,
         downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
     ),
     messageSource = MessageSource.Self
 )
 
 @Suppress("MagicNumber")
-val mockedImg = UIMessageContent.ImageMessage(UserAssetId("a", "domain"), ByteArray(16), 0, 0)
+fun mockedImg(uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED) = UIMessageContent.ImageMessage(
+    UserAssetId("a", "domain"), null, 0, 0, uploadStatus = uploadStatus
+)
+@Suppress("MagicNumber")
+fun mockedImageUIMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED) = UIMessage(
+    userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
+    messageHeader = MessageHeader(
+        username = UIText.DynamicString("John Doe"),
+        membership = Membership.External,
+        isLegalHold = false,
+        messageTime = MessageTime("12.23pm"),
+        messageStatus = MessageStatus.Edited("May 31, 2022 12.24pm"),
+        messageId = "4",
+        connectionState = ConnectionState.ACCEPTED
+    ),
+    messageContent = mockedImg(uploadStatus),
+    messageSource = MessageSource.Self
+)
 
 @Suppress("LongMethod", "MagicNumber")
 fun getMockedMessages(): List<UIMessage> = listOf(
@@ -95,7 +113,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.Guest,
             isLegalHold = true,
-            messageTime = MessageTime(  "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Untouched,
             messageId = "1",
             connectionState = ConnectionState.ACCEPTED
@@ -118,12 +136,12 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.Guest,
             isLegalHold = true,
-            messageTime = MessageTime(  "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Deleted,
             messageId = "2",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = mockedImg,
+        messageContent = mockedImg(),
         messageSource = MessageSource.Self
     ),
     UIMessage(
@@ -132,12 +150,12 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.External,
             isLegalHold = false,
-            messageTime = MessageTime(  "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Edited("May 31, 2022 12.24pm"),
             messageId = "3",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = mockedImg,
+        messageContent = mockedImg(),
         messageSource = MessageSource.Self
     ),
     UIMessage(
@@ -146,12 +164,12 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.External,
             isLegalHold = false,
-            messageTime = MessageTime( "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Edited("May 31, 2022 12.24pm"),
             messageId = "4",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = mockedImg,
+        messageContent = mockedImg(),
         messageSource = MessageSource.Self
     ),
     UIMessage(
@@ -160,7 +178,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.External,
             isLegalHold = false,
-            messageTime = MessageTime( "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Deleted,
             messageId = "5",
             connectionState = ConnectionState.ACCEPTED
@@ -183,12 +201,12 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.External,
             isLegalHold = false,
-            messageTime = MessageTime( "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Edited("May 31, 2022 12.24pm"),
             messageId = "6",
             connectionState = ConnectionState.ACCEPTED
         ),
-        messageContent = mockedImg,
+        messageContent = mockedImg(),
         messageSource = MessageSource.Self
     ),
     UIMessage(
@@ -197,7 +215,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             username = UIText.DynamicString("John Doe"),
             membership = Membership.External,
             isLegalHold = false,
-            messageTime = MessageTime( "12.23pm"),
+            messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus.Edited("May 31, 2022 12.24pm"),
             messageId = "7",
             connectionState = ConnectionState.ACCEPTED

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -400,7 +400,8 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         assetDownloadStatus == NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
         assetDownloadStatus == SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
         assetDownloadStatus == DOWNLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
-        assetDownloadStatus == SAVED_EXTERNALLY || assetUploadStatus == UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+        assetDownloadStatus == SAVED_EXTERNALLY
+                || assetUploadStatus == UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
         assetDownloadStatus == FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
         else -> ""
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -111,7 +111,7 @@ fun MessageImage(
                 onLongClick = onImageClick.onLongClick,
             )
     ) {
-        when (assetUploadStatus) {
+        when     (assetUploadStatus) {
             // Default states, we try to draw the image
             Message.UploadStatus.NOT_UPLOADED -> {}
             Message.UploadStatus.UPLOADED -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -111,7 +111,7 @@ fun MessageImage(
                 onLongClick = onImageClick.onLongClick,
             )
     ) {
-        when     (assetUploadStatus) {
+        when (assetUploadStatus) {
             // Default states, we try to draw the image
             Message.UploadStatus.NOT_UPLOADED -> {}
             Message.UploadStatus.UPLOADED -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +53,7 @@ import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.MessageComposerViewModel
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
@@ -133,9 +133,13 @@ fun MessageImage(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .size(dimensions().spacing200x)
+                        .width(imgParams.normalizedWidth)
+                        .height(imgParams.normalizedHeight)
                 ) {
-                    CircularProgressIndicator()
+                    WireCircularProgressIndicator(
+                        progressColor = MaterialTheme.wireColorScheme.primary,
+                        size = MaterialTheme.wireDimensions.spacing24x
+                    )
                     Text(
                         text = stringResource(id = R.string.asset_message_upload_in_progress_text),
                         style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
@@ -165,7 +169,7 @@ fun MessageImage(
                     Text(
                         text = stringResource(id = R.string.error_uploading_image_message),
                         textAlign = TextAlign.Center,
-                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.error),
+                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.error)
                     )
                 }
             }
@@ -406,11 +410,14 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         else -> ""
     }
 
-@Suppress("MagicNumber")
-private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String = when {
-    assetSizeInBytes < 1000 -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
-    assetSizeInBytes in 1000..999999 -> "${assetExtension.uppercase()} (${assetSizeInBytes / 1000} KB)"
-    else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / 1000000f) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
+private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
+    val oneKB = 1024L
+    val oneMB = oneKB * oneKB
+    return when {
+        assetSizeInBytes < oneKB -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
+        assetSizeInBytes in oneKB..oneMB -> "${assetExtension.uppercase()} (${assetSizeInBytes / oneKB} KB)"
+        else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / oneMB) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
+    }
 }
 
 // TODO:we should provide the SpanStyle by LocalProvider to our Theme, later on

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -59,14 +58,14 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.UploadStatus.FAILED_UPLOAD
-import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOAD_IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOAD_IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED_DOWNLOAD
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
+import com.wire.kalium.logic.data.message.Message.UploadStatus.FAILED_UPLOAD
 import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOADED
+import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOAD_IN_PROGRESS
 import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
@@ -407,12 +406,10 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
     }
 
 @Suppress("MagicNumber")
-private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
-    return when {
-        assetSizeInBytes < 1000 -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
-        assetSizeInBytes in 1000..999999 -> "${assetExtension.uppercase()} (${assetSizeInBytes / 1000} KB)"
-        else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / 1000000f) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
-    }
+private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String = when {
+    assetSizeInBytes < 1000 -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
+    assetSizeInBytes in 1000..999999 -> "${assetExtension.uppercase()} (${assetSizeInBytes / 1000} KB)"
+    else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / 1000000f) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
 }
 
 // TODO:we should provide the SpanStyle by LocalProvider to our Theme, later on

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -410,6 +410,7 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         else -> ""
     }
 
+@Suppress("MagicNumber")
 private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
     val oneKB = 1024L
     val oneMB = oneKB * oneKB

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -13,14 +13,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -36,6 +40,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
@@ -54,11 +59,14 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
+import com.wire.kalium.logic.data.message.Message.UploadStatus.FAILED_UPLOAD
+import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOAD_IN_PROGRESS
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOAD_IN_PROGRESS
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED_DOWNLOAD
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
+import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOADED
 import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
@@ -80,30 +88,89 @@ internal fun MessageBody(messageBody: MessageBody, onLongClick: (() -> Unit)? = 
 fun MessageImage(
     rawImgData: ByteArray?,
     imgParams: ImageMessageParams,
+    assetUploadStatus: Message.UploadStatus,
     onImageClick: Clickable,
 ) {
+    val imageData: Bitmap? = if (rawImgData != null && rawImgData.size < MessageComposerViewModel.IMAGE_SIZE_LIMIT_BYTES)
+        rawImgData.toBitmap() else null
     Box(
         Modifier
             .clip(shape = RoundedCornerShape(dimensions().messageAssetBorderRadius))
+            .background(
+                color = MaterialTheme.wireColorScheme.onPrimary,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .wrapContentSize()
             .combinedClickable(
                 enabled = onImageClick.enabled,
                 onClick = onImageClick.onClick,
                 onLongClick = onImageClick.onLongClick,
             )
     ) {
-        // TODO: We should not use rawImgData, but use something like the current ImageLoader instead.
-        val imageData: Bitmap? =
-            if (rawImgData != null && rawImgData.size < MessageComposerViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null
-
-        Image(
-            painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
-            alignment = Alignment.CenterStart,
-            contentDescription = stringResource(R.string.content_description_image_message),
-            modifier = Modifier
-                .width(if (imageData != null) imgParams.normalizedWidth else dimensions().spacing24x)
-                .height(if (imageData != null) imgParams.normalizedHeight else dimensions().spacing24x),
-            contentScale = ContentScale.Crop
-        )
+        when (assetUploadStatus) {
+            // Default states, we try to draw the image
+            Message.UploadStatus.NOT_UPLOADED -> {}
+            Message.UploadStatus.UPLOADED -> {
+                Image(
+                    painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
+                    contentDescription = stringResource(R.string.content_description_image_message),
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .width(if (imageData != null) imgParams.normalizedWidth else dimensions().spacing24x)
+                        .height(if (imageData != null) imgParams.normalizedHeight else dimensions().spacing24x),
+                    alignment = Alignment.CenterStart,
+                    contentScale = ContentScale.Crop
+                )
+            }
+            // Trying to upload the asset
+            Message.UploadStatus.UPLOAD_IN_PROGRESS -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(dimensions().spacing200x)
+                ) {
+                    CircularProgressIndicator()
+                    Text(
+                        text = stringResource(id = R.string.asset_message_upload_in_progress_text),
+                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1
+                    )
+                }
+            }
+            Message.UploadStatus.FAILED_UPLOAD -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(dimensions().spacing200x)
+                ) {
+                    Image(
+                        painter = rememberAsyncImagePainter(getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .width(dimensions().spacing24x)
+                            .height(dimensions().spacing24x),
+                        alignment = Alignment.CenterStart,
+                        colorFilter = ColorFilter.tint(Color.Red),
+                        contentScale = ContentScale.Crop
+                    )
+                    Text(
+                        text = stringResource(id = R.string.error_uploading_image_message),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.error),
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -115,7 +182,9 @@ fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String) {
         border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.divider)
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().height(dimensions().messageImageMaxWidth),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(dimensions().messageImageMaxWidth),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -221,6 +290,7 @@ internal fun MessageAsset(
     assetExtension: String,
     assetSizeInBytes: Long,
     onAssetClick: Clickable,
+    assetUploadStatus: Message.UploadStatus,
     assetDownloadStatus: Message.DownloadStatus
 ) {
     val assetDescription = provideAssetDescription(assetExtension, assetSizeInBytes)
@@ -286,13 +356,13 @@ internal fun MessageAsset(
                 ) {
                     Text(
                         modifier = Modifier.padding(end = dimensions().spacing4x),
-                        text = getDownloadStatusText(assetDownloadStatus),
+                        text = getDownloadStatusText(assetDownloadStatus, assetUploadStatus),
                         color = MaterialTheme.wireColorScheme.run {
-                            if (assetDownloadStatus == FAILED) error else secondaryText
+                            if (assetDownloadStatus == FAILED_DOWNLOAD || assetUploadStatus == FAILED_UPLOAD) error else secondaryText
                         },
                         style = MaterialTheme.wireTypography.subline01
                     )
-                    DownloadStatusIcon(assetDownloadStatus)
+                    DownloadStatusIcon(assetDownloadStatus, assetUploadStatus)
                 }
             }
         }
@@ -300,19 +370,20 @@ internal fun MessageAsset(
 }
 
 @Composable
-private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
-    return when (assetDownloadStatus) {
-        IN_PROGRESS -> WireCircularProgressIndicator(
+private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
+    return when {
+        assetUploadStatus == UPLOAD_IN_PROGRESS || assetDownloadStatus == DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )
-        SAVED_INTERNALLY -> Icon(
+        assetUploadStatus == FAILED_UPLOAD -> {}
+        assetDownloadStatus == SAVED_INTERNALLY -> Icon(
             painter = painterResource(id = R.drawable.ic_download),
             contentDescription = stringResource(R.string.content_description_download_icon),
             modifier = Modifier.size(dimensions().wireIconButtonSize),
             tint = MaterialTheme.wireColorScheme.secondaryText
         )
-        SAVED_EXTERNALLY -> Icon(
+        assetDownloadStatus == SAVED_EXTERNALLY -> Icon(
             painter = painterResource(id = R.drawable.ic_check_tick),
             contentDescription = stringResource(R.string.content_description_check),
             modifier = Modifier.size(dimensions().wireIconButtonSize),
@@ -323,13 +394,16 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
 }
 
 @Composable
-fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus): String =
-    when (assetDownloadStatus) {
-        NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
-        SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
-        IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
-        SAVED_EXTERNALLY -> stringResource(R.string.asset_message_saved_externally_text)
-        FAILED -> stringResource(R.string.asset_message_failed_download_text)
+fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus): String =
+    when {
+        assetUploadStatus == UPLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_upload_in_progress_text)
+        assetUploadStatus == FAILED_UPLOAD -> stringResource(R.string.asset_message_failed_upload_text)
+        assetDownloadStatus == NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
+        assetDownloadStatus == SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
+        assetDownloadStatus == DOWNLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
+        assetDownloadStatus == SAVED_EXTERNALLY || assetUploadStatus == UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+        assetDownloadStatus == FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
+        else -> ""
     }
 
 @Suppress("MagicNumber")

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -7,7 +7,9 @@ import com.wire.android.ui.home.conversations.MessageItem
 import com.wire.android.ui.home.conversations.SystemMessageItem
 import com.wire.android.ui.home.conversations.mock.mockAssetMessage
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
+import com.wire.android.ui.home.conversations.mock.mockedImageUIMessage
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.message.Message
 
 @Preview(showBackground = true)
 @Composable
@@ -46,7 +48,42 @@ fun PreviewDeletedMessage() {
 @Composable
 fun PreviewAssetMessage() {
     MessageItem(
-        message = mockAssetMessage,
+        message = mockAssetMessage(),
+        onLongClicked = {},
+        onAssetMessageClicked = {},
+        onImageMessageClicked = { _, _ -> },
+        onAvatarClicked = { _, _ -> }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewImageMessageUploaded() {
+    MessageItem(
+        message = mockedImageUIMessage(Message.UploadStatus.UPLOADED),
+        onLongClicked = {},
+        onAssetMessageClicked = {},
+        onImageMessageClicked = { _, _ -> },
+        onAvatarClicked = { _, _ -> }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewImageMessageUploading() {
+    MessageItem(
+        message = mockedImageUIMessage(Message.UploadStatus.UPLOAD_IN_PROGRESS),
+        onLongClicked = {},
+        onAssetMessageClicked = {},
+        onImageMessageClicked = { _, _ -> },
+        onAvatarClicked = { _, _ -> }
+    )
+}
+@Preview(showBackground = true)
+@Composable
+fun PreviewImageMessageFailedUpload() {
+    MessageItem(
+        message = mockedImageUIMessage(Message.UploadStatus.FAILED_UPLOAD),
         onLongClicked = {},
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -70,16 +70,24 @@ sealed class UIMessageContent {
         val assetExtension: String,
         val assetId: AssetId,
         val assetSizeInBytes: Long,
+        val uploadStatus: Message.UploadStatus,
         val downloadStatus: Message.DownloadStatus
     ) : ClientMessage()
 
-    data class ImageMessage(val assetId: AssetId, val imgData: ByteArray?, val width: Int, val height: Int) : UIMessageContent() {
+    data class ImageMessage(
+        val assetId: AssetId,
+        var imgData: ByteArray?,
+        val width: Int,
+        val height: Int,
+        val uploadStatus: Message.UploadStatus
+    ) : UIMessageContent() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
             other as ImageMessage
             if (assetId != other.assetId) return false
             if (!imgData.contentEquals(other.imgData)) return false
+            if (uploadStatus != other.uploadStatus) return false
             return true
         }
 
@@ -127,6 +135,6 @@ enum class MessageSource {
     Self, OtherUser
 }
 
-data class MessageTime(val utcISO : String){
+data class MessageTime(val utcISO: String) {
     val formattedDate = utcISO.uiMessageDateTime() ?: ""
 }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -117,6 +117,8 @@ data class WireDimensions(
     val spacing64x: Dp,
     val spacing72x: Dp,
     val spacing80x: Dp,
+    val spacing100x: Dp,
+    val spacing200x: Dp,
     // Corners
     val corner2x: Dp,
     val corner4x: Dp,
@@ -248,6 +250,8 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     spacing64x = 64.dp,
     spacing72x = 72.dp,
     spacing80x = 80.dp,
+    spacing100x = 100.dp,
+    spacing200x = 200.dp,
     corner2x = 2.dp,
     corner4x = 4.dp,
     corner6x = 6.dp,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="asset_message_downloaded_internally_text">Downloaded</string>
     <string name="asset_message_saved_externally_text">Saved</string>
     <string name="asset_message_failed_download_text">File not available</string>
+    <string name="asset_message_failed_upload_text">File upload failed</string>
     <string name="asset_download_dialog_text">Do you want to open the file, or save it to your
         devices downloads folder?
     </string>
@@ -414,7 +415,7 @@
     <string name="error_no_network_message">Please check your Internet connection and try again</string>
     <string name="error_downloading_user_info">There was an error downloading the user information. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Picture could not be uploaded</string>
-    <string name="error_uploading_image_message">Image message could not be sent</string>
+    <string name="error_uploading_image_message">Image upload failed</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
     <string name="error_conversation_sending_image">The picture could not be sent. Please check your internet connection and try again.</string>
     <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check your Internet connection and try again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <string name="group_name_exceeded_limit_error">Group name should not exceed 64 characters
     </string>
     <string name="asset_message_tap_to_download_text">Tap to download</string>
+    <string name="asset_message_upload_in_progress_text">Uploading…</string>
     <string name="asset_message_download_in_progress_text">Downloading…</string>
     <string name="asset_message_downloaded_internally_text">Downloaded</string>
     <string name="asset_message_saved_externally_text">Saved</string>
@@ -413,6 +414,7 @@
     <string name="error_no_network_message">Please check your Internet connection and try again</string>
     <string name="error_downloading_user_info">There was an error downloading the user information. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Picture could not be uploaded</string>
+    <string name="error_uploading_image_message">Image message could not be sent</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
     <string name="error_conversation_sending_image">The picture could not be sent. Please check your internet connection and try again.</string>
     <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check your Internet connection and try again</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -1,5 +1,6 @@
 package com.wire.android.framework
 
+import com.wire.android.mapper.AssetMessageData
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UIMessageContent.TextMessage
@@ -39,7 +40,13 @@ object TestMessage {
         encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
     )
     val ASSET_IMAGE_CONTENT = AssetContent(
-        0L, "name", "image/jpg", AssetContent.AssetMetadata.Image(100, 100), DUMMY_ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
+        0L,
+        "name",
+        "image/jpg",
+        AssetContent.AssetMetadata.Image(100, 100),
+        DUMMY_ASSET_REMOTE_DATA,
+        Message.UploadStatus.NOT_UPLOADED,
+        Message.DownloadStatus.NOT_DOWNLOADED
     )
     val ASSET_MESSAGE = Message.Regular(
         id = "messageID",
@@ -51,6 +58,17 @@ object TestMessage {
         status = Message.Status.SENT,
         editStatus = Message.EditStatus.NotEdited
     )
+    fun buildAssetMessage(assetContent: AssetContent) = Message.Regular(
+        id = "messageID",
+        content = MessageContent.Asset(assetContent),
+        conversationId = ConversationId("convo-id", "convo.domain"),
+        date = "some-date",
+        senderUserId = UserId("user-id", "domain"),
+        senderClientId = ClientId("client-id"),
+        status = Message.Status.SENT,
+        editStatus = Message.EditStatus.NotEdited
+    )
+
     val MEMBER_REMOVED_MESSAGE = Message.System(
         id = "messageID",
         content = MessageContent.MemberChange.Removed(listOf(UserId("user-id", "domain"))),
@@ -58,6 +76,17 @@ object TestMessage {
         date = "some-date",
         senderUserId = UserId("user-id", "domain"),
         status = Message.Status.SENT
+    )
+    val IMAGE_ASSET_MESSAGE_DATA_TEST = AssetMessageData(
+        AssetContent(
+            100L,
+            "dummy_data.tiff",
+            "image/tiff",
+            AssetContent.AssetMetadata.Image(50, 50),
+            AssetContent.RemoteData(ByteArray(16), ByteArray(16), "asset-id", "token", "domain.com", MessageEncryptionAlgorithm.AES_CBC),
+            Message.UploadStatus.NOT_UPLOADED,
+            Message.DownloadStatus.NOT_DOWNLOADED
+        )
     )
     val UI_MESSAGE_HEADER = MessageHeader(
         username = UIText.DynamicString("username"),

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.test.runTest
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -55,11 +56,11 @@ class MessageContentMapperTest {
         val deleted = mapper.toSystemMessageMemberName(deletedMemberDetails.user, MessageContentMapper.SelfNameType.NameOrDeleted)
         val otherName = mapper.toSystemMessageMemberName(otherMemberDetails.user, MessageContentMapper.SelfNameType.NameOrDeleted)
         // Then
-        assert(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.name)
-        assert(selfResLower is UIText.StringResource && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase)
-        assert(selfResTitle is UIText.StringResource && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase)
-        assert(deleted is UIText.StringResource && deleted.resId == arrangement.messageResourceProvider.memberNameDeleted)
-        assert(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.name)
+        assertTrue(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.name)
+        assertTrue(selfResLower is UIText.StringResource && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase)
+        assertTrue(selfResTitle is UIText.StringResource && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase)
+        assertTrue(deleted is UIText.StringResource && deleted.resId == arrangement.messageResourceProvider.memberNameDeleted)
+        assertTrue(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.name)
     }
 
     @Test
@@ -72,13 +73,13 @@ class MessageContentMapperTest {
         val resultText = mapper.toText(textContent)
         val resultNonText = mapper.toText(nonTextContent)
         with(resultText) {
-            assert(
+            assertTrue(
                 messageBody.message is UIText.DynamicString &&
                         (messageBody.message as UIText.DynamicString).value == textContent.value
             )
         }
         with(resultNonText) {
-            assert(
+            assertTrue(
                 messageBody.message is UIText.StringResource &&
                         (messageBody.message as UIText.StringResource).resId == arrangement.messageResourceProvider.sentAMessageWithContent
             )
@@ -111,30 +112,30 @@ class MessageContentMapperTest {
         val resultMyMissedCall = mapper.fromMessage(missedCallMessage, listOf(selfCaller.user))
         val resultOtherMissedCall = mapper.fromMessage(missedCallMessage, listOf(otherCaller.user))
         // Then
-        assert(
+        assertTrue(
             resultContentLeft is SystemMessage.MemberLeft &&
                     resultContentLeft.author.asString(arrangement.resources) == member1.name
         )
-        assert(
+        assertTrue(
             resultContentRemoved is SystemMessage.MemberRemoved &&
                     resultContentRemoved.author.asString(arrangement.resources) == member1.name &&
                     resultContentRemoved.memberNames.size == 1 &&
                     resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.name
 
         )
-        assert(
+        assertTrue(
             resultContentAdded is SystemMessage.MemberAdded &&
                     resultContentAdded.author.asString(arrangement.resources) == member1.name &&
                     resultContentAdded.memberNames.size == 2 &&
                     resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.name &&
                     resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.name
         )
-        assert(resultContentAddedSelf == null)
-        assert(
+        assertTrue(resultContentAddedSelf == null)
+        assertTrue(
             resultOtherMissedCall is SystemMessage.MissedCall &&
                     resultOtherMissedCall.author.asString(arrangement.resources) == TestUser.OTHER_USER.name
         )
-        assert(
+        assertTrue(
             resultMyMissedCall is SystemMessage.MissedCall &&
                     (resultMyMissedCall.author as UIText.StringResource).resId == arrangement.messageResourceProvider.memberNameYouTitlecase
         )
@@ -173,12 +174,12 @@ class MessageContentMapperTest {
             // When - Then
             val resultContentOther = mapper.toUIMessageContent(AssetMessageData(unknownImageMessageContent), testMessage1, scope)
             coVerify(exactly = 0) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
-            assert(resultContentOther is AssetMessage && resultContentOther.assetId.value == unknownImageMessageContent.remoteData.assetId)
+            assertTrue(resultContentOther is AssetMessage && resultContentOther.assetId.value == unknownImageMessageContent.remoteData.assetId)
 
             // When - Then
             val resultContentImage = mapper.toUIMessageContent(AssetMessageData(correctJPGImage), testMessage2, scope)
             coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
-            assert(resultContentImage is ImageMessage && resultContentImage.assetId.value == correctJPGImage.remoteData.assetId)
+            assertTrue(resultContentImage is ImageMessage && resultContentImage.assetId.value == correctJPGImage.remoteData.assetId)
         }
     }
 
@@ -202,7 +203,7 @@ class MessageContentMapperTest {
 
         // Then
         coVerify(inverse = true) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
-        assert(resultContentImage is AssetMessage)
+        assertTrue(resultContentImage is AssetMessage)
     }
 
     @Test
@@ -239,8 +240,8 @@ class MessageContentMapperTest {
             val resultContentImage2 = mapper.toUIMessageContent(AssetMessageData(contentImage2), testMessage2, scope)
 
             // Then
-            assert(resultContentImage1 is AssetMessage)
-            assert(resultContentImage2 is ImageMessage)
+            assertTrue(resultContentImage1 is AssetMessage)
+            assertTrue(resultContentImage2 is ImageMessage)
 
             // Only the image with valid metadata is downloaded
             coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
@@ -265,9 +266,9 @@ class MessageContentMapperTest {
         val resultContentDeleted = mapper.fromMessage(deletedMessage, listOf())
         val resultContentHidden = mapper.fromMessage(hiddenMessage, listOf())
         // Then
-        assert(resultContentVisible != null)
-        assert(resultContentDeleted == null)
-        assert(resultContentHidden == null)
+        assertTrue(resultContentVisible != null)
+        assertTrue(resultContentDeleted == null)
+        assertTrue(resultContentHidden == null)
     }
 
     private class Arrangement {

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -57,8 +57,10 @@ class MessageContentMapperTest {
         val otherName = mapper.toSystemMessageMemberName(otherMemberDetails.user, MessageContentMapper.SelfNameType.NameOrDeleted)
         // Then
         assertTrue(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.name)
-        assertTrue(selfResLower is UIText.StringResource && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase)
-        assertTrue(selfResTitle is UIText.StringResource && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase)
+        assertTrue(selfResLower is UIText.StringResource
+                && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase)
+        assertTrue(selfResTitle is UIText.StringResource
+                && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase)
         assertTrue(deleted is UIText.StringResource && deleted.resId == arrangement.messageResourceProvider.memberNameDeleted)
         assertTrue(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.name)
     }
@@ -172,12 +174,13 @@ class MessageContentMapperTest {
 
         with(arrangement) {
             // When - Then
-            val resultContentOther = mapper.toUIMessageContent(AssetMessageData(unknownImageMessageContent), testMessage1, scope)
+            val resultContentOther = mapper.toUIMessageContent(AssetMessageData(unknownImageMessageContent), testMessage1)
             coVerify(exactly = 0) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
-            assertTrue(resultContentOther is AssetMessage && resultContentOther.assetId.value == unknownImageMessageContent.remoteData.assetId)
+            assertTrue(resultContentOther is AssetMessage
+                    && resultContentOther.assetId.value == unknownImageMessageContent.remoteData.assetId)
 
             // When - Then
-            val resultContentImage = mapper.toUIMessageContent(AssetMessageData(correctJPGImage), testMessage2, scope)
+            val resultContentImage = mapper.toUIMessageContent(AssetMessageData(correctJPGImage), testMessage2)
             coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
             assertTrue(resultContentImage is ImageMessage && resultContentImage.assetId.value == correctJPGImage.remoteData.assetId)
         }
@@ -199,7 +202,7 @@ class MessageContentMapperTest {
         val testMessage = buildAssetMessage(contentImage)
 
         // When
-        val resultContentImage = mapper.toUIMessageContent(AssetMessageData(contentImage), testMessage, arrangement.scope)
+        val resultContentImage = mapper.toUIMessageContent(AssetMessageData(contentImage), testMessage)
 
         // Then
         coVerify(inverse = true) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
@@ -236,8 +239,8 @@ class MessageContentMapperTest {
 
         // When
         with(arrangement) {
-            val resultContentImage1 = mapper.toUIMessageContent(AssetMessageData(contentImage1), testMessage1, scope)
-            val resultContentImage2 = mapper.toUIMessageContent(AssetMessageData(contentImage2), testMessage2, scope)
+            val resultContentImage1 = mapper.toUIMessageContent(AssetMessageData(contentImage1), testMessage1)
+            val resultContentImage2 = mapper.toUIMessageContent(AssetMessageData(contentImage2), testMessage2)
 
             // Then
             assertTrue(resultContentImage1 is AssetMessage)
@@ -283,8 +286,6 @@ class MessageContentMapperTest {
         lateinit var resources: Resources
 
         val testDispatcher = TestDispatcherProvider()
-
-        val scope = CoroutineScope(SupervisorJob() + testDispatcher.default())
 
         private val messageContentMapper by lazy {
             MessageContentMapper(getMessageAssetUseCase, messageResourceProvider, fakeKaliumFileSystem, testDispatcher)

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -161,11 +161,11 @@ class MessageContentMapperTest {
             Message.DownloadStatus.NOT_DOWNLOADED
         )
         // When - Then
-        val resultContentOther = mapper.toAsset(QualifiedID("id", "domain"), "message-id", unknownImageFormatMessage)
+        val resultContentOther = mapper.toUIMessageContent(QualifiedID("id", "domain"), "message-id", unknownImageFormatMessage)
         coVerify(exactly = 0) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
         assert(resultContentOther is AssetMessage && resultContentOther.assetId.value == unknownImageFormatMessage.remoteData.assetId)
         // When - Then
-        val resultContentImage = mapper.toAsset(QualifiedID("id", "domain"), "message-id", correctJPGImage)
+        val resultContentImage = mapper.toUIMessageContent(QualifiedID("id", "domain"), "message-id", correctJPGImage)
         coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
         assert(resultContentImage is ImageMessage && resultContentImage.assetId.value == correctJPGImage.remoteData.assetId)
     }
@@ -184,7 +184,7 @@ class MessageContentMapperTest {
         )
 
         // When
-        val resultContentImage = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentImage)
+        val resultContentImage = mapper.toUIMessageContent(QualifiedID("id", "domain"), "message-id", contentImage)
 
         // Then
         coVerify(inverse = true) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
@@ -216,8 +216,8 @@ class MessageContentMapperTest {
         )
 
         // When
-        val resultContentImage1 = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentImage1)
-        val resultContentImage2 = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentImage2)
+        val resultContentImage1 = mapper.toUIMessageContent(QualifiedID("id", "domain"), "message-id", contentImage1)
+        val resultContentImage2 = mapper.toUIMessageContent(QualifiedID("id", "domain"), "message-id", contentImage2)
 
         // Then
         assert(resultContentImage1 is AssetMessage)

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -1,6 +1,7 @@
 package com.wire.android.mapper
 
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.model.MessageBody
@@ -21,6 +22,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -127,7 +129,7 @@ class MessageMapperTest {
         private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
         private val messageMapper by lazy {
-            MessageMapper(userTypeMapper, messageContentMapper, isoFormatter, wireSessionImageLoader)
+            MessageMapper(TestDispatcherProvider(), userTypeMapper, messageContentMapper, isoFormatter, wireSessionImageLoader)
         }
 
         init {

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -128,7 +128,7 @@ class MessageMapperTest {
         private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
         private val messageMapper by lazy {
-            MessageMapper(TestDispatcherProvider(), userTypeMapper, messageContentMapper, isoFormatter, wireSessionImageLoader)
+            MessageMapper(userTypeMapper, messageContentMapper, isoFormatter, wireSessionImageLoader)
         }
 
         init {

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -1,7 +1,6 @@
 package com.wire.android.mapper
 
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.model.MessageBody


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1671" title="AR-1671" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1671</a>  No loading indicator when uploading large file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Assets upload was being executed before persisting the meessage into memory and therefore blocking the display of this message until the upload to the server was finishing. Therefore we needed to make some changes in Kalium to add an extra field `assetUploadStatus` that could be persisted and updated accordingly to the final result of the upload api.

### Dependencies (Optional)

- https://github.com/wireapp/kalium/pull/907

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Just open a conversation, select an asset to upload, then double check the asset shows up in the conversation nad goes from upload to success or failure states.

### Attachments (Optional)


https://user-images.githubusercontent.com/2468164/191057696-be11f2bc-9edb-4d59-b130-4f19e4f51d48.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
