### PR TITLE
fix: mention suggestion list does not follow cursor position(RC)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/DropDownMentionsSuggestions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/DropDownMentionsSuggestions.kt
@@ -120,21 +120,24 @@ private fun updateDropDownCoordinateY(
     currentSelectedLineIndex: Int,
     screenHeight: Int
 ): Int {
-    var coordinateY = cursorCoordinateY
+    var coordinateY = cursorCoordinateY + SIXTY
     // since we are using BottomYCoordinate of the cursor, we reduce some space from Y coordinate
-    // for approximately the second part of the screen.
-    if (cursorCoordinateY >= screenHeight / HALF_SCREEN) {
-        coordinateY = cursorCoordinateY - THIRTY
+    // when reaching approximately the second part of the screen with more 3 participants to show
+    if (membersToMentionSize >= THREE && cursorCoordinateY >= (screenHeight * HALF_SCREEN)) {
+        coordinateY = cursorCoordinateY
     }
-    // If there is only one item to show, in the second part of the screen, the DropDown will be displayed above the cursor.
-    // Fixing this by adding more space
-    if (membersToMentionSize == ONE && cursorCoordinateY < screenHeight * EIGHTY_PERCENT) {
-        coordinateY = cursorCoordinateY + TWENTY
+    // when reaching approximately sixty percent of the screen with 2 participants to show
+    if (membersToMentionSize == TWO && cursorCoordinateY >= (screenHeight * SIXTY_PERCENT)) {
+        coordinateY = cursorCoordinateY
     }
-    // For the first line, we get the wrong Y coordinate of the cursor.
+    // when reaching approximately seventy percent of the screen with 1 participants to show
+    if (membersToMentionSize == ONE && cursorCoordinateY >= (screenHeight * SEVENTY_PERCENT)) {
+        coordinateY = cursorCoordinateY
+    }
+    // For the first line, we get a wrong Y coordinate of the cursor.
     // Fixing this by adding more space
     if (currentSelectedLineIndex == FIRST_LINE_INDEX) {
-        coordinateY = cursorCoordinateY + THIRTY
+        coordinateY += TWENTY
     }
     return coordinateY.toInt()
 }
@@ -143,10 +146,12 @@ private const val MINIMUM_SCREEN_HEIGHT = 700
 private val DROP_DOWN_HEIGHT_SMALL = 150.dp
 private val DROP_DOWN_HEIGHT_LARGE = 200.dp
 private const val FIRST_LINE_INDEX = 0
-private const val HALF_SCREEN = 2.5
-private const val EIGHTY_PERCENT = 0.80
+private const val HALF_SCREEN = 0.45
+private const val SIXTY_PERCENT = 0.75
+private const val SEVENTY_PERCENT = 0.75
 private const val ONE = 1
 private const val TWO = 2
-private const val THIRTY = 30
+private const val THREE = 3
+private const val SIXTY = 60
 private const val TWENTY = 20
 private val DropdownMenuVerticalPadding = 8.dp

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -314,7 +314,7 @@ private fun EnabledMessageComposerInput(
     onMentionPicked: (Contact) -> Unit,
     onCancelReply: () -> Unit
 ) {
-    Column {
+    Box {
         var currentSelectedLineIndex by remember {
             mutableStateOf(0)
         }
@@ -322,36 +322,38 @@ private fun EnabledMessageComposerInput(
         var cursorCoordinateY by remember {
             mutableStateOf(0F)
         }
-
-        MessageComposeInput(
-            transition = transition,
-            messageComposerState = messageComposerInnerState,
-            quotedMessageData = messageComposerInnerState.quotedMessageData,
-            securityClassificationType = securityClassificationType,
-            onCancelReply = onCancelReply,
-            onToggleFullScreen = onToggleFullScreen,
-            onSendButtonClicked = onSendButtonClicked,
-            onSelectedLineIndexChange = { currentSelectedLineIndex = it },
-            onLineBottomCoordinateChange = { cursorCoordinateY = it },
-            modifier = Modifier
-                .fillMaxWidth()
-                .let {
-                    if (messageComposerInnerState.messageComposeInputState == MessageComposeInputState.FullScreen)
-                        it.weight(1f)
-                    else
-                        it.wrapContentHeight()
-                }
-        )
-        MessageComposeActionsBox(
-            transition,
-            messageComposerInnerState,
-            membersToMention.isNotEmpty()
-        )
         if (membersToMention.isNotEmpty()
             && messageComposerInnerState.messageComposeInputState == MessageComposeInputState.FullScreen
         ) {
             DropDownMentionsSuggestions(currentSelectedLineIndex, cursorCoordinateY, membersToMention, onMentionPicked)
         }
+        Column {
+            MessageComposeInput(
+                transition = transition,
+                messageComposerState = messageComposerInnerState,
+                quotedMessageData = messageComposerInnerState.quotedMessageData,
+                securityClassificationType = securityClassificationType,
+                onCancelReply = onCancelReply,
+                onToggleFullScreen = onToggleFullScreen,
+                onSendButtonClicked = onSendButtonClicked,
+                onSelectedLineIndexChange = { currentSelectedLineIndex = it },
+                onLineBottomCoordinateChange = { cursorCoordinateY = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .let {
+                        if (messageComposerInnerState.messageComposeInputState == MessageComposeInputState.FullScreen)
+                            it.weight(1f)
+                        else
+                            it.wrapContentHeight()
+                    }
+            )
+            MessageComposeActionsBox(
+                transition,
+                messageComposerInnerState,
+                membersToMention.isNotEmpty()
+            )
+        }
+
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When expanding the text field and you try to mention someone, suggestion list does not follow cursor position and it's displayed randomly

### Causes (Optional)

Refactor done in #1231 has invalidated some cursor position calculations.

### Solutions

re-do it.


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Expand the text field by clicking on the top arrow
- Try to mention someone

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

https://user-images.githubusercontent.com/18124919/214287513-d3f9a4aa-31ad-4995-933f-063449f0cac1.mp4 

https://user-images.githubusercontent.com/18124919/214287166-49df889b-ddd3-4a27-b303-f1e2714b98e1.mp4 


----




#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
