### PR TITLE
fix: show guest banner only in group conversation (AR-2378)

### DIFF
--- a/app/src/test/kotlin/com/wire/android/framework/TestConnection.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConnection.kt
@@ -1,0 +1,17 @@
+package com.wire.android.framework
+
+import com.wire.kalium.logic.data.user.Connection
+import com.wire.kalium.logic.data.user.ConnectionState
+
+object TestConnection {
+    val CONNECTION = Connection(
+        TestConversation.ID.value,
+        "FROM",
+        "2022-03-30T15:36:00.000Z",
+        TestConversation.ID,
+        TestUser.USER_ID,
+        ConnectionState.SENT,
+        TestUser.OTHER_USER.id.value,
+        TestUser.OTHER_USER
+    )
+}

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -1,0 +1,104 @@
+package com.wire.android.framework
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.Conversation.Member
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.PlainId
+import com.wire.kalium.logic.data.user.UserId
+
+object TestConversation {
+    val ID = ConversationId("valueConvo", "domainConvo")
+
+    fun id(suffix: Int = 0) = ConversationId("valueConvo_$suffix", "domainConvo")
+
+    val ONE_ON_ONE = Conversation(
+        ID.copy(value = "1O1 ID"),
+        "ONE_ON_ONE Name",
+        Conversation.Type.ONE_ON_ONE,
+        TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
+        MutedConversationStatus.AllAllowed,
+        null,
+        PlainId("someValue"),
+        null,
+        null,
+        lastReadDate = "2022-03-30T15:36:00.000Z",
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
+    val SELF = Conversation(
+        ID.copy(value = "SELF ID"),
+        "SELF Name",
+        Conversation.Type.SELF,
+        TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
+        MutedConversationStatus.AllAllowed,
+        null,
+        PlainId("someValue"),
+        null,
+        null,
+        lastReadDate = "2022-03-30T15:36:00.000Z",
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
+
+    fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
+        ID,
+        "GROUP Name",
+        Conversation.Type.GROUP,
+        TestTeam.TEAM_ID,
+        protocolInfo,
+        MutedConversationStatus.AllAllowed,
+        null,
+        PlainId("someValue"),
+        null,
+        null,
+        lastReadDate = "2022-03-30T15:36:00.000Z",
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
+
+
+    fun one_on_one(convId: ConversationId) = Conversation(
+        convId,
+        "ONE_ON_ONE Name",
+        Conversation.Type.ONE_ON_ONE,
+        TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
+        MutedConversationStatus.AllAllowed,
+        null,
+        PlainId("someValue"),
+        null,
+        null,
+        lastReadDate = "2022-03-30T15:36:00.000Z",
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
+
+    val USER_1 = UserId("member1", "domainMember")
+    val MEMBER_TEST1 = Member(USER_1, Member.Role.Admin)
+    val USER_2 = UserId("member2", "domainMember")
+    val MEMBER_TEST2 = Member(USER_2, Member.Role.Member)
+
+    val GROUP_ID = GroupID("mlsGroupId")
+
+    val CONVERSATION = Conversation(
+        ConversationId("conv_id", "domain"),
+        "ONE_ON_ONE Name",
+        Conversation.Type.ONE_ON_ONE,
+        TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
+        MutedConversationStatus.AllAllowed,
+        null,
+        PlainId("someValue"),
+        null,
+        null,
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
+        lastReadDate = "2022-03-30T15:36:00.000Z"
+    )
+
+}

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
@@ -1,0 +1,38 @@
+package com.wire.android.framework
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.user.type.UserType
+
+object TestConversationDetails {
+
+    val CONNECTION = ConversationDetails.Connection(
+        TestConversation.ID,
+        TestUser.OTHER_USER,
+        UserType.EXTERNAL,
+        "2022-03-30T15:36:00.000Z",
+        TestConnection.CONNECTION,
+        protocolInfo = ProtocolInfo.Proteus,
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
+
+    val CONVERSATION_ONE_ONE = ConversationDetails.OneOne(
+        TestConversation.ONE_ON_ONE,
+        TestUser.OTHER_USER,
+        LegalHoldStatus.DISABLED,
+        UserType.EXTERNAL,
+        unreadMessagesCount = 0,
+        lastUnreadMessage = null
+    )
+
+    val GROUP = ConversationDetails.Group(
+        TestConversation.ONE_ON_ONE,
+        LegalHoldStatus.DISABLED,
+        unreadMessagesCount = 0,
+        lastUnreadMessage = null
+    )
+
+}

--- a/app/src/test/kotlin/com/wire/android/framework/TestTeam.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestTeam.kt
@@ -1,0 +1,9 @@
+package com.wire.android.framework
+
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.team.Team
+
+object TestTeam {
+    val TEAM: Team = Team(id = "Some-team", name = "Some-name", icon = "icon")
+    val TEAM_ID = TeamId("Some-team")
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModelTest.kt
@@ -19,6 +19,8 @@ import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.amshove.kluent.internal.assertNotEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -38,7 +40,7 @@ class ConversationBannerViewModelTest {
         // When
         arrangement.observeConversationMembersByTypesUseCase(qualifiedId).test {
             awaitItem()
-            assert(viewModel.bannerState != null)
+            assertNotEquals(null, viewModel.bannerState)
             awaitComplete()
         }
     }
@@ -54,7 +56,7 @@ class ConversationBannerViewModelTest {
         // When
         arrangement.observeConversationMembersByTypesUseCase(qualifiedId).test {
             awaitComplete()
-            assert(viewModel.bannerState == null)
+            assertEquals(null, viewModel.bannerState)
         }
     }
 
@@ -70,7 +72,7 @@ class ConversationBannerViewModelTest {
         // When
         arrangement.observeConversationMembersByTypesUseCase(qualifiedId).test {
             awaitItem()
-            assert(viewModel.bannerState == null)
+            assertEquals(null, viewModel.bannerState)
             awaitComplete()
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2378" title="AR-2378" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2378</a>  Indicate bots and services/guests/externals/federated in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Disabled guest, services, federated, and external users banner in conversations that aren't group conversations.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
