### PR TITLE
feat: Message Details Reactions Empty State

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -267,6 +267,11 @@ enum class NavigationItem(
         }
     },
 
+    MessageDetailsReactionsLearnMore(
+        primaryRoute = MESSAGE_DETAILS_REACTIONS_LEARN_MORE_URL,
+        content = { },
+    ),
+
     GroupConversationDetails(
         primaryRoute = GROUP_CONVERSATION_DETAILS,
         canonicalRoute = "$GROUP_CONVERSATION_DETAILS/{$EXTRA_CONVERSATION_ID}",
@@ -453,3 +458,5 @@ enum class ScreenMode {
     WAKE_UP, // wake up the device on navigating to that NavigationItem (i.e IncomingCall)
     NONE // do not wake up and allow device to sleep
 }
+
+private const val MESSAGE_DETAILS_REACTIONS_LEARN_MORE_URL = "https://support.wire.com/hc/en-us/articles/212053645-Like-a-message"

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -267,11 +267,6 @@ enum class NavigationItem(
         }
     },
 
-    MessageDetailsReactionsLearnMore(
-        primaryRoute = MESSAGE_DETAILS_REACTIONS_LEARN_MORE_URL,
-        content = { },
-    ),
-
     GroupConversationDetails(
         primaryRoute = GROUP_CONVERSATION_DETAILS,
         canonicalRoute = "$GROUP_CONVERSATION_DETAILS/{$EXTRA_CONVERSATION_ID}",
@@ -458,5 +453,3 @@ enum class ScreenMode {
     WAKE_UP, // wake up the device on navigating to that NavigationItem (i.e IncomingCall)
     NONE // do not wake up and allow device to sleep
 }
-
-private const val MESSAGE_DETAILS_REACTIONS_LEARN_MORE_URL = "https://support.wire.com/hc/en-us/articles/212053645-Like-a-message"

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
@@ -1,31 +1,86 @@
 package com.wire.android.ui.home.conversations.messagedetails
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.details.participants.folderWithElements
 
 @Composable
 fun MessageDetailsReactions(
     messageDetailsState: MessageDetailsState,
-    lazyListState: LazyListState = rememberLazyListState()
+    lazyListState: LazyListState = rememberLazyListState(),
+    onReactionsLearnMore: () -> Unit
 ) {
     Column {
-        LazyColumn(
-            state = lazyListState,
-            modifier = Modifier.weight(weight = 1f, fill = true)
-        ) {
-            messageDetailsState.reactionsData.reactions.forEach {
-                folderWithElements(
-                    header = "${it.key} ${it.value.size}",
-                    items = it.value,
-                    onRowItemClicked = { },
-                    showRightArrow = false
+        if (messageDetailsState.reactionsData.reactions.isEmpty()) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .weight(weight = 1f, fill = true)
+                    .align(Alignment.CenterHorizontally)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.message_details_reactions_empty_text),
+                    textAlign = TextAlign.Center
                 )
+                val learnMoreText = stringResource(id = R.string.message_details_reactions_empty_learn_more)
+                val learnMore = buildAnnotatedString {
+                    append(learnMoreText)
+                    addStyle(
+                        style = SpanStyle(
+                            color = Color.Blue,
+                            textDecoration = TextDecoration.Underline
+                        ),
+                        start = 0,
+                        end = learnMoreText.length
+                    )
+                }
+                ClickableText(
+                    text = learnMore,
+                    modifier = Modifier.padding(top = dimensions().spacing48x),
+                    onClick = { onReactionsLearnMore() }
+                )
+            }
+        } else {
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.weight(weight = 1f, fill = true)
+            ) {
+                messageDetailsState.reactionsData.reactions.forEach {
+                    folderWithElements(
+                        header = "${it.key} ${it.value.size}",
+                        items = it.value,
+                        onRowItemClicked = { },
+                        showRightArrow = false
+                    )
+                }
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MessageDetailsReactionsPreview() {
+    MessageDetailsReactions(
+        messageDetailsState = MessageDetailsState(),
+        onReactionsLearnMore = {}
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -34,6 +35,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
 import com.wire.android.R
+import com.wire.android.navigation.NavigationItem
 import com.wire.android.ui.common.TabItem
 import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
@@ -43,13 +45,25 @@ import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.CustomTabsHelper
 import kotlinx.coroutines.launch
 
 @Composable
 fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
+    val context = LocalContext.current
+    val onReactionsLearnMore = remember {
+        {
+            CustomTabsHelper.launchUrl(
+                context,
+                NavigationItem.MessageDetailsReactionsLearnMore.getRouteWithArgs()
+            )
+        }
+    }
+
     MessageDetailsScreenContent(
         messageDetailsState = viewModel.messageDetailsState,
-        onBackPressed = viewModel::navigateBack
+        onBackPressed = viewModel::navigateBack,
+        onReactionsLearnMore = onReactionsLearnMore
     )
 }
 
@@ -63,7 +77,8 @@ fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
 @Composable
 private fun MessageDetailsScreenContent(
     messageDetailsState: MessageDetailsState,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    onReactionsLearnMore: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val lazyListStates: List<LazyListState> = MessageDetailsTab.values().map { rememberLazyListState() }
@@ -81,6 +96,10 @@ private fun MessageDetailsScreenContent(
         coroutineScope = rememberCoroutineScope(),
         sheetContent = {}
     ) {
+        val tabItems = provideMessageDetailsTabItems(
+            messageDetailsState = messageDetailsState,
+            isSelfMessage = messageDetailsState.isSelfMessage
+        )
         Scaffold(
             topBar = {
                 WireCenterAlignedTopAppBar(
@@ -90,10 +109,7 @@ private fun MessageDetailsScreenContent(
                     onNavigationPressed = onBackPressed
                 ) {
                     WireTabRow(
-                        tabs = provideMessageDetailsTabItems(
-                            messageDetailsState = messageDetailsState,
-                            isSelfMessage = messageDetailsState.isSelfMessage
-                        ),
+                        tabs = tabItems,
                         selectedTabIndex = currentTabState,
                         onTabChange = { scope.launch { pagerState.animateScrollToPage(it) } },
                         modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing16x),
@@ -116,7 +132,7 @@ private fun MessageDetailsScreenContent(
             CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
                 HorizontalPager(
                     state = pagerState,
-                    count = MessageDetailsTab.values().size,
+                    count = tabItems.size,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(internalPadding)
@@ -124,7 +140,8 @@ private fun MessageDetailsScreenContent(
                     when (MessageDetailsTab.values()[pageIndex]) {
                         MessageDetailsTab.REACTIONS -> MessageDetailsReactions(
                             messageDetailsState = messageDetailsState,
-                            lazyListState = lazyListStates[pageIndex]
+                            lazyListState = lazyListStates[pageIndex],
+                            onReactionsLearnMore = onReactionsLearnMore
                         )
                         MessageDetailsTab.READ_RECEIPTS -> {
                             // Not implemented yet.

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -35,7 +35,6 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
 import com.wire.android.R
-import com.wire.android.navigation.NavigationItem
 import com.wire.android.ui.common.TabItem
 import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -51,11 +51,13 @@ import kotlinx.coroutines.launch
 @Composable
 fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
     val context = LocalContext.current
+
+    val reactionsLearnMoreUrl = stringResource(id = R.string.url_message_details_reactions_learn_more)
     val onReactionsLearnMore = remember {
         {
             CustomTabsHelper.launchUrl(
                 context,
-                NavigationItem.MessageDetailsReactionsLearnMore.getRouteWithArgs()
+                reactionsLearnMoreUrl
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <!-- Non translatable strings-->
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>
     <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/en-us/articles/6655706999581-What-s-new-on-Android-</string>
+    <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/212053645-Like-a-message</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,8 @@
     <string name="message_details_title">Message Details</string>
     <string name="message_details_reactions_tab">REACTIONS (%s)</string>
     <string name="message_details_read_receipts_tab">READ RECEIPTS (%s)</string>
+    <string name="message_details_reactions_empty_text">No one reacted on this message yet 😱</string>
+    <string name="message_details_reactions_empty_learn_more">Learn more about reactions</string>
 
     <!-- Attachment options -->
     <string name="attachment_share_file">Attach File</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2741 - Show empty state for Reactions in Message Details](https://wearezeta.atlassian.net/browse/AR-2741)

### Issues

MessageDetails reactions tab didn't have an empty state.

### Causes (Optional)

It wasn't implemented.

### Solutions

Add empty state

#### How to Test

- Open App
- Open Conversation Screen
- Long click on a message and select Message Details (message must not have a reaction)
- Empty State should be shown


### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5890660/203337167-b45a1a5d-2495-4981-b9ac-f6be805eaa8f.png" width="200" height="400" alt="Message Details Screen showing reactions empty state" />

