### PR TITLE
fix: saml reset password (AR-1944)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -118,7 +118,7 @@ fun MyAccountContent(
 @Composable
 fun MyAccountScreenPreview() {
     MyAccountContent(
-        listOf(
+        accountDetailItems = listOf(
             AccountDetailsItem.DisplayName("Bob"),
             AccountDetailsItem.Username("@bob_wire"),
             AccountDetailsItem.Email("bob@wire.com"),

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -124,6 +124,6 @@ fun MyAccountScreenPreview() {
             AccountDetailsItem.Email("bob@wire.com"),
             AccountDetailsItem.Team("Wire"),
         ),
-        "http://wire.com"
+        forgotPasswordUrl = "http://wire.com"
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
@@ -6,5 +6,5 @@ data class MyAccountState(
     val email: String = "",
     val teamName: String = "",
     val domain: String = "",
-    val changePasswordUrl: String = ""
+    val changePasswordUrl: String? = null
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1944" title="AR-1944" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1944</a>  Reset password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fix issue regarding SAML users being able to reset password, when they shouldn't.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
