### PR TITLE
feat: conversation banner (AR-2378)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -225,8 +225,10 @@ enum class NavigationItem(
                 conversationCallViewModel = hiltSavedStateViewModel(it.navBackStackEntry),
                 conversationInfoViewModel = hiltSavedStateViewModel(it.navBackStackEntry),
                 conversationMessagesViewModel = hiltSavedStateViewModel(it.navBackStackEntry),
-                commonTopAppBarViewModel = hiltViewModel()
-            )
+                commonTopAppBarViewModel = hiltViewModel(),
+                conversationBannerViewModel = hiltSavedStateViewModel(it.navBackStackEntry),
+
+                )
         },
         animationConfig = NavigationAnimationConfig.NoAnimation
     ) {

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.wire.android.ui.common.topappbar
 
 import androidx.compose.animation.AnimatedVisibility
@@ -23,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -124,6 +127,16 @@ private fun OngoingCallContent(isMuted: Boolean) {
 private fun StatusLabel(stringResource: Int) {
     Text(
         text = stringResource(id = stringResource).uppercase(),
+        color = MaterialTheme.wireColorScheme.connectivityBarTextColor,
+        style = MaterialTheme.wireTypography.title03,
+    )
+}
+
+@Composable
+fun StatusLabel(message: String) {
+    Text(
+        text = message,
+        textAlign = TextAlign.Center,
         color = MaterialTheme.wireColorScheme.connectivityBarTextColor,
         style = MaterialTheme.wireTypography.title03,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -50,6 +50,8 @@ import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.Error
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingImage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnFileDownloaded
+import com.wire.android.ui.home.conversations.banner.ConversationBanner
+import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
 import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
 import com.wire.android.ui.home.conversations.call.ConversationCallViewState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
@@ -91,6 +93,7 @@ fun ConversationScreen(
     conversationCallViewModel: ConversationCallViewModel,
     conversationInfoViewModel: ConversationInfoViewModel,
     conversationMessagesViewModel: ConversationMessagesViewModel,
+    conversationBannerViewModel: ConversationBannerViewModel,
     commonTopAppBarViewModel: CommonTopAppBarViewModel
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -129,6 +132,7 @@ fun ConversationScreen(
         conversationCallViewState = conversationCallViewModel.conversationCallViewState,
         conversationInfoViewState = conversationInfoViewModel.conversationInfoViewState,
         conversationMessagesViewState = conversationMessagesViewModel.conversationViewState,
+        bannerMessage = conversationBannerViewModel.bannerState,
         connectivityUIState = commonTopAppBarViewModel.connectivityState,
         onOpenOngoingCallScreen = commonTopAppBarViewModel::openOngoingCallScreen,
         onSendMessage = messageComposerViewModel::sendMessage,
@@ -196,6 +200,7 @@ private fun ConversationScreen(
     conversationCallViewState: ConversationCallViewState,
     conversationInfoViewState: ConversationInfoViewState,
     conversationMessagesViewState: ConversationMessagesViewState,
+    bannerMessage: UIText?,
     connectivityUIState: ConnectivityUIState,
     onOpenOngoingCallScreen: () -> Unit,
     onSendMessage: (String) -> Unit,
@@ -261,7 +266,7 @@ private fun ConversationScreen(
                     Column {
                         CommonTopAppBar(
                             connectivityUIState = connectivityUIState,
-                            onReturnToCallClick = onOpenOngoingCallScreen
+                            onReturnToCallClick = onOpenOngoingCallScreen,
                         )
                         ConversationScreenTopAppBar(
                             conversationInfoViewState = conversationInfoViewState,
@@ -275,6 +280,7 @@ private fun ConversationScreen(
                             isUserBlocked = conversationInfoViewState.isUserBlocked,
                             isCallingEnabled = isSendingMessagesAllowed
                         )
+                        ConversationBanner(bannerMessage)
                     }
                 },
                 snackbarHost = {
@@ -486,6 +492,7 @@ fun ConversationScreenPreview() {
         conversationInfoViewState = ConversationInfoViewState(conversationName = UIText.DynamicString("Some test conversation")),
         conversationMessagesViewState = ConversationMessagesViewState(),
         connectivityUIState = ConnectivityUIState(info = ConnectivityUIState.Info.None),
+        bannerMessage = null,
         onOpenOngoingCallScreen = { },
         onSendMessage = { },
         onSendAttachment = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBanner.kt
@@ -1,0 +1,35 @@
+package com.wire.android.ui.home.conversations.banner
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.topappbar.StatusLabel
+import com.wire.android.util.ui.UIText
+
+@Composable
+fun ConversationBanner(bannerMessage: UIText?) {
+    bannerMessage?.let {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = MaterialTheme.colorScheme.primary)
+                .padding(vertical = dimensions().spacing6x, horizontal = dimensions().spacing16x),
+            contentAlignment = Alignment.Center
+        ) {
+            StatusLabel(it.asString())
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ConversationBannerPreview() {
+    ConversationBanner(bannerMessage = UIText.DynamicString("Federated users, Externals, guests and services are present"))
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
@@ -1,0 +1,73 @@
+package com.wire.android.ui.home.conversations.banner
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.wire.android.R
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.navigation.SavedStateViewModel
+import com.wire.android.ui.home.conversations.banner.usecase.ObserveConversationMembersByTypesUseCase
+import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.type.UserType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+@HiltViewModel
+class ConversationBannerViewModel @Inject constructor(
+    qualifiedIdMapper: QualifiedIdMapper,
+    override val savedStateHandle: SavedStateHandle,
+    private val observeConversationMembersByTypes: ObserveConversationMembersByTypesUseCase,
+) : SavedStateViewModel(savedStateHandle) {
+
+    var bannerState by mutableStateOf<UIText?>(null)
+
+    val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
+        savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!
+    )
+
+    init {
+        viewModelScope.launch {
+            observeConversationMembersByTypes(conversationId).collect(::handleConversationMemberTypes)
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun handleConversationMemberTypes(userTypes: Set<UserType>) {
+        val containsGuests = userTypes.contains(UserType.GUEST)
+        val containsFederated = userTypes.contains(UserType.FEDERATED)
+        val containsExternal = userTypes.contains(UserType.EXTERNAL)
+        val containsService = userTypes.contains(UserType.SERVICE)
+
+        bannerState = when {
+            (containsFederated && containsExternal && containsGuests && containsService)
+            -> UIText.StringResource(R.string.conversation_banner_federated_externals_guests_services_present)
+            (containsFederated && containsExternal && containsGuests)
+            -> UIText.StringResource(R.string.conversation_banner_federated_externals_guests_present)
+            (containsFederated && containsExternal && containsService)
+            -> UIText.StringResource(R.string.conversation_banner_federated_externals_services_present)
+            (containsFederated && containsGuests && containsService)
+            -> UIText.StringResource(R.string.conversation_banner_federated_guests_services_present)
+            (containsExternal && containsGuests && containsService)
+            -> UIText.StringResource(R.string.conversation_banner_externals_guests_services_present)
+            (containsFederated && containsService) -> UIText.StringResource(R.string.conversation_banner_federated_services_present)
+            (containsFederated && containsGuests) -> UIText.StringResource(R.string.conversation_banner_federated_guests_present)
+            (containsFederated && containsExternal) -> UIText.StringResource(R.string.conversation_banner_federated_externals_present)
+            (containsExternal && containsService) -> UIText.StringResource(R.string.conversation_banner_externals_services_present)
+            (containsExternal && containsGuests) -> UIText.StringResource(R.string.conversation_banner_externals_guests_present)
+            (containsGuests && containsService) -> UIText.StringResource(R.string.conversation_banner_guests_services_present)
+            (containsFederated) -> UIText.StringResource(R.string.conversation_banner_federated_present)
+            (containsGuests) -> UIText.StringResource(R.string.conversation_banner_guests_present)
+            (containsExternal) -> UIText.StringResource(R.string.conversation_banner_externals_present)
+            (containsService) -> UIText.StringResource(R.string.conversation_banner_services_active)
+            else -> null
+        }
+
+    }
+
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/usecase/ObserveConversationMembersByTypesUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/usecase/ObserveConversationMembersByTypesUseCase.kt
@@ -1,0 +1,27 @@
+package com.wire.android.ui.home.conversations.banner.usecase
+
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ObserveConversationMembersByTypesUseCase @Inject constructor(
+    private val observeConversationMembers: ObserveConversationMembersUseCase,
+    private val dispatchers: DispatcherProvider
+) {
+    suspend operator fun invoke(conversationId: ConversationId): Flow<Set<UserType>> =
+        observeConversationMembers(conversationId)
+            .map { memberDetails ->
+                memberDetails.map {it.user}
+                    .filter { (it is OtherUser) }
+                    .map { (it as OtherUser).userType }
+                    .toSet()
+            }
+            .flowOn(dispatchers.io())
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,24 @@
     <string name="label_edit">Edit</string>
     <string name="label_delete">Delete</string>
     <string name="info_message_copied">Message copied</string>
+    <string name="conversation_banner_federated_externals_guests_services_present">Federated users, Externals, guests and services are present</string>
+
+    <string name="conversation_banner_federated_externals_guests_present">Federated users, Externals and guests are present</string>
+    <string name="conversation_banner_federated_externals_services_present">Federated users, Externals and services are present</string>
+
+    <string name="conversation_banner_federated_guests_services_present">Federated users, guests and services are present</string>
+    <string name="conversation_banner_federated_services_present">Federated users and services are present</string>
+    <string name="conversation_banner_federated_guests_present">Federated users and guests are present</string>
+    <string name="conversation_banner_federated_externals_present">Federated users and Externals are present</string>
+    <string name="conversation_banner_externals_guests_services_present">Externals, guests and services are present</string>
+    <string name="conversation_banner_externals_services_present">Externals and services are present</string>
+    <string name="conversation_banner_externals_guests_present">Externals and guests are present</string>
+    <string name="conversation_banner_guests_services_present">Guests and services are present</string>
+    <string name="conversation_banner_federated_present">Federated users are present</string>
+    <string name="conversation_banner_guests_present">Guests are present</string>
+    <string name="conversation_banner_externals_present">Externals are present</string>
+    <string name="conversation_banner_services_active">Services are active</string>
+
     <!-- System messages -->
     <string name="label_system_message_added">%1$s added %2$s to the conversation</string>
     <string name="label_system_message_removed">%1$s removed %2$s from the conversation</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModelTest.kt
@@ -1,0 +1,97 @@
+package com.wire.android.ui.home.conversations.banner
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.mockUri
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.ui.home.conversations.banner.usecase.ObserveConversationMembersByTypesUseCase
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.type.UserType
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class ConversationBannerViewModelTest {
+
+
+    @Test
+    fun `given a group members, when at least one is not internal team member, then banner should not be null`() = runTest {
+        // Given
+        val qualifiedId = ConversationId("some-dummy-value", "some.dummy.domain")
+
+        val (arrangement, viewModel) = Arrangement()
+            .withConversationParticipantsUserTypesUpdate(listOf(UserType.EXTERNAL))
+            .arrange()
+        // When
+        arrangement.observeConversationMembersByTypesUseCase(qualifiedId).test {
+            awaitItem()
+            assert(viewModel.bannerState != null)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given a group members, when all of them are internal team members, then banner should be null`() = runTest {
+        // Given
+        val qualifiedId = ConversationId("some-dummy-value", "some.dummy.domain")
+
+        val (arrangement, viewModel) = Arrangement()
+            .withConversationParticipantsUserTypesUpdate(listOf(UserType.INTERNAL, UserType.INTERNAL))
+            .arrange()
+        // When
+        arrangement.observeConversationMembersByTypesUseCase(qualifiedId).test {
+            awaitItem()
+            assert(viewModel.bannerState == null)
+            awaitComplete()
+        }
+    }
+}
+
+private class Arrangement {
+
+    @MockK
+    private lateinit var savedStateHandle: SavedStateHandle
+
+    @MockK
+    private lateinit var qualifiedIdMapper: QualifiedIdMapper
+
+    @MockK
+    lateinit var observeConversationMembersByTypesUseCase: ObserveConversationMembersByTypesUseCase
+    private val viewModel by lazy {
+        ConversationBannerViewModel(
+            qualifiedIdMapper,
+                    savedStateHandle,
+            observeConversationMembersByTypesUseCase,
+        )
+    }
+    val conversationId = "some-dummy-value@some.dummy.domain"
+
+    init {
+        // Tests setup
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        mockUri()
+        every {
+            qualifiedIdMapper.fromStringToQualifiedID("some-dummy-value@some.dummy.domain")
+        } returns QualifiedID("some-dummy-value", "some.dummy.domain")
+        every { savedStateHandle.get<String>(EXTRA_CONVERSATION_ID) } returns conversationId
+        // Default empty values
+        coEvery { observeConversationMembersByTypesUseCase(any()) } returns flowOf()
+    }
+
+    suspend fun withConversationParticipantsUserTypesUpdate(participants: List<UserType>) = apply {
+        coEvery { observeConversationMembersByTypesUseCase(any()) } returns flowOf(participants.toSet())
+    }
+
+    fun arrange() = this to viewModel
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/usecase/ObserveConversationMembersByTypesUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/usecase/ObserveConversationMembersByTypesUseCaseTest.kt
@@ -1,0 +1,135 @@
+package com.wire.android.ui.home.conversations.banner.usecase
+
+import app.cash.turbine.test
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.mapper.testOtherUser
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveConversationMembersByTypesUseCaseTest {
+
+    @Test
+    fun `given a group members, when there are external members, then set should contain external type`() =
+        runTest {
+            // Given
+            val members = listOf(
+                MemberDetails(
+                    testOtherUser(0).copy(userType = UserType.EXTERNAL),
+                    Conversation.Member.Role.Member
+                )
+            )
+
+            val (_, useCase) = Arrangement()
+                .withConversationMembersUpdate(members)
+                .arrange()
+            // When - Then
+            useCase(ConversationId("", "")).test {
+                val data = awaitItem()
+                assert(data.contains(UserType.EXTERNAL))
+            }
+        }
+
+    @Test
+    fun `given a group members, when there are federated members, then set should contain federated type`() =
+        runTest {
+            // Given
+            val members = listOf(
+                MemberDetails(
+                    testOtherUser(0).copy(userType = UserType.FEDERATED),
+                    Conversation.Member.Role.Member
+                )
+            )
+
+            val (_, useCase) = Arrangement()
+                .withConversationMembersUpdate(members)
+                .arrange()
+            // When - Then
+            useCase(ConversationId("", "")).test {
+                val data = awaitItem()
+                assert(data.contains(UserType.FEDERATED))
+            }
+        }
+
+    @Test
+    fun `given a group members, when there are guest members, then set should contain guest type`() =
+        runTest {
+            // Given
+            val members = listOf(
+                MemberDetails(
+                    testOtherUser(0).copy(userType = UserType.GUEST),
+                    Conversation.Member.Role.Member
+                )
+            )
+
+            val (_, useCase) = Arrangement()
+                .withConversationMembersUpdate(members)
+                .arrange()
+            // When - Then
+            useCase(ConversationId("", "")).test {
+                val data = awaitItem()
+                assert(data.contains(UserType.GUEST))
+            }
+        }
+
+    @Test
+    fun `given a group members, when there are service bots, then set should contain service type`() =
+        runTest {
+            // Given
+            val members = listOf(
+                MemberDetails(
+                    testOtherUser(0).copy(userType = UserType.SERVICE),
+                    Conversation.Member.Role.Member
+                )
+            )
+
+            val (_, useCase) = Arrangement()
+                .withConversationMembersUpdate(members)
+                .arrange()
+            // When - Then
+            useCase(ConversationId("", "")).test {
+                val data = awaitItem()
+                assert(data.contains(UserType.SERVICE))
+            }
+        }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var observeConversationMembersUseCase: ObserveConversationMembersUseCase
+        private val conversationMembersChannel = Channel<List<MemberDetails>>(capacity = Channel.UNLIMITED)
+        private val useCase by lazy {
+            ObserveConversationMembersByTypesUseCase(
+                observeConversationMembersUseCase,
+                dispatchers = TestDispatcherProvider()
+            )
+        }
+
+        init {
+            // Tests setup
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            // Default empty values
+            coEvery { observeConversationMembersUseCase(any()) } returns flowOf()
+        }
+
+        suspend fun withConversationMembersUpdate(members: List<MemberDetails>) = apply {
+            coEvery { observeConversationMembersUseCase(any()) } returns conversationMembersChannel.consumeAsFlow()
+            conversationMembersChannel.send(members)
+        }
+
+        fun arrange() = this to useCase
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2378" title="AR-2378" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2378</a>  Indicate bots and services/guests/externals/federated in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Implemented banner which indicates in conversation:
- services bots
- external users
- federated users
- guests users


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
