### PR TITLE
fix(notification): [RC] fix connections notifications ANR (AR-2898)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -56,9 +56,7 @@ class MessageNotificationManager
     }
 
     fun hideAllNotifications() {
-        notificationManager.activeNotifications
-            ?.filter { it.groupKey.contains(NotificationConstants.getMessagesGroupKey(null)) }
-            ?.forEach { notificationManagerCompat.cancel(it.id) }
+        notificationManager.cancelAll()
     }
 
     fun hideAllNotificationsForUser(userId: QualifiedID) {
@@ -209,7 +207,6 @@ class MessageNotificationManager
             }
     }
 
-
     private fun NotificationMessage.intoStyledMessage(): NotificationCompat.MessagingStyle.Message {
         val sender = Person.Builder()
             .apply {
@@ -227,7 +224,6 @@ class MessageNotificationManager
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
         }
         return NotificationCompat.MessagingStyle.Message(message, time, sender)
-
     }
 
     /**

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -10,7 +10,6 @@ import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
@@ -176,18 +175,14 @@ class WireNotificationManager @Inject constructor(
      */
     @Suppress("NestedBlockDepth")
     private suspend fun checkIfUserIsAuthenticated(userId: String): QualifiedID? =
-        coreLogic.globalScope { getSessions() }.let {
-            when (it) {
+        coreLogic.globalScope { getSessions() }.let { sessionsResult ->
+            when (sessionsResult) {
                 is GetAllSessionsResult.Success -> {
-                    for (sessions in it.sessions) {
-                        if (sessions.userId.value == userId)
-                            return@let sessions.userId
-                    }
-                    null
+                    return@let sessionsResult.sessions.firstOrNull { it.userId.value == userId }?.userId
                 }
 
                 is GetAllSessionsResult.Failure.Generic -> {
-                    appLogger.e("get sessions failed ${it.genericFailure} ")
+                    appLogger.e("get sessions failed ${sessionsResult.genericFailure} ")
                     null
                 }
 
@@ -237,7 +232,7 @@ class WireNotificationManager @Inject constructor(
 
                 when (screens) {
                     is CurrentScreen.Conversation -> messagesNotificationManager.hideNotification(screens.id, userId)
-                    is CurrentScreen.OtherUserProfile -> hideConnectionRequestNotification(userId, screens.id)
+                    is CurrentScreen.OtherUserProfile -> messagesNotificationManager.hideNotification(screens.id, userId)
                     is CurrentScreen.IncomingCallScreen -> callNotificationManager.hideIncomingCallNotification()
                     else -> {}
                 }
@@ -323,8 +318,8 @@ class WireNotificationManager @Inject constructor(
             .collect { (newNotifications, userId, userName) ->
                 appLogger.d("$TAG got ${newNotifications.size} notifications")
                 messagesNotificationManager.handleNotification(newNotifications, userId, userName)
-                markMessagesAsNotified(userId, null)
-                markConnectionAsNotified(userId, null)
+                markMessagesAsNotified(userId)
+                markConnectionAsNotified(userId)
             }
     }
 
@@ -379,43 +374,21 @@ class WireNotificationManager @Inject constructor(
             newNotifications
         }
 
-    private suspend fun markMessagesAsNotified(userId: QualifiedID, conversationId: ConversationId?) {
-        val markNotified = if (conversationId == null) {
-            MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
-        } else {
+    private suspend fun markMessagesAsNotified(userId: QualifiedID, conversationId: ConversationId? = null) {
+        val markNotified = conversationId?.let {
             MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId)
-        }
+        } ?: MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
         coreLogic.getSessionScope(userId)
             .messages
             .markMessagesAsNotified(markNotified)
     }
 
-    private suspend fun markConnectionAsNotified(userId: QualifiedID?, connectionRequestUserId: QualifiedID?) {
+    private suspend fun markConnectionAsNotified(userId: QualifiedID?, connectionRequestUserId: QualifiedID? = null) {
         appLogger.d("$TAG markConnectionAsNotified")
         userId?.let {
             coreLogic.getSessionScope(it)
                 .conversations
                 .markConnectionRequestAsNotified(connectionRequestUserId)
-        }
-    }
-
-    private suspend fun hideConnectionRequestNotification(userId: QualifiedID?, connectionRequestUserId: QualifiedID?) {
-        // to hide ConnectionRequestNotification we need to get conversationId for it
-        // cause it's used as Notification ID
-        userId?.let {
-            coreLogic.getSessionScope(it)
-                .conversations
-                .observeConnectionList()
-                .first()
-                .firstOrNull { conversationDetails ->
-                    conversationDetails is ConversationDetails.Connection
-                            && conversationDetails.otherUser?.id == connectionRequestUserId
-                }
-                ?.conversation
-                ?.id
-                ?.let { conversationId ->
-                    messagesNotificationManager.hideNotification(conversationId, userId)
-                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("StringTemplate")
+
 package com.wire.android.util
 
 import android.content.Context
@@ -8,7 +10,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.wire.android.appLogger
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
-import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.getCurrentNavigationItem
 import com.wire.kalium.logic.data.id.ConversationId
@@ -74,7 +75,6 @@ class CurrentScreenManager @Inject constructor(
 
     companion object {
         private const val TAG = "CurrentScreenManager"
-
     }
 }
 
@@ -87,7 +87,7 @@ sealed class CurrentScreen {
     data class Conversation(val id: ConversationId) : CurrentScreen()
 
     // Another User Profile Screen is opened
-    data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
+    data class OtherUserProfile(val id: ConversationId) : CurrentScreen()
 
     // Ongoing call screen is opened
     data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
@@ -118,7 +118,7 @@ sealed class CurrentScreen {
                         ?: SomeOther
                 }
                 NavigationItem.OtherUserProfile -> {
-                    arguments?.getString(EXTRA_USER_ID)
+                    arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OtherUserProfile(it) }
                         ?: SomeOther


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2898" title="AR-2898" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2898</a>  ANR [Connection Request Notification]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

To manage the notifications [ Show and Clear programmatically if necessary], we use the conversationId as the identifier. When a user go the connection request screen, we were passing the userId instead of passing the conversationId to the CurrentScreenManager; then we had to fetch the conversationId by the userId from the DB in a insufficient way! In this fix we pass the conversation Id from userProfileScreen.
The previous solution was causing database lock and then ANR issues on the main thread [the main thread will be fixed in another PR]

### Causes (Optional)
Database lock due to lot of db connections.

### Solutions
Pass the value that exist instead of fetching again from the DB.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
