### PR TITLE
fix: connection issues top bar is not displayed on app start

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,7 +34,6 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.id.ConversationId
-import kotlinx.coroutines.delay
 
 @Composable
 fun CommonTopAppBar(
@@ -70,23 +68,11 @@ private fun ConnectivityStatusBar(
 
         ConnectivityUIState.Info.None -> lastVisibleBackgroundColor
     }
-
-    /**
-     * Adding some delay here to avoid some bad UX : ongoing call banner displayed and hided in a short time when the user hangs up the call
-     * Call events could take some time to be received and this function could be called when the screen is changed, so we delayed
-     * showing the banner until getting the correct calling values
-     */
-    var shouldRunAfterDelay by remember { mutableStateOf(false) }
-    LaunchedEffect(key1 = Unit) {
-        if (connectivityInfo is ConnectivityUIState.Info.EstablishedCall)
-            delay(WAITING_TIME_TO_SHOW_ONGOING_CALL_BANNER)
-        shouldRunAfterDelay = isVisible
-    }
-    if (!isVisible && shouldRunAfterDelay) {
+    if (!isVisible) {
         clearStatusBarColor()
     }
 
-    if (isVisible && shouldRunAfterDelay) {
+    if (isVisible) {
         lastVisibleBackgroundColor = backgroundColor
         val darkIcons = MaterialTheme.wireColorScheme.connectivityBarShouldUseDarkIcons
         rememberSystemUiController().setStatusBarColor(
@@ -105,7 +91,7 @@ private fun ConnectivityStatusBar(
         }
 
     AnimatedVisibility(
-        visible = isVisible && shouldRunAfterDelay,
+        visible = isVisible,
         enter = expandIn(initialSize = { fullSize -> IntSize(fullSize.width, 0) }),
         exit = shrinkOut(targetSize = { fullSize -> IntSize(fullSize.width, 0) })
     ) {
@@ -247,4 +233,3 @@ fun CommonTopAppConnectionStatusIsNone() {
         onReturnToCallClick = { }
     )
 }
-private const val WAITING_TIME_TO_SHOW_ONGOING_CALL_BANNER = 500L

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -16,7 +16,9 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -92,10 +94,20 @@ class CommonTopAppBarViewModel @Inject constructor(
         }
     }
 
+    @OptIn(FlowPreview::class)
     private suspend fun activeCallFlow() = establishedCalls().map { calls ->
         calls.firstOrNull()
-    }
+        /**
+         * Adding some delay here to avoid some bad UX : ongoing call banner displayed and hided in a short time when the user hangs up the call
+         * Call events could take some time to be received and this function could be called when the screen is changed, so we delayed
+         * showing the banner until getting the correct calling values
+         */
+    }.debounce(WAITING_TIME_TO_SHOW_ONGOING_CALL_BANNER)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun currentScreenFlow() = currentScreenManager.observeCurrentScreen(viewModelScope)
+
+    private companion object {
+        const val WAITING_TIME_TO_SHOW_ONGOING_CALL_BANNER = 500L
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -34,6 +34,7 @@ class CommonTopAppBarViewModel @Inject constructor(
 ) : CommonTopAppBarBaseViewModel() {
 
     var connectivityState by mutableStateOf(ConnectivityUIState(ConnectivityUIState.Info.None))
+
     init {
         viewModelScope.launch {
             combine(activeCallFlow(), currentScreenFlow(), connectivityFlow()) { activeCall, currentScreen, connectivity ->
@@ -98,8 +99,10 @@ class CommonTopAppBarViewModel @Inject constructor(
     private suspend fun activeCallFlow() = establishedCalls().map { calls ->
         calls.firstOrNull()
         /**
-         * Adding some delay here to avoid some bad UX : ongoing call banner displayed and hided in a short time when the user hangs up the call
-         * Call events could take some time to be received and this function could be called when the screen is changed, so we delayed
+         * Adding some delay here to avoid some bad UX : ongoing call banner displayed and
+         * hided in a short time when the user hangs up the call
+         * Call events could take some time to be received and this function
+         * could be called when the screen is changed, so we delayed
          * showing the banner until getting the correct calling values
          */
     }.debounce(WAITING_TIME_TO_SHOW_ONGOING_CALL_BANNER)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the blue top bar notifying the user of no internet connection is not displayed on the first app start.

### Solutions

removing the shouldRunAfterDelay logic form the `CommonTopAppBar` composable and replace it with a debounce to the activeCall flow 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
