### PR TITLE
feat: welcome to new android (AR-2118)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -21,6 +21,7 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
 
         // keys
         private val MIGRATION_COMPLETED = booleanPreferencesKey("migration_completed")
+        private val WELCOME_SCREEN_PRESENTED = booleanPreferencesKey("welcome_screen_presented")
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
     }
 
@@ -28,12 +29,25 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         context.dataStore.edit { it.clear() }
     }
 
-    fun isMigrationCompletedFlow(): Flow<Boolean> = context.dataStore.data.map { it[MIGRATION_COMPLETED] ?: false }
+    private fun getBooleanPreference(key: Preferences.Key<Boolean>, defaultValue: Boolean): Flow<Boolean> =
+        context.dataStore.data.map { it[key] ?: defaultValue }
+
+    fun isMigrationCompletedFlow(): Flow<Boolean> = getBooleanPreference(MIGRATION_COMPLETED, false)
 
     suspend fun isMigrationCompleted(): Boolean = isMigrationCompletedFlow().firstOrNull() ?: false
 
 
     suspend fun setMigrationCompleted() {
         context.dataStore.edit { it[MIGRATION_COMPLETED] = true }
+    }
+
+    suspend fun isWelcomeScreenPresented(): Boolean = getBooleanPreference(WELCOME_SCREEN_PRESENTED, false).firstOrNull() ?: false
+
+    suspend fun setWelcomeScreenPresented() {
+        context.dataStore.edit { it[WELCOME_SCREEN_PRESENTED] = true }
+    }
+
+    suspend fun setWelcomeScreenNotPresented() {
+        context.dataStore.edit { it[WELCOME_SCREEN_PRESENTED] = false }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
-
 @Suppress("LongParameterList")
 @Singleton
 class MigrationManager @Inject constructor(
@@ -46,10 +45,16 @@ class MigrationManager @Inject constructor(
     suspend fun shouldMigrate(): Boolean = when {
         // already migrated
         globalDataStore.isMigrationCompleted() -> false
-        // not yet migrated and old DB is present
-        isScalaDBPresent() -> true
+        // not yet migrated and old DB is present and mark that we should present the welcome to new android dialog
+        isScalaDBPresent() -> {
+            globalDataStore.setWelcomeScreenNotPresented()
+            true
+        }
         // not yet migrated and no DB to migrate from - skip and set as migrated because it's not an update of the old app version
-        else -> globalDataStore.setMigrationCompleted().let { false }
+        else -> {
+            globalDataStore.setWelcomeScreenPresented()
+            globalDataStore.setMigrationCompleted().let { false }
+        }
     }
 
     fun isMigrationCompletedFlow(): Flow<Boolean> = globalDataStore.isMigrationCompletedFlow()

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -117,20 +117,20 @@ fun handleWelcomeNewUserDialog(
 ) {
     if (homeState.shouldDisplayWelcomeMessage) {
         WireDialog(
-            title = stringResource(id = R.string.team_settings_changed),
-            text = stringResource(id = R.string.welcome_footer_text),
+            title = stringResource(id = R.string.welcome_migration_dialog_title),
+            text = stringResource(id = R.string.welcome_migration_dialog_content),
             onDismiss = dismissDialog,
             optionButton1Properties = WireDialogButtonProperties(
                 onClick = {
                     dismissDialog.invoke()
                     CustomTabsHelper.launchUrl(context, "https://google.com")
                 },
-                text = stringResource(id = R.string.label_learn_more), // todo: change to learn more
+                text = stringResource(id = R.string.label_learn_more),
                 type = WireDialogButtonType.Primary,
             ),
             optionButton2Properties = WireDialogButtonProperties(
                 onClick = { /* todo: hide and persist flag */ },
-                text = stringResource(id = R.string.label_get_started), // todo: change to start using wire
+                text = stringResource(id = R.string.welcome_migration_dialog_continue),
                 type = WireDialogButtonType.Primary,
             )
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -116,6 +116,7 @@ fun handleWelcomeNewUserDialog(
     context: Context = LocalContext.current
 ) {
     if (homeState.shouldDisplayWelcomeMessage) {
+        val welcomeToNewAndroidUrl = stringResource(id = R.string.url_welcome_to_new_android)
         WireDialog(
             title = stringResource(id = R.string.welcome_migration_dialog_title),
             text = stringResource(id = R.string.welcome_migration_dialog_content),
@@ -123,7 +124,7 @@ fun handleWelcomeNewUserDialog(
             optionButton1Properties = WireDialogButtonProperties(
                 onClick = {
                     dismissDialog.invoke()
-                    CustomTabsHelper.launchUrl(context, "https://google.com")
+                    CustomTabsHelper.launchUrl(context, welcomeToNewAndroidUrl)
                 },
                 text = stringResource(id = R.string.label_learn_more),
                 type = WireDialogButtonType.Primary,

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -81,7 +81,54 @@ fun HomeScreen(
     )
 
     val featureFlagState = featureFlagNotificationViewModel.featureFlagState
+    val homeState = homeViewModel.homeState
 
+    handleWelcomeNewUserDialog(homeState, homeViewModel)
+    handleFeatureFlagChangedNotification(featureFlagState, featureFlagNotificationViewModel)
+
+    HomeContent(
+        connectivityState = commonTopAppBarViewModel.connectivityState,
+        homeState = homeState,
+        homeStateHolder = homeScreenState,
+        conversationListState = conversationListViewModel.conversationListState,
+        onReturnToCallClick = commonTopAppBarViewModel::openOngoingCallScreen,
+        onNewConversationClick = conversationListViewModel::openNewConversation,
+        onSelfUserClick = homeViewModel::navigateToSelfUserProfile,
+        navigateToItem = homeViewModel::navigateTo
+    )
+
+    BackHandler(homeScreenState.searchBarState.isSearchActive) {
+        homeScreenState.searchBarState.closeSearch()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun handleWelcomeNewUserDialog(homeState: HomeState, homeViewModel: HomeViewModel) {
+    if (homeState.shouldDisplayWelcomeMessage) {
+        WireDialog(
+            title = stringResource(id = R.string.team_settings_changed),
+            text = stringResource(id = R.string.welcome_footer_text),
+            onDismiss = homeViewModel::dismissDialog,
+            optionButton1Properties = WireDialogButtonProperties(
+                onClick = { homeViewModel.navigateTo(NavigationItem.Support) },
+                text = stringResource(id = R.string.label_learn_more), // todo: change to learn more
+                type = WireDialogButtonType.Primary,
+            ),
+            optionButton2Properties = WireDialogButtonProperties(
+                onClick = { /* todo: hide and persist flag */ },
+                text = stringResource(id = R.string.label_get_started), // todo: change to start using wire
+                type = WireDialogButtonType.Primary,
+            )
+        )
+    }
+}
+
+@Composable
+private fun handleFeatureFlagChangedNotification(
+    featureFlagState: FeatureFlagState,
+    featureFlagNotificationViewModel: FeatureFlagNotificationViewModel
+) {
     if (featureFlagState.showFileSharingDialog) {
         val text: String = if (featureFlagState.isFileSharingEnabledState) {
             stringResource(id = R.string.sharing_files_enabled)
@@ -99,21 +146,6 @@ fun HomeScreen(
                 type = WireDialogButtonType.Primary,
             )
         )
-    }
-
-    HomeContent(
-        connectivityState = commonTopAppBarViewModel.connectivityState,
-        homeState = homeViewModel.homeState,
-        homeStateHolder = homeScreenState,
-        conversationListState = conversationListViewModel.conversationListState,
-        onReturnToCallClick = commonTopAppBarViewModel::openOngoingCallScreen,
-        onNewConversationClick = conversationListViewModel::openNewConversation,
-        onSelfUserClick = homeViewModel::navigateToSelfUserProfile,
-        navigateToItem = homeViewModel::navigateTo
-    )
-
-    BackHandler(homeScreenState.searchBarState.isSearchActive) {
-        homeScreenState.searchBarState.closeSearch()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -70,9 +70,15 @@ class HomeViewModel @Inject constructor(
                     )
                     return@launch
                 }
+                isFirstInstall() -> {
+                    homeState = homeState.copy(shouldDisplayWelcomeMessage = true)
+                }
             }
         }
     }
+
+    // todo: change this for a use case with persistence on shared pref.
+    private fun isFirstInstall() = true
 
     fun checkPendingSnackbarState(): HomeSnackbarState? {
         return with(savedStateHandle) {
@@ -97,6 +103,11 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun dismissDialog() {
+        // todo: this should be performed to persist the flag on shared pref to false
+        homeState = homeState.copy(shouldDisplayWelcomeMessage = false)
+    }
+
     fun navigateTo(item: NavigationItem) {
         viewModelScope.launch {
             navigationManager.navigate(NavigationCommand(destination = item.getRouteWithArgs()))
@@ -109,7 +120,8 @@ class HomeViewModel @Inject constructor(
 data class HomeState(
     val avatarAsset: UserAvatarAsset? = null,
     val status: UserAvailabilityStatus = UserAvailabilityStatus.NONE,
-    val logFilePath: String
+    val logFilePath: String,
+    val shouldDisplayWelcomeMessage: Boolean = false,
 )
 
 // TODO change to extend [SnackBarMessage]

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -103,7 +103,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun dismissDialog() {
+    fun dismissWelcomeMessage() {
         // todo: this should be performed to persist the flag on shared pref to false
         homeState = homeState.copy(shouldDisplayWelcomeMessage = false)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="content_description_more_emojis">More emojis</string>
     <!-- Non translatable strings-->
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>
+    <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/en-us/articles/6655706999581-What-s-new-on-Android-</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,10 @@
     <string name="welcome_button_create_team">Create a Team</string>
     <string name="server_details_dialog_body">Backend name:\n%1$s\n\nBackend URL:\n%2$s</string>
     <string name="server_details_dialog_title">On-premises Backend</string>
+    <string name="welcome_migration_dialog_title">Welcome To Our New Android App 👋</string>
+    <string name="welcome_migration_dialog_content">We rebuilt the app to make it more usable for everyone.\n\nFind out more about Wire’s redesigned app—new options and improved accessibility, with the same strong security.</string>
+    <string name="welcome_migration_dialog_continue">Start Using Wire</string>
+
     <!-- API Versioning Dialogs -->
     <string name="api_versioning_client_update_required_title">Update required</string>
     <string name="api_versioning_client_update_required_message">You are missing out on new features. Update to the latest version of Wire to continue using the app with this account.</string>

--- a/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
@@ -26,29 +26,33 @@ class MigrationManagerTest {
 
     @Test
     fun givenDBFileExistsAndMigrationCompleted_whenCheckingWhetherToMigrate_thenReturnFalse() = runTest {
-        val (_, manager) = Arrangement()
+        val (arrangement, manager) = Arrangement()
             .withDBFileExists(true)
             .withMigrationCompleted(true)
             .arrange()
         assert(!manager.shouldMigrate())
+        coVerify(exactly = 0) { arrangement.globalDataStore.setWelcomeScreenPresented() }
     }
 
     @Test
     fun givenDBFileNotExistsAndMigrationCompleted_whenCheckingWhetherToMigrate_thenReturnFalse() = runTest {
-        val (_, manager) = Arrangement()
+        val (arrangement, manager) = Arrangement()
             .withDBFileExists(false)
             .withMigrationCompleted(true)
             .arrange()
         assert(!manager.shouldMigrate())
+        coVerify(exactly = 0) { arrangement.globalDataStore.setWelcomeScreenPresented() }
     }
 
     @Test
     fun givenDBFileExistsAndMigrationNotCompleted_whenCheckingWhetherToMigrate_thenReturnTrue() = runTest {
-        val (_, manager) = Arrangement()
+        val (arrangement, manager) = Arrangement()
             .withDBFileExists(true)
             .withMigrationCompleted(false)
             .arrange()
+
         assert(manager.shouldMigrate())
+        coVerify(exactly = 1) { arrangement.globalDataStore.setWelcomeScreenNotPresented() }
     }
 
     @Test
@@ -58,7 +62,10 @@ class MigrationManagerTest {
             .withMigrationCompleted(false)
             .arrange()
         assert(!manager.shouldMigrate())
-        coVerify(exactly = 1) { arrangement.globalDataStore.setMigrationCompleted() }
+        coVerify(exactly = 1) {
+            arrangement.globalDataStore.setWelcomeScreenPresented()
+            arrangement.globalDataStore.setMigrationCompleted()
+        }
     }
 
     private class Arrangement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2118" title="AR-2118" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2118</a>  Welcome to New Android - information to users when they just installed it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After run a migration, we want to display for old users a brief information (only once) about what's new in the new version.

### Causes (Optional)

Displays a dialog only once after run the migration process.

### Solutions

Creates a flag, that will be read on first open, to identify if we need to display the info dialog or not to a migrated users.
For example, new users will not have this info.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Install the Scala app, then install on top the new version and see the dialog displayed.

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/203037969-eb44e254-abb3-4c97-95db-be21da38d42d.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
