### PR TITLE
fix: video calls (AR-2490)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -51,7 +51,6 @@ fun ParticipantTile(
     onGoingCallTileUsernameMaxWidth: Dp = 350.dp,
     avatarSize: Dp = dimensions().onGoingCallUserAvatarSize,
     isSelfUser: Boolean,
-    shouldRecomposeVideoRenderer: Boolean,
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit
 ) {
@@ -95,15 +94,7 @@ fun ParticipantTile(
                         val frameLayout = FrameLayout(it)
                         frameLayout.addView(videoRenderer)
                         frameLayout
-                    },
-                        update = {
-                            if (shouldRecomposeVideoRenderer) {
-                                // Needed to disconnect renderer from container, skipping this will lead to some issues like video freezing
-                                it.removeAllViews()
-
-                                it.addView(videoRenderer)
-                            }
-                        }
+                    }
                     )
                 }
             }
@@ -259,7 +250,6 @@ private fun ParticipantTilePreview() {
         ),
         onClearSelfUserVideoPreview = {},
         onSelfUserVideoPreviewCreated = {},
-        isSelfUser = false,
-        shouldRecomposeVideoRenderer = false
+        isSelfUser = false
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -25,8 +25,6 @@ import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.QualifiedID
 
-val lastParticipants = mutableMapOf<Int, List<UICallParticipant>>()
-
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun GroupCallGrid(
@@ -39,8 +37,6 @@ fun GroupCallGrid(
 ) {
     val config = LocalConfiguration.current
 
-    // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
-    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants, pageIndex)
     LazyVerticalGrid(
         userScrollEnabled = false,
         contentPadding = PaddingValues(MaterialTheme.wireDimensions.spacing4x),
@@ -105,26 +101,10 @@ fun GroupCallGrid(
                     if (isSelfUser) {
                         onSelfClearVideoPreview()
                     }
-                },
-                shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
+                }
             )
         }
-        lastParticipants.remove(pageIndex)
-        lastParticipants[pageIndex] = participants
     }
-}
-
-@Suppress("ReturnCount")
-fun isVideoStateChangedComparedToLastList(newParticipants: List<UICallParticipant>, pageIndex: Int) : Boolean {
-    if (lastParticipants[pageIndex].isNullOrEmpty())
-        return true
-    if(lastParticipants[pageIndex]?.size == newParticipants.size) {
-        lastParticipants[pageIndex]?.zip(newParticipants)?.forEach { pair ->
-            if (pair.first.isCameraOn != pair.second.isCameraOn || (pair.first.isSharingScreen != pair.second.isSharingScreen))
-                return true
-        }
-    }
-    return false
 }
 
 /**

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
@@ -34,9 +34,6 @@ fun OneOnOneCallView(
 ) {
     val config = LocalConfiguration.current
 
-    // We use this to check if we need to recompose renderers or not, mainly used to avoid recomposition which makes the screen flickering
-    val shouldRecomposeVideoRenderer = isVideoStateChangedComparedToLastList(participants, pageIndex)
-
     LazyColumn(
         modifier = Modifier.padding(dimensions().spacing4x),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.wireDimensions.spacing2x)
@@ -81,11 +78,8 @@ fun OneOnOneCallView(
                 onClearSelfUserVideoPreview = {
                     if (isSelfUser)
                         onSelfClearVideoPreview()
-                },
-                shouldRecomposeVideoRenderer = shouldRecomposeVideoRenderer
+                }
             )
-            lastParticipants.remove(pageIndex)
-            lastParticipants[pageIndex] = participants
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2490" title="AR-2490" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2490</a>  Can't see some videos on AR
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Video flickering 
2. Crash when toggling video many times
3.  random crash in a video call

### Causes (Optional)

1. Video renderer are created using `TextureView`, so we need every time to clear old renderers before creating new ones
2.  mainly because we are creating multiple render for same user

### Solutions

1. Fixed on AVS by using SurfaceView instead of `TextureView`
2. Create render on factory lambda on `AndroidView`

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

[chore: bump avs version to 8.2.15 
](https://github.com/wireapp/kalium/pull/988)
- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
