### PR TITLE
chore: inherit AGP version from Kalium

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,4 @@
 private object Dependencies {
-    const val androidBuildTools = "com.android.tools.build:gradle:7.2.2"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"
@@ -21,7 +20,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation(Dependencies.androidBuildTools)
+    implementation("com.android.tools.build:gradle:${klibs.versions.agp.get()}")
     implementation(Dependencies.kotlinGradlePlugin)
     implementation(Dependencies.detektGradlePlugin)
     implementation(Dependencies.spotless)

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,9 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("klibs") {
+            from(files("../kalium/gradle/libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The same exact AGP version must be used in Kalium and in Reloaded, otherwise AGP will complain and refuse to build.

Currently, we're declaring manually in two places.

### Solutions

Use Kalium's version catalog (exposed with the name of `klibs`) to figure out the current AGP version.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
