### PR TITLE
fix: call set connection policy in c scope

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -68,8 +68,10 @@ class ConnectionPolicyManager @Inject constructor(
      * this will downgrade the policy back to [ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS].
      */
     suspend fun handleConnectionOnPushNotification(userId: UserId) {
-        logger.d("$TAG Handling connection policy for push notification of " +
-                "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}")
+        logger.d(
+            "$TAG Handling connection policy for push notification of " +
+                    "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}"
+        )
         coreLogic.getSessionScope(userId).run {
             logger.d("$TAG Forcing KEEP_ALIVE policy")
             // Force KEEP_ALIVE policy, so we gather pending events and become online
@@ -122,7 +124,9 @@ class ConnectionPolicyManager @Inject constructor(
         } else {
             ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS
         }
-        coreLogic.getSessionScope(userId).setConnectionPolicy(connectionPolicy)
+        CoroutineScope(dispatcherProvider.default()).launch {
+            coreLogic.getSessionScope(userId).setConnectionPolicy(connectionPolicy)
+        }
     }
 
     private suspend fun allValidSessions() =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

set connection policy use case set as suspend but didn't reflect the changes in AR


### Solutions

call it inside coroutines scope 

### Testing

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
