### PR TITLE
fix: various issues with Android 13 and permissions [AR-2735]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,14 +6,16 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- needed to switch between speaker/earpiece -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+            android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import com.wire.android.ui.common.topappbar.search.SearchTopBar
 import com.wire.android.ui.home.conversationslist.ConversationListState
 import com.wire.android.ui.home.conversationslist.ConversationListViewModel
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
+import com.wire.android.util.permission.rememberRequestPushNotificationsPermissionFlow
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 
@@ -69,9 +70,12 @@ fun HomeScreen(
     homeViewModel.checkRequirements()
 
     val homeScreenState = rememberHomeScreenState()
+    val showNotificationsFlow = rememberRequestPushNotificationsPermissionFlow(
+        onPermissionDenied = { /** TODO: Show a dialog rationale explaining why the permission is needed **/ })
 
     LaunchedEffect(homeViewModel.savedStateHandle) {
         homeViewModel.checkPendingSnackbarState()?.let(homeScreenState::setSnackBarState)
+        showNotificationsFlow.launch()
     }
 
     handleSnackBarMessage(

--- a/app/src/main/kotlin/com/wire/android/util/permission/RequestPushNotificationsPermissionFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/RequestPushNotificationsPermissionFlow.kt
@@ -1,0 +1,39 @@
+package com.wire.android.util.permission
+
+import android.content.Context
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.wire.android.util.extension.checkPermission
+
+class RequestPushNotificationsPermissionFlow(
+    private val context: Context,
+    private val notificationPermissionLauncher: ManagedActivityResultLauncher<String, Boolean>
+) {
+
+    fun launch() {
+        if (!context.checkPermission(android.Manifest.permission.POST_NOTIFICATIONS)) {
+            notificationPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+}
+
+@Composable
+fun rememberRequestPushNotificationsPermissionFlow(
+    onPermissionDenied: () -> Unit,
+): RequestPushNotificationsPermissionFlow {
+    val context = LocalContext.current
+
+    val requestPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (!isGranted) { onPermissionDenied() }
+    }
+
+    return remember {
+        RequestPushNotificationsPermissionFlow(context, requestPermissionLauncher)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/permission/UseStorageRequestFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/UseStorageRequestFlow.kt
@@ -1,7 +1,9 @@
 package com.wire.android.util.permission
 
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import androidx.activity.compose.ManagedActivityResultLauncher
 import com.wire.android.util.extension.checkPermission
 
@@ -12,10 +14,14 @@ class UseStorageRequestFlow(
     private val accessFilePermissionLauncher: ManagedActivityResultLauncher<String, Boolean>
 ) {
     fun launch() {
-        if (context.checkPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            browseStorageActivityLauncher.launch(mimeType)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (context.checkPermission(READ_EXTERNAL_STORAGE)) {
+                browseStorageActivityLauncher.launch(mimeType)
+            } else {
+                accessFilePermissionLauncher.launch(READ_EXTERNAL_STORAGE)
+            }
         } else {
-            accessFilePermissionLauncher.launch(android.Manifest.permission.READ_EXTERNAL_STORAGE)
+            browseStorageActivityLauncher.launch(mimeType)
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2735" title="AR-2735" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2735</a>  Permission dialogs on Android 13
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
After bumping our app's target API to Android 13, it caused some side effects. Namely:
1. Starting from Tiramisu version, `READ_EXTERNAL_STORAGE` permission got deprecated and it is not needed to be requested unless user wants to read other image, video or audio that has actually been created and only owned by other apps. For now, we are fine since all these images are already owned by the default us.
2. After targetting Tiramisue version, now the permission to show android notifications must be requested in the same way that other permissions. 


### Solutions

Adapted to Android 13 new permission requirements.


#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Start the app and make sure that images and files can be shared, and that android push notifications are actually arriving to the device.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
