### PR TITLE
fix: login/continue button is hidden under the keyboard [AR-1993]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.authentication.create.details
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -16,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -38,12 +40,14 @@ import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
+import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.textfield.clearAutofillTree
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -101,36 +105,48 @@ private fun DetailsContent(
         },
     ) { internalPadding ->
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top,
             modifier = Modifier
                 .padding(internalPadding)
                 .fillMaxHeight()
-                .verticalScroll(scrollState)
         ) {
-            Text(
-                text = stringResource(R.string.create_personal_account_details_text),
-                style = MaterialTheme.wireTypography.body01,
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        horizontal = MaterialTheme.wireDimensions.spacing16x,
-                        vertical = MaterialTheme.wireDimensions.spacing24x
+                    .weight(weight = 1f, fill = true)
+                    .verticalScroll(scrollState)
+            ) {
+                Text(
+                    text = stringResource(R.string.create_personal_account_details_text),
+                    style = MaterialTheme.wireTypography.body01,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = MaterialTheme.wireDimensions.spacing16x,
+                            vertical = MaterialTheme.wireDimensions.spacing24x
+                        )
+                )
+                NameTextFields(state, onFirstNameChange, onLastNameChange, onTeamNameChange, coroutineScope)
+                PasswordTextFields(state, onPasswordChange, onConfirmPasswordChange, coroutineScope)
+                Spacer(modifier = Modifier.weight(1f))
+
+            }
+
+            Surface(
+                shadowElevation = scrollState.rememberBottomBarElevationState().value,
+                color = MaterialTheme.wireColorScheme.background
+            ) {
+                Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
+                    WirePrimaryButton(
+                        text = stringResource(R.string.label_continue),
+                        onClick = onContinuePressed,
+                        fillMaxWidth = true,
+                        loading = state.loading,
+                        state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
+                        modifier = Modifier.fillMaxWidth()
                     )
-            )
-            NameTextFields(state, onFirstNameChange, onLastNameChange, onTeamNameChange, coroutineScope)
-            PasswordTextFields(state, onPasswordChange, onConfirmPasswordChange, coroutineScope)
-            Spacer(modifier = Modifier.weight(1f))
-            WirePrimaryButton(
-                text = stringResource(R.string.label_continue),
-                onClick = onContinuePressed,
-                fillMaxWidth = true,
-                loading = state.loading,
-                state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(MaterialTheme.wireDimensions.spacing16x),
-            )
+                }
+            }
         }
     }
     if (state.error is CreateAccountDetailsViewState.DetailsError.DialogError.GenericError)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -97,8 +97,7 @@ private fun LoginContent(
                     onTabChange = { scope.launch { pagerState.animateScrollToPage(it) } },
                     modifier = Modifier.padding(
                         start = MaterialTheme.wireDimensions.spacing16x,
-                        end = MaterialTheme.wireDimensions.spacing16x,
-                        top = MaterialTheme.wireDimensions.spacing16x
+                        end = MaterialTheme.wireDimensions.spacing16x
                     ),
                     divider = {} // no divider
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -15,6 +16,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -42,11 +44,13 @@ import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.textfield.AutoFillTextField
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.textfield.clearAutofillTree
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
@@ -94,59 +98,72 @@ private fun LoginEmailContent(
     Column(
         modifier = Modifier
             .fillMaxHeight()
-            .verticalScroll(scrollState)
-            .padding(MaterialTheme.wireDimensions.spacing16x)
     ) {
-        if (loginState.isProxyAuthRequired) {
-            Text(
-                text = stringResource(R.string.label_wire_credentials),
-                style = MaterialTheme.wireTypography.title03.copy(
-                    color = colorsScheme().labelText
-                ),
+
+        Column(
+            modifier = Modifier
+                .weight(weight = 1f, fill = true)
+                .verticalScroll(scrollState)
+                .padding(MaterialTheme.wireDimensions.spacing16x)
+        ) {
+            if (loginState.isProxyAuthRequired) {
+                Text(
+                    text = stringResource(R.string.label_wire_credentials),
+                    style = MaterialTheme.wireTypography.title03.copy(
+                        color = colorsScheme().labelText
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            vertical = MaterialTheme.wireDimensions.spacing16x
+                        )
+                )
+            }
+            UserIdentifierInput(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(
-                        vertical = MaterialTheme.wireDimensions.spacing16x
-                    )
+                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+                userIdentifier = loginState.userIdentifier,
+                onUserIdentifierChange = onUserIdentifierChange,
+                error = when (loginState.loginError) {
+                    LoginError.TextFieldError.InvalidValue -> stringResource(R.string.login_error_invalid_user_identifier)
+                    else -> null
+                }
             )
-        }
-        UserIdentifierInput(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-            userIdentifier = loginState.userIdentifier,
-            onUserIdentifierChange = onUserIdentifierChange,
-            error = when (loginState.loginError) {
-                LoginError.TextFieldError.InvalidValue -> stringResource(R.string.login_error_invalid_user_identifier)
-                else -> null
+            PasswordInput(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+                password = loginState.password,
+                onPasswordChange = onPasswordChange
+            )
+            ForgotPasswordLabel(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+                forgotPasswordUrl = forgotPasswordUrl
+            )
+            if (loginState.isProxyAuthRequired) {
+                ProxyScreen()
             }
-        )
-        PasswordInput(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-            password = loginState.password,
-            onPasswordChange = onPasswordChange
-        )
-        ForgotPasswordLabel(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-            forgotPasswordUrl = forgotPasswordUrl
-        )
-        if (loginState.isProxyAuthRequired) {
-            ProxyScreen()
+
+            Spacer(modifier = Modifier.weight(1f))
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
-        LoginButton(
-            modifier = Modifier.fillMaxWidth(),
-            loading = loginState.emailLoginLoading,
-            enabled = loginState.emailLoginEnabled
+        Surface(
+            shadowElevation = scrollState.rememberBottomBarElevationState().value,
+            color = MaterialTheme.wireColorScheme.background
         ) {
-            scope.launch {
-                onLoginButtonClick()
+            Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
+                LoginButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    loading = loginState.emailLoginLoading,
+                    enabled = loginState.emailLoginEnabled
+                ) {
+                    scope.launch {
+                        onLoginButtonClick()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1993" title="AR-1993" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1993</a>  Keyboard on login screen is hiding login button on devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On some devices, the keyboard is hiding the Login button on login screen and the Continue button on create account enter details screen.

### Causes (Optional)

The screen itself is scrollable so the user can scroll down to reach the button but he/she can get confused and not be sure that it needs to be scrolled down. 

### Solutions

Place the button under the scrollable area, this way button is always above the keyboard and at the bottom of the available screen space. The downside is that the scrollable area can become quite small (we need to fit top bar, tab bar and bottom bar with the button), but we'll see if that's really the case.

### Testing

#### How to Test

Open login screen or create account enter details screen on a device with smaller screen height.

### Attachments (Optional)

#### Before:

https://user-images.githubusercontent.com/30429749/204866626-798520e5-891e-40d5-9f78-9c5df12fcad1.mp4

#### After: 

https://user-images.githubusercontent.com/30429749/204866935-9b96575a-b2b6-408a-ae67-66d7be8db868.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
