### PR TITLE
fix: blocked user UI fixes

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
@@ -85,6 +85,7 @@ enum class HomeNavigationItem(
                     itemType = ConversationItemType.ALL_CONVERSATIONS,
                     onHomeBottomSheetContentChanged = homeState::changeBottomSheetContent,
                     onOpenBottomSheet = homeState::openBottomSheet,
+                    onCloseBottomSheet = homeState::closeBottomSheet,
                     onSnackBarStateChanged = homeState::setSnackBarState
                 )
             }
@@ -103,6 +104,7 @@ enum class HomeNavigationItem(
                     itemType = ConversationItemType.CALLS,
                     onHomeBottomSheetContentChanged = homeState::changeBottomSheetContent,
                     onOpenBottomSheet = homeState::openBottomSheet,
+                    onCloseBottomSheet = homeState::closeBottomSheet,
                     onSnackBarStateChanged = homeState::setSnackBarState
                 )
             }
@@ -121,6 +123,7 @@ enum class HomeNavigationItem(
                     itemType = ConversationItemType.MENTIONS,
                     onHomeBottomSheetContentChanged = homeState::changeBottomSheetContent,
                     onOpenBottomSheet = homeState::openBottomSheet,
+                    onCloseBottomSheet = homeState::closeBottomSheet,
                     onSnackBarStateChanged = homeState::setSnackBarState
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/DialogStates.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/DialogStates.kt
@@ -3,4 +3,4 @@ package com.wire.android.ui.common.dialogs
 import com.wire.kalium.logic.data.user.UserId
 
 data class BlockUserDialogState(val userName: String, val userId: UserId)
-data class UnblockUserDialogState(val username: String, val userId: UserId)
+data class UnblockUserDialogState(val userName: String, val userId: UserId)

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/UnblockUserDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/UnblockUserDialogs.kt
@@ -31,7 +31,7 @@ fun UnblockUserDialogContent(
                 MaterialTheme.wireTypography.body02,
                 colorsScheme().onBackground,
                 colorsScheme().onBackground,
-                state.username
+                state.userName
             ),
             onDismiss = dialogState::dismiss,
             optionButton1Properties = WireDialogButtonProperties(

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -245,6 +245,7 @@ private fun handleSnackBarMessage(
                 stringResource(id = R.string.blocking_user_success, messageType.userName)
             HomeSnackbarState.MutingOperationError -> stringResource(id = R.string.error_updating_muting_setting)
             HomeSnackbarState.BlockingUserOperationError -> stringResource(id = R.string.error_blocking_user)
+            HomeSnackbarState.UnblockingUserOperationError -> stringResource(id = R.string.error_unblocking_user)
             HomeSnackbarState.None -> ""
             is HomeSnackbarState.DeletedConversationGroupSuccess ->
                 stringResource(id = R.string.conversation_group_removed_success, messageType.groupName)

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -108,6 +108,7 @@ sealed class HomeSnackbarState {
     object MutingOperationError : HomeSnackbarState()
     object BlockingUserOperationError : HomeSnackbarState()
     class BlockingUserOperationSuccess(val userName: String) : HomeSnackbarState()
+    object UnblockingUserOperationError : HomeSnackbarState()
     class DeletedConversationGroupSuccess(val groupName: String) : HomeSnackbarState()
     object DeleteConversationGroupError : HomeSnackbarState()
     object LeftConversationSuccess : HomeSnackbarState()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +23,9 @@ import com.wire.android.ui.home.conversations.details.participants.model.UIParti
 import com.wire.android.ui.home.conversations.search.HighlightName
 import com.wire.android.ui.home.conversations.search.HighlightSubtitle
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.UserId
 
@@ -41,6 +44,19 @@ fun GroupConversationParticipantItem(
                     searchQuery = searchQuery,
                     modifier = Modifier.weight(weight = 1f, fill = false)
                 )
+                if (uiParticipant.isSelf) {
+                    Text(
+                        text = stringResource(R.string.conversation_participant_you_label),
+                        style = MaterialTheme.wireTypography.title02.copy(
+                            color = MaterialTheme.wireColorScheme.secondaryText
+                        ),
+                        modifier = Modifier
+                            .padding(
+                                start = dimensions().spacing4x,
+                                end = dimensions().spacing4x
+                            )
+                    )
+                }
                 UserBadge(
                     membership = uiParticipant.membership,
                     connectionState = uiParticipant.connectionState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -78,19 +78,18 @@ class ConversationInfoViewModel @Inject constructor(
     }
 
     private fun handleConversationDetails(conversationDetails: ConversationDetails) {
-        val isConversationUnavailable = when (conversationDetails) {
-            is ConversationDetails.OneOne -> conversationDetails.otherUser.isUnavailableUser
-            else -> false
+        val (isConversationUnavailable, isUserBlocked) = when (conversationDetails) {
+            is ConversationDetails.OneOne -> conversationDetails.otherUser
+                .run { isUnavailableUser to (connectionStatus == ConnectionState.BLOCKED) }
+            else -> false to false
         }
-
-        val connectionStateOrNull = (conversationInfoViewState.conversationDetailsData as? ConversationDetailsData.OneOne)?.connectionState
 
         val detailsData = getConversationDetailsData(conversationDetails)
         conversationInfoViewState = conversationInfoViewState.copy(
             conversationName = getConversationName(conversationDetails, isConversationUnavailable),
             conversationAvatar = getConversationAvatar(conversationDetails),
             conversationDetailsData = detailsData,
-            isUserBlocked = connectionStateOrNull == ConnectionState.BLOCKED,
+            isUserBlocked = isUserBlocked,
             hasUserPermissionToEdit = detailsData !is ConversationDetailsData.None
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -90,7 +90,6 @@ class ConversationListViewModel @Inject constructor(
 
     private fun startObservingConversationsAndConnections() = viewModelScope.launch {
         observeConversationListDetailsUseCase()
-            .distinctUntilChanged()
             .flowOn(dispatcher.io())
             .collect { conversationListDetails ->
                 state = ConversationListState(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.ui.common.dialogs.BlockUserDialogContent
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
+import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
+import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.home.HomeSnackbarState
 import com.wire.android.ui.home.conversations.details.menu.DeleteConversationGroupDialog
@@ -31,6 +33,7 @@ fun ConversationRouterHomeBridge(
     itemType: ConversationItemType,
     onHomeBottomSheetContentChanged: (@Composable ColumnScope.() -> Unit) -> Unit,
     onOpenBottomSheet: () -> Unit,
+    onCloseBottomSheet: () -> Unit,
     onSnackBarStateChanged: (HomeSnackbarState) -> Unit
 ) {
     val viewModel: ConversationListViewModel = hiltViewModel()
@@ -38,15 +41,21 @@ fun ConversationRouterHomeBridge(
     LaunchedEffect(Unit) {
         viewModel.snackBarState.collect { onSnackBarStateChanged(it) }
     }
+    LaunchedEffect(Unit) {
+        viewModel.closeBottomSheet.collect { onCloseBottomSheet() }
+    }
 
     val leaveGroupDialogState = rememberVisibilityState<GroupDialogState>()
     val deleteGroupDialogState = rememberVisibilityState<GroupDialogState>()
     val blockUserDialogState = rememberVisibilityState<BlockUserDialogState>()
+    val unblockUserDialogState = rememberVisibilityState<UnblockUserDialogState>()
 
-    if (!viewModel.requestInProgress) {
+    val requestInProgress = viewModel.requestInProgress
+    if (!requestInProgress) {
         leaveGroupDialogState.dismiss()
         deleteGroupDialogState.dismiss()
         blockUserDialogState.dismiss()
+        unblockUserDialogState.dismiss()
     }
 
     fun openConversationBottomSheet(
@@ -83,6 +92,7 @@ fun ConversationRouterHomeBridge(
                 moveConversationToArchive = viewModel::moveConversationToArchive,
                 clearConversationContent = viewModel::clearConversationContent,
                 blockUser = blockUserDialogState::show,
+                unblockUser = unblockUserDialogState::show,
                 leaveGroup = leaveGroupDialogState::show,
                 deleteGroup = deleteGroupDialogState::show
             )
@@ -143,21 +153,27 @@ fun ConversationRouterHomeBridge(
     }
 
     BlockUserDialogContent(
-        isLoading = viewModel.requestInProgress,
+        isLoading = requestInProgress,
         dialogState = blockUserDialogState,
         onBlock = viewModel::blockUser
     )
 
     DeleteConversationGroupDialog(
-        isLoading = viewModel.requestInProgress,
+        isLoading = requestInProgress,
         dialogState = deleteGroupDialogState,
         onDeleteGroup = viewModel::deleteGroup
     )
 
     LeaveConversationGroupDialog(
         dialogState = leaveGroupDialogState,
-        isLoading = viewModel.requestInProgress,
+        isLoading = requestInProgress,
         onLeaveGroup = viewModel::leaveGroup
+    )
+
+    UnblockUserDialogContent(
+        dialogState = unblockUserDialogState,
+        onUnblock = viewModel::unblockUser,
+        isLoading = requestInProgress,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/ConversationSheetContent.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
+import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -20,6 +21,7 @@ fun ConversationSheetContent(
     moveConversationToArchive: () -> Unit,
     clearConversationContent: () -> Unit,
     blockUser: (BlockUserDialogState) -> Unit,
+    unblockUser: (UnblockUserDialogState) -> Unit,
     leaveGroup: (GroupDialogState) -> Unit,
     deleteGroup: (GroupDialogState) -> Unit
 ) {
@@ -34,6 +36,7 @@ fun ConversationSheetContent(
 //                moveConversationToArchive = moveConversationToArchive,
 //                clearConversationContent = clearConversationContent,
                 blockUserClick = blockUser,
+                unblockUserClick = unblockUser,
                 leaveGroup = leaveGroup,
                 deleteGroup = deleteGroup,
                 navigateToNotification = conversationSheetState::toMutingNotificationOption

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
@@ -23,6 +23,7 @@ import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.conversationColor
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
+import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
 import com.wire.android.ui.home.conversationslist.model.BlockingState
@@ -43,6 +44,7 @@ internal fun ConversationMainSheetContent(
 //    moveConversationToArchive: () -> Unit,
 //    clearConversationContent: () -> Unit,
     blockUserClick: (BlockUserDialogState) -> Unit,
+    unblockUserClick: (UnblockUserDialogState) -> Unit,
     leaveGroup: (GroupDialogState) -> Unit,
     deleteGroup: (GroupDialogState) -> Unit,
     navigateToNotification: () -> Unit
@@ -51,7 +53,7 @@ internal fun ConversationMainSheetContent(
         header = MenuModalSheetHeader.Visible(
             title = conversationSheetContent.title,
             leadingIcon = {
-                    if (conversationSheetContent.conversationTypeDetail is ConversationTypeDetail.Group) {
+                if (conversationSheetContent.conversationTypeDetail is ConversationTypeDetail.Group) {
                     GroupConversationAvatar(
                         color = colorsScheme()
                             .conversationColor(id = conversationSheetContent.conversationTypeDetail.conversationId)
@@ -150,6 +152,26 @@ internal fun ConversationMainSheetContent(
                                 onItemClick = {
                                     blockUserClick(
                                         BlockUserDialogState(
+                                            userName = conversationSheetContent.title,
+                                            userId = conversationSheetContent.conversationTypeDetail.userId
+                                        )
+                                    )
+                                }
+                            )
+                        }
+                    } else if (conversationSheetContent.conversationTypeDetail.blockingState == BlockingState.BLOCKED) {
+                        CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+                            MenuBottomSheetItem(
+                                icon = {
+                                    MenuItemIcon(
+                                        id = R.drawable.ic_block,
+                                        contentDescription = stringResource(R.string.content_description_unblock_the_user)
+                                    )
+                                },
+                                title = stringResource(R.string.label_unblock),
+                                onItemClick = {
+                                    unblockUserClick(
+                                        UnblockUserDialogState(
                                             userName = conversationSheetContent.title,
                                             userId = conversationSheetContent.conversationTypeDetail.userId
                                         )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileBottomSheet.kt
@@ -4,6 +4,7 @@ import MutingOptionsSheetContent
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
+import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.home.conversationslist.bottomsheet.ConversationMainSheetContent
 
 @Composable
@@ -11,6 +12,7 @@ fun OtherUserProfileBottomSheetContent(
     bottomSheetState: BottomSheetContent?,
     eventsHandler: OtherUserProfileBottomSheetEventsHandler,
     blockUser: (BlockUserDialogState) -> Unit,
+    unblockUser: (UnblockUserDialogState) -> Unit,
     closeBottomSheet: () -> Unit
 ) {
     when (bottomSheetState) {
@@ -27,7 +29,8 @@ fun OtherUserProfileBottomSheetContent(
                 blockUserClick = blockUser,
                 leaveGroup = { },
                 deleteGroup = { },
-                navigateToNotification = eventsHandler::setBottomSheetStateToMuteOptions
+                navigateToNotification = eventsHandler::setBottomSheetStateToMuteOptions,
+                unblockUserClick = unblockUser
             )
         }
         is BottomSheetContent.Mute ->

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -96,8 +96,12 @@ fun OtherUserProfileScreen(viewModel: OtherUserProfileScreenViewModel = hiltView
 
     LaunchedEffect(Unit) {
         viewModel.infoMessage.collect {
-            closeBottomSheet()
             snackbarHostState.showSnackbar(it.asString(context.resources))
+        }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.closeBottomSheet.collect {
+            closeBottomSheet()
         }
     }
 
@@ -172,6 +176,7 @@ fun OtherProfileScreenContent(
                 bottomSheetState = state.bottomSheetContentState,
                 eventsHandler = bottomSheetEventsHandler,
                 blockUser = blockUserDialogState::show,
+                unblockUser = unblockUserDialogState::show,
                 closeBottomSheet = closeBottomSheet,
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -141,7 +141,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 when (getInfoResult) {
                     is GetUserInfoResult.Failure -> {
                         appLogger.d("Couldn't not find the user with provided id: $userId")
-                        showInfoMessage(LoadUserInformationError)
+                        closeBottomSheetAndShowInfoMessage(LoadUserInformationError)
                     }
                     is GetUserInfoResult.Success -> {
                         val otherUser = getInfoResult.otherUser
@@ -242,11 +242,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (sendConnectionRequest(userId)) {
                 is SendConnectionRequestResult.Failure -> {
                     appLogger.d(("Couldn't send a connect request to user $userId"))
-                    showInfoMessage(ConnectionRequestError)
+                    closeBottomSheetAndShowInfoMessage(ConnectionRequestError)
                 }
                 is SendConnectionRequestResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.SENT)
-                    showInfoMessage(SuccessConnectionSentRequest)
+                    closeBottomSheetAndShowInfoMessage(SuccessConnectionSentRequest)
                 }
             }
         }
@@ -257,11 +257,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (cancelConnectionRequest(userId)) {
                 is CancelConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't cancel a connect request to user $userId"))
-                    showInfoMessage(ConnectionCancelError)
+                    closeBottomSheetAndShowInfoMessage(ConnectionCancelError)
                 }
                 is CancelConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.NOT_CONNECTED)
-                    showInfoMessage(SuccessConnectionCancelRequest)
+                    closeBottomSheetAndShowInfoMessage(SuccessConnectionCancelRequest)
                 }
             }
         }
@@ -272,11 +272,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (acceptConnectionRequest(userId)) {
                 is AcceptConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't accept a connect request to user $userId"))
-                    showInfoMessage(ConnectionAcceptError)
+                    closeBottomSheetAndShowInfoMessage(ConnectionAcceptError)
                 }
                 is AcceptConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.ACCEPTED)
-                    showInfoMessage(SuccessConnectionAcceptRequest)
+                    closeBottomSheetAndShowInfoMessage(SuccessConnectionAcceptRequest)
                 }
             }
         }
@@ -287,7 +287,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (ignoreConnectionRequest(userId)) {
                 is IgnoreConnectionRequestUseCaseResult.Failure -> {
                     appLogger.d(("Couldn't ignore a connect request to user $userId"))
-                    showInfoMessage(ConnectionIgnoreError)
+                    closeBottomSheetAndShowInfoMessage(ConnectionIgnoreError)
                 }
                 is IgnoreConnectionRequestUseCaseResult.Success -> {
                     state = state.copy(connectionState = ConnectionState.IGNORED)
@@ -306,13 +306,13 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             if (conversationId != null) {
                 updateMemberRole(conversationId, userId, role).also {
                     if (it is UpdateConversationMemberRoleResult.Failure)
-                        showInfoMessage(ChangeGroupRoleError)
+                        closeBottomSheetAndShowInfoMessage(ChangeGroupRoleError)
                 }
             }
         }
     }
 
-    private suspend fun showInfoMessage(type: SnackBarMessage) {
+    private suspend fun closeBottomSheetAndShowInfoMessage(type: SnackBarMessage) {
         _closeBottomSheet.emit(Unit)
         _infoMessage.emit(type.uiText)
     }
@@ -328,7 +328,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             }
 
             if (response is RemoveMemberFromConversationUseCase.Result.Failure)
-                showInfoMessage(RemoveConversationMemberError)
+                closeBottomSheetAndShowInfoMessage(RemoveConversationMemberError)
 
             requestInProgress = false
         }
@@ -338,7 +338,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         conversationId?.let {
             viewModelScope.launch {
                 when (updateConversationMutedStatus(conversationId, status, Date().time)) {
-                    ConversationUpdateStatusResult.Failure -> showInfoMessage(MutingOperationError)
+                    ConversationUpdateStatusResult.Failure -> closeBottomSheetAndShowInfoMessage(MutingOperationError)
                     ConversationUpdateStatusResult.Success -> {
                         state = state.updateMuteStatus(status)
                         appLogger.i("MutedStatus changed for conversation: $conversationId to $status")
@@ -354,11 +354,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             when (val result = blockUser(userId)) {
                 BlockUserResult.Success -> {
                     appLogger.i("User $userId was blocked")
-                    showInfoMessage(BlockingUserOperationSuccess(blockUserState.userName))
+                    closeBottomSheetAndShowInfoMessage(BlockingUserOperationSuccess(blockUserState.userName))
                 }
                 is BlockUserResult.Failure -> {
                     appLogger.e("Error while blocking user $userId ; Error ${result.coreFailure}")
-                    showInfoMessage(BlockingUserOperationError)
+                    closeBottomSheetAndShowInfoMessage(BlockingUserOperationError)
                 }
             }
             requestInProgress = false
@@ -375,7 +375,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 }
                 is UnblockUserResult.Failure -> {
                     appLogger.e("Error while unblocking user $userId ; Error ${result.coreFailure}")
-                    showInfoMessage(UnblockingUserOperationError)
+                    closeBottomSheetAndShowInfoMessage(UnblockingUserOperationError)
                 }
             }
             requestInProgress = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,7 @@
     <string name="conversation_details_show_all_participants">Show all participants (%d)</string>
     <string name="conversation_details_group_participants_title">Group Participants</string>
     <string name="conversation_details_group_participants_add">Add participants</string>
+    <string name="conversation_participant_you_label">(You)</string>
     <string name="conversation_details_is_classified">SECURITY LEVEL: VS-NfD</string>
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
     <string name="conversation_options_guests_label">Guests</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="content_description_move_to_folder">Move to folder</string>
     <string name="content_description_move_to_archive">Move to archive</string>
     <string name="content_description_block_the_user">Block</string>
+    <string name="content_description_unblock_the_user">Unblock</string>
     <string name="content_description_leave_the_group">Leave the group</string>
     <string name="content_description_delete_the_group">Delete the group</string>
     <string name="content_description_conversation_phone_icon">Start audio call</string>
@@ -366,6 +367,7 @@
     <string name="label_move_to_archive">Move to Archive</string>
     <string name="label_clear_content">Clear Content…</string>
     <string name="label_block">Block</string>
+    <string name="label_unblock">Unblock</string>
     <string name="label_leave_group">Leave Group</string>
     <string name="label_delete_group">Delete Group</string>
     <!-- Muting options BottomSheet -->

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -191,7 +191,6 @@ internal fun withMockConversationDetailsOneOnOne(
         every { connectionStatus } returns connectionState
         every { isUnavailableUser } returns unavailable
     },
-    connectionState = ConnectionState.PENDING,
     legalHoldStatus = LegalHoldStatus.DISABLED,
     userType = UserType.INTERNAL,
     unreadMessagesCount = 0L,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -21,8 +21,10 @@ import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.AnswerCallUseCase
-import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.BlockUserResult
+import com.wire.kalium.logic.feature.connection.BlockUserUseCase
+import com.wire.kalium.logic.feature.connection.UnblockUserResult
+import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsUseCase
@@ -72,6 +74,9 @@ class ConversationListViewModelTest {
     lateinit var blockUser: BlockUserUseCase
 
     @MockK
+    lateinit var unblockUser: UnblockUserUseCase
+
+    @MockK
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
     @BeforeEach
@@ -89,6 +94,7 @@ class ConversationListViewModelTest {
                 leaveConversation,
                 deleteTeamConversationUseCase,
                 blockUser,
+                unblockUser,
                 wireSessionImageLoader,
                 UserTypeMapper(),
             )
@@ -160,6 +166,14 @@ class ConversationListViewModelTest {
         )
 
         coVerify(exactly = 1) { blockUser(userId) }
+    }
+
+    @Test
+    fun `given a valid conversation muting state, when calling unblock user, then should call BlockUserUseCase`() = runTest {
+        coEvery { unblockUser(any()) } returns UnblockUserResult.Success
+        conversationListViewModel.unblockUser(userId)
+
+        coVerify(exactly = 1) { unblockUser(userId) }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -295,7 +295,6 @@ class MediaGalleryViewModelTest {
                 null,
                 false
             ),
-            connectionState = ConnectionState.ACCEPTED,
             legalHoldStatus = LegalHoldStatus.DISABLED,
             userType = UserType.INTERNAL,
             unreadMessagesCount = 0L,


### PR DESCRIPTION
# What's new in this PR?

### Issues

1. in OtherUserProfileScreen: for blocked user OptionsBottomSheet was displayed as empty
2. in ConversationsListScreen: BlockUserDialog do not disappear after blocking user  
3. in ConversationScreen: with blocked user message editText was not disabeled (sometimes)
4. Block user not working when just recently connected

### Causes (Optional)

1. the bottomSheet content was not specified for the blocked user 🤷‍♂️

2. BlockUserDialog disappears once request is done, for that we have `MutableState requestInProgress` in viewModel. So it is set to true once use click the button and suppose to set to false when request is done. But for some reason setting to false was done outside of the CoroutineScope where request happens. So it was like: set to true and set to false almost at the same time.

3. the problem was that `isUserBlocked` was checked from the UiState and should be from the data that came from DB 🤷‍♂️

4. fixed by kalium update

### Dependencies (Optional)

Depends on kalium PR

Needs releases after:

https://github.com/wireapp/kalium/pull/998
