### PR TITLE
fix: sync stuck when waiting until live (AR-2524) (AR-2533)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -75,7 +76,10 @@ class PersistentWebSocketService : Service() {
         coreLogic.globalScope { sessionRepository.currentSession() }.fold({
             appLogger.e("error while getting the current session from persistent web socket service $it")
         }, { currentAccount ->
-            coreLogic.getSessionScope(currentAccount.userId).setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+            runBlocking {
+                coreLogic.getSessionScope(currentAccount.userId)
+                    .setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+            }
 
             val observeUserId = currentSessionFlow()
                 .map { result ->
@@ -85,7 +89,6 @@ class PersistentWebSocketService : Service() {
                 .distinctUntilChanged()
                 .flowOn(dispatcherProvider.io())
                 .shareIn(scope, SharingStarted.WhileSubscribed(), 1)
-
 
             scope.launch {
                 notificationManager.observeNotificationsAndCalls(observeUserId, scope) {

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.SetConnectionPolicyUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.every
@@ -50,7 +51,7 @@ class ConnectionPolicyManagerTest {
 
         coVerify(exactly = 1) {
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLive()
+            arrangement.syncManager.waitUntilLiveOrFailure()
         }
     }
 
@@ -67,7 +68,7 @@ class ConnectionPolicyManagerTest {
 
         coVerify(exactly = 1) {
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLive()
+            arrangement.syncManager.waitUntilLiveOrFailure()
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
         }
     }
@@ -85,7 +86,7 @@ class ConnectionPolicyManagerTest {
 
         coVerify(exactly = 1) {
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLive()
+            arrangement.syncManager.waitUntilLiveOrFailure()
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
         }
     }
@@ -103,7 +104,7 @@ class ConnectionPolicyManagerTest {
 
         coVerifyOrder {
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLive()
+            arrangement.syncManager.waitUntilLiveOrFailure()
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
         }
     }
@@ -139,6 +140,7 @@ class ConnectionPolicyManagerTest {
             every { coreLogic.getSessionScope(USER_ID) } returns userSessionScope
             every { userSessionScope.setConnectionPolicy } returns setConnectionPolicyUseCase
             every { userSessionScope.syncManager } returns syncManager
+            coEvery { syncManager.waitUntilLiveOrFailure() } returns Either.Right(Unit)
         }
 
         fun withAppInTheBackground() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2524" title="AR-2524" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2524</a>  second account doesnt display waiting for networ.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes sync was getting stuck while waiting until live.

### Causes

See:
- https://github.com/wireapp/kalium/pull/984

### Solutions

Solution added in Kalium.
On this PR:
- Addressing breaking changes (`setConnectionPolicy` is now suspending).
- Replace `waitUntilLive` with `waitUntilLiveOrFailure`.


### Dependencies


Needs releases with:

- https://github.com/wireapp/kalium/pull/984

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
