### PR TITLE
fix: observe changes of members for security classified label (AR-2710)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -791,7 +791,7 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): ObserveSecurityClassificationLabelUseCase =
-        coreLogic.getSessionScope(currentAccount).getSecurityClassificationType
+        coreLogic.getSessionScope(currentAccount).observeSecurityClassificationLabel
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -35,8 +35,8 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
@@ -77,9 +77,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -149,10 +149,10 @@ class CoreLogicModule {
 @Module
 @InstallIn(ViewModelComponent::class)
 class SessionModule {
+    // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
     @CurrentAccount
     @ViewModelScoped
     @Provides
-    // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
     fun provideCurrentSession(@KaliumCoreLogic coreLogic: CoreLogic): UserId {
         return runBlocking {
             return@runBlocking when (val result = coreLogic.getGlobalScope().session.currentSession.invoke()) {
@@ -644,13 +644,15 @@ class UseCaseModule {
     @ViewModelScoped
     @Provides
     fun providePersistPersistentWebSocketConnectionStatusUseCase(
-        @KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
     ) = coreLogic.getSessionScope(currentAccount).persistPersistentWebSocketConnectionStatus
 
     @ViewModelScoped
     @Provides
     fun provideGetPersistentWebSocketStatusUseCase(
-        @KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
     ) = coreLogic.getSessionScope(currentAccount).getPersistentWebSocketStatus
 
     @ViewModelScoped
@@ -785,10 +787,10 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetConversationClassifiedTypeUseCase(
+    fun observeSecurityClassificationLabelUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
-    ): GetSecurityClassificationTypeUseCase =
+    ): ObserveSecurityClassificationLabelUseCase =
         coreLogic.getSessionScope(currentAccount).getSecurityClassificationType
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.media.CallRinger
@@ -35,11 +34,11 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.conversation.SecurityClassificationTypeResult
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
@@ -52,7 +51,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -75,8 +73,8 @@ class SharedCallingViewModel @Inject constructor(
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
     private val currentScreenManager: CurrentScreenManager,
-    private val getConversationClassifiedType: GetSecurityClassificationTypeUseCase,
-    private val dispatchers: DispatcherProvider,
+    private val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase,
+    private val dispatchers: DispatcherProvider
 ) : ViewModel() {
 
     var callState by mutableStateOf(CallState())
@@ -92,8 +90,8 @@ class SharedCallingViewModel @Inject constructor(
             val allCallsSharedFlow = allCalls().map {
                 it.find { call ->
                     call.conversationId == conversationId &&
-                            call.status != CallStatus.CLOSED &&
-                            call.status != CallStatus.MISSED
+                        call.status != CallStatus.CLOSED &&
+                        call.status != CallStatus.MISSED
                 }
             }.flowOn(dispatchers.io()).shareIn(this, started = SharingStarted.Lazily)
 
@@ -122,11 +120,8 @@ class SharedCallingViewModel @Inject constructor(
     }
 
     private suspend fun setClassificationType() {
-        when (val result = getConversationClassifiedType(conversationId)) {
-            is SecurityClassificationTypeResult.Failure -> appLogger.e("Could not determine the classification type")
-            is SecurityClassificationTypeResult.Success -> {
-                callState = callState.copy(securityClassificationType = result.classificationType)
-            }
+        observeSecurityClassificationLabel(conversationId).collect { classificationType ->
+            callState = callState.copy(securityClassificationType = classificationType)
         }
     }
 
@@ -180,7 +175,7 @@ class SharedCallingViewModel @Inject constructor(
     }
 
     private suspend fun observeOnMute() {
-        //We should only mute established calls
+        // We should only mute established calls
         snapshotFlow { callState.isMuted to callState.callStatus }.collectLatest { (isMuted, callStatus) ->
             if (callStatus == CallStatus.ESTABLISHED) {
                 isMuted?.let {
@@ -199,7 +194,7 @@ class SharedCallingViewModel @Inject constructor(
             callState = callState.copy(
                 callStatus = call.status,
                 callerName = call.callerName,
-                isCameraOn = call.isCameraOn,
+                isCameraOn = call.isCameraOn
             )
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -22,14 +22,13 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -96,7 +95,7 @@ class SharedCallingViewModelTest {
     private lateinit var currentScreenManager: CurrentScreenManager
 
     @MockK
-    private lateinit var getConversationClassifiedType: GetSecurityClassificationTypeUseCase
+    private lateinit var observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
 
     private val uiCallParticipantMapper: UICallParticipantMapper by lazy { UICallParticipantMapper(wireSessionImageLoader, userTypeMapper) }
 
@@ -133,7 +132,7 @@ class SharedCallingViewModelTest {
             userTypeMapper = userTypeMapper,
             currentScreenManager = currentScreenManager,
             qualifiedIdMapper = qualifiedIdMapper,
-            getConversationClassifiedType = getConversationClassifiedType,
+            observeSecurityClassificationLabel = observeSecurityClassificationLabel,
             dispatchers = TestDispatcherProvider()
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -36,11 +36,11 @@ import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.conversation.IsInteractionAvailableResult
 import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
@@ -122,7 +122,7 @@ internal class ConversationsViewModelArrangement {
     private lateinit var updateConversationReadDateUseCase: UpdateConversationReadDateUseCase
 
     @MockK
-    private lateinit var getSecurityClassificationType: GetSecurityClassificationTypeUseCase
+    private lateinit var observeSecurityClassificationType: ObserveSecurityClassificationLabelUseCase
 
     @MockK
     private lateinit var observeSyncState: ObserveSyncStateUseCase
@@ -150,7 +150,7 @@ internal class ConversationsViewModelArrangement {
             kaliumFileSystem = fakeKaliumFileSystem,
             updateConversationReadDateUseCase = updateConversationReadDateUseCase,
             observeConversationInteractionAvailability = observeConversationInteractionAvailabilityUseCase,
-            getConversationClassifiedType = getSecurityClassificationType,
+            observeSecurityClassificationLabel = observeSecurityClassificationType,
             contactMapper = contactMapper,
             membersToMention = membersToMention
         )
@@ -198,7 +198,6 @@ internal class ConversationsViewModelArrangement {
     }
 
     fun arrange() = this to viewModel
-
 }
 
 internal fun withMockConversationDetailsOneOnOne(
@@ -226,7 +225,7 @@ internal fun withMockConversationDetailsOneOnOne(
 
 internal fun mockConversationDetailsGroup(
     conversationName: String,
-    mockedConversationId: ConversationId = ConversationId("someId", "someDomain"),
+    mockedConversationId: ConversationId = ConversationId("someId", "someDomain")
 ) = ConversationDetails.Group(
     conversation = TestConversation.GROUP()
         .copy(name = conversationName, id = mockedConversationId),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2710" title="AR-2710" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2710</a>  Classified banners don't update when a user is added which is not classified
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are not getting live updates for member changes in a conversation and its computation of the classification security label

### Causes (Optional)

We were getting the result once, not observing for changes

### Solutions

Observe for member changes, returning a flow instead of a cold value
This PR, just observes the new use case, no logic changed on this side.

### Dependencies (Optional)

https://github.com/wireapp/kalium/pull/1300

Needs releases with:

- [x] GitHub link to other pull request

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/210569499-3fb4d65c-410e-416d-b82d-cc3214bb9997.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[SQPIT-764]: https://wearezeta.atlassian.net/browse/SQPIT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQPIT-764]: https://wearezeta.atlassian.net/browse/SQPIT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AR-2710]: https://wearezeta.atlassian.net/browse/AR-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2710]: https://wearezeta.atlassian.net/browse/AR-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2710]: https://wearezeta.atlassian.net/browse/AR-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ