### PR TITLE
fix: support multi user notification (AR-2797)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -48,7 +48,7 @@ class CallNotificationManager @Inject constructor(private val context: Context) 
         val userIdString = userId.toString()
         val title = getNotificationTitle(call)
         val content = getNotificationBody(call)
-        val channelId = NotificationChannelsManager.getChanelIdForUser(userId, NotificationConstants.INCOMING_CALL_CHANNEL_ID)
+        val channelId = NotificationConstants.getIncomingChannelId(userId)
 
         val notification = NotificationCompat.Builder(context, channelId)
             .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -75,7 +75,7 @@ class CallNotificationManager @Inject constructor(private val context: Context) 
     }
 
     fun getOngoingCallNotification(callName: String, conversationId: String, userId: UserId): Notification {
-        val channelId = NotificationChannelsManager.getChanelIdForUser(userId, NotificationConstants.ONGOING_CALL_CHANNEL_ID)
+        val channelId = NotificationConstants.getOngoingChannelId(userId)
         return NotificationCompat.Builder(context, channelId)
             .setContentTitle(callName)
             .setContentText(context.getString(R.string.notification_ongoing_call_content))

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -84,7 +84,7 @@ class MessageNotificationManager
         userId: String?,
         activeNotifications: Array<StatusBarNotification>
     ) {
-        val notificationId = getConversationNotificationId(conversation.id)
+        val notificationId = getConversationNotificationId(conversation.id + userId)
         getConversationNotification(conversation, userId, activeNotifications)?.let { notification ->
             appLogger.i("$TAG adding ConversationNotification")
             notificationManagerCompat.notify(notificationId, notification)
@@ -115,7 +115,7 @@ class MessageNotificationManager
         activeNotifications: Array<StatusBarNotification>
     ): Notification? {
 
-        val updatedMessageStyle = getUpdatedMessageStyle(conversation, activeNotifications) ?: return null
+        val updatedMessageStyle = getUpdatedMessageStyle(conversation, userId, activeNotifications) ?: return null
 
         return setUpNotificationBuilder(context).apply {
             conversation.messages
@@ -152,11 +152,12 @@ class MessageNotificationManager
      */
     private fun getUpdatedMessageStyle(
         conversation: NotificationConversation,
+        userId: String?,
         activeNotifications: Array<StatusBarNotification>
     ): NotificationCompat.Style? {
 
         val activeMessages = activeNotifications
-            .find { it.id == getConversationNotificationId(conversation.id) }
+            .find { it.id == getConversationNotificationId(conversation.id + userId) }
             ?.notification
             ?.let { NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(it) }
             ?.messages

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -1,0 +1,141 @@
+package com.wire.android.notification
+
+import android.app.NotificationChannelGroup
+import android.content.ContentResolver
+import android.content.Context
+import android.media.AudioAttributes
+import android.net.Uri
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationManagerCompat
+import com.wire.android.appLogger
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationChannelsManager @Inject constructor(
+    private val context: Context,
+    private val notificationManagerCompat: NotificationManagerCompat
+) {
+    private val incomingCallSoundUri by lazy { Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/raw/ringing_from_them") }
+
+    fun createNotificationChannels(allUsers: List<SelfUser>) {
+        appLogger.i("${TAG}: creating all the channels for ${allUsers.size} users")
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        // creating regular NotificationChannels, that are common for all users and shouldn't be grouped.
+        createRegularChannel(NotificationConstants.OTHER_CHANNEL_ID, NotificationConstants.OTHER_CHANNEL_NAME)
+        createRegularChannel(NotificationConstants.WEB_SOCKET_CHANNEL_ID, NotificationConstants.WEB_SOCKET_CHANNEL_NAME)
+        createRegularChannel(NotificationConstants.MESSAGE_SYNC_CHANNEL_ID, NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME)
+
+        // creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
+        allUsers.forEach { user ->
+            val groupId = createNotificationChannelGroup(user.id, user.handle ?: user.name ?: user.id.value)
+
+            createIncomingCallsChannel(groupId, user.id)
+            createOngoingNotificationChannel(groupId, user.id)
+            createMessagesNotificationChannel(user.id, groupId)
+        }
+    }
+
+    /**
+     * Deletes NotificationChanelGroup (and all NotificationChannels that belongs to it) for a specific User.
+     * Use it on logout.
+     */
+    fun deleteChannelGroup(userId: UserId) {
+        notificationManagerCompat.deleteNotificationChannelGroup(getChanelGroupIdForUser(userId))
+    }
+
+    /**
+     * @return created groupId.
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createNotificationChannelGroup(userId: UserId, userName: String): String {
+        val chanelGroupId = getChanelGroupIdForUser(userId)
+        val channelGroup = NotificationChannelGroup(
+            chanelGroupId,
+            getChanelGroupNameForUser(userName)
+        )
+        notificationManagerCompat.createNotificationChannelGroup(channelGroup)
+        return chanelGroupId
+    }
+
+    private fun createIncomingCallsChannel(groupId: String, userId: UserId) {
+        val audioAttributes = AudioAttributes.Builder()
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+            .setUsage(getAudioAttributeUsageByOsLevel())
+            .build()
+
+        val chanelId = getChanelIdForUser(userId, NotificationConstants.INCOMING_CALL_CHANNEL_ID)
+        val notificationChannel = NotificationChannelCompat
+            .Builder(chanelId, NotificationManagerCompat.IMPORTANCE_HIGH)
+            .setName(NotificationConstants.INCOMING_CALL_CHANNEL_NAME)
+            .setSound(incomingCallSoundUri, audioAttributes)
+            .setShowBadge(false)
+            .setVibrationEnabled(true)
+            .setGroup(groupId)
+            .build()
+
+        notificationManagerCompat.createNotificationChannel(notificationChannel)
+    }
+
+    private fun createOngoingNotificationChannel(groupId: String, userId: UserId) {
+        val chanelId = getChanelIdForUser(userId, NotificationConstants.ONGOING_CALL_CHANNEL_ID)
+        val notificationChannel = NotificationChannelCompat
+            .Builder(chanelId, NotificationManagerCompat.IMPORTANCE_MAX)
+            .setName(NotificationConstants.ONGOING_CALL_CHANNEL_NAME)
+            .setVibrationEnabled(false)
+            .setImportance(NotificationManagerCompat.IMPORTANCE_DEFAULT)
+            .setSound(null, null)
+            .setGroup(groupId)
+            .build()
+
+        notificationManagerCompat.createNotificationChannel(notificationChannel)
+    }
+
+    private fun createMessagesNotificationChannel(userId: UserId, channelGroupId: String) {
+        val notificationChannel = NotificationChannelCompat
+            .Builder(getChanelIdForUser(userId, NotificationConstants.MESSAGE_CHANNEL_ID), NotificationManagerCompat.IMPORTANCE_HIGH)
+            .setName(NotificationConstants.MESSAGE_CHANNEL_NAME)
+            .setGroup(channelGroupId)
+            .build()
+
+        notificationManagerCompat.createNotificationChannel(notificationChannel)
+    }
+
+    private fun createRegularChannel(channelId: String, channelName: String) {
+        val notificationChannel = NotificationChannelCompat
+            .Builder(channelId, NotificationManagerCompat.IMPORTANCE_HIGH)
+            .setName(channelName)
+            .build()
+
+        notificationManagerCompat.createNotificationChannel(notificationChannel)
+    }
+
+    /**
+     * Tricky bug: No documentation whatsoever, but these values affect how the system cancels or not the vibration of the notification
+     * on different Android OS levels, probably channel creation related.
+     */
+    private fun getAudioAttributeUsageByOsLevel() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) AudioAttributes.USAGE_NOTIFICATION_RINGTONE else AudioAttributes.USAGE_MEDIA
+
+    companion object {
+        /**
+         * @return NotificationChannelId [String] specific for user, use it to post a notifications.
+         * @param userId [UserId] which received the notification
+         * @param channelIdPrefix prefix of the NotificationChannelId,
+         * one of [NotificationConstants.ONGOING_CALL_CHANNEL_ID], [NotificationConstants.INCOMING_CALL_CHANNEL_ID],
+         * [NotificationConstants.MESSAGE_CHANNEL_ID].
+         */
+        fun getChanelIdForUser(userId: UserId, channelIdPrefix: String): String = "$channelIdPrefix.$userId"
+
+        private fun getChanelGroupIdForUser(userId: UserId): String = "${NotificationConstants.CHANNEL_GROUP_ID}.$userId"
+        private fun getChanelGroupNameForUser(userName: String): String = "${NotificationConstants.CHANNEL_GROUP_NAME} $userName"
+
+        private const val TAG = "NotificationChannelsManager"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -21,7 +21,12 @@ class NotificationChannelsManager @Inject constructor(
     private val context: Context,
     private val notificationManagerCompat: NotificationManagerCompat
 ) {
-    private val incomingCallSoundUri by lazy { Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/raw/ringing_from_them") }
+    private val incomingCallSoundUri by lazy {
+        Uri.parse(
+            "${ContentResolver.SCHEME_ANDROID_RESOURCE}://" +
+                    "${context.packageName}/raw/ringing_from_them"
+        )
+    }
 
     fun createNotificationChannels(allUsers: List<SelfUser>) {
         appLogger.i("${TAG}: creating all the channels for ${allUsers.size} users")

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -24,6 +24,9 @@ object NotificationConstants {
     const val OTHER_CHANNEL_ID = "com.wire.android.other"
     const val OTHER_CHANNEL_NAME = "Other essential actions"
 
+    const val CHANNEL_GROUP_ID = "com.wire.notification_channel_group"
+    const val CHANNEL_GROUP_NAME = "Notifications for"
+
     //Notification IDs (has to be unique!)
     val MESSAGE_SUMMARY_ID = "wire_messages_summary_notification".hashCode()
     val CALL_INCOMING_NOTIFICATION_ID = "wire_incoming_call_notification".hashCode()

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -1,21 +1,22 @@
 package com.wire.android.notification
 
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
 
 //TODO: The names need to be localisable
 object NotificationConstants {
 
-    const val INCOMING_CALL_CHANNEL_ID = "com.wire.android.notification_incoming_call_channel"
+    private const val INCOMING_CALL_CHANNEL_ID = "com.wire.android.notification_incoming_call_channel"
     const val INCOMING_CALL_CHANNEL_NAME = "Incoming calls"
-    const val ONGOING_CALL_CHANNEL_ID = "com.wire.android.notification_ongoing_call_channel"
+    private const val ONGOING_CALL_CHANNEL_ID = "com.wire.android.notification_ongoing_call_channel"
     const val ONGOING_CALL_CHANNEL_NAME = "Ongoing calls"
 
     const val WEB_SOCKET_CHANNEL_ID = "com.wire.android.persistent_web_socket_channel"
     const val WEB_SOCKET_CHANNEL_NAME = "Persistent WebSocket"
 
-    const val MESSAGE_CHANNEL_ID = "com.wire.android.notification_channel"
+    private const val MESSAGE_CHANNEL_ID = "com.wire.android.notification_channel"
     const val MESSAGE_CHANNEL_NAME = "Messages"
-    const val MESSAGE_GROUP_KEY = "wire_reloaded_notification_group"
+    private const val MESSAGE_GROUP_KEY_PREFIX = "wire_reloaded_notification_group_"
     const val KEY_TEXT_REPLY = "key_text_notification_reply"
 
     const val MESSAGE_SYNC_CHANNEL_ID = "com.wire.android.message_synchronization"
@@ -24,17 +25,33 @@ object NotificationConstants {
     const val OTHER_CHANNEL_ID = "com.wire.android.other"
     const val OTHER_CHANNEL_NAME = "Other essential actions"
 
-    const val CHANNEL_GROUP_ID = "com.wire.notification_channel_group"
-    const val CHANNEL_GROUP_NAME = "Notifications for"
+    private const val CHANNEL_GROUP_ID_PREFIX = "com.wire.notification_channel_group"
 
     //Notification IDs (has to be unique!)
-    val MESSAGE_SUMMARY_ID = "wire_messages_summary_notification".hashCode()
     val CALL_INCOMING_NOTIFICATION_ID = "wire_incoming_call_notification".hashCode()
     val CALL_ONGOING_NOTIFICATION_ID = "wire_ongoing_call_notification".hashCode()
     val PERSISTENT_NOTIFICATION_ID = "wire_persistent_web_socket_notification".hashCode()
     val MESSAGE_SYNC_NOTIFICATION_ID = "wire_notification_fetch_notification".hashCode()
     val MIGRATION_NOTIFICATION_ID = "wire_migration_notification".hashCode()
 
+    // MessagesSummaryNotification ID depends on User, use fun getMessagesSummaryId(userId: UserId) to get it
+    private const val MESSAGE_SUMMARY_ID_STRING = "wire_messages_summary_notification"
+
     fun getConversationNotificationId(conversationId: ConversationId) = getConversationNotificationId(conversationId.toString())
     fun getConversationNotificationId(conversationIdString: String) = conversationIdString.hashCode()
+    fun getMessagesGroupKey(userId: UserId?): String = "$MESSAGE_GROUP_KEY_PREFIX${userId?.toString() ?: ""}"
+    fun getMessagesSummaryId(userId: UserId): Int = "$MESSAGE_SUMMARY_ID_STRING${userId.toString()}".hashCode()
+    fun getChanelGroupIdForUser(userId: UserId): String = "${CHANNEL_GROUP_ID_PREFIX}.$userId"
+    fun getMessagesChannelId(userId: UserId): String = getChanelIdForUser(userId, MESSAGE_CHANNEL_ID)
+    fun getIncomingChannelId(userId: UserId): String = getChanelIdForUser(userId, INCOMING_CALL_CHANNEL_ID)
+    fun getOngoingChannelId(userId: UserId): String = getChanelIdForUser(userId, ONGOING_CALL_CHANNEL_ID)
+
+    /**
+     * @return NotificationChannelId [String] specific for user, use it to post a notifications.
+     * @param userId [UserId] which received the notification
+     * @param channelIdPrefix prefix of the NotificationChannelId,
+     * one of [NotificationConstants.ONGOING_CALL_CHANNEL_ID], [NotificationConstants.INCOMING_CALL_CHANNEL_ID],
+     * [NotificationConstants.MESSAGE_CHANNEL_ID].
+     */
+    private fun getChanelIdForUser(userId: UserId, channelIdPrefix: String): String = "$channelIdPrefix.$userId"
 }

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -315,7 +315,7 @@ class WireNotificationManager @Inject constructor(
                             )
                             // combining all the data that is necessary for Notifications into small data class,
                             // just to make it more readable than
-                            // Pair<List<LocalNotificationConversation>, QualifiedID?>
+                            // Pair<List<LocalNotificationConversation>, QualifiedID>
                             MessagesNotificationsData(notificationsList, userId)
                         }
                 } ?: flowOf(null)
@@ -420,7 +420,7 @@ class WireNotificationManager @Inject constructor(
 
     data class MessagesNotificationsData(
         val newNotifications: List<LocalNotificationConversation>,
-        val userId: QualifiedID?
+        val userId: QualifiedID
     )
 
     private data class OngoingCallData(val notificationTitle: String, val conversationId: ConversationId, val userId: UserId)

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
@@ -10,6 +10,7 @@ import com.wire.android.notification.MessageNotificationManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.functional.fold
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,15 +47,15 @@ class NotificationReplyReceiver : BroadcastReceiver() { // requires zero argumen
                 CoroutineScope(coroutineContext + dispatcherProvider.io()).launch {
                     messages.sendTextMessage(qualifiedConversationId, replyText)
                         .fold(
-                            { updateNotification(context, conversationId, userId, null) },
-                            { updateNotification(context, conversationId, userId, replyText) }
+                            { updateNotification(context, conversationId, qualifiedUserId, null) },
+                            { updateNotification(context, conversationId, qualifiedUserId, replyText) }
                         )
                 }
             }
         }
     }
 
-    private fun updateNotification(context: Context, conversationId: String, userId: String, replyText: String?) =
+    private fun updateNotification(context: Context, conversationId: String, userId: QualifiedID, replyText: String?) =
         MessageNotificationManager.updateNotificationAfterQuickReply(context, conversationId, userId, replyText)
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -11,8 +11,10 @@ import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.notification.NotificationConstants.CALL_ONGOING_NOTIFICATION_ID
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -66,11 +68,11 @@ class OngoingCallService : Service() {
                     }
             }
 
-            generateForegroundNotification(callName, conversationIdString, userIdString)
+            generateForegroundNotification(callName, conversationIdString, userId)
         } else {
             appLogger.w(
                 "$TAG: stopSelf. Reason: some of the parameter is absent. " +
-                        "userIdString: $userIdString, conversationIdString: $conversationIdString, callName: $callName"
+                        "userIdString: ${userIdString?.obfuscateId()}, conversationIdString: ${conversationIdString?.obfuscateId()}, callName: $callName"
             )
             stopSelf()
         }
@@ -83,9 +85,7 @@ class OngoingCallService : Service() {
         appLogger.i("$TAG: onDestroy")
     }
 
-    private fun generateForegroundNotification(callName: String, conversationId: String, userId: String) {
-        callNotificationManager.createOngoingNotificationChannel()
-
+    private fun generateForegroundNotification(callName: String, conversationId: String, userId: UserId) {
         val notification: Notification = callNotificationManager.getOngoingCallNotification(callName, conversationId, userId)
         startForeground(CALL_ONGOING_NOTIFICATION_ID, notification)
     }

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -57,10 +57,7 @@ class OngoingCallService : Service() {
             val userId = qualifiedIdMapper.fromStringToQualifiedID(userIdString)
 
             scope.launch {
-                coreLogic.getSessionScope(userId)
-                    .calls
-                    .establishedCall()
-                    .collect { establishedCall ->
+                coreLogic.getSessionScope(userId).calls.establishedCall().collect { establishedCall ->
                         if (establishedCall.isEmpty()) {
                             appLogger.i("$TAG: stopSelf. Reason: call was ended")
                             stopSelf()
@@ -72,7 +69,9 @@ class OngoingCallService : Service() {
         } else {
             appLogger.w(
                 "$TAG: stopSelf. Reason: some of the parameter is absent. " +
-                        "userIdString: ${userIdString?.obfuscateId()}, conversationIdString: ${conversationIdString?.obfuscateId()}, callName: $callName"
+                        "userIdString: ${userIdString?.obfuscateId()}, " +
+                        "conversationIdString: ${conversationIdString?.obfuscateId()}, " +
+                        "callName: $callName"
             )
             stopSelf()
         }

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -4,11 +4,8 @@ import android.app.Notification
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.location.Location
 import android.os.IBinder
-import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.di.CurrentSessionFlowService
@@ -18,7 +15,6 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.notification.NotificationConstants.PERSISTENT_NOTIFICATION_ID
 import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_ID
-import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_NAME
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -120,14 +116,6 @@ class PersistentWebSocketService : Service() {
     }
 
     private fun generateForegroundNotification() {
-        val notificationManager = NotificationManagerCompat.from(this)
-        val notificationChannel = NotificationChannelCompat
-            .Builder(WEB_SOCKET_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_HIGH)
-            .setName(WEB_SOCKET_CHANNEL_NAME)
-            .build()
-
-        notificationManager.createNotificationChannel(notificationChannel)
-
         val notification: Notification = Notification.Builder(this, WEB_SOCKET_CHANNEL_ID)
             .setContentTitle("${resources.getString(R.string.app_name)} ${resources.getString(R.string.settings_service_is_running)}")
             .setSmallIcon(R.drawable.websocket_notification_icon_small)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -17,6 +17,7 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.services.ServicesManager
 import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialogState
@@ -36,6 +37,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
+import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -49,6 +51,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -72,7 +75,9 @@ class WireActivityViewModel @Inject constructor(
     private val migrationManager: MigrationManager,
     private val servicesManager: ServicesManager,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
-    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase
+    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
+    private val observeValidAccounts: ObserveValidAccountsUseCase,
+    private val notificationChannelsManager: NotificationChannelsManager
 ) : ViewModel() {
 
     private val navigationArguments = mutableMapOf<String, Any>(SERVER_CONFIG_ARG to ServerConfig.DEFAULT)
@@ -104,6 +109,13 @@ class WireActivityViewModel @Inject constructor(
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
 
     init {
+        viewModelScope.launch(dispatchers.io()) {
+            observeValidAccounts()
+                .onStart { emit(listOf()) }
+                .collect { list ->
+                    notificationChannelsManager.createNotificationChannels(list.map { it.first })
+                }
+        }
         viewModelScope.launch(dispatchers.io()) {
             observePersistentWebSocketConnectionStatus().let {
                 when (it) {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -112,6 +112,7 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             observeValidAccounts()
                 .onStart { emit(listOf()) }
+                .distinctUntilChanged()
                 .collect { list ->
                     notificationChannelsManager.createNotificationChannels(list.map { it.first })
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -175,9 +175,20 @@ class SelfUserProfileViewModel @Inject constructor(
                 }
             }.join()
 
+            launch {
+                getSelf()
+                    .collect {
+                        // TODO delete notificationChannelGroup
+                        println("cyka logout selfUser: ${it.id}")
+                    }
+            }
+
             val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
             logout(logoutReason)
-            if (wipeData) dataStore.clear() // TODO this should be moved to some service that will clear all the data in the app
+            if (wipeData) {
+                // TODO this should be moved to some service that will clear all the data in the app
+                dataStore.clear()
+            }
             accountSwitch(SwitchAccountParam.SwitchToNextAccountOrWelcome)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -1,7 +1,6 @@
 package com.wire.android.workmanager
 
 import android.content.Context
-import androidx.core.app.NotificationManagerCompat
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
@@ -18,7 +17,6 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WireWorkerFactory @Inject constructor(
-    private val notificationManagerCompat: NotificationManagerCompat,
     private val wireNotificationManager: WireNotificationManager,
     private val migrationManager: MigrationManager,
     @KaliumCoreLogic
@@ -31,9 +29,9 @@ class WireWorkerFactory @Inject constructor(
                 WrapperWorkerFactory(coreLogic, WireForegroundNotificationDetailsProvider)
                     .createWorker(appContext, workerClassName, workerParameters)
             NotificationFetchWorker::class.java.canonicalName ->
-                NotificationFetchWorker(appContext, workerParameters, wireNotificationManager, notificationManagerCompat)
+                NotificationFetchWorker(appContext, workerParameters, wireNotificationManager)
             MigrationWorker::class.java.canonicalName ->
-                MigrationWorker(appContext, workerParameters, migrationManager, notificationManagerCompat)
+                MigrationWorker(appContext, workerParameters, migrationManager)
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
@@ -1,9 +1,7 @@
 package com.wire.android.workmanager.worker
 
 import android.content.Context
-import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorker
 import androidx.lifecycle.asFlow
 import androidx.work.BackoffPolicy
@@ -34,8 +32,7 @@ class MigrationWorker
 @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
-    private val migrationManager: MigrationManager,
-    private val notificationManager: NotificationManagerCompat
+    private val migrationManager: MigrationManager
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result = migrationManager.migrate().let {
@@ -46,8 +43,6 @@ class MigrationWorker
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        createNotificationChannel()
-
         val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.OTHER_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon_small)
             .setAutoCancel(true)
@@ -60,15 +55,6 @@ class MigrationWorker
             .build()
 
         return ForegroundInfo(NotificationConstants.MIGRATION_NOTIFICATION_ID, notification)
-    }
-
-    private fun createNotificationChannel() {
-        val notificationChannel = NotificationChannelCompat
-            .Builder(NotificationConstants.OTHER_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_MIN)
-            .setName(NotificationConstants.OTHER_CHANNEL_NAME)
-            .build()
-
-        notificationManager.createNotificationChannel(notificationChannel)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -1,9 +1,7 @@
 package com.wire.android.workmanager.worker
 
 import android.content.Context
-import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
@@ -22,7 +20,6 @@ class NotificationFetchWorker
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wireNotificationManager: WireNotificationManager,
-    private val notificationManager: NotificationManagerCompat
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         const val USER_ID_INPUT_DATA = "worker_user_id_input_data"
@@ -38,8 +35,6 @@ class NotificationFetchWorker
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        createNotificationChannel()
-
         val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.MESSAGE_SYNC_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon_small)
             .setAutoCancel(true)
@@ -51,15 +46,6 @@ class NotificationFetchWorker
             .build()
 
         return ForegroundInfo(NotificationConstants.MESSAGE_SYNC_NOTIFICATION_ID, notification)
-    }
-
-    private fun createNotificationChannel() {
-        val notificationChannel = NotificationChannelCompat
-            .Builder(NotificationConstants.MESSAGE_SYNC_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_MIN)
-            .setName(NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME)
-            .build()
-
-        notificationManager.createNotificationChannel(notificationChannel)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2797" title="AR-2797" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2797</a>  Notifications are not received for first logged in account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->



# What's new in this PR?

### Issues

when a session is not active, the user won't receive a notification on that account


### Solutions
Remove the check if the session is active, add userId to the notification channel, and create a group channel for each logged in user.
Also group the notifications for different users and mark the groups to determine for which user is it. 


### Attachments (Optional)

![Wire 2022-12-12 at 17_23 copy](https://user-images.githubusercontent.com/6539347/207297832-cc273c3a-5ed7-4447-8585-caad15fc4293.jpg)


