### PR TITLE
fix: use a unique worker to fetch the notification instead of cancelling jobs

### DIFF
--- a/app/src/main/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
@@ -55,7 +55,6 @@ class WireFirebaseMessagingService : FirebaseMessagingService() {
             )
         )
         enqueueNotificationFetchWorker(extractUserId(message))
-
         appLogger.i("$TAG: onMessageReceived End")
     }
 

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -22,16 +22,19 @@ class WireWorkerFactory @Inject constructor(
 ) : WorkerFactory() {
 
     override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
-        val kaliumWorker = WrapperWorkerFactory(
+        return WrapperWorkerFactory(
             coreLogic, WireForegroundNotificationDetailsProvider
         ).createWorker(appContext, workerClassName, workerParameters)
-
-        return kaliumWorker ?: NotificationFetchWorker(
-            appContext,
-            workerParameters,
-            wireNotificationManager,
-            notificationManagerCompat
-        )
+            ?: if (workerClassName == NotificationFetchWorker::class.java.canonicalName) {
+                NotificationFetchWorker(
+                    appContext,
+                    workerParameters,
+                    wireNotificationManager,
+                    notificationManagerCompat
+                )
+            } else {
+                null
+            }
     }
 
 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.WireNotificationManager
 import dagger.assisted.Assisted
@@ -26,13 +27,21 @@ class NotificationFetchWorker
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         const val USER_ID_INPUT_DATA = "worker_user_id_input_data"
+        const val TAG = "notification_fetch_worker"
     }
 
     override suspend fun doWork(): Result {
-        inputData.getString(USER_ID_INPUT_DATA)?.let { userId ->
-            wireNotificationManager.fetchAndShowNotificationsOnce(userId)
+        try {
+            inputData.getString(USER_ID_INPUT_DATA)?.let { userId ->
+                appLogger.d("$TAG Starting the NotificationFetchWorker")
+                wireNotificationManager.fetchAndShowNotificationsOnce(userId)
+            }
+        } catch (exception: Exception) {
+            appLogger.d("$TAG NotificationFetchWorker failed with exception: $exception")
+            return Result.failure()
         }
 
+        appLogger.d("$TAG NotificationFetchWorker finished successfully")
         return Result.success()
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Worker was hanging forever causing the foreground notiifcation to be hanging as well
### Causes (Optional)

I do not have the exact reason, but there was lots of dancing with jobs and checking the status manually, launching a seperate Job on a outer scope that lives within WireNotificationManager making things more complicated.

The reproduction was quite easy however, spam the messages from two differents groups for example.

I also noticed two other things : 

- We did not handle exception inside the Worker
- We did not return null inside the WireWorkerFactory to return default Worker

### Solutions

Since we are running a single Worker per userId we do not need to do this dance with a jobs, we can relay on a Worker having single instance running.

Since the change of executing Worker per userId I have no reproduction.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
