### PR TITLE
fix: Update conversation data in context menu when it was changed (AR-2491)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -2,7 +2,6 @@ package com.wire.android.ui.common.bottomsheet.conversation
 
 import MutingOptionsSheetContent
 import androidx.activity.compose.BackHandler
-import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import com.wire.android.R
 import com.wire.android.model.ImageAsset.UserAvatarAsset
@@ -27,6 +26,7 @@ fun ConversationSheetContent(
     unblockUser: (UnblockUserDialogState) -> Unit,
     leaveGroup: (GroupDialogState) -> Unit,
     deleteGroup: (GroupDialogState) -> Unit,
+    closeBottomSheet: () -> Unit = {},
     isBottomSheetVisible: () -> Boolean = { true }
 ) {
     // it may be null as initial state
@@ -50,20 +50,27 @@ fun ConversationSheetContent(
             )
         }
         ConversationOptionNavigation.MutingNotificationOption -> {
+            val goBack: () -> Unit = {
+                if (conversationSheetState.startOptionNavigation == ConversationOptionNavigation.Home)
+                    conversationSheetState.toHome()
+                else
+                    closeBottomSheet()
+            }
             MutingOptionsSheetContent(
                 mutingConversationState = conversationSheetState.conversationSheetContent!!.mutingConversationState,
                 onMuteConversation = { mutedStatus ->
                     conversationSheetState.muteConversation(mutedStatus)
                     onMutingConversationStatusChange()
-                    conversationSheetState.toHome()
+                    goBack()
                 },
-                onBackClick = conversationSheetState::toHome
+                onBackClick = goBack
             )
         }
     }
 
     BackHandler(
-        conversationSheetState.currentOptionNavigation is ConversationOptionNavigation.MutingNotificationOption
+        conversationSheetState.currentOptionNavigation == ConversationOptionNavigation.MutingNotificationOption
+                && conversationSheetState.startOptionNavigation != ConversationOptionNavigation.MutingNotificationOption
                 && isBottomSheetVisible()
     ) {
         conversationSheetState.toHome()

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -15,6 +15,7 @@ class ConversationSheetState(
     conversationSheetContent: ConversationSheetContent? = null,
     conversationOptionNavigation: ConversationOptionNavigation = ConversationOptionNavigation.Home
 ) {
+    val startOptionNavigation = conversationOptionNavigation
 
     var conversationSheetContent: ConversationSheetContent? by mutableStateOf(conversationSheetContent)
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
@@ -2,13 +2,15 @@ package com.wire.android.ui.home.conversationslist
 
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 
 data class ConversationListState(
-    val searchQuery : String = "",
+    val searchQuery: String = "",
+    private val allConversations: List<ConversationItem> = persistentListOf(),
     val conversations: ImmutableMap<ConversationFolder, List<ConversationItem>> = persistentMapOf(),
     val hasNoConversations: Boolean = false,
     val conversationSearchResult: ImmutableMap<ConversationFolder, List<ConversationItem>> = persistentMapOf(),
@@ -19,4 +21,7 @@ data class ConversationListState(
     val newActivityCount: Long = 0,
     val missedCallsCount: Long = 0,
     val unreadMentionsCount: Long = 0
-)
+) {
+    fun findConversationById(conversationId: ConversationId): ConversationItem? =
+        allConversations.firstOrNull { it.conversationId == conversationId }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -134,6 +134,7 @@ class ConversationListViewModel @Inject constructor(
 
     private fun conversationListDetailsToState(conversationListDetails: List<ConversationDetails>) {
         conversationListState = conversationListState.copy(
+            allConversations = conversationListDetails.map { it.toConversationItem(wireSessionImageLoader, userTypeMapper) },
             conversations = conversationListDetails.toConversationsFoldersMap().toImmutableMap(),
             hasNoConversations = conversationListDetails.none { it !is Self },
             callHistory = mockCallHistory.toImmutableList(), // TODO: needs to be implemented

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -80,8 +80,12 @@ fun ConversationRouterHomeBridge(
             conversationOptionNavigation: ConversationOptionNavigation = ConversationOptionNavigation.Home
         ) {
             onHomeBottomSheetContentChanged {
+                // if we just use [conversationItem] we won't be able to observe changes in conversation details (e.g. name changing).
+                // So we need to find ConversationItem in the State by id and use it for BottomSheet content.
+                val item: ConversationItem? = viewModel.conversationListState.findConversationById(conversationItem.conversationId)
+
                 val conversationState = rememberConversationSheetState(
-                    conversationItem = conversationItem,
+                    conversationItem = item ?: conversationItem,
                     conversationOptionNavigation = conversationOptionNavigation
                 )
                 // if we reopen the BottomSheet of the previous conversation for example:
@@ -97,25 +101,25 @@ fun ConversationRouterHomeBridge(
                     }
                 }
 
-            ConversationSheetContent(
-                conversationSheetState = conversationState,
-                onMutingConversationStatusChange = {
-                    viewModel.muteConversation(
-                        conversationId = conversationState.conversationId,
-                        mutedConversationStatus = conversationState.conversationSheetContent!!.mutingConversationState
-                    )
-                },
-                addConversationToFavourites = viewModel::addConversationToFavourites,
-                moveConversationToFolder = viewModel::moveConversationToFolder,
-                moveConversationToArchive = viewModel::moveConversationToArchive,
-                clearConversationContent = viewModel::clearConversationContent,
-                blockUser = blockUserDialogState::show,
-                unblockUser = unblockUserDialogState::show,
-                leaveGroup = leaveGroupDialogState::show,
-                deleteGroup = deleteGroupDialogState::show,
-                isBottomSheetVisible = isBottomSheetVisible
-            )
-        }
+                ConversationSheetContent(
+                    conversationSheetState = conversationState,
+                    onMutingConversationStatusChange = {
+                        viewModel.muteConversation(
+                            conversationId = conversationState.conversationId,
+                            mutedConversationStatus = conversationState.conversationSheetContent!!.mutingConversationState
+                        )
+                    },
+                    addConversationToFavourites = viewModel::addConversationToFavourites,
+                    moveConversationToFolder = viewModel::moveConversationToFolder,
+                    moveConversationToArchive = viewModel::moveConversationToArchive,
+                    clearConversationContent = viewModel::clearConversationContent,
+                    blockUser = blockUserDialogState::show,
+                    unblockUser = unblockUserDialogState::show,
+                    leaveGroup = leaveGroupDialogState::show,
+                    deleteGroup = deleteGroupDialogState::show,
+                    isBottomSheetVisible = isBottomSheetVisible
+                )
+            }
 
             onOpenBottomSheet()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -119,6 +119,7 @@ fun ConversationRouterHomeBridge(
                     unblockUser = unblockUserDialogState::show,
                     leaveGroup = leaveGroupDialogState::show,
                     deleteGroup = deleteGroupDialogState::show,
+                    closeBottomSheet = onCloseBottomSheet,
                     isBottomSheetVisible = isBottomSheetVisible
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -64,8 +64,8 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.userprofile.common.EditableState
 import com.wire.android.ui.userprofile.common.UserProfileInfo
 import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
+import com.wire.android.ui.userprofile.other.bottomsheet.OtherUserBottomSheetState
 import com.wire.android.ui.userprofile.other.bottomsheet.OtherUserProfileBottomSheetContent
-import com.wire.android.ui.userprofile.other.bottomsheet.rememberOtherUserProfileSheetState
 import com.wire.kalium.logic.data.user.ConnectionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -134,7 +134,8 @@ fun OtherProfileScreenContent(
     val unblockUserDialogState = rememberVisibilityState<UnblockUserDialogState>()
     val removeMemberDialogState = rememberVisibilityState<RemoveConversationMemberState>()
     val getBottomSheetVisibility: () -> Boolean = remember(sheetState) { { sheetState.isVisible } }
-    val bottomSheetState = rememberOtherUserProfileSheetState(state.conversationSheetContent, state.groupState)
+    val bottomSheetState = remember { OtherUserBottomSheetState() }
+    bottomSheetState.setContents(state.conversationSheetContent, state.groupState)
     val openConversationBottomSheet: () -> Unit = remember(bottomSheetState) {
         {
             bottomSheetState.toConversation()

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserBottomSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserBottomSheetState.kt
@@ -1,26 +1,31 @@
 package com.wire.android.ui.userprofile.other.bottomsheet
 
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetContent
 import com.wire.android.ui.userprofile.other.OtherUserProfileGroupState
-import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 
-class OtherUserBottomSheetState(
-    private val groupState: OtherUserProfileGroupState? = null,
-    conversationSheetContent: ConversationSheetContent? = null,
-) {
+class OtherUserBottomSheetState {
 
-    private var conversationSheetContent: ConversationSheetContent? by mutableStateOf(conversationSheetContent)
+    private var conversationSheetContent: ConversationSheetContent? by mutableStateOf(null)
+    private var groupState: OtherUserProfileGroupState? by mutableStateOf(null)
     var bottomSheetContentState: BottomSheetContent? by mutableStateOf(null)
 
     fun toConversation() = conversationSheetContent?.let { bottomSheetContentState = BottomSheetContent.Conversation(it) }
 
-    fun muteConversation(mutedConversationStatus: MutedConversationStatus) {
-        conversationSheetContent = conversationSheetContent?.copy(mutingConversationState = mutedConversationStatus)
+    fun setContents(conversationSheetContent: ConversationSheetContent?, groupState: OtherUserProfileGroupState?) {
+        this.conversationSheetContent = conversationSheetContent
+        this.groupState = groupState
+        updateBottomSheetContentIfNeeded()
+    }
+
+    private fun updateBottomSheetContentIfNeeded() {
+        when (bottomSheetContentState) {
+            is BottomSheetContent.Conversation -> toConversation()
+            is BottomSheetContent.ChangeRole -> toChangeRole()
+            null -> {}
+        }
     }
 
     fun toChangeRole() = groupState?.let { bottomSheetContentState = BottomSheetContent.ChangeRole(it) }
@@ -34,22 +39,4 @@ class OtherUserBottomSheetState(
 sealed class BottomSheetContent {
     data class Conversation(val conversationData: ConversationSheetContent) : BottomSheetContent()
     data class ChangeRole(val groupState: OtherUserProfileGroupState) : BottomSheetContent()
-}
-
-@Composable
-fun rememberOtherUserProfileSheetState(
-    conversationSheetContent: ConversationSheetContent?,
-    groupState: OtherUserProfileGroupState?
-): OtherUserBottomSheetState {
-    // MutedConversationStatus may be changed and it will cause re-composing the whole BottomSheet, which we don't want.
-    // So we use always the same MutedConversationStatus in remembering-key
-    val ignoreMutedConversationStatusKey =
-        conversationSheetContent?.copy(mutingConversationState = MutedConversationStatus.AllMuted)
-
-    return remember(ignoreMutedConversationStatusKey, groupState) {
-        OtherUserBottomSheetState(
-            conversationSheetContent = conversationSheetContent,
-            groupState = groupState
-        )
-    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserProfileBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserProfileBottomSheet.kt
@@ -28,7 +28,6 @@ fun OtherUserProfileBottomSheetContent(
                         conversationSheetState.conversationId,
                         mutedConversationStatus
                     )
-                    bottomSheetState.muteConversation(mutedConversationStatus)
                 },
                 addConversationToFavourites = eventsHandler::onAddConversationToFavourites,
                 moveConversationToFolder = eventsHandler::onMoveConversationToFolder,

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -195,7 +195,7 @@ internal class OtherUserProfileViewModelArrangement {
     }
 
     fun withGetConversationDetails(result: GetOneToOneConversationUseCase.Result) = apply {
-        coEvery { getConversationUseCase(any()) } returns result
+        coEvery { getConversationUseCase(any()) } returns flowOf(result)
     }
 
     fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2491" title="AR-2491" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2491</a>  Handle incremental update users events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Conversation name was not updating in context menu (while it's opened) when the name was changed

### Causes (Optional)

The whole conversation data was fetching once and wasn't observed for that menu.

### Solutions

- Make ConversationData Observable (changes in `kalium`)
- add the ability to update that data in bottomSheet menus 

### Dependencies (Optional)

Waiting for [kalium changes](https://github.com/wireapp/kalium/pull/1136) be merged

### Attachments (Optional)


https://user-images.githubusercontent.com/6539347/202487336-41da8dac-9ab7-4174-8cb0-daf60239ba6e.mp4

