### PR TITLE
fix: changing conversation options are displayed for personal users

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
@@ -833,4 +834,12 @@ class UseCaseModule {
     @Provides
     fun providePersistReadReceiptsStatusConfig(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).users.persistReadReceiptsStatusConfig
+
+    @ViewModelScoped
+    @Provides
+    fun providesIsSelfTeamMemberUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): IsSelfATeamMemberUseCase = coreLogic.getSessionScope(currentAccount).team.isSelfATeamMember
+
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
@@ -12,6 +12,7 @@ data class GroupMetadataState(
     val isLoading: Boolean = false,
     val error: NewGroupError = NewGroupError.None,
     val mode: GroupNameMode = GroupNameMode.CREATION,
+    val isSelfTeamMember: Boolean = false
 ) {
     sealed interface NewGroupError {
         object None : NewGroupError

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -62,7 +62,13 @@ fun NewConversationRouter() {
                         onBackPressed = newConversationNavController::popBackStack,
                         newGroupState = newConversationViewModel.newGroupState,
                         onGroupNameChange = newConversationViewModel::onGroupNameChange,
-                        onContinuePressed = { newConversationNavController.navigate(Screen.GroupOptionsScreen.route) },
+                        onContinuePressed = {
+                            if (newConversationViewModel.newGroupState.isSelfTeamMember) {
+                                newConversationNavController.navigate(Screen.GroupOptionsScreen.route)
+                            } else {
+                                newConversationViewModel.createGroupWithCustomOptions()
+                            }
+                        },
                         onGroupNameErrorAnimated = newConversationViewModel::onGroupNameErrorAnimated
                     )
                 }
@@ -72,7 +78,7 @@ fun NewConversationRouter() {
                 content = {
                     GroupOptionScreen(
                         onBackPressed = newConversationNavController::popBackStack,
-                        onCreateGroup = newConversationViewModel::createGroup,
+                        onCreateGroup = newConversationViewModel::createGroupWithCustomOptions,
                         groupOptionState = newConversationViewModel.groupOptionsState,
                         onAllowGuestChanged = newConversationViewModel::onAllowGuestStatusChanged,
                         onAllowServicesChanged = newConversationViewModel::onAllowServicesStatusChanged,
@@ -98,6 +104,7 @@ private fun handleSnackBarMessage(
         val message = when (messageType) {
             is NewConversationSnackbarState.SuccessSendConnectionRequest ->
                 stringResource(id = R.string.connection_request_sent)
+
             NewConversationSnackbarState.None -> ""
         }
         LaunchedEffect(messageType) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -66,7 +66,7 @@ fun NewConversationRouter() {
                             if (newConversationViewModel.newGroupState.isSelfTeamMember) {
                                 newConversationNavController.navigate(Screen.GroupOptionsScreen.route)
                             } else {
-                                newConversationViewModel.createGroupWithCustomOptions()
+                                newConversationViewModel.createGroup()
                             }
                         },
                         onGroupNameErrorAnimated = newConversationViewModel::onGroupNameErrorAnimated
@@ -78,7 +78,7 @@ fun NewConversationRouter() {
                 content = {
                     GroupOptionScreen(
                         onBackPressed = newConversationNavController::popBackStack,
-                        onCreateGroup = newConversationViewModel::createGroupWithCustomOptions,
+                        onCreateGroup = newConversationViewModel::createGroup,
                         groupOptionState = newConversationViewModel.groupOptionsState,
                         onAllowGuestChanged = newConversationViewModel::onAllowGuestStatusChanged,
                         onAllowServicesChanged = newConversationViewModel::onAllowServicesStatusChanged,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -36,7 +36,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NewConversationViewModel @Inject constructor(
     private val createGroupConversation: CreateGroupConversationUseCase,
-    private val isSelfATeamMemberUseCase: IsSelfATeamMemberUseCase,
+    private val isSelfATeamMember: IsSelfATeamMemberUseCase,
     getAllKnownUsers: GetAllContactsUseCase,
     searchKnownUsers: SearchKnownUsersUseCase,
     searchPublicUsers: SearchPublicUsersUseCase,
@@ -58,7 +58,7 @@ class NewConversationViewModel @Inject constructor(
     var newGroupState: GroupMetadataState by mutableStateOf(
         GroupMetadataState(
             mlsEnabled = isMLSEnabled(),
-            isSelfTeamMember = runBlocking { isSelfATeamMemberUseCase() })
+            isSelfTeamMember = runBlocking { isSelfATeamMember() })
     )
 
     var groupOptionsState: GroupOptionState by mutableStateOf(GroupOptionState())
@@ -138,7 +138,15 @@ class NewConversationViewModel @Inject constructor(
         return false
     }
 
-    fun createGroupWithoutOption() {
+    fun createGroup() {
+        if (newGroupState.isSelfTeamMember) {
+            createGroupWithCustomOptions(true)
+        } else {
+            createGroupWithoutOption()
+        }
+    }
+
+    private fun createGroupWithoutOption() {
         viewModelScope.launch {
             newGroupState = newGroupState.copy(isLoading = true)
             val result = createGroupConversation(
@@ -155,7 +163,7 @@ class NewConversationViewModel @Inject constructor(
         }
     }
 
-    fun createGroupWithCustomOptions(shouldCheckGuests: Boolean = true) {
+    private fun createGroupWithCustomOptions(shouldCheckGuests: Boolean = true) {
         if (shouldCheckGuests && checkIfGuestAdded())
             return
         viewModelScope.launch {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -178,7 +178,7 @@ internal class NewConversationViewModelArrangement {
             sendConnectionRequest = sendConnectionRequestUseCase,
             dispatchers = TestDispatcherProvider(),
             isMLSEnabled = isMLSEnabledUseCase,
-            isSelfATeamMemberUseCase = isSelfTeamMember
+            isSelfATeamMember = isSelfTeamMember
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -15,7 +15,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -27,10 +26,11 @@ import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
-import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchPublicUsersUseCase
+import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
+import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -109,6 +109,9 @@ internal class NewConversationViewModelArrangement {
     lateinit var wireSessionImageLoader: WireSessionImageLoader
 
     @MockK
+    lateinit var isSelfTeamMember: IsSelfATeamMemberUseCase
+
+    @MockK
     private lateinit var savedStateHandle: SavedStateHandle
 
     private companion object {
@@ -127,7 +130,7 @@ internal class NewConversationViewModelArrangement {
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER),
             creatorId = null
-            )
+        )
 
         val PUBLIC_USER = OtherUser(
             TestUser.USER_ID.copy(value = "publicValue"),
@@ -174,7 +177,8 @@ internal class NewConversationViewModelArrangement {
             contactMapper = contactMapper,
             sendConnectionRequest = sendConnectionRequestUseCase,
             dispatchers = TestDispatcherProvider(),
-            isMLSEnabled = isMLSEnabledUseCase
+            isMLSEnabled = isMLSEnabledUseCase,
+            isSelfATeamMemberUseCase = isSelfTeamMember
         )
     }
 
@@ -194,6 +198,10 @@ internal class NewConversationViewModelArrangement {
         coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.UnknownFailure(
             CoreFailure.MissingClientRegistration
         )
+    }
+
+    fun withIsSelfTeamMember(result: Boolean) = apply {
+        coEvery { isSelfTeamMember() } returns result
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -92,7 +92,7 @@ class NewConversationViewModelTest {
             .withSyncFailureOnCreatingGroup()
             .arrange()
 
-        viewModel.createGroup()
+        viewModel.createGroupWithCustomOptions()
         advanceUntilIdle()
 
         viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.LackingConnection
@@ -104,7 +104,7 @@ class NewConversationViewModelTest {
             .withUnknownFailureOnCreatingGroup()
             .arrange()
 
-        viewModel.createGroup()
+        viewModel.createGroupWithCustomOptions()
         advanceUntilIdle()
 
         viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.Unknown
@@ -114,7 +114,7 @@ class NewConversationViewModelTest {
     fun `given no failure, when creating group, then options state should have no error`() = runTest {
         val (_, viewModel) = NewConversationViewModelArrangement().arrange()
 
-        viewModel.createGroup()
+        viewModel.createGroupWithCustomOptions()
         advanceUntilIdle()
 
         viewModel.groupOptionsState.error.shouldBeNull()

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -31,7 +31,9 @@ class NewConversationViewModelTest {
     fun `when search with search query, return results for known and public search`() {
         runTest {
             // Given
-            val (arrangement, viewModel) = NewConversationViewModelArrangement().arrange()
+            val (arrangement, viewModel) = NewConversationViewModelArrangement()
+                .withIsSelfTeamMember(true)
+                .arrange()
 
             // When
             viewModel.searchQueryChanged(TextFieldValue("search"))
@@ -89,6 +91,7 @@ class NewConversationViewModelTest {
     @Test
     fun `given sync failure, when creating group, then should update options state with connectivity error`() = runTest {
         val (_, viewModel) = NewConversationViewModelArrangement()
+            .withIsSelfTeamMember(true)
             .withSyncFailureOnCreatingGroup()
             .arrange()
 
@@ -101,6 +104,7 @@ class NewConversationViewModelTest {
     @Test
     fun `given unknown failure, when creating group, then should update options state with unknown error`() = runTest {
         val (_, viewModel) = NewConversationViewModelArrangement()
+            .withIsSelfTeamMember(true)
             .withUnknownFailureOnCreatingGroup()
             .arrange()
 
@@ -112,7 +116,9 @@ class NewConversationViewModelTest {
 
     @Test
     fun `given no failure, when creating group, then options state should have no error`() = runTest {
-        val (_, viewModel) = NewConversationViewModelArrangement().arrange()
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withIsSelfTeamMember(true)
+            .arrange()
 
         viewModel.createGroupWithCustomOptions()
         advanceUntilIdle()
@@ -125,6 +131,7 @@ class NewConversationViewModelTest {
         runTest {
             // Given
             val (_, viewModel) = NewConversationViewModelArrangement()
+                .withIsSelfTeamMember(true)
                 .withFailureKnownSearchResponse()
                 .withFailurePublicSearchResponse()
                 .arrange()

--- a/default.json
+++ b/default.json
@@ -19,7 +19,7 @@
         "appName": "Wire Dev",
         "launcherIcon": "ic_launcher_wire_dev",
         "version_name_postfix": "-dev",
-        "developer_features_enabled": false,
+        "developer_features_enabled": true,
         "logging_enabled": true,
         "safe_logging": false,
         "private_build": true,
@@ -121,6 +121,6 @@
     "force_constant_bitrate_calls": false,
     "web_link_preview": true,
     "keep_websocket_on": false,
-    "mls_support_enabled": false,
+    "mls_support_enabled": true,
     "encrypt_proteus_storage": false
 }

--- a/default.json
+++ b/default.json
@@ -19,7 +19,7 @@
         "appName": "Wire Dev",
         "launcherIcon": "ic_launcher_wire_dev",
         "version_name_postfix": "-dev",
-        "developer_features_enabled": true,
+        "developer_features_enabled": false,
         "logging_enabled": true,
         "safe_logging": false,
         "private_build": true,
@@ -121,6 +121,6 @@
     "force_constant_bitrate_calls": false,
     "web_link_preview": true,
     "keep_websocket_on": false,
-    "mls_support_enabled": true,
+    "mls_support_enabled": false,
     "encrypt_proteus_storage": false
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

changing conversation options are displayed for personal users

### Solutions

if self is a team member, then show the options, otherwise create the conversation with default values

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/1207

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
