### PR TITLE
ci: fix missing github credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,13 @@ pipeline {
           }
         }
 
+        stage('Copy local.properties to Kalium') {
+          steps {
+            sh 'rm kalium/${propertiesFile}'
+            sh 'cp ${propertiesFile} kalium/${propertiesFile}'
+          }
+        }
+
         stage('Spawn Gradle Wrapper') {
           steps {
             withGradle() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
 
         stage('Copy local.properties to Kalium') {
           steps {
-            sh '\cp -f ${propertiesFile} kalium/${propertiesFile}'
+            sh '\\cp -f ${propertiesFile} kalium/${propertiesFile}'
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,8 +146,7 @@ pipeline {
 
         stage('Copy local.properties to Kalium') {
           steps {
-            sh 'rm kalium/${propertiesFile}'
-            sh 'cp ${propertiesFile} kalium/${propertiesFile}'
+            sh '\cp -f ${propertiesFile} kalium/${propertiesFile}'
           }
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CI Builds are failing when trying to fetch GitHub packages

### Causes

We've set credentials in `local.properties`, but we need to add those to `kalium/local.properties`.

### Solutions

Copy `local.properties` to `kalium/local.properties` too.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
