### PR TITLE
fix: delete conversation option is displayed for non team conversations

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
@@ -65,7 +65,7 @@ enum class HomeNavigationItem(
                     onSnackBarStateChanged = homeState::setSnackBarState,
                     searchBarState = homeState.searchBarState,
                     isBottomSheetVisible = homeState::isBottomSheetVisible
-                )
+                 )
             }
         }
     ),

--- a/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
@@ -65,7 +65,7 @@ enum class HomeNavigationItem(
                     onSnackBarStateChanged = homeState::setSnackBarState,
                     searchBarState = homeState.searchBarState,
                     isBottomSheetVisible = homeState::isBottomSheetVisible
-                 )
+                )
             }
         }
     ),

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -49,6 +49,7 @@ fun ConversationSheetContent(
                 navigateToNotification = conversationSheetState::toMutingNotificationOption
             )
         }
+
         ConversationOptionNavigation.MutingNotificationOption -> {
             val goBack: () -> Unit = {
                 if (conversationSheetState.startOptionNavigation == ConversationOptionNavigation.Home)
@@ -101,14 +102,16 @@ data class ConversationSheetContent(
     val conversationId: ConversationId,
     val mutingConversationState: MutedConversationStatus,
     val conversationTypeDetail: ConversationTypeDetail,
-    val isSelfUserMember: Boolean = true
+    val isSelfUserMember: Boolean = true,
+    val isTeamConversation: Boolean
 ) {
     fun canEditNotifications(): Boolean = isSelfUserMember
             && ((conversationTypeDetail is ConversationTypeDetail.Private
             && (conversationTypeDetail.blockingState != BlockingState.BLOCKED))
             || conversationTypeDetail is ConversationTypeDetail.Group)
 
-    fun canDeleteGroup(): Boolean = conversationTypeDetail is ConversationTypeDetail.Group && conversationTypeDetail.isCreator
+    fun canDeleteGroup(): Boolean =
+        conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember && conversationTypeDetail.isCreator && isTeamConversation
 
     fun canLeaveTheGroup(): Boolean = conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -53,7 +53,8 @@ fun rememberConversationSheetState(
                         conversationId = conversationId,
                         isCreator = isSelfUserCreator
                     ),
-                    isSelfUserMember = isSelfUserMember
+                    isSelfUserMember = isSelfUserMember,
+                    isTeamConversation = teamId != null
                 )
             }
         }
@@ -69,7 +70,8 @@ fun rememberConversationSheetState(
                         userAvatarData.asset,
                         userId,
                         blockingState
-                    )
+                    ),
+                    isTeamConversation = isTeamConversation
                 )
             }
         }
@@ -81,7 +83,8 @@ fun rememberConversationSheetState(
                     mutingConversationState = mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Connection(
                         userAvatarData.asset
-                    )
+                    ),
+                    isTeamConversation = isTeamConversation
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -56,7 +57,7 @@ internal fun WireTextField(
     readOnly: Boolean = false,
     singleLine: Boolean = true,
     maxLines: Int = 1,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences, autoCorrect = true),
     keyboardActions: KeyboardActions = KeyboardActions(),
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
@@ -75,7 +76,7 @@ internal fun WireTextField(
     modifier: Modifier = Modifier,
     onSelectedLineIndexChanged: (Int) -> Unit = { },
     onLineBottomYCoordinateChanged: (Float) -> Unit = { },
-) {
+    ) {
     val enabled = state !is WireTextFieldState.Disabled
 
     Column(modifier = modifier) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -125,7 +125,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     conversationId = conversationId,
                     mutingConversationState = groupDetails.conversation.mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
-                    isSelfUserMember = groupDetails.isSelfUserMember
+                    isSelfUserMember = groupDetails.isSelfUserMember,
+                    isTeamConversation = groupDetails.conversation.teamId?.value != null
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -25,7 +25,6 @@ import com.wire.android.ui.home.conversationslist.model.BlockState
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
-import com.wire.android.ui.home.conversationslist.model.ConversationLastEvent
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -58,7 +57,6 @@ import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.Result
 import com.wire.kalium.logic.functional.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -380,7 +378,8 @@ private fun ConversationDetails.toConversationItem(
             badgeEventType = parseConversationEventType(conversation.mutedStatus, unreadMentionsCount, unreadEventCount),
             hasOnGoingCall = hasOngoingCall,
             isSelfUserCreator = isSelfUserCreator,
-            isSelfUserMember = isSelfUserMember
+            isSelfUserMember = isSelfUserMember,
+            teamId = conversation.teamId
         )
     }
 
@@ -406,7 +405,8 @@ private fun ConversationDetails.toConversationItem(
                 parseConversationEventType(conversation.mutedStatus, unreadMentionsCount, unreadEventCount)
             ),
             userId = otherUser.id,
-            blockingState = otherUser.BlockState
+            blockingState = otherUser.BlockState,
+            teamId = otherUser.teamId
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -5,6 +5,7 @@ import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.home.conversationslist.common.UserInfoLabel
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
@@ -16,6 +17,10 @@ sealed class ConversationItem {
     abstract val isLegalHold: Boolean
     abstract val lastMessageContent: UILastMessageContent?
     abstract val badgeEventType: BadgeEventType
+    abstract val teamId: TeamId?
+
+    val isTeamConversation get() = teamId != null
+
     data class GroupConversation(
         val groupName: String,
         override val conversationId: ConversationId,
@@ -23,9 +28,10 @@ sealed class ConversationItem {
         override val isLegalHold: Boolean = false,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
+        override val teamId: TeamId?,
         val hasOnGoingCall: Boolean = false,
         val isSelfUserCreator: Boolean = false,
-        val isSelfUserMember: Boolean = true
+        val isSelfUserMember: Boolean = true,
     ) : ConversationItem()
 
     data class PrivateConversation(
@@ -38,6 +44,7 @@ sealed class ConversationItem {
         override val isLegalHold: Boolean = false,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
+        override val teamId: TeamId?
     ) : ConversationItem()
 
     data class ConnectionConversation(
@@ -47,8 +54,10 @@ sealed class ConversationItem {
         override val mutedStatus: MutedConversationStatus,
         override val isLegalHold: Boolean = false,
         override val lastMessageContent: UILastMessageContent?,
-        override val badgeEventType: BadgeEventType
-    ) : ConversationItem()
+        override val badgeEventType: BadgeEventType,
+    ) : ConversationItem() {
+        override val teamId: TeamId? = null
+    }
 }
 
 data class ConversationInfo(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.model.ImageAsset
@@ -82,7 +81,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -208,7 +206,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                                         userAvatarAsset,
                                         userId,
                                         otherUser.BlockState
-                                    )
+                                    ),
+                                    isTeamConversation = conversationResult.conversation.isTeamGroup()
                                 )
                             )
                         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -387,7 +387,8 @@ class GroupConversationDetailsViewModelTest {
             conversationId = details.conversation.id,
             mutingConversationState = details.conversation.mutedStatus,
             conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
-            isSelfUserMember = true
+            isSelfUserMember = true,
+            isTeamConversation = false
         )
         // When - Then
         assertEquals(expected, viewModel.conversationSheetContent)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class GroupConversationDetailsViewModelTest {
@@ -388,7 +387,7 @@ class GroupConversationDetailsViewModelTest {
             mutingConversationState = details.conversation.mutedStatus,
             conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
             isSelfUserMember = true,
-            isTeamConversation = false
+            isTeamConversation = details.conversation.isTeamGroup()
         )
         // When - Then
         assertEquals(expected, viewModel.conversationSheetContent)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -193,7 +193,8 @@ class ConversationListViewModelTest {
             lastMessageContent = UILastMessageContent.None,
             badgeEventType = BadgeEventType.None,
             userId = userId,
-            blockingState = BlockingState.CAN_NOT_BE_BLOCKED
+            blockingState = BlockingState.CAN_NOT_BE_BLOCKED,
+            teamId = null
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

delete conversation option is displayed for non team conversations

### Solutions

display the delete conversation option if and only if the conversation have the following criteria:
- [x] is team conversation.
- [x] self is the creator.
- [x] self is still a member.
- [x] conversation is a group conversation.
- [ ] self is Admin(this case is still not covered to avoid over complicating the PR since it require changes in the conversation view).



Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
