### PR TITLE
fix: OngoingCall Notification does not disappear when app is killed and call ends (AR-2581)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -5,13 +5,19 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.notification.NotificationConstants.CALL_ONGOING_NOTIFICATION_ID
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,8 +31,16 @@ class OngoingCallService : Service() {
     lateinit var callNotificationManager: CallNotificationManager
 
     @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
+
+    private val scope by lazy {
+        // There's no UI, no need to run anything using the Main/UI Dispatcher
+        CoroutineScope(SupervisorJob() + dispatcherProvider.default())
+    }
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -40,15 +54,33 @@ class OngoingCallService : Service() {
         if (userIdString != null && conversationIdString != null && callName != null) {
             val userId = qualifiedIdMapper.fromStringToQualifiedID(userIdString)
 
-            // we just need to keep some reference to the CallsScope,
-            // so it keeps CallManager alive
-            coreLogic.getSessionScope(userId).calls
+            scope.launch {
+                coreLogic.getSessionScope(userId)
+                    .calls
+                    .establishedCall()
+                    .collect { establishedCall ->
+                        if (establishedCall.isEmpty()) {
+                            appLogger.i("$TAG: stopSelf. Reason: call was ended")
+                            stopSelf()
+                        }
+                    }
+            }
 
             generateForegroundNotification(callName, conversationIdString, userIdString)
         } else {
-            stopForeground(true)
+            appLogger.i(
+                "$TAG: stopSelf. Reason: some of the parameter is absent. " +
+                        "userIdString: $userIdString, conversationIdString: $conversationIdString, callName: $callName"
+            )
+            stopSelf()
         }
         return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+        appLogger.i("$TAG: onDestroy")
     }
 
     private fun generateForegroundNotification(callName: String, conversationId: String, userId: String) {
@@ -59,6 +91,7 @@ class OngoingCallService : Service() {
     }
 
     companion object {
+        private const val TAG = "OngoingCallService"
         private const val EXTRA_USER_ID = "user_id_extra"
         private const val EXTRA_CONVERSATION_ID = "conversation_id_extra"
         private const val EXTRA_CALL_NAME = "call_name_extra"

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -68,7 +68,7 @@ class OngoingCallService : Service() {
 
             generateForegroundNotification(callName, conversationIdString, userIdString)
         } else {
-            appLogger.i(
+            appLogger.w(
                 "$TAG: stopSelf. Reason: some of the parameter is absent. " +
                         "userIdString: $userIdString, conversationIdString: $conversationIdString, callName: $callName"
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2581" title="AR-2581" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2581</a>  notification for ongoing call does not disappear when app is killed and call is hung up from notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

- be in a group call
- minimze the call
- terminate the app (swipe it away from background)
- notification about ongoing call is shown
- tap hang up button

Expected:
call should end and notification should disappear

Actual:
call ends, but the notification does not disappear and stays in the notification center

### Causes (Optional)

`OngoingCallService` doesn't observe the state of a call.  So when call ends there is no "anybody" who could stop the service and remove the notification.

### Solutions

Observe the call state in `OngoingCallService` and cancel the service when the call was ended.
