### PR TITLE
feat: support more images formats

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
 
     // Image handling
     implementation(Libraries.coil)
+    implementation(Libraries.coilGif)
     implementation(Libraries.coilCompose)
 
     /** lifecycle **/

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -8,7 +8,7 @@ import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
-import com.wire.kalium.logic.data.asset.isValidImage
+import com.wire.kalium.logic.data.asset.isDisplayableMimeType
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
@@ -145,7 +145,7 @@ class MessageContentMapper @Inject constructor(
         with(assetMessageContentMetadata.assetMessageContent) {
             when {
                 // If it's an image, we download it right away
-                assetMessageContentMetadata.isValidImage() -> {
+                assetMessageContentMetadata.isDisplayableImage() -> {
                     val imageData = withContext(dispatcherProvider.io()) {
                         imageRawData(message.conversationId, message.id)
                     }
@@ -231,7 +231,8 @@ class AssetMessageContentMetadata(val assetMessageContent: AssetContent) {
             else -> 0
         }
 
-    fun isValidImage(): Boolean = isValidImage(assetMessageContent.mimeType) && imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
+    fun isDisplayableImage(): Boolean = isDisplayableMimeType(assetMessageContent.mimeType) &&
+            imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
 }
 
 // TODO: should we keep it here ?

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -168,9 +168,10 @@ class MessageComposerViewModel @Inject constructor(
                         AttachmentType.IMAGE -> {
                             if (dataSize > IMAGE_SIZE_LIMIT_BYTES) onSnackbarMessage(ErrorMaxImageSize)
                             else {
-                                val (imgWidth, imgHeight) = ImageUtil.extractImageWidthAndHeight(
-                                    kaliumFileSystem.source(attachmentBundle.dataPath).buffer().inputStream()
-                                )
+                                val (imgWidth, imgHeight) =
+                                    ImageUtil.extractImageWidthAndHeight(
+                                        kaliumFileSystem.source(attachmentBundle.dataPath).buffer().inputStream(), mimeType
+                                    )
                                 val result = sendAssetMessage(
                                     conversationId = conversationId,
                                     assetDataPath = dataPath,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -19,7 +19,7 @@ import com.wire.android.util.getFileName
 import com.wire.android.util.getMimeType
 import com.wire.android.util.orDefault
 import com.wire.android.util.resampleImageAndCopyToTempPath
-import com.wire.kalium.logic.data.asset.isValidImage
+import com.wire.kalium.logic.data.asset.isDisplayableMimeType
 import okio.Path
 import okio.Path.Companion.toPath
 import java.io.IOException
@@ -123,7 +123,7 @@ class AttachmentInnerState(val context: Context) {
             val fullTempAssetPath = "$tempCachePath/${UUID.randomUUID()}".toPath()
             val assetFileName = context.getFileName(attachmentUri) ?: throw IOException("The selected asset has an invalid name")
             val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
-            val attachmentType = if (isValidImage(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
+            val attachmentType = if (isDisplayableMimeType(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
             val assetSize = if (attachmentType == AttachmentType.IMAGE)
                 attachmentUri.resampleImageAndCopyToTempPath(context, fullTempAssetPath)
             else attachmentUri.copyToTempPath(context, fullTempAssetPath)

--- a/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
@@ -14,7 +14,6 @@ import kotlin.math.ceil
 import kotlin.math.round
 import kotlin.math.sqrt
 
-const val DEFAULT_IMAGE_MIME_TYPE = "image/jpeg"
 const val DEFAULT_FILE_MIME_TYPE = "file/*"
 
 object ImageUtil {
@@ -30,11 +29,18 @@ object ImageUtil {
     /**
      * Attempts to read the width and height of an image represented by the input parameter
      */
-    fun extractImageWidthAndHeight(imageDataInputStream: InputStream): Pair<Int, Int> {
-        val exifInterface = ExifInterface(imageDataInputStream)
-        val exifWidth: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0)
-        val exifHeight: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0)
-        return exifWidth to exifHeight
+    fun extractImageWidthAndHeight(imageDataInputStream: InputStream, mimeType: String): Pair<Int, Int> {
+        val isAnimated = mimeType.contains("gif") || mimeType.contains("webp")
+        if (isAnimated) {
+            BitmapFactory.decodeStream(imageDataInputStream).let { bitmap ->
+                return bitmap.width to bitmap.height
+            }
+        } else {
+            val exifInterface = ExifInterface(imageDataInputStream)
+            val exifWidth: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0)
+            val exifHeight: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0)
+            return exifWidth to exifHeight
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/wire/android/util/ui/DrawableResultWrapper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/DrawableResultWrapper.kt
@@ -1,16 +1,11 @@
 package com.wire.android.util.ui
 
 import android.content.res.Resources
-import android.graphics.drawable.BitmapDrawable
 import coil.decode.DataSource
 import coil.decode.ImageSource
 import coil.fetch.FetchResult
 import coil.fetch.SourceResult
-import com.wire.kalium.logic.feature.asset.MessageAssetResult
-import com.wire.kalium.logic.feature.asset.PublicAssetResult
 import okio.Path
-import okio.Source
-import okio.buffer
 
 internal class DrawableResultWrapper(val resources: Resources) {
 

--- a/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
@@ -1,6 +1,7 @@
 package com.wire.android.util.ui
 
 import android.content.Context
+import android.os.Build.VERSION.SDK_INT
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.painter.Painter
@@ -8,6 +9,8 @@ import androidx.compose.ui.platform.LocalContext
 import coil.Coil
 import coil.ImageLoader
 import coil.compose.rememberAsyncImagePainter
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
 import com.wire.android.model.ImageAsset
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
@@ -49,6 +52,11 @@ class WireSessionImageLoader(private val coilImageLoader: ImageLoader) {
             defaultImageLoader.newBuilder()
                 .components {
                     add(AssetImageFetcher.Factory(getAvatarAsset, getPrivateAsset, resources))
+                    if (SDK_INT >= 28) {
+                        add(ImageDecoderDecoder.Factory())
+                    } else {
+                        add(GifDecoder.Factory())
+                    }
                 }.build()
         )
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -120,6 +120,7 @@ object Libraries {
     const val browser                   = "androidx.browser:browser:${Versions.browser}"
     const val splashscreen              = "androidx.core:core-splashscreen:${Versions.splashscreen}"
     const val coil                      = "io.coil-kt:coil:${Versions.coil}"
+    const val coilGif                   = "io.coil-kt:coil-gif:${Versions.coil}"
     const val coilCompose               = "io.coil-kt:coil-compose:${Versions.coil}"
     const val dataDog                   = "com.datadoghq:dd-sdk-android:${Versions.dataDog}"
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Just adding some support for animated images to be displayed inline

### Dependencies (Optional)

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/1014

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Just send or receive a gif or animated webp image

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
