### PR TITLE
chore: use default dispatcher for non IO operations

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/CallNotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/CallNotificationDismissReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
+import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationManager
@@ -14,6 +15,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,27 +34,32 @@ class CallNotificationDismissReceiver : BroadcastReceiver() {  // requires zero 
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
+    @Inject
+    @ApplicationScope
+    lateinit var coroutineScope: CoroutineScope
+
     override fun onReceive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
         appLogger.i("CallNotificationDismissReceiver: onReceive, conversationId: $conversationId")
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
-        val sessionScope =
-            if (userId != null) {
-                coreLogic.getSessionScope(userId)
-            } else {
-                val currentSession = coreLogic.globalScope { session.currentSession() }
-                if (currentSession is CurrentSessionResult.Success) {
-                    coreLogic.getSessionScope(currentSession.accountInfo.userId)
+        coroutineScope.launch(Dispatchers.Default) {
+            val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
+            val sessionScope =
+                if (userId != null) {
+                    coreLogic.getSessionScope(userId)
                 } else {
-                    null
+                    val currentSession = coreLogic.globalScope { session.currentSession() }
+                    if (currentSession is CurrentSessionResult.Success) {
+                        coreLogic.getSessionScope(currentSession.accountInfo.userId)
+                    } else {
+                        null
+                    }
                 }
-            }
-        sessionScope?.let {
-            it.launch(Dispatchers.IO) {
+
+            sessionScope?.let {
                 it.calls.rejectCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
             }
+            CallNotificationManager.hideIncomingCallNotification(context)
         }
-        CallNotificationManager.hideIncomingCallNotification(context)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
+import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -13,7 +14,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -31,12 +32,17 @@ class EndOngoingCallReceiver : BroadcastReceiver() {
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
+    @Inject
+    @ApplicationScope
+    lateinit var coroutineScope: CoroutineScope
+
     override fun onReceive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
         appLogger.i("CallNotificationDismissReceiver: onReceive, conversationId: $conversationId")
 
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
-         val sessionScope =
+        coroutineScope.launch() {
+            val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
+            val sessionScope =
                 if (userId != null) {
                     coreLogic.getSessionScope(userId)
                 } else {
@@ -49,10 +55,10 @@ class EndOngoingCallReceiver : BroadcastReceiver() {
                 }
 
             sessionScope?.let {
-                it.launch(Dispatchers.IO) {
-                    it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
-                }
+                it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
             }
+        }
+
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -93,7 +93,7 @@ class SharedCallingViewModel @Inject constructor(
                         call.status != CallStatus.CLOSED &&
                         call.status != CallStatus.MISSED
                 }
-            }.flowOn(dispatchers.io()).shareIn(this, started = SharingStarted.Lazily)
+            }.flowOn(dispatchers.default()).shareIn(this, started = SharingStarted.Lazily)
 
             launch {
                 observeConversationDetails(this)
@@ -140,7 +140,7 @@ class SharedCallingViewModel @Inject constructor(
         conversationDetails(conversationId = conversationId)
             .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>() // TODO handle StorageFailure
             .map { it.conversationDetails }
-            .flowOn(dispatchers.io())
+            .flowOn(dispatchers.default())
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(1))
             .collect { details ->
                 callState = when (details) {
@@ -167,7 +167,7 @@ class SharedCallingViewModel @Inject constructor(
 
     private suspend fun observeOnSpeaker(coroutineScope: CoroutineScope) {
         observeSpeaker()
-            .flowOn(dispatchers.io())
+            .flowOn(dispatchers.default())
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(1))
             .collectLatest {
                 callState = callState.copy(isSpeakerOn = it)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -148,7 +148,7 @@ class ConversationInfoViewModel @Inject constructor(
             else UIText.StringResource(R.string.member_name_deleted_label)
     }
 
-    fun navigateToDetails() = viewModelScope.launch(dispatchers.io()) {
+    fun navigateToDetails() = viewModelScope.launch(dispatchers.default()) {
         when (val data = conversationInfoViewState.conversationDetailsData) {
             is ConversationDetailsData.OneOne -> navigationManager.navigate(
                 command = NavigationCommand(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -116,7 +116,6 @@ class ConversationListViewModel @Inject constructor(
                 }
             )
                 .map { (searchQuery, conversationItems) -> conversationItems.withFolders().toImmutableMap() to searchQuery }
-                .flowOn(dispatcher.io())
                 .collect { (conversationsWithFolders, searchQuery) ->
                     conversationListState = conversationListState.copy(
                         conversationSearchResult = if (searchQuery.isEmpty()) conversationsWithFolders else searchConversation(
@@ -126,8 +125,7 @@ class ConversationListViewModel @Inject constructor(
                         hasNoConversations = conversationsWithFolders.isEmpty(),
                         foldersWithConversations = conversationsWithFolders,
                         searchQuery = searchQuery,
-
-                        )
+                    )
                 }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -1,6 +1,7 @@
 package com.wire.android.util.lifecycle
 
 import com.wire.android.appLogger
+import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.migration.MigrationManager
 import com.wire.android.util.CurrentScreenManager
@@ -19,6 +20,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.nullableFold
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -43,7 +45,8 @@ class ConnectionPolicyManager @Inject constructor(
     private val currentScreenManager: CurrentScreenManager,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val dispatcherProvider: DispatcherProvider,
-    private val migrationManager: MigrationManager
+    private val migrationManager: MigrationManager,
+    @ApplicationScope private val coroutineScope: CoroutineScope
 ) {
 
     private val logger by lazy { appLogger.withFeatureId(SYNC) }
@@ -112,15 +115,15 @@ class ConnectionPolicyManager @Inject constructor(
         }
     }
 
-    private fun isCurrentSession(userId: UserId): Boolean {
+    private suspend fun isCurrentSession(userId: UserId): Boolean = coroutineScope.async {
         val isCurrentSession = coreLogic.getGlobalScope().sessionRepository.currentSession().fold({
             // Assume so in case of failure
             true
         }, {
             it.userId == userId
         })
-        return isCurrentSession
-    }
+        return@async isCurrentSession
+    }.await()
 
     private suspend fun setPolicyForSessions(
         userIdList: List<QualifiedID>,

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -19,6 +19,7 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -134,8 +135,11 @@ class ConnectionPolicyManagerTest {
         @MockK
         lateinit var migrationManager: MigrationManager
 
+        @MockK
+        lateinit var coroutineScope: CoroutineScope
+
         private val connectionPolicyManager by lazy {
-            ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider(), migrationManager)
+            ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider(), migrationManager, coroutineScope)
         }
 
         init {
@@ -160,7 +164,7 @@ class ConnectionPolicyManagerTest {
         fun withCurrentSession(userId: UserId) = apply {
             val authSession: AccountInfo = mockk()
             every { authSession.userId } returns userId
-            every { sessionRepository.currentSession() } returns Either.Right(authSession)
+            coEvery { sessionRepository.currentSession() } returns Either.Right(authSession)
         }
 
         fun arrange() = this to connectionPolicyManager

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -19,9 +19,9 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -135,8 +135,7 @@ class ConnectionPolicyManagerTest {
         @MockK
         lateinit var migrationManager: MigrationManager
 
-        @MockK
-        lateinit var coroutineScope: CoroutineScope
+        var coroutineScope = TestCoroutineScope()
 
         private val connectionPolicyManager by lazy {
             ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider(), migrationManager, coroutineScope)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IO dispatcher is used for non IO operations

### Solutions

Use Default instead


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
