### PR TITLE
chore: use expedited Worker to fetch notifications on FCM message (AR-2437) (AR-2407) (AR-2458)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.AndroidSourceSet
+
 plugins {
     // Application Specific plugins
     id(BuildPlugins.androidApplication)
@@ -196,6 +197,8 @@ dependencies {
     kaptAndroidTest(Libraries.Hilt.compiler)
     androidTestUtil(TestLibraries.testOrchestrator)
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
+
+    implementation(Libraries.Hilt.hiltWork)
 
     // Development dependencies
     debugImplementation(DevLibraries.leakCanary)

--- a/app/src/androidTest/java/com/wire/android/ui/ConversationScreenTest.kt
+++ b/app/src/androidTest/java/com/wire/android/ui/ConversationScreenTest.kt
@@ -16,6 +16,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
 import com.wire.android.ui.home.conversations.ConversationScreen
 import com.wire.android.ui.home.conversations.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+import com.wire.android.ui.home.conversations.info.ConversationInfoViewModel
+import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.utils.WorkManagerTestRule
 import com.wire.android.utils.getViewModel
@@ -58,7 +61,10 @@ class ConversationScreenTest {
                 WireTheme {
                     ConversationScreen(
                         getViewModel(activity, MessageComposerViewModel::class),
-                        getViewModel(activity, CommonTopAppBarViewModel::class)
+                        getViewModel(activity, ConversationCallViewModel::class),
+                        getViewModel(activity, ConversationInfoViewModel::class),
+                        getViewModel(activity, ConversationMessagesViewModel::class),
+                        getViewModel(activity, CommonTopAppBarViewModel::class),
                     )
                 }
             }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,6 +131,25 @@
                 android:exported="false"
                 android:foregroundServiceType="phoneCall" />
 
+        <!-- If you want to disable android.startup completely. -->
+        <provider
+                android:name="androidx.startup.InitializationProvider"
+                android:authorities="${applicationId}.androidx-startup"
+                tools:node="remove">
+        </provider>
+
+        <provider
+                android:name="androidx.startup.InitializationProvider"
+                android:authorities="${applicationId}.androidx-startup"
+                android:exported="false"
+                tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                    android:name="androidx.work.WorkManagerInitializer"
+                    android:value="androidx.startup"
+                    tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -17,15 +17,16 @@ import com.wire.android.util.DataDogLogger
 import com.wire.android.util.LogFileWriter
 import com.wire.android.util.extension.isGoogleServicesAvailable
 import com.wire.android.util.getDeviceId
-import com.wire.android.util.sha256
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
+import com.wire.android.util.sha256
+import com.wire.android.workmanager.WireWorkerFactory
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.sync.WrapperWorkerFactory
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
+
 
 /**
  * Indicates whether the build is private (dev || internal) or public
@@ -40,6 +41,7 @@ var appLogger = KaliumLogger(
     platformLogWriter()
 )
 
+
 @HiltAndroidApp
 class WireApplication : Application(), Configuration.Provider {
 
@@ -53,10 +55,12 @@ class WireApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var connectionPolicyManager: ConnectionPolicyManager
 
+    @Inject
+    lateinit var wireWorkerFactory: WireWorkerFactory
+
     override fun getWorkManagerConfiguration(): Configuration {
-        val myWorkerFactory = WrapperWorkerFactory(coreLogic)
         return Configuration.Builder()
-            .setWorkerFactory(myWorkerFactory)
+            .setWorkerFactory(wireWorkerFactory)
             .build()
     }
 
@@ -146,6 +150,7 @@ class WireApplication : Application(), Configuration.Provider {
             TRIM_MEMORY_RUNNING_LOW(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW),
             TRIM_MEMORY_RUNNING_MODERATE(ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE),
             TRIM_MEMORY_UI_HIDDEN(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN),
+
             @Suppress("MagicNumber")
             TRIM_MEMORY_UNKNOWN(-1);
 

--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -1,7 +1,9 @@
 package com.wire.android.di
 
+import android.app.NotificationManager
 import android.content.Context
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.core.app.NotificationManagerCompat
 import com.wire.android.mapper.MessageResourceProvider
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.util.deeplink.DeepLinkProcessor
@@ -36,4 +38,13 @@ object AppModule {
 
     @Provides
     fun provideMessageResourceProvider(): MessageResourceProvider = MessageResourceProvider()
+
+    @Provides
+    fun provideNotificationManagerCompat(appContext: Context): NotificationManagerCompat =
+        NotificationManagerCompat.from(appContext)
+
+    @Provides
+    fun provideNotificationManager(appContext: Context): NotificationManager =
+        appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
 }

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -27,16 +27,16 @@ import javax.inject.Singleton
 
 @Suppress("TooManyFunctions")
 @Singleton
-class MessageNotificationManager @Inject constructor(private val context: Context) {
-
-    private val notificationManager = NotificationManagerCompat.from(context)
-    private val oldNotificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
+class MessageNotificationManager
+@Inject constructor(
+    private val context: Context,
+    private val notificationManagerCompat: NotificationManagerCompat,
+    private val notificationManager: NotificationManager
+) {
     fun handleNotification(newNotifications: List<LocalNotificationConversation>, userId: QualifiedID?) {
-
         if (newNotifications.isEmpty()) return
 
-        val activeNotifications: Array<StatusBarNotification> = oldNotificationManager.activeNotifications ?: arrayOf()
+        val activeNotifications: Array<StatusBarNotification> = notificationManager.activeNotifications ?: arrayOf()
         val userIdString = userId?.toString()
 
         createNotificationChannel()
@@ -52,7 +52,7 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
         val notificationId = getConversationNotificationId(conversationsId)
 
         if (isThereAnyOtherWireNotification(notificationId)) {
-            notificationManager.cancel(notificationId)
+            notificationManagerCompat.cancel(notificationId)
         } else {
             hideAllNotifications()
         }
@@ -60,7 +60,7 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
 
     fun hideAllNotifications() {
         // removing groupSummary removes all the notifications in a group
-        notificationManager.cancel(NotificationConstants.MESSAGE_SUMMARY_ID)
+        notificationManagerCompat.cancel(NotificationConstants.MESSAGE_SUMMARY_ID)
     }
 
     private fun createNotificationChannel() {
@@ -69,7 +69,7 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
             .setName(NotificationConstants.MESSAGE_CHANNEL_NAME)
             .build()
 
-        notificationManager.createNotificationChannel(notificationChannel)
+        notificationManagerCompat.createNotificationChannel(notificationChannel)
     }
 
     private fun showSummaryIfNeeded(activeNotifications: Array<StatusBarNotification>) {
@@ -87,7 +87,7 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
         val notificationId = getConversationNotificationId(conversation.id)
         getConversationNotification(conversation, userId, activeNotifications)?.let { notification ->
             appLogger.i("$TAG adding ConversationNotification")
-            notificationManager.notify(notificationId, notification)
+            notificationManagerCompat.notify(notificationId, notification)
         }
     }
 
@@ -220,8 +220,8 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
         }
-
         return NotificationCompat.MessagingStyle.Message(message, time, sender)
+
     }
 
     /**
@@ -229,7 +229,7 @@ class MessageNotificationManager @Inject constructor(private val context: Contex
      * and notification with id [exceptNotificationId]
      */
     private fun isThereAnyOtherWireNotification(exceptNotificationId: Int): Boolean {
-        return oldNotificationManager.activeNotifications
+        return notificationManager.activeNotifications
             ?.any {
                 it.groupKey.endsWith(NotificationConstants.MESSAGE_GROUP_KEY)
                         && it.id != exceptNotificationId

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -2,6 +2,7 @@ package com.wire.android.notification
 
 import com.wire.kalium.logic.data.id.ConversationId
 
+//TODO: The names need to be localisable
 object NotificationConstants {
     const val INCOMING_CALL_CHANNEL_ID = "com.wire.android.notification_incoming_call_channel"
     const val INCOMING_CALL_CHANNEL_NAME = "Incoming calls"
@@ -15,6 +16,9 @@ object NotificationConstants {
     const val MESSAGE_CHANNEL_NAME = "Messages Channel"
     const val MESSAGE_GROUP_KEY = "wire_reloaded_notification_group"
     const val KEY_TEXT_REPLY = "key_text_notification_reply"
+
+    const val OTHER_CHANNEL_ID = "com.wire.android.message_synchronization"
+    const val OTHER_CHANNEL_NAME = "Message Synchronization"
 
     //Notification IDs (has to be unique!)
     val MESSAGE_SUMMARY_ID = "wire_messages_summary_notification".hashCode()

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -100,6 +100,7 @@ class WireNotificationManager @Inject constructor(
             val observeMessagesJob = scope.launch {
                 observeMessageNotifications(flowOf(userId), MutableStateFlow(CurrentScreen.InBackground))
             }
+
             appLogger.d("$TAG start syncing")
             connectionPolicyManager.handleConnectionOnPushNotification(userId)
 
@@ -382,7 +383,7 @@ class WireNotificationManager @Inject constructor(
         }
     }
 
-    private data class MessagesNotificationsData(
+    data class MessagesNotificationsData(
         val newNotifications: List<LocalNotificationConversation>,
         val userId: QualifiedID?
     )

--- a/app/src/main/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
@@ -1,31 +1,31 @@
 package com.wire.android.services
 
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.workDataOf
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
-import com.wire.android.notification.WireNotificationManager
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.workmanager.worker.NotificationFetchWorker
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.notificationToken.SaveNotificationTokenUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-@OptIn(ExperimentalCoroutinesApi::class)
 class WireFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
-
-    @Inject
-    lateinit var wireNotificationManager: WireNotificationManager
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -38,24 +38,38 @@ class WireFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         appLogger.i("$TAG: notification received")
+
+        enqueueNotificationFetchWorker(extractUserId(message))
+
+        appLogger.i("$TAG: onMessageReceived End")
+    }
+
+    private fun enqueueNotificationFetchWorker(userId: String) {
+        val request = OneTimeWorkRequestBuilder<NotificationFetchWorker>()
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .setInputData(workDataOf(NotificationFetchWorker.USER_ID_INPUT_DATA to userId))
+            .build()
+
+        val workManager = WorkManager.getInstance(applicationContext)
+
+        workManager.enqueueUniqueWork(
+            userId,
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+    }
+
+    private fun extractUserId(message: RemoteMessage): String {
         var userIdValue = ""
+
         for (items in message.data) {
             if (items.key == "user") {
                 userIdValue = items.value
                 break
             }
         }
-        scope.launch {
-            wireNotificationManager.fetchAndShowNotificationsOnce(userIdValue)
-        }
 
-        appLogger.i("$TAG: onMessageReceived End")
-    }
-
-    override fun onDestroy() {
-        scope.cancel("WireFirebaseMessagingService was destroyed")
-        appLogger.i("$TAG: onDestroy")
-        super.onDestroy()
+        return userIdValue
     }
 
     override fun onNewToken(p0: String) {
@@ -76,6 +90,12 @@ class WireFirebaseMessagingService : FirebaseMessagingService() {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        appLogger.i("$TAG: onDestroy")
+        super.onDestroy()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -29,7 +29,6 @@ class CurrentScreenManager @Inject constructor() : DefaultLifecycleObserver, Nav
 
     private val currentScreenState = MutableStateFlow<CurrentScreen>(CurrentScreen.SomeOther)
     private val isAppVisibleFlow = MutableStateFlow(false)
-    private val wasAppEverVisibleFlow = MutableStateFlow(false)
 
     suspend fun observeCurrentScreen(scope: CoroutineScope): StateFlow<CurrentScreen> = isAppVisibleFlow
         .flatMapLatest { isAppVisible ->
@@ -41,12 +40,11 @@ class CurrentScreenManager @Inject constructor() : DefaultLifecycleObserver, Nav
     /**
      * Informs if the UI was visible at least once since the app started
      */
-    fun appWasVisibleAtLeastOnceFlow(): StateFlow<Boolean> = wasAppEverVisibleFlow
+    fun isAppOnForegroundFlow(): StateFlow<Boolean> = isAppVisibleFlow
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         isAppVisibleFlow.value = true
-        wasAppEverVisibleFlow.value = true
     }
 
     override fun onPause(owner: LifecycleOwner) {

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -49,10 +49,10 @@ class ConnectionPolicyManager @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     fun startObservingAppLifecycle() {
         CoroutineScope(dispatcherProvider.default()).launch {
-            currentScreenManager.appWasVisibleAtLeastOnceFlow()
-                .combine(currentSessionFlow()) { wasVisible, currentSession -> wasVisible to currentSession }
-                .collect { (wasVisible, currentSession) ->
-                    setPolicyForSessions(allValidSessions(), currentSession, wasVisible)
+            currentScreenManager.isAppOnForegroundFlow()
+                .combine(currentSessionFlow()) { isOnForeground, currentSession -> isOnForeground to currentSession }
+                .collect { (isOnForeground, currentSession) ->
+                    setPolicyForSessions(allValidSessions(), currentSession, isOnForeground)
                 }
         }
     }
@@ -90,9 +90,9 @@ class ConnectionPolicyManager @Inject constructor(
         userId: UserId
     ) {
         val isCurrentSession = isCurrentSession(userId)
-        val hasInitialisedUI = currentScreenManager.appWasVisibleAtLeastOnceFlow().value
+        val isAppOnForeground = currentScreenManager.isAppOnForegroundFlow().value
         logger.d("isCurrentSession = $isCurrentSession; hasInitialisedUI = $isCurrentSession")
-        val shouldKeepLivePolicy = isCurrentSession && hasInitialisedUI
+        val shouldKeepLivePolicy = isCurrentSession && isAppOnForeground
         if (!shouldKeepLivePolicy) {
             logger.d("Downgrading policy as conditions to KEEP_ALIVE are not met")
             setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -1,0 +1,37 @@
+package com.wire.android.workmanager
+
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.notification.WireNotificationManager
+import com.wire.android.workmanager.worker.NotificationFetchWorker
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.sync.WrapperWorkerFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WireWorkerFactory @Inject constructor(
+    private val notificationManagerCompat: NotificationManagerCompat,
+    private val wireNotificationManager: WireNotificationManager,
+    @KaliumCoreLogic
+    private val coreLogic: CoreLogic
+) : WorkerFactory() {
+
+    override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
+        val kaliumWorker = WrapperWorkerFactory(
+            coreLogic
+        ).createWorker(appContext, workerClassName, workerParameters)
+
+        return kaliumWorker ?: NotificationFetchWorker(
+            appContext,
+            workerParameters,
+            wireNotificationManager,
+            notificationManagerCompat
+        )
+    }
+
+}

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -1,0 +1,64 @@
+package com.wire.android.workmanager.worker
+
+import android.content.Context
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import com.wire.android.R
+import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.WireNotificationManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltWorker
+class NotificationFetchWorker
+@AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val wireNotificationManager: WireNotificationManager,
+    private val notificationManager: NotificationManagerCompat
+) : CoroutineWorker(appContext, workerParams) {
+    companion object {
+        const val USER_ID_INPUT_DATA = "worker_user_id_input_data"
+    }
+
+    override suspend fun doWork(): Result {
+        inputData.getString(USER_ID_INPUT_DATA)?.let { userId ->
+            wireNotificationManager.fetchAndShowNotificationsOnce(userId)
+        }
+
+        return Result.success()
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        createNotificationChannel()
+
+        val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.OTHER_CHANNEL_ID)
+            .setSmallIcon(R.drawable.notification_icon_small)
+            .setAutoCancel(true)
+            .setSilent(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setProgress(0, 0, true)
+            .setContentTitle(applicationContext.getString(R.string.label_fetching_your_messages))
+            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .build()
+
+        return ForegroundInfo(1, notification)
+    }
+
+    private fun createNotificationChannel() {
+        val notificationChannel = NotificationChannelCompat
+            .Builder(NotificationConstants.OTHER_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_MIN)
+            .setName(NotificationConstants.OTHER_CHANNEL_NAME)
+            .build()
+
+        notificationManager.createNotificationChannel(notificationChannel)
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,4 +569,5 @@
     <string name="cant_switch_account_in_call">Can not switch accounts while in call</string>
     <string name="custom_backend_dialog_title">Redirect to an on-premises backend?</string>
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:\n\nBackend name:\n%1$s\n\nBackend URL:\n%2$s</string>
+    <string name="label_fetching_your_messages">Receiving new messages</string>
 </resources>

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -1,6 +1,5 @@
 package com.wire.android.util.lifecycle
 
-import android.accounts.Account
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logic.CoreLogic
@@ -30,7 +29,7 @@ class ConnectionPolicyManagerTest {
 
         val (arrangement, connectionPolicyManager) = Arrangement()
             .withCurrentSession(user)
-            .withUiInitialized()
+            .withAppInTheForeground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
@@ -44,7 +43,7 @@ class ConnectionPolicyManagerTest {
 
         val (arrangement, connectionPolicyManager) = Arrangement()
             .withCurrentSession(user)
-            .withUiInitialized()
+            .withAppInTheForeground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
@@ -61,7 +60,7 @@ class ConnectionPolicyManagerTest {
 
         val (arrangement, connectionPolicyManager) = Arrangement()
             .withCurrentSession(user)
-            .withUiNotInitialized()
+            .withAppInTheBackground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
@@ -79,7 +78,7 @@ class ConnectionPolicyManagerTest {
 
         val (arrangement, connectionPolicyManager) = Arrangement()
             .withCurrentSession(USER_ID_2)
-            .withUiInitialized()
+            .withAppInTheForeground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
@@ -97,7 +96,7 @@ class ConnectionPolicyManagerTest {
 
         val (arrangement, connectionPolicyManager) = Arrangement()
             .withCurrentSession(USER_ID_2)
-            .withUiNotInitialized()
+            .withAppInTheBackground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
@@ -142,12 +141,12 @@ class ConnectionPolicyManagerTest {
             every { userSessionScope.syncManager } returns syncManager
         }
 
-        fun withUiNotInitialized() = apply {
-            every { currentScreenManager.appWasVisibleAtLeastOnceFlow() } returns MutableStateFlow(false)
+        fun withAppInTheBackground() = apply {
+            every { currentScreenManager.isAppOnForegroundFlow() } returns MutableStateFlow(false)
         }
 
-        fun withUiInitialized() = apply {
-            every { currentScreenManager.appWasVisibleAtLeastOnceFlow() } returns MutableStateFlow(true)
+        fun withAppInTheForeground() = apply {
+            every { currentScreenManager.isAppOnForegroundFlow() } returns MutableStateFlow(true)
         }
 
         fun withCurrentSession(userId: UserId) = apply {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -70,6 +70,7 @@ object Libraries {
         const val accompanist = "0.25.0"
         const val composeConstraint = "1.0.0"
         const val hilt = "2.38.1"
+        const val hiltWork = "1.0.0"
         const val lifecycle = "2.4.0"
         const val visibilityModifiers = "1.1.0"
         const val composeHiltNavigation = "1.0.0-alpha03"
@@ -128,6 +129,7 @@ object Libraries {
         const val gradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:${Versions.hilt}"
         const val navigationCompose = "androidx.hilt:hilt-navigation-compose:${Versions.composeHiltNavigation}"
         const val hiltTest = "com.google.dagger:hilt-android-testing:${Versions.hilt}"
+        const val hiltWork = "androidx.hilt:hilt-work:${Versions.hiltWork}"
     }
 
     object Lifecycle {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2437" title="AR-2437" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2437</a>  Notifications stop when app is on background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues


On some devices for example Samsung SM-A226B, when going to background the network gets almost immediately cut off from the AR, this means that the socket dies within the timeout, which results in a exception being thrown, that exception is being swallowed by SyncExceptionHandler, it then retries to recover from the exception, with no luck because of no network access. Because we do not have the chance to close the socket connection manually because of the timeout, we relay on the server to close it, which has it's own timeout when no pinging from the client, which seems to be around 5 minutes (?). Which in the end results in no FCM messages until server thinks we are disconnected from the socket.

### Solutions

The solution to that is to close socket when going to background, that way we can be sure that we receive FCM and we do not have to relay on server timeout or to fight with other OEM restrictions and running a risk's of not receiving the notification. Also to avoid the situation where the OS could cut us from fetching the messages in the background which we will present as a notification after FCM receive, we decided to use expedited Worker, which should be the most reliable solution making sure this works under the doze mode, app stand-by mode and any crazy situations that would results in OS limiting the execution

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

Tested manually in different scenario's : 
- Background
- Doze
- Screen locked
- App standby

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
