### PR TITLE
fix: activating the inputfield works not as expected (AR-2720)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptionButton.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.home.messagecomposer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
@@ -13,4 +14,10 @@ fun AdditionalOptionButton(isSelected: Boolean = false, onClick: () -> Unit) {
         contentDescription = R.string.content_description_attachment_item,
         state = if (isSelected) WireButtonState.Selected else WireButtonState.Default,
     )
+}
+
+@Preview
+@Composable
+private fun AdditionalOptionButtonPreview() {
+    AdditionalOptionButton(isSelected = false, onClick = {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
@@ -18,10 +18,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 
 @ExperimentalAnimationApi
@@ -137,4 +140,23 @@ private fun PingAction() {
         iconResource = R.drawable.ic_ping,
         contentDescription = R.string.content_description_ping_everyone
     )
+}
+
+@Preview
+@Composable
+private fun MessageActionsBoxPreview() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(dimensions().spacing56x)
+    ) {
+        AdditionalOptionButton(isSelected = false, onClick = {})
+        RichTextEditingAction()
+        AddEmojiAction()
+        AddGifAction()
+        AddMentionAction(isSelected = false, addMentionAction = {})
+        PingAction()
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -158,11 +158,6 @@ private fun MessageComposer(
             targetState = messageComposerState.messageComposeInputState,
             label = stringResource(R.string.animation_label_messagecomposeinput_state_transistion)
         )
-
-        BackHandler(enabled = messageComposerState.attachmentOptionsDisplayed) {
-            messageComposerState.toggleAttachmentOptionsVisibility()
-        }
-
         // ConstraintLayout wrapping the whole content to give us the possibility to constrain SendButton to top of AdditionalOptions, which
         // constrains to bottom of MessageComposerInput
         // so that MessageComposerInput is the only component animating freely, when going to Fullscreen mode
@@ -307,7 +302,7 @@ private fun MessageComposer(
                     // changed which is applied only for
                     // MessageComposerInput and CollapsingButton
                     SendActions(
-                        Modifier.Companion.constrainAs(sendActions) {
+                        Modifier.constrainAs(sendActions) {
                             bottom.linkTo(additionalActions.top)
                             end.linkTo(parent.end)
                         },
@@ -318,7 +313,7 @@ private fun MessageComposer(
                     // Box wrapping MessageComposeActions() so that we can constrain it to the bottom of MessageComposerInput and after that
                     // constrain our SendActions to it
                     MessageComposeActionsBox(
-                        Modifier.Companion
+                        Modifier
                             .constrainAs(additionalActions) {
                                 top.linkTo(messageInput.bottom)
                                 bottom.linkTo(parent.bottom)
@@ -345,6 +340,10 @@ private fun MessageComposer(
                 )
             }
         }
+    }
+
+    BackHandler(enabled = messageComposerState.attachmentOptionsDisplayed) {
+        messageComposerState.toggleAttachmentOptionsVisibility()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -151,8 +151,15 @@ data class MessageComposerInnerState(
         }
     }
 
-    fun toActive() {
+    fun showAttachmentOptions() {
+        attachmentOptionsDisplayed = true
+    }
+
+    fun hideAttachmentOptions() {
         attachmentOptionsDisplayed = false
+    }
+
+    fun toActive() {
         messageComposeInputState = MessageComposeInputState.Active
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
@@ -67,7 +67,8 @@ fun ColumnScope.MessageComposerInputRow(
         ) {
             Box(modifier = Modifier.padding(start = dimensions().spacing8x)) {
                 AdditionalOptionButton(messageComposerState.attachmentOptionsDisplayed) {
-                    messageComposerState.toggleAttachmentOptionsVisibility()
+                    messageComposerState.toActive()
+                    messageComposerState.showAttachmentOptions()
                 }
             }
         }
@@ -82,6 +83,7 @@ fun ColumnScope.MessageComposerInputRow(
             messageComposerInputState = messageComposerState.messageComposeInputState,
             onIsFocused = {
                 messageComposerState.toActive()
+                messageComposerState.hideAttachmentOptions()
             },
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2720" title="AR-2720" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2720</a>  [Message composer] Activating the inputfield works not as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

**Current**

When tapping on the inactive inputfield in a conversation, the the current implementation is not following the design specs:

Tapping on the “plus” icon when the inputfield is not active, does not reveal the options bar below the inputfield.

When leaving the inputfield, so that the keyboard is not shown anymore, the options bar below the inputfield is still visible. 

**Expected**

Tapping on the “plus” icon when the inputfield is NOT active should reveal the options bar below the inputfield.

When leaving the inputfield, so that the keyboard is not shown anymore, it should return to its initial state (inactive), where the plus icon is shown to the left of the inputfied, in one line.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
