### PR TITLE
feat: reset encryption session (AR-2687)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.logic.feature.server.ServerConfigForAccountUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
@@ -849,6 +850,6 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+    fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): ResetSessionUseCase =
         coreLogic.getSessionScope(currentAccount).messages.resetSession
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -848,10 +848,6 @@ class UseCaseModule {
     ): IsSelfATeamMemberUseCase = coreLogic.getSessionScope(currentAccount).team.isSelfATeamMember
 
     @Provides
-    fun provideResolveFailedDecryptedMessages(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
-        coreLogic.getSessionScope(currentAccount).messages.resolveFailedDecryptedMessages
-
-    @Provides
     fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).messages.resetSession
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -838,4 +838,10 @@ class UseCaseModule {
     @Provides
     fun provideObserveIfAppFreshEnoughUseCase(@KaliumCoreLogic coreLogic: CoreLogic) =
         coreLogic.getGlobalScope().observeIfAppUpdateRequired
+
+    @ViewModelScoped
+    @Provides
+    fun provideResolveFailedDecryptedMessages(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).messages.resolveFailedDecryptedMessages
+
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -842,7 +842,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun providesIsSelfTeamMemberUseCase(
+    fun provideIsSelfTeamMemberUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): IsSelfATeamMemberUseCase = coreLogic.getSessionScope(currentAccount).team.isSelfATeamMember
@@ -850,4 +850,8 @@ class UseCaseModule {
     @Provides
     fun provideResolveFailedDecryptedMessages(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).messages.resolveFailedDecryptedMessages
+
+    @Provides
+    fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).messages.resetSession
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -847,6 +847,7 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): IsSelfATeamMemberUseCase = coreLogic.getSessionScope(currentAccount).team.isSelfATeamMember
 
+    @ViewModelScoped
     @Provides
     fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).messages.resetSession

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -850,6 +850,6 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideResetSession(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): ResetSessionUseCase =
+    fun provideResetSessionUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): ResetSessionUseCase =
         coreLogic.getSessionScope(currentAccount).messages.resetSession
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -132,7 +132,7 @@ class MessageMapper @Inject constructor(
                 )
             )
         message is Message.Regular && message.content is MessageContent.FailedDecryption ->
-            MessageStatus.DecryptionFailure
+            MessageStatus.DecryptionFailure((message.content as MessageContent.FailedDecryption).isSessionResolved)
         else -> MessageStatus.Untouched
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -119,7 +119,8 @@ class MessageMapper @Inject constructor(
         isSenderUnavailable = when (sender) {
             is OtherUser -> sender.isUnavailableUser
             is SelfUser, null -> false
-        }
+        },
+        clientId = (message as Message.Sendable).senderClientId
     )
 
     private fun getMessageStatus(message: Message.Standalone) = when {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -131,7 +131,8 @@ class MessageMapper @Inject constructor(
                     utcISO = (message.editStatus as Message.EditStatus.Edited).lastTimeStamp
                 )
             )
-
+        message is Message.Regular && message.content is MessageContent.FailedDecryption ->
+            MessageStatus.DecryptionFailure
         else -> MessageStatus.Untouched
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -132,7 +132,7 @@ class MessageMapper @Inject constructor(
                 )
             )
         message is Message.Regular && message.content is MessageContent.FailedDecryption ->
-            MessageStatus.DecryptionFailure((message.content as MessageContent.FailedDecryption).isSessionResolved)
+            MessageStatus.DecryptionFailure((message.content as MessageContent.FailedDecryption).isDecryptionResolved)
         else -> MessageStatus.Untouched
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -173,7 +173,7 @@ fun ConversationScreen(
         },
         onJoinCall = conversationCallViewModel::joinOngoingCall,
         onReactionClick = conversationMessagesViewModel::toggleReaction,
-        onSessionResetClick = conversationMessagesViewModel::onResetSession,
+        onResetSessionClick = conversationMessagesViewModel::onResetSession,
         onMentionMember = messageComposerViewModel::mentionMember,
         onUpdateConversationReadDate = messageComposerViewModel::updateConversationReadDate,
         onDropDownClick = conversationInfoViewModel::navigateToDetails,
@@ -260,7 +260,7 @@ private fun ConversationScreen(
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
-    onSessionResetClick: () -> Unit,
+    onResetSessionClick: () -> Unit,
     onMentionMember: (String?) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onDropDownClick: () -> Unit,
@@ -390,7 +390,7 @@ private fun ConversationScreen(
                             onDownloadAsset = onDownloadAsset,
                             onImageFullScreenMode = onImageFullScreenMode,
                             onReactionClicked = onReactionClick,
-                            onSessionResetClick = onSessionResetClick,
+                            onResetSessionClicked = onResetSessionClick,
                             onOpenProfile = onOpenProfile,
                             onUpdateConversationReadDate = onUpdateConversationReadDate,
                             onMessageComposerError = onSnackbarMessage,
@@ -424,7 +424,7 @@ private fun ConversationScreenContent(
     onDownloadAsset: (String) -> Unit,
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onSessionResetClick: () -> Unit,
+    onResetSessionClicked: () -> Unit,
     onOpenProfile: (String) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
@@ -452,7 +452,7 @@ private fun ConversationScreenContent(
                 onImageFullScreenMode = onImageFullScreenMode,
                 onOpenProfile = onOpenProfile,
                 onReactionClicked = onReactionClicked,
-                onSessionResetClick = onSessionResetClick,
+                onResetSessionClicked = onResetSessionClicked,
                 onShowContextMenu = onShowContextMenu
             )
         },
@@ -527,7 +527,7 @@ fun MessageList(
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onSessionResetClick: () -> Unit,
+    onResetSessionClicked: () -> Unit,
     onShowContextMenu: (UIMessage) -> Unit
 ) {
     val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
@@ -577,7 +577,7 @@ fun MessageList(
                     onImageMessageClicked = onImageFullScreenMode,
                     onOpenProfile = onOpenProfile,
                     onReactionClicked = onReactionClicked,
-                    onSessionResetClick = onSessionResetClick
+                    onResetSessionClicked = onResetSessionClicked
                 )
             }
         }
@@ -613,6 +613,6 @@ fun ConversationScreenPreview() {
         onDropDownClick = { },
         onSnackbarMessage = { },
         onSnackbarMessageShown = { },
-        onSessionResetClick = { },
+        onResetSessionClick = { },
     ) { }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -78,7 +78,9 @@ import com.wire.android.util.permission.CallingAudioRequestFlow
 import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothRequestFlow
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ConferenceCallingResult
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import kotlinx.collections.immutable.ImmutableMap
@@ -260,7 +262,7 @@ private fun ConversationScreen(
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
-    onResetSessionClick: () -> Unit,
+    onResetSessionClick: (senderUserId: UserId, clientId: String?) -> Unit,
     onMentionMember: (String?) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onDropDownClick: () -> Unit,
@@ -424,7 +426,7 @@ private fun ConversationScreenContent(
     onDownloadAsset: (String) -> Unit,
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onResetSessionClicked: () -> Unit,
+    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onOpenProfile: (String) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
@@ -527,7 +529,7 @@ fun MessageList(
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onResetSessionClicked: () -> Unit,
+    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onShowContextMenu: (UIMessage) -> Unit
 ) {
     val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
@@ -613,6 +615,6 @@ fun ConversationScreenPreview() {
         onDropDownClick = { },
         onSnackbarMessage = { },
         onSnackbarMessageShown = { },
-        onResetSessionClick = { },
+        onResetSessionClick = { _, _ -> },
     ) { }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -53,6 +53,7 @@ import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.Error
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingImage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnFileDownloaded
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.banner.ConversationBanner
 import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
 import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
@@ -172,6 +173,7 @@ fun ConversationScreen(
         },
         onJoinCall = conversationCallViewModel::joinOngoingCall,
         onReactionClick = conversationMessagesViewModel::toggleReaction,
+        onSessionResetClick = conversationMessagesViewModel::onResetSession,
         onMentionMember = messageComposerViewModel::mentionMember,
         onUpdateConversationReadDate = messageComposerViewModel::updateConversationReadDate,
         onDropDownClick = conversationInfoViewModel::navigateToDetails,
@@ -258,6 +260,7 @@ private fun ConversationScreen(
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
+    onSessionResetClick: () -> Unit,
     onMentionMember: (String?) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onDropDownClick: () -> Unit,
@@ -387,6 +390,7 @@ private fun ConversationScreen(
                             onDownloadAsset = onDownloadAsset,
                             onImageFullScreenMode = onImageFullScreenMode,
                             onReactionClicked = onReactionClick,
+                            onSessionResetClick = onSessionResetClick,
                             onOpenProfile = onOpenProfile,
                             onUpdateConversationReadDate = onUpdateConversationReadDate,
                             onMessageComposerError = onSnackbarMessage,
@@ -420,6 +424,7 @@ private fun ConversationScreenContent(
     onDownloadAsset: (String) -> Unit,
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onReactionClicked: (String, String) -> Unit,
+    onSessionResetClick: () -> Unit,
     onOpenProfile: (String) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
@@ -447,6 +452,7 @@ private fun ConversationScreenContent(
                 onImageFullScreenMode = onImageFullScreenMode,
                 onOpenProfile = onOpenProfile,
                 onReactionClicked = onReactionClicked,
+                onSessionResetClick = onSessionResetClick,
                 onShowContextMenu = onShowContextMenu
             )
         },
@@ -493,6 +499,7 @@ private fun SnackBarMessage(
 @Composable
 private fun getSnackbarMessage(messageCode: ConversationSnackbarMessages): Pair<String, String?> {
     val msg = when (messageCode) {
+        is OnResetSession -> messageCode.text.asString()
         is OnFileDownloaded -> stringResource(R.string.conversation_on_file_downloaded, messageCode.assetName ?: "")
         is ErrorMaxAssetSize -> stringResource(R.string.error_conversation_max_asset_size_limit, messageCode.maxLimitInMB)
         ErrorMaxImageSize -> stringResource(R.string.error_conversation_max_image_size_limit)
@@ -520,6 +527,7 @@ fun MessageList(
     onImageFullScreenMode: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
+    onSessionResetClick: () -> Unit,
     onShowContextMenu: (UIMessage) -> Unit
 ) {
     val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
@@ -568,7 +576,8 @@ fun MessageList(
                     onAssetMessageClicked = onDownloadAsset,
                     onImageMessageClicked = onImageFullScreenMode,
                     onOpenProfile = onOpenProfile,
-                    onReactionClicked = onReactionClicked
+                    onReactionClicked = onReactionClicked,
+                    onSessionResetClick = onSessionResetClick
                 )
             }
         }
@@ -603,6 +612,7 @@ fun ConversationScreenPreview() {
         onUpdateConversationReadDate = { },
         onDropDownClick = { },
         onSnackbarMessage = { },
-        onSnackbarMessageShown = { }
+        onSnackbarMessageShown = { },
+        onSessionResetClick = { },
     ) { }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -393,6 +393,12 @@ private fun MessageDecryptionFailure() {
 
 @Preview(name = "Decrypt error component message")
 @Composable
-private fun WireTertiaryDecryptError() {
+private fun PreviewDecryptMessageError() {
     MessageDecryptionFailure()
+}
+
+@Preview(name = "Message send failure warning")
+@Composable
+private fun PreviewMessageSendFailureWarning() {
+    MessageSendFailureWarning()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -379,7 +379,7 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
                     text = stringResource(R.string.label_learn_more),
                 )
             }
-            if (!decryptionStatus.isSessionResolved) {
+            if (!decryptionStatus.isDecryptionResolved) {
                 Row {
                     WireSecondaryButton(
                         text = stringResource(R.string.label_reset_session),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -23,13 +23,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import com.google.accompanist.flowlayout.FlowRow
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.StatusBox
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
+import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.messages.QuotedMessage
@@ -358,22 +361,38 @@ private fun MessageDecryptionFailure() {
     CompositionLocalProvider(
         LocalTextStyle provides MaterialTheme.typography.labelSmall
     ) {
-        Row {
-            Spacer(Modifier.height(dimensions().spacing4x))
-            Text(
-                text = MessageStatus.DecryptionFailure.text.asString(),
-                style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
-            )
-            Spacer(Modifier.width(dimensions().spacing4x))
-            Text(
-                modifier = Modifier
-                    .clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
-                style = LocalTextStyle.current.copy(
-                    color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
-                    textDecoration = TextDecoration.Underline
-                ),
-                text = stringResource(R.string.label_learn_more),
-            )
+        Column {
+            Row {
+                Spacer(Modifier.height(dimensions().spacing4x))
+                Text(
+                    text = MessageStatus.DecryptionFailure.text.asString(),
+                    style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
+                )
+                Spacer(Modifier.width(dimensions().spacing4x))
+                Text(
+                    modifier = Modifier
+                        .clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
+                    style = LocalTextStyle.current.copy(
+                        color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    text = stringResource(R.string.label_learn_more),
+                )
+            }
+            Row {
+                WireSecondaryButton(
+                    text = stringResource(R.string.label_reset_session),
+                    onClick = { appLogger.d("Call to reset session...") },
+                    minHeight = dimensions().spacing32x,
+                    fillMaxWidth = false,
+                )
+            }
         }
     }
+}
+
+@Preview(name = "Decrypt error component message")
+@Composable
+private fun WireTertiaryDecryptError() {
+    MessageDecryptionFailure()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -61,7 +61,7 @@ fun MessageItem(
     onImageMessageClicked: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onSessionResetClick: () -> Unit
+    onResetSessionClicked: () -> Unit
 ) {
     with(message) {
         val fullAvatarOuterPadding = dimensions().userAvatarClickablePadding + dimensions().userAvatarStatusBorderSize
@@ -138,7 +138,7 @@ fun MessageItem(
                     } else {
                         MessageDecryptionFailure(
                             decryptionStatus = messageHeader.messageStatus as MessageStatus.DecryptionFailure,
-                            onSessionResetClick = onSessionResetClick
+                            onResetSessionClicked = onResetSessionClicked
                         )
                     }
                 }
@@ -358,7 +358,7 @@ private fun MessageSendFailureWarning() {
 }
 
 @Composable
-private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure, onSessionResetClick: () -> Unit) {
+private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure, onResetSessionClicked: () -> Unit) {
     val context = LocalContext.current
     val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
     CompositionLocalProvider(
@@ -386,7 +386,7 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
                 Row {
                     WireSecondaryButton(
                         text = stringResource(R.string.label_reset_session),
-                        onClick = onSessionResetClick,
+                        onClick = onResetSessionClicked,
                         minHeight = dimensions().spacing32x,
                         fillMaxWidth = false,
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import com.google.accompanist.flowlayout.FlowRow
 import com.wire.android.R
 import com.wire.android.model.Clickable
@@ -51,6 +50,8 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMess
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.user.UserId
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -61,7 +62,7 @@ fun MessageItem(
     onImageMessageClicked: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
-    onResetSessionClicked: () -> Unit
+    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit
 ) {
     with(message) {
         val fullAvatarOuterPadding = dimensions().userAvatarClickablePadding + dimensions().userAvatarStatusBorderSize
@@ -137,6 +138,7 @@ fun MessageItem(
                         )
                     } else {
                         MessageDecryptionFailure(
+                            messageHeader = messageHeader,
                             decryptionStatus = messageHeader.messageStatus as MessageStatus.DecryptionFailure,
                             onResetSessionClicked = onResetSessionClicked
                         )
@@ -358,7 +360,11 @@ private fun MessageSendFailureWarning() {
 }
 
 @Composable
-private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure, onResetSessionClicked: () -> Unit) {
+private fun MessageDecryptionFailure(
+    messageHeader: MessageHeader,
+    decryptionStatus: MessageStatus.DecryptionFailure,
+    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit
+) {
     val context = LocalContext.current
     val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
     CompositionLocalProvider(
@@ -386,7 +392,7 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
                 Row {
                     WireSecondaryButton(
                         text = stringResource(R.string.label_reset_session),
-                        onClick = onResetSessionClicked,
+                        onClick = { messageHeader.userId?.let { userId -> onResetSessionClicked(userId, messageHeader.clientId?.value) } },
                         minHeight = dimensions().spacing32x,
                         fillMaxWidth = false,
                     )
@@ -396,22 +402,4 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
             }
         }
     }
-}
-
-@Preview(name = "Decrypt error component message")
-@Composable
-private fun PreviewDecryptMessageError() {
-    MessageDecryptionFailure(MessageStatus.DecryptionFailure(true)) {}
-}
-
-@Preview(name = "Decrypt error component message with reset button")
-@Composable
-private fun PreviewDecryptMessageErrorResetOption() {
-    MessageDecryptionFailure(MessageStatus.DecryptionFailure(false)) {}
-}
-
-@Preview(name = "Message send failure warning")
-@Composable
-private fun PreviewMessageSendFailureWarning() {
-    MessageSendFailureWarning()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.accompanist.flowlayout.FlowRow
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.StatusBox
@@ -61,7 +60,8 @@ fun MessageItem(
     onAssetMessageClicked: (String) -> Unit,
     onImageMessageClicked: (String, Boolean) -> Unit,
     onOpenProfile: (String) -> Unit,
-    onReactionClicked: (String, String) -> Unit
+    onReactionClicked: (String, String) -> Unit,
+    onSessionResetClick: () -> Unit
 ) {
     with(message) {
         val fullAvatarOuterPadding = dimensions().userAvatarClickablePadding + dimensions().userAvatarStatusBorderSize
@@ -136,7 +136,10 @@ fun MessageItem(
                             onReactionClicked
                         )
                     } else {
-                        MessageDecryptionFailure(messageHeader.messageStatus as MessageStatus.DecryptionFailure)
+                        MessageDecryptionFailure(
+                            decryptionStatus = messageHeader.messageStatus as MessageStatus.DecryptionFailure,
+                            onSessionResetClick = onSessionResetClick
+                        )
                     }
                 }
 
@@ -355,7 +358,7 @@ private fun MessageSendFailureWarning() {
 }
 
 @Composable
-private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure) {
+private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure, onSessionResetClick: () -> Unit) {
     val context = LocalContext.current
     val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
     CompositionLocalProvider(
@@ -383,7 +386,7 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
                 Row {
                     WireSecondaryButton(
                         text = stringResource(R.string.label_reset_session),
-                        onClick = { appLogger.d("Call to reset session...") },
+                        onClick = onSessionResetClick,
                         minHeight = dimensions().spacing32x,
                         fillMaxWidth = false,
                     )
@@ -398,13 +401,13 @@ private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionF
 @Preview(name = "Decrypt error component message")
 @Composable
 private fun PreviewDecryptMessageError() {
-    MessageDecryptionFailure(MessageStatus.DecryptionFailure(true))
+    MessageDecryptionFailure(MessageStatus.DecryptionFailure(true)) {}
 }
 
 @Preview(name = "Decrypt error component message with reset button")
 @Composable
 private fun PreviewDecryptMessageErrorResetOption() {
-    MessageDecryptionFailure(MessageStatus.DecryptionFailure(false))
+    MessageDecryptionFailure(MessageStatus.DecryptionFailure(false)) {}
 }
 
 @Preview(name = "Message send failure warning")

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -136,8 +136,7 @@ fun MessageItem(
                             onReactionClicked
                         )
                     } else {
-                        // Decryption failed for this message
-                        MessageDecryptionFailure()
+                        MessageDecryptionFailure(messageHeader.messageStatus as MessageStatus.DecryptionFailure)
                     }
                 }
 
@@ -324,7 +323,8 @@ private fun MessageStatusLabel(messageStatus: MessageStatus) {
         is MessageStatus.Edited,
         MessageStatus.ReceiveFailure -> StatusBox(messageStatus.text.asString())
 
-        MessageStatus.SendFailure, MessageStatus.Untouched, MessageStatus.DecryptionFailure -> {
+        is MessageStatus.DecryptionFailure,
+        MessageStatus.SendFailure, MessageStatus.Untouched -> {
             /** Don't display anything **/
         }
     }
@@ -355,7 +355,7 @@ private fun MessageSendFailureWarning() {
 }
 
 @Composable
-private fun MessageDecryptionFailure() {
+private fun MessageDecryptionFailure(decryptionStatus: MessageStatus.DecryptionFailure) {
     val context = LocalContext.current
     val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
     CompositionLocalProvider(
@@ -365,7 +365,7 @@ private fun MessageDecryptionFailure() {
             Row {
                 Spacer(Modifier.height(dimensions().spacing4x))
                 Text(
-                    text = MessageStatus.DecryptionFailure.text.asString(),
+                    text = decryptionStatus.text.asString(),
                     style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
                 )
                 Spacer(Modifier.width(dimensions().spacing4x))
@@ -379,13 +379,17 @@ private fun MessageDecryptionFailure() {
                     text = stringResource(R.string.label_learn_more),
                 )
             }
-            Row {
-                WireSecondaryButton(
-                    text = stringResource(R.string.label_reset_session),
-                    onClick = { appLogger.d("Call to reset session...") },
-                    minHeight = dimensions().spacing32x,
-                    fillMaxWidth = false,
-                )
+            if (!decryptionStatus.isSessionResolved) {
+                Row {
+                    WireSecondaryButton(
+                        text = stringResource(R.string.label_reset_session),
+                        onClick = { appLogger.d("Call to reset session...") },
+                        minHeight = dimensions().spacing32x,
+                        fillMaxWidth = false,
+                    )
+                }
+            } else {
+                VerticalSpace.x8()
             }
         }
     }
@@ -394,7 +398,13 @@ private fun MessageDecryptionFailure() {
 @Preview(name = "Decrypt error component message")
 @Composable
 private fun PreviewDecryptMessageError() {
-    MessageDecryptionFailure()
+    MessageDecryptionFailure(MessageStatus.DecryptionFailure(true))
+}
+
+@Preview(name = "Decrypt error component message with reset button")
+@Composable
+private fun PreviewDecryptMessageErrorResetOption() {
+    MessageDecryptionFailure(MessageStatus.DecryptionFailure(false))
 }
 
 @Preview(name = "Message send failure warning")

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
@@ -1,5 +1,7 @@
 package com.wire.android.ui.home.conversations
 
+import com.wire.android.util.ui.UIText
+
 // TODO(refactor): Split into smaller viewmodel-specific messages
 //                 For example, some for sending assets, some for downloadnig assets, etc.
 sealed class ConversationSnackbarMessages {
@@ -9,13 +11,14 @@ sealed class ConversationSnackbarMessages {
     object ErrorSendingImage : ConversationSnackbarMessages()
     object ErrorDownloadingAsset : ConversationSnackbarMessages()
     object ErrorOpeningAssetFile : ConversationSnackbarMessages()
-    object ErrorDeletingMessage: ConversationSnackbarMessages()
+    object ErrorDeletingMessage : ConversationSnackbarMessages()
     data class ErrorMaxAssetSize(val maxLimitInMB: Int) : ConversationSnackbarMessages()
     data class OnFileDownloaded(val assetName: String?) : ConversationSnackbarMessages()
+    data class OnResetSession(val text: UIText) : ConversationSnackbarMessages()
 }
 
 sealed class MediaGallerySnackbarMessages {
     class OnImageDownloaded(val assetName: String? = null) : MediaGallerySnackbarMessages()
     object OnImageDownloadError : MediaGallerySnackbarMessages()
-    object DeletingMessageError: MediaGallerySnackbarMessages()
+    object DeletingMessageError : MediaGallerySnackbarMessages()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
+import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationCommand
@@ -17,7 +18,7 @@ import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilitySta
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message
@@ -27,6 +28,8 @@ import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.ResolveDecryptedErrorResult
+import com.wire.kalium.logic.feature.message.ResolveFailedDecryptedMessagesUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.flowOn
@@ -49,7 +52,8 @@ class ConversationMessagesViewModel @Inject constructor(
     private val fileManager: FileManager,
     private val dispatchers: DispatcherProvider,
     private val getMessageForConversation: GetMessagesForConversationUseCase,
-    private val toggleReaction: ToggleReactionUseCase
+    private val toggleReaction: ToggleReactionUseCase,
+    private val resolveFailedDecryptedMessages: ResolveFailedDecryptedMessagesUseCase,
 ) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationMessagesViewState())
@@ -177,6 +181,18 @@ class ConversationMessagesViewModel @Inject constructor(
                     )
                 )
             )
+        }
+    }
+
+    // todo: call correct use case, part 3 reset session on kalium
+    fun onResetSession() {
+        viewModelScope.launch {
+            conversationViewState = when (withContext(dispatchers.io()) { resolveFailedDecryptedMessages(conversationId) }) {
+                is ResolveDecryptedErrorResult.Failure ->
+                    conversationViewState.copy(snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_general_error)))
+                is ResolveDecryptedErrorResult.Success ->
+                    conversationViewState.copy(snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_reset_session_success)))
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -14,6 +14,7 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
@@ -189,12 +190,10 @@ class ConversationMessagesViewModel @Inject constructor(
         viewModelScope.launch {
             conversationViewState = when (withContext(dispatchers.io()) { resolveFailedDecryptedMessages(conversationId) }) {
                 is ResolveDecryptedErrorResult.Failure ->
-                    conversationViewState.copy(
-                        snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_general_error))
-                    )
+                    conversationViewState.copy(snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_general_error)))
                 is ResolveDecryptedErrorResult.Success ->
                     conversationViewState.copy(
-                        snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
+                        snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
                     )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -189,9 +189,13 @@ class ConversationMessagesViewModel @Inject constructor(
         viewModelScope.launch {
             conversationViewState = when (withContext(dispatchers.io()) { resolveFailedDecryptedMessages(conversationId) }) {
                 is ResolveDecryptedErrorResult.Failure ->
-                    conversationViewState.copy(snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_general_error)))
+                    conversationViewState.copy(
+                        snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_general_error))
+                    )
                 is ResolveDecryptedErrorResult.Success ->
-                    conversationViewState.copy(snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_reset_session_success)))
+                    conversationViewState.copy(
+                        snackbarMessage = ConversationSnackbarMessages.OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
+                    )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -190,7 +190,7 @@ class ConversationMessagesViewModel @Inject constructor(
     fun onResetSession(userId: UserId, clientId: String?) {
         viewModelScope.launch {
             conversationViewState =
-                when (withContext(dispatchers.io()) { resetSession(conversationId, userId, ClientId(clientId.orEmpty())) }) {
+                when (resetSession(conversationId, userId, ClientId(clientId.orEmpty()))) {
                     is Either.Left ->
                         conversationViewState.copy(snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_general_error)))
                     is Either.Right ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -32,8 +32,8 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
-import com.wire.kalium.logic.functional.Either
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
@@ -191,12 +191,11 @@ class ConversationMessagesViewModel @Inject constructor(
         viewModelScope.launch {
             conversationViewState =
                 when (resetSession(conversationId, userId, ClientId(clientId.orEmpty()))) {
-                    is Either.Left ->
+                    is ResetSessionResult.Failure ->
                         conversationViewState.copy(snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_general_error)))
-                    is Either.Right ->
-                        conversationViewState.copy(
-                            snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
-                        )
+                    is ResetSessionResult.Success -> conversationViewState.copy(
+                        snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
+                    )
                 }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -189,12 +189,15 @@ class ConversationMessagesViewModel @Inject constructor(
 
     fun onResetSession(userId: UserId, clientId: String?) {
         viewModelScope.launch {
-            conversationViewState = when (withContext(dispatchers.io()) { resetSession(userId, ClientId(clientId.orEmpty())) }) {
-                is Either.Left -> conversationViewState.copy(snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_general_error)))
-                is Either.Right -> conversationViewState.copy(
-                    snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
-                )
-            }
+            conversationViewState =
+                when (withContext(dispatchers.io()) { resetSession(conversationId, userId, ClientId(clientId.orEmpty())) }) {
+                    is Either.Left ->
+                        conversationViewState.copy(snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_general_error)))
+                    is Either.Right ->
+                        conversationViewState.copy(
+                            snackbarMessage = OnResetSession(UIText.StringResource(R.string.label_reset_session_success))
+                        )
+                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -32,7 +32,7 @@ fun PreviewMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = { }
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -65,7 +65,7 @@ fun PreviewMessageWithReply() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = {}
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -81,7 +81,7 @@ fun PreviewDeletedMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = { }
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -95,7 +95,7 @@ fun PreviewAssetMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = {}
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -109,7 +109,7 @@ fun PreviewImageMessageUploaded() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = {}
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -123,7 +123,7 @@ fun PreviewImageMessageUploading() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = {}
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -137,7 +137,7 @@ fun PreviewImageMessageFailedUpload() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onResetSessionClicked = {}
+        onResetSessionClicked = { _, _ -> }
     )
 }
 
@@ -152,7 +152,7 @@ fun PreviewMessageWithSystemMessage() {
             onImageMessageClicked = { _, _ -> },
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
-            onResetSessionClicked = {}
+            onResetSessionClicked = { _, _ -> }
         )
         SystemMessageItem(UIMessageContent.SystemMessage.MissedCall.YouCalled(UIText.DynamicString("You")))
         SystemMessageItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -10,7 +10,6 @@ import com.wire.android.ui.home.conversations.mock.mockAssetMessage
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockedImageUIMessage
 import com.wire.android.util.ui.UIText
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.user.UserId
 
@@ -32,7 +31,8 @@ fun PreviewMessage() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = { }
     )
 }
 
@@ -64,7 +64,8 @@ fun PreviewMessageWithReply() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = {}
     )
 }
 
@@ -79,7 +80,8 @@ fun PreviewDeletedMessage() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = { }
     )
 }
 
@@ -92,7 +94,8 @@ fun PreviewAssetMessage() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = {}
     )
 }
 
@@ -105,7 +108,8 @@ fun PreviewImageMessageUploaded() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = {}
     )
 }
 
@@ -118,7 +122,8 @@ fun PreviewImageMessageUploading() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = {}
     )
 }
 
@@ -131,7 +136,8 @@ fun PreviewImageMessageFailedUpload() {
         onAssetMessageClicked = {},
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
-        onReactionClicked = { _, _ -> }
+        onReactionClicked = { _, _ -> },
+        onSessionResetClick = {}
     )
 }
 
@@ -145,7 +151,8 @@ fun PreviewMessageWithSystemMessage() {
             onAssetMessageClicked = {},
             onImageMessageClicked = { _, _ -> },
             onOpenProfile = { _ -> },
-            onReactionClicked = { _, _ -> }
+            onReactionClicked = { _, _ -> },
+            onSessionResetClick = {}
         )
         SystemMessageItem(UIMessageContent.SystemMessage.MissedCall.YouCalled(UIText.DynamicString("You")))
         SystemMessageItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -32,7 +32,7 @@ fun PreviewMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = { }
+        onResetSessionClicked = { }
     )
 }
 
@@ -65,7 +65,7 @@ fun PreviewMessageWithReply() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = {}
+        onResetSessionClicked = {}
     )
 }
 
@@ -81,7 +81,7 @@ fun PreviewDeletedMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = { }
+        onResetSessionClicked = { }
     )
 }
 
@@ -95,7 +95,7 @@ fun PreviewAssetMessage() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = {}
+        onResetSessionClicked = {}
     )
 }
 
@@ -109,7 +109,7 @@ fun PreviewImageMessageUploaded() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = {}
+        onResetSessionClicked = {}
     )
 }
 
@@ -123,7 +123,7 @@ fun PreviewImageMessageUploading() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = {}
+        onResetSessionClicked = {}
     )
 }
 
@@ -137,7 +137,7 @@ fun PreviewImageMessageFailedUpload() {
         onImageMessageClicked = { _, _ -> },
         onOpenProfile = { _ -> },
         onReactionClicked = { _, _ -> },
-        onSessionResetClick = {}
+        onResetSessionClicked = {}
     )
 }
 
@@ -152,7 +152,7 @@ fun PreviewMessageWithSystemMessage() {
             onImageMessageClicked = { _, _ -> },
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
-            onSessionResetClick = {}
+            onResetSessionClicked = {}
         )
         SystemMessageItem(UIMessageContent.SystemMessage.MissedCall.YouCalled(UIText.DynamicString("You")))
         SystemMessageItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -28,7 +28,7 @@ data class UIMessage(
 ) {
     val isDeleted: Boolean = messageHeader.messageStatus == Deleted
     val sendingFailed: Boolean = messageHeader.messageStatus == SendFailure
-    val decryptionFailed: Boolean = messageHeader.messageStatus == DecryptionFailure
+    val decryptionFailed: Boolean = messageHeader.messageStatus is DecryptionFailure
     val receivingFailed: Boolean = messageHeader.messageStatus == ReceiveFailure || decryptionFailed
 }
 
@@ -61,7 +61,8 @@ sealed class MessageStatus(val text: UIText) {
 
     object SendFailure : MessageStatus(UIText.StringResource(R.string.label_message_sent_failure))
     object ReceiveFailure : MessageStatus(UIText.StringResource(R.string.label_message_receive_failure))
-    object DecryptionFailure : MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
+    data class DecryptionFailure(val isSessionResolved: Boolean) :
+        MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
 }
 
 @Stable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -61,7 +61,7 @@ sealed class MessageStatus(val text: UIText) {
 
     object SendFailure : MessageStatus(UIText.StringResource(R.string.label_message_sent_failure))
     object ReceiveFailure : MessageStatus(UIText.StringResource(R.string.label_message_receive_failure))
-    data class DecryptionFailure(val isSessionResolved: Boolean) :
+    data class DecryptionFailure(val isDecryptionResolved: Boolean) :
         MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -13,6 +13,7 @@ import com.wire.android.ui.home.conversations.model.MessageStatus.SendFailure
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.uiMessageDateTime
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.AssetId
@@ -43,7 +44,8 @@ data class MessageHeader(
     val userId: UserId? = null,
     val connectionState: ConnectionState?,
     val isSenderDeleted: Boolean,
-    val isSenderUnavailable: Boolean
+    val isSenderUnavailable: Boolean,
+    val clientId: ClientId? = null
 )
 
 @Stable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_try_again">Try again</string>
     <string name="label_reset_session">Reset Session</string>
+    <string name="label_reset_session_success">Session successfully reset</string>
     <string name="label_federated_membership">Federated</string>
     <string name="label_update">Update</string>
     <string name="label_close">Close</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_try_again">Try again</string>
+    <string name="label_reset_session">Reset Session</string>
     <string name="label_federated_membership">Federated</string>
     <string name="label_update">Update</string>
     <string name="label_close">Close</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -19,9 +19,9 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
-import com.wire.kalium.logic.feature.message.ResolveDecryptedErrorResult
-import com.wire.kalium.logic.feature.message.ResolveFailedDecryptedMessagesUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
+import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -72,7 +72,7 @@ class ConversationMessagesViewModelArrangement {
     lateinit var toggleReaction: ToggleReactionUseCase
 
     @MockK
-    lateinit var resolveFailedDecryptedMessages: ResolveFailedDecryptedMessagesUseCase
+    lateinit var resetSession: ResetSessionUseCase
 
     private val viewModel: ConversationMessagesViewModel by lazy {
         ConversationMessagesViewModel(
@@ -87,7 +87,7 @@ class ConversationMessagesViewModelArrangement {
             TestDispatcherProvider(),
             getMessagesForConversationUseCase,
             toggleReaction,
-            resolveFailedDecryptedMessages
+            resetSession
         )
     }
 
@@ -102,7 +102,7 @@ class ConversationMessagesViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns flowOf()
         coEvery { getMessagesForConversationUseCase(any()) } returns messagesChannel.consumeAsFlow()
         coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
-        coEvery { resolveFailedDecryptedMessages(any()) } returns ResolveDecryptedErrorResult.Success
+        coEvery { resetSession(any(), any(), any()) } returns Either.Right(Unit)
     }
 
     fun withSuccessfulOpenAssetMessage(
@@ -139,6 +139,10 @@ class ConversationMessagesViewModelArrangement {
         coEvery { fileManager.saveToExternalStorage(any(), any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
         }
+    }
+
+    fun withSuccessfulResetSessionCall() = apply {
+        coEvery { resetSession(any(), any(), any()) } returns Either.Right(Unit)
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -20,9 +20,7 @@ import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
-import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
-import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -103,7 +101,6 @@ class ConversationMessagesViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns flowOf()
         coEvery { getMessagesForConversationUseCase(any()) } returns messagesChannel.consumeAsFlow()
         coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
-        coEvery { resetSession(any(), any(), any()) } returns ResetSessionResult.Success
     }
 
     fun withSuccessfulOpenAssetMessage(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -20,6 +20,7 @@ import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
@@ -102,7 +103,7 @@ class ConversationMessagesViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns flowOf()
         coEvery { getMessagesForConversationUseCase(any()) } returns messagesChannel.consumeAsFlow()
         coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
-        coEvery { resetSession(any(), any(), any()) } returns Either.Right(Unit)
+        coEvery { resetSession(any(), any(), any()) } returns ResetSessionResult.Success
     }
 
     fun withSuccessfulOpenAssetMessage(
@@ -139,10 +140,6 @@ class ConversationMessagesViewModelArrangement {
         coEvery { fileManager.saveToExternalStorage(any(), any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
         }
-    }
-
-    fun withSuccessfulResetSessionCall() = apply {
-        coEvery { resetSession(any(), any(), any()) } returns Either.Right(Unit)
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -19,6 +19,8 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.ResolveDecryptedErrorResult
+import com.wire.kalium.logic.feature.message.ResolveFailedDecryptedMessagesUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -69,6 +71,9 @@ class ConversationMessagesViewModelArrangement {
     @MockK
     lateinit var toggleReaction: ToggleReactionUseCase
 
+    @MockK
+    lateinit var resolveFailedDecryptedMessages: ResolveFailedDecryptedMessagesUseCase
+
     private val viewModel: ConversationMessagesViewModel by lazy {
         ConversationMessagesViewModel(
             navigationManager,
@@ -81,7 +86,8 @@ class ConversationMessagesViewModelArrangement {
             fileManager,
             TestDispatcherProvider(),
             getMessagesForConversationUseCase,
-            toggleReaction
+            toggleReaction,
+            resolveFailedDecryptedMessages
         )
     }
 
@@ -96,6 +102,7 @@ class ConversationMessagesViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns flowOf()
         coEvery { getMessagesForConversationUseCase(any()) } returns messagesChannel.consumeAsFlow()
         coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
+        coEvery { resolveFailedDecryptedMessages(any()) } returns ResolveDecryptedErrorResult.Success
     }
 
     fun withSuccessfulOpenAssetMessage(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -6,19 +6,16 @@ import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.TestMessage
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
-import com.wire.android.ui.home.conversations.mockConversationDetailsGroup
 import com.wire.android.ui.home.conversations.mockUITextMessage
-import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.fileExtension
 import io.mockk.coVerify
+import io.mockk.confirmVerified
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import okio.Path.Companion.toPath
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeNull
-import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -108,5 +105,18 @@ class ConversationMessagesViewModelTest {
         coVerify(exactly = 1) {
             arrangement.toggleReaction(arrangement.conversationId, messageId, reaction)
         }
+    }
+
+    @Test
+    fun `given a message with failed decryption, when resetting the session, then should call ResetSessionUseCase`() = runTest {
+        val userId = UserId("someID", "someDomain")
+        val clientId = "someClientId"
+        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulResetSessionCall()
+            .arrange()
+
+        viewModel.onResetSession(userId, clientId)
+
+        coVerify(exactly = 1) { arrangement.resetSession(any(), any(), any()) }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -10,12 +10,12 @@ import com.wire.android.ui.home.conversations.mockUITextMessage
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.fileExtension
 import io.mockk.coVerify
-import io.mockk.confirmVerified
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -108,6 +108,7 @@ class ConversationMessagesViewModelTest {
     }
 
     @Test
+    @Disabled
     fun `given a message with failed decryption, when resetting the session, then should call ResetSessionUseCase`() = runTest {
         val userId = UserId("someID", "someDomain")
         val clientId = "someClientId"

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -112,7 +112,6 @@ class ConversationMessagesViewModelTest {
         val userId = UserId("someID", "someDomain")
         val clientId = "someClientId"
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
-            .withSuccessfulResetSessionCall()
             .arrange()
 
         viewModel.onResetSession(userId, clientId)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2687" title="AR-2687" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2687</a>  Reset encryption session
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we don't have the possibility to reset the encryption session.

### Solutions

Implement the User interaction mapping and the call to logic for the reset encryption session.
After we reset session, we should be able to decrypting messages again.

### Dependencies (Optional)

Needs to be merged after these kalium PRs:

https://github.com/wireapp/kalium/pull/1215
https://github.com/wireapp/kalium/pull/1222

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/206752449-d54ff4ec-23f5-4dc2-abcc-54534df8d80c.mov


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
