### PR TITLE
refactor: remove the usage of Global scope in calling and notification

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
@@ -13,7 +13,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,9 +36,7 @@ class EndOngoingCallReceiver : BroadcastReceiver() {
         appLogger.i("CallNotificationDismissReceiver: onReceive, conversationId: $conversationId")
 
         val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
-
-        GlobalScope.launch(dispatcherProvider.io()) {
-            val sessionScope =
+         val sessionScope =
                 if (userId != null) {
                     coreLogic.getSessionScope(userId)
                 } else {
@@ -51,10 +49,10 @@ class EndOngoingCallReceiver : BroadcastReceiver() {
                 }
 
             sessionScope?.let {
-                it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
+                it.launch(Dispatchers.IO) {
+                    it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
+                }
             }
-
-        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ProximitySensorManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ProximitySensorManager.kt
@@ -7,11 +7,12 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.PowerManager
 import androidx.appcompat.app.AppCompatActivity
+import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,7 +21,8 @@ import javax.inject.Singleton
 class ProximitySensorManager @Inject constructor(
     private val context: Context,
     private val currentSession: CurrentSessionUseCase,
-    @KaliumCoreLogic private val coreLogic: CoreLogic
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    @ApplicationScope private val appCoroutineScope: CoroutineScope
 ) {
 
     private lateinit var sensorManager: SensorManager
@@ -47,7 +49,7 @@ class ProximitySensorManager @Inject constructor(
     private val sensorEventListener = object : SensorEventListener {
 
         override fun onSensorChanged(event: SensorEvent) {
-            GlobalScope.launch {
+            appCoroutineScope.launch {
                 coreLogic.globalScope {
                     when (val currentSession = currentSession()) {
                         is CurrentSessionResult.Success -> {
@@ -61,6 +63,7 @@ class ProximitySensorManager @Inject constructor(
                                 wakeLock.release()
                             }
                         }
+
                         else -> {
                             // NO SESSION - Nothing to do
                         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

some places we are using Global Scope to run suspend function

### Solutions

replace it with the user session coroutine scope or an application scope

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
