### PR TITLE
fix: adjust reply UI (AR-2484)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/spacers/VerticalSpace.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/spacers/VerticalSpace.kt
@@ -9,6 +9,11 @@ import com.wire.android.ui.common.dimensions
 object VerticalSpace {
 
     @Composable
+    fun x4() {
+        Spacer(Modifier.height(dimensions().spacing4x))
+    }
+
+    @Composable
     fun x8() {
         Spacer(Modifier.height(dimensions().spacing8x))
     }
@@ -22,7 +27,7 @@ object VerticalSpace {
     fun x24() {
         Spacer(Modifier.height(dimensions().spacing16x))
     }
-    
+
     @Composable
     fun x32() {
         Spacer(Modifier.height(dimensions().spacing32x))

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -34,6 +34,7 @@ import com.wire.android.ui.common.StatusBox
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.messages.QuotedMessage
 import com.wire.android.ui.home.conversations.messages.ReactionPill
 import com.wire.android.ui.home.conversations.model.MessageBody
@@ -257,7 +258,9 @@ private fun MessageContent(
 
         is UIMessageContent.TextMessage -> {
             messageContent.messageBody.quotedMessage?.let {
+                VerticalSpace.x4()
                 QuotedMessage(it)
+                VerticalSpace.x4()
             }
             MessageBody(
                 messageBody = messageContent.messageBody,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -61,6 +61,18 @@ fun EditMessageMenuItems(
                 )
             }
         }
+        add {
+            MenuBottomSheetItem(
+                icon = {
+                    MenuItemIcon(
+                        id = R.drawable.ic_reply,
+                        contentDescription = stringResource(R.string.content_description_reply_to_messge),
+                    )
+                },
+                title = stringResource(R.string.notification_action_reply),
+                onItemClick = onReply
+            )
+        }
         if (isEditable) {
             add {
                 MenuBottomSheetItem(
@@ -88,19 +100,6 @@ fun EditMessageMenuItems(
                 )
             }
         }
-        add {
-            MenuBottomSheetItem(
-                icon = {
-                    MenuItemIcon(
-                        id = R.drawable.ic_reply,
-                        contentDescription = stringResource(R.string.content_description_reply_to_messge),
-                    )
-                },
-                title = stringResource(R.string.notification_action_reply),
-                onItemClick = onReply
-            )
-        }
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -112,7 +112,10 @@ private fun QuotedMessageContent(
 
 @Composable
 private fun QuotedMessageTopRow(senderName: String?) {
-    Row(horizontalArrangement = Arrangement.spacedBy(dimensions().spacing2x)) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(dimensions().spacing2x),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_reply),
             tint = colorsScheme().secondaryText,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -112,11 +112,12 @@ private fun QuotedMessageContent(
 
 @Composable
 private fun QuotedMessageTopRow(senderName: String?) {
-    Row(horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(dimensions().spacing2x)) {
         Icon(
-            painter = painterResource(id = R.drawable.ic_event_badge_unread_reply),
+            painter = painterResource(id = R.drawable.ic_reply),
             tint = colorsScheme().secondaryText,
-            contentDescription = null
+            contentDescription = null,
+            modifier = Modifier.size(dimensions().messageQuoteIconSize)
         )
         senderName?.let {
             Text(text = senderName, style = typography().label02, color = colorsScheme().secondaryText)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.model.ImageAsset
@@ -33,6 +34,8 @@ import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.model.QuotedMessageUIData
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
+
+private const val TEXT_QUOTE_MAX_LINES = 7
 
 @Composable
 internal fun QuotedMessage(
@@ -203,7 +206,7 @@ private fun QuotedImage(
 
 @Composable
 private fun MainContentText(text: String) {
-    Text(text = text, style = typography().subline01)
+    Text(text = text, style = typography().subline01, maxLines = TEXT_QUOTE_MAX_LINES, overflow = TextOverflow.Ellipsis)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ReplyMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ReplyMessage.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.theme.wireTypography
 @Composable
 fun ReplyMessage(
     messageReplyType: MessageReplyType,
+    modifier: Modifier = Modifier,
     onCancelReply: () -> Unit
 ) {
     when (messageReplyType) {
@@ -42,6 +43,7 @@ fun ReplyMessage(
             ReplyContainer(
                 replyAuthor = messageReplyType.author,
                 replyBody = messageReplyType.assetName,
+                modifier = modifier,
                 onCancelReply = onCancelReply
             )
         }
@@ -50,6 +52,7 @@ fun ReplyMessage(
             ReplyContainer(
                 replyAuthor = messageReplyType.author,
                 replyBody = "Picture",
+                modifier = modifier,
                 replyIcon = {
                     Image(
                         painter = messageReplyType.imagePath!!.paint(),
@@ -70,6 +73,7 @@ fun ReplyMessage(
             ReplyContainer(
                 replyAuthor = messageReplyType.author,
                 replyBody = messageReplyType.textBody,
+                modifier = modifier,
                 onCancelReply = onCancelReply
             )
         }
@@ -80,13 +84,14 @@ fun ReplyMessage(
 private fun ReplyContainer(
     replyAuthor: String,
     replyBody: String,
+    modifier: Modifier = Modifier,
     replyIcon: @Composable (() -> Unit)? = null,
     onCancelReply: () -> Unit
 ) {
     Row(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .padding(8.dp)
             .wrapContentHeight()
             .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -279,12 +279,10 @@ private fun MessageComposer(
                                     messageComposerState = messageComposerState
                                 )
                                 if (messageReplyState != null) {
-                                    VerticalSpace.x4()
                                     ReplyMessage(
                                         messageReplyType = messageReplyState,
                                         onCancelReply = messageComposerState::cancelReply
                                     )
-                                    VerticalSpace.x4()
                                 }
                                 // Row wrapping the AdditionalOptionButton() when we are in Enabled state and MessageComposerInput()
                                 // when we are in the Fullscreen state, we want to align the TextField to Top of the Row,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -279,10 +279,12 @@ private fun MessageComposer(
                                     messageComposerState = messageComposerState
                                 )
                                 if (messageReplyState != null) {
+                                    VerticalSpace.x4()
                                     ReplyMessage(
                                         messageReplyType = messageReplyState,
                                         onCancelReply = messageComposerState::cancelReply
                                     )
+                                    VerticalSpace.x4()
                                 }
                                 // Row wrapping the AdditionalOptionButton() when we are in Enabled state and MessageComposerInput()
                                 // when we are in the Fullscreen state, we want to align the TextField to Top of the Row,

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -54,6 +54,7 @@ data class WireDimensions(
     val messageImageMaxWidth: Dp,
     val messageQuoteBorderWidth: Dp,
     val messageQuoteBorderRadius: Dp,
+    val messageQuoteIconSize: Dp,
     val messageAssetBorderRadius: Dp,
     // Message composer
     val messageComposerActiveInputMaxHeight: Dp,
@@ -201,6 +202,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     messageImageMaxWidth = 200.dp,
     messageQuoteBorderWidth = 1.dp,
     messageQuoteBorderRadius = 1.dp,
+    messageQuoteIconSize = 10.dp,
     messageAssetBorderRadius = 10.dp,
     messageComposerActiveInputMaxHeight = 168.dp,
     attachmentButtonSize = 40.dp,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2484" title="AR-2484" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2484</a>  Receive Replies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some margins were not respected compared with the original design files.

### Solutions

Add some missing margins/spacers and adjust the size of the Reply arrow.

### Attachments 

| Before | After |
| ----------- | ------------ |
|  <img src="https://user-images.githubusercontent.com/9389043/204300900-bd21a51b-5dff-4c4f-823f-ba410e19f9fc.png" width="500"/> | <img src="https://user-images.githubusercontent.com/9389043/204301047-981df5d7-0d72-42ca-84d6-2325a3ce654c.png" width="500"/> |

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
