### PR TITLE
fix(notification): not repeating notifications after changing user status/data

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -304,11 +303,6 @@ class WireNotificationManager @Inject constructor(
                         .messages
                         .getNotifications()
                         .cancellable()
-                        // no need to do the whole work if there is no notifications
-                        .filter {
-                            appLogger.i("$TAG filtering notifications ${it.size}")
-                            it.isNotEmpty()
-                        }
                         .combine(observeSelfUser) { newNotifications, selfUser ->
                             // we don't want to display notifications for the Conversation that user currently in.
                             val notificationsList = filterAccordingToScreenAndUpdateNotifyDate(

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.message.MarkMessagesAsNotifiedUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -382,9 +383,14 @@ class WireNotificationManager @Inject constructor(
 
     private suspend fun markMessagesAsNotified(userId: QualifiedID?, conversationId: ConversationId?) {
         userId?.let {
+            val markNotified = if (conversationId == null) {
+                MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
+            } else {
+                MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId)
+            }
             coreLogic.getSessionScope(it)
                 .messages
-                .markMessagesAsNotified(conversationId)
+                .markMessagesAsNotified(markNotified)
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
@@ -156,9 +156,10 @@ class EncodedMessageContentMapperTest {
     @Test
     fun givenAssetContent_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
         // Given
+
         val dummyPath = fakeKaliumFileSystem.providePersistentAssetPath("dummy-path")
         val (arrangement, mapper) = Arrangement()
-            .withSuccessfulGetMessageAssetResult(dummyPath, 1)
+            .withSuccessfulGetMessageAssetResult(dummyPath, 1, "name1")
             .arrange()
         val unknownImageMessageContent = AssetContent(
             0L,
@@ -226,7 +227,7 @@ class EncodedMessageContentMapperTest {
         // Given
         val dummyPath = "some-dummy-path".toPath()
         val (arrangement, mapper) = Arrangement()
-            .withSuccessfulGetMessageAssetResult(dummyPath, 1)
+            .withSuccessfulGetMessageAssetResult(dummyPath, 1, "name1")
             .arrange()
         val contentImage1 = AssetContent(
             0L,
@@ -311,7 +312,7 @@ class EncodedMessageContentMapperTest {
             every { messageResourceProvider.sentAMessageWithContent } returns 45407124
         }
 
-        fun withSuccessfulGetMessageAssetResult(expectedAssetPath: Path, expectedAssetSize: Long): Arrangement {
+        fun withSuccessfulGetMessageAssetResult(expectedAssetPath: Path, expectedAssetSize: Long, assetName: String): Arrangement {
             val dummyData = "dummy-data".toByteArray()
             fakeKaliumFileSystem.sink(expectedAssetPath).buffer().use {
                 it.write(dummyData)
@@ -321,7 +322,7 @@ class EncodedMessageContentMapperTest {
                     any(),
                     any()
                 )
-            } returns CompletableDeferred(MessageAssetResult.Success(expectedAssetPath, expectedAssetSize))
+            } returns CompletableDeferred(MessageAssetResult.Success(expectedAssetPath, expectedAssetSize, assetName))
             return this
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -119,8 +119,14 @@ class ConversationMessagesViewModelArrangement {
         coEvery { getMessageById(any(), any()) } returns GetMessageByIdUseCase.Result.Success(message)
     }
 
-    fun withGetMessageAssetUseCaseReturning(decodedAssetPath: Path, assetSize: Long) = apply {
-        coEvery { getMessageAsset(any(), any()) } returns CompletableDeferred(MessageAssetResult.Success(decodedAssetPath, assetSize))
+    fun withGetMessageAssetUseCaseReturning(decodedAssetPath: Path, assetSize: Long, assetName: String = "name") = apply {
+        coEvery { getMessageAsset(any(), any()) } returns CompletableDeferred(
+            MessageAssetResult.Success(
+                decodedAssetPath,
+                assetSize,
+                assetName
+            )
+        )
     }
 
     suspend fun withPaginatedMessagesReturning(pagingDataFlow: PagingData<UIMessage>) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -237,8 +237,14 @@ class MediaGalleryViewModelTest {
             return this
         }
 
-        fun withSuccessfulImageData(imageDataPath: Path, imageSize: Long): Arrangement {
-            coEvery { getImageData(any(), any()) } returns CompletableDeferred(MessageAssetResult.Success(imageDataPath, imageSize))
+        fun withSuccessfulImageData(imageDataPath: Path, imageSize: Long, assetName: String = "name"): Arrangement {
+            coEvery { getImageData(any(), any()) } returns CompletableDeferred(
+                MessageAssetResult.Success(
+                    imageDataPath,
+                    imageSize,
+                    assetName
+                )
+            )
             return this
         }
 

--- a/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
@@ -101,14 +101,20 @@ internal class AssetImageFetcherTest {
         val mockFetchResult = mockk<FetchResult>()
         lateinit var imageData: ImageAsset
 
-        fun withSuccessfulImageData(data: ImageAsset, expectedAssetPath: Path, expectedAssetSize: Long): Arrangement {
+        fun withSuccessfulImageData(
+            data: ImageAsset,
+            expectedAssetPath: Path,
+            expectedAssetSize: Long,
+            assetName: String = "name"
+        ): Arrangement {
             imageData = data
             coEvery { getPublicAsset.invoke((any())) }.returns(PublicAssetResult.Success(expectedAssetPath))
             coEvery { getPrivateAsset.invoke(any(), any()) }.returns(
                 CompletableDeferred(
                     MessageAssetResult.Success(
                         expectedAssetPath,
-                        expectedAssetSize
+                        expectedAssetSize,
+                        assetName
                     )
                 )
             )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fixing the notifications repeating themself after user changes availability or receives any update of the user data changes.

### Issues
In the `WireNotificationManager` we combine the `user flow` with the notifications, when we the user changes their status or other data, the notifications was restarting with old data and was repeating the notifications.

### Causes (Optional)
Extra filtering causes data flow update break.

### Solutions

Remove the extra filter.

### Testing

#### Test Coverage (Optional)

No way to test now, we need instrumental tests later!

#### How to Test

- Receive any notifications
- Clear the notifications
- Go to the user profile and change the user status
- The notifications should not appears again![the old one that you've cleared]
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
