### PR TITLE
chore: tests for coverage for password recovery my account context (AR-1944)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -15,13 +15,13 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
@@ -60,8 +60,8 @@ class MyAccountViewModel @Inject constructor(
     private suspend fun fetchChangePasswordUrl() {
         when (val result = withContext(dispatchers.io()) { serverConfig() }) {
             is SelfServerConfigUseCase.Result.Failure -> appLogger.e("Error when fetching the accounts url for change password")
-            is SelfServerConfigUseCase.Result.Success -> myAccountState =
-                myAccountState.copy(changePasswordUrl = result.serverLinks.links.forgotPassword)
+            is SelfServerConfigUseCase.Result.Success ->
+                myAccountState = myAccountState.copy(changePasswordUrl = result.serverLinks.links.forgotPassword)
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
@@ -52,7 +52,15 @@ class MyAccountViewModelTest {
             .withUserRequiresPasswordResult(Success(true))
             .arrange()
 
-        coVerify { arrangement.selfServerConfigUseCase() }
+        coVerify(exactly = 1) { arrangement.selfServerConfigUseCase() }
+    }
+
+    @Test
+    fun `when navigating back requested, then should delegate call to manager navigateBack`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.navigateBack()
+
+        coVerify(exactly = 1) { arrangement.navigationManager.navigateBack() }
     }
 
     private class Arrangement {

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.wire.android.ui.home.settings.account
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.navigation.NavigationManager
+import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import io.mockk.Called
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class MyAccountViewModelTest {
+
+    @Test
+    fun `when user does not requires password, then should not load forgot password url context`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withUserRequiresPassword(false)
+            .arrange()
+
+        verify {
+            arrangement.selfServerConfigUseCase wasNot Called
+        }
+    }
+
+    @Test
+    fun `when user requires a password, then should load forgot password url context`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withUserRequiresPassword(true)
+            .arrange()
+
+        coVerify { arrangement.selfServerConfigUseCase() }
+    }
+
+    private class Arrangement {
+        @MockK
+        lateinit var navigationManager: NavigationManager
+
+        @MockK
+        lateinit var getSelfUserUseCase: GetSelfUserUseCase
+
+        @MockK
+        lateinit var getSelfTeamUseCase: GetSelfTeamUseCase
+
+        @MockK
+        lateinit var selfServerConfigUseCase: SelfServerConfigUseCase
+
+        @MockK
+        lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
+
+        val viewModel by lazy {
+            MyAccountViewModel(
+                getSelfUserUseCase,
+                getSelfTeamUseCase,
+                selfServerConfigUseCase,
+                isPasswordRequiredUseCase,
+                navigationManager,
+                TestDispatcherProvider()
+            )
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun withUserRequiresPassword(requiresPassword: Boolean = true) = apply {
+            coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(requiresPassword)
+        }
+
+        fun arrange() = this to viewModel
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1944" title="AR-1944" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1944</a>  Reset password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add missing unit test cases for the logic of displaying the context of forgot password flow.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
