### PR TITLE
fix: crash when leaving or deleting group from details [AR-2589]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
@@ -12,7 +12,7 @@ class NavigationManager {
     }
 
     suspend fun navigateBack(previousBackStackPassedArgs: Map<String, Any> = mapOf()) {
-        navigateBack.emit(previousBackStackPassedArgs)
+        navigateBack.emit(previousBackStackPassedArgs.toMap())
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -49,7 +49,7 @@ internal fun NavController.popWithArguments(arguments: Map<String, Any>?): Boole
         it.savedStateHandle.remove<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
         arguments?.let { arguments ->
             appLogger.d("Destination is ${it.destination}")
-            it.savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = arguments
+            it.savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = arguments.toMap()
         }
     }
     return popBackStack()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -123,7 +123,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     conversationId = conversationId,
                     mutingConversationState = groupDetails.conversation.mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
-                    isSelfUserMember = groupDetails.isSelfUserCreator
+                    isSelfUserMember = groupDetails.isSelfUserMember
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2589" title="AR-2589" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2589</a>  app crashing on some devices after group was deleted or when trying to add a member to a group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crashes when leaving or deleting a group from the group details screen.

### Causes (Optional)

`SavedStateHandle` doesn't accept `ImmutableMap` even though it's also a `Map`.

### Solutions

Change any map that's passed as a parameter to the back navigation to regular map using `.toMap()`.

### Testing

#### How to Test

Create a group, open the group details screen and try to leave or delete the group.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
