### PR TITLE
fix: disable button when no members are selected (AR-2590)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.ui.common.button.IconAlignment
+import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.WirePrimaryButton
@@ -28,7 +29,7 @@ import com.wire.android.ui.theme.wireDimensions
 
 @Composable
 fun SelectParticipantsButtonsRow(
-    count: Int,
+    count: Int = 0,
     mainButtonText: String,
     elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
     modifier: Modifier = Modifier
@@ -50,10 +51,11 @@ fun SelectParticipantsButtonsRow(
             WirePrimaryButton(
                 text = "$mainButtonText ($count)",
                 onClick = onMainButtonClick,
+                state = if (count <= 0) WireButtonState.Disabled else WireButtonState.Default,
                 blockUntilSynced = true,
                 modifier = Modifier.weight(1f)
             )
-            if(onMoreButtonClick != null) {
+            if (onMoreButtonClick != null) {
                 Spacer(Modifier.width(dimensions().spacing8x))
                 WireSecondaryButton(
                     onClick = onMoreButtonClick,
@@ -83,4 +85,10 @@ private fun SelectParticipantsButtonsRowPreview() {
 @Composable
 private fun SelectParticipantsButtonsRowWithoutMoreButtonPreview() {
     SelectParticipantsButtonsRow(count = 3, mainButtonText = "Continue", onMainButtonClick = {})
+}
+
+@Preview
+@Composable
+private fun SelectParticipantsButtonsRowDisabledButtonPreview() {
+    SelectParticipantsButtonsRow(count = 0, mainButtonText = "Continue", onMainButtonClick = {})
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2590" title="AR-2590" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2590</a>  It is possible to add 0 participants to an existing group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

State handling of non-selected users to add to a group, creation and edit.

### Solutions

Disable the button if the count of selected users is less than 1

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5806454/195042983-60fb75c1-6e73-4d7e-9876-652b50aef276.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
