### PR TITLE
fix: show unavailable username in replies for null sendername [AR-2871]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -165,7 +165,7 @@ class MessageContentMapper @Inject constructor(
     private fun mapQuoteData(conversationId: ConversationId, it: MessageContent.QuotedMessageDetails) = QuotedMessageUIData(
         it.messageId,
         it.senderId,
-        it.senderName,
+        it.senderName.orUnknownName(),
         UIText.StringResource(R.string.label_quote_original_message_date, isoFormatter.fromISO8601ToTimeFormat(it.timeInstant.toString())),
         it.editInstant?.let { instant ->
             UIText.StringResource(R.string.label_message_status_edited_with_date, isoFormatter.fromISO8601ToTimeFormat(instant.toString()))
@@ -284,3 +284,9 @@ data class MessageResourceProvider(
     @StringRes val memberNameYouTitlecase: Int = R.string.member_name_you_label_titlecase,
     @StringRes val sentAMessageWithContent: Int = R.string.sent_a_message_with_content
 )
+
+private fun String?.orUnknownName(): UIText = when {
+    this != null -> UIText.DynamicString(this)
+    else -> UIText.StringResource(R.string.username_unavailable_label)
+
+}

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -47,7 +47,7 @@ fun MessagePreview?.toUIPreview(unreadEventCount: UnreadEventCount): UILastMessa
     return uiLastMessageContent()
 }
 
-fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
+private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
     isSelfMessage -> UIText.StringResource(R.string.member_name_you_label_titlecase)
     this != null -> UIText.DynamicString(this)
     else -> UIText.StringResource(R.string.username_unavailable_label)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -162,7 +162,9 @@ private fun QuotedMessageContent(
                 width = 1.dp,
                 color = MaterialTheme.wireColorScheme.divider,
                 shape = quoteOutlineShape
-            ).padding(dimensions().spacing4x).fillMaxWidth()
+            )
+            .padding(dimensions().spacing4x)
+            .fillMaxWidth()
     ) {
         Box(modifier = Modifier.padding(start = dimensions().spacing4x)) {
             startContent()
@@ -184,10 +186,15 @@ private fun QuotedMessageContent(
         }
 
         // Make sure the end content is all the way to the end by spacing it
-        Spacer(modifier = modifier.weight(1f).fillMaxWidth())
+        Spacer(
+            modifier = modifier
+                .weight(1f)
+                .fillMaxWidth()
+        )
         val endContentExtraPadding = if (style == COMPLETE) dimensions().spacing4x else dimensions().spacing0x
         Box(
-            modifier = Modifier.align(Alignment.CenterVertically)
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
                 .padding(bottom = endContentExtraPadding, top = endContentExtraPadding, end = endContentExtraPadding)
         ) {
             endContent()
@@ -227,14 +234,14 @@ private fun QuotedInvalid(style: QuotedMessageStyle) {
 
 @Composable
 private fun QuotedDeleted(
-    senderName: String,
+    senderName: UIText,
     originalDateDescription: UIText,
     style: QuotedMessageStyle,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {},
 ) {
     QuotedMessageContent(
-        senderName,
+        senderName.asString(),
         style = style,
         modifier = modifier,
         startContent = {
@@ -252,13 +259,13 @@ private fun QuotedText(
     text: String,
     editedTimeDescription: UIText?,
     originalDateTimeDescription: UIText,
-    senderName: String,
+    senderName: UIText,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {},
     style: QuotedMessageStyle
 ) {
     QuotedMessageContent(
-        senderName,
+        senderName.asString(),
         style = style,
         modifier = modifier,
         startContent = {
@@ -285,7 +292,7 @@ private fun QuotedMessageOriginalDate(
 
 @Composable
 private fun QuotedImage(
-    senderName: String,
+    senderName: UIText,
     asset: ImageAsset.PrivateAsset,
     originalDateTimeText: UIText,
     startContent: @Composable () -> Unit = {},
@@ -293,7 +300,7 @@ private fun QuotedImage(
     modifier: Modifier
 ) {
     val imageDimension = if (style == COMPLETE) dimensions().spacing56x else dimensions().spacing40x
-    QuotedMessageContent(senderName, style = style, modifier = modifier, endContent = {
+    QuotedMessageContent(senderName.asString(), style = style, modifier = modifier, endContent = {
         Image(
             painter = asset.paint(),
             contentDescription = stringResource(R.string.content_description_image_message),
@@ -326,7 +333,7 @@ private fun MainContentText(text: String) {
 
 @Composable
 private fun QuotedGenericAsset(
-    senderName: String,
+    senderName: UIText,
     originalDateTimeText: UIText,
     assetName: String?,
     style: QuotedMessageStyle,
@@ -334,7 +341,7 @@ private fun QuotedGenericAsset(
     modifier: Modifier
 ) {
     QuotedMessageContent(
-        senderName = senderName, style = style, modifier = modifier, centerContent = {
+        senderName = senderName.asString(), style = style, modifier = modifier, centerContent = {
             assetName?.let {
                 MainContentText(it)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -52,7 +52,7 @@ fun PreviewMessageWithReply() {
                     quotedMessage = QuotedMessageUIData(
                         messageId = "asdoij",
                         senderId = previewUserId,
-                        senderName = "John Doe",
+                        senderName = UIText.DynamicString("John Doe"),
                         originalMessageDateDescription = UIText.StringResource(R.string.label_quote_original_message_date, "10:30"),
                         editedTimeDescription = UIText.StringResource(R.string.label_message_status_edited_with_date, "10:32"),
                         quotedContent = QuotedMessageUIData.Text("Hey, can I call right now?")

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -164,7 +164,7 @@ data class MessageBody(
 data class QuotedMessageUIData(
     val messageId: String,
     val senderId: UserId,
-    val senderName: String,
+    val senderName: UIText,
     val originalMessageDateDescription: UIText,
     val editedTimeDescription: UIText?,
     val quotedContent: Content

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -253,7 +253,7 @@ data class MessageComposerInnerState(
     }
 
     fun reply(uiMessage: UIMessage) {
-        val authorName = uiMessage.messageHeader.username.asString(context.resources)
+        val authorName = uiMessage.messageHeader.username
         val authorId = uiMessage.messageHeader.userId ?: return
 
         val content = when (val content = uiMessage.messageContent) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2871" title="AR-2871" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2871</a>  Group crashes when trying to open it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
For the nullable quoted sender name we need to show the unavailable username for the `null` case

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
