### PR TITLE
ci: switch ui and unit tests to buildjet

### DIFF
--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,10 +12,10 @@ concurrency:
 jobs:
   ui-tests:
     if: ${{ contains(github.head_ref, 'qa/') || contains(github.ref_name, 'qa/')}}  # disable for as they are not yet completed
-    runs-on: macos-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [30]
 
     steps:
       - name: Checkout
@@ -24,12 +24,12 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: gradle
+      # - name: Set up JDK 17
+      #   uses: actions/setup-java@v3
+      #   with:
+      #     java-version: '17'
+      #     distribution: 'temurin'
+      #     cache: gradle
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-8vcpu-ubuntu-2204
 
     steps:
       - name: Checkout
@@ -23,12 +23,12 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: gradle
+      # - name: Set up JDK 17
+      #   uses: actions/setup-java@v3
+      #   with:
+      #     java-version: '17'
+      #     distribution: 'temurin'
+      #     cache: gradle
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Unit and UI tests run times are a bit long

### Solutions

Switch runners to buildjet

----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
