### PR TITLE
fix: Cleaning notification on conversation openning (AR-2873)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -46,7 +46,7 @@ class MessageNotificationManager
     }
 
     fun hideNotification(conversationsId: ConversationId, userId: QualifiedID) {
-        val notificationId = getConversationNotificationId(conversationsId.toString() + userId.toString())
+        val notificationId = getConversationNotificationId(conversationsId.toString(), userId.toString())
 
         if (isThereAnyOtherWireNotification(notificationId, userId)) {
             notificationManagerCompat.cancel(notificationId)
@@ -78,7 +78,7 @@ class MessageNotificationManager
         userId: QualifiedID,
         activeNotifications: Array<StatusBarNotification>
     ) {
-        val notificationId = getConversationNotificationId(conversation.id + userId.toString())
+        val notificationId = getConversationNotificationId(conversation.id, userId.toString())
         getConversationNotification(conversation, userId, activeNotifications)?.let { notification ->
             appLogger.i("$TAG adding ConversationNotification")
             notificationManagerCompat.notify(notificationId, notification)
@@ -156,7 +156,7 @@ class MessageNotificationManager
     ): NotificationCompat.Style? {
 
         val activeMessages = activeNotifications
-            .find { it.id == getConversationNotificationId(conversation.id + userId) }
+            .find { it.id == getConversationNotificationId(conversation.id, userId.orEmpty()) }
             ?.notification
             ?.let { NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(it) }
             ?.messages
@@ -264,7 +264,7 @@ class MessageNotificationManager
             userId: QualifiedID,
             replyText: String?
         ) {
-            val conversationNotificationId = getConversationNotificationId(conversationId)
+            val conversationNotificationId = getConversationNotificationId(conversationId, userId.toString())
             val userIdString = userId.toString()
 
             val currentNotification = (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -46,7 +46,7 @@ class MessageNotificationManager
     }
 
     fun hideNotification(conversationsId: ConversationId, userId: QualifiedID) {
-        val notificationId = getConversationNotificationId(conversationsId)
+        val notificationId = getConversationNotificationId(conversationsId.toString() + userId.toString())
 
         if (isThereAnyOtherWireNotification(notificationId, userId)) {
             notificationManagerCompat.cancel(notificationId)

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -37,8 +37,7 @@ object NotificationConstants {
     // MessagesSummaryNotification ID depends on User, use fun getMessagesSummaryId(userId: UserId) to get it
     private const val MESSAGE_SUMMARY_ID_STRING = "wire_messages_summary_notification"
 
-    fun getConversationNotificationId(conversationId: ConversationId) = getConversationNotificationId(conversationId.toString())
-    fun getConversationNotificationId(conversationIdString: String) = conversationIdString.hashCode()
+    fun getConversationNotificationId(conversationIdString: String, userIdString: String) = (conversationIdString + userIdString).hashCode()
     fun getMessagesGroupKey(userId: UserId?): String = "$MESSAGE_GROUP_KEY_PREFIX${userId?.toString() ?: ""}"
     fun getMessagesSummaryId(userId: UserId): Int = "$MESSAGE_SUMMARY_ID_STRING${userId.toString()}".hashCode()
     fun getChanelGroupIdForUser(userId: UserId): String = "${CHANNEL_GROUP_ID_PREFIX}.$userId"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2873" title="AR-2873" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2873</a>  Messages don't get cleared from notification center after message was read
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

when the conversation is opened notification for the messages in that conversation wasn't removed

### Causes (Optional)

While changes to receive notifications for multiple accs we changed notification id generating. From now on NotificationId contains CoversationId and UserId. 
But we forgot to change it in `fun hideNotification()`

### Solutions

update `hideNotification` to use propper `getConversationNotificationId` method AND removed redundant `NotificationConstants.getConversationNotificationId` to not repeat that mistake anymore.
