### PR TITLE
fix(mls): disable mls everywhere and only considering the BE flags (AR-2653)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.common.Icon
 import com.wire.android.ui.common.ShakeAnimation
@@ -104,18 +103,16 @@ fun GroupNameScreen(
                             )
                         }
                     }
-                    if (mlsEnabled || BuildConfig.MLS_SUPPORT_ENABLED) {
-                        if (mode == CREATION) {
-                            WireDropDown(
-                                items =
-                                ConversationOptions.Protocol.values().map { it.name },
-                                defaultItemIndex = 0,
-                                stringResource(R.string.protocol),
-                                modifier = Modifier
-                                    .padding(MaterialTheme.wireDimensions.spacing16x)
-                            ) { selectedIndex ->
-                                groupProtocol = ConversationOptions.Protocol.values()[selectedIndex]
-                            }
+                    if (mode == CREATION && mlsEnabled) {
+                        WireDropDown(
+                            items =
+                            ConversationOptions.Protocol.values().map { it.name },
+                            defaultItemIndex = 0,
+                            stringResource(R.string.protocol),
+                            modifier = Modifier
+                                .padding(MaterialTheme.wireDimensions.spacing16x)
+                        ) { selectedIndex ->
+                            groupProtocol = ConversationOptions.Protocol.values()[selectedIndex]
                         }
                     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
@@ -86,9 +86,6 @@ fun GroupNameScreen(
                                 vertical = MaterialTheme.wireDimensions.spacing24x
                             )
                     )
-
-                    Spacer(modifier = Modifier.weight(1f))
-
                     Box {
                         ShakeAnimation { animate ->
                             if (animatedGroupNameError) {
@@ -107,7 +104,7 @@ fun GroupNameScreen(
                             )
                         }
                     }
-                    if (mlsEnabled || (BuildConfig.PRIVATE_BUILD && BuildConfig.MLS_SUPPORT_ENABLED)) {
+                    if (mlsEnabled || BuildConfig.MLS_SUPPORT_ENABLED) {
                         if (mode == CREATION) {
                             WireDropDown(
                                 items =

--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
         "safe_logging": false,
         "private_build": true,
         "development_api_enabled": true,
-        "mls_support_enabled": false,
+        "mls_support_enabled": true,
         "firebasePushSenderId": "782078216207",
         "firebaseAppId": "1:782078216207:android:d3db2443512d2055",
         "googleApiKey": "AIzaSyBXtNKuX6GCKv2jDtsFImUaxCRL21DTLEQ",
@@ -31,7 +31,7 @@
         "safe_logging": false,
         "private_build": true,
         "development_api_enabled": true,
-        "mls_support_enabled": false,
+        "mls_support_enabled": true,
         "firebasePushSenderId": "723990470614",
         "firebaseAppId": "1:723990470614:android:10cf802bfcc7bb71d28e77",
         "googleApiKey": "AIzaSyAGCoJGUtDBLJJiQPLxHQRrdkbyI0wlbo8",
@@ -81,7 +81,7 @@
     "countly_server_url": "https://countly.wire.com",
     "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
     "force_constant_bitrate_calls": false,
-    "mls_support_enabled": false,
+    "mls_support_enabled": true,
     "encrypt_proteus_storage": false,
     "update_app_url": "https://wire.com/en/download/"
 }

--- a/default.json
+++ b/default.json
@@ -57,7 +57,7 @@
         "safe_logging": true,
         "private_build": true,
         "development_api_enabled": false,
-        "mls_support_enabled": false,
+        "mls_support_enabled": true,
         "firebasePushSenderId": "782078216207",
         "firebaseAppId": "1:782078216207:android:d3db2443512d2055",
         "googleApiKey": "AIzaSyBXtNKuX6GCKv2jDtsFImUaxCRL21DTLEQ",

--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
         "safe_logging": false,
         "private_build": true,
         "development_api_enabled": true,
-        "mls_support_enabled": true,
+        "mls_support_enabled": false,
         "firebasePushSenderId": "782078216207",
         "firebaseAppId": "1:782078216207:android:d3db2443512d2055",
         "googleApiKey": "AIzaSyBXtNKuX6GCKv2jDtsFImUaxCRL21DTLEQ",
@@ -31,7 +31,7 @@
         "safe_logging": false,
         "private_build": true,
         "development_api_enabled": true,
-        "mls_support_enabled": true,
+        "mls_support_enabled": false,
         "firebasePushSenderId": "723990470614",
         "firebaseAppId": "1:723990470614:android:10cf802bfcc7bb71d28e77",
         "googleApiKey": "AIzaSyAGCoJGUtDBLJJiQPLxHQRrdkbyI0wlbo8",
@@ -81,7 +81,7 @@
     "countly_server_url": "https://countly.wire.com",
     "countly_app_key": "79c8fc20713e0e877aa8d320ea078530604d3ea6",
     "force_constant_bitrate_calls": false,
-    "mls_support_enabled": true,
+    "mls_support_enabled": false,
     "encrypt_proteus_storage": false,
     "update_app_url": "https://wire.com/en/download/"
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2653" title="AR-2653" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2653</a>  Hide MLS options in versions that use V1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
We were overriding the MLS enabled values for different envs to make it easy for test.
The QA asked to disable all of them and only rely on the API Version and the feature config on the team settings.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
