### PR TITLE
ci: run tests only after deteket succeeds

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,8 +1,6 @@
 name: "Check Codestyle"
 
-on:
-  pull_request:
-    types: [ opened, synchronize ] # Don't rerun on `edited` to save time
+on: [workflow_call]
 
 jobs:
   static-code-analysis:
@@ -13,12 +11,6 @@ jobs:
         with:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Run Detekt

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -10,7 +10,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  detekt:
+    uses: ./.github/workflows/codestyle.yml
   ui-tests:
+    needs: [detekt]
     if: ${{ contains(github.head_ref, 'qa/') || contains(github.ref_name, 'qa/')}}  # disable for as they are not yet completed
     runs-on: buildjet-8vcpu-ubuntu-2204
     strategy:

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -13,7 +13,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  detekt:
+    uses: ./.github/workflows/codestyle.yml
   unit-tests:
+    needs: [detekt]
     runs-on: buildjet-8vcpu-ubuntu-2204
 
     steps:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If Detekt fails, a PR author is required to fix the code style issues. This triggers another full run of tests that occupy GitHub runners.

### Solutions

Save some runners by first requiring Detekt to succeed

----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
