### PR TITLE
fix: Bottom padding in WelcomeScreen (AR-2323)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -7,8 +7,8 @@ import androidx.annotation.ArrayRes
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -255,6 +255,8 @@ private fun WelcomeFooter(modifier: Modifier, onPrivateAccountClick: () -> Unit)
                     interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onPrivateAccountClick
                 )
         )
+
+        Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.welcomeVerticalPadding))
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2323" title="AR-2323" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2323</a>  [Login Screen] Layout is broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

bottom padding was wrong on WelcomeScreen 

### Causes (Optional)

looks like it just wasn't there 

### Solutions

add it

### Attachments (Optional)

![photo_5278661308574712507_y](https://user-images.githubusercontent.com/6539347/191023125-6fc762d5-f63a-4403-ad7f-54caef2af875.jpg)
