### PR TITLE
fix: use compatibility build profile for the dev flavour [AR-2776]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,10 @@ def defineBuildType() {
     if(overwrite != null) {
         return overwrite
     }
+    def flavor = defineFlavor()
+    if (flavor == "Dev") {
+        return "Debug"
+    }
     return "Release"
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,10 @@ def defineBuildType() {
     if(overwrite != null) {
         return overwrite
     }
+    // use the scala client signing keys for testing upgrades.
     def flavor = defineFlavor()
     if (flavor == "Dev") {
-        return "Debug"
+        return "Compat"
     }
     return "Release"
 }
@@ -129,10 +130,12 @@ pipeline {
     stage('Fetch Signing Files') {
       steps {
         configFileProvider([
+         configFile(fileId: env.COMPAT_KEYSTORE_FILE_ID, targetLocation: env.COMPAT_ENC_TARGET_LOCATION),
          configFile(fileId: env.DEBUG_KEYSTORE_FILE_ID, targetLocation: env.DEBUG_ENC_TARGET_LOCATION),
          configFile(fileId: env.RELEASE_KEYSTORE_FILE_ID, targetLocation: env.RELEASE_ENC_TARGET_LOCATION),
         ]) {
           sh '''
+            base64 --decode $COMPAT_ENC_TARGET_LOCATION > $COMPAT_DEC_TARGET_LOCATION
             base64 --decode $DEBUG_ENC_TARGET_LOCATION > $DEBUG_DEC_TARGET_LOCATION
             base64 --decode $RELEASE_ENC_TARGET_LOCATION > $RELEASE_DEC_TARGET_LOCATION
           '''

--- a/buildSrc/src/main/kotlin/ClientConfig.kt
+++ b/buildSrc/src/main/kotlin/ClientConfig.kt
@@ -16,6 +16,7 @@ object ClientConfig {
 
         // Config field values for DEBUG Build Type
         BuildTypes.DEBUG to ConfigFields.values().associate { Pair(it, it.defaultValue) },
+        BuildTypes.COMPAT to ConfigFields.values().associate { Pair(it, it.defaultValue) },
 
         // Config field values for RELEASE Build Type
         // TODO: Certificate pinning, change backend based on flavour

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -85,9 +85,11 @@ android {
                 signingConfig = signingConfigs.getByName("release")
         }
         create(BuildTypes.COMPAT) {
+            initWith(getByName(BuildTypes.RELEASE))
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             isDebuggable = false
+            matchingFallbacks.add("release")
             if (enableSigning)
                 signingConfig = signingConfigs.getByName("compat")
         }

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -17,6 +17,7 @@ plugins { id("com.android.application") apply false }
 object BuildTypes {
     const val DEBUG = "debug"
     const val RELEASE = "release"
+    const val COMPAT = "compat"
 }
 
 object ProductFlavors {
@@ -57,6 +58,12 @@ android {
                 keyAlias = System.getenv("KEYSTORE_KEY_NAME_DEBUG")
                 keyPassword = System.getenv("KEYPWD_DEBUG")
             }
+            maybeCreate(BuildTypes.COMPAT).apply {
+                storeFile = file(System.getenv("KEYSTORE_FILE_PATH_COMPAT"))
+                storePassword = System.getenv("KEYSTOREPWD_COMPAT")
+                keyAlias = System.getenv("KEYSTORE_KEY_NAME_COMPAT")
+                keyPassword = System.getenv("KEYPWD_COMPAT")
+            }
         }
     }
 
@@ -76,6 +83,13 @@ android {
             isDebuggable = false
             if (enableSigning)
                 signingConfig = signingConfigs.getByName("release")
+        }
+        create(BuildTypes.COMPAT) {
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            isDebuggable = false
+            if (enableSigning)
+                signingConfig = signingConfigs.getByName("compat")
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2776" title="AR-2776" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2776</a>  Update product flavours
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QA wants to test the upgrade path from the old Scala app to Reloaded. As Android requires the same signing key to be used when upgrading an application to a newer version, this means that we need the Reloaded APK to be signed with the old app's key. We only want to change the signing key for the `dev`-flavoured build, to allow QA to test the upgrade functions without interfering with our existing beta testers.

The build scripts for Reloaded have two build configurations, `debug` and `release`; orthogonally, there are (at least) three different build *flavours*: `public`, `internal`, and `dev`. The Jenkins pipeline is configured to use different signing keys for `debug` and `release` builds, but presently does not have any logic for switching the signing keys for different build flavours.

However, while the build scripts default to using the debug config, the Jenkins pipeline is hardcoded to override this to use the release config.

### Solutions

**Edit:** I've changed my approach here. I had missed the fact that building clients in the `debug` configuration adds a ".debug" suffix to the application ID, which means that it's not possible to use a `dev+debug` debug build of Reloaded to upgrade over a `dev+release` version of the Scala app.

After much frustration with Gradle and some help from @MohamadJaara, we've opted instead to extend the build scripts with a third `compat` build flavour, which is otherwise identical to `release` other than using a different signing configuration. The Jenkins pipeline is updated in this PR to build `dev` clients in the `compat` config, and at the time of writing I've updated the Jenkins configuration with the required environment variables to use the Scala app's signing keys for the `compat` profile.

**Old solution:**

*As a first step, I have extended the logic of the pipeline to use the debug build config when compiling `dev`-flavoured builds. This decouples the signing configuration for `dev` from the signing configuration for `internal` and `public`, so once this change is in `develop`, the configuration in Jenkins can be updated so that the old Scala app's signing key is used for debug builds, which will only affect the `dev` flavour.*

### Testing

#### How to Test

- Observe that builds on this PR branch should be compiled in the debug configuration.
- Once the keystore configuration in Jenkins has been updated, check whether builds on this PR branch can be installed over an install of the old Scala client with the same application ID.

