### PR TITLE
fix: after hanging up the call from notification the ongoing call screen is still visible

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -54,8 +54,9 @@ class OngoingCallViewModel @OptIn(ExperimentalCoroutinesApi::class)
                 val currentScreen = currentScreenManager.observeCurrentScreen(viewModelScope).first()
                 val isCurrentlyOnOngoingScreen = currentScreen is CurrentScreen.OngoingCallScreen
                 val isOnBackground = currentScreen is CurrentScreen.InBackground
-                if (currentCall == null && (isCurrentlyOnOngoingScreen || isOnBackground))
+                if (currentCall == null && (isCurrentlyOnOngoingScreen || isOnBackground)) {
                     navigateBack()
+                }
             }
     }
 
@@ -71,5 +72,4 @@ class OngoingCallViewModel @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun navigateBack() {
         navigationManager.navigateBack()
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -52,7 +52,9 @@ class OngoingCallViewModel @OptIn(ExperimentalCoroutinesApi::class)
             .collect { calls ->
                 val currentCall = calls.find { call -> call.conversationId == conversationId }
                 val currentScreen = currentScreenManager.observeCurrentScreen(viewModelScope).first()
-                if (currentCall == null && currentScreen is CurrentScreen.OngoingCallScreen)
+                val isCurrentlyOnOngoingScreen = currentScreen is CurrentScreen.OngoingCallScreen
+                val isOnBackground = currentScreen is CurrentScreen.InBackground
+                if (currentCall == null && (isCurrentlyOnOngoingScreen || isOnBackground))
                     navigateBack()
             }
     }


### PR DESCRIPTION

(cherry picked from commit 43b419dea7ed3bced2af979c8ed814f88a651a0c)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Merging same changes of #1278 to develop



----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
