### PR TITLE
fix: request video streams per page in the calling grid (AR-2490)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -387,6 +387,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
+    fun provideRequestVideoStreamsUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).calls.requestVideoStreams
+
+    @ViewModelScoped
+    @Provides
     fun provideIsLastCallClosedUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).calls.isLastCallClosed
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
@@ -66,7 +66,8 @@ fun OngoingCallScreen(
             sharedCallingViewModel::toggleVideo,
             sharedCallingViewModel::setVideoPreview,
             sharedCallingViewModel::clearVideoPreview,
-            sharedCallingViewModel::navigateBack
+            sharedCallingViewModel::navigateBack,
+            ongoingCallViewModel::requestVideoStreams
         )
         isCameraOn?.let {
             BackHandler(enabled = it, sharedCallingViewModel::navigateBack)
@@ -89,7 +90,8 @@ private fun OngoingCallContent(
     toggleVideo: () -> Unit,
     setVideoPreview: (view: View) -> Unit,
     clearVideoPreview: () -> Unit,
-    navigateBack: () -> Unit
+    navigateBack: () -> Unit,
+    requestVideoStreams: (participants: List<UICallParticipant>) -> Unit
 ) {
     val sheetState = rememberBottomSheetState(
         initialValue = if (classificationType == SecurityClassificationType.NONE) BottomSheetValue.Collapsed else BottomSheetValue.Expanded
@@ -151,7 +153,8 @@ private fun OngoingCallContent(
                     isSelfUserCameraOn = isCameraOn,
                     isSelfUserMuted = isMuted,
                     onSelfVideoPreviewCreated = setVideoPreview,
-                    onSelfClearVideoPreview = clearVideoPreview
+                    onSelfClearVideoPreview = clearVideoPreview,
+                    requestVideoStreams = requestVideoStreams
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallViewModel.kt
@@ -5,11 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.calling.model.UICallParticipant
+import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -22,6 +24,7 @@ class OngoingCallViewModel @Inject constructor(
     qualifiedIdMapper: QualifiedIdMapper,
     private val navigationManager: NavigationManager,
     private val establishedCall: ObserveEstablishedCallsUseCase,
+    private val requestVideoStreams: RequestVideoStreamsUseCase
 ) : ViewModel() {
 
     private val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
@@ -44,6 +47,15 @@ class OngoingCallViewModel @Inject constructor(
                 val currentCall = calls.find { call -> call.conversationId == conversationId }
                 if (currentCall == null) navigateBack()
             }
+    }
+
+    fun requestVideoStreams(participants: List<UICallParticipant>) {
+        viewModelScope.launch {
+            val clients : List<CallClient> = participants.map {
+                CallClient(it.id.toString(), it.clientId)
+            }
+            requestVideoStreams(conversationId, clients)
+        }
     }
 
     private suspend fun navigateBack() {

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.wire.android.navigation.NavigationManager
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -29,6 +30,9 @@ class OngoingCallViewModelTest {
     private lateinit var establishedCall: ObserveEstablishedCallsUseCase
 
     @MockK
+    private lateinit var requestVideoStreams: RequestVideoStreamsUseCase
+
+    @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     private lateinit var ongoingCallViewModel: OngoingCallViewModel
@@ -46,7 +50,8 @@ class OngoingCallViewModelTest {
             savedStateHandle = savedStateHandle,
             qualifiedIdMapper = qualifiedIdMapper,
             navigationManager = navigationManager,
-            establishedCall = establishedCall
+            establishedCall = establishedCall,
+            requestVideoStreams= requestVideoStreams
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2490" title="AR-2490" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2490</a>  Can't see some videos on AR
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were following the old app in requesting video streams, it was done in every participants change which wrong.
And since we can only show 10 videos at a time, some video will be missed. We will only see 10 videos in all grid pages

### Causes (Optional)

We should get video streams for every grid page in the screen

### Solutions

Invoke the use case for that, when we swipe pages or there is a change in camera statues

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:
[feat: create request videos stream use case
](https://github.com/wireapp/kalium/pull/959)
- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
