### PR TITLE
fix: datadog logs init order

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 
 
 // App wide global logger, carefully initialized when our application is "onCreate"
-lateinit var appLogger: KaliumLogger
+var appLogger: KaliumLogger = KaliumLogger.disabled()
 
 @HiltAndroidApp
 class WireApplication : Application(), Configuration.Provider {

--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -24,10 +24,6 @@ class CallNotificationManager @Inject constructor(private val context: Context) 
     private val notificationManager = NotificationManagerCompat.from(context)
     private val soundUri by lazy { Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/raw/ringing_from_them") }
 
-    init {
-        appLogger.i("${TAG}: initialized")
-    }
-
     fun handleIncomingCallNotifications(calls: List<Call>, userId: QualifiedID?) {
         if (calls.isEmpty() || userId == null) {
             hideIncomingCallNotification()

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -44,7 +44,7 @@ class ConnectionPolicyManager @Inject constructor(
     private val dispatcherProvider: DispatcherProvider
 ) {
 
-    private val logger = appLogger.withFeatureId(SYNC)
+    private val logger by lazy { appLogger.withFeatureId(SYNC) }
 
     /**
      * Starts observing the app state and take action.
@@ -69,8 +69,10 @@ class ConnectionPolicyManager @Inject constructor(
      * this will downgrade the policy back to [ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS].
      */
     suspend fun handleConnectionOnPushNotification(userId: UserId) {
-        logger.d("$TAG Handling connection policy for push notification of " +
-                "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}")
+        logger.d(
+            "$TAG Handling connection policy for push notification of " +
+                    "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}"
+        )
         coreLogic.getSessionScope(userId).run {
             logger.d("$TAG Forcing KEEP_ALIVE policy")
             // Force KEEP_ALIVE policy, so we gather pending events and become online


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logs are not being sent to the platform due to a wrong initialization order, needed by the SDK.

### Causes (Optional)

Logs were not sent to the platform, only crashes
https://github.com/DataDog/dd-sdk-android/issues/955#issuecomment-1235496352

### Solutions

Change init order to have first initialized `DataDog` SDK, and later our internal logging framework

#### How to Test

Build, interact into the app and see if logs are sent under live tail in datadog platform 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
