### PR TITLE
feat: horizontal pager solution to paddings and scroll (AR-2949)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -36,7 +36,6 @@ import com.wire.android.model.Clickable
 import com.wire.android.ui.common.WireCircularProgressIndicator
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.sharing.ImportedMediaAsset
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -68,7 +67,6 @@ internal fun MessageAsset(
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
             .clickable(if (isNotClickable(assetDownloadStatus, assetUploadStatus)) null else onAssetClick)
-            .padding(dimensions().spacing8x)
     ) {
         val isUploadInProgress = assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS
         if (isUploadInProgress) {
@@ -76,12 +74,12 @@ internal fun MessageAsset(
         } else {
             val assetModifier = if (shouldFillMaxWidth) Modifier.fillMaxWidth()
             else Modifier.size(dimensions().importedMediaAssetSize)
-            Column(modifier = assetModifier) {
+            Column(modifier = assetModifier.padding(dimensions().spacing8x)) {
                 Text(
                     text = assetName,
                     style = MaterialTheme.wireTypography.body02,
                     maxLines = if (shouldFillMaxWidth) 2 else 4,
-                    overflow = TextOverflow.Ellipsis,
+                    overflow = TextOverflow.Ellipsis
                 )
                 val descriptionModifier = Modifier.padding(top = dimensions().spacing8x).fillMaxWidth()
                 Row(verticalAlignment = Alignment.Bottom) {
@@ -119,7 +117,7 @@ internal fun MessageAsset(
                                         top.linkTo(parent.top)
                                         end.linkTo(parent.end)
                                         bottom.linkTo(parent.bottom)
-                                    },
+                                    }
                             ) {
                                 Text(
                                     modifier = Modifier.padding(end = dimensions().spacing4x),
@@ -209,13 +207,14 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
     ) {
         val assetName = fileName.split(".").dropLast(1).joinToString(".")
         val assetDescription = provideAssetDescription(
-            fileName.split(".").last(), fileSize
+            fileName.split(".").last(),
+            fileSize
         )
 
         ConstraintLayout(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(dimensions().spacing8x),
+                .padding(dimensions().spacing8x)
         ) {
             val (
                 name, icon, size, message
@@ -247,7 +246,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                 ),
                 alignment = Alignment.Center,
                 contentDescription = stringResource(R.string.content_description_image_message),
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText),
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText)
             )
 
             Text(
@@ -279,7 +278,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
 private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, assetUploadStatus: Message.UploadStatus) {
     return when {
         assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS ||
-                assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
+            assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )
@@ -314,7 +313,7 @@ fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus, assetUplo
             stringResource(R.string.asset_message_download_in_progress_text)
 
         assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY ||
-                assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
+            assetUploadStatus == Message.UploadStatus.UPLOADED -> stringResource(R.string.asset_message_saved_externally_text)
 
         assetDownloadStatus == Message.DownloadStatus.FAILED_DOWNLOAD -> stringResource(R.string.asset_message_failed_download_text)
         else -> ""

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -61,20 +61,19 @@ fun ImportMediaScreen(importMediaViewModel: ImportMediaViewModel = hiltViewModel
 @Composable
 fun ImportMediaContent(searchBarState: SearchBarState, importMediaViewModel: ImportMediaViewModel) {
     val actionButtonTitle = stringResource(R.string.import_media_send_button_title)
-    Scaffold(
-        topBar = {
-            WireCenterAlignedTopAppBar(
-                elevation = 0.dp,
-                onNavigationPressed = importMediaViewModel::navigateBack,
-                title = stringResource(id = R.string.import_media_content_title),
-                actions = {
-                    UserProfileAvatar(
-                        avatarData = UserAvatarData(importMediaViewModel.importMediaState.avatarAsset),
-                        clickable = remember { Clickable(enabled = false) { } }
-                    )
-                }
-            )
-        },
+    Scaffold(topBar = {
+        WireCenterAlignedTopAppBar(
+            elevation = 0.dp,
+            onNavigationPressed = importMediaViewModel::navigateBack,
+            title = stringResource(id = R.string.import_media_content_title),
+            actions = {
+                UserProfileAvatar(
+                    avatarData = UserAvatarData(importMediaViewModel.importMediaState.avatarAsset),
+                    clickable = remember { Clickable(enabled = false) { } }
+                )
+            },
+        )
+    },
         modifier = Modifier.background(colorsScheme().background),
         bottomBar = {
             SelectParticipantsButtonsRow(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2949" title="AR-2949" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-2949</a>  Implement imported media horizontal pager and conversation selection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Horizontal pager scroll had padding issues when combining generic assets and image assets.

### Causes (Optional)

The horizontal scroll had a glitch when doing swipe

### Solutions

- Add correct padding to content not container for generic assets
- Add `LocalOverscrollConfiguration` behavior to horizontal pager


### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
