### PR TITLE
fix(revert-me): work around because the backend is not updating the list of clients immediately

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.feature.client.SelfClientsResult
 import com.wire.kalium.logic.feature.client.SelfClientsUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -119,7 +120,12 @@ class RemoveDeviceViewModel @Inject constructor(
             }
             DeleteClientResult.Failure.InvalidCredentials -> state = state.copy(error = RemoveDeviceError.InvalidCredentialsError)
             DeleteClientResult.Failure.PasswordAuthRequired -> showDeleteClientDialog(device)
-            DeleteClientResult.Success -> registerClient(password)
+            DeleteClientResult.Success -> {
+                // this delay is only a work around because the backend is not updating the list of clients immediately
+                // TODO: remove the delay once the server side bug is fixed
+                delay(500L)
+                registerClient(password)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -123,7 +123,7 @@ class RemoveDeviceViewModel @Inject constructor(
             DeleteClientResult.Success -> {
                 // this delay is only a work around because the backend is not updating the list of clients immediately
                 // TODO: remove the delay once the server side bug is fixed
-                delay(500L)
+                delay(REGISTER_CLIENT_AFTER_DELETE_DELAY)
                 registerClient(password)
             }
         }
@@ -157,4 +157,8 @@ class RemoveDeviceViewModel @Inject constructor(
 
     private suspend fun navigateToConvScreen() =
         navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
+
+    private companion object {
+        const val REGISTER_CLIENT_AFTER_DELETE_DELAY = 500L
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users seeing server error after removing device 

### Causes (Optional)

the server response with `TooManyClients` when registering client after removing one
the reason is the server now deleting client asynchronously and the app run into race condition when registering clients right after deleting one 

### Solutions

add half a sec delay between deleting a client and registering a new one this fixes the issue
this is a workaround and not a solution by any means and should be removed as soon as the server fix deleting client end point

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
