### PR TITLE
fix: improve performance on displaying user avatars (AR-2462)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ImageLoadingModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ImageLoadingModule.kt
@@ -2,7 +2,6 @@ package com.wire.android.di
 
 import android.content.Context
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import dagger.Module
@@ -24,8 +23,7 @@ class ImageLoadingModule {
         @ApplicationContext context: Context,
         getAvatarAsset: GetAvatarAssetUseCase,
         getMessageAsset: GetMessageAssetUseCase,
-        kaliumFileSystem: KaliumFileSystem
-    ): WireSessionImageLoader.Factory = WireSessionImageLoader.Factory(context, getAvatarAsset, getMessageAsset, kaliumFileSystem)
+    ): WireSessionImageLoader.Factory = WireSessionImageLoader.Factory(context, getAvatarAsset, getMessageAsset)
 
     // For better performance/caching. We shouldn't create many of these ImageLoaders.
     @Provides

--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -2,7 +2,6 @@ package com.wire.android.mapper
 
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
-import com.wire.android.ui.home.conversations.previewAsset
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
 import com.wire.android.util.ui.WireSessionImageLoader

--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -2,6 +2,7 @@ package com.wire.android.mapper
 
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.previewAsset
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -22,7 +23,7 @@ class ContactMapper
                 name = name.orEmpty(),
                 label = mapUserLabel(otherUser),
                 avatarData = UserAvatarData(
-                    asset = completePicture?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) },
+                    asset = previewPicture?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) },
                     connectionState = connectionStatus
                 ),
                 membership = userTypeMapper.toMembership(userType),

--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -15,8 +15,8 @@ sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
      */
     abstract val uniqueKey: String
 
-    class UserAvatarAsset(
-        imageLoader: WireSessionImageLoader,
+    data class UserAvatarAsset(
+        private val imageLoader: WireSessionImageLoader,
         val userAssetId: UserAssetId
     ) : ImageAsset(imageLoader) {
         override val uniqueKey: String

--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -9,11 +9,19 @@ import com.wire.kalium.logic.data.user.UserAssetId
 
 @Stable
 sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
+    /**
+     * Value that uniquely identifies this Asset,
+     * can be used for caching purposes, for example.
+     */
+    abstract val uniqueKey: String
 
-    data class UserAvatarAsset(
-        private val imageLoader: WireSessionImageLoader,
+    class UserAvatarAsset(
+        imageLoader: WireSessionImageLoader,
         val userAssetId: UserAssetId
-    ) : ImageAsset(imageLoader)
+    ) : ImageAsset(imageLoader) {
+        override val uniqueKey: String
+            get() = userAssetId.toString()
+    }
 
     data class PrivateAsset(
         private val imageLoader: WireSessionImageLoader,
@@ -22,6 +30,8 @@ sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
         val isSelfAsset: Boolean
     ) : ImageAsset(imageLoader) {
         override fun toString(): String = "$conversationId:$messageId:$isSelfAsset"
+        override val uniqueKey: String
+            get() = toString()
     }
 
     @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -91,6 +91,7 @@ fun MessageImage(
                 onLongClick = onImageClick.onLongClick,
             )
     ) {
+        // TODO: We should not use rawImgData, but use something like the current ImageLoader instead.
         val imageData: Bitmap? =
             if (rawImgData != null && rawImgData.size < MessageComposerViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null
 

--- a/app/src/main/kotlin/com/wire/android/util/ui/AssetImageFetcher.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/AssetImageFetcher.kt
@@ -6,19 +6,17 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.Options
 import com.wire.android.model.ImageAsset
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.PublicAssetResult
 
 internal class AssetImageFetcher(
-    val data: ImageAsset,
-    val getPublicAsset: GetAvatarAssetUseCase,
-    val getPrivateAsset: GetMessageAssetUseCase,
-    val resources: Resources,
-    val drawableResultWrapper: DrawableResultWrapper = DrawableResultWrapper(resources),
-    val kaliumFileSystem: KaliumFileSystem
+    private val data: ImageAsset,
+    private val getPublicAsset: GetAvatarAssetUseCase,
+    private val getPrivateAsset: GetMessageAssetUseCase,
+    private val resources: Resources,
+    private val drawableResultWrapper: DrawableResultWrapper = DrawableResultWrapper(resources),
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult? {
@@ -27,18 +25,15 @@ internal class AssetImageFetcher(
                 when (val result = getPublicAsset(data.userAssetId)) {
                     is PublicAssetResult.Failure -> null
                     is PublicAssetResult.Success -> {
-                        // Does coil cache this in memory? We can add our own cache if needed
-                        // imageLoader.memoryCache.set(MemoryCache.Key("assetKey"), MemoryCache.Value("result.asset.toBitmap()"))
                         drawableResultWrapper.toFetchResult(result.assetPath)
                     }
                 }
             }
+
             is ImageAsset.PrivateAsset -> {
                 when (val result = getPrivateAsset(data.conversationId, data.messageId)) {
                     is MessageAssetResult.Failure -> null
                     is MessageAssetResult.Success -> {
-                        // Does coil cache this in memory? We can add our own cache if needed
-                        // imageLoader.memoryCache.set(MemoryCache.Key("assetKey"), MemoryCache.Value("result.asset.toBitmap()"))
                         drawableResultWrapper.toFetchResult(result.decodedAssetPath)
                     }
                 }
@@ -50,7 +45,6 @@ internal class AssetImageFetcher(
         private val getPublicAssetUseCase: GetAvatarAssetUseCase,
         private val getPrivateAssetUseCase: GetMessageAssetUseCase,
         private val resources: Resources,
-        private val kaliumFileSystem: KaliumFileSystem
     ) : Fetcher.Factory<ImageAsset> {
         override fun create(data: ImageAsset, options: Options, imageLoader: ImageLoader): Fetcher =
             AssetImageFetcher(
@@ -58,7 +52,6 @@ internal class AssetImageFetcher(
                 getPublicAsset = getPublicAssetUseCase,
                 getPrivateAsset = getPrivateAssetUseCase,
                 resources = resources,
-                kaliumFileSystem = kaliumFileSystem
             )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
@@ -4,11 +4,12 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
 import coil.Coil
 import coil.ImageLoader
 import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.wire.android.model.ImageAsset
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 
@@ -28,13 +29,18 @@ class WireSessionImageLoader(private val coilImageLoader: ImageLoader) {
     fun paint(
         asset: ImageAsset?,
         fallbackData: Any? = null
-    ): Painter = rememberAsyncImagePainter(asset ?: fallbackData, imageLoader = coilImageLoader)
+    ): Painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(LocalContext.current)
+            .memoryCacheKey(asset?.uniqueKey)
+            .data(asset ?: fallbackData)
+            .build(),
+        imageLoader = coilImageLoader
+    )
 
     class Factory(
         context: Context,
         private val getAvatarAsset: GetAvatarAssetUseCase,
         private val getPrivateAsset: GetMessageAssetUseCase,
-        private val kaliumFileSystem: KaliumFileSystem
     ) {
         private val defaultImageLoader = Coil.imageLoader(context)
         private val resources = context.resources
@@ -42,7 +48,7 @@ class WireSessionImageLoader(private val coilImageLoader: ImageLoader) {
         fun newImageLoader(): WireSessionImageLoader = WireSessionImageLoader(
             defaultImageLoader.newBuilder()
                 .components {
-                    add(AssetImageFetcher.Factory(getAvatarAsset, getPrivateAsset, resources, kaliumFileSystem))
+                    add(AssetImageFetcher.Factory(getAvatarAsset, getPrivateAsset, resources))
                 }.build()
         )
     }

--- a/app/src/test/kotlin/com/wire/android/model/ImageAssetTest.kt
+++ b/app/src/test/kotlin/com/wire/android/model/ImageAssetTest.kt
@@ -1,0 +1,106 @@
+package com.wire.android.model
+
+import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserAssetId
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ImageAssetTest {
+
+    @MockK
+    private lateinit var imageLoader: WireSessionImageLoader
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    fun createUserAvatarAsset(userAssetId: UserAssetId) = ImageAsset.UserAvatarAsset(
+        imageLoader, userAssetId
+    )
+
+    fun createPrivateAsset(
+        conversationId: ConversationId,
+        messageId: String,
+        isSelfAsset: Boolean
+    ) = ImageAsset.PrivateAsset(
+        imageLoader, conversationId, messageId, isSelfAsset
+    )
+
+    @Test
+    fun givenEqualUserAvatarAssets_whenGettingUniqueKey_thenResultsShouldBeEqual() {
+        val userAssetId = UserAssetId(value = "xu", domain = "bi")
+        val subject1 = createUserAvatarAsset(userAssetId)
+        val subject2 = createUserAvatarAsset(userAssetId)
+
+        subject1.uniqueKey shouldBeEqualTo subject2.uniqueKey
+    }
+
+    @Test
+    fun givenDifferentUserAvatarAssets_whenGettingUniqueKey_thenResultsShouldBeDifferent() {
+        val userAssetId = UserAssetId(value = "xu", domain = "bi")
+        val baseSubject = createUserAvatarAsset(userAssetId)
+        val alteredValueSubject = createUserAvatarAsset(userAssetId.copy(value = "anotherValue"))
+        val alteredDomainSubject = createUserAvatarAsset(userAssetId.copy(domain = "anotherDomain"))
+
+        baseSubject.uniqueKey shouldNotBeEqualTo alteredValueSubject.uniqueKey
+        baseSubject.uniqueKey shouldNotBeEqualTo alteredDomainSubject.uniqueKey
+    }
+
+    @Test
+    fun givenEqualPrivateAssets_whenGettingUniqueKey_thenResultsShouldBeEqual() {
+        val conversationId = ConversationId("xu", "bi")
+        val messageId = "messageId"
+        val isSelfAsset = true
+
+        val subject1 = createPrivateAsset(
+            conversationId,
+            messageId,
+            isSelfAsset
+        )
+        val subject2 = createPrivateAsset(
+            conversationId,
+            messageId,
+            isSelfAsset
+        )
+
+        subject1.uniqueKey shouldBeEqualTo subject2.uniqueKey
+    }
+
+    @Test
+    fun givenDifferentPrivateAssets_whenGettingUniqueKey_thenResultsShouldBeDifferent() {
+        val conversationId = ConversationId("xu", "bi")
+        val messageId = "messageId"
+        val isSelfAsset = true
+
+        val baseSubject = createPrivateAsset(
+            conversationId,
+            messageId,
+            isSelfAsset
+        )
+        val alteredConversationIdSubject = createPrivateAsset(
+            conversationId.copy(value = "SomeOtherValue"),
+            messageId,
+            isSelfAsset
+        )
+        val alteredMessageIdSubject = createPrivateAsset(
+            conversationId,
+            "someOtherMessageId",
+            isSelfAsset
+        )
+        val alteredSelfAssetSubject = createPrivateAsset(
+            conversationId,
+            messageId,
+            isSelfAsset.not()
+        )
+
+        baseSubject.uniqueKey shouldNotBeEqualTo alteredConversationIdSubject.uniqueKey
+        baseSubject.uniqueKey shouldNotBeEqualTo alteredMessageIdSubject.uniqueKey
+        baseSubject.uniqueKey shouldNotBeEqualTo alteredSelfAssetSubject.uniqueKey
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
@@ -131,7 +131,6 @@ internal class AssetImageFetcherTest {
             getPrivateAsset = getPrivateAsset,
             resources = resources,
             drawableResultWrapper = drawableResultWrapper,
-            kaliumFileSystem = fakeKaliumFileSystem
         )
     }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -78,7 +78,7 @@ object Libraries {
         const val paging3 = "3.1.1"
         const val paging3Compose = "1.0.0-alpha15"
         const val splashscreen = "1.0.0-beta01"
-        const val coil = "2.0.0-rc02"
+        const val coil = "2.2.1"
         const val exif = "1.3.3"
         const val firebaseBOM = "29.3.1"
         const val dataDog = "1.13.0"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2462" title="AR-2462" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2462</a>  Loading profile pictures is slow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When scrolling through messages and list of users, it takes some time to display the avatar image.

### Causes

We're fetching from local storage every time (when the Image is not yet downloaded).

### Solutions

- Use Coil's built-in memory cache.
Easy to use: Just add a `cacheKey` to the asset when creating the Coil request.

- Use `preview` image instead of `complete` image when displaying users in a list.



### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Scroll in a conversation content view or when searching users.


### Attachments

#### Without cache

https://user-images.githubusercontent.com/9389043/191202183-ba0a88ba-ee71-4bd7-a5fb-c1c5a24700bb.mp4 

#### With cache

https://user-images.githubusercontent.com/9389043/191202231-40571a15-9f73-4fe2-ab1c-711131fc9bdb.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
