### PR TITLE
fix: disable button for group edit and enable always for creation (AR-2590)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
@@ -25,10 +25,10 @@ import com.wire.android.ui.common.topappbar.search.SearchTopBar
 import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
 import com.wire.android.ui.home.conversations.details.AddMembersToConversationViewModel
 import com.wire.android.ui.home.newconversation.common.SearchListScreens
+import com.wire.android.ui.home.newconversation.common.SelectParticipantsButtonsAlwaysEnabled
 import com.wire.android.ui.home.newconversation.common.SelectParticipantsButtonsRow
 import com.wire.android.ui.home.newconversation.contacts.ContactsScreen
 import com.wire.android.ui.home.newconversation.model.Contact
-
 
 @Composable
 fun AddMembersSearchRouter(
@@ -165,11 +165,19 @@ fun SearchPeopleContent(
                 }
             },
             bottomBar = {
-                SelectParticipantsButtonsRow(
-                    count = contactsAddedToGroup.size,
-                    mainButtonText = actionButtonTitle,
-                    onMainButtonClick = onGroupSelectionSubmitAction
-                )
+                if (searchPeopleState.isGroupCreationContext) {
+                    SelectParticipantsButtonsAlwaysEnabled(
+                        count = contactsAddedToGroup.size,
+                        mainButtonText = actionButtonTitle,
+                        onMainButtonClick = onGroupSelectionSubmitAction
+                    )
+                } else {
+                    SelectParticipantsButtonsRow(
+                        count = contactsAddedToGroup.size,
+                        mainButtonText = actionButtonTitle,
+                        onMainButtonClick = onGroupSelectionSubmitAction
+                    )
+                }
             },
             snapOnFling = false,
             keepElevationWhenCollapsed = true

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleState.kt
@@ -9,7 +9,8 @@ data class SearchPeopleState(
     val searchQuery: TextFieldValue = TextFieldValue(""),
     val searchResult: Map<SearchResultTitle, ContactSearchResult> = emptyMap(),
     val noneSearchSucceed: Boolean = false,
-    val contactsAddedToGroup: List<Contact> = emptyList()
+    val contactsAddedToGroup: List<Contact> = emptyList(),
+    val isGroupCreationContext: Boolean = true
 )
 
 sealed class ContactSearchResult(val searchResultState: SearchResultState) {
@@ -32,4 +33,4 @@ sealed class SearchResultState {
     data class Success(val result: List<Contact>) : SearchResultState()
 }
 
-data class SearchResultTitle(@StringRes val stringRes : Int)
+data class SearchResultTitle(@StringRes val stringRes: Int)

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -21,11 +21,26 @@ import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.ui.common.button.IconAlignment
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+
+@Composable
+fun SelectParticipantsButtonsAlwaysEnabled(
+    count: Int = 0,
+    mainButtonText: String,
+    elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
+    modifier: Modifier = Modifier
+        .padding(horizontal = dimensions().spacing16x)
+        .height(dimensions().groupButtonHeight)
+        .fillMaxWidth(),
+    onMoreButtonClick: (() -> Unit)? = null,
+    onMainButtonClick: () -> Unit,
+) {
+    SelectParticipantsButtonsRow(count, mainButtonText, true, elevation, modifier, onMoreButtonClick, onMainButtonClick)
+}
 
 @Composable
 fun SelectParticipantsButtonsRow(
@@ -37,7 +52,23 @@ fun SelectParticipantsButtonsRow(
         .height(dimensions().groupButtonHeight)
         .fillMaxWidth(),
     onMoreButtonClick: (() -> Unit)? = null,
-    onMainButtonClick: () -> Unit
+    onMainButtonClick: () -> Unit,
+) {
+    SelectParticipantsButtonsRow(count, mainButtonText, false, elevation, modifier, onMoreButtonClick, onMainButtonClick)
+}
+
+@Composable
+private fun SelectParticipantsButtonsRow(
+    count: Int = 0,
+    mainButtonText: String,
+    shouldAllowNoSelectionContinue: Boolean = false,
+    elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
+    modifier: Modifier = Modifier
+        .padding(horizontal = dimensions().spacing16x)
+        .height(dimensions().groupButtonHeight)
+        .fillMaxWidth(),
+    onMoreButtonClick: (() -> Unit)? = null,
+    onMainButtonClick: () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.wireColorScheme.background,
@@ -51,7 +82,7 @@ fun SelectParticipantsButtonsRow(
             WirePrimaryButton(
                 text = "$mainButtonText ($count)",
                 onClick = onMainButtonClick,
-                state = if (count <= 0) WireButtonState.Disabled else WireButtonState.Default,
+                state = computeButtonState(count, shouldAllowNoSelectionContinue),
                 blockUntilSynced = true,
                 modifier = Modifier.weight(1f)
             )
@@ -72,6 +103,14 @@ fun SelectParticipantsButtonsRow(
                 )
             }
         }
+    }
+}
+
+private fun computeButtonState(count: Int = 0, shouldAllowNoSelectionContinue: Boolean): WireButtonState {
+    return when {
+        shouldAllowNoSelectionContinue -> WireButtonState.Default
+        count > 0 -> WireButtonState.Default
+        else -> WireButtonState.Disabled
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2590" title="AR-2590" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2590</a>  It is possible to add 0 participants to an existing group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AC missed for disabling the group of adding members only when we are editing an existing conversation.
Otherwise, allow group with empty members.

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5806454/195886865-259eb554-a1a3-402b-bcf8-abf0ee7464b6.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
