### PR TITLE
feat: hide UI depending on feature visibility flags

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
@@ -1,8 +1,6 @@
 package com.wire.android.navigation
 
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import com.google.accompanist.navigation.animation.AnimatedNavHost

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -33,6 +34,8 @@ import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialog
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.userprofile.self.MaxAccountReachedDialog
 import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.debug.FeatureVisibilityFlags
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ui.updateScreenSettings
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -76,22 +79,24 @@ class WireActivity : AppCompatActivity() {
 
     private fun setComposableContent() {
         setContent {
-            WireTheme {
-                val scope = rememberCoroutineScope()
-                val navController = rememberAnimatedNavController()
-                val startDestination = viewModel.startNavigationRoute()
-                Scaffold {
-                    NavigationGraph(navController = navController, startDestination, viewModel.navigationArguments())
-                }
-                setUpNavigation(navController, scope)
+            CompositionLocalProvider(LocalFeatureVisibilityFlags provides FeatureVisibilityFlags) {
+                WireTheme {
+                    val scope = rememberCoroutineScope()
+                    val navController = rememberAnimatedNavController()
+                    val startDestination = viewModel.startNavigationRoute()
+                    Scaffold {
+                        NavigationGraph(navController = navController, startDestination, viewModel.navigationArguments())
+                    }
+                    setUpNavigation(navController, scope)
 
-                handleCustomBackendDialog(viewModel.globalAppState.customBackendDialog.shouldShowDialog)
-                maxAccountDialog(
-                    viewModel::openProfile,
-                    viewModel::dismissMaxAccountDialog,
-                    viewModel.globalAppState.maxAccountDialog
-                )
-                AccountLongedOutDialog(viewModel.globalAppState.blockUserUI, viewModel::navigateToNextAccountOrWelcome)
+                    handleCustomBackendDialog(viewModel.globalAppState.customBackendDialog.shouldShowDialog)
+                    maxAccountDialog(
+                        viewModel::openProfile,
+                        viewModel::dismissMaxAccountDialog,
+                        viewModel.globalAppState.maxAccountDialog
+                    )
+                    AccountLongedOutDialog(viewModel.globalAppState.blockUserUI, viewModel::navigateToNextAccountOrWelcome)
+                }
             }
         }
     }
@@ -174,3 +179,5 @@ class WireActivity : AppCompatActivity() {
         }
     }
 }
+
+

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
@@ -28,13 +28,11 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.HomeNavigationItem
-import com.wire.android.navigation.HomeNavigationItem.Conversations
 import com.wire.android.navigation.HomeNavigationItem.Settings
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationItem.Debug
@@ -46,7 +44,7 @@ import com.wire.android.ui.common.selectableBackground
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
-import com.wire.android.util.EMPTY
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -100,7 +98,14 @@ fun HomeDrawer(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        val bottomItems = listOf(Settings, Support, Debug)
+        val bottomItems = buildList {
+            if (LocalFeatureVisibilityFlags.current.Settings) {
+                add(Settings)
+            }
+            add(Support)
+            add(Debug)
+        }
+
         bottomItems.forEach { item ->
             DrawerItem(
                 data = item.getDrawerData(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -65,6 +65,7 @@ import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.messagecomposer.KeyboardHeight
 import com.wire.android.ui.home.messagecomposer.MessageComposer
 import com.wire.android.ui.home.messagecomposer.MessageComposerStateTransition
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.permission.CallingAudioRequestFlow
 import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothRequestFlow
 import com.wire.android.util.ui.UIText
@@ -219,16 +220,19 @@ private fun ConversationScreen(
             conversationScreenState.hideEditContextMenu()
             onDeleteMessage(
                 conversationScreenState.selectedMessage?.messageHeader!!.messageId,
-                conversationScreenState.isSelectedMessageMyMessage()
+                conversationScreenState.isMyMessage
             )
         }
     }
+
+    val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
 
     MenuModalSheetLayout(
         sheetState = conversationScreenState.modalBottomSheetState,
         coroutineScope = conversationScreenState.coroutineScope,
         menuItems = EditMessageMenuItems(
-            isMyMessage = conversationScreenState.isSelectedMessageMyMessage(),
+            isCopyable = conversationScreenState.isTextMessage,
+            isEditable = conversationScreenState.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon,
             onCopyMessage = conversationScreenState::copyMessage,
             onDeleteMessage = menuModalOnDeleteMessage
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
+import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
-import com.wire.android.ui.home.conversations.model.MessageSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -56,7 +56,11 @@ class ConversationScreenState(
 
     var selectedMessage by mutableStateOf<UIMessage?>(null)
 
-    fun isSelectedMessageMyMessage() = selectedMessage?.messageSource == MessageSource.Self
+    val isMyMessage
+        get() = selectedMessage?.messageSource == MessageSource.Self
+
+    val isTextMessage
+        get() = selectedMessage?.messageContent is UIMessageContent.TextMessage
 
     fun showEditContextMenu(message: UIMessage) {
         selectedMessage = message
@@ -64,7 +68,7 @@ class ConversationScreenState(
         coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Expanded) }
     }
 
-    fun hideEditContextMenu(){
+    fun hideEditContextMenu() {
         coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Hidden) }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -36,6 +36,7 @@ import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
 import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -81,21 +82,26 @@ fun ConversationScreenTopAppBar(
         },
         navigationIcon = { BackNavigationIconButton(onBackButtonClick = onBackButtonClick) },
         actions = {
-            WireSecondaryButton(
-                onClick = onSearchButtonClick,
-                leadingIcon = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_search),
-                        contentDescription = stringResource(R.string.content_description_conversation_search_icon),
-                        tint = MaterialTheme.colorScheme.onBackground
-                    )
-                },
-                fillMaxWidth = false,
-                minHeight = MaterialTheme.wireDimensions.spacing32x,
-                minWidth = MaterialTheme.wireDimensions.spacing40x,
-                shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.corner12x),
-                contentPadding = PaddingValues(0.dp)
-            )
+            val featureVisibilityFlags = LocalFeatureVisibilityFlags.current
+
+            if (featureVisibilityFlags.ConversationSearchIcon) {
+                WireSecondaryButton(
+                    onClick = onSearchButtonClick,
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_search),
+                            contentDescription = stringResource(R.string.content_description_conversation_search_icon),
+                            tint = MaterialTheme.colorScheme.onBackground
+                        )
+                    },
+                    fillMaxWidth = false,
+                    minHeight = MaterialTheme.wireDimensions.spacing32x,
+                    minWidth = MaterialTheme.wireDimensions.spacing40x,
+                    shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.corner12x),
+                    contentPadding = PaddingValues(0.dp)
+                )
+            }
+
             Spacer(Modifier.width(MaterialTheme.wireDimensions.spacing6x))
             callControlButton(
                 hasOngoingCall = hasOngoingCall,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -11,24 +11,27 @@ import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 
 @Composable
 fun EditMessageMenuItems(
-    isMyMessage: Boolean,
+    isCopyable: Boolean,
+    isEditable: Boolean,
     onCopyMessage: () -> Unit,
     onDeleteMessage: () -> Unit,
 ): List<@Composable () -> Unit> {
     return buildList {
         add {
-            MenuBottomSheetItem(
-                icon = {
-                    MenuItemIcon(
-                        id = R.drawable.ic_copy,
-                        contentDescription = stringResource(R.string.content_description_block_the_user),
-                    )
-                },
-                title = stringResource(R.string.label_copy),
-                onItemClick = onCopyMessage
-            )
+            if (isCopyable) {
+                MenuBottomSheetItem(
+                    icon = {
+                        MenuItemIcon(
+                            id = R.drawable.ic_copy,
+                            contentDescription = stringResource(R.string.content_description_copy_the_message),
+                        )
+                    },
+                    title = stringResource(R.string.label_copy),
+                    onItemClick = onCopyMessage
+                )
+            }
         }
-        if (isMyMessage)
+        if (isEditable) {
             add {
                 MenuBottomSheetItem(
                     icon = {
@@ -40,6 +43,7 @@ fun EditMessageMenuItems(
                     title = stringResource(R.string.label_edit),
                 )
             }
+        }
         add {
             CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
                 MenuBottomSheetItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.FocusManager
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 
 @ExperimentalAnimationApi
 @Composable
@@ -53,6 +54,8 @@ private fun MessageComposeActions(
     messageComposerState: MessageComposerInnerState,
     focusManager: FocusManager
 ) {
+    val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
@@ -60,15 +63,22 @@ private fun MessageComposeActions(
             .fillMaxWidth()
             .height(dimensions().spacing56x)
     ) {
-        AdditionalOptionButton(messageComposerState.attachmentOptionsDisplayed) {
-            focusManager.clearFocus()
-            messageComposerState.toggleAttachmentOptionsVisibility()
+        with(localFeatureVisibilityFlags) {
+            AdditionalOptionButton(messageComposerState.attachmentOptionsDisplayed) {
+                focusManager.clearFocus()
+                messageComposerState.toggleAttachmentOptionsVisibility()
+            }
+            if (RichTextIcon)
+                RichTextEditingAction()
+            if (EmojiIcon)
+                AddEmojiAction()
+            if (GifIcon)
+                AddGifAction()
+            if (MentionIcon)
+                AddMentionAction()
+            if (PingIcon)
+                PingAction()
         }
-        RichTextEditingAction()
-        AddEmojiAction()
-        AddGifAction()
-        AddMentionAction()
-        TakePictureAction()
     }
 }
 
@@ -109,7 +119,7 @@ private fun AddMentionAction() {
 }
 
 @Composable
-private fun TakePictureAction() {
+private fun PingAction() {
     WireIconButton(
         onButtonClicked = {},
         iconResource = R.drawable.ic_ping,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -30,6 +30,7 @@ import com.wire.android.ui.home.messagecomposer.AttachmentInnerState
 import com.wire.android.ui.home.messagecomposer.AttachmentState
 import com.wire.android.ui.home.messagecomposer.KeyboardHeight
 import com.wire.android.ui.home.messagecomposer.MessageComposerInnerState
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.getTempWritableImageUri
 import com.wire.android.util.getTempWritableVideoUri
 import com.wire.android.util.permission.UseCameraRequestFlow
@@ -191,17 +192,56 @@ private fun buildAttachmentOptionItems(
     val shareCurrentLocationFlow = ShareCurrentLocationFlow()
     val recordAudioFlow = RecordAudioFlow()
 
-    return listOf(
-        AttachmentOptionItem(isFileSharingEnabled, R.string.attachment_share_file, R.drawable.ic_attach_file) { fileFlow.launch() },
-        AttachmentOptionItem(isFileSharingEnabled, R.string.attachment_share_image, R.drawable.ic_gallery) { galleryFlow.launch() },
-        AttachmentOptionItem(isFileSharingEnabled, R.string.attachment_take_photo, R.drawable.ic_camera) { cameraFlow.launch() },
-        AttachmentOptionItem(isFileSharingEnabled, R.string.attachment_record_video, R.drawable.ic_video) { captureVideoFlow.launch() },
-        AttachmentOptionItem(isFileSharingEnabled, R.string.attachment_voice_message, R.drawable.ic_mic_on) { recordAudioFlow.launch() },
-        AttachmentOptionItem(
-            text = R.string.attachment_share_location,
-            icon = R.drawable.ic_location
-        ) { shareCurrentLocationFlow.launch() }
-    )
+    return buildList {
+        val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
+
+        with(localFeatureVisibilityFlags) {
+            add(
+                AttachmentOptionItem(
+                    isFileSharingEnabled,
+                    R.string.attachment_share_file,
+                    R.drawable.ic_attach_file
+                ) { fileFlow.launch() }
+            )
+            add(
+                AttachmentOptionItem(
+                    isFileSharingEnabled,
+                    R.string.attachment_share_image,
+                    R.drawable.ic_gallery
+                ) { galleryFlow.launch() }
+            )
+            add(
+                AttachmentOptionItem(
+                    isFileSharingEnabled,
+                    R.string.attachment_take_photo,
+                    R.drawable.ic_camera
+                ) { cameraFlow.launch() }
+            )
+            add(
+                AttachmentOptionItem(
+                    isFileSharingEnabled,
+                    R.string.attachment_record_video,
+                    R.drawable.ic_video
+                ) { captureVideoFlow.launch() }
+            )
+            if (AudioMessagesIcon) {
+                add(
+                    AttachmentOptionItem(
+                        isFileSharingEnabled,
+                        R.string.attachment_voice_message,
+                        R.drawable.ic_mic_on
+                    ) { recordAudioFlow.launch() })
+            }
+            if (ShareLocationIcon) {
+                add(
+                    AttachmentOptionItem(
+                        text = R.string.attachment_share_location,
+                        icon = R.drawable.ic_location
+                    ) { shareCurrentLocationFlow.launch() }
+                )
+            }
+        }
+    }
 }
 
 private data class AttachmentOptionItem(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ifNotEmpty
 import com.wire.kalium.logic.data.user.ConnectionState
 
@@ -114,18 +115,21 @@ fun UserProfileInfo(
                 )
                 UserBadge(membership, connection, topPadding = dimensions().spacing8x)
             }
+            val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
 
-            if (editableState is EditableState.IsEditable) {
-                ManageMemberButton(
-                    modifier = Modifier
-                        .padding(start = dimensions().spacing16x)
-                        .constrainAs(editButton) {
-                            top.linkTo(userDescription.top)
-                            bottom.linkTo(userDescription.bottom)
-                            end.linkTo(userDescription.end)
-                        },
-                    onEditClick = editableState.onEditClick
-                )
+            if (localFeatureVisibilityFlags.UserProfileEditIcon) {
+                if (editableState is EditableState.IsEditable) {
+                    ManageMemberButton(
+                        modifier = Modifier
+                            .padding(start = dimensions().spacing16x)
+                            .constrainAs(editButton) {
+                                top.linkTo(userDescription.top)
+                                bottom.linkTo(userDescription.bottom)
+                                end.linkTo(userDescription.end)
+                            },
+                        onEditClick = editableState.onEditClick
+                    )
+                }
             }
 
             if (teamName != null) {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -69,7 +69,6 @@ import com.wire.kalium.logic.data.user.UserId
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelfUserProfileScreen(viewModelSelf: SelfUserProfileViewModel = hiltViewModel()) {
-    val context = LocalContext.current
     SelfUserProfileContent(
         state = viewModelSelf.userProfileState,
         onCloseClick = viewModelSelf::navigateBack,
@@ -84,8 +83,7 @@ fun SelfUserProfileScreen(viewModelSelf: SelfUserProfileViewModel = hiltViewMode
         onMessageShown = viewModelSelf::clearErrorMessage,
         onMaxAccountReachedDialogDismissed = viewModelSelf::onMaxAccountReachedDialogDismissed,
         onOtherAccountClick = viewModelSelf::switchAccount,
-        isUserInCall = viewModelSelf::isUserInCall,
-        context = context
+        isUserInCall = viewModelSelf::isUserInCall
     )
 }
 
@@ -106,7 +104,6 @@ private fun SelfUserProfileContent(
     onMaxAccountReachedDialogDismissed: () -> Unit = {},
     onOtherAccountClick: (UserId) -> Unit = {},
     isUserInCall: () -> Boolean,
-    context: Context
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -420,8 +417,7 @@ private fun SelfUserProfileScreenPreview() {
             ),
             statusDialogData = null
         ),
-        isUserInCall = { false },
-        context = LocalContext.current
+        isUserInCall = { false }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
+++ b/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
@@ -1,0 +1,42 @@
+package com.wire.android.util.debug
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+//As a Beta user I don’t want to press on buttons that don’t have functions yet because then I will think something is not working in the app.
+//
+//ACCEPTANCE CRITERIA
+//
+//Buttons to remove from the UI:
+//Settings → App settings entry
+//Settings → Backup and restore information entry
+//Conversation view → + icon → Audio messages
+//Conversation View → + icon → share location
+//Conversation View → Aa icon
+//Conversation View → :smile: icon
+//Conversation View → GIF icon
+//Conversation View → @ icon
+//Conversation View → ping icon
+//Conversation View → search icon
+//User Profile → Edit icon
+//long press on text → edit entry
+//long press on images → edit
+//long press on images → copy
+
+
+// Those flags can be removed once we set all flags to true :)
+object FeatureVisibilityFlags {
+    const val Settings = false
+    const val AudioMessagesIcon = false
+    const val ShareLocationIcon = false
+    const val RichTextIcon = false
+    const val EmojiIcon = false
+    const val GifIcon = false
+    const val MentionIcon = false
+    const val PingIcon = false
+    const val ConversationSearchIcon = false
+    const val UserProfileEditIcon = false
+    const val MessageEditIcon = false
+}
+
+
+val LocalFeatureVisibilityFlags = staticCompositionLocalOf { FeatureVisibilityFlags }

--- a/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
+++ b/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
@@ -2,7 +2,8 @@ package com.wire.android.util.debug
 
 import androidx.compose.runtime.staticCompositionLocalOf
 
-//As a Beta user I don’t want to press on buttons that don’t have functions yet because then I will think something is not working in the app.
+//As a Beta user I don’t want to press on buttons that don’t have functions yet,
+// because then I will think something is not working in the app.
 //
 //ACCEPTANCE CRITERIA
 //


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Hide the UI component that is currently no supported depending on the simple boolean flags

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
