### PR TITLE
refactor: narrow down the subtype of Message when displaying items

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -43,7 +43,7 @@ class MessageMapper @Inject constructor(
         )
     }.distinct()
 
-    fun toUIMessages(userList: List<User>, messages: List<Message>): List<UIMessage> = messages.mapNotNull { message ->
+    fun toUIMessages(userList: List<User>, messages: List<Message.Standalone>): List<UIMessage> = messages.mapNotNull { message ->
         val sender = userList.findUser(message.senderUserId)
         val content = messageContentMapper.fromMessage(
             message = message,
@@ -99,7 +99,7 @@ class MessageMapper @Inject constructor(
 
     private fun isHeart(it: String) = it == "❤️" || it == "❤"
 
-    private fun provideMessageHeader(sender: User?, message: Message): MessageHeader = MessageHeader(
+    private fun provideMessageHeader(sender: User?, message: Message.Standalone): MessageHeader = MessageHeader(
         username = sender?.name?.let { UIText.DynamicString(it) }
             ?: UIText.StringResource(R.string.username_unavailable_label),
         membership = when (sender) {
@@ -118,7 +118,7 @@ class MessageMapper @Inject constructor(
         }
     )
 
-    private fun getMessageStatus(message: Message) = when {
+    private fun getMessageStatus(message: Message.Standalone) = when {
         message.status == Message.Status.FAILED -> MessageStatus.SendFailure
         message.visibility == Message.Visibility.DELETED -> MessageStatus.Deleted
         message is Message.Regular && message.editStatus is Message.EditStatus.Edited ->

--- a/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
@@ -261,17 +261,17 @@ class EncodedMessageContentMapperTest {
     }
 
     @Test
-    fun givenMessage_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
+    fun givenMessagesWithDifferentVisibilities_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
         // Given
         val (_, mapper) = Arrangement().arrange()
         val visibleMessage = TestMessage.TEXT_MESSAGE.copy(visibility = Message.Visibility.VISIBLE)
         val deletedMessage = TestMessage.TEXT_MESSAGE.copy(
             visibility = Message.Visibility.DELETED,
-            content = MessageContent.DeleteMessage("")
+            content = MessageContent.Text("")
         )
         val hiddenMessage = TestMessage.TEXT_MESSAGE.copy(
             visibility = Message.Visibility.HIDDEN,
-            content = MessageContent.DeleteMessage("")
+            content = MessageContent.Text("")
         )
         // When
         val resultContentVisible = mapper.fromMessage(visibleMessage, listOf())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Breaking changes from:
- https://github.com/wireapp/kalium/pull/1177
- https://github.com/wireapp/kalium/pull/1171

### Solutions

Fix them by bringing the `Standalone` type here.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/1177

### Testing

Compiler is our tester for this one.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
