### PR TITLE
feat: Create Group Receipt Mode System Message

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -3,6 +3,7 @@ package com.wire.android
 import android.app.Application
 import android.content.ComponentCallbacks2
 import android.os.Build
+import android.os.StrictMode
 import androidx.work.Configuration
 import co.touchlab.kermit.platformLogWriter
 import com.datadog.android.Datadog
@@ -28,7 +29,6 @@ import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
-
 
 // App wide global logger, carefully initialized when our application is "onCreate"
 var appLogger: KaliumLogger = KaliumLogger.disabled()
@@ -57,8 +57,11 @@ class WireApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+
+        enableStrictMode()
+
         if (this.isGoogleServicesAvailable()) {
-            val firebaseOptions =  FirebaseOptions.Builder()
+            val firebaseOptions = FirebaseOptions.Builder()
                 .setApplicationId(BuildConfig.FIREBASE_APP_ID)
                 .setGcmSenderId(BuildConfig.FIREBASE_PUSH_SENDER_ID)
                 .setApiKey(BuildConfig.GOOGLE_API_KEY)
@@ -72,6 +75,27 @@ class WireApplication : Application(), Configuration.Provider {
 
         // TODO: Can be handled in one of Sync steps
         coreLogic.updateApiVersionsScheduler.schedulePeriodicApiVersionUpdate()
+    }
+
+    private fun enableStrictMode() {
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectDiskReads()
+                .detectDiskWrites()
+                .detectNetwork()
+                .penaltyLog()
+                // .penaltyDeath() TODO: add it later after fixing reported violations
+                .build()
+        )
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .detectAll()
+                .penaltyLog()
+                // .penaltyDeath() TODO: add it later after fixing reported violations
+                .build()
+        )
     }
 
     private fun initializeApplicationLoggingFrameworks() {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -2,6 +2,7 @@ package com.wire.android.mapper
 
 import androidx.annotation.StringRes
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.AttachmentType
@@ -61,6 +62,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.ConversationRenamed -> mapConversationRenamedMessage(message.senderUserId, content, members)
         is MessageContent.TeamMemberRemoved -> mapTeamMemberRemovedMessage(content)
         is MessageContent.CryptoSessionReset -> mapResetSession(message.senderUserId, members)
+        is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(message.senderUserId, content, members)
     }
 
     private fun mapResetSession(
@@ -86,6 +88,25 @@ class MessageContentMapper @Inject constructor(
         } else {
             UIMessageContent.SystemMessage.MissedCall.OtherCalled(authorName)
         }
+    }
+
+    private fun mapNewConversationReceiptMode(
+        senderUserId: UserId,
+        content: MessageContent.NewConversationReceiptMode,
+        userList: List<User>
+    ): UIMessageContent.SystemMessage {
+//        val sender = userList.findUser(userId = senderUserId)
+//        val creatorName = toSystemMessageMemberName(
+//            user = sender,
+//            type = SelfNameType.ResourceTitleCase
+//        )
+        appLogger.d("[NCRRM][mapNewConversationReceiptMode] - content.receiptMode: [${content.receiptMode}]")
+        return UIMessageContent.SystemMessage.NewConversationReceiptMode(
+            receiptMode = when (content.receiptMode) {
+                true -> "on"
+                else -> "off"
+            }
+        )
     }
 
     private fun mapTeamMemberRemovedMessage(

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -2,7 +2,6 @@ package com.wire.android.mapper
 
 import androidx.annotation.StringRes
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.AttachmentType
@@ -62,7 +61,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.ConversationRenamed -> mapConversationRenamedMessage(message.senderUserId, content, members)
         is MessageContent.TeamMemberRemoved -> mapTeamMemberRemovedMessage(content)
         is MessageContent.CryptoSessionReset -> mapResetSession(message.senderUserId, members)
-        is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(message.senderUserId, content, members)
+        is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(content)
     }
 
     private fun mapResetSession(
@@ -91,16 +90,8 @@ class MessageContentMapper @Inject constructor(
     }
 
     private fun mapNewConversationReceiptMode(
-        senderUserId: UserId,
-        content: MessageContent.NewConversationReceiptMode,
-        userList: List<User>
+        content: MessageContent.NewConversationReceiptMode
     ): UIMessageContent.SystemMessage {
-//        val sender = userList.findUser(userId = senderUserId)
-//        val creatorName = toSystemMessageMemberName(
-//            user = sender,
-//            type = SelfNameType.ResourceTitleCase
-//        )
-        appLogger.d("[NCRRM][mapNewConversationReceiptMode] - content.receiptMode: [${content.receiptMode}]")
         return UIMessageContent.SystemMessage.NewConversationReceiptMode(
             receiptMode = when (content.receiptMode) {
                 true -> "on"

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.util.isGreaterThan
 import javax.inject.Inject
 
 // TODO: splits mapping into more classes
+@Suppress("TooManyFunctions")
 class MessageContentMapper @Inject constructor(
     private val messageResourceProvider: MessageResourceProvider,
     private val wireSessionImageLoader: WireSessionImageLoader,
@@ -300,5 +301,4 @@ data class MessageResourceProvider(
 private fun String?.orUnknownName(): UIText = when {
     this != null -> UIText.DynamicString(this)
     else -> UIText.StringResource(R.string.username_unavailable_label)
-
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -94,8 +94,8 @@ class MessageContentMapper @Inject constructor(
     ): UIMessageContent.SystemMessage {
         return UIMessageContent.SystemMessage.NewConversationReceiptMode(
             receiptMode = when (content.receiptMode) {
-                true -> "on"
-                else -> "off"
+                true -> UIText.StringResource(R.string.label_system_message_receipt_mode_on)
+                else -> UIText.StringResource(R.string.label_system_message_receipt_mode_off)
             }
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -315,6 +315,7 @@ private fun MessageContent(
         is UIMessageContent.PreviewAssetMessage -> {}
         is UIMessageContent.SystemMessage.MissedCall.YouCalled -> {}
         is UIMessageContent.SystemMessage.MissedCall.OtherCalled -> {}
+        is UIMessageContent.SystemMessage.NewConversationReceiptMode -> {}
         null -> {
             throw NullPointerException("messageContent is null")
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -174,6 +174,7 @@ private val SystemMessage.expandable
         is SystemMessage.RenamedConversation -> false
         is SystemMessage.TeamMemberRemoved -> false
         is SystemMessage.CryptoSessionReset -> false
+        is SystemMessage.NewConversationReceiptMode -> false
     }
 
 private fun List<String>.toUserNamesListString(res: Resources) = when {
@@ -216,6 +217,7 @@ fun SystemMessage.annotatedString(
         is SystemMessage.RenamedConversation -> arrayOf(author.asString(res), additionalContent)
         is SystemMessage.TeamMemberRemoved -> arrayOf(content.userName)
         is SystemMessage.CryptoSessionReset -> arrayOf(author.asString(res))
+        is SystemMessage.NewConversationReceiptMode -> arrayOf(receiptMode)
     }
     return res.stringWithStyledArgs(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -217,7 +217,7 @@ fun SystemMessage.annotatedString(
         is SystemMessage.RenamedConversation -> arrayOf(author.asString(res), additionalContent)
         is SystemMessage.TeamMemberRemoved -> arrayOf(content.userName)
         is SystemMessage.CryptoSessionReset -> arrayOf(author.asString(res))
-        is SystemMessage.NewConversationReceiptMode -> arrayOf(receiptMode)
+        is SystemMessage.NewConversationReceiptMode -> arrayOf(receiptMode.asString(res))
     }
     return res.stringWithStyledArgs(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -153,6 +153,9 @@ sealed class UIMessageContent {
         data class CryptoSessionReset(val author: UIText) :
             SystemMessage(R.drawable.ic_info, R.string.label_system_message_session_reset, true)
 
+        data class NewConversationReceiptMode(
+            val receiptMode: String
+        ) : SystemMessage(R.drawable.ic_view, R.string.label_system_message_new_conversation_receipt_mode)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -154,7 +154,7 @@ sealed class UIMessageContent {
             SystemMessage(R.drawable.ic_info, R.string.label_system_message_session_reset, true)
 
         data class NewConversationReceiptMode(
-            val receiptMode: String
+            val receiptMode: UIText
         ) : SystemMessage(R.drawable.ic_view, R.string.label_system_message_new_conversation_receipt_mode)
     }
 }

--- a/app/src/main/res/drawable/ic_view.xml
+++ b/app/src/main/res/drawable/ic_view.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="13dp"
+    android:viewportWidth="12"
+    android:viewportHeight="13">
+  <path
+      android:pathData="M12,6.5C11.127,3.878 8.77,2 6,2C3.23,2 0.873,3.878 0,6.5C0.873,9.122 3.23,11 6,11C8.77,11 11.127,9.122 12,6.5ZM6,8.75C7.243,8.75 8.25,7.743 8.25,6.5C8.25,5.257 7.243,4.25 6,4.25C4.757,4.25 3.75,5.257 3.75,6.5C3.75,7.743 4.757,8.75 6,8.75Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,7 +467,7 @@
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
     <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_receipt_mode_on">on</string>
-    <string name="label_system_message_receipt_mode_off">on</string>
+    <string name="label_system_message_receipt_mode_off">off</string>
 
     <!-- Last messages -->
     <string name="last_message_asset">shared an asset.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,8 @@
     <string name="label_system_message_renamed_the_conversation">%1$s renamed the conversation\n%2$s</string>
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
+    <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
+    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
 
     <!-- Last messages -->
     <string name="last_message_asset">shared an asset.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,6 +466,8 @@
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
     <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_receipt_mode_on">on</string>
+    <string name="label_system_message_receipt_mode_off">on</string>
 
     <!-- Last messages -->
     <string name="last_message_asset">shared an asset.</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2712 - Show a system message when read receipts are turned on](https://wearezeta.atlassian.net/browse/AR-2712)

This PR handles receipt mode value to be shown as a system message in a group conversation as soon as it is created.
The handling of receipt mode from changes in group settings screen will be handled in a later PR.

### Issues

New group conversations [from event or user in-app created] were not adding a system message for receipt mode.

### Causes (Optional)

It was not implemented.

### Solutions

Add implementation to always add a system message informing the members of the conversation what is the receipt mode status if the creator/receiver of the new group event matches the criteria of:
- isSelfATeamMember
- conversation is of GROUP type
- receipt mode status is NOT NULL (for users without a team it will be null when invoking `CreateGroupConversationUseCase` thus not showing for them)

### Dependencies (Optional)

Needs releases with:

- [X] [feat: Group Conversation - Receipt Mode System Message #1309](https://github.com/wireapp/kalium/pull/1309)

### Testing

#### How to Test

Account with Team
- Open App
- Create Group Conversation [read receipt ON or OFF]
- system message should be shown in conversation screen with selected value

Account with no Team
- Open APp
- Create Group Conversation [NO options available]
- No system message will be shown

### Attachments (Optional)

| Receipt Mode ON | Receipt Mode OFF |
| ----------- | ------------ |
| <img src="https://user-images.githubusercontent.com/5890660/211323668-f2775ffd-8e3e-4066-9204-f7d539108815.png" width="200" height="400" alt="read receipt on" /> | <img src="https://user-images.githubusercontent.com/5890660/211323677-b00fe0af-bd84-4f39-95df-645c4f6f7afb.png" width="200" height="400" alt="read receipt off" /> |