### PR TITLE
feat: handle pings, replies and mentions in notifications [AR-2765]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -222,7 +222,7 @@ class MessageNotificationManager
             .build()
 
         val message = when (this) {
-            is NotificationMessage.Text -> text
+            is NotificationMessage.Text -> if (isQuotingSelfUser) context.getString(R.string.notification_reply, text) else text
             is NotificationMessage.Comment -> italicTextFromResId(textResId.value)
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -17,7 +17,12 @@ data class NotificationConversation(
 )
 
 sealed class NotificationMessage(open val author: NotificationMessageAuthor, open val time: Long) {
-    data class Text(override val author: NotificationMessageAuthor, override val time: Long, val text: String) :
+    data class Text(
+        override val author: NotificationMessageAuthor,
+        override val time: Long,
+        val text: String,
+        val isQuotingSelfUser: Boolean
+    ) :
         NotificationMessage(author, time)
 
     // shared file, picture, reaction
@@ -38,7 +43,8 @@ enum class CommentResId(@StringRes val value: Int) {
     FILE(R.string.notification_shared_file),
     REACTION(R.string.notification_reacted),
     MISSED_CALL(R.string.notification_missed_call),
-    NOT_SUPPORTED(R.string.notification_not_supported_issue)
+    KNOCK(R.string.notification_knock),
+    NOT_SUPPORTED(R.string.notification_not_supported_issue),
 }
 
 fun LocalNotificationConversation.intoNotificationConversation(): NotificationConversation {
@@ -62,7 +68,12 @@ fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
     val notificationMessageTime = time.toTimeInMillis()
 
     return when (this) {
-        is LocalNotificationMessage.Text -> NotificationMessage.Text(notificationMessageAuthor, notificationMessageTime, text)
+        is LocalNotificationMessage.Text -> NotificationMessage.Text(
+            author = notificationMessageAuthor,
+            time = notificationMessageTime,
+            text = text,
+            isQuotingSelfUser = isQuotingSelfUser
+        )
         is LocalNotificationMessage.Comment -> NotificationMessage.Comment(
             notificationMessageAuthor,
             notificationMessageTime,
@@ -88,5 +99,6 @@ fun LocalNotificationCommentType.intoCommentResId(): CommentResId =
         LocalNotificationCommentType.FILE -> CommentResId.FILE
         LocalNotificationCommentType.REACTION -> CommentResId.REACTION
         LocalNotificationCommentType.MISSED_CALL -> CommentResId.MISSED_CALL
+        LocalNotificationCommentType.KNOCK -> CommentResId.KNOCK
         LocalNotificationCommentType.NOT_SUPPORTED_YET -> CommentResId.NOT_SUPPORTED
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,8 @@
     <string name="notification_shared_file">Shared a file</string>
     <string name="notification_reacted">Added a reaction</string>
     <string name="notification_missed_call">Missed call</string>
+    <string name="notification_knock">Pinged</string>
+    <string name="notification_reply">Reply: %1$s</string>
     <string name="notification_not_supported_issue">Something not supported in notifications</string>
     <string name="notification_connection_request">Wants to connect</string>
     <string name="notification_conversation_deleted">Deleted the group</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2765" title="AR-2765" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2765</a>  No replies are received as a push notification when group notification status is set to mentions&replies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Handler for reply and ping notification

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
