### PR TITLE
fix: Logout problem (AR-2839)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.di.AuthServerConfigProvider
+import com.wire.android.di.CurrentAccount
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.mapper.OtherAccountMapper
@@ -55,6 +56,7 @@ import javax.inject.Inject
 @ExperimentalMaterial3Api
 @HiltViewModel
 class SelfUserProfileViewModel @Inject constructor(
+    @CurrentAccount private val selfUserId: UserId,
     private val navigationManager: NavigationManager,
     private val dataStore: UserDataStore,
     private val getSelf: GetSelfUserUseCase,
@@ -184,7 +186,7 @@ class SelfUserProfileViewModel @Inject constructor(
                 dataStore.clear()
             }
 
-            getSelf().first().let { notificationChannelsManager.deleteChannelGroup(it.id) }
+            notificationChannelsManager.deleteChannelGroup(selfUserId)
             accountSwitch(SwitchAccountParam.SwitchToNextAccountOrWelcome)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -184,9 +184,7 @@ class SelfUserProfileViewModel @Inject constructor(
                 dataStore.clear()
             }
 
-            launch {
-                getSelf().collect { notificationChannelsManager.deleteChannelGroup(it.id) }
-            }.join()
+            getSelf().first().let { notificationChannelsManager.deleteChannelGroup(it.id) }
             accountSwitch(SwitchAccountParam.SwitchToNextAccountOrWelcome)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2839" title="AR-2839" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2839</a>  Logout not possible anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

on logout user was not navigated into propper screen and logout was to actually finised.

### Causes (Optional)

after logout we needed to remove all the android notification channels, for that we need userId.
To get user Id we were using `GetSelfUserUseCase` which returns `Flow<SelfUser>`,  that Flow was never ending so logout process too :) 

### Solutions

use only first emition of `GetSelfUserUseCase Flow`.
