### PR TITLE
fix(rc): recomposition crash when updating globalAppState [AR-2986]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -103,20 +103,25 @@ class WireActivity : AppCompatActivity() {
                     }
                     setUpNavigation(navController, scope)
 
-                    handleCustomBackendDialog(viewModel.globalAppState.customBackendDialog.shouldShowDialog)
-                    maxAccountDialog(
-                        viewModel::openProfile,
-                        viewModel::dismissMaxAccountDialog,
-                        viewModel.globalAppState.maxAccountDialog
-                    )
-                    updateAppDialog(
-                        { updateTheApp() },
-                        viewModel.globalAppState.updateAppDialog
-                    )
-                    AccountLongedOutDialog(viewModel.globalAppState.blockUserUI, viewModel::navigateToNextAccountOrWelcome)
+                    handleDialogs()
                 }
             }
         }
+    }
+
+    @Composable
+    private fun handleDialogs() {
+        handleCustomBackendDialog(viewModel.globalAppState.customBackendDialog.shouldShowDialog)
+        maxAccountDialog(
+            viewModel::openProfile,
+            viewModel::dismissMaxAccountDialog,
+            viewModel.globalAppState.maxAccountDialog
+        )
+        updateAppDialog(
+            { updateTheApp() },
+            viewModel.globalAppState.updateAppDialog
+        )
+        AccountLoggedOutDialog(viewModel.globalAppState.blockUserUI, viewModel::navigateToNextAccountOrWelcome)
     }
 
     @Composable
@@ -159,7 +164,7 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    fun AccountLongedOutDialog(reason: CurrentSessionErrorState?, navigateAway: () -> Unit) {
+    fun AccountLoggedOutDialog(reason: CurrentSessionErrorState?, navigateAway: () -> Unit) {
         appLogger.e("AccountLongedOutDialog: $reason")
         reason?.let {
             val (@StringRes title: Int, @StringRes text: Int) = when (reason) {
@@ -230,5 +235,3 @@ class WireActivity : AppCompatActivity() {
         proximitySensorManager.unRegisterListener()
     }
 }
-
-


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2986" title="AR-2986" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2986</a>  You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes we still receive this error:

`java.lang.IllegalStateException: You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed`

### Causes (Optional)

In `WireActivity` when we update the `globalAppState` the whole Activity's composable recomposes which can change the navigation `startDestination` and mess up the back stack.

### Solutions

Move handling dialogs out of the main composable, this way `globalAppState` isn't used directly in the main composable so there is no need to recompose the whole screen, when this state changes. Instead, only `handleDialogs` is being recomposed.

### Testing

#### How to Test

In automation the error was randomly observed when following this flow:
- have an active wire team account
- be logged in into the app with this account
- get removed from the team (account deleted)
- see alert shows, which tells you that you got removed from the team
- tap on OK button

It also happened when there is a force to update required, basically every update to `globalAppState` could crash the app.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.