### PR TITLE
fix: Add missing parameter for conversation read receipt mode changed

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -233,7 +233,7 @@ fun SystemMessage.annotatedString(
         is SystemMessage.TeamMemberRemoved -> arrayOf(content.userName)
         is SystemMessage.CryptoSessionReset -> arrayOf(author.asString(res))
         is SystemMessage.NewConversationReceiptMode -> arrayOf(receiptMode.asString(res))
-        is SystemMessage.ConversationReceiptModeChanged -> arrayOf(receiptMode.asString(res))
+        is SystemMessage.ConversationReceiptModeChanged -> arrayOf(author.asString(res), receiptMode.asString(res))
         is SystemMessage.Knock -> arrayOf(author.asString(res))
         is SystemMessage.HistoryLost -> arrayOf()
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2712 - Show a system message when read receipts are turned on ](https://wearezeta.atlassian.net/browse/AR-2712)

### Issues

String for Conversation Read Receipt Mode Changed expects 2 parameters and only 1 was being passed.

### Causes (Optional)

Forgot to add.

### Solutions

Add missing parameter.

### Testing

#### How to Test

- Open App
- Open Group Conversation
- Change Read Receipt Mode from other platform other than AR
- App should continue working and not crash
