### PR TITLE
fix: migrate asset names and sizes [AR-2939]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -64,7 +64,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.CryptoSessionReset -> mapResetSession(message.senderUserId, members)
         is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(content)
         is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
-        MessageContent.HistoryLost -> TODO()
+        MessageContent.HistoryLost -> null // TODO
     }
 
     private fun mapResetSession(

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -64,6 +64,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.CryptoSessionReset -> mapResetSession(message.senderUserId, members)
         is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(content)
         is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
+        MessageContent.HistoryLost -> TODO()
     }
 
     private fun mapResetSession(

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -75,7 +75,9 @@ class MigrationMapper @Inject constructor() {
             senderClientId = ClientId(scalaMessage.senderClientId.orEmpty()),
             timestampIso = scalaMessage.time.timestampToServerDate().orEmpty(),
             content = scalaMessage.content.orEmpty(),
-            encryptedProto = scalaMessage.proto
+            encryptedProto = scalaMessage.proto,
+            assetName = scalaMessage.assetName,
+            assetSize = scalaMessage.assetSize,
         )
 
     private fun mapAccess(access: String): List<Access> {

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
@@ -20,6 +20,7 @@ data class ScalaMessageData(
     val assetName: String?,
     val assetSize: Int?,
 )
+
 class ScalaMessageDAO(private val db: ScalaUserDatabase) {
 
     fun messages(scalaConversations: List<ScalaConversationData>): List<ScalaMessageData> {
@@ -31,7 +32,11 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
     }
 
     private fun messagesFromConversation(scalaConversation: ScalaConversationData): List<ScalaMessageData> {
-        val cursor = db.rawQuery("SELECT * from $MESSAGES_TABLE_NAME LEFT JOIN $ASSETS_TABLE_NAME ON $MESSAGES_TABLE_NAME.$COLUMN_ASSET_ID = $ASSETS_TABLE_NAME.$COLUMN_ID WHERE $COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id))
+        val cursor = db.rawQuery(
+            "SELECT * from $MESSAGES_TABLE_NAME " +
+                    "LEFT JOIN $ASSETS_TABLE_NAME ON $MESSAGES_TABLE_NAME.$COLUMN_ASSET_ID = $ASSETS_TABLE_NAME.$COLUMN_ID " +
+                    "WHERE $COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id)
+        )
         return try {
             if (!cursor.moveToFirst()) {
                 emptyList()

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
@@ -1,5 +1,6 @@
 package com.wire.android.migration.userDatabase
 
+import androidx.core.database.getIntOrNull
 import androidx.core.database.getLongOrNull
 import com.wire.android.appLogger
 import com.wire.android.migration.util.getStringOrNull
@@ -15,7 +16,9 @@ data class ScalaMessageData(
     val senderId: String,
     val senderClientId: String?,
     val content: String?,
-    val proto: ByteArray?
+    val proto: ByteArray?,
+    val assetName: String?,
+    val assetSize: Int?,
 )
 class ScalaMessageDAO(private val db: ScalaUserDatabase) {
 
@@ -28,18 +31,20 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
     }
 
     private fun messagesFromConversation(scalaConversation: ScalaConversationData): List<ScalaMessageData> {
-        val cursor = db.rawQuery("SELECT * from $TABLE_NAME WHERE $COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id))
+        val cursor = db.rawQuery("SELECT * from $MESSAGES_TABLE_NAME LEFT JOIN $ASSETS_TABLE_NAME ON $MESSAGES_TABLE_NAME.$COLUMN_ASSET_ID = $ASSETS_TABLE_NAME.$COLUMN_ID WHERE $COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id))
         return try {
             if (!cursor.moveToFirst()) {
                 emptyList()
             } else {
-                val idIndex = cursor.getColumnIndex(COLUMN_ID)
-                val timeIndex = cursor.getColumnIndex(COLUMN_TIME)
-                val editTimeIndex = cursor.getColumnIndex(COLUMN_EDIT_TIME)
-                val userIdIndex = cursor.getColumnIndex(COLUMN_USER_ID)
-                val clientIdIndex = cursor.getColumnIndex(COLUMN_CLIENT_ID)
-                val contentIndex = cursor.getColumnIndex(COLUMN_CONTENT)
-                val protoIndex = cursor.getColumnIndex(COLUMN_PROTO_BLOB)
+                val idIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_ID")
+                val timeIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_TIME")
+                val editTimeIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_EDIT_TIME")
+                val userIdIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_USER_ID")
+                val clientIdIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_CLIENT_ID")
+                val contentIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_CONTENT")
+                val protoIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_PROTO_BLOB")
+                val assetNameIndex = cursor.getColumnIndex("$ASSETS_TABLE_NAME.$COLUMN_NAME")
+                val assetSizeIndex = cursor.getColumnIndex("$ASSETS_TABLE_NAME.$COLUMN_SIZE")
                 val accumulator = mutableListOf<ScalaMessageData>()
                 do {
                     accumulator += ScalaMessageData(
@@ -52,7 +57,9 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
                         senderId = cursor.getStringOrNull(userIdIndex).orEmpty(),
                         senderClientId = cursor.getStringOrNull(clientIdIndex),
                         content = cursor.getStringOrNull(contentIndex),
-                        proto = cursor.getBlob(protoIndex)
+                        proto = cursor.getBlob(protoIndex),
+                        assetName = cursor.getStringOrNull(assetNameIndex),
+                        assetSize = cursor.getIntOrNull(assetSizeIndex)
                     )
                 } while (cursor.moveToNext())
                 accumulator
@@ -66,8 +73,10 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
     }
 
     companion object {
-        const val TABLE_NAME = "Messages"
+        const val MESSAGES_TABLE_NAME = "Messages"
+        const val ASSETS_TABLE_NAME = "Assets2"
         const val COLUMN_ID = "_id"
+        const val COLUMN_ASSET_ID = "asset_id"
         const val COLUMN_CONVERSATION_ID = "conv_id"
         const val COLUMN_CLIENT_ID = "client_id"
         const val COLUMN_USER_ID = "user_id"
@@ -75,5 +84,7 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
         const val COLUMN_EDIT_TIME = "edit_time"
         const val COLUMN_CONTENT = "content"
         const val COLUMN_PROTO_BLOB = "protos"
+        const val COLUMN_NAME = "name"
+        const val COLUMN_SIZE = "size"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2939" title="AR-2939" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2939</a>  Assets received from web are empty after migration to new android app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we migrate from the old scala app and have some assets from web to migrate, they are shown as empty in the new android app.

### Causes (Optional)

Sometimes there are two events with the same message id received: first with the metadata (name, size, etc.), second with remote data (key, etc.). Scala app stores the metadata in another table but replaces the whole proto in the Messages table, so when we migrate and take only the proto, we miss these data.

### Solutions

Take name and size from Assets table and include it in the migration message data.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/1344

### Testing

#### How to Test

Install scala app, send some assets and update to the AR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
