### PR TITLE
chore: show you in participant list

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +23,9 @@ import com.wire.android.ui.home.conversations.details.participants.model.UIParti
 import com.wire.android.ui.home.conversations.search.HighlightName
 import com.wire.android.ui.home.conversations.search.HighlightSubtitle
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.UserId
 
@@ -40,6 +43,17 @@ fun GroupConversationParticipantItem(
                     name = if (uiParticipant.unavailable) stringResource(R.string.username_unavailable_label) else uiParticipant.name,
                     searchQuery = searchQuery,
                     modifier = Modifier.weight(weight = 1f, fill = false)
+                )
+                Text(
+                    text = stringResource(R.string.conversation_participant_you_label),
+                    style = MaterialTheme.wireTypography.title02.copy(
+                        color = MaterialTheme.wireColorScheme.secondaryText
+                    ),
+                    modifier = Modifier
+                        .padding(
+                            start = dimensions().spacing4x,
+                            end = dimensions().spacing4x
+                        )
                 )
                 UserBadge(
                     membership = uiParticipant.membership,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
@@ -44,17 +44,19 @@ fun GroupConversationParticipantItem(
                     searchQuery = searchQuery,
                     modifier = Modifier.weight(weight = 1f, fill = false)
                 )
-                Text(
-                    text = stringResource(R.string.conversation_participant_you_label),
-                    style = MaterialTheme.wireTypography.title02.copy(
-                        color = MaterialTheme.wireColorScheme.secondaryText
-                    ),
-                    modifier = Modifier
-                        .padding(
-                            start = dimensions().spacing4x,
-                            end = dimensions().spacing4x
-                        )
-                )
+                if (uiParticipant.isSelf) {
+                    Text(
+                        text = stringResource(R.string.conversation_participant_you_label),
+                        style = MaterialTheme.wireTypography.title02.copy(
+                            color = MaterialTheme.wireColorScheme.secondaryText
+                        ),
+                        modifier = Modifier
+                            .padding(
+                                start = dimensions().spacing4x,
+                                end = dimensions().spacing4x
+                            )
+                    )
+                }
                 UserBadge(
                     membership = uiParticipant.membership,
                     connectionState = uiParticipant.connectionState,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,7 @@
     <string name="conversation_details_show_all_participants">Show all participants (%d)</string>
     <string name="conversation_details_group_participants_title">Group Participants</string>
     <string name="conversation_details_group_participants_add">Add participants</string>
+    <string name="conversation_participant_you_label">(You)</string>
     <string name="conversation_details_is_classified">SECURITY LEVEL: VS-NfD</string>
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
     <string name="conversation_options_guests_label">Guests</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User can't see which is their contact in the group 


### Solutions
 add a label to define who is the account owner in the participant list 

### Testing

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._


### Attachments (Optional)
<img width="444" alt="Screenshot 2022-09-27 at 11 29 16" src="https://user-images.githubusercontent.com/34056732/192490283-c6598896-a491-433e-96e6-3b30ec5faf17.png">


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
