### PR TITLE
fix: notification badge before unread events badge

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/RowItemTemplate.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/RowItemTemplate.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.wire.android.model.Clickable
+import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversationslist.common.EventBadgeFactory
 import com.wire.android.ui.home.conversationslist.common.RowItem
 import com.wire.android.ui.home.conversationslist.model.BadgeEventType
@@ -67,15 +68,10 @@ fun RowItemTemplate(
             title()
             subTitle()
         }
-        Box(
-            modifier = Modifier
-                .wrapContentWidth()
-                .padding(horizontal = dimensions().spacing8x)
-        ) {
-            if (eventType != BadgeEventType.None) {
-                EventBadgeFactory(eventType = eventType, modifier = Modifier.align(Alignment.TopEnd))
-            }
-        }
         trailingIcon()
+        if (eventType != BadgeEventType.None) {
+            EventBadgeFactory(eventType = eventType)
+            HorizontalSpace.x8()
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -9,8 +9,8 @@ import com.wire.android.ui.calling.controlbuttons.JoinButton
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.conversationColor
+import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
-import com.wire.android.ui.home.conversationslist.MutedConversationBadge
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.toUserInfoLabel
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -101,6 +101,7 @@ private fun GeneralConversationItem(
                             JoinButton(buttonClick = onJoinCallClick)
                         else if (mutedStatus != MutedConversationStatus.AllAllowed) {
                             MutedConversationBadge(onMutedIconClick)
+                            HorizontalSpace.x8()
                         }
                     },
                 )
@@ -123,6 +124,7 @@ private fun GeneralConversationItem(
                     trailingIcon = {
                         if (mutedStatus != MutedConversationStatus.AllAllowed) {
                             MutedConversationBadge(onMutedIconClick)
+                            HorizontalSpace.x8()
                         }
                     }
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -1,13 +1,17 @@
-package com.wire.android.ui.home.conversationslist
+package com.wire.android.ui.home.conversationslist.common
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
@@ -15,19 +19,29 @@ import com.wire.android.ui.common.dimensions
 
 @Composable
 fun MutedConversationBadge(onClick: () -> Unit) {
-    WireSecondaryButton(
-        onClick = onClick,
-        leadingIcon = {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_mute),
-                contentDescription = stringResource(R.string.content_description_muted_conversation),
-                modifier = Modifier.size(dimensions().spacing16x)
-            )
-        },
-        fillMaxWidth = false,
-        minHeight = dimensions().badgeSmallMinSize.height,
-        minWidth = dimensions().badgeSmallMinSize.width,
-        shape = RoundedCornerShape(size = dimensions().spacing6x),
-        contentPadding = PaddingValues(0.dp),
-    )
+    Box(modifier = Modifier
+        .width(dimensions().spacing24x)
+        .height(dimensions().spacing18x)) {
+        WireSecondaryButton(
+            onClick = onClick,
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_mute),
+                    contentDescription = stringResource(R.string.content_description_muted_conversation),
+                    modifier = Modifier.size(dimensions().spacing12x)
+                )
+            },
+            fillMaxWidth = false,
+            minHeight = dimensions().badgeSmallMinSize.height,
+            minWidth = dimensions().badgeSmallMinSize.width,
+            shape = RoundedCornerShape(size = dimensions().spacing6x),
+            contentPadding = PaddingValues(0.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewMutedConversationBadge() {
+    MutedConversationBadge {}
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Changed order of muted notification badge before unread events counter

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
