### PR TITLE
fix: italic notification text is cut off v2 [AR-1990]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -199,12 +199,10 @@ class MessageNotificationManager
     private fun italicTextFromResId(@StringRes stringResId: Int): Spannable {
         return context.getString(stringResId)
             .let {
-                val typeface = Typeface.defaultFromStyle(Typeface.ITALIC)
-                val isItalicFaked = !typeface.isItalic
-                // Default typeface doesn't support italic, system will fake it by skewing the glyphs using `textPaint.textSkewX = -0.25f`,
-                // but the width won't be adjusted so we have to add a space after the text.
+                // On some devices typeface used by default in notifications doesn't support italic, system will fake it by skewing the
+                // glyphs using `textPaint.textSkewX = -0.25f`, but the width won't be adjusted so we have to add a space after the text.
                 // https://saket.me/android-fake-vs-true-bold-and-italic/
-                if (isItalicFaked) "$it\u00A0" else it
+                "$it "
             }
             .toSpannable()
             .apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1990" title="AR-1990" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1990</a>  Push Notification for missed call is slightly cut off in the UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we receive a push notification for a missed call, on some devices the message is still cut off.

### Solutions

Looks like we can't check whether the default typeface supports italics or system uses a different one for notifications.
Instead, just add a single space after the text every time, for the "fake italics" it should have enough width to fully fit, for others that normally support italics the suffix space shouldn't be any problem.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
