### PR TITLE
fix: image message issues [AR-2485]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -35,17 +35,17 @@ import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.home.conversations.model.ImageMessageParams
-import com.wire.android.ui.home.conversations.model.MessageAsset
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.MessageGenericAsset
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageImage
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
-import com.wire.android.ui.home.conversations.model.RestrictedAssetMessage
-import com.wire.android.ui.home.conversations.model.RestrictedFileMessage
 import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.messagetypes.asset.RestrictedAssetMessage
+import com.wire.android.ui.home.conversations.model.messagetypes.asset.RestrictedGenericFileMessage
+import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageParams
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
@@ -210,14 +210,15 @@ private fun MessageContent(
         is UIMessageContent.ImageMessage -> MessageImage(
             rawImgData = messageContent.imgData,
             imgParams = ImageMessageParams(messageContent.width, messageContent.height),
-            assetUploadStatus = messageContent.uploadStatus,
+            uploadStatus = messageContent.uploadStatus,
+            downloadStatus = messageContent.downloadStatus,
             onImageClick = onImageClick
         )
         is UIMessageContent.TextMessage -> MessageBody(
             messageBody = messageContent.messageBody,
             onLongClick = onLongClick
         )
-        is UIMessageContent.AssetMessage -> MessageAsset(
+        is UIMessageContent.AssetMessage -> MessageGenericAsset(
             assetName = messageContent.assetName,
             assetExtension = messageContent.assetExtension,
             assetSizeInBytes = messageContent.assetSizeInBytes,
@@ -240,7 +241,7 @@ private fun MessageContent(
                     RestrictedAssetMessage(R.drawable.ic_speaker_on, stringResource(id = R.string.prohibited_audio_message))
                 }
                 else -> {
-                    RestrictedFileMessage(messageContent.assetName, messageContent.assetSizeInBytes)
+                    RestrictedGenericFileMessage(messageContent.assetName, messageContent.assetSizeInBytes)
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -86,9 +86,13 @@ fun mockAssetMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.U
 )
 
 @Suppress("MagicNumber")
-fun mockedImg(uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED) = UIMessageContent.ImageMessage(
-    UserAssetId("a", "domain"), null, 0, 0, uploadStatus = uploadStatus
+fun mockedImg(
+    uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED,
+    downloadStatus: Message.DownloadStatus = Message.DownloadStatus.SAVED_INTERNALLY
+) = UIMessageContent.ImageMessage(
+    UserAssetId("a", "domain"), null, 0, 0, uploadStatus = uploadStatus, downloadStatus = downloadStatus
 )
+
 @Suppress("MagicNumber")
 fun mockedImageUIMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED) = UIMessage(
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -2,71 +2,36 @@ package com.wire.android.ui.home.conversations.model
 
 import android.graphics.Bitmap
 import android.text.util.Linkify
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import coil.compose.rememberAsyncImagePainter
-import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.LinkifyText
-import com.wire.android.ui.common.WireCircularProgressIndicator
-import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.model.messagetypes.asset.MessageAsset
+import com.wire.android.ui.home.conversations.model.messagetypes.image.DisplayableImageMessage
+import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageFailed
+import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageInProgress
+import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageParams
 import com.wire.android.ui.theme.wireColorScheme
-import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOAD_IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED_DOWNLOAD
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
 import com.wire.kalium.logic.data.message.Message.UploadStatus.FAILED_UPLOAD
-import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOADED
 import com.wire.kalium.logic.data.message.Message.UploadStatus.UPLOAD_IN_PROGRESS
-import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
 // waiting for the backend to implement mapping logic for the MessageBody
@@ -87,7 +52,8 @@ internal fun MessageBody(messageBody: MessageBody, onLongClick: (() -> Unit)? = 
 fun MessageImage(
     rawImgData: ByteArray?,
     imgParams: ImageMessageParams,
-    assetUploadStatus: Message.UploadStatus,
+    uploadStatus: Message.UploadStatus,
+    downloadStatus: Message.DownloadStatus,
     onImageClick: Clickable,
 ) {
     val imageData: Bitmap? = if (rawImgData != null && rawImgData.size < MessageComposerViewModel.IMAGE_SIZE_LIMIT_BYTES)
@@ -111,184 +77,24 @@ fun MessageImage(
                 onLongClick = onImageClick.onLongClick,
             )
     ) {
-        when (assetUploadStatus) {
-            // Default states, we try to draw the image
-            Message.UploadStatus.NOT_UPLOADED -> {}
-            Message.UploadStatus.UPLOADED -> {
-                Image(
-                    painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
-                    contentDescription = stringResource(R.string.content_description_image_message),
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .width(if (imageData != null) imgParams.normalizedWidth else dimensions().spacing24x)
-                        .height(if (imageData != null) imgParams.normalizedHeight else dimensions().spacing24x),
-                    alignment = Alignment.CenterStart,
-                    contentScale = ContentScale.Crop
-                )
-            }
+        when {
+            imageData != null -> DisplayableImageMessage(imageData, imgParams)
+
             // Trying to upload the asset
-            Message.UploadStatus.UPLOAD_IN_PROGRESS -> {
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .width(imgParams.normalizedWidth)
-                        .height(imgParams.normalizedHeight)
-                ) {
-                    WireCircularProgressIndicator(
-                        progressColor = MaterialTheme.wireColorScheme.primary,
-                        size = MaterialTheme.wireDimensions.spacing24x
-                    )
-                    Text(
-                        text = stringResource(id = R.string.asset_message_upload_in_progress_text),
-                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
-                        overflow = TextOverflow.Ellipsis,
-                        maxLines = 1
-                    )
-                }
+            uploadStatus == UPLOAD_IN_PROGRESS || downloadStatus == DOWNLOAD_IN_PROGRESS -> {
+                ImageMessageInProgress(imgParams, downloadStatus == DOWNLOAD_IN_PROGRESS)
             }
-            Message.UploadStatus.FAILED_UPLOAD -> {
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(dimensions().spacing200x)
-                ) {
-                    Image(
-                        painter = rememberAsyncImagePainter(getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .width(dimensions().spacing24x)
-                            .height(dimensions().spacing24x),
-                        alignment = Alignment.CenterStart,
-                        colorFilter = ColorFilter.tint(Color.Red),
-                        contentScale = ContentScale.Crop
-                    )
-                    Text(
-                        text = stringResource(id = R.string.error_uploading_image_message),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.error)
-                    )
-                }
+
+            // Show error placeholder
+            uploadStatus == FAILED_UPLOAD || downloadStatus == FAILED_DOWNLOAD -> {
+                ImageMessageFailed(downloadStatus == FAILED_DOWNLOAD)
             }
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String) {
-    Card(
-        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
-        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.divider)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(dimensions().messageImageMaxWidth),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Image(
-                modifier = Modifier
-                    .padding(bottom = dimensions().spacing4x)
-                    .size(height = dimensions().spacing24x, width = dimensions().spacing24x),
-                painter = painterResource(
-                    id = assetTypeIcon
-                ),
-                alignment = Alignment.Center,
-                contentDescription = stringResource(R.string.content_description_image_message),
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText)
-            )
-
-            Text(
-                text = restrictedAssetMessage,
-                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun RestrictedFileMessage(fileName: String, fileSize: Long) {
-    Card(
-        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
-        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.divider)
-    ) {
-        val assetName = fileName.split(".").dropLast(1).joinToString(".")
-        val assetDescription = provideAssetDescription(
-            fileName.split(".").last(), fileSize
-        )
-
-        ConstraintLayout(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(dimensions().spacing8x),
-        ) {
-            val (
-                name, icon, size, message) = createRefs()
-            Text(
-                text = assetName,
-                style = MaterialTheme.wireTypography.body02,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                modifier = Modifier
-                    .padding(bottom = dimensions().spacing4x)
-                    .constrainAs(name) {
-                        top.linkTo(parent.top)
-                        start.linkTo(parent.start)
-                    }
-            )
-
-            Image(
-                modifier = Modifier
-                    .height(dimensions().spacing12x)
-                    .width(dimensions().spacing12x)
-                    .constrainAs(icon) {
-                        top.linkTo(name.bottom)
-                        bottom.linkTo(parent.bottom)
-                        start.linkTo(parent.start)
-
-                    },
-                painter = painterResource(
-                    id = R.drawable.ic_file
-                ),
-                alignment = Alignment.Center,
-                contentDescription = stringResource(R.string.content_description_image_message),
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText),
-            )
-
-            Text(text = assetDescription,
-                style = MaterialTheme.wireTypography.body01,
-                modifier = Modifier
-                    .padding(start = dimensions().spacing4x)
-                    .constrainAs(size) {
-                        start.linkTo(icon.end)
-                        top.linkTo(name.bottom)
-                    })
-
-            Text(
-                text = stringResource(id = R.string.prohibited_file_message),
-                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                modifier = Modifier.constrainAs(message) {
-                    end.linkTo(parent.end)
-                    top.linkTo(name.bottom)
-                }
-            )
-        }
-
-    }
-}
-
-@Composable
-internal fun MessageAsset(
+internal fun MessageGenericAsset(
     assetName: String,
     assetExtension: String,
     assetSizeInBytes: Long,
@@ -296,156 +102,5 @@ internal fun MessageAsset(
     assetUploadStatus: Message.UploadStatus,
     assetDownloadStatus: Message.DownloadStatus
 ) {
-    val assetDescription = provideAssetDescription(assetExtension, assetSizeInBytes)
-    Box(
-        modifier = Modifier
-            .padding(top = dimensions().spacing4x)
-            .background(
-                color = MaterialTheme.wireColorScheme.onPrimary,
-                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
-            )
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
-                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
-            )
-            .clickable(onAssetClick)
-            .padding(dimensions().spacing8x)
-    ) {
-        Column {
-            Text(
-                text = assetName,
-                style = MaterialTheme.wireTypography.body02,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-            ConstraintLayout(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(top = dimensions().spacing8x)
-            ) {
-                val (icon, description, downloadStatus) = createRefs()
-                Image(
-                    modifier = Modifier
-                        .constrainAs(icon) {
-                            top.linkTo(parent.top)
-                            start.linkTo(parent.start)
-                            bottom.linkTo(parent.bottom)
-                        },
-                    painter = painterResource(R.drawable.ic_file),
-                    contentDescription = stringResource(R.string.content_description_image_message),
-                    colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.badge)
-                )
-                Text(
-                    modifier = Modifier
-                        .padding(start = dimensions().spacing4x)
-                        .constrainAs(description) {
-                            top.linkTo(parent.top)
-                            start.linkTo(icon.end)
-                            bottom.linkTo(parent.bottom)
-                        },
-                    text = assetDescription,
-                    color = MaterialTheme.wireColorScheme.secondaryText,
-                    style = MaterialTheme.wireTypography.subline01
-                )
-                Row(
-                    modifier = Modifier
-                        .wrapContentWidth()
-                        .constrainAs(downloadStatus) {
-                            top.linkTo(parent.top)
-                            end.linkTo(parent.end)
-                            bottom.linkTo(parent.bottom)
-                        },
-                ) {
-                    Text(
-                        modifier = Modifier.padding(end = dimensions().spacing4x),
-                        text = getDownloadStatusText(assetDownloadStatus, assetUploadStatus),
-                        color = MaterialTheme.wireColorScheme.run {
-                            if (assetDownloadStatus == FAILED_DOWNLOAD || assetUploadStatus == FAILED_UPLOAD) error else secondaryText
-                        },
-                        style = MaterialTheme.wireTypography.subline01
-                    )
-                    DownloadStatusIcon(assetDownloadStatus, assetUploadStatus)
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
-    return when {
-        assetUploadStatus == UPLOAD_IN_PROGRESS || assetDownloadStatus == DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
-            progressColor = MaterialTheme.wireColorScheme.secondaryText,
-            size = dimensions().spacing16x
-        )
-        assetUploadStatus == FAILED_UPLOAD -> {}
-        assetDownloadStatus == SAVED_INTERNALLY -> Icon(
-            painter = painterResource(id = R.drawable.ic_download),
-            contentDescription = stringResource(R.string.content_description_download_icon),
-            modifier = Modifier.size(dimensions().wireIconButtonSize),
-            tint = MaterialTheme.wireColorScheme.secondaryText
-        )
-        assetDownloadStatus == SAVED_EXTERNALLY -> Icon(
-            painter = painterResource(id = R.drawable.ic_check_tick),
-            contentDescription = stringResource(R.string.content_description_check),
-            modifier = Modifier.size(dimensions().wireIconButtonSize),
-            tint = MaterialTheme.wireColorScheme.secondaryText
-        )
-        else -> {}
-    }
-}
-
-@Composable
-fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus): String =
-    when {
-        assetUploadStatus == UPLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_upload_in_progress_text)
-        assetUploadStatus == FAILED_UPLOAD -> stringResource(R.string.asset_message_failed_upload_text)
-        assetDownloadStatus == NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
-        assetDownloadStatus == SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
-        assetDownloadStatus == DOWNLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
-        assetDownloadStatus == SAVED_EXTERNALLY
-                || assetUploadStatus == UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
-        assetDownloadStatus == FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
-        else -> ""
-    }
-
-@Suppress("MagicNumber")
-private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
-    val oneKB = 1024L
-    val oneMB = oneKB * oneKB
-    return when {
-        assetSizeInBytes < oneKB -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
-        assetSizeInBytes in oneKB..oneMB -> "${assetExtension.uppercase()} (${assetSizeInBytes / oneKB} KB)"
-        else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / oneMB) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
-    }
-}
-
-// TODO:we should provide the SpanStyle by LocalProvider to our Theme, later on
-@Composable
-private fun AnnotatedString.Builder.appendMentionLabel(label: String) {
-    withStyle(
-        style = SpanStyle(
-            color = MaterialTheme.colorScheme.primary,
-            background = MaterialTheme.colorScheme.primaryContainer,
-        )
-    ) {
-        append("$label ")
-    }
-}
-
-@Composable
-private fun AnnotatedString.Builder.appendBody(messageBody: MessageBody) {
-    append(messageBody.message.asString())
-}
-
-data class ImageMessageParams(private val realImgWidth: Int, private val realImgHeight: Int) {
-    // Image size normalizations to keep the ratio of the inline message image
-    val normalizedWidth: Dp
-        @Composable
-        get() = dimensions().messageImageMaxWidth
-
-    val normalizedHeight: Dp
-        @Composable
-        get() = Dp(normalizedWidth.value * realImgHeight.toFloat() / realImgWidth)
+    MessageAsset(assetName, assetExtension, assetSizeInBytes, onAssetClick, assetUploadStatus, assetDownloadStatus)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -73,14 +73,15 @@ sealed class UIMessageContent {
         val assetSizeInBytes: Long,
         val uploadStatus: Message.UploadStatus,
         val downloadStatus: Message.DownloadStatus
-    ) : ClientMessage()
+    ) : UIMessageContent()
 
     data class ImageMessage(
         val assetId: AssetId,
         var imgData: ByteArray?,
         val width: Int,
         val height: Int,
-        val uploadStatus: Message.UploadStatus
+        val uploadStatus: Message.UploadStatus,
+        val downloadStatus: Message.DownloadStatus
     ) : UIMessageContent() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -89,6 +90,7 @@ sealed class UIMessageContent {
             if (assetId != other.assetId) return false
             if (!imgData.contentEquals(other.imgData)) return false
             if (uploadStatus != other.uploadStatus) return false
+            if (downloadStatus != other.downloadStatus) return false
             return true
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -113,7 +113,9 @@ internal fun MessageAsset(
                         modifier = Modifier.padding(end = dimensions().spacing4x),
                         text = getDownloadStatusText(assetDownloadStatus, assetUploadStatus),
                         color = MaterialTheme.wireColorScheme.run {
-                            if (assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD || assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD) error else secondaryText
+                            if (assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD ||
+                                assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD
+                            ) error else secondaryText
                         },
                         style = MaterialTheme.wireTypography.subline01
                     )
@@ -237,7 +239,8 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
 @Composable
 private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
     return when {
-        assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS || assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
+        assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS ||
+                assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -268,7 +268,8 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD -> stringResource(R.string.asset_message_failed_upload_text)
         assetDownloadStatus == Message.DownloadStatus.NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
         assetDownloadStatus == Message.DownloadStatus.SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
-        assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
+        assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS ->
+            stringResource(R.string.asset_message_download_in_progress_text)
         assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
                 || assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
         assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -1,0 +1,284 @@
+package com.wire.android.ui.home.conversations.model.messagetypes.asset
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.wire.android.R
+import com.wire.android.model.Clickable
+import com.wire.android.ui.common.WireCircularProgressIndicator
+import com.wire.android.ui.common.clickable
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+import com.wire.kalium.logic.data.message.Message
+import kotlin.math.roundToInt
+
+@Composable
+internal fun MessageAsset(
+    assetName: String,
+    assetExtension: String,
+    assetSizeInBytes: Long,
+    onAssetClick: Clickable,
+    assetUploadStatus: Message.UploadStatus,
+    assetDownloadStatus: Message.DownloadStatus
+) {
+    val assetDescription = provideAssetDescription(assetExtension, assetSizeInBytes)
+    Box(
+        modifier = Modifier
+            .padding(top = dimensions().spacing4x)
+            .background(
+                color = MaterialTheme.wireColorScheme.onPrimary,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .clickable(onAssetClick)
+            .padding(dimensions().spacing8x)
+    ) {
+        Column {
+            Text(
+                text = assetName,
+                style = MaterialTheme.wireTypography.body02,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            ConstraintLayout(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = dimensions().spacing8x)
+            ) {
+                val (icon, description, downloadStatus) = createRefs()
+                Image(
+                    modifier = Modifier
+                        .constrainAs(icon) {
+                            top.linkTo(parent.top)
+                            start.linkTo(parent.start)
+                            bottom.linkTo(parent.bottom)
+                        },
+                    painter = painterResource(R.drawable.ic_file),
+                    contentDescription = stringResource(R.string.content_description_image_message),
+                    colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.badge)
+                )
+                Text(
+                    modifier = Modifier
+                        .padding(start = dimensions().spacing4x)
+                        .constrainAs(description) {
+                            top.linkTo(parent.top)
+                            start.linkTo(icon.end)
+                            bottom.linkTo(parent.bottom)
+                        },
+                    text = assetDescription,
+                    color = MaterialTheme.wireColorScheme.secondaryText,
+                    style = MaterialTheme.wireTypography.subline01
+                )
+                Row(
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .constrainAs(downloadStatus) {
+                            top.linkTo(parent.top)
+                            end.linkTo(parent.end)
+                            bottom.linkTo(parent.bottom)
+                        },
+                ) {
+                    Text(
+                        modifier = Modifier.padding(end = dimensions().spacing4x),
+                        text = getDownloadStatusText(assetDownloadStatus, assetUploadStatus),
+                        color = MaterialTheme.wireColorScheme.run {
+                            if (assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD || assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD) error else secondaryText
+                        },
+                        style = MaterialTheme.wireTypography.subline01
+                    )
+                    DownloadStatusIcon(assetDownloadStatus, assetUploadStatus)
+                }
+            }
+        }
+    }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String) {
+    Card(
+        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
+        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.divider)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(dimensions().messageImageMaxWidth),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                modifier = Modifier
+                    .padding(bottom = dimensions().spacing4x)
+                    .size(height = dimensions().spacing24x, width = dimensions().spacing24x),
+                painter = painterResource(
+                    id = assetTypeIcon
+                ),
+                alignment = Alignment.Center,
+                contentDescription = stringResource(R.string.content_description_image_message),
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText)
+            )
+
+            Text(
+                text = restrictedAssetMessage,
+                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
+    Card(
+        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
+        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.divider)
+    ) {
+        val assetName = fileName.split(".").dropLast(1).joinToString(".")
+        val assetDescription = provideAssetDescription(
+            fileName.split(".").last(), fileSize
+        )
+
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensions().spacing8x),
+        ) {
+            val (
+                name, icon, size, message) = createRefs()
+            Text(
+                text = assetName,
+                style = MaterialTheme.wireTypography.body02,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                modifier = Modifier
+                    .padding(bottom = dimensions().spacing4x)
+                    .constrainAs(name) {
+                        top.linkTo(parent.top)
+                        start.linkTo(parent.start)
+                    }
+            )
+
+            Image(
+                modifier = Modifier
+                    .height(dimensions().spacing12x)
+                    .width(dimensions().spacing12x)
+                    .constrainAs(icon) {
+                        top.linkTo(name.bottom)
+                        bottom.linkTo(parent.bottom)
+                        start.linkTo(parent.start)
+
+                    },
+                painter = painterResource(
+                    id = R.drawable.ic_file
+                ),
+                alignment = Alignment.Center,
+                contentDescription = stringResource(R.string.content_description_image_message),
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText),
+            )
+
+            Text(text = assetDescription,
+                style = MaterialTheme.wireTypography.body01,
+                modifier = Modifier
+                    .padding(start = dimensions().spacing4x)
+                    .constrainAs(size) {
+                        start.linkTo(icon.end)
+                        top.linkTo(name.bottom)
+                    })
+
+            Text(
+                text = stringResource(id = R.string.prohibited_file_message),
+                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                modifier = Modifier.constrainAs(message) {
+                    end.linkTo(parent.end)
+                    top.linkTo(name.bottom)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
+    return when {
+        assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS || assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
+            progressColor = MaterialTheme.wireColorScheme.secondaryText,
+            size = dimensions().spacing16x
+        )
+        assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD -> {}
+        assetDownloadStatus == Message.DownloadStatus.SAVED_INTERNALLY -> Icon(
+            painter = painterResource(id = R.drawable.ic_download),
+            contentDescription = stringResource(R.string.content_description_download_icon),
+            modifier = Modifier.size(dimensions().wireIconButtonSize),
+            tint = MaterialTheme.wireColorScheme.secondaryText
+        )
+        assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY -> Icon(
+            painter = painterResource(id = R.drawable.ic_check_tick),
+            contentDescription = stringResource(R.string.content_description_check),
+            modifier = Modifier.size(dimensions().wireIconButtonSize),
+            tint = MaterialTheme.wireColorScheme.secondaryText
+        )
+        else -> {}
+    }
+}
+
+@Composable
+fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus): String =
+    when {
+        assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_upload_in_progress_text)
+        assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD -> stringResource(R.string.asset_message_failed_upload_text)
+        assetDownloadStatus == Message.DownloadStatus.NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
+        assetDownloadStatus == Message.DownloadStatus.SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
+        assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
+        assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                || assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+        assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
+        else -> ""
+    }
+
+@Suppress("MagicNumber")
+private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
+    val oneKB = 1024L
+    val oneMB = oneKB * oneKB
+    return when {
+        assetSizeInBytes < oneKB -> "${assetExtension.uppercase()} ($assetSizeInBytes B)"
+        assetSizeInBytes in oneKB..oneMB -> "${assetExtension.uppercase()} (${assetSizeInBytes / oneKB} KB)"
+        else -> "${assetExtension.uppercase()} (${((assetSizeInBytes / oneMB) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageParams.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageParams.kt
@@ -1,0 +1,16 @@
+package com.wire.android.ui.home.conversations.model.messagetypes.image
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import com.wire.android.ui.common.dimensions
+
+data class ImageMessageParams(private val realImgWidth: Int, private val realImgHeight: Int) {
+    // Image size normalizations to keep the ratio of the inline message image
+    val normalizedWidth: Dp
+        @Composable
+        get() = dimensions().messageImageMaxWidth
+
+    val normalizedHeight: Dp
+        @Composable
+        get() = Dp(normalizedWidth.value * realImgHeight.toFloat() / realImgWidth)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
@@ -1,0 +1,103 @@
+package com.wire.android.ui.home.conversations.model.messagetypes.image
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import coil.compose.rememberAsyncImagePainter
+import com.wire.android.R
+import com.wire.android.ui.common.WireCircularProgressIndicator
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.getUriFromDrawable
+
+@Composable
+fun DisplayableImageMessage(imageData: Bitmap?, imgParams: ImageMessageParams) {
+    Image(
+        painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
+        contentDescription = stringResource(R.string.content_description_image_message),
+        modifier = Modifier
+            .width(if (imageData != null) imgParams.normalizedWidth else dimensions().spacing24x)
+            .height(if (imageData != null) imgParams.normalizedHeight else dimensions().spacing24x),
+        alignment = Alignment.Center,
+        contentScale = ContentScale.Crop
+    )
+}
+
+@Composable
+fun ImageMessageInProgress(imgParams: ImageMessageParams, isDownloading: Boolean) {
+    Box {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .width(imgParams.normalizedWidth)
+                .height(imgParams.normalizedHeight)
+        ) {
+            WireCircularProgressIndicator(
+                progressColor = MaterialTheme.wireColorScheme.primary,
+                size = MaterialTheme.wireDimensions.spacing24x
+            )
+            Text(
+                text = stringResource(
+                    id = if (isDownloading) R.string.asset_message_download_in_progress_text
+                    else R.string.asset_message_upload_in_progress_text
+                ),
+                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+fun ImageMessageFailed(isDownloadFailure: Boolean) {
+    Box {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(dimensions().spacing200x)
+        ) {
+            Image(
+                painter = rememberAsyncImagePainter(getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
+                contentDescription = null,
+                modifier = Modifier
+                    .width(dimensions().spacing24x)
+                    .height(dimensions().spacing24x),
+                alignment = Alignment.CenterStart,
+                colorFilter = ColorFilter.tint(Color.Red),
+                contentScale = ContentScale.Crop
+            )
+            Text(
+                text = stringResource(
+                    id = if (isDownloadFailure) R.string.error_downloading_image_message
+                    else R.string.error_uploading_image_message
+                ),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.error)
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -417,6 +417,7 @@
     <string name="error_downloading_user_info">There was an error downloading the user information. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Picture could not be uploaded</string>
     <string name="error_uploading_image_message">Image upload failed</string>
+    <string name="error_downloading_image_message">Image download failed</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
     <string name="error_conversation_sending_image">The picture could not be sent. Please check your internet connection and try again.</string>
     <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check your Internet connection and try again</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -1,6 +1,6 @@
 package com.wire.android.framework
 
-import com.wire.android.mapper.AssetMessageData
+import com.wire.android.mapper.AssetMessageContentMetadata
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UIMessageContent.TextMessage
@@ -77,7 +77,7 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         status = Message.Status.SENT
     )
-    val IMAGE_ASSET_MESSAGE_DATA_TEST = AssetMessageData(
+    val IMAGE_ASSET_MESSAGE_DATA_TEST = AssetMessageContentMetadata(
         AssetContent(
             100L,
             "dummy_data.tiff",

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -27,9 +27,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.runTest
 import okio.Path
 import okio.Path.Companion.toPath
@@ -174,13 +172,13 @@ class MessageContentMapperTest {
 
         with(arrangement) {
             // When - Then
-            val resultContentOther = mapper.toUIMessageContent(AssetMessageData(unknownImageMessageContent), testMessage1)
+            val resultContentOther = mapper.toUIMessageContent(AssetMessageContentMetadata(unknownImageMessageContent), testMessage1)
             coVerify(exactly = 0) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
             assertTrue(resultContentOther is AssetMessage
                     && resultContentOther.assetId.value == unknownImageMessageContent.remoteData.assetId)
 
             // When - Then
-            val resultContentImage = mapper.toUIMessageContent(AssetMessageData(correctJPGImage), testMessage2)
+            val resultContentImage = mapper.toUIMessageContent(AssetMessageContentMetadata(correctJPGImage), testMessage2)
             coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
             assertTrue(resultContentImage is ImageMessage && resultContentImage.assetId.value == correctJPGImage.remoteData.assetId)
         }
@@ -202,7 +200,7 @@ class MessageContentMapperTest {
         val testMessage = buildAssetMessage(contentImage)
 
         // When
-        val resultContentImage = mapper.toUIMessageContent(AssetMessageData(contentImage), testMessage)
+        val resultContentImage = mapper.toUIMessageContent(AssetMessageContentMetadata(contentImage), testMessage)
 
         // Then
         coVerify(inverse = true) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
@@ -239,8 +237,8 @@ class MessageContentMapperTest {
 
         // When
         with(arrangement) {
-            val resultContentImage1 = mapper.toUIMessageContent(AssetMessageData(contentImage1), testMessage1)
-            val resultContentImage2 = mapper.toUIMessageContent(AssetMessageData(contentImage2), testMessage2)
+            val resultContentImage1 = mapper.toUIMessageContent(AssetMessageContentMetadata(contentImage1), testMessage1)
+            val resultContentImage2 = mapper.toUIMessageContent(AssetMessageContentMetadata(contentImage2), testMessage2)
 
             // Then
             assertTrue(resultContentImage1 is AssetMessage)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2485" title="AR-2485" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2485</a>  Displaying received images not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After my last PR introducing the extra field for assets objects `assetUploadStatus`, I made a mistake when mapping these messages, as I was only checking the upload status of the assets, instead of checking both of them, upload and download status. This PR fixes it, as well as introducing the progress bar for image assets while being downloaded instead of waiting until the image gets fully downloaded.


### Dependencies (Optional)

- https://github.com/wireapp/kalium/pull/948

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

just open your AR app and receive an image from a different user

### Attachments (Optional)

https://user-images.githubusercontent.com/2468164/191727479-eb90557e-d768-4e67-86ee-87e6c9ba836f.mov




----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
