### PR TITLE
fix: unread missed calls count in conversation last message [AR-2940]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -61,7 +61,7 @@ fun MessagePreview?.toUIPreview(unreadEventCount: UnreadEventCount): UILastMessa
             return UILastMessageContent.MultipleMessage(listOf(first, second))
         } else if (unreadContentTexts.isNotEmpty()) {
             val unreadContent = unreadContentTexts.entries.first()
-            if (unreadContent.key == UnreadEventType.MISSED_CALL) {
+            if (unreadContent.key != UnreadEventType.MESSAGE) {
                 return UILastMessageContent.TextMessage(MessageBody(unreadContent.value))
             }
         }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -22,25 +22,48 @@ fun MessagePreview?.toUIPreview(unreadEventCount: UnreadEventCount): UILastMessa
         .toSortedMap()
 
     // we want to show last message content instead of counter when there are only one type of unread events
-    if (sortedUnreadContent.size > 1) {
+    if (sortedUnreadContent.isNotEmpty()) {
         val unreadContentTexts = sortedUnreadContent
             .mapNotNull { type ->
                 when (type.key) {
-                    UnreadEventType.KNOCK -> UIText.PluralResource(R.plurals.unread_event_knock, type.value, type.value)
-                    UnreadEventType.MISSED_CALL -> UIText.PluralResource(R.plurals.unread_event_call, type.value, type.value)
-                    UnreadEventType.MENTION -> UIText.PluralResource(R.plurals.unread_event_mention, type.value, type.value)
-                    UnreadEventType.REPLY -> UIText.PluralResource(R.plurals.unread_event_reply, type.value, type.value)
-                    UnreadEventType.MESSAGE -> UIText.PluralResource(R.plurals.unread_event_message, type.value, type.value)
+                    UnreadEventType.KNOCK -> UnreadEventType.KNOCK to UIText.PluralResource(
+                        R.plurals.unread_event_knock,
+                        type.value,
+                        type.value
+                    )
+                    UnreadEventType.MISSED_CALL -> UnreadEventType.MISSED_CALL to UIText.PluralResource(
+                        R.plurals.unread_event_call,
+                        type.value,
+                        type.value
+                    )
+                    UnreadEventType.MENTION -> UnreadEventType.MENTION to UIText.PluralResource(
+                        R.plurals.unread_event_mention,
+                        type.value,
+                        type.value
+                    )
+                    UnreadEventType.REPLY -> UnreadEventType.REPLY to UIText.PluralResource(
+                        R.plurals.unread_event_reply,
+                        type.value,
+                        type.value
+                    )
+                    UnreadEventType.MESSAGE -> UnreadEventType.MESSAGE to UIText.PluralResource(
+                        R.plurals.unread_event_message,
+                        type.value,
+                        type.value
+                    )
                     UnreadEventType.IGNORED -> null
                     null -> null
                 }
-            }
+            }.associate { it }
         if (unreadContentTexts.size > 1) {
-            val first = unreadContentTexts.first()
-            val second = unreadContentTexts.elementAt(1)
+            val first = unreadContentTexts.values.first()
+            val second = unreadContentTexts.values.elementAt(1)
             return UILastMessageContent.MultipleMessage(listOf(first, second))
         } else if (unreadContentTexts.isNotEmpty()) {
-            return UILastMessageContent.TextMessage(MessageBody(unreadContentTexts.first()))
+            val unreadContent = unreadContentTexts.entries.first()
+            if (unreadContent.key == UnreadEventType.MISSED_CALL) {
+                return UILastMessageContent.TextMessage(MessageBody(unreadContent.value))
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -74,7 +74,6 @@ private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
     isSelfMessage -> UIText.StringResource(R.string.member_name_you_label_titlecase)
     this != null -> UIText.DynamicString(this)
     else -> UIText.StringResource(R.string.username_unavailable_label)
-
 }
 
 @Suppress("LongMethod", "ComplexMethod")
@@ -95,7 +94,6 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         UILastMessageContent.SenderWithMessage(userUIText, UIText.StringResource(R.string.last_message_asset))
                     AssetType.FILE ->
                         UILastMessageContent.SenderWithMessage(userUIText, UIText.StringResource(R.string.last_message_file))
-
                 }
                 is WithUser.ConversationNameChange -> UILastMessageContent.SenderWithMessage(
                     userUIText,

--- a/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
@@ -45,14 +45,75 @@ class MessagePreviewContentMapperTest {
         val messagePreview = TestMessage.PREVIEW.copy(
             content = MessagePreviewContent.WithUser.MissedCall("admin"),
         )
-        val unreadMissedCallsCount = 2
-        val unreadEventCount = mapOf(UnreadEventType.MISSED_CALL to unreadMissedCallsCount)
+        val unreadCount = 2
+        val unreadEventCount = mapOf(UnreadEventType.MISSED_CALL to unreadCount)
 
         val textMessage = messagePreview.toUIPreview(unreadEventCount).shouldBeInstanceOf<UILastMessageContent.TextMessage>()
         val result = textMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
 
         result.resId shouldBeEqualTo R.plurals.unread_event_call
-        result.count shouldBeEqualTo unreadMissedCallsCount
+        result.count shouldBeEqualTo unreadCount
+    }
+
+    @Test
+    fun givenUnreadMentions_whenMappingToUIPreview_thenCorrectUILastMessageContentShouldBeReturned() = runTest {
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.MentionedSelf("admin"),
+        )
+        val unreadCount = 2
+        val unreadEventCount = mapOf(UnreadEventType.MENTION to unreadCount)
+
+        val textMessage = messagePreview.toUIPreview(unreadEventCount).shouldBeInstanceOf<UILastMessageContent.TextMessage>()
+        val result = textMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
+
+        result.resId shouldBeEqualTo R.plurals.unread_event_mention
+        result.count shouldBeEqualTo unreadCount
+    }
+
+    @Test
+    fun givenUnreadReplies_whenMappingToUIPreview_thenCorrectUILastMessageContentShouldBeReturned() = runTest {
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.MentionedSelf("admin"),
+        )
+        val unreadCount = 2
+        val unreadEventCount = mapOf(UnreadEventType.REPLY to unreadCount)
+
+        val textMessage = messagePreview.toUIPreview(unreadEventCount).shouldBeInstanceOf<UILastMessageContent.TextMessage>()
+        val result = textMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
+
+        result.resId shouldBeEqualTo R.plurals.unread_event_reply
+        result.count shouldBeEqualTo unreadCount
+    }
+
+    @Test
+    fun givenUnreadPings_whenMappingToUIPreview_thenCorrectUILastMessageContentShouldBeReturned() = runTest {
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.Knock("admin"),
+        )
+        val unreadCount = 2
+        val unreadEventCount = mapOf(UnreadEventType.KNOCK to unreadCount)
+
+        val textMessage = messagePreview.toUIPreview(unreadEventCount).shouldBeInstanceOf<UILastMessageContent.TextMessage>()
+        val result = textMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
+
+        result.resId shouldBeEqualTo R.plurals.unread_event_knock
+        result.count shouldBeEqualTo unreadCount
+    }
+
+    @Test
+    fun givenUnreadMessages_whenMappingToUIPreview_thenLastTextMessageContentShouldBeReturned() = runTest {
+        val lastMessage = "See ya"
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.Text("admin", lastMessage),
+        )
+
+        val unreadCount = 2
+        val unreadEventCount = mapOf(UnreadEventType.MESSAGE to unreadCount)
+
+        val senderWithMessage = messagePreview.toUIPreview(unreadEventCount).shouldBeInstanceOf<UILastMessageContent.SenderWithMessage>()
+        val result = senderWithMessage.message.shouldBeInstanceOf<UIText.DynamicString>()
+
+        result.value shouldBeEqualTo lastMessage
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2940" title="AR-2940" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2940</a>  Missed calls not counted correctly 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there was more than 1 unread missed calls events, last message showed bad count. Missed calls events and other types excluding text message should behave differently when there are more than one events of their type. If there are only unread text events we show last message, otherwise we should show counter


### Solutions

Handle multiple unread events for except text messages differently to show proper counter

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
