### PR TITLE
feat: read receipts empty screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsEmptyScreenText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsEmptyScreenText.kt
@@ -1,0 +1,56 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun MessageDetailsEmptyScreenText(
+    onClick: () -> Unit,
+    modifier: Modifier,
+    text: String,
+    learnMoreText: String
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+    ) {
+        Text(
+            text = text,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.wireTypography.body01
+        )
+        val learnMore = buildAnnotatedString {
+            append(learnMoreText)
+            addStyle(
+                style = SpanStyle(
+                    color = Color.Blue,
+                    textDecoration = TextDecoration.Underline
+                ),
+                start = 0,
+                end = learnMoreText.length
+            )
+        }
+        ClickableText(
+            text = learnMore,
+            modifier = Modifier.padding(top = dimensions().spacing48x),
+            onClick = { onClick() },
+            style = MaterialTheme.wireTypography.body02.copy(
+                textDecoration = TextDecoration.Underline,
+                color = MaterialTheme.colorScheme.primary
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
@@ -1,69 +1,40 @@
 package com.wire.android.ui.home.conversations.messagedetails
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.text.ClickableText
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.details.participants.folderWithElements
+import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
 
 @Composable
 fun MessageDetailsReactions(
-    messageDetailsState: MessageDetailsState,
+    reactionsData: MessageDetailsReactionsData,
     lazyListState: LazyListState = rememberLazyListState(),
     onReactionsLearnMore: () -> Unit
 ) {
     Column {
-        if (messageDetailsState.reactionsData.reactions.isEmpty()) {
-            Box(
-                contentAlignment = Alignment.Center,
+        if (reactionsData.reactions.isEmpty()) {
+            MessageDetailsEmptyScreenText(
+                onClick = onReactionsLearnMore,
                 modifier = Modifier
                     .weight(weight = 1f, fill = true)
-                    .align(Alignment.CenterHorizontally)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.message_details_reactions_empty_text),
-                    textAlign = TextAlign.Center
-                )
-                val learnMoreText = stringResource(id = R.string.message_details_reactions_empty_learn_more)
-                val learnMore = buildAnnotatedString {
-                    append(learnMoreText)
-                    addStyle(
-                        style = SpanStyle(
-                            color = Color.Blue,
-                            textDecoration = TextDecoration.Underline
-                        ),
-                        start = 0,
-                        end = learnMoreText.length
-                    )
-                }
-                ClickableText(
-                    text = learnMore,
-                    modifier = Modifier.padding(top = dimensions().spacing48x),
-                    onClick = { onReactionsLearnMore() }
-                )
-            }
+                    .align(Alignment.CenterHorizontally),
+                text = stringResource(id = R.string.message_details_reactions_empty_text),
+                learnMoreText = stringResource(id = R.string.message_details_reactions_empty_learn_more)
+            )
         } else {
             LazyColumn(
                 state = lazyListState,
                 modifier = Modifier.weight(weight = 1f, fill = true)
             ) {
-                messageDetailsState.reactionsData.reactions.forEach {
+                reactionsData.reactions.forEach {
                     folderWithElements(
                         header = "${it.key} ${it.value.size}",
                         items = it.value,
@@ -80,7 +51,7 @@ fun MessageDetailsReactions(
 @Composable
 fun MessageDetailsReactionsPreview() {
     MessageDetailsReactions(
-        messageDetailsState = MessageDetailsState(),
+        reactionsData = MessageDetailsReactionsData(),
         onReactionsLearnMore = {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReadReceipts.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReadReceipts.kt
@@ -1,0 +1,55 @@
+package com.wire.android.ui.home.conversations.messagedetails
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.ui.home.conversations.details.participants.folderWithElements
+import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReadReceiptsData
+
+@Composable
+fun MessageDetailsReadReceipts(
+    readReceiptsData: MessageDetailsReadReceiptsData,
+    lazyListState: LazyListState = rememberLazyListState(),
+    onReadReceiptsLearnMore: () -> Unit
+) {
+    Column {
+        if (readReceiptsData.readReceipts.isEmpty()) {
+            MessageDetailsEmptyScreenText(
+                onClick = onReadReceiptsLearnMore,
+                modifier = Modifier
+                    .weight(weight = 1f, fill = true)
+                    .align(Alignment.CenterHorizontally),
+                text = stringResource(id = R.string.message_details_read_receipts_empty_text),
+                learnMoreText = stringResource(id = R.string.message_details_read_receipts_empty_learn_more)
+            )
+        } else {
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.weight(weight = 1f, fill = true)
+            ) {
+                folderWithElements(
+                    header = "", // TODO: double check what should go here
+                    items = readReceiptsData.readReceipts,
+                    onRowItemClicked = { },
+                    showRightArrow = false
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MessageDetailsReadReceiptsPreview() {
+    MessageDetailsReadReceipts(
+        readReceiptsData = MessageDetailsReadReceiptsData(),
+        onReadReceiptsLearnMore = {}
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -60,11 +60,22 @@ fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
             )
         }
     }
+    
+    val readReceiptsLearnMoreUrl = stringResource(id = R.string.url_message_details_read_receipts_learn_more)
+    val onReadReceiptsLearnMore = remember {
+        {
+            CustomTabsHelper.launchUrl(
+                context,
+                readReceiptsLearnMoreUrl
+            )
+        }
+    }
 
     MessageDetailsScreenContent(
         messageDetailsState = viewModel.messageDetailsState,
         onBackPressed = viewModel::navigateBack,
-        onReactionsLearnMore = onReactionsLearnMore
+        onReactionsLearnMore = onReactionsLearnMore,
+        onReadReceiptsLearnMore = onReadReceiptsLearnMore
     )
 }
 
@@ -79,7 +90,8 @@ fun MessageDetailsScreen(viewModel: MessageDetailsViewModel = hiltViewModel()) {
 private fun MessageDetailsScreenContent(
     messageDetailsState: MessageDetailsState,
     onBackPressed: () -> Unit,
-    onReactionsLearnMore: () -> Unit
+    onReactionsLearnMore: () -> Unit,
+    onReadReceiptsLearnMore: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val lazyListStates: List<LazyListState> = MessageDetailsTab.values().map { rememberLazyListState() }
@@ -140,13 +152,15 @@ private fun MessageDetailsScreenContent(
                 ) { pageIndex ->
                     when (MessageDetailsTab.values()[pageIndex]) {
                         MessageDetailsTab.REACTIONS -> MessageDetailsReactions(
-                            messageDetailsState = messageDetailsState,
+                            reactionsData = messageDetailsState.reactionsData,
                             lazyListState = lazyListStates[pageIndex],
                             onReactionsLearnMore = onReactionsLearnMore
                         )
-                        MessageDetailsTab.READ_RECEIPTS -> {
-                            // Not implemented yet.
-                        }
+                        MessageDetailsTab.READ_RECEIPTS -> MessageDetailsReadReceipts(
+                            readReceiptsData = messageDetailsState.readReceiptsData,
+                            lazyListState = lazyListStates[pageIndex],
+                            onReadReceiptsLearnMore = onReadReceiptsLearnMore
+                        )
                     }
                 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsState.kt
@@ -1,8 +1,10 @@
 package com.wire.android.ui.home.conversations.messagedetails
 
 import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReactionsData
+import com.wire.android.ui.home.conversations.messagedetails.model.MessageDetailsReadReceiptsData
 
 data class MessageDetailsState(
     val isSelfMessage: Boolean = false, // Default is false as Read Receipts is yet not implemented and we don't need to know it for now.
-    val reactionsData: MessageDetailsReactionsData = MessageDetailsReactionsData()
+    val reactionsData: MessageDetailsReactionsData = MessageDetailsReactionsData(),
+    val readReceiptsData: MessageDetailsReadReceiptsData = MessageDetailsReadReceiptsData()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/model/MessageDetailsReadReceiptsData.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/model/MessageDetailsReadReceiptsData.kt
@@ -1,0 +1,7 @@
+package com.wire.android.ui.home.conversations.messagedetails.model
+
+import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
+
+data class MessageDetailsReadReceiptsData(
+    val readReceipts: List<UIParticipant> = listOf()
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>
     <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/en-us/articles/6655706999581-What-s-new-on-Android-</string>
     <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/212053645-Like-a-message</string>
+    <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/360000665277-Activate-or-deactivate-read-receipts</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,8 @@
     <string name="message_details_read_receipts_tab">READ RECEIPTS (%s)</string>
     <string name="message_details_reactions_empty_text">No one reacted on this message yet 😱</string>
     <string name="message_details_reactions_empty_learn_more">Learn more about reactions</string>
+    <string name="message_details_read_receipts_empty_text">No one read this message yet 👀</string>
+    <string name="message_details_read_receipts_empty_learn_more">Learn more about read receipts</string>
 
     <!-- Attachment options -->
     <string name="attachment_share_file">Attach File</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2683 - Read Reactions empty screen](https://wearezeta.atlassian.net/browse/AR-2683)

### Issues

There was no empty screen when a message wasn't read yet.

### Causes (Optional)

Was not implemented.

### Solutions

Implement it.

### Testing

#### How to Test

- Change `isSelfMessage` to `true` in `MessageDetailsState.kt` for now
- Run App
- Select a Conversation / Long click a Message and go into Message Details
- Click on `READ RECEIPTS` tab
- should see the new empty screen

### Notes (Optional)

Data classes for Read Receipts are still in dummy mode, as soon as Vitor's changes takes place on Kalium we will then properly implement the list showing the participants who read the message and then fully implemented the needed data classes and values that will come from Kalium.

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5890660/203957681-82f4f24d-1414-4e7d-bbcf-526211cd77cc.png" width="200" height="400" alt="Message Details Screen showing an empty screen for Read Receipts with Text and Learn More URL" />