### PR TITLE
fix: crash related to last reply message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,7 +469,7 @@
     <string name="last_message_knock">pinged.</string>
     <string name="last_message_call">called.</string>
     <string name="last_message_mentioned">mentioned you</string>
-    <string name="last_message_replied">%1$s replied to you</string>
+    <string name="last_message_replied">replied to you</string>
     <string name="last_message_change_conversation_name">changed conversation name</string>
     <string name="last_message_calling">%1$s calling...</string>
     <plurals name="last_message_people_added">


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash because of the unneeded `%1$s` in the strings text.

### Solutions

Remove `%1$s` as it's not even needed there.
