### PR TITLE
fix(calling): flickering in large conference calls

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -116,12 +116,13 @@ fun GroupCallGrid(
 
 @Suppress("ReturnCount")
 fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>, pageIndex: Int) : Boolean {
-    if (lastParticipants[pageIndex]?.isEmpty() == true)
+    if (lastParticipants[pageIndex].isNullOrEmpty())
         return true
-    val s = lastParticipants[pageIndex]
-    lastParticipants[pageIndex]?.zip(newParticipants)?.forEach { pair ->
-        if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isSharingScreen != pair.second.isSharingScreen))
-            return true
+    if(lastParticipants[pageIndex]?.size == newParticipants.size) {
+        lastParticipants[pageIndex]?.zip(newParticipants)?.forEach { pair ->
+            if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isSharingScreen != pair.second.isSharingScreen))
+                return true
+        }
     }
     return false
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -25,7 +25,7 @@ import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.QualifiedID
 
-val lastParticipants = mutableListOf<UICallParticipant>()
+val lastParticipants = mutableMapOf<Int, List<UICallParticipant>>()
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -40,7 +40,7 @@ fun GroupCallGrid(
     val config = LocalConfiguration.current
 
     // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
-    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants)
+    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants, pageIndex)
     LazyVerticalGrid(
         userScrollEnabled = false,
         contentPadding = PaddingValues(MaterialTheme.wireDimensions.spacing4x),
@@ -51,7 +51,7 @@ fun GroupCallGrid(
 
         items(
             items = participants,
-            key = { it.id.toString() + it.clientId },
+            key = { it.id.toString() + it.clientId + pageIndex },
             contentType = { getContentType(it.isCameraOn, it.isSharingScreen) }
         ) { participant ->
             // since we are getting participants by chunk of 8 items,
@@ -109,16 +109,17 @@ fun GroupCallGrid(
                 shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
             )
         }
-        lastParticipants.clear()
-        lastParticipants.addAll(participants)
+        lastParticipants.remove(pageIndex)
+        lastParticipants[pageIndex] = participants
     }
 }
 
 @Suppress("ReturnCount")
-fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>) : Boolean {
-    if (lastParticipants.isEmpty())
+fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>, pageIndex: Int) : Boolean {
+    if (lastParticipants[pageIndex]?.isEmpty() == true)
         return true
-    lastParticipants.zip(newParticipants).forEach { pair ->
+    val s = lastParticipants[pageIndex]
+    lastParticipants[pageIndex]?.zip(newParticipants)?.forEach { pair ->
         if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isSharingScreen != pair.second.isSharingScreen))
             return true
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
@@ -35,7 +35,7 @@ fun OneOnOneCallView(
     val config = LocalConfiguration.current
 
     // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
-    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants)
+    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants, pageIndex)
 
     LazyColumn(
         modifier = Modifier.padding(dimensions().spacing4x),
@@ -84,8 +84,8 @@ fun OneOnOneCallView(
                 },
                 shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
             )
-            lastParticipants.clear()
-            lastParticipants.addAll(participants)
+            lastParticipants.remove(pageIndex)
+            lastParticipants[pageIndex] = participants
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- On a large conference call(more than 8 participants), the video starts flickering when someone starts speaking 
- Some Video streams are missing

### Causes (Optional)

Comparing with wrong old participants list, which lead to remove recently created renderers

### Solutions

Same approach as #998, but I check for each page of the grid if we need to recompose.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

A similar PR raised (#998) but that one only fixes flickering if there is only one grid.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
