### PR TITLE
fix: notifications being handled on the main thread (AR-2924)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -216,9 +216,9 @@ class WireActivityViewModel @Inject constructor(
 
                     is DeepLinkResult.IncomingCall -> {
                         if (isLaunchedFromHistory(intent)) {
-                            //We don't need to handle deepLink, if activity was launched from history.
-                            //For example: user opened app by deepLink, then closed it by back button click,
-                            //then open the app from the "Recent Apps"
+                            // We don't need to handle deepLink, if activity was launched from history.
+                            // For example: user opened app by deepLink, then closed it by back button click,
+                            // then open the app from the "Recent Apps"
                             appLogger.i("IncomingCall deepLink launched from the history")
                         } else {
                             navigationArguments.put(INCOMING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
@@ -227,9 +227,9 @@ class WireActivityViewModel @Inject constructor(
 
                     is DeepLinkResult.OngoingCall -> {
                         if (isLaunchedFromHistory(intent)) {
-                            //We don't need to handle deepLink, if activity was launched from history.
-                            //For example: user opened app by deepLink, then closed it by back button click,
-                            //then open the app from the "Recent Apps"
+                            // We don't need to handle deepLink, if activity was launched from history.
+                            // For example: user opened app by deepLink, then closed it by back button click,
+                            // then open the app from the "Recent Apps"
                             appLogger.i("IncomingCall deepLink launched from the history")
                         } else {
                             navigationArguments.put(ONGOING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
@@ -268,7 +268,7 @@ class WireActivityViewModel @Inject constructor(
      */
     fun handleDeepLinkOnNewIntent(intent: Intent?): Boolean {
 
-        //removing arguments that could be there from prev deeplink handling
+        // removing arguments that could be there from prev deeplink handling
         navigationArguments.apply {
             remove(INCOMING_CALL_CONVERSATION_ID_ARG)
             remove(ONGOING_CALL_CONVERSATION_ID_ARG)

--- a/app/src/test/kotlin/com/wire/android/common/TestsCommon.kt
+++ b/app/src/test/kotlin/com/wire/android/common/TestsCommon.kt
@@ -6,14 +6,22 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.platformClassName
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * this workaround solves kotlinx.coroutines.test.UncompletedCoroutinesError in tests
+ *
+ * FIXME: This shouldn't exist.
+ *        We should handle and test the fact that coroutines are cancelled properly.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-fun runTestWithCancellation(body: suspend TestScope.() -> Unit): TestResult =
+fun runTestWithCancellation(
+    context: CoroutineContext = EmptyCoroutineContext,
+    body: suspend TestScope.() -> Unit
+): TestResult =
     try {
-        runTest {
+        runTest(context) {
             body()
             cancel()
         }

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -81,7 +81,7 @@ class WireNotificationManagerTest {
         verify(exactly = 0) { arrangement.callNotificationManager.handleIncomingCallNotifications(any(), any()) }
     }
 
-    //todo: check later with boris!
+    // todo: check later with boris!
     @Ignore
     fun givenAuthenticatedUser_whenFetchAndShowNotificationsOnceCalled_thenConnectionPolicyManagerIsCalled() =
         runTest(dispatcherProvider.main()) {
@@ -493,7 +493,6 @@ class WireNotificationManagerTest {
         private fun provideLocalNotificationMessage(): LocalNotificationMessage = LocalNotificationMessage.Text(
             LocalNotificationMessageAuthor("author", null), "", "testing text"
         )
-
 
         private fun provideUserId() = UserId("value", "domain")
 

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -64,10 +64,8 @@ class WireNotificationManagerTest {
 
     @Test
     fun givenNotAuthenticatedUser_whenFetchAndShowNotificationsOnceCalled_thenNothingHappen() = runTest(dispatcherProvider.main()) {
-        val (arrangement, manager) = Arrangement()
-            .withSession(GetAllSessionsResult.Failure.NoSessionFound)
-            .withCurrentUserSession(provideCurrentInvalidUserSession())
-            .arrange()
+        val (arrangement, manager) = Arrangement().withSession(GetAllSessionsResult.Failure.NoSessionFound)
+            .withCurrentUserSession(provideCurrentInvalidUserSession()).arrange()
 
         manager.fetchAndShowNotificationsOnce("user_id")
         advanceUntilIdle()
@@ -75,9 +73,9 @@ class WireNotificationManagerTest {
         verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
         verify(exactly = 0) {
             arrangement.messageNotificationManager.handleNotification(
-                any(),
-                any(),
-                TestUser.SELF_USER.handle!!
+                newNotifications = any(),
+                userId = any(),
+                userName = TestUser.SELF_USER.handle!!
             )
         }
         verify(exactly = 0) { arrangement.callNotificationManager.handleIncomingCallNotifications(any(), any()) }
@@ -87,11 +85,8 @@ class WireNotificationManagerTest {
     @Ignore
     fun givenAuthenticatedUser_whenFetchAndShowNotificationsOnceCalled_thenConnectionPolicyManagerIsCalled() =
         runTest(dispatcherProvider.main()) {
-            val (arrangement, manager) = Arrangement()
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession())
-                .withMessageNotifications(listOf())
-                .withIncomingCalls(listOf())
+            val (arrangement, manager) = Arrangement().withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+                .withCurrentUserSession(provideCurrentValidUserSession()).withMessageNotifications(listOf()).withIncomingCalls(listOf())
                 .arrange()
 
             manager.fetchAndShowNotificationsOnce("user_id")
@@ -99,34 +94,32 @@ class WireNotificationManagerTest {
 
             verify(atLeast = 1) { arrangement.coreLogic.getSessionScope(any()) }
             coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(TEST_AUTH_TOKEN.userId) }
-            verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-                listOf(),
-                any(),
-                TestUser.SELF_USER.handle!!
-            ) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    newNotifications = listOf(),
+                    userId = any(),
+                    userName = TestUser.SELF_USER.handle!!
+                )
+            }
             verify(exactly = 1) { arrangement.callNotificationManager.handleIncomingCallNotifications(listOf(), any()) }
         }
 
     @Test
-    fun givenNotAuthenticatedUser_whenObserveCalled_thenNothingHappenAndCallNotificationHides() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenNotAuthenticatedUser_whenObserveCalled_thenNothingHappenAndCallNotificationHides() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        advanceUntilIdle()
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            advanceUntilIdle()
 
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideIncomingCallNotification() }
-    }
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideIncomingCallNotification() }
+        }
 
     @Test
-    fun givenNoIncomingCalls_whenObserveCalled_thenCallNotificationHides() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf())
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenNoIncomingCalls_whenObserveCalled_thenCallNotificationHides() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf()).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -135,13 +128,9 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeIncomingCalls_whenAppIsNotVisible_thenCallNotificationHidden() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .withEstablishedCall(listOf())
-            .arrange()
+    fun givenSomeIncomingCalls_whenAppIsNotVisible_thenCallNotificationHidden() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).withEstablishedCall(listOf()).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -151,12 +140,9 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeIncomingCalls_whenAppIsVisible_thenCallNotificationShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .withMessageNotifications(listOf())
-            .arrange()
+    fun givenSomeIncomingCalls_whenAppIsVisible_thenCallNotificationShowed() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withCurrentScreen(CurrentScreen.SomeOther)
+            .withMessageNotifications(listOf()).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -166,88 +152,83 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeNotifications_whenAppIsInForegroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenSomeNotifications_whenAppIsInForegroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(
+                    listOf(
+                        provideLocalNotificationConversation(
+                            messages = listOf(provideLocalNotificationMessage())
+                        )
+                    )
+                ).withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        runCurrent()
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            runCurrent()
 
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-            listOf(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
-    }
-
-    @Test
-    fun givenSomeNotifications_whenAppIsInBackgroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .arrange()
-
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        runCurrent()
-
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-            listOf(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
-    }
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    newNotifications = listOf(), userId = any(), userName = TestUser.SELF_USER.handle!!
+                )
+            }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
+        }
 
     @Test
-    fun givenSomeNotifications_whenObserveCalled_thenCallNotificationShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withIncomingCalls(listOf())
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenSomeNotifications_whenAppIsInBackgroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(
+                    listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage())))
+                ).withCurrentScreen(CurrentScreen.InBackground).arrange()
+
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            runCurrent()
+
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    listOf(), any(), TestUser.SELF_USER.handle!!
+                )
+            }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
+        }
+
+    @Test
+    fun givenSomeNotifications_whenObserveCalled_thenCallNotificationShowed() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withMessageNotifications(
+            listOf(
+                provideLocalNotificationConversation(
+                    messages = listOf(provideLocalNotificationMessage())
+                )
+            )
+        ).withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
 
-        verify(exactly = 1) { arrangement.messageNotificationManager.handleNotification(
-            any(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
+        verify(exactly = 1) {
+            arrangement.messageNotificationManager.handleNotification(
+                any(), any(), TestUser.SELF_USER.handle!!
+            )
+        }
     }
 
     @Test
     fun givenSomeNotificationsAndCurrentScreenIsConversation_whenObserveCalled_thenNotificationIsNotShowed() =
-        runTestWithCancellation {
+        runTestWithCancellation(dispatcherProvider.main()) {
             val conversationId = ConversationId("conversation_value", "conversation_domain")
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(
-                    listOf(
-                        provideLocalNotificationConversation(
-                            id = conversationId,
-                            messages = listOf(provideLocalNotificationMessage())
-                        )
-                    )
+            val (arrangement, manager) = Arrangement().withMessageNotifications(
+                listOf(
+                    provideLocalNotificationConversation(id = conversationId, messages = listOf(provideLocalNotificationMessage()))
                 )
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.Conversation(conversationId))
-                .arrange()
+            ).withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.Conversation(conversationId)).arrange()
 
             manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
             runCurrent()
 
             verify(exactly = 1) {
                 arrangement.messageNotificationManager.handleNotification(
-                    listOf(),
-                    any(),
-                    TestUser.SELF_USER.handle!!
+                    listOf(), any(), TestUser.SELF_USER.handle!!
                 )
             }
             coVerify(atLeast = 1) {
@@ -261,13 +242,10 @@ class WireNotificationManagerTest {
 
     @Test
     fun givenCurrentScreenIsConversation_whenObserveCalled_thenNotificationForThatConversationIsHidden() =
-        runTestWithCancellation {
+        runTestWithCancellation(dispatcherProvider.main()) {
             val conversationId = ConversationId("conversation_value", "conversation_domain")
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.Conversation(conversationId))
-                .arrange()
+            val (arrangement, manager) = Arrangement().withMessageNotifications(listOf()).withIncomingCalls(listOf())
+                .withCurrentScreen(CurrentScreen.Conversation(conversationId)).arrange()
 
             manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
             runCurrent()
@@ -279,13 +257,9 @@ class WireNotificationManagerTest {
     fun givenASingleUserId_whenCallingFetchAndShowOnceInParallel_thenPushNotificationIsHandledOnlyOnce() =
         runTest(dispatcherProvider.main()) {
             val userId = TEST_AUTH_TOKEN.userId
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession())
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.InBackground)
-                .arrange()
+            val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN))).withCurrentUserSession(provideCurrentValidUserSession())
+                .withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.InBackground).arrange()
 
             coEvery { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) } coAnswers {
                 // Push handling is taking 10 minutes
@@ -314,31 +288,26 @@ class WireNotificationManagerTest {
         }
 
     @Test
-    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUser_shouldSkipNotification() =
-        runTest(dispatcherProvider.main()) {
-            val otherAuthSession = provideAccountInfo("other_id")
-            val userId = otherAuthSession.userId
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.InBackground)
-                .arrange()
+    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUser_shouldSkipNotification() = runTest(dispatcherProvider.main()) {
+        val otherAuthSession = provideAccountInfo("other_id")
+        val userId = otherAuthSession.userId
+        val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+            .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN)).withIncomingCalls(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).arrange()
 
-            manager.fetchAndShowNotificationsOnce(userId.value)
-            advanceUntilIdle()
+        manager.fetchAndShowNotificationsOnce(userId.value)
+        advanceUntilIdle()
 
-            coVerify(exactly = 0) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
-        }
+        coVerify(exactly = 0) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
+    }
 
     @Test
-    fun givenSomeEstablishedCalls_whenAppIsNotVisible_thenOngoingCallServiceRun() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf())
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .withEstablishedCall(listOf(provideCall().copy(status = CallStatus.ESTABLISHED)))
+    fun givenSomeEstablishedCalls_whenAppIsNotVisible_thenOngoingCallServiceRun() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf()).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).withEstablishedCall(
+                listOf(provideCall().copy(status = CallStatus.ESTABLISHED))
+            )
             .arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
@@ -517,18 +486,12 @@ class WireNotificationManagerTest {
         private fun provideLocalNotificationConversation(
             id: ConversationId = ConversationId("conversation_value", "conversation_domain"),
             messages: List<LocalNotificationMessage> = listOf()
-        ) =
-            LocalNotificationConversation(
-                id,
-                "name_${id.value}",
-                messages,
-                true
-            )
+        ) = LocalNotificationConversation(
+            id, "name_${id.value}", messages, true
+        )
 
         private fun provideLocalNotificationMessage(): LocalNotificationMessage = LocalNotificationMessage.Text(
-            LocalNotificationMessageAuthor("author", null),
-            "",
-            "testing text"
+            LocalNotificationMessageAuthor("author", null), "", "testing text"
         )
 
 
@@ -537,8 +500,7 @@ class WireNotificationManagerTest {
         private fun appVisibleFlow() = MutableStateFlow(true)
         private fun appInvisibleFlow() = MutableStateFlow(false)
 
-        private fun provideCurrentValidUserSession(authSession: AccountInfo = TEST_AUTH_TOKEN) =
-            CurrentSessionResult.Success(authSession)
+        private fun provideCurrentValidUserSession(authSession: AccountInfo = TEST_AUTH_TOKEN) = CurrentSessionResult.Success(authSession)
 
         private fun provideCurrentInvalidUserSession() = CurrentSessionResult.Failure.SessionNotFound
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2924" title="AR-2924" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2924</a>  App syncing very slowly and crashing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While the app is receiving messages and displaying notifications, it can become super slow, especially when the database is filled with data.

### Causes

We're calculating notifications on the Main Thread!

We're doing something like this in `WireActivityViewModel`:

```kt
viewModelScope.launch(dispatchers.io()) {
    notificationManager.observeNotificationsAndCalls(observeUserId, viewModelScope)
}
```

Passing the `viewModelScope` –which uses the Main dispatcher– instead of using the created scope with the IO dispatcher.

### Solutions

Quite simply:

```diff
viewModelScope.launch(dispatchers.io()) {
-    notificationManager.observeNotificationsAndCalls(observeUserId, viewModelScope)
+    notificationManager.observeNotificationsAndCalls(observeUserId, this)
}
```

I've also took some measures to make sure that `observeNotificationsAndCalls` will always use the IO dispatcher, so in general, the dispatcher passed with the scope is ignored.

### Testing

#### Test Coverage

This ViewModel and the WireNotificationManager is quite hard to test at the moment. I also found a couple more bugs with the logic and added a TODO there.
I want to work partial refactor of this Notification logic ASAP to fix the bug mentioned in the comment and also make it so it is easy to test.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
