### PR TITLE
fix: BottomSheetItem click remembering (AR-2613)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
@@ -1,7 +1,6 @@
 package com.wire.android.ui.common.bottomsheet
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -39,7 +38,7 @@ fun MenuBottomSheetItem(
     blockUntilSynced: Boolean = false,
     onItemClick: () -> Unit = {}
 ) {
-    val clickable = remember { Clickable(blockUntilSynced = blockUntilSynced) { onItemClick() } }
+    val clickable = remember(onItemClick, blockUntilSynced) { Clickable(blockUntilSynced = blockUntilSynced) { onItemClick() } }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2613" title="AR-2613" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2613</a>  Notifications setting menu disfunction on second time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

1. Login
2. Long tap on a conv.
3. Tap Notifications
4. Select a notification status
5. Repeat step 3 and 4

Actual Result:
Nothing happens, there is no notification status change image

Expected Result:
Notification status should change with indicator displayed

### Causes (Optional)

in `MenuBottomSheetItem`: `Clickable` was remembered no matter if `onItemClick` was changed. 

### Solutions

add `onItemClick` into remember-key, so it will be re-remembered after `onItemClick` changed
