### PR TITLE
fix(notification): refactor  connections notifications to prevent ANR (AR-2898)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -207,7 +207,6 @@ class MessageNotificationManager
             }
     }
 
-
     private fun NotificationMessage.intoStyledMessage(): NotificationCompat.MessagingStyle.Message {
         val sender = Person.Builder()
             .apply {
@@ -225,7 +224,6 @@ class MessageNotificationManager
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
         }
         return NotificationCompat.MessagingStyle.Message(message, time, sender)
-
     }
 
     /**

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -56,12 +56,10 @@ class MessageNotificationManager
     }
 
     fun hideAllNotifications() {
-        notificationManager.activeNotifications
-            ?.filter { it.groupKey.contains(NotificationConstants.getMessagesGroupKey(null)) }
-            ?.forEach { notificationManagerCompat.cancel(it.id) }
+        notificationManager.cancelAll()
     }
 
-    fun hideAllNotificationsForUser(userId: QualifiedID) {
+    private fun hideAllNotificationsForUser(userId: QualifiedID) {
         // removing groupSummary removes all the notifications in a group
         notificationManagerCompat.cancel(NotificationConstants.getMessagesSummaryId(userId))
     }

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -59,7 +59,7 @@ class MessageNotificationManager
         notificationManager.cancelAll()
     }
 
-    private fun hideAllNotificationsForUser(userId: QualifiedID) {
+    fun hideAllNotificationsForUser(userId: QualifiedID) {
         // removing groupSummary removes all the notifications in a group
         notificationManagerCompat.cancel(NotificationConstants.getMessagesSummaryId(userId))
     }

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -232,7 +232,7 @@ class WireNotificationManager @Inject constructor(
 
                 when (screens) {
                     is CurrentScreen.Conversation -> messagesNotificationManager.hideNotification(screens.id, userId)
-                    is CurrentScreen.ConnectionRequest -> messagesNotificationManager.hideNotification(screens.id, userId)
+                    is CurrentScreen.OtherUserProfile -> messagesNotificationManager.hideNotification(screens.id, userId)
                     is CurrentScreen.IncomingCallScreen -> callNotificationManager.hideIncomingCallNotification()
                     else -> {}
                 }

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -175,18 +175,14 @@ class WireNotificationManager @Inject constructor(
      */
     @Suppress("NestedBlockDepth")
     private suspend fun checkIfUserIsAuthenticated(userId: String): QualifiedID? =
-        coreLogic.globalScope { getSessions() }.let {
-            when (it) {
+        coreLogic.globalScope { getSessions() }.let { sessionsResult ->
+            when (sessionsResult) {
                 is GetAllSessionsResult.Success -> {
-                    for (sessions in it.sessions) {
-                        if (sessions.userId.value == userId)
-                            return@let sessions.userId
-                    }
-                    null
+                    return@let sessionsResult.sessions.firstOrNull { it.userId.value == userId }?.userId
                 }
 
                 is GetAllSessionsResult.Failure.Generic -> {
-                    appLogger.e("get sessions failed ${it.genericFailure} ")
+                    appLogger.e("get sessions failed ${sessionsResult.genericFailure} ")
                     null
                 }
 

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("StringTemplate")
+
 package com.wire.android.util
 
 import android.content.Context
@@ -54,14 +56,12 @@ class CurrentScreenManager @Inject constructor(
      */
     fun isAppOnForegroundFlow(): StateFlow<Boolean> = isOnForegroundFlow
 
-    @Suppress("StringTemplate")
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         appLogger.i("${TAG}: onResume called")
         isOnForegroundFlow.value = true
     }
 
-    @Suppress("StringTemplate")
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         appLogger.i("${TAG}: onStop called")

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -54,12 +54,14 @@ class CurrentScreenManager @Inject constructor(
      */
     fun isAppOnForegroundFlow(): StateFlow<Boolean> = isOnForegroundFlow
 
+    @Suppress("StringTemplate")
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         appLogger.i("${TAG}: onResume called")
         isOnForegroundFlow.value = true
     }
 
+    @Suppress("StringTemplate")
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         appLogger.i("${TAG}: onStop called")
@@ -73,7 +75,6 @@ class CurrentScreenManager @Inject constructor(
 
     companion object {
         private const val TAG = "CurrentScreenManager"
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -87,10 +87,7 @@ sealed class CurrentScreen {
     data class Conversation(val id: ConversationId) : CurrentScreen()
 
     // Another User Profile Screen is opened
-    data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
-
-    // Another User Profile Screen is opened
-    data class ConnectionRequest(val id: ConversationId) : CurrentScreen()
+    data class OtherUserProfile(val id: ConversationId) : CurrentScreen()
 
     // Ongoing call screen is opened
     data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
@@ -123,7 +120,7 @@ sealed class CurrentScreen {
                 NavigationItem.OtherUserProfile -> {
                     arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
-                        ?.let { ConnectionRequest(it) }
+                        ?.let { OtherUserProfile(it) }
                         ?: SomeOther
                 }
                 NavigationItem.OngoingCall -> {

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -8,7 +8,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.wire.android.appLogger
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
-import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.getCurrentNavigationItem
 import com.wire.kalium.logic.data.id.ConversationId
@@ -89,6 +88,9 @@ sealed class CurrentScreen {
     // Another User Profile Screen is opened
     data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
 
+    // Another User Profile Screen is opened
+    data class ConnectionRequest(val id: ConversationId) : CurrentScreen()
+
     // Ongoing call screen is opened
     data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
 
@@ -118,9 +120,9 @@ sealed class CurrentScreen {
                         ?: SomeOther
                 }
                 NavigationItem.OtherUserProfile -> {
-                    arguments?.getString(EXTRA_USER_ID)
+                    arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
-                        ?.let { OtherUserProfile(it) }
+                        ?.let { ConnectionRequest(it) }
                         ?: SomeOther
                 }
                 NavigationItem.OngoingCall -> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2898" title="AR-2898" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2898</a>  ANR [Connection Request Notification]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

To manage the notifications [ Show and Clear programmatically if necessary], we use the conversationId as the identifier. When a user go the connection request screen, we were passing the userId instead of passing the conversationId to the CurrentScreenManager; then we had to fetch the conversationId by the userId from the DB in a insufficient way! In this fix we pass the conversation Id from userProfileScreen.
The previous solution was causing database lock and then ANR issues on the main thread [the main thread will be fixed in another PR]

### Causes (Optional)
Database lock due to lot of db connections.

### Solutions
Pass the value that exist instead of fetching again from the DB.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
