### PR TITLE
fix: safe cast for clientId on system messages

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -120,7 +120,7 @@ class MessageMapper @Inject constructor(
             is OtherUser -> sender.isUnavailableUser
             is SelfUser, null -> false
         },
-        clientId = (message as? Message.Sendable)?.senderClientId
+        clientId = (message as Message.Regular).senderClientId
     )
 
     private fun getMessageStatus(message: Message.Standalone) = when {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -120,7 +120,10 @@ class MessageMapper @Inject constructor(
             is OtherUser -> sender.isUnavailableUser
             is SelfUser, null -> false
         },
-        clientId = (message as Message.Regular).senderClientId
+        clientId = when (message) {
+            is Message.Regular -> message.senderClientId
+            is Message.System -> null
+        }
     )
 
     private fun getMessageStatus(message: Message.Standalone) = when {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -120,7 +120,7 @@ class MessageMapper @Inject constructor(
             is OtherUser -> sender.isUnavailableUser
             is SelfUser, null -> false
         },
-        clientId = (message as Message.Sendable).senderClientId
+        clientId = (message as? Message.Sendable)?.senderClientId
     )
 
     private fun getMessageStatus(message: Message.Standalone) = when {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

System messages don't have a `clientId`, the field is optional.

### Causes (Optional)

Crash occurred when system messages are received and the mapper tries to cast the system message to a `Sendable`

### Solutions

The field `clientId` is optional on mapping, so if a message is `Regular` send the value, if not just null

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
