### PR TITLE
fix: use correct string for device id

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreen.kt
@@ -167,7 +167,7 @@ private fun LogOptions(
 
         if (deviceId != null) {
             SettingsItem(
-                title = stringResource(R.string.label_client_id, deviceId),
+                title = stringResource(R.string.label_device_id, deviceId),
                 trailingIcon = R.drawable.ic_copy,
                 onIconPressed = Clickable(
                     enabled = true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In the logs section of the debug options, device id is mislabel "Client ID"

### Solutions

Use the right string

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
