### PR TITLE
feat: message details reactions

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusU
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.ObserveMessageReactionsUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.message.getPaginatedFlowOfMessagesByConversation
@@ -71,9 +72,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -415,6 +416,13 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): ToggleReactionUseCase = coreLogic.getSessionScope(currentAccount).messages.toggleReaction
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveMessageReactionsUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): ObserveMessageReactionsUseCase = coreLogic.getSessionScope(currentAccount).messages.observeMessageReactions
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -8,7 +8,7 @@ import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.kalium.logic.data.asset.isDisplayableMimeType
+import com.wire.kalium.logic.data.asset.isDisplayableImageMimeType
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -221,7 +221,7 @@ class AssetMessageContentMetadata(val assetMessageContent: AssetContent) {
             else -> 0
         }
 
-    fun isDisplayableImage(): Boolean = isDisplayableMimeType(assetMessageContent.mimeType) &&
+    fun isDisplayableImage(): Boolean = isDisplayableImageMimeType(assetMessageContent.mimeType) &&
             imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
 }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
@@ -30,7 +30,7 @@ class UIParticipantMapper @Inject constructor(
             membership = userTypeMapper.toMembership(userType),
             connectionState = connectionState,
             unavailable = unavailable,
-            isDeleted = if (user is OtherUser) user.deleted else false
+            isDeleted = (user is OtherUser && user.deleted)
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
@@ -2,7 +2,9 @@ package com.wire.android.mapper
 
 import com.wire.android.ui.home.conversations.avatar
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
+import com.wire.android.ui.home.conversations.previewAsset
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.message.reaction.MessageReaction
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
@@ -28,7 +30,20 @@ class UIParticipantMapper @Inject constructor(
             membership = userTypeMapper.toMembership(userType),
             connectionState = connectionState,
             unavailable = unavailable,
-            isDeleted = if(user is OtherUser) user.deleted else false
+            isDeleted = if (user is OtherUser) user.deleted else false
+        )
+    }
+
+    fun toUIParticipant(messageReaction: MessageReaction): UIParticipant = with(messageReaction) {
+        return UIParticipant(
+            id = userId,
+            name = name.orEmpty(),
+            handle = handle.orEmpty(),
+            avatarData = previewAsset(wireSessionImageLoader),
+            membership = userTypeMapper.toMembership(userType),
+            unavailable = !deleted && name.orEmpty().isEmpty(),
+            isDeleted = deleted,
+            isSelf = isSelfUser
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -26,6 +26,7 @@ import com.wire.android.navigation.NavigationItemDestinationsRoutes.INCOMING_CAL
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.INITIATING_CALL
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.LOGIN
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.MEDIA_GALLERY
+import com.wire.android.navigation.NavigationItemDestinationsRoutes.MESSAGE_DETAILS
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.MIGRATION
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.MY_ACCOUNT
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.NETWORK_SETTINGS
@@ -55,6 +56,7 @@ import com.wire.android.ui.home.conversations.ConversationScreen
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsScreen
 import com.wire.android.ui.home.conversations.details.metadata.EditConversationNameScreen
 import com.wire.android.ui.home.conversations.details.participants.GroupConversationAllParticipantsScreen
+import com.wire.android.ui.home.conversations.messagedetails.MessageDetailsScreen
 import com.wire.android.ui.home.conversations.search.AddMembersSearchRouter
 import com.wire.android.ui.home.gallery.MediaGalleryScreen
 import com.wire.android.ui.home.newconversation.NewConversationRouter
@@ -244,6 +246,20 @@ enum class NavigationItem(
         }
     },
 
+    MessageDetails(
+        primaryRoute = MESSAGE_DETAILS,
+        canonicalRoute = "$MESSAGE_DETAILS?$EXTRA_CONVERSATION_ID={$EXTRA_CONVERSATION_ID}&$EXTRA_MESSAGE_ID={$EXTRA_MESSAGE_ID}",
+        content = { MessageDetailsScreen() }
+    ) {
+        override fun getRouteWithArgs(arguments: List<Any>): String {
+            val conversationIdString: String = arguments.filterIsInstance<ConversationId>().firstOrNull()?.toString()
+                ?: "{$EXTRA_CONVERSATION_ID}"
+            val messageIdString: String = arguments.filterIsInstance<String>().firstOrNull()?.toString()
+                ?: "{$EXTRA_MESSAGE_ID}"
+            return "$MESSAGE_DETAILS?$EXTRA_CONVERSATION_ID=$conversationIdString&$EXTRA_MESSAGE_ID=$messageIdString"
+        }
+    },
+
     GroupConversationDetails(
         primaryRoute = GROUP_CONVERSATION_DETAILS,
         canonicalRoute = "$GROUP_CONVERSATION_DETAILS/{$EXTRA_CONVERSATION_ID}",
@@ -381,6 +397,7 @@ object NavigationItemDestinationsRoutes {
     const val CONVERSATION = "detailed_conversation_screen"
     const val EDIT_CONVERSATION_NAME = "edit_conversation_name_screen"
     const val GROUP_CONVERSATION_DETAILS = "group_conversation_details_screen"
+    const val MESSAGE_DETAILS = "message_details_screen"
     const val GROUP_CONVERSATION_ALL_PARTICIPANTS = "group_conversation_all_participants_screen"
     const val ADD_CONVERSATION_PARTICIPANTS = "add_conversation_participants"
     const val APP_SETTINGS = "app_settings_screen"
@@ -405,6 +422,7 @@ const val EXTRA_USER_DOMAIN = "extra_user_domain"
 const val EXTRA_CONVERSATION_ID = "extra_conversation_id"
 const val EXTRA_CREATE_ACCOUNT_FLOW_TYPE = "extra_create_account_flow_type"
 const val EXTRA_IMAGE_DATA = "extra_image_data"
+const val EXTRA_MESSAGE_ID = "extra_message_id"
 const val EXTRA_MESSAGE_TO_DELETE_ID = "extra_message_to_delete"
 const val EXTRA_MESSAGE_TO_DELETE_IS_SELF = "extra_message_to_delete_is_self"
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireTabRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireTabRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
+import com.wire.android.ui.home.conversations.messagedetails.MessageDetailsTabItem
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import kotlin.math.absoluteValue
@@ -45,11 +46,19 @@ fun WireTabRow(
     ) {
         tabs.forEachIndexed { index, tabItem ->
             val selected = selectedTabIndex == index
+            val text = if (tabItem is MessageDetailsTabItem) {
+                stringResource(id = tabItem.titleResId, tabItem.count)
+            } else {
+                stringResource(id = tabItem.titleResId)
+            }.let {
+                if(upperCaseTitles) it.uppercase() else it
+            }
+
             Tab(
                 enabled = true,
                 text = {
                     Text(
-                        text = stringResource(id = tabItem.titleResId).let { if(upperCaseTitles) it.uppercase() else it },
+                        text = text,
                         style = MaterialTheme.wireTypography.title03
                     )
                 },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
@@ -4,6 +4,7 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.message.reaction.MessageReaction
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
@@ -47,3 +48,11 @@ val MemberDetails.userType: UserType
         is OtherUser -> (user as OtherUser).userType
         is SelfUser -> UserType.INTERNAL
     }
+
+fun MessageReaction.previewAsset(
+    wireSessionImageLoader: WireSessionImageLoader
+) = UserAvatarData(
+    asset = this.previewAssetId?.let { UserAvatarAsset(wireSessionImageLoader, it) },
+    availabilityStatus = userAvailabilityStatus,
+    connectionState = connectionStatus
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -322,7 +322,6 @@ private fun ConversationScreen(
 
             // if the currentScreenHeight is smaller than the initial fullScreenHeight,
             // and we don't know the keyboard height yet
-            // and we don't know the keyboard height yet
             // calculated at the first composition of the ConversationScreen, then we know the keyboard size
             if (keyboardHeight is KeyboardHeight.NotKnown && currentScreenHeight < fullScreenHeight) {
                 val difference = fullScreenHeight - currentScreenHeight

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -266,30 +266,33 @@ private fun ConversationScreen(
 
     val menuModalOnDeleteMessage = remember {
         {
-            conversationScreenState.hideEditContextMenu()
-            onDeleteMessage(
-                conversationScreenState.selectedMessage?.messageHeader!!.messageId,
-                conversationScreenState.isMyMessage
-            )
+            conversationScreenState.hideEditContextMenu {
+                onDeleteMessage(
+                    conversationScreenState.selectedMessage?.messageHeader!!.messageId,
+                    conversationScreenState.isMyMessage
+                )
+            }
         }
     }
 
     val menuModalOnReactionClick = remember {
         { emoji: String ->
-            conversationScreenState.hideEditContextMenu()
-            onReactionClick(
-                conversationScreenState.selectedMessage?.messageHeader!!.messageId,
-                emoji
-            )
+            conversationScreenState.hideEditContextMenu {
+                onReactionClick(
+                    conversationScreenState.selectedMessage?.messageHeader!!.messageId,
+                    emoji
+                )
+            }
         }
     }
 
     val menuModalOnMessageDetailsClick = remember {
         {
-            // conversationScreenState.hideEditContextMenu() // TODO: doesnt hide itself and some menus are hidden because its null
-            onMessageDetailsClick(
-                conversationScreenState.selectedMessage?.messageHeader!!.messageId
-            )
+            conversationScreenState.hideEditContextMenu {
+                onMessageDetailsClick(
+                    conversationScreenState.selectedMessage?.messageHeader!!.messageId
+                )
+            }
         }
     }
 
@@ -318,6 +321,7 @@ private fun ConversationScreen(
             }
 
             // if the currentScreenHeight is smaller than the initial fullScreenHeight,
+            // and we don't know the keyboard height yet
             // and we don't know the keyboard height yet
             // calculated at the first composition of the ConversationScreen, then we know the keyboard size
             if (keyboardHeight is KeyboardHeight.NotKnown && currentScreenHeight < fullScreenHeight) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -157,6 +157,7 @@ fun ConversationScreen(
         onBackButtonClick = messageComposerViewModel::navigateBack,
         onDeleteMessage = messageComposerViewModel::showDeleteMessageDialog,
         onReactionClick = conversationMessagesViewModel::toggleReaction,
+        onMessageDetailsClick = conversationMessagesViewModel::openMessageDetails,
         onStartCall = {
             startCallIfPossible(
                 conversationCallViewModel,
@@ -249,6 +250,7 @@ private fun ConversationScreen(
     onBackButtonClick: () -> Unit,
     onDeleteMessage: (String, Boolean) -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
+    onMessageDetailsClick: (messageId: String) -> Unit,
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onSnackbarMessage: (ConversationSnackbarMessages) -> Unit,
@@ -282,6 +284,15 @@ private fun ConversationScreen(
         }
     }
 
+    val menuModalOnMessageDetailsClick = remember {
+        {
+            // conversationScreenState.hideEditContextMenu() // TODO: doesnt hide itself and some menus are hidden because its null
+            onMessageDetailsClick(
+                conversationScreenState.selectedMessage?.messageHeader!!.messageId
+            )
+        }
+    }
+
     val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
 
     MenuModalSheetLayout(
@@ -292,7 +303,8 @@ private fun ConversationScreen(
             isEditable = conversationScreenState.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon,
             onCopyMessage = conversationScreenState::copyMessage,
             onDeleteMessage = menuModalOnDeleteMessage,
-            onReactionClick = menuModalOnReactionClick
+            onReactionClick = menuModalOnReactionClick,
+            onMessageDetailsClick = menuModalOnMessageDetailsClick
         )
     ) {
         BoxWithConstraints {
@@ -554,7 +566,7 @@ fun ConversationScreenPreview() {
         connectivityUIState = ConnectivityUIState(info = ConnectivityUIState.Info.None),
         bannerMessage = null,
         onOpenOngoingCallScreen = { },
-        onSendMessage = {_, _ -> },
+        onSendMessage = { _, _ -> },
         onSendAttachment = { },
         onMentionMember = { },
         onDownloadAsset = { },
@@ -572,5 +584,6 @@ fun ConversationScreenPreview() {
         onUpdateConversationReadDate = { },
         interactionAvailability = InteractionAvailability.ENABLED,
         membersToMention = listOf(),
+        onMessageDetailsClick = { }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -68,8 +68,11 @@ class ConversationScreenState(
         coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Expanded) }
     }
 
-    fun hideEditContextMenu() {
-        coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Hidden) }
+    fun hideEditContextMenu(onComplete: () -> Unit) {
+        coroutineScope.launch {
+            modalBottomSheetState.animateTo(ModalBottomSheetValue.Hidden)
+            onComplete()
+        }
     }
 
     fun copyMessage() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
@@ -30,10 +30,11 @@ import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.UserId
 
 @Composable
-fun GroupConversationParticipantItem(
+fun ConversationParticipantItem(
     uiParticipant: UIParticipant,
     searchQuery: String = String.EMPTY,
-    clickable: Clickable
+    clickable: Clickable,
+    showRightArrow: Boolean = true
 ) {
     RowItemTemplate(
         leadingIcon = { UserProfileAvatar(uiParticipant.avatarData) },
@@ -75,12 +76,14 @@ fun GroupConversationParticipantItem(
             )
         },
         actions = {
-            Box(
-                modifier = Modifier
-                    .wrapContentWidth()
-                    .padding(end = MaterialTheme.wireDimensions.spacing8x)
-            ) {
-                ArrowRightIcon(Modifier.align(Alignment.TopEnd))
+            if (showRightArrow) {
+                Box(
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .padding(end = MaterialTheme.wireDimensions.spacing8x)
+                ) {
+                    ArrowRightIcon(Modifier.align(Alignment.TopEnd))
+                }
             }
         },
         clickable = clickable,
@@ -91,7 +94,7 @@ fun GroupConversationParticipantItem(
 @Preview
 @Composable
 fun GroupConversationParticipantItemPreview() {
-    GroupConversationParticipantItem(
+    ConversationParticipantItem(
         UIParticipant(UserId("0", ""), "name", "handle", false, UserAvatarData(), Membership.Guest),
         clickable = Clickable(enabled = true) {}
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.util.extension.folderWithElements
 
 fun LazyListScope.participantsFoldersWithElements(
     context: Context,
@@ -32,14 +32,16 @@ fun LazyListScope.participantsFoldersWithElements(
 fun LazyListScope.folderWithElements(
     header: String,
     items: List<UIParticipant>,
-    onRowItemClicked: (UIParticipant) -> Unit
+    onRowItemClicked: (UIParticipant) -> Unit,
+    showRightArrow: Boolean = true
 ) = folderWithElements(
     header = header,
     items = items.associateBy { it.id.toString() },
     factory = {
-        GroupConversationParticipantItem(
+        ConversationParticipantItem(
             uiParticipant = it,
-            clickable = remember { Clickable(enabled = true) { onRowItemClicked(it) } }
+            clickable = remember { Clickable(enabled = true) { onRowItemClicked(it) } },
+            showRightArrow = showRightArrow
         )
     },
     divider = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -41,9 +41,11 @@ fun EditMessageMenuItems(
     onCopyMessage: () -> Unit,
     onDeleteMessage: () -> Unit,
     onReactionClick: (emoji: String) -> Unit,
+    onMessageDetailsClick: () -> Unit
 ): List<@Composable () -> Unit> {
     return buildList {
         add { ReactionOptions(onReactionClick) }
+        add { MessageDetails(onMessageDetailsClick) }
         add {
             if (isCopyable) {
                 MenuBottomSheetItem(
@@ -106,7 +108,7 @@ private fun ReactionOptions(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            listOf("❤️", "👍",  "😁", "🙂", "☹️", "👎").forEach { emoji ->
+            listOf("❤️", "👍", "😁", "🙂", "☹️", "👎").forEach { emoji ->
                 CompositionLocalProvider(
                     LocalMinimumTouchTargetEnforcement provides false
                 ) {
@@ -149,4 +151,20 @@ private fun ReactionOptions(
             }
         }
     }
+}
+
+@Composable
+private fun MessageDetails(
+    onMessageDetailsClick: () -> Unit
+) {
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_info,
+                contentDescription = stringResource(R.string.content_description_open_message_details),
+            )
+        },
+        title = stringResource(R.string.label_message_details),
+        onItemClick = onMessageDetailsClick
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
@@ -1,0 +1,31 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.wire.android.ui.home.conversations.details.participants.folderWithElements
+
+@Composable
+fun MessageDetailsReactions(
+    messageDetailsState: MessageDetailsState,
+    lazyListState: LazyListState = rememberLazyListState()
+) {
+    Column {
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier.weight(weight = 1f, fill = true)
+        ) {
+            messageDetailsState.reactionsData.reactions.forEach {
+                folderWithElements(
+                    header = "${it.key} ${it.value.size}",
+                    items = it.value,
+                    onRowItemClicked = { },
+                    showRightArrow = false
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -1,0 +1,147 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.rememberPagerState
+import com.wire.android.R
+import com.wire.android.ui.common.TabItem
+import com.wire.android.ui.common.WireTabRow
+import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
+import com.wire.android.ui.common.calculateCurrentTab
+import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
+import com.wire.android.ui.common.topBarElevation
+import com.wire.android.ui.common.topappbar.NavigationIconType
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireDimensions
+import kotlinx.coroutines.launch
+
+@Composable
+fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
+    MessageDetailsScreenContent(
+        messageDetailsState = viewModel.messageDetailsState,
+        onBackPressed = viewModel::navigateBack
+    )
+}
+
+@OptIn(
+    ExperimentalPagerApi::class,
+    ExperimentalMaterialApi::class,
+    ExperimentalMaterial3Api::class,
+    ExperimentalComposeUiApi::class,
+    ExperimentalFoundationApi::class
+)
+@Composable
+private fun MessageDetailsScreenContent(
+    messageDetailsState: MessageDetailsState,
+    onBackPressed: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val lazyListStates: List<LazyListState> = MessageDetailsTabItem.values().map { rememberLazyListState() }
+    val initialPageIndex = MessageDetailsTabItem.REACTIONS.ordinal
+    val pagerState = rememberPagerState(initialPage = initialPageIndex)
+    val maxAppBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
+    val currentTabState by remember { derivedStateOf { pagerState.calculateCurrentTab() } }
+    val elevationState by remember { derivedStateOf { lazyListStates[currentTabState].topBarElevation(maxAppBarElevation) } }
+
+    val sheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    WireModalSheetLayout(
+        sheetState = sheetState,
+        coroutineScope = rememberCoroutineScope(),
+        sheetContent = {}
+    ) {
+        Scaffold(
+            topBar = {
+                WireCenterAlignedTopAppBar(
+                    elevation = elevationState,
+                    title = stringResource(R.string.message_details_title),
+                    navigationIconType = NavigationIconType.Close,
+                    onNavigationPressed = onBackPressed
+                ) {
+                    WireTabRow(
+                        tabs = MessageDetailsTabItem.values().toList(),
+                        selectedTabIndex = currentTabState,
+                        onTabChange = { scope.launch { pagerState.animateScrollToPage(it) } },
+                        modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing16x),
+                        divider = {} // no divider
+                    )
+                }
+            },
+            modifier = Modifier.fillMaxHeight(),
+            snackbarHost = {
+                SwipeDismissSnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+        ) { internalPadding ->
+            var focusedTabIndex: Int by remember { mutableStateOf(initialPageIndex) }
+            val keyboardController = LocalSoftwareKeyboardController.current
+            val focusManager = LocalFocusManager.current
+
+            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                HorizontalPager(
+                    state = pagerState,
+                    count = MessageDetailsTabItem.values().size,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(internalPadding)
+                ) { pageIndex ->
+                    when (MessageDetailsTabItem.values()[pageIndex]) {
+                        MessageDetailsTabItem.REACTIONS -> MessageDetailsReactions(
+                            messageDetailsState = messageDetailsState,
+                            lazyListState = lazyListStates[pageIndex]
+                        )
+                        MessageDetailsTabItem.READ_RECEIPTS -> {
+                            // Not implemented yet.
+                        }
+                    }
+                }
+
+                LaunchedEffect(pagerState.isScrollInProgress, focusedTabIndex, pagerState.currentPage) {
+                    if (!pagerState.isScrollInProgress && focusedTabIndex != pagerState.currentPage) {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                        focusedTabIndex = pagerState.currentPage
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum class MessageDetailsTabItem(@StringRes override val titleResId: Int) : TabItem {
+    REACTIONS(R.string.message_details_reactions_tab),
+    READ_RECEIPTS(R.string.message_details_read_receipts_tab)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -90,7 +90,7 @@ private fun MessageDetailsScreenContent(
                     onNavigationPressed = onBackPressed
                 ) {
                     WireTabRow(
-                        tabs = MessageDetailsTabItem.values().toList(),
+                        tabs = provideMessageDetailsTabItems(isSelfMessage = messageDetailsState.isSelfMessage),
                         selectedTabIndex = currentTabState,
                         onTabChange = { scope.launch { pagerState.animateScrollToPage(it) } },
                         modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing16x),
@@ -145,3 +145,7 @@ enum class MessageDetailsTabItem(@StringRes override val titleResId: Int) : TabI
     REACTIONS(R.string.message_details_reactions_tab),
     READ_RECEIPTS(R.string.message_details_read_receipts_tab)
 }
+
+private fun provideMessageDetailsTabItems(isSelfMessage: Boolean) =
+    if (isSelfMessage) MessageDetailsTabItem.values().toList()
+    else listOf(MessageDetailsTabItem.REACTIONS)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
@@ -1,0 +1,7 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
+
+data class MessageDetailsState(
+    val reactionsData: MessageDetailsReactionsData = MessageDetailsReactionsData()
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
@@ -3,6 +3,6 @@ package com.wire.android.ui.home.conversations.messagedetails
 import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
 
 data class MessageDetailsState(
-    val isSelfMessage: Boolean = false,
+    val isSelfMessage: Boolean = false, // Default is false as Read Receipts is yet not implemented and we don't need to know it for now.
     val reactionsData: MessageDetailsReactionsData = MessageDetailsReactionsData()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
@@ -3,5 +3,6 @@ package com.wire.android.ui.home.conversations.messagedetails
 import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
 
 data class MessageDetailsState(
+    val isSelfMessage: Boolean = false,
     val reactionsData: MessageDetailsReactionsData = MessageDetailsReactionsData()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsViewModel.kt
@@ -1,0 +1,50 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.navigation.EXTRA_MESSAGE_ID
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.navigation.SavedStateViewModel
+import com.wire.android.ui.home.conversations.messagedetails.usecase.ObserveReactionsForMessageUseCase
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MessageDetailsViewModel @Inject constructor(
+    qualifiedIdMapper: QualifiedIdMapper,
+    override val savedStateHandle: SavedStateHandle,
+    private val navigationManager: NavigationManager,
+    private val observeReactionsForMessage: ObserveReactionsForMessageUseCase
+) : SavedStateViewModel(savedStateHandle) {
+
+    private val conversationId: QualifiedID = qualifiedIdMapper
+        .fromStringToQualifiedID(savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!)
+
+    private val messageId: String = savedStateHandle.get<String>(EXTRA_MESSAGE_ID)!!
+
+    var messageDetailsState: MessageDetailsState by mutableStateOf(MessageDetailsState())
+
+    init {
+        viewModelScope.launch {
+            observeReactionsForMessage(
+                conversationId = conversationId,
+                messageId = messageId
+            ).collect {
+                messageDetailsState = messageDetailsState.copy(
+                    reactionsData = it
+                )
+            }
+        }
+    }
+
+    fun navigateBack() = viewModelScope.launch {
+        navigationManager.navigateBack()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/model/MessageDetailsReactionsData.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/model/MessageDetailsReactionsData.kt
@@ -1,0 +1,7 @@
+package com.wire.android.ui.home.conversations.messagedetails.model
+
+import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
+
+data class MessageDetailsReactionsData(
+    val reactions: Map<String, List<UIParticipant>> = mapOf()
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/usecase/ObserveReactionsForMessageUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/usecase/ObserveReactionsForMessageUseCase.kt
@@ -1,0 +1,42 @@
+package com.wire.android.ui.home.conversations.messagedetails.usecase
+
+import com.wire.android.mapper.UIParticipantMapper
+import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
+import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.message.ObserveMessageReactionsUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ObserveReactionsForMessageUseCase @Inject constructor(
+    private val observeMessageReactions: ObserveMessageReactionsUseCase,
+    private val uiParticipantMapper: UIParticipantMapper,
+    private val dispatchers: DispatcherProvider
+) {
+
+    suspend operator fun invoke(conversationId: ConversationId, messageId: String): Flow<MessageDetailsReactionsData> =
+        observeMessageReactions(
+            conversationId = conversationId,
+            messageId = messageId
+        ).map { messageReactionsList ->
+            messageReactionsList
+                .groupBy { it.emoji }
+                .toList()
+                .sortedBy { it.second.size }
+                .reversed()
+                .toMap()
+        }.map { mapResult ->
+            val result = mutableMapOf<String, List<UIParticipant>>()
+
+            mapResult.forEach {
+                result[it.key] = it.value.map(uiParticipantMapper::toUIParticipant)
+            }
+
+            MessageDetailsReactionsData(
+                reactions = result
+            )
+        }.flowOn(dispatchers.io())
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -8,6 +8,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.wire.android.appLogger
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
+import com.wire.android.navigation.NavigationManager
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
@@ -36,6 +39,7 @@ import javax.inject.Inject
 @HiltViewModel
 @Suppress("LongParameterList")
 class ConversationMessagesViewModel @Inject constructor(
+    private val navigationManager: NavigationManager,
     qualifiedIdMapper: QualifiedIdMapper,
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
@@ -166,6 +170,18 @@ class ConversationMessagesViewModel @Inject constructor(
     fun toggleReaction(messageId: String, reactionEmoji: String) {
         viewModelScope.launch {
             toggleReaction(conversationId, messageId, reactionEmoji)
+        }
+    }
+
+    fun openMessageDetails(messageId: String) {
+        viewModelScope.launch {
+            navigationManager.navigate(
+                command = NavigationCommand(
+                    destination = NavigationItem.MessageDetails.getRouteWithArgs(
+                        listOf(conversationId, messageId)
+                    )
+                )
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -37,7 +37,7 @@ import okio.Path
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class ConversationMessagesViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     qualifiedIdMapper: QualifiedIdMapper,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleScreen.kt
@@ -26,8 +26,8 @@ import com.wire.android.ui.common.WireCircularProgressIndicator
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.android.util.extension.folderWithElements
 
 private const val DEFAULT_SEARCH_RESULT_ITEM_SIZE = 4
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/call/CallsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/call/CallsScreen.kt
@@ -4,14 +4,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.wire.android.R
 import com.wire.android.ui.home.conversationslist.common.ConversationItemFactory
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.util.extension.folderWithElements
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -10,13 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.util.extension.folderWithElements
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.ImmutableMap
-
 
 @Composable
 fun ConversationList(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mention/MentionScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mention/MentionScreen.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.wire.android.R
 import com.wire.android.ui.home.conversationslist.common.ConversationItemFactory
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.util.extension.folderWithElements
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import androidx.compose.foundation.lazy.rememberLazyListState

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -29,7 +29,7 @@ import com.wire.android.util.getFileName
 import com.wire.android.util.getMimeType
 import com.wire.android.util.orDefault
 import com.wire.android.util.resampleImageAndCopyToTempPath
-import com.wire.kalium.logic.data.asset.isDisplayableMimeType
+import com.wire.kalium.logic.data.asset.isDisplayableImageMimeType
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -294,7 +294,7 @@ class AttachmentInnerState(val context: Context) {
             val fullTempAssetPath = "$tempCachePath/${UUID.randomUUID()}".toPath()
             val assetFileName = context.getFileName(attachmentUri) ?: throw IOException("The selected asset has an invalid name")
             val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
-            val attachmentType = if (isDisplayableMimeType(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
+            val attachmentType = if (isDisplayableImageMimeType(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
             val assetSize = if (attachmentType == AttachmentType.IMAGE)
                 attachmentUri.resampleImageAndCopyToTempPath(context, fullTempAssetPath)
             else attachmentUri.copyToTempPath(context, fullTempAssetPath)

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
+import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.RowItemTemplate
-import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.WireCheckbox
@@ -30,10 +30,10 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.loading.CenteredCircularProgressBarIndicator
 import com.wire.android.ui.home.conversations.search.SearchResultState
 import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.extension.folderWithElements
 import com.wire.kalium.logic.data.user.ConnectionState
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -28,11 +28,11 @@ import com.wire.android.navigation.isExternalRoute
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
+import com.wire.android.util.extension.folderWithElements
 
 @Composable
 fun SettingsScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -23,10 +23,10 @@ import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.extension.folderWithElements
 
 @Composable
 fun MyAccountScreen(viewModel: MyAccountViewModel = hiltViewModel()) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -24,9 +24,9 @@ import com.wire.android.ui.authentication.devices.DeviceItem
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
-import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.settings.devices.model.SelfDevicesState
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.util.extension.folderWithElements
 
 @Composable
 fun SelfDevicesScreen(viewModel: SelfDevicesViewModel = hiltViewModel()) {
@@ -104,9 +104,11 @@ private fun LazyListScope.folderDeviceItems(
             )
         }
     ) { item ->
-        DeviceItem(item,
+        DeviceItem(
+            item,
             background = MaterialTheme.wireColorScheme.surface,
-            placeholder = false)
+            placeholder = false
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/extension/LazyListScope.kt
+++ b/app/src/main/kotlin/com/wire/android/util/extension/LazyListScope.kt
@@ -1,4 +1,4 @@
-package com.wire.android.ui.home.conversationslist
+package com.wire.android.util.extension
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -34,9 +34,10 @@ inline fun <T, K : Any> LazyListScope.folderWithElements(
         }
         itemsIndexed(
             items = list,
-            key = { _: Int, item: Map.Entry<K, T> -> item.key })
+            key = { _: Int, item: Map.Entry<K, T> -> "$header:${item.key}" })
         { index: Int, item: Map.Entry<K, T> ->
-            Box(modifier = Modifier
+            Box(
+                modifier = Modifier
                     .wrapContentSize()
                     .animateItemPlacement()
             ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="content_description_left_arrow">Go back</string>
     <string name="content_description_mention_icon">Mention icon</string>
     <string name="content_description_attachment_item">Attach new item to conversation</string>
+    <string name="content_description_open_message_details">Open Message Details</string>
     <string name="content_description_copy_the_message">Copy the message</string>
     <string name="content_description_delete_the_message">Delete the message</string>
     <string name="content_description_edit_the_message">Edit the message</string>
@@ -326,6 +327,11 @@
     <string name="delete_group_conversation_dialog_title">Remove “%s”?</string>
     <string name="delete_group_conversation_dialog_description">The group will be removed from your conversations list on all devices. You will no longer be able to access the group and its content.</string>
 
+    <!-- Messages -->
+    <string name="message_details_title">Message Details</string>
+    <string name="message_details_reactions_tab">REACTIONS</string>
+    <string name="message_details_read_receipts_tab">READ RECEIPTS</string>
+
     <!-- Attachment options -->
     <string name="attachment_share_file">Attach File</string>
     <string name="attachment_share_image">Attach Picture</string>
@@ -396,6 +402,7 @@
     <string name="profile_image_take_a_picture_menu_item">Take a picture</string>
     <string name="profile_image_change_image_button_label">Change Picture…</string>
     <!--Conversation-->
+    <string name="label_message_details">Message Details</string>
     <string name="label_copy">Copy</string>
     <string name="label_edit">Edit</string>
     <string name="label_delete">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,8 +329,8 @@
 
     <!-- Messages -->
     <string name="message_details_title">Message Details</string>
-    <string name="message_details_reactions_tab">REACTIONS</string>
-    <string name="message_details_read_receipts_tab">READ RECEIPTS</string>
+    <string name="message_details_reactions_tab">REACTIONS (%s)</string>
+    <string name="message_details_read_receipts_tab">READ RECEIPTS (%s)</string>
 
     <!-- Attachment options -->
     <string name="attachment_share_file">Attach File</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.paging.PagingData
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
+import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
@@ -39,6 +40,9 @@ class ConversationMessagesViewModelArrangement {
     val conversationDetailsChannel = Channel<ConversationDetails>(capacity = Channel.UNLIMITED)
 
     @MockK
+    lateinit var navigationManager: NavigationManager
+
+    @MockK
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     @MockK
@@ -67,6 +71,7 @@ class ConversationMessagesViewModelArrangement {
 
     private val viewModel: ConversationMessagesViewModel by lazy {
         ConversationMessagesViewModel(
+            navigationManager,
             qualifiedIdMapper,
             savedStateHandle,
             observeConversationDetails,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2681 - UI for MessageDetailsScreen](https://wearezeta.atlassian.net/browse/AR-2681)

### Issues

Not displaying reactions on message details.

### Causes (Optional)

Didn't exist.

### Solutions

Create `MessageDetailsScreen` and show reactions for selected message.

### Testing

#### How to Test

- Open App
- Open Conversation
- Long Click on a message with reactions
- Select Message Details
- Should see reactions for selected message


### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5890660/202419729-fdee01a9-da93-4f88-8721-0c7209be802a.png" alt="message details reactions" width="200" height="400" />