### PR TITLE
chore: remove .debug suffix form dev builds [DO NOT MERGE]

### DIFF
--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -59,7 +59,7 @@ android {
     buildTypes {
         getByName(BuildTypes.DEBUG) {
             isMinifyEnabled = false
-            applicationIdSuffix = ".${BuildTypes.DEBUG}"
+//            applicationIdSuffix = ".${BuildTypes.DEBUG}"
             isDebuggable = true
             // Just in case a developer is trying to debug some prod crashes by turning on minify
             if (isMinifyEnabled) proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

app package name have a .debug suffix which is effecting automation written for testing scala app migration 

this change ill only effect dev build 
