### PR TITLE
fix(notification): [RC] fix connections notifications ANR (AR-2898)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -35,8 +35,8 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
@@ -77,9 +77,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -149,10 +149,10 @@ class CoreLogicModule {
 @Module
 @InstallIn(ViewModelComponent::class)
 class SessionModule {
+    // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
     @CurrentAccount
     @ViewModelScoped
     @Provides
-    // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
     fun provideCurrentSession(@KaliumCoreLogic coreLogic: CoreLogic): UserId {
         return runBlocking {
             return@runBlocking when (val result = coreLogic.getGlobalScope().session.currentSession.invoke()) {
@@ -644,13 +644,15 @@ class UseCaseModule {
     @ViewModelScoped
     @Provides
     fun providePersistPersistentWebSocketConnectionStatusUseCase(
-        @KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
     ) = coreLogic.getSessionScope(currentAccount).persistPersistentWebSocketConnectionStatus
 
     @ViewModelScoped
     @Provides
     fun provideGetPersistentWebSocketStatusUseCase(
-        @KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
     ) = coreLogic.getSessionScope(currentAccount).getPersistentWebSocketStatus
 
     @ViewModelScoped
@@ -785,11 +787,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetConversationClassifiedTypeUseCase(
+    fun observeSecurityClassificationLabelUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
-    ): GetSecurityClassificationTypeUseCase =
-        coreLogic.getSessionScope(currentAccount).getSecurityClassificationType
+    ): ObserveSecurityClassificationLabelUseCase =
+        coreLogic.getSessionScope(currentAccount).observeSecurityClassificationLabel
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -56,9 +56,7 @@ class MessageNotificationManager
     }
 
     fun hideAllNotifications() {
-        notificationManager.activeNotifications
-            ?.filter { it.groupKey.contains(NotificationConstants.getMessagesGroupKey(null)) }
-            ?.forEach { notificationManagerCompat.cancel(it.id) }
+        notificationManager.cancelAll()
     }
 
     fun hideAllNotificationsForUser(userId: QualifiedID) {
@@ -209,7 +207,6 @@ class MessageNotificationManager
             }
     }
 
-
     private fun NotificationMessage.intoStyledMessage(): NotificationCompat.MessagingStyle.Message {
         val sender = Person.Builder()
             .apply {
@@ -227,7 +224,6 @@ class MessageNotificationManager
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
         }
         return NotificationCompat.MessagingStyle.Message(message, time, sender)
-
     }
 
     /**

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -10,7 +10,6 @@ import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
@@ -176,18 +175,14 @@ class WireNotificationManager @Inject constructor(
      */
     @Suppress("NestedBlockDepth")
     private suspend fun checkIfUserIsAuthenticated(userId: String): QualifiedID? =
-        coreLogic.globalScope { getSessions() }.let {
-            when (it) {
+        coreLogic.globalScope { getSessions() }.let { sessionsResult ->
+            when (sessionsResult) {
                 is GetAllSessionsResult.Success -> {
-                    for (sessions in it.sessions) {
-                        if (sessions.userId.value == userId)
-                            return@let sessions.userId
-                    }
-                    null
+                    return@let sessionsResult.sessions.firstOrNull { it.userId.value == userId }?.userId
                 }
 
                 is GetAllSessionsResult.Failure.Generic -> {
-                    appLogger.e("get sessions failed ${it.genericFailure} ")
+                    appLogger.e("get sessions failed ${sessionsResult.genericFailure} ")
                     null
                 }
 
@@ -237,7 +232,7 @@ class WireNotificationManager @Inject constructor(
 
                 when (screens) {
                     is CurrentScreen.Conversation -> messagesNotificationManager.hideNotification(screens.id, userId)
-                    is CurrentScreen.OtherUserProfile -> hideConnectionRequestNotification(userId, screens.id)
+                    is CurrentScreen.OtherUserProfile -> messagesNotificationManager.hideNotification(screens.id, userId)
                     is CurrentScreen.IncomingCallScreen -> callNotificationManager.hideIncomingCallNotification()
                     else -> {}
                 }
@@ -323,8 +318,8 @@ class WireNotificationManager @Inject constructor(
             .collect { (newNotifications, userId, userName) ->
                 appLogger.d("$TAG got ${newNotifications.size} notifications")
                 messagesNotificationManager.handleNotification(newNotifications, userId, userName)
-                markMessagesAsNotified(userId, null)
-                markConnectionAsNotified(userId, null)
+                markMessagesAsNotified(userId)
+                markConnectionAsNotified(userId)
             }
     }
 
@@ -379,43 +374,21 @@ class WireNotificationManager @Inject constructor(
             newNotifications
         }
 
-    private suspend fun markMessagesAsNotified(userId: QualifiedID, conversationId: ConversationId?) {
-        val markNotified = if (conversationId == null) {
-            MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
-        } else {
+    private suspend fun markMessagesAsNotified(userId: QualifiedID, conversationId: ConversationId? = null) {
+        val markNotified = conversationId?.let {
             MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId)
-        }
+            } ?: MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
         coreLogic.getSessionScope(userId)
             .messages
             .markMessagesAsNotified(markNotified)
     }
 
-    private suspend fun markConnectionAsNotified(userId: QualifiedID?, connectionRequestUserId: QualifiedID?) {
+    private suspend fun markConnectionAsNotified(userId: QualifiedID?, connectionRequestUserId: QualifiedID? = null) {
         appLogger.d("$TAG markConnectionAsNotified")
         userId?.let {
             coreLogic.getSessionScope(it)
                 .conversations
                 .markConnectionRequestAsNotified(connectionRequestUserId)
-        }
-    }
-
-    private suspend fun hideConnectionRequestNotification(userId: QualifiedID?, connectionRequestUserId: QualifiedID?) {
-        // to hide ConnectionRequestNotification we need to get conversationId for it
-        // cause it's used as Notification ID
-        userId?.let {
-            coreLogic.getSessionScope(it)
-                .conversations
-                .observeConnectionList()
-                .first()
-                .firstOrNull { conversationDetails ->
-                    conversationDetails is ConversationDetails.Connection
-                            && conversationDetails.otherUser?.id == connectionRequestUserId
-                }
-                ?.conversation
-                ?.id
-                ?.let { conversationId ->
-                    messagesNotificationManager.hideNotification(conversationId, userId)
-                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.media.CallRinger
@@ -35,11 +34,11 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.conversation.SecurityClassificationTypeResult
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
@@ -52,7 +51,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -75,8 +73,8 @@ class SharedCallingViewModel @Inject constructor(
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
     private val currentScreenManager: CurrentScreenManager,
-    private val getConversationClassifiedType: GetSecurityClassificationTypeUseCase,
-    private val dispatchers: DispatcherProvider,
+    private val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase,
+    private val dispatchers: DispatcherProvider
 ) : ViewModel() {
 
     var callState by mutableStateOf(CallState())
@@ -92,8 +90,8 @@ class SharedCallingViewModel @Inject constructor(
             val allCallsSharedFlow = allCalls().map {
                 it.find { call ->
                     call.conversationId == conversationId &&
-                            call.status != CallStatus.CLOSED &&
-                            call.status != CallStatus.MISSED
+                        call.status != CallStatus.CLOSED &&
+                        call.status != CallStatus.MISSED
                 }
             }.flowOn(dispatchers.io()).shareIn(this, started = SharingStarted.Lazily)
 
@@ -122,11 +120,8 @@ class SharedCallingViewModel @Inject constructor(
     }
 
     private suspend fun setClassificationType() {
-        when (val result = getConversationClassifiedType(conversationId)) {
-            is SecurityClassificationTypeResult.Failure -> appLogger.e("Could not determine the classification type")
-            is SecurityClassificationTypeResult.Success -> {
-                callState = callState.copy(securityClassificationType = result.classificationType)
-            }
+        observeSecurityClassificationLabel(conversationId).collect { classificationType ->
+            callState = callState.copy(securityClassificationType = classificationType)
         }
     }
 
@@ -180,7 +175,7 @@ class SharedCallingViewModel @Inject constructor(
     }
 
     private suspend fun observeOnMute() {
-        //We should only mute established calls
+        // We should only mute established calls
         snapshotFlow { callState.isMuted to callState.callStatus }.collectLatest { (isMuted, callStatus) ->
             if (callStatus == CallStatus.ESTABLISHED) {
                 isMuted?.let {
@@ -199,7 +194,7 @@ class SharedCallingViewModel @Inject constructor(
             callState = callState.copy(
                 callStatus = call.status,
                 callerName = call.callerName,
-                isCameraOn = call.isCameraOn,
+                isCameraOn = call.isCameraOn
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -52,7 +52,9 @@ class OngoingCallViewModel @OptIn(ExperimentalCoroutinesApi::class)
             .collect { calls ->
                 val currentCall = calls.find { call -> call.conversationId == conversationId }
                 val currentScreen = currentScreenManager.observeCurrentScreen(viewModelScope).first()
-                if (currentCall == null && currentScreen is CurrentScreen.OngoingCallScreen)
+                val isCurrentlyOnOngoingScreen = currentScreen is CurrentScreen.OngoingCallScreen
+                val isOnBackground = currentScreen is CurrentScreen.InBackground
+                if (currentCall == null && (isCurrentlyOnOngoingScreen || isOnBackground))
                     navigateBack()
             }
     }

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("StringTemplate")
+
 package com.wire.android.util
 
 import android.content.Context
@@ -8,7 +10,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.wire.android.appLogger
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
-import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.getCurrentNavigationItem
 import com.wire.kalium.logic.data.id.ConversationId
@@ -74,7 +75,6 @@ class CurrentScreenManager @Inject constructor(
 
     companion object {
         private const val TAG = "CurrentScreenManager"
-
     }
 }
 
@@ -87,7 +87,7 @@ sealed class CurrentScreen {
     data class Conversation(val id: ConversationId) : CurrentScreen()
 
     // Another User Profile Screen is opened
-    data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
+    data class OtherUserProfile(val id: ConversationId) : CurrentScreen()
 
     // Ongoing call screen is opened
     data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
@@ -118,7 +118,7 @@ sealed class CurrentScreen {
                         ?: SomeOther
                 }
                 NavigationItem.OtherUserProfile -> {
-                    arguments?.getString(EXTRA_USER_ID)
+                    arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OtherUserProfile(it) }
                         ?: SomeOther

--- a/app/src/main/kotlin/com/wire/android/util/ui/ScreenSettingsUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/ScreenSettingsUtil.kt
@@ -38,14 +38,12 @@ private fun Activity.wakeUpDevice() {
 private fun Activity.addScreenOnFlags() {
     window.addFlags(
         WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-                or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
     )
 }
 
 private fun Activity.removeScreenOnFlags() {
     window.clearFlags(
         WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-                or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
     )
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {

--- a/app/src/test/kotlin/com/wire/android/common/TestsCommon.kt
+++ b/app/src/test/kotlin/com/wire/android/common/TestsCommon.kt
@@ -6,14 +6,22 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.platformClassName
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * this workaround solves kotlinx.coroutines.test.UncompletedCoroutinesError in tests
+ *
+ * FIXME: This shouldn't exist.
+ *        We should handle and test the fact that coroutines are cancelled properly.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-fun runTestWithCancellation(body: suspend TestScope.() -> Unit): TestResult =
+fun runTestWithCancellation(
+    context: CoroutineContext = EmptyCoroutineContext,
+    body: suspend TestScope.() -> Unit
+): TestResult =
     try {
-        runTest {
+        runTest(context) {
             body()
             cancel()
         }

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -64,10 +64,8 @@ class WireNotificationManagerTest {
 
     @Test
     fun givenNotAuthenticatedUser_whenFetchAndShowNotificationsOnceCalled_thenNothingHappen() = runTest(dispatcherProvider.main()) {
-        val (arrangement, manager) = Arrangement()
-            .withSession(GetAllSessionsResult.Failure.NoSessionFound)
-            .withCurrentUserSession(provideCurrentInvalidUserSession())
-            .arrange()
+        val (arrangement, manager) = Arrangement().withSession(GetAllSessionsResult.Failure.NoSessionFound)
+            .withCurrentUserSession(provideCurrentInvalidUserSession()).arrange()
 
         manager.fetchAndShowNotificationsOnce("user_id")
         advanceUntilIdle()
@@ -75,23 +73,20 @@ class WireNotificationManagerTest {
         verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
         verify(exactly = 0) {
             arrangement.messageNotificationManager.handleNotification(
-                any(),
-                any(),
-                TestUser.SELF_USER.handle!!
+                newNotifications = any(),
+                userId = any(),
+                userName = TestUser.SELF_USER.handle!!
             )
         }
         verify(exactly = 0) { arrangement.callNotificationManager.handleIncomingCallNotifications(any(), any()) }
     }
 
-    //todo: check later with boris!
+    // todo: check later with boris!
     @Ignore
     fun givenAuthenticatedUser_whenFetchAndShowNotificationsOnceCalled_thenConnectionPolicyManagerIsCalled() =
         runTest(dispatcherProvider.main()) {
-            val (arrangement, manager) = Arrangement()
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession())
-                .withMessageNotifications(listOf())
-                .withIncomingCalls(listOf())
+            val (arrangement, manager) = Arrangement().withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+                .withCurrentUserSession(provideCurrentValidUserSession()).withMessageNotifications(listOf()).withIncomingCalls(listOf())
                 .arrange()
 
             manager.fetchAndShowNotificationsOnce("user_id")
@@ -99,34 +94,32 @@ class WireNotificationManagerTest {
 
             verify(atLeast = 1) { arrangement.coreLogic.getSessionScope(any()) }
             coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(TEST_AUTH_TOKEN.userId) }
-            verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-                listOf(),
-                any(),
-                TestUser.SELF_USER.handle!!
-            ) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    newNotifications = listOf(),
+                    userId = any(),
+                    userName = TestUser.SELF_USER.handle!!
+                )
+            }
             verify(exactly = 1) { arrangement.callNotificationManager.handleIncomingCallNotifications(listOf(), any()) }
         }
 
     @Test
-    fun givenNotAuthenticatedUser_whenObserveCalled_thenNothingHappenAndCallNotificationHides() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenNotAuthenticatedUser_whenObserveCalled_thenNothingHappenAndCallNotificationHides() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        advanceUntilIdle()
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            advanceUntilIdle()
 
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideIncomingCallNotification() }
-    }
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideIncomingCallNotification() }
+        }
 
     @Test
-    fun givenNoIncomingCalls_whenObserveCalled_thenCallNotificationHides() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf())
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenNoIncomingCalls_whenObserveCalled_thenCallNotificationHides() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf()).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -135,13 +128,9 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeIncomingCalls_whenAppIsNotVisible_thenCallNotificationHidden() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .withEstablishedCall(listOf())
-            .arrange()
+    fun givenSomeIncomingCalls_whenAppIsNotVisible_thenCallNotificationHidden() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).withEstablishedCall(listOf()).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -151,12 +140,9 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeIncomingCalls_whenAppIsVisible_thenCallNotificationShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .withMessageNotifications(listOf())
-            .arrange()
+    fun givenSomeIncomingCalls_whenAppIsVisible_thenCallNotificationShowed() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withCurrentScreen(CurrentScreen.SomeOther)
+            .withMessageNotifications(listOf()).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
@@ -166,88 +152,83 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenSomeNotifications_whenAppIsInForegroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenSomeNotifications_whenAppIsInForegroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(
+                    listOf(
+                        provideLocalNotificationConversation(
+                            messages = listOf(provideLocalNotificationMessage())
+                        )
+                    )
+                ).withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        runCurrent()
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            runCurrent()
 
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-            listOf(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
-    }
-
-    @Test
-    fun givenSomeNotifications_whenAppIsInBackgroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf(provideCall()))
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .arrange()
-
-        manager.observeNotificationsAndCalls(flowOf(null), this) {}
-        runCurrent()
-
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
-        verify(exactly = 0) { arrangement.messageNotificationManager.handleNotification(
-            listOf(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
-        verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
-    }
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    newNotifications = listOf(), userId = any(), userName = TestUser.SELF_USER.handle!!
+                )
+            }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
+        }
 
     @Test
-    fun givenSomeNotifications_whenObserveCalled_thenCallNotificationShowed() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withMessageNotifications(listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage()))))
-            .withIncomingCalls(listOf())
-            .withCurrentScreen(CurrentScreen.SomeOther)
-            .arrange()
+    fun givenSomeNotifications_whenAppIsInBackgroundAndNoUserLoggedIn_thenMessageNotificationNotShowed() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement().withIncomingCalls(listOf(provideCall())).withMessageNotifications(
+                    listOf(provideLocalNotificationConversation(messages = listOf(provideLocalNotificationMessage())))
+                ).withCurrentScreen(CurrentScreen.InBackground).arrange()
+
+            manager.observeNotificationsAndCalls(flowOf(null), this) {}
+            runCurrent()
+
+            verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    listOf(), any(), TestUser.SELF_USER.handle!!
+                )
+            }
+            verify(exactly = 1) { arrangement.callNotificationManager.hideAllNotifications() }
+        }
+
+    @Test
+    fun givenSomeNotifications_whenObserveCalled_thenCallNotificationShowed() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withMessageNotifications(
+            listOf(
+                provideLocalNotificationConversation(
+                    messages = listOf(provideLocalNotificationMessage())
+                )
+            )
+        ).withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.SomeOther).arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
         runCurrent()
 
-        verify(exactly = 1) { arrangement.messageNotificationManager.handleNotification(
-            any(),
-            any(),
-            TestUser.SELF_USER.handle!!
-        ) }
+        verify(exactly = 1) {
+            arrangement.messageNotificationManager.handleNotification(
+                any(), any(), TestUser.SELF_USER.handle!!
+            )
+        }
     }
 
     @Test
     fun givenSomeNotificationsAndCurrentScreenIsConversation_whenObserveCalled_thenNotificationIsNotShowed() =
-        runTestWithCancellation {
+        runTestWithCancellation(dispatcherProvider.main()) {
             val conversationId = ConversationId("conversation_value", "conversation_domain")
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(
-                    listOf(
-                        provideLocalNotificationConversation(
-                            id = conversationId,
-                            messages = listOf(provideLocalNotificationMessage())
-                        )
-                    )
+            val (arrangement, manager) = Arrangement().withMessageNotifications(
+                listOf(
+                    provideLocalNotificationConversation(id = conversationId, messages = listOf(provideLocalNotificationMessage()))
                 )
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.Conversation(conversationId))
-                .arrange()
+            ).withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.Conversation(conversationId)).arrange()
 
             manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
             runCurrent()
 
             verify(exactly = 1) {
                 arrangement.messageNotificationManager.handleNotification(
-                    listOf(),
-                    any(),
-                    TestUser.SELF_USER.handle!!
+                    listOf(), any(), TestUser.SELF_USER.handle!!
                 )
             }
             coVerify(atLeast = 1) {
@@ -261,13 +242,10 @@ class WireNotificationManagerTest {
 
     @Test
     fun givenCurrentScreenIsConversation_whenObserveCalled_thenNotificationForThatConversationIsHidden() =
-        runTestWithCancellation {
+        runTestWithCancellation(dispatcherProvider.main()) {
             val conversationId = ConversationId("conversation_value", "conversation_domain")
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.Conversation(conversationId))
-                .arrange()
+            val (arrangement, manager) = Arrangement().withMessageNotifications(listOf()).withIncomingCalls(listOf())
+                .withCurrentScreen(CurrentScreen.Conversation(conversationId)).arrange()
 
             manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
             runCurrent()
@@ -279,13 +257,9 @@ class WireNotificationManagerTest {
     fun givenASingleUserId_whenCallingFetchAndShowOnceInParallel_thenPushNotificationIsHandledOnlyOnce() =
         runTest(dispatcherProvider.main()) {
             val userId = TEST_AUTH_TOKEN.userId
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession())
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.InBackground)
-                .arrange()
+            val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN))).withCurrentUserSession(provideCurrentValidUserSession())
+                .withIncomingCalls(listOf()).withCurrentScreen(CurrentScreen.InBackground).arrange()
 
             coEvery { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) } coAnswers {
                 // Push handling is taking 10 minutes
@@ -314,31 +288,26 @@ class WireNotificationManagerTest {
         }
 
     @Test
-    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUser_shouldSkipNotification() =
-        runTest(dispatcherProvider.main()) {
-            val otherAuthSession = provideAccountInfo("other_id")
-            val userId = otherAuthSession.userId
-            val (arrangement, manager) = Arrangement()
-                .withMessageNotifications(listOf())
-                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-                .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
-                .withIncomingCalls(listOf())
-                .withCurrentScreen(CurrentScreen.InBackground)
-                .arrange()
+    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUser_shouldSkipNotification() = runTest(dispatcherProvider.main()) {
+        val otherAuthSession = provideAccountInfo("other_id")
+        val userId = otherAuthSession.userId
+        val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+            .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN)).withIncomingCalls(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).arrange()
 
-            manager.fetchAndShowNotificationsOnce(userId.value)
-            advanceUntilIdle()
+        manager.fetchAndShowNotificationsOnce(userId.value)
+        advanceUntilIdle()
 
-            coVerify(exactly = 0) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
-        }
+        coVerify(exactly = 0) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
+    }
 
     @Test
-    fun givenSomeEstablishedCalls_whenAppIsNotVisible_thenOngoingCallServiceRun() = runTestWithCancellation {
-        val (arrangement, manager) = Arrangement()
-            .withIncomingCalls(listOf())
-            .withMessageNotifications(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .withEstablishedCall(listOf(provideCall().copy(status = CallStatus.ESTABLISHED)))
+    fun givenSomeEstablishedCalls_whenAppIsNotVisible_thenOngoingCallServiceRun() = runTestWithCancellation(dispatcherProvider.main()) {
+        val (arrangement, manager) = Arrangement().withIncomingCalls(listOf()).withMessageNotifications(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground).withEstablishedCall(
+                listOf(provideCall().copy(status = CallStatus.ESTABLISHED))
+            )
             .arrange()
 
         manager.observeNotificationsAndCalls(flowOf(provideUserId()), this) {}
@@ -517,28 +486,20 @@ class WireNotificationManagerTest {
         private fun provideLocalNotificationConversation(
             id: ConversationId = ConversationId("conversation_value", "conversation_domain"),
             messages: List<LocalNotificationMessage> = listOf()
-        ) =
-            LocalNotificationConversation(
-                id,
-                "name_${id.value}",
-                messages,
-                true
-            )
-
-        private fun provideLocalNotificationMessage(): LocalNotificationMessage = LocalNotificationMessage.Text(
-            LocalNotificationMessageAuthor("author", null),
-            "",
-            "testing text"
+        ) = LocalNotificationConversation(
+            id, "name_${id.value}", messages, true
         )
 
+        private fun provideLocalNotificationMessage(): LocalNotificationMessage = LocalNotificationMessage.Text(
+            LocalNotificationMessageAuthor("author", null), "", "testing text"
+        )
 
         private fun provideUserId() = UserId("value", "domain")
 
         private fun appVisibleFlow() = MutableStateFlow(true)
         private fun appInvisibleFlow() = MutableStateFlow(false)
 
-        private fun provideCurrentValidUserSession(authSession: AccountInfo = TEST_AUTH_TOKEN) =
-            CurrentSessionResult.Success(authSession)
+        private fun provideCurrentValidUserSession(authSession: AccountInfo = TEST_AUTH_TOKEN) = CurrentSessionResult.Success(authSession)
 
         private fun provideCurrentInvalidUserSession() = CurrentSessionResult.Failure.SessionNotFound
     }

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -22,14 +22,13 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -96,7 +95,7 @@ class SharedCallingViewModelTest {
     private lateinit var currentScreenManager: CurrentScreenManager
 
     @MockK
-    private lateinit var getConversationClassifiedType: GetSecurityClassificationTypeUseCase
+    private lateinit var observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
 
     private val uiCallParticipantMapper: UICallParticipantMapper by lazy { UICallParticipantMapper(wireSessionImageLoader, userTypeMapper) }
 
@@ -133,7 +132,7 @@ class SharedCallingViewModelTest {
             userTypeMapper = userTypeMapper,
             currentScreenManager = currentScreenManager,
             qualifiedIdMapper = qualifiedIdMapper,
-            getConversationClassifiedType = getConversationClassifiedType,
+            observeSecurityClassificationLabel = observeSecurityClassificationLabel,
             dispatchers = TestDispatcherProvider()
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -36,11 +36,11 @@ import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
-import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.conversation.IsInteractionAvailableResult
 import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
@@ -122,7 +122,7 @@ internal class ConversationsViewModelArrangement {
     private lateinit var updateConversationReadDateUseCase: UpdateConversationReadDateUseCase
 
     @MockK
-    private lateinit var getSecurityClassificationType: GetSecurityClassificationTypeUseCase
+    private lateinit var observeSecurityClassificationType: ObserveSecurityClassificationLabelUseCase
 
     @MockK
     private lateinit var observeSyncState: ObserveSyncStateUseCase
@@ -150,7 +150,7 @@ internal class ConversationsViewModelArrangement {
             kaliumFileSystem = fakeKaliumFileSystem,
             updateConversationReadDateUseCase = updateConversationReadDateUseCase,
             observeConversationInteractionAvailability = observeConversationInteractionAvailabilityUseCase,
-            getConversationClassifiedType = getSecurityClassificationType,
+            observeSecurityClassificationLabel = observeSecurityClassificationType,
             contactMapper = contactMapper,
             membersToMention = membersToMention
         )
@@ -198,7 +198,6 @@ internal class ConversationsViewModelArrangement {
     }
 
     fun arrange() = this to viewModel
-
 }
 
 internal fun withMockConversationDetailsOneOnOne(
@@ -226,7 +225,7 @@ internal fun withMockConversationDetailsOneOnOne(
 
 internal fun mockConversationDetailsGroup(
     conversationName: String,
-    mockedConversationId: ConversationId = ConversationId("someId", "someDomain"),
+    mockedConversationId: ConversationId = ConversationId("someId", "someDomain")
 ) = ConversationDetails.Group(
     conversation = TestConversation.GROUP()
         .copy(name = conversationName, id = mockedConversationId),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2898" title="AR-2898" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2898</a>  ANR [Connection Request Notification]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

To manage the notifications [ Show and Clear programmatically if necessary], we use the conversationId as the identifier. When a user go the connection request screen, we were passing the userId instead of passing the conversationId to the CurrentScreenManager; then we had to fetch the conversationId by the userId from the DB in a insufficient way! In this fix we pass the conversation Id from userProfileScreen.
The previous solution was causing database lock and then ANR issues on the main thread [the main thread will be fixed in another PR]

### Causes (Optional)
Database lock due to lot of db connections.

### Solutions
Pass the value that exist instead of fetching again from the DB.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
