### PR TITLE
feat: handle group receipt mode change

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -63,6 +63,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.TeamMemberRemoved -> mapTeamMemberRemovedMessage(content)
         is MessageContent.CryptoSessionReset -> mapResetSession(message.senderUserId, members)
         is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(content)
+        is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
     }
 
     private fun mapResetSession(
@@ -94,6 +95,25 @@ class MessageContentMapper @Inject constructor(
         content: MessageContent.NewConversationReceiptMode
     ): UIMessageContent.SystemMessage {
         return UIMessageContent.SystemMessage.NewConversationReceiptMode(
+            receiptMode = when (content.receiptMode) {
+                true -> UIText.StringResource(R.string.label_system_message_receipt_mode_on)
+                else -> UIText.StringResource(R.string.label_system_message_receipt_mode_off)
+            }
+        )
+    }
+
+    private fun mapConversationReceiptModeChanged(
+        senderUserId: UserId,
+        content: MessageContent.ConversationReceiptModeChanged,
+        userList: List<User>
+    ): UIMessageContent.SystemMessage {
+        val sender = userList.findUser(userId = senderUserId)
+        val authorName = toSystemMessageMemberName(
+            user = sender,
+            type = SelfNameType.ResourceTitleCase
+        )
+        return UIMessageContent.SystemMessage.ConversationReceiptModeChanged(
+            author = authorName,
             receiptMode = when (content.receiptMode) {
                 true -> UIText.StringResource(R.string.label_system_message_receipt_mode_on)
                 else -> UIText.StringResource(R.string.label_system_message_receipt_mode_off)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -315,6 +315,7 @@ private fun MessageContent(
         is UIMessageContent.SystemMessage.MissedCall.YouCalled -> {}
         is UIMessageContent.SystemMessage.MissedCall.OtherCalled -> {}
         is UIMessageContent.SystemMessage.NewConversationReceiptMode -> {}
+        is UIMessageContent.SystemMessage.ConversationReceiptModeChanged -> {}
         null -> {
             throw NullPointerException("messageContent is null")
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -187,6 +187,7 @@ private val SystemMessage.expandable
         is SystemMessage.TeamMemberRemoved -> false
         is SystemMessage.CryptoSessionReset -> false
         is SystemMessage.NewConversationReceiptMode -> false
+        is SystemMessage.ConversationReceiptModeChanged -> false
         is SystemMessage.Knock -> false
     }
 
@@ -231,6 +232,7 @@ fun SystemMessage.annotatedString(
         is SystemMessage.TeamMemberRemoved -> arrayOf(content.userName)
         is SystemMessage.CryptoSessionReset -> arrayOf(author.asString(res))
         is SystemMessage.NewConversationReceiptMode -> arrayOf(receiptMode.asString(res))
+        is SystemMessage.ConversationReceiptModeChanged -> arrayOf(receiptMode.asString(res))
         is SystemMessage.Knock -> arrayOf(author.asString(res))
     }
     return res.stringWithStyledArgs(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -160,6 +160,11 @@ sealed class UIMessageContent {
         data class NewConversationReceiptMode(
             val receiptMode: UIText
         ) : SystemMessage(R.drawable.ic_view, R.string.label_system_message_new_conversation_receipt_mode)
+
+        data class ConversationReceiptModeChanged(
+            val author: UIText,
+            val receiptMode: UIText
+        ) : SystemMessage(R.drawable.ic_view, R.string.label_system_message_read_receipt_changed)
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2712 - Show a system message when read receipts are turned on](https://wearezeta.atlassian.net/browse/AR-2712)

This PR is only for handling receipt mode from changes from group settings screen(in-app and from other sources as events).

### Issues

There was no handling of showing a system message for when receipt mode was changed on a group setting.

### Causes (Optional)

It was not implemented.

### Solutions

Add implementation to always add a system message informing the members of the conversation that the receipt mode value was changed.

### Dependencies (Optional)

- [X] [feat: handle group settings receipt mode changed #1324](https://github.com/wireapp/kalium/pull/1324)

### Testing

#### How to Test

- Open App
- Open A Group Conversation
- Change Read Receipt value/toggle throught web or other client (not yet available from AR)
- Watch system messages arise 🙌🏻 

### Screenshots:

<img src="https://user-images.githubusercontent.com/5890660/212364444-f59a692c-8c9f-41c9-be58-3f775fad5fa9.png" width="200" height="400" alt="conversation screen with read receipt system messages" />
