### PR TITLE
chore: adjust test coverage settings

### DIFF
--- a/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
@@ -11,7 +11,7 @@ class DateTimeUtilKtTest {
         assertEquals(null, result)
     }
 
-    @Test
+    // @Test @Ignore("This test is failing on locally, but not on CI")
     fun `given a valid date, when performing a transformation, then return with medium format`() {
         val result = "2022-03-24T18:02:30.360Z".formatMediumDateTime()
         assertEquals("Mar 24, 2022, 6:02:30 PM", result)

--- a/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
@@ -11,7 +11,7 @@ class DateTimeUtilKtTest {
         assertEquals(null, result)
     }
 
-    // @Test @Ignore("This test is failing on locally, but not on CI")
+    @Test
     fun `given a valid date, when performing a transformation, then return with medium format`() {
         val result = "2022-03-24T18:02:30.360Z".formatMediumDateTime()
         assertEquals("Mar 24, 2022, 6:02:30 PM", result)

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -2,7 +2,6 @@ package scripts
 
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import org.gradle.configurationcache.extensions.capitalized
 
 plugins {
     id("com.android.application") apply false
@@ -84,7 +83,7 @@ val jacocoReport by tasks.registering(JacocoReport::class) {
     group = "Quality"
     description = "Reports code coverage on tests within the Wire Android codebase"
     val buildVariant = "devDebug" // It's not necessary to run unit tests on every variant so we default to "devDebug"
-    dependsOn("test${buildVariant.capitalized()}UnitTest")
+    dependsOn("test${buildVariant.capitalize()}UnitTest")
 
     val outputDir = "$buildDir/jacoco/html"
     val classPathBuildVariant = buildVariant

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -2,7 +2,7 @@ package scripts
 
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import scripts.Variants_gradle.Default
+import org.gradle.configurationcache.extensions.capitalized
 
 plugins {
     id("com.android.application") apply false
@@ -83,10 +83,11 @@ tasks.register("staticCodeAnalysis") {
 val jacocoReport by tasks.registering(JacocoReport::class) {
     group = "Quality"
     description = "Reports code coverage on tests within the Wire Android codebase"
-    dependsOn("test${Default.BUILD_VARIANT}UnitTest")
+    val buildVariant = "internalDebug" // It's not necessary to run unit tests on every variant so we default to "internalDebug"
+    dependsOn("test${buildVariant.capitalized()}UnitTest")
 
     val outputDir = "$buildDir/jacoco/html"
-    val classPathBuildVariant = "${Default.BUILD_FLAVOR}${Default.BUILD_TYPE.capitalize()}"
+    val classPathBuildVariant = buildVariant
 
     reports {
         xml.required.set(true)
@@ -97,9 +98,7 @@ val jacocoReport by tasks.registering(JacocoReport::class) {
     classDirectories.setFrom(
         fileTree(project.buildDir) {
             include(
-                "**/classes/**/main/**",
-                "**/intermediates/classes/$classPathBuildVariant/**",
-                "**/intermediates/javac/$classPathBuildVariant/*/classes/**",
+                "**/classes/**/main/**", // This probably can be removed
                 "**/tmp/kotlin-classes/$classPathBuildVariant/**"
             )
             exclude(
@@ -118,8 +117,9 @@ val jacocoReport by tasks.registering(JacocoReport::class) {
                 "**/*Response.*",
                 "**/*Application.*",
                 "**/*Entity.*",
-                "**/*Screen.*",
                 "**/mock/**",
+                "**/*Screen*", // These are composable classes
+                "**/*Kt*", // These are "usually" kotlin generated classes
                 "**/theme/**/*.*", // Ignores jetpack compose theme related code
                 "**/common/**/*.*", // Ignores jetpack compose common components related code
                 "**/navigation/**/*.*" // Ignores jetpack navigation related code

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -83,7 +83,7 @@ tasks.register("staticCodeAnalysis") {
 val jacocoReport by tasks.registering(JacocoReport::class) {
     group = "Quality"
     description = "Reports code coverage on tests within the Wire Android codebase"
-    val buildVariant = "internalDebug" // It's not necessary to run unit tests on every variant so we default to "internalDebug"
+    val buildVariant = "devDebug" // It's not necessary to run unit tests on every variant so we default to "devDebug"
     dependsOn("test${buildVariant.capitalized()}UnitTest")
 
     val outputDir = "$buildDir/jacoco/html"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,6 @@ coverage:
     status:
         project:
             default:
-                # basic
                 target: auto
                 threshold: 2%
                 base: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,34 +1,43 @@
 # Coverage configuration
+#
+# Validate this file using the following command in root project:
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate
 # ----------------------
+codecov:
+    notify:
+        wait_for_ci: false
+
 coverage:
-  status:
-    project:
-      default:
-        # basic
-        target: auto
-        threshold: 5%
-        base: auto
-    patch: false
+    status:
+        project:
+            default:
+                # basic
+                target: auto
+                threshold: 2%
+                base: auto
+        patch: false
 
 # Ignoring Paths
 # --------------
 # which folders/files to ignore
 ignore:
-  - ".*/test/.*"
-  - "buildSrc/.*"
-  - "kalium/.*"
-  - ".*/androidTest/.*"
-  - ".*/_version.py"
-  - "setup.py"
-  - ".*/_Screen.kt"
-  - ".*/mock/.*"
-  - ".*/theme/.*"
-  - ".*/common/.*"
-  - ".*/navigation/.*"
+    - ".*/test/.*"
+    - "buildSrc/.*"
+    - "kalium/.*"
+    - ".*/androidTest/.*"
+    - ".*/_version.py"
+    - "setup.py"
+    - ".*/_Screen.kt"
+    - ".*/mock/.*"
+    - ".*/theme/.*"
+    - ".*/common/.*"
+    - ".*/navigation/.*"
 
 # Pull request comments:
 # ----------------------
 # Diff is the Coverage Diff of the pull request.
 # Files are the files impacted by the pull request
 comment:
-  layout: diff, files  # accepted in any order: reach, diff, flags, and/or files
+    layout: diff, files, footer
+    behavior: default
+    require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,11 @@ coverage:
                 target: auto
                 threshold: 2%
                 base: auto
-        patch: false
+        patch:
+            default:
+                informational: true # don't fail the build if patch coverage is below threshold
+                target: 80%
+                base: auto
 
 # Ignoring Paths
 # --------------
@@ -32,6 +36,8 @@ ignore:
     - ".*/theme/.*"
     - ".*/common/.*"
     - ".*/navigation/.*"
+    - ".*/di/.*"
+    - ".*/.*Screen*.kt"
 
 # Pull request comments:
 # ----------------------


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- I realized that right now, coverage comments are always being updated on n +1 commits in a PR.
- Also the jacoco config task is executing unit tests on all flavors, that means: (beta, dev, internal, release, staging) * each buildType, we don't require this for unit testing, since these are supposed to be isolated tests, so the running time of this CI stage is expected to decrease too 🤞 
- We don't know if we are doing well in each PR by facts or encouraging increase of coverage.

### Solutions

- Now, the checks for PR will be executed with a threshold of 80 % coverage (this is the suggested standard, but we can aim differently), but just informative, later we can enforce failure status checks on CI
- Now the coverage will increase, because we will exclude classes, that are supposed to be tested with other kind of tests, ie: regressions, ui, snapshot.
- Only if there are changes in coverage, comment the PR.

### Attachment

Now we will see on the codecov stage report something like this (patch and project) being patch the checks on the PR against base.
<img src="https://cloud.githubusercontent.com/assets/2041757/10752151/dfdda3d2-7c86-11e5-9eec-a23320394015.gif"/>

### Notes

I will open a PR on Kalium as well, modifying the comment behavior at least, so we get updates only on every change of coverage.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
