### PR TITLE
fix: import content pager adjustments (AR-2949)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -81,9 +82,13 @@ internal fun MessageAsset(
                     maxLines = if (shouldFillMaxWidth) 2 else 4,
                     overflow = TextOverflow.Ellipsis
                 )
-                val descriptionModifier = Modifier.padding(top = dimensions().spacing8x).fillMaxWidth()
+                val descriptionModifier = Modifier.padding(
+                    top = dimensions().spacing8x,
+                    start = dimensions().spacing4x,
+                    end = dimensions().spacing4x
+                ).fillMaxWidth()
                 Row(verticalAlignment = Alignment.Bottom) {
-                    ConstraintLayout(if (!shouldFillMaxWidth) descriptionModifier.fillMaxHeight() else descriptionModifier) {
+                    ConstraintLayout(modifier = (if (!shouldFillMaxWidth) descriptionModifier.fillMaxHeight() else descriptionModifier)) {
                         val (icon, description, downloadStatus) = createRefs()
                         Image(
                             modifier = Modifier
@@ -98,7 +103,6 @@ internal fun MessageAsset(
                         )
                         Text(
                             modifier = Modifier
-                                .padding(start = dimensions().spacing4x)
                                 .constrainAs(description) {
                                     top.linkTo(parent.top)
                                     start.linkTo(icon.end)
@@ -106,6 +110,7 @@ internal fun MessageAsset(
                                 },
                             text = assetDescription,
                             maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.wireColorScheme.secondaryText,
                             style = MaterialTheme.wireTypography.subline01
                         )
@@ -324,6 +329,7 @@ private fun isNotClickable(assetDownloadStatus: Message.DownloadStatus, assetUpl
     assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS || assetUploadStatus == Message.UploadStatus.UPLOAD_IN_PROGRESS
 
 @Suppress("MagicNumber")
+@Stable
 private fun provideAssetDescription(assetExtension: String, assetSizeInBytes: Long): String {
     val oneKB = 1024L
     val oneMB = oneKB * oneKB

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsEndWidth
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -89,8 +92,9 @@ fun ImportMediaContent(searchBarState: SearchBarState, snackbarHostState: Snackb
         modifier = Modifier.background(colorsScheme().background),
         content = { internalPadding ->
             val importedItemsList: List<ImportedMediaAsset> = importMediaViewModel.importMediaState.importedAssets
+            val itemsToImport = importedItemsList.size
             val pagerState = rememberPagerState()
-            val isMultipleImport = importedItemsList.size > 1
+            val isMultipleImport = itemsToImport > 1
 
             Column(
                 modifier = Modifier
@@ -105,8 +109,8 @@ fun ImportMediaContent(searchBarState: SearchBarState, snackbarHostState: Snackb
                 CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
                     HorizontalPager(
                         state = pagerState,
-                        count = importedItemsList.size,
-                        modifier = Modifier.fillMaxWidth(),
+                        count = itemsToImport,
+                        modifier = Modifier.wrapContentWidth(),
                         contentPadding = contentPadding,
                         itemSpacing = dimensions().spacing8x
                     ) { page ->

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -97,7 +97,7 @@ fun ImportMediaContent(searchBarState: SearchBarState, snackbarHostState: Snackb
                     .padding(internalPadding)
                     .fillMaxSize()
             ) {
-                val horizontalPadding = dimensions().spacing16x
+                val horizontalPadding = dimensions().spacing8x
                 val screenWidth = LocalConfiguration.current.screenWidthDp.dp
                 val itemWidth = if (isMultipleImport) dimensions().importedMediaAssetSize else screenWidth - (horizontalPadding * 2)
                 val contentPadding = PaddingValues(start = horizontalPadding, end = (screenWidth - itemWidth + horizontalPadding))

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -96,7 +96,8 @@ fun ImportMediaContent(searchBarState: SearchBarState, importMediaViewModel: Imp
                         state = pagerState,
                         count = importedItemsList.size,
                         modifier = Modifier.fillMaxWidth(),
-                        contentPadding = contentPadding
+                        contentPadding = contentPadding,
+                        itemSpacing = dimensions().spacing8x
                     ) { page ->
                         ImportedMediaItemView(importedItemsList[page], isMultipleImport, importMediaViewModel.wireSessionImageLoader)
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -361,6 +362,7 @@ class ImportMediaViewModel @Inject constructor(
     }
 }
 
+@Stable
 data class ImportMediaState(
     val avatarAsset: ImageAsset.UserAvatarAsset? = null,
     val importedAssets: ArrayList<ImportedMediaAsset> = arrayListOf()

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -295,7 +295,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     messageItemBottomPadding = 12.dp,
     conversationOptionsItemMinHeight = 57.dp,
     ongoingCallLabelHeight = 28.dp,
-    importedMediaAssetSize = 120.dp,
+    importedMediaAssetSize = 120.dp
 )
 
 private val DefaultPhoneLandscapeWireDimensions: WireDimensions = DefaultPhonePortraitWireDimensions


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2949" title="AR-2949" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-2949</a>  Imported media horizontal pager UI fixes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adjust spacing between items and item sizes.

Note: At the end, the scroll couldn't fix it, but it seems not a big deal for now. If someone with a better eye can have a look would be better 

### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5806454/214406195-b8694645-cc33-4f20-ab4d-ea9b50f8e44a.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
