### PR TITLE
fix: Mention in new line bug

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -22,6 +22,7 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.DEFAULT_FILE_MIME_TYPE
 import com.wire.android.util.EMPTY
 import com.wire.android.util.MENTION_SYMBOL
+import com.wire.android.util.NEW_LINE_SYMBOL
 import com.wire.android.util.WHITE_SPACE
 import com.wire.android.util.copyToTempPath
 import com.wire.android.util.getFileName
@@ -87,7 +88,7 @@ data class MessageComposerInnerState(
     fun startMention() {
         val beforeSelection = messageText.text.subSequence(0, messageText.selection.min)
             .run {
-                if (endsWith(String.WHITE_SPACE) || this == String.EMPTY) {
+                if (endsWith(String.WHITE_SPACE) || endsWith(String.NEW_LINE_SYMBOL) || this == String.EMPTY) {
                     this.toString()
                 } else {
                     StringBuilder(this)
@@ -271,7 +272,7 @@ private fun TextFieldValue.currentMentionStartIndex(): Int {
 
     return when {
         (lastIndexOfAt <= 0) ||
-                (text[lastIndexOfAt - 1].toString() == String.WHITE_SPACE) -> lastIndexOfAt
+                (text[lastIndexOfAt - 1].toString() in listOf(String.WHITE_SPACE, String.NEW_LINE_SYMBOL)) -> lastIndexOfAt
         else -> -1
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
@@ -9,6 +9,8 @@ val String.Companion.WHITE_SPACE get() = " "
 
 val String.Companion.MENTION_SYMBOL get() = "@"
 
+val String.Companion.NEW_LINE_SYMBOL get() = "\n"
+
 fun String?.orDefault(default: String) = this ?: default
 
 public inline fun String.ifNotEmpty(transform: () -> String): String = if (!isEmpty()) transform() else this

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
@@ -32,7 +32,7 @@ class MessageComposerInnerStateTest {
     }
 
     @Test
-    fun `when @ symbol is added into message, then mention is queried`() = runTest {
+    fun `given some message, when mention symbol is added into message, then mention is queried`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("start text"))
 
@@ -42,7 +42,7 @@ class MessageComposerInnerStateTest {
     }
 
     @Test
-    fun `when @ symbol is added into message without space before it, then mention is not queried`() = runTest {
+    fun `given some message, when mention symbol is added without space before it, then mention is not queried`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("start text"))
 
@@ -52,7 +52,7 @@ class MessageComposerInnerStateTest {
     }
 
     @Test
-    fun `when mention is started in message, then mention is queried with corresponding query`() = runTest {
+    fun `given mention is started in message, then mention is queried with corresponding query`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("start text @"))
 
@@ -62,7 +62,7 @@ class MessageComposerInnerStateTest {
     }
 
     @Test
-    fun `when mention is started in message and user type space, then mention stop querying`() = runTest {
+    fun `given mention is started in message, when user type space, then mention stop querying`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("start text @"))
 
@@ -123,7 +123,7 @@ class MessageComposerInnerStateTest {
 
     // case was found by manual testing
     @Test
-    fun `when message starts from mention and then it's removed, then mention is not requested anymore`() = runTest {
+    fun `given message starts from mention, when mention symbol is removed, then mention is not requested anymore`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("@"))
 
@@ -135,7 +135,7 @@ class MessageComposerInnerStateTest {
 
     // case was found by manual testing
     @Test
-    fun `when selection goes just before mention symbol, then mention is not requested`() = runTest {
+    fun `given selection goes just before mention symbol, then mention is not requested`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("@ @ "))
 
@@ -150,7 +150,7 @@ class MessageComposerInnerStateTest {
 
     // case was found by manual testing
     @Test
-    fun `when mention symbol is at the begin of new line, then mention is requested`() = runTest {
+    fun `given cursor is at the begin of new line, when mention symbol is added, then mention is requested`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("some text\n"))
 
@@ -161,7 +161,7 @@ class MessageComposerInnerStateTest {
 
     // case was found by manual testing
     @Test
-    fun `when cursor is at the begin of new line, and add mention btn clicked, then mention is requested`() = runTest {
+    fun `given cursor is at the begin of new line, when add mention button clicked, then mention is requested`() = runTest {
         val state = createState(context)
         state.setMessageTextValue(textFieldValueWithSelection("some text\n"))
         state.startMention()

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
@@ -148,6 +148,28 @@ class MessageComposerInnerStateTest {
         assertEquals(null, state.mentionQueryFlowState.value)
     }
 
+    // case was found by manual testing
+    @Test
+    fun `when mention symbol is at the begin of new line, then mention is requested`() = runTest {
+        val state = createState(context)
+        state.setMessageTextValue(textFieldValueWithSelection("some text\n"))
+
+        state.setMessageTextValue(textFieldValueWithSelection("some text\n@"))
+
+        assertEquals("", state.mentionQueryFlowState.value)
+    }
+
+    // case was found by manual testing
+    @Test
+    fun `when cursor is at the begin of new line, and add mention btn clicked, then mention is requested`() = runTest {
+        val state = createState(context)
+        state.setMessageTextValue(textFieldValueWithSelection("some text\n"))
+        state.startMention()
+
+        assertEquals("", state.mentionQueryFlowState.value)
+        assertEquals("some text\n@", state.messageText.text)
+    }
+
     private fun textFieldValueWithSelection(text: String) = TextFieldValue(text, TextRange(text.length))
 
     private fun contact(suffix: Int = 0) = Contact(


### PR DESCRIPTION
# What's new in this PR?

### Issues

1. when the cursor is in a new line and user types `@`, then mention list is not displayed
2. when the cursor is in a new line and user clicks on `@` button, then mention list is displayed, but it adds space just before `@`

### Causes (Optional)

1. we were checking if `@` goes at the begin of text OR there is a `space` before it, then we'll show mentions
2. the same reason as in `#1`

### Solutions

update checking "if mention should be displayed" to accept `\n` too.
and update unit tests.
