### PR TITLE
fix(dev): broken session after migration [AR-2941]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -65,9 +65,9 @@ class MigrationManager @Inject constructor(
                 appLogger.d("$TAG - Step 1 - Migrating accounts")
                 migrateActiveAccounts(it)
             }
-            .flatMap {
+            .flatMap { (userIdList, isFederated) ->
                 appLogger.d("$TAG - Step 2 - Migrating clients")
-                migrateClientsData(it)
+                migrateClientsData(userIdList, isFederated)
             }
             .flatMap {
                 appLogger.d("$TAG - Step 3 - Migrating users")

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,47 +25,48 @@ class MigrateActiveAccountsUseCase @Inject constructor(
     private val scalaGlobalDB: ScalaAppDataBaseProvider,
     private val mapper: MigrationMapper
 ) {
-    suspend operator fun invoke(serverConfig: ServerConfig): Either<CoreFailure, List<UserId>> =
-        scalaGlobalDB.scalaAccountsDAO.activeAccounts().foldToEitherWhileRight(emptyList()) { item, acc ->
+    suspend operator fun invoke(serverConfig: ServerConfig): Either<CoreFailure, Pair<List<UserId>, Boolean>> =
+        scalaGlobalDB.scalaAccountsDAO.activeAccounts()
+            .foldToEitherWhileRight(emptyList()) { item: ScalaActiveAccountsEntity, acc: List<UserId> ->
 
-            val activeAccount = item.copy(refreshToken = item.refreshToken.removePrefix(REFRESH_TOKEN_PREFIX))
-            val isDataComplete = isDataComplete(serverConfig, activeAccount)
-            val ssoId = activeAccount.ssoId?.let { ssoId -> mapper.fromScalaSsoID(ssoId) }
-            val authTokensEither: Either<CoreFailure, AuthTokens> = if (isDataComplete) {
-                val domain = activeAccount.domain ?: serverConfig.metaData.domain!!
-                val userId = UserId(activeAccount.id, domain)
-                Either.Right(
-                    AuthTokens(
-                        userId = userId,
-                        accessToken = activeAccount.accessToken?.token!!,
-                        tokenType = activeAccount.accessToken.tokenType,
-                        refreshToken = activeAccount.refreshToken,
-                        cookieLabel = null
+                val activeAccount = item.copy(refreshToken = item.refreshToken.removePrefix(REFRESH_TOKEN_PREFIX))
+                val isDataComplete = isDataComplete(serverConfig, activeAccount)
+                val ssoId = activeAccount.ssoId?.let { ssoId -> mapper.fromScalaSsoID(ssoId) }
+                val authTokensEither: Either<CoreFailure, AuthTokens> = if (isDataComplete) {
+                    val domain = activeAccount.domain ?: serverConfig.metaData.domain!!
+                    val userId = UserId(activeAccount.id, domain)
+                    Either.Right(
+                        AuthTokens(
+                            userId = userId,
+                            accessToken = activeAccount.accessToken?.token!!,
+                            tokenType = activeAccount.accessToken.tokenType,
+                            refreshToken = activeAccount.refreshToken,
+                            cookieLabel = null
+                        )
                     )
-                )
-            } else {
-                handleMissingData(
-                    serverConfig,
-                    activeAccount.refreshToken
-                )
-            }
-
-            authTokensEither.flatMap { authTokens ->
-                val addAccountResult = coreLogic.globalScope {
-                    addAuthenticatedAccount(
-                        serverConfigId = serverConfig.id,
-                        ssoId = ssoId,
-                        authTokens = authTokens,
-                        null, // uses migrated form the scala app will not have proxy
-                        replace = false
+                } else {
+                    handleMissingData(
+                        serverConfig,
+                        activeAccount.refreshToken
                     )
                 }
-                when (addAccountResult) {
-                    is AddAuthenticatedUserUseCase.Result.Failure.Generic -> Either.Left(addAccountResult.genericFailure)
-                    else -> Either.Right(acc + authTokens.userId)
+
+                authTokensEither.flatMap { authTokens ->
+                    val addAccountResult = coreLogic.globalScope {
+                        addAuthenticatedAccount(
+                            serverConfigId = serverConfig.id,
+                            ssoId = ssoId,
+                            authTokens = authTokens,
+                            null, // uses migrated form the scala app will not have proxy
+                            replace = false
+                        )
+                    }
+                    when (addAccountResult) {
+                        is AddAuthenticatedUserUseCase.Result.Failure.Generic -> Either.Left(addAccountResult.genericFailure)
+                        else -> Either.Right(acc + authTokens.userId)
+                    }
                 }
-            }
-        }
+            }.map { it to serverConfig.metaData.federation }
 
     private fun isDataComplete(serverConfig: ServerConfig, activeAccount: ScalaActiveAccountsEntity): Boolean {
         val isDomainExist = (activeAccount.domain != null) or (serverConfig.metaData.domain != null)

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
@@ -111,7 +111,7 @@ class MigrateClientsDataUseCase @Inject constructor(
             val filesWithoutDomain = getSessionFileNamesWithoutDomain(sessionsDir)
                 .map { file -> file.name.substringBefore("_") to file }
             val sessionUserIds = filesWithoutDomain.map { (userId, _) -> userId }.distinct()
-            val sessionUsers = sessionUserIds.chunked(500)
+            val sessionUsers = sessionUserIds.chunked(SESSION_USER_IDS_CHUNK_SIZE)
                 .map { scalaUserDBProvider.userDAO(userId)?.users(it) ?: listOf() }
                 .flatten()
                 .associateBy { it.id }
@@ -148,5 +148,6 @@ class MigrateClientsDataUseCase @Inject constructor(
 
     companion object {
         const val SYNC_START_TIMEOUT = 20_000L
+        const val SESSION_USER_IDS_CHUNK_SIZE = 500
     }
 }

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
@@ -31,7 +31,7 @@ class MigrateClientsDataUseCase @Inject constructor(
     private val scalaUserDBProvider: ScalaUserDatabaseProvider,
     private val userDataStoreProvider: UserDataStoreProvider
 ) {
-    suspend operator fun invoke(userIds: List<UserId>): Either<CoreFailure, List<UserId>> =
+    suspend operator fun invoke(userIds: List<UserId>, isFederated: Boolean): Either<CoreFailure, List<UserId>> =
         userIds.foldToEitherWhileRight(emptyList()) { userId, acc ->
 
             val clientId = scalaUserDBProvider.clientDAO(userId)?.clientInfo()?.clientId?.let { ClientId(it) }
@@ -44,7 +44,7 @@ class MigrateClientsDataUseCase @Inject constructor(
             scalaDir.copyRecursively(target = currentDir, overwrite = false)
             // Session file names from the scala app contain user ids without a domain, AR uses session file names having user ids
             // with a domain, so migrated session file names have to be fixed by adding a domain to them.
-            fixSessionFileNames(currentDir, userId.domain)
+            fixSessionFileNames(userId, currentDir, isFederated, scalaUserDBProvider)
             scalaDir.deleteRecursively()
 
             // add registered client id, sync will start when the registered id is persisted
@@ -79,16 +79,43 @@ class MigrateClientsDataUseCase @Inject constructor(
             }
         }
 
-    private fun fixSessionFileNames(proteusDir: File, domain: String) {
-        val sessionsDir = File(proteusDir, "sessions")
+    @VisibleForTesting
+    fun getSessionFileNamesWithoutDomain(sessionsDir: File): List<File> =
         if (sessionsDir.exists() && sessionsDir.isDirectory) {
-            sessionsDir.listFiles { file -> !file.isDirectory }?.forEach { session ->
-                val fixedSessionFileName = fixSessionFileName(session.name, domain)
-                if (fixedSessionFileName != session.name) {
-                    session.renameTo(File(sessionsDir, fixedSessionFileName))
-                }
+            sessionsDir.listFiles { file ->
+                !file.isDirectory && !file.name.contains("@")
+            }?.asList() ?: listOf()
+        } else listOf()
+
+    @VisibleForTesting
+    fun fixSessionFileNames(userId: UserId, proteusDir: File, isFederated: Boolean, scalaUserDBProvider: ScalaUserDatabaseProvider) {
+        val sessionsDir = File(proteusDir, "sessions")
+        if (isFederated) {
+            val filesWithoutDomain = getSessionFileNamesWithoutDomain(sessionsDir)
+                .map { file -> file.name.substringBefore("_") to file }
+            val sessionUserIds = filesWithoutDomain.map { (userId, _) -> userId }.distinct()
+            val sessionUsers = sessionUserIds.chunked(500)
+                .map { scalaUserDBProvider.userDAO(userId)?.users(it) ?: listOf() }
+                .flatten()
+                .associateBy { it.id }
+            filesWithoutDomain.forEach { (sessionUserId, file) ->
+                renameSessionFileIfNeeded(sessionsDir, file, sessionUsers[sessionUserId]?.domain ?: userId.domain)
+            }
+        } else {
+            getSessionFileNamesWithoutDomain(sessionsDir).forEach { file ->
+                renameSessionFileIfNeeded(sessionsDir, file, userId.domain)
             }
         }
+    }
+
+    @VisibleForTesting
+    fun renameSessionFileIfNeeded(sessionsDir: File, file: File, domain: String): File {
+        val fixedSessionFileName = fixSessionFileName(file.name, domain)
+        if (fixedSessionFileName != file.name) {
+            val newFile = File(sessionsDir, fixedSessionFileName)
+            return if (file.renameTo(newFile)) newFile else file
+        }
+        return file
     }
 
     @VisibleForTesting

--- a/app/src/main/kotlin/com/wire/android/migration/preference/ScalaBackendPreferences.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/preference/ScalaBackendPreferences.kt
@@ -3,6 +3,7 @@ package com.wire.android.migration.preference
 import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
+import androidx.annotation.VisibleForTesting
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,21 +17,30 @@ class ScalaBackendPreferences @Inject constructor(@ApplicationContext private va
     val baseUrl: String? get() = sharedPreferences.getString(BASE_URL_PREF, null)
     val customConfigUrl: String? get() = sharedPreferences.getString(CONFIG_URL_PREF, null)
     val websocketUrl: String? get() = sharedPreferences.getString(WEBSOCKET_URL_PREF, null)
-    val blacklistUrl: String? get() = sharedPreferences.getString(BLACKLIST_HOST_PREF, null)
+    val blacklistUrl: String? get() = sharedPreferences.getString(BLACKLIST_HOST_PREF, null).parseOptionString()
     val teamsUrl: String? get() = sharedPreferences.getString(TEAMS_URL_PREF, null)
     val accountsUrl: String? get() = sharedPreferences.getString(ACCOUNTS_URL_PREF, null)
     val websiteUrl: String? get() = sharedPreferences.getString(WEBSITE_URL_PREF, null)
     val apiVersion: String? get() = sharedPreferences.getString(API_VERSION_INFORMATION, null)
 
+    // Some urls in scala app are wrapped in Option and actually stored as strings this way, so we have to parse them correctly.
+    private fun String?.parseOptionString(): String? = this?.let {
+        when {
+            it == "None" -> null
+            it.startsWith("Some(") && it.endsWith(")") -> it.removePrefix("Some(").removeSuffix(")")
+            else -> it
+        }
+    }
+
     companion object {
-        private const val ENVIRONMENT_PREF = "CUSTOM_BACKEND_ENVIRONMENT"
-        private const val BASE_URL_PREF = "CUSTOM_BACKEND_BASE_URL"
-        private const val WEBSOCKET_URL_PREF = "CUSTOM_BACKEND_WEBSOCKET_URL"
-        private const val BLACKLIST_HOST_PREF = "CUSTOM_BACKEND_BLACKLIST_HOST"
-        private const val TEAMS_URL_PREF = "CUSTOM_BACKEND_TEAMS_URL"
-        private const val ACCOUNTS_URL_PREF = "CUSTOM_BACKEND_ACCOUNTS_URL"
-        private const val WEBSITE_URL_PREF = "CUSTOM_BACKEND_WEBSITE_URL"
-        private const val CONFIG_URL_PREF = "CUSTOM_BACKEND_CONFIG_URL"
-        private const val API_VERSION_INFORMATION = "API_VERSION_INFORMATION"
+        @VisibleForTesting const val ENVIRONMENT_PREF = "CUSTOM_BACKEND_ENVIRONMENT"
+        @VisibleForTesting const val BASE_URL_PREF = "CUSTOM_BACKEND_BASE_URL"
+        @VisibleForTesting const val WEBSOCKET_URL_PREF = "CUSTOM_BACKEND_WEBSOCKET_URL"
+        @VisibleForTesting const val BLACKLIST_HOST_PREF = "CUSTOM_BACKEND_BLACKLIST_HOST"
+        @VisibleForTesting const val TEAMS_URL_PREF = "CUSTOM_BACKEND_TEAMS_URL"
+        @VisibleForTesting const val ACCOUNTS_URL_PREF = "CUSTOM_BACKEND_ACCOUNTS_URL"
+        @VisibleForTesting const val WEBSITE_URL_PREF = "CUSTOM_BACKEND_WEBSITE_URL"
+        @VisibleForTesting const val CONFIG_URL_PREF = "CUSTOM_BACKEND_CONFIG_URL"
+        @VisibleForTesting const val API_VERSION_INFORMATION = "API_VERSION_INFORMATION"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
@@ -40,6 +40,8 @@ data class ScalaMessageData(
             if (other.proto == null) return false
             if (!proto.contentEquals(other.proto)) return false
         } else if (other.proto != null) return false
+        if (assetName != other.assetName) return false
+        if (assetSize != other.assetSize) return false
 
         return true
     }
@@ -55,6 +57,8 @@ data class ScalaMessageData(
         result = 31 * result + (senderClientId?.hashCode() ?: 0)
         result = 31 * result + (content?.hashCode() ?: 0)
         result = 31 * result + (proto?.contentHashCode() ?: 0)
+        result = 31 * result + (assetName.hashCode())
+        result = 31 * result + (assetSize?.hashCode() ?: 0)
         return result
     }
 }

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaMessageDAO.kt
@@ -33,23 +33,33 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
 
     private fun messagesFromConversation(scalaConversation: ScalaConversationData): List<ScalaMessageData> {
         val cursor = db.rawQuery(
-            "SELECT * from $MESSAGES_TABLE_NAME " +
+            "SELECT " + // Assets are required, otherwise we get exception "requesting column name with table name".
+                    "$MESSAGES_TABLE_NAME.$COLUMN_ID AS $MESSAGE_ALIAS_PREFIX$COLUMN_ID, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_TIME AS $MESSAGE_ALIAS_PREFIX$COLUMN_TIME, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_EDIT_TIME AS $MESSAGE_ALIAS_PREFIX$COLUMN_EDIT_TIME, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_USER_ID AS $MESSAGE_ALIAS_PREFIX$COLUMN_USER_ID, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_CLIENT_ID AS $MESSAGE_ALIAS_PREFIX$COLUMN_CLIENT_ID, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_CONTENT AS $MESSAGE_ALIAS_PREFIX$COLUMN_CONTENT, " +
+                    "$MESSAGES_TABLE_NAME.$COLUMN_PROTO_BLOB AS $MESSAGE_ALIAS_PREFIX$COLUMN_PROTO_BLOB, " +
+                    "$ASSETS_TABLE_NAME.$COLUMN_NAME AS $ASSET_ALIAS_PREFIX$COLUMN_NAME, " +
+                    "$ASSETS_TABLE_NAME.$COLUMN_SIZE AS $ASSET_ALIAS_PREFIX$COLUMN_SIZE " +
+                    "FROM $MESSAGES_TABLE_NAME " +
                     "LEFT JOIN $ASSETS_TABLE_NAME ON $MESSAGES_TABLE_NAME.$COLUMN_ASSET_ID = $ASSETS_TABLE_NAME.$COLUMN_ID " +
-                    "WHERE $COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id)
+                    "WHERE $MESSAGES_TABLE_NAME.$COLUMN_CONVERSATION_ID = ?", arrayOf(scalaConversation.id)
         )
         return try {
             if (!cursor.moveToFirst()) {
                 emptyList()
             } else {
-                val idIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_ID")
-                val timeIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_TIME")
-                val editTimeIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_EDIT_TIME")
-                val userIdIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_USER_ID")
-                val clientIdIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_CLIENT_ID")
-                val contentIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_CONTENT")
-                val protoIndex = cursor.getColumnIndex("$MESSAGES_TABLE_NAME.$COLUMN_PROTO_BLOB")
-                val assetNameIndex = cursor.getColumnIndex("$ASSETS_TABLE_NAME.$COLUMN_NAME")
-                val assetSizeIndex = cursor.getColumnIndex("$ASSETS_TABLE_NAME.$COLUMN_SIZE")
+                val idIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_ID")
+                val timeIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_TIME")
+                val editTimeIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_EDIT_TIME")
+                val userIdIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_USER_ID")
+                val clientIdIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_CLIENT_ID")
+                val contentIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_CONTENT")
+                val protoIndex = cursor.getColumnIndex("$MESSAGE_ALIAS_PREFIX$COLUMN_PROTO_BLOB")
+                val assetNameIndex = cursor.getColumnIndex("$ASSET_ALIAS_PREFIX$COLUMN_NAME")
+                val assetSizeIndex = cursor.getColumnIndex("$ASSET_ALIAS_PREFIX$COLUMN_SIZE")
                 val accumulator = mutableListOf<ScalaMessageData>()
                 do {
                     accumulator += ScalaMessageData(
@@ -80,6 +90,8 @@ class ScalaMessageDAO(private val db: ScalaUserDatabase) {
     companion object {
         const val MESSAGES_TABLE_NAME = "Messages"
         const val ASSETS_TABLE_NAME = "Assets2"
+        const val MESSAGE_ALIAS_PREFIX = "message_"
+        const val ASSET_ALIAS_PREFIX = "asset_"
         const val COLUMN_ID = "_id"
         const val COLUMN_ASSET_ID = "asset_id"
         const val COLUMN_CONVERSATION_ID = "conv_id"

--- a/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
@@ -1,0 +1,52 @@
+package com.wire.android.migration
+
+import com.wire.android.datastore.UserDataStoreProvider
+import com.wire.android.migration.feature.MigrateClientsDataUseCase
+import com.wire.android.migration.userDatabase.ScalaUserDatabaseProvider
+import com.wire.android.migration.util.ScalaCryptoBoxDirectoryProvider
+import com.wire.kalium.logic.CoreLogic
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Test
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrateClientsDataUseCaseTest {
+
+    @Test
+    fun `given session file name without domain when fixing session file names then return updated session file with domain`() = runTest {
+        // given
+        val sessionFileNameWithoutDomain = "123-321_123"
+        val domain = "domain.com"
+        val expected = "123-321@domain.com_123"
+        // when
+        val (arrangement, useCase) = Arrangement().arrange()
+        val result = useCase.fixSessionFileName(sessionFileNameWithoutDomain, domain)
+        // then
+        assertEquals(result, expected)
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var coreLogic: CoreLogic
+        @MockK
+        lateinit var scalaCryptoBoxDirectoryProvider: ScalaCryptoBoxDirectoryProvider
+        @MockK
+        lateinit var scalaUserDBProvider: ScalaUserDatabaseProvider
+        @MockK
+        lateinit var userDataStoreProvider: UserDataStoreProvider
+
+        private val useCase: MigrateClientsDataUseCase by lazy {
+            MigrateClientsDataUseCase(coreLogic, scalaCryptoBoxDirectoryProvider, scalaUserDBProvider, userDataStoreProvider)
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun arrange() = this to useCase
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
@@ -2,18 +2,28 @@ package com.wire.android.migration
 
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.migration.feature.MigrateClientsDataUseCase
+import com.wire.android.migration.userDatabase.ScalaUserData
 import com.wire.android.migration.userDatabase.ScalaUserDatabaseProvider
 import com.wire.android.migration.util.ScalaCryptoBoxDirectoryProvider
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.jupiter.api.Test
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MigrateClientsDataUseCaseTest {
+
+    @TempDir
+    val proteusDir = File("proteus")
 
     @Test
     fun `given session file name without domain when fixing session file names then return updated session file with domain`() = runTest {
@@ -28,6 +38,103 @@ class MigrateClientsDataUseCaseTest {
         assertEquals(result, expected)
     }
 
+    @Test
+    fun `given session directory with files when getting session files without domain return proper list`() = runTest {
+        // given
+        val sessionsDir = File(proteusDir, "sessions").apply { mkdirs() }
+        val sessionFileWithDomain = File(sessionsDir, "1@domain.com_123").apply { createNewFile() }
+        val sessionFileWithoutDomain = File(sessionsDir, "2_123").apply { createNewFile() }
+        // when
+        val (arrangement, useCase) = Arrangement().arrange()
+        val result = useCase.getSessionFileNamesWithoutDomain(sessionsDir)
+        // then
+        assertEquals(listOf(sessionFileWithoutDomain), result)
+    }
+
+    @Test
+    fun `given session file without domain when renaming if needed then add domain to the file name`() = runTest {
+        // given
+        val sessionsDir = File(proteusDir, "sessions").apply { mkdirs() }
+        val sessionFile = File(sessionsDir, "1_123").apply { createNewFile() }
+        val domain = "domain.com"
+        val expected = "1@domain.com_123"
+        // when
+        val (arrangement, useCase) = Arrangement().arrange()
+        val result = useCase.renameSessionFileIfNeeded(sessionsDir, sessionFile, domain)
+        // then
+        assertEquals(expected, result.name)
+    }
+
+    @Test
+    fun `given session file with domain when renaming if needed then do nothing with the file name`() = runTest {
+        // given
+        val sessionsDir = File(proteusDir, "sessions").apply { mkdirs() }
+        val sessionFile = File(sessionsDir, "1@domain.com_123").apply { createNewFile() }
+        val domain = "domain.com"
+        val expected = "1@domain.com_123"
+        // when
+        val (arrangement, useCase) = Arrangement().arrange()
+        val result = useCase.renameSessionFileIfNeeded(sessionsDir, sessionFile, domain)
+        // then
+        assertEquals(expected, result.name)
+    }
+
+    @Test
+    fun `given not federated server when fixing session files then set current user domain`() = runTest {
+        // given
+        val userId = UserId("id", "domain.com")
+        val sessionUserDomain = "otherdomain.com"
+        val sessionsDir = File(proteusDir, "sessions").apply { mkdirs() }
+        val sessionFile = File(sessionsDir, "1_123").apply { createNewFile() }
+        val expected = "1@domain.com_123"
+        // when
+        val (arrangement, useCase) = Arrangement()
+            .withGetUsers { it.map { fakeScalaUserData(it, sessionUserDomain) } }
+            .arrange()
+        useCase.fixSessionFileNames(userId, proteusDir, false, arrangement.scalaUserDBProvider)
+        // then
+        sessionsDir.listFiles()?.let {
+            assert(it.none { !it.name.contains("@") })
+        }
+        assertEquals(listOf(expected), sessionsDir.listFiles()?.map { it.name })
+        verify(exactly = 0) { arrangement.scalaUserDBProvider.userDAO(any())?.users(any()) }
+    }
+
+    @Test
+    fun `given federated server when fixing session files then set proper user domain`() = runTest {
+        // given
+        val userId = UserId("id", "domain.com")
+        val sessionUserDomain = "otherdomain.com"
+        val sessionsDir = File(proteusDir, "sessions").apply { mkdirs() }
+        val sessionFile = File(sessionsDir, "1_123").apply { createNewFile() }
+        val expected = "1@otherdomain.com_123"
+        // when
+        val (arrangement, useCase) = Arrangement()
+            .withGetUsers { it.map { fakeScalaUserData(it, sessionUserDomain) } }
+            .arrange()
+        useCase.fixSessionFileNames(userId, proteusDir, true, arrangement.scalaUserDBProvider)
+        // then
+        assertEquals(listOf(expected), sessionsDir.listFiles()?.map { it.name })
+        verify(atLeast = 1) { arrangement.scalaUserDBProvider.userDAO(any())?.users(any()) }
+    }
+
+    private fun fakeScalaUserData(id: String, domain: String) =  ScalaUserData(
+        id = id,
+        domain = domain,
+        teamId = null,
+        name = id,
+        handle = null,
+        email = null,
+        phone = null,
+        accentId = 0,
+        connection = "",
+        pictureAssetId = null,
+        availability = 0,
+        deleted = false,
+        serviceProviderId = null,
+        serviceIntegrationId = null
+    )
+
     private class Arrangement {
 
         @MockK
@@ -40,11 +147,23 @@ class MigrateClientsDataUseCaseTest {
         lateinit var userDataStoreProvider: UserDataStoreProvider
 
         private val useCase: MigrateClientsDataUseCase by lazy {
-            MigrateClientsDataUseCase(coreLogic, scalaCryptoBoxDirectoryProvider, scalaUserDBProvider, userDataStoreProvider)
+            MigrateClientsDataUseCase(
+                coreLogic,
+                scalaCryptoBoxDirectoryProvider,
+                scalaUserDBProvider,
+                userDataStoreProvider
+            )
         }
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun withGetUsers(result: (List<String>) -> List<ScalaUserData>): Arrangement {
+            every { scalaUserDBProvider.userDAO(any())?.users(any()) } answers {
+                result(firstArg())
+            }
+            return this
         }
 
         fun arrange() = this to useCase

--- a/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrateClientsDataUseCaseTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
-
 @OptIn(ExperimentalCoroutinesApi::class)
 class MigrateClientsDataUseCaseTest {
 
@@ -118,7 +117,7 @@ class MigrateClientsDataUseCaseTest {
         verify(atLeast = 1) { arrangement.scalaUserDBProvider.userDAO(any())?.users(any()) }
     }
 
-    private fun fakeScalaUserData(id: String, domain: String) =  ScalaUserData(
+    private fun fakeScalaUserData(id: String, domain: String) = ScalaUserData(
         id = id,
         domain = domain,
         teamId = null,

--- a/app/src/test/kotlin/com/wire/android/migration/ScalaBackendPreferencesTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/ScalaBackendPreferencesTest.kt
@@ -17,7 +17,7 @@ import org.amshove.kluent.internal.assertEquals
 class ScalaBackendPreferencesTest {
 
     @Test
-    fun `given regular url when fetching scala backend data then return this url`()  = runTest {
+    fun `given regular url when fetching scala backend data then return this url`() = runTest {
         // given
         val blacklistUrl = "https://wire.com/blacklist"
         // when
@@ -29,7 +29,7 @@ class ScalaBackendPreferencesTest {
     }
 
     @Test
-    fun `given optional url when fetching scala backend data then extract proper url from the string`()  = runTest {
+    fun `given optional url when fetching scala backend data then extract proper url from the string`() = runTest {
         // given
         val blacklistUrl = "https://wire.com/blacklist"
         val optionalBlacklistUrl = "Some($blacklistUrl)"
@@ -42,7 +42,7 @@ class ScalaBackendPreferencesTest {
     }
 
     @Test
-    fun `given optional empty url when fetching scala backend data then return null`()  = runTest {
+    fun `given optional empty url when fetching scala backend data then return null`() = runTest {
         // given
         val optionalBlacklistUrl = "None"
         // when

--- a/app/src/test/kotlin/com/wire/android/migration/ScalaBackendPreferencesTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/ScalaBackendPreferencesTest.kt
@@ -1,0 +1,81 @@
+package com.wire.android.migration
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import com.wire.android.migration.preference.ScalaBackendPreferences
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Test
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScalaBackendPreferencesTest {
+
+    @Test
+    fun `given regular url when fetching scala backend data then return this url`()  = runTest {
+        // given
+        val blacklistUrl = "https://wire.com/blacklist"
+        // when
+        val (arrangement, scalaBackendPreferences) = Arrangement()
+            .withSpecificPref(ScalaBackendPreferences.Companion.BLACKLIST_HOST_PREF, blacklistUrl)
+            .arrange()
+        // then
+        assertEquals(blacklistUrl, scalaBackendPreferences.blacklistUrl)
+    }
+
+    @Test
+    fun `given optional url when fetching scala backend data then extract proper url from the string`()  = runTest {
+        // given
+        val blacklistUrl = "https://wire.com/blacklist"
+        val optionalBlacklistUrl = "Some($blacklistUrl)"
+        // when
+        val (arrangement, scalaBackendPreferences) = Arrangement()
+            .withSpecificPref(ScalaBackendPreferences.Companion.BLACKLIST_HOST_PREF, optionalBlacklistUrl)
+            .arrange()
+        // then
+        assertEquals(blacklistUrl, scalaBackendPreferences.blacklistUrl)
+    }
+
+    @Test
+    fun `given optional empty url when fetching scala backend data then return null`()  = runTest {
+        // given
+        val optionalBlacklistUrl = "None"
+        // when
+        val (arrangement, scalaBackendPreferences) = Arrangement()
+            .withSpecificPref(ScalaBackendPreferences.Companion.BLACKLIST_HOST_PREF, optionalBlacklistUrl)
+            .arrange()
+        // then
+        assertEquals(null, scalaBackendPreferences.blacklistUrl)
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var sharedPreferences: SharedPreferences
+        @MockK
+        lateinit var context: Context
+
+        private val scalaBackendPreferences: ScalaBackendPreferences by lazy {
+            ScalaBackendPreferences(context)
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            mockkStatic(PreferenceManager::class)
+            every { PreferenceManager.getDefaultSharedPreferences(any()) } returns sharedPreferences
+            every { sharedPreferences.getString(any(), any()) } returns null
+        }
+
+        fun withSpecificPref(key: String, value: String): Arrangement {
+            every { sharedPreferences.getString(key, any()) } returns value
+            return this
+        }
+
+        fun arrange() = this to scalaBackendPreferences
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2941" title="AR-2941" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2941</a>  Session is broken after upgrading from scala app when receiving new messages in new app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
 
When upgrading to the new app, we can not receive new messages in a group conversation. Instead we receive decryption errors. Only after sending a message, everything starts working fine.

### Causes (Optional)

All proteus files are migrated correctly to the proper directory for AR but names of session files are wrong - in scala app session files contain user ids without domains, but in AR we use full user ids with domains. When we send a message, the app creates all missing sessions, that's why it works after that.
Also, versioning API request returns an error because blacklist url is optional in scala app, so it's wrapped in Option: `Some(https://wire.com/blacklist)`, and it's actually stored this way.

### Solutions

Rename session files when migrating to include domains for AR.
Parse optional urls properly by extracting only the proper url part from the whole string.
Fix `ScalaMessageDAO` cursor and prevent from exception "requesting column name with table name" by adding aliases to tables.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Install scala app, have a group conversation, update app to AR, receive a message on that group.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
