### PR TITLE
fix: add isIncomingCall as false when call is established

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
@@ -105,7 +105,7 @@ class InitiatingCallViewModel @Inject constructor(
     }
 
     private suspend fun onCallEstablished() {
-        callRinger.ring(R.raw.ready_to_talk, isLooping = false)
+        callRinger.ring(R.raw.ready_to_talk, isLooping = false, isIncomingCall = false)
         navigationManager.navigate(
             command = NavigationCommand(
                 destination = NavigationItem.OngoingCall.getRouteWithArgs(listOf(conversationId)),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2824 - Call Vibration Doesn't Stop](https://wearezeta.atlassian.net/browse/AR-2824)

### Issues

When starting a 1:1 call and call is accepted from other user, then phone vibrates non-stop

### Causes (Optional)

Sending default(true) param when calling ringer/vibration for isIncomingCall when it was called from onEstablished call.

### Solutions

Send correct(false) param when calling ringer/vibration from on established call.

### Testing

#### Test Coverage (Optional)

#### How to Test

- Open AR
- Start 1:1 Call
- Wait 5~ seconds then accept call
- AR phone should NOT vibrate non-stop
