### PR TITLE
fix: display delete conversation option only when self is admin

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -103,11 +103,11 @@ data class ConversationSheetContent(
     val conversationId: ConversationId,
     val mutingConversationState: MutedConversationStatus,
     val conversationTypeDetail: ConversationTypeDetail,
-    val selfMemberRole: Conversation.Member.Role?,
+    val selfRole: Conversation.Member.Role?,
     val isTeamConversation: Boolean
 ) {
 
-    private val isSelfUserMember: Boolean get() = selfMemberRole != null
+    private val isSelfUserMember: Boolean get() = selfRole != null
 
     fun canEditNotifications(): Boolean = isSelfUserMember
             && ((conversationTypeDetail is ConversationTypeDetail.Private
@@ -116,7 +116,7 @@ data class ConversationSheetContent(
 
     fun canDeleteGroup(): Boolean =
         conversationTypeDetail is ConversationTypeDetail.Group &&
-                selfMemberRole == Conversation.Member.Role.Admin &&
+                selfRole == Conversation.Member.Role.Admin &&
                 conversationTypeDetail.isCreator && isTeamConversation
 
     fun canLeaveTheGroup(): Boolean = conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -10,6 +10,7 @@ import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -102,16 +103,21 @@ data class ConversationSheetContent(
     val conversationId: ConversationId,
     val mutingConversationState: MutedConversationStatus,
     val conversationTypeDetail: ConversationTypeDetail,
-    val isSelfUserMember: Boolean = true,
+    val selfMemberRole: Conversation.Member.Role?,
     val isTeamConversation: Boolean
 ) {
+
+    private val isSelfUserMember: Boolean get() = selfMemberRole != null
+
     fun canEditNotifications(): Boolean = isSelfUserMember
             && ((conversationTypeDetail is ConversationTypeDetail.Private
             && (conversationTypeDetail.blockingState != BlockingState.BLOCKED))
             || conversationTypeDetail is ConversationTypeDetail.Group)
 
     fun canDeleteGroup(): Boolean =
-        conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember && conversationTypeDetail.isCreator && isTeamConversation
+        conversationTypeDetail is ConversationTypeDetail.Group &&
+                selfMemberRole == Conversation.Member.Role.Admin &&
+                conversationTypeDetail.isCreator && isTeamConversation
 
     fun canLeaveTheGroup(): Boolean = conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -55,7 +55,7 @@ fun rememberConversationSheetState(
                         isCreator = isSelfUserCreator
                     ),
                     isTeamConversation = teamId != null,
-                    selfMemberRole = selfMemberRole
+                    selfRole = selfMemberRole
                 )
             }
         }
@@ -73,7 +73,7 @@ fun rememberConversationSheetState(
                         blockingState
                     ),
                     isTeamConversation = isTeamConversation,
-                    selfMemberRole = Conversation.Member.Role.Member
+                    selfRole = Conversation.Member.Role.Member
                 )
             }
         }
@@ -87,7 +87,7 @@ fun rememberConversationSheetState(
                         userAvatarData.asset
                     ),
                     isTeamConversation = isTeamConversation,
-                    selfMemberRole = Conversation.Member.Role.Member
+                    selfRole = Conversation.Member.Role.Member
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 
@@ -53,8 +54,8 @@ fun rememberConversationSheetState(
                         conversationId = conversationId,
                         isCreator = isSelfUserCreator
                     ),
-                    isSelfUserMember = isSelfUserMember,
-                    isTeamConversation = teamId != null
+                    isTeamConversation = teamId != null,
+                    selfMemberRole = selfMemberRole
                 )
             }
         }
@@ -71,7 +72,8 @@ fun rememberConversationSheetState(
                         userId,
                         blockingState
                     ),
-                    isTeamConversation = isTeamConversation
+                    isTeamConversation = isTeamConversation,
+                    selfMemberRole = Conversation.Member.Role.Member
                 )
             }
         }
@@ -84,7 +86,8 @@ fun rememberConversationSheetState(
                     conversationTypeDetail = ConversationTypeDetail.Connection(
                         userAvatarData.asset
                     ),
-                    isTeamConversation = isTeamConversation
+                    isTeamConversation = isTeamConversation,
+                    selfMemberRole = Conversation.Member.Role.Member
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -90,7 +91,7 @@ internal fun WireTextField(
                     else it
                 )
             },
-            textStyle = textStyle.copy(color = colors.textColor(state = state).value),
+            textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             singleLine = singleLine,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -126,7 +126,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     mutingConversationState = groupDetails.conversation.mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
                     isTeamConversation = groupDetails.conversation.teamId?.value != null,
-                    selfMemberRole = groupDetails.selfRole
+                    selfRole = groupDetails.selfRole
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -125,8 +125,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     conversationId = conversationId,
                     mutingConversationState = groupDetails.conversation.mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
-                    isSelfUserMember = groupDetails.isSelfUserMember,
-                    isTeamConversation = groupDetails.conversation.teamId?.value != null
+                    isTeamConversation = groupDetails.conversation.teamId?.value != null,
+                    selfMemberRole = groupDetails.selfRole
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -384,7 +384,8 @@ private fun ConversationDetails.toConversationItem(
             hasOnGoingCall = hasOngoingCall,
             isSelfUserCreator = isSelfUserCreator,
             isSelfUserMember = isSelfUserMember,
-            teamId = conversation.teamId
+            teamId = conversation.teamId,
+            selfMemberRole = selfRole
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.home.conversationslist.model
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.home.conversationslist.common.UserInfoLabel
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
@@ -31,6 +32,7 @@ sealed class ConversationItem {
         override val teamId: TeamId?,
         val hasOnGoingCall: Boolean = false,
         val isSelfUserCreator: Boolean = false,
+        val selfMemberRole: Conversation.Member.Role?,
         val isSelfUserMember: Boolean = true,
     ) : ConversationItem()
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -208,7 +208,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                                         otherUser.BlockState
                                     ),
                                     isTeamConversation = conversationResult.conversation.isTeamGroup(),
-                                    selfMemberRole = Conversation.Member.Role.Member
+                                    selfRole = Conversation.Member.Role.Member
                                 )
                             )
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -207,7 +207,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                                         userId,
                                         otherUser.BlockState
                                     ),
-                                    isTeamConversation = conversationResult.conversation.isTeamGroup()
+                                    isTeamConversation = conversationResult.conversation.isTeamGroup(),
+                                    selfMemberRole = Conversation.Member.Role.Member
                                 )
                             )
                         }

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
@@ -36,7 +36,8 @@ object TestConversationDetails {
         lastMessage = null,
         isSelfUserCreator = true,
         isSelfUserMember = true,
-        unreadEventCount = emptyMap()
+        unreadEventCount = emptyMap(),
+        selfRole = Conversation.Member.Role.Member
     )
 
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -17,6 +17,7 @@ import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.FileSharingStatus
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.id.ConversationId
@@ -236,7 +237,8 @@ internal fun mockConversationDetailsGroup(
     lastMessage = null,
     isSelfUserCreator = true,
     isSelfUserMember = true,
-    unreadEventCount = emptyMap()
+    unreadEventCount = emptyMap(),
+    selfRole = Conversation.Member.Role.Member
 )
 
 internal fun mockUITextMessage(id: String = "someId", userName: String = "mockUserName"): UIMessage {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -386,7 +386,7 @@ class GroupConversationDetailsViewModelTest {
             conversationId = details.conversation.id,
             mutingConversationState = details.conversation.mutedStatus,
             conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
-            isSelfUserMember = true,
+            selfRole = Conversation.Member.Role.Member,
             isTeamConversation = details.conversation.isTeamGroup()
         )
         // When - Then
@@ -417,7 +417,8 @@ class GroupConversationDetailsViewModelTest {
             lastMessage = null,
             isSelfUserCreator = false,
             isSelfUserMember = true,
-            unreadEventCount = emptyMap()
+            unreadEventCount = emptyMap(),
+            selfRole = Conversation.Member.Role.Member
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

delete conversation option was visible even of the user is not an admin anymore

### Solutions

check if the user is still an admin

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
