### PR TITLE
chore: timeout call notifications observing on background (AR-2437)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,12 +37,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 
 @ExperimentalCoroutinesApi
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -105,7 +110,13 @@ class WireNotificationManager @Inject constructor(
             connectionPolicyManager.handleConnectionOnPushNotification(userId)
 
             appLogger.d("$TAG checking calls once")
-            fetchAndShowCallNotificationsOnce(userId)
+            try {
+                withTimeout(8.seconds) {
+                    fetchAndShowCallNotificationsOnce(userId)
+                }
+            } catch (timeout: TimeoutCancellationException) {
+                appLogger.e("$TAG Fetching call notifications was stopped due to timeout", timeout)
+            }
 
             appLogger.d("$TAG checked the notifications once, canceling observing.")
             observeMessagesJob.cancel("$TAG checked the notifications once, canceling observing.")
@@ -118,17 +129,34 @@ class WireNotificationManager @Inject constructor(
         //      but we don't get it from the first GetIncomingCallsUseCase() call.
         //      To cover that case we have this `intervalFlow().take(CHECK_INCOMING_CALLS_TRIES)`
         //      to try get incoming calls 6 times, if it returns nothing we assume there is no incoming call
+        var periodicCheckCount = 0
+        val tag = "$TAG.fetchAndShowCallNotificationsOnce"
         intervalFlow(CHECK_INCOMING_CALLS_PERIOD_MS)
+            .cancellable()
+            .onCompletion {
+                if (it != null) {
+                    appLogger.e("$tag; Completed fetching calls with exception", it)
+                } else {
+                    appLogger.d("$tag; Completed fetching calls normally")
+                }
+            }
+            .onEach {
+                periodicCheckCount++
+                appLogger.d("$tag; Periodic check on call notifications: $periodicCheckCount")
+            }
             .map {
+                appLogger.d("$tag; Getting incoming calls for")
                 coreLogic.getSessionScope(userId)
                     .calls
                     .getIncomingCalls()
-                    .first()
+                    .first().also {
+                        appLogger.d("$tag; Incoming calls result list size = ${it.size}")
+                    }
             }
             .take(CHECK_INCOMING_CALLS_TRIES)
             .distinctUntilChanged()
-            .cancellable()
             .collect { callsList ->
+                appLogger.d("$tag; Collecting call list. Terminal operation.")
                 callNotificationManager.handleIncomingCallNotifications(callsList, userId)
             }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModelTest.kt
@@ -68,7 +68,8 @@ class CreateAccountUsernameViewModelTest {
     @Test
     fun `given forbidden character, when entering username, then forbidden character is ignored`() {
         coEvery { validateUserHandleUseCase.invoke("a1_") } returns ValidateUserHandleResult.Valid("a1_")
-        coEvery { validateUserHandleUseCase.invoke("a1_$") } returns ValidateUserHandleResult.Invalid.InvalidCharacters("a1_")
+        coEvery { validateUserHandleUseCase.invoke("a1_$") } returns
+                ValidateUserHandleResult.Invalid.InvalidCharacters("a1_", listOf())
         createAccountUsernameViewModel.onUsernameChange(TextFieldValue("a1_"))
         createAccountUsernameViewModel.state.username.text shouldBeEqualTo "a1_"
         createAccountUsernameViewModel.onUsernameChange(TextFieldValue("a1_$"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2437" title="AR-2437" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2437</a>  Notifications stop when app is on background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're investigating an issue where `fetchAndShowCallNotificationsOnce` is hanging for minutes when receiving a push notification.

### Causes

Still unknown

### Solutions

1. Add more logs to that code area.
2. Add a timeout to `fetchAndShowCallNotificationsOnce`.
3. Update Kalium to add more logs to `GetIncomingCallsUseCase`, which is used by this function.
4. Move the `cancellable` check further up. So we check for cancellation on each emission of the `intervalFlow`, instead of only checking downstream, when emissions are less frequent.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/947

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
