### PR TITLE
fix: assets progress indicator and multiple click action

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -61,7 +61,7 @@ internal fun MessageAsset(
                 color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
-            .clickable(onAssetClick)
+            .clickable(if (assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS) null else onAssetClick)
             .padding(dimensions().spacing8x)
     ) {
         Column {
@@ -126,7 +126,6 @@ internal fun MessageAsset(
     }
 }
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String) {
@@ -181,7 +180,8 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                 .padding(dimensions().spacing8x),
         ) {
             val (
-                name, icon, size, message) = createRefs()
+                name, icon, size, message
+            ) = createRefs()
             Text(
                 text = assetName,
                 style = MaterialTheme.wireTypography.body02,
@@ -203,7 +203,6 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                         top.linkTo(name.bottom)
                         bottom.linkTo(parent.bottom)
                         start.linkTo(parent.start)
-
                     },
                 painter = painterResource(
                     id = R.drawable.ic_file
@@ -213,14 +212,16 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                 colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText),
             )
 
-            Text(text = assetDescription,
+            Text(
+                text = assetDescription,
                 style = MaterialTheme.wireTypography.body01,
                 modifier = Modifier
                     .padding(start = dimensions().spacing4x)
                     .constrainAs(size) {
                         start.linkTo(icon.end)
                         top.linkTo(name.bottom)
-                    })
+                    }
+            )
 
             Text(
                 text = stringResource(id = R.string.prohibited_file_message),
@@ -240,7 +241,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
 private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
     return when {
         assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS ||
-                assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
+            assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )
@@ -270,8 +271,8 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         assetDownloadStatus == Message.DownloadStatus.SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
         assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS ->
             stringResource(R.string.asset_message_download_in_progress_text)
-        assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
-                || assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+        assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY ||
+            assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
         assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
         else -> ""
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -61,7 +61,7 @@ internal fun MessageAsset(
                 color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
-            .clickable(if (assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS) null else onAssetClick)
+            .clickable(if (canNotClick(assetDownloadStatus, assetUploadStatus)) null else onAssetClick)
             .padding(dimensions().spacing8x)
     ) {
         Column {
@@ -241,7 +241,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
 private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
     return when {
         assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS ||
-            assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
+                assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )
@@ -272,10 +272,14 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
         assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS ->
             stringResource(R.string.asset_message_download_in_progress_text)
         assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY ||
-            assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+                assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
         assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
         else -> ""
     }
+
+@Composable
+private fun canNotClick(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) =
+    assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS || assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS
 
 @Suppress("MagicNumber")
 private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -61,7 +61,7 @@ internal fun MessageAsset(
                 color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
-            .clickable(if (canNotClick(assetDownloadStatus, assetUploadStatus)) null else onAssetClick)
+            .clickable(if (isNotClickable(assetDownloadStatus, assetUploadStatus)) null else onAssetClick)
             .padding(dimensions().spacing8x)
     ) {
         Column {
@@ -278,7 +278,7 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
     }
 
 @Composable
-private fun canNotClick(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) =
+private fun isNotClickable(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) =
     assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS || assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS
 
 @Suppress("MagicNumber")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR fixes the crash that was triggered by clicking multiple times while downloading an asset.

### Solutions

Disable the clickable action if the asset is on: `DOWNLOAD_IN_PROGRESS` status or `UPLOAD_IN_PROGRESS`

### Dependencies (Optional)

Needs releases with:

https://github.com/wireapp/kalium/pull/1010

- [x] GitHub link to other pull request

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
