### PR TITLE
fix: run fetch and show notifications synchronously (AR-2437)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -20,6 +20,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.util.toStringDate
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -70,25 +71,43 @@ class WireNotificationManager @Inject constructor(
      * and display notifications for new events.
      * Can be used in Services (e.g., after receiving FCM push).
      *
-     * This function is asynchronous and thread-safe.
-     * It ignores successive calls with the same [userIdValue]
-     * until the first call is finished processing.
+     * This function is synchronized and won't allow parallel
+     * executions for the same [userIdValue].
+     * Successive calls with the same [userIdValue]
+     * will join the first execution and return together.
      * @param userIdValue String value param of QualifiedID of the User that need to check Notifications for
      */
-    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) = fetchOnceMutex.withLock {
-        if (isNotCurrentUser(userIdValue)) {
-            appLogger.d("$TAG Ignoring notification for user=${userIdValue.obfuscateId()}, because not current user")
-            return@withLock
-        }
-        val isJobRunningForUser = fetchOnceJobs[userIdValue]?.isActive ?: false
-        if (isJobRunningForUser) {
-            appLogger.d("$TAG Already processing notifications for user=${userIdValue.obfuscateId()}, ignoring request")
-        } else {
-            appLogger.d("$TAG Starting to processing notifications for user=${userIdValue.obfuscateId()}")
-            fetchOnceJobs[userIdValue] = scope.launch {
-                triggerSyncForUserIfAuthenticated(userIdValue)
+    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
+        val jobForUser = fetchOnceMutex.withLock {
+            // Use the lock to create a new coroutine if needed
+            if (isNotCurrentUser(userIdValue)) {
+                appLogger.d("$TAG Ignoring notification for user=${userIdValue.obfuscateId()}, because not current user")
+                return@withLock null
+            }
+            val currentJobForUser = fetchOnceJobs[userIdValue]
+            val isJobRunningForUser = currentJobForUser?.run {
+                // Coroutine started, or didn't start yet, and it's waiting to be started
+                isActive || !isCompleted
+            } ?: false
+            if (isJobRunningForUser) {
+                // Return the currently existing job if it's active
+                appLogger.d(
+                    "$TAG Already processing notifications for user=${userIdValue.obfuscateId()}, and joining original execution"
+                )
+                currentJobForUser
+            } else {
+                // Create a new job for this user
+                appLogger.d("$TAG Starting to processing notifications for user=${userIdValue.obfuscateId()}")
+                val newJob = scope.launch(start = CoroutineStart.LAZY) {
+                    triggerSyncForUserIfAuthenticated(userIdValue)
+                }
+                fetchOnceJobs[userIdValue] = newJob
+                newJob
             }
         }
+        // Join the job for the user, waiting for its completion
+        jobForUser?.start()
+        jobForUser?.join()
     }
 
     private fun isNotCurrentUser(userId: String): Boolean {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2437" title="AR-2437" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2437</a>  Notifications stop when app is on background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`NotificationFetchWorker` doesn't wait until notifications are fetched to return `SUCCESS`.

This is roughly what's happening:

```mermaid
%%{init: { 'theme': 'base', 'gitGraph': {'mainBranchName': 'WireMessagingService'}} }%%
    gitGraph
      commit id: "onMessageReceive"
      commit id: "Schedule Worker"
      branch Worker
      checkout WireMessagingService
      commit id: "FCM END"
      checkout Worker
      commit id: "call fetchNotificationsOnce"
      branch WireNotificationManager
      commit id: "Upgrade Connection Policy"
      checkout Worker
      commit id: "Worker END"
      checkout WireNotificationManager
      branch Sync
      checkout WireNotificationManager
      commit id: "Wait Until Live"
      commit id: "Downgrade Policy"
      checkout Sync
      commit id: "Start sync"
      checkout WireNotificationManager
      merge Sync
      commit id: "Handle Notifications"
      checkout Sync
      commit id: "Live"
      commit id: "Finish Sync"
```

### Causes

`fetchAndShowNotificationsOnce` is completely asynchronous and independent.

### Solutions

Make `fetchAndShowNotificationsOnce` suspending, but not asynchronous.
It will spawn a new job if needed and wait until its conclusion.
If there's a job already being done and it's called again with the same parameters, it will join the currently running job.

With this implemented + [the PR in Kalium that addresses another issue](https://github.com/wireapp/kalium/pull/958), the flow becomes roughly like this:

```mermaid
%%{init: { 'theme': 'base', 'gitGraph': {'mainBranchName': 'WireMessagingService'}} }%%
    gitGraph
      commit id: "onMessageReceive"
      commit id: "Schedule Worker"
      branch Worker
      checkout WireMessagingService
      commit id: "FCM END"
      checkout Worker
      commit id: "call fetchNotificationsOnce"
      branch WireNotificationManager
      commit id: "Upgrade Connection Policy"
      branch Sync
      checkout Sync
      commit id: "Start Sync"
      checkout WireNotificationManager
      commit id: "Wait Until Live"
      checkout Sync
      commit id: "Live"
      checkout WireNotificationManager
      commit id: "Downgrade Policy"
      checkout Sync
      commit id: "Finish Sync"
      checkout WireNotificationManager
      merge Sync
      commit id: "Handle Notifications"
      checkout Worker
      merge WireNotificationManager
      commit id: "Worker END"
```

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
