### PR TITLE
fix(rc): handle migration progress and network errors [AR-3013]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.failure.ServerConfigFailure
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.mapLeft
+import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -79,46 +80,59 @@ class MigrationManager @Inject constructor(
 
     fun isMigrationCompletedFlow(): Flow<Boolean> = globalDataStore.isMigrationCompletedFlow()
 
-    suspend fun migrate(): MigrationResult =
-        migrateServerConfig()
+    suspend fun migrate(
+        updateProgress: suspend (MigrationData.Progress) -> Unit
+    ): MigrationData.Result =
+        updateProgress(MigrationData.Progress(MigrationData.Progress.Type.SERVER_CONFIGS))
+            .run { migrateServerConfig() }
             .flatMap {
                 appLogger.d("$TAG - Step 1 - Migrating accounts")
+                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.ACCOUNTS))
                 migrateActiveAccounts(it)
             }
             .onSuccess { (userIdList, isFederated) ->
                 // the result of this step is ignored
                 appLogger.d("$TAG - Step 2 - Migrating clients")
+                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.CLIENTS))
                 migrateClientsData(userIdList, isFederated)
             }
             .flatMap { (userIdList, _) ->
                 appLogger.d("$TAG - Step 3 - Migrating users")
+                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.USERS))
                 migrateUsers(userIdList)
             }
             .flatMap {
                 appLogger.d("$TAG - Step 4 - Migrating conversations")
+                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.CONVERSATIONS))
                 migrateConversations(it)
             }
             .flatMap {
                 appLogger.d("$TAG - Step 5 - Migrating messages")
+                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.MESSAGES))
                 migrateMessages(it)
             }
             .mapLeft(::migrationFailure)
             .onSuccess { globalDataStore.setMigrationCompleted() }
+            .onFailure {
+                if (it != MigrationData.Result.Failure.Type.NO_NETWORK) {
+                    globalDataStore.setMigrationCompleted() // only for network errors we show the info and "retry" button to the user
+                }
+            }
             .fold({
                 appLogger.e("$TAG - Failure - Migrating data from old client - $it")
-                MigrationResult.Failure(it)
+                MigrationData.Result.Failure(it)
             }, {
                 appLogger.d("$TAG - Success - Migrated data from old client")
-                MigrationResult.Success
+                MigrationData.Result.Success
             })
 
-    private fun migrationFailure(failure: CoreFailure): MigrationResult.Failure.Type = when (failure) {
-        is NetworkFailure.NoNetworkConnection -> MigrationResult.Failure.Type.NO_NETWORK
-        is StorageFailure.DataNotFound -> MigrationResult.Failure.Type.DATA_NOT_FOUND
-        is ServerConfigFailure.UnknownServerVersion -> MigrationResult.Failure.Type.UNKNOWN_SERVER_VERSION
-        is ServerConfigFailure.NewServerVersion -> MigrationResult.Failure.Type.TOO_NEW_VERSION
-        is MigrationFailure.InvalidRefreshToken -> MigrationResult.Failure.Type.UNKNOWN
-        else -> MigrationResult.Failure.Type.UNKNOWN
+    private fun migrationFailure(failure: CoreFailure): MigrationData.Result.Failure.Type = when (failure) {
+        is NetworkFailure.NoNetworkConnection -> MigrationData.Result.Failure.Type.NO_NETWORK
+        is StorageFailure.DataNotFound -> MigrationData.Result.Failure.Type.DATA_NOT_FOUND
+        is ServerConfigFailure.UnknownServerVersion -> MigrationData.Result.Failure.Type.UNKNOWN_SERVER_VERSION
+        is ServerConfigFailure.NewServerVersion -> MigrationData.Result.Failure.Type.TOO_NEW_VERSION
+        is MigrationFailure.InvalidRefreshToken -> MigrationData.Result.Failure.Type.UNKNOWN
+        else -> MigrationData.Result.Failure.Type.UNKNOWN
     }
 
     companion object {
@@ -126,23 +140,43 @@ class MigrationManager @Inject constructor(
     }
 }
 
-sealed class MigrationResult {
-    object Success : MigrationResult()
-    data class Failure(val type: Type) : MigrationResult() {
-        enum class Type { UNKNOWN_SERVER_VERSION, TOO_NEW_VERSION, DATA_NOT_FOUND, NO_NETWORK, UNKNOWN; }
+sealed class MigrationData {
+    data class Progress(val type: Type) : MigrationData() {
+        enum class Type { SERVER_CONFIGS, ACCOUNTS, CLIENTS, USERS, CONVERSATIONS, MESSAGES, UNKNOWN; }
         companion object {
-            const val KEY_FAILURE_TYPE = "failure_type"
+            const val KEY_PROGRESS_TYPE = "progress_type"
+        }
+    }
+
+    sealed class Result : MigrationData() {
+        object Success : Result()
+        data class Failure(val type: Type) : Result() {
+            enum class Type { UNKNOWN_SERVER_VERSION, TOO_NEW_VERSION, DATA_NOT_FOUND, NO_NETWORK, UNKNOWN; }
+            companion object {
+                const val KEY_FAILURE_TYPE = "failure_type"
+            }
         }
     }
 }
 
-fun MigrationResult.Failure.Type.toData(): Data = workDataOf(MigrationResult.Failure.KEY_FAILURE_TYPE to this.name)
+fun MigrationData.Result.Failure.Type.toData(): Data = workDataOf(MigrationData.Result.Failure.KEY_FAILURE_TYPE to this.name)
 
-fun Data.getMigrationFailure(): MigrationResult.Failure.Type = this.getString(MigrationResult.Failure.KEY_FAILURE_TYPE)
+fun Data.getMigrationFailure(): MigrationData.Result.Failure.Type = this.getString(MigrationData.Result.Failure.KEY_FAILURE_TYPE)
     ?.let {
         try {
-            MigrationResult.Failure.Type.valueOf(it)
+            MigrationData.Result.Failure.Type.valueOf(it)
         } catch (e: IllegalArgumentException) {
             null
         }
-    } ?: MigrationResult.Failure.Type.UNKNOWN
+    } ?: MigrationData.Result.Failure.Type.UNKNOWN
+
+fun MigrationData.Progress.Type.toData(): Data = workDataOf(MigrationData.Progress.KEY_PROGRESS_TYPE to this.name)
+
+fun Data.getMigrationProgress(): MigrationData.Progress.Type = this.getString(MigrationData.Progress.KEY_PROGRESS_TYPE)
+    ?.let {
+        try {
+            MigrationData.Progress.Type.valueOf(it)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    } ?: MigrationData.Progress.Type.UNKNOWN

--- a/app/src/main/kotlin/com/wire/android/ui/common/SettingUpWireScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SettingUpWireScreenContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -53,6 +54,7 @@ fun SettingUpWireScreenContent(
     @StringRes titleResId: Int = R.string.migration_title,
     @StringRes messageResId: Int = R.string.migration_message,
     @DrawableRes iconResId: Int = R.drawable.ic_migration,
+    type: SettingUpWireScreenType = SettingUpWireScreenType.Progress
 ) {
     Scaffold(
         topBar = {
@@ -80,7 +82,9 @@ fun SettingUpWireScreenContent(
                         vertical = MaterialTheme.wireDimensions.welcomeVerticalSpacing
                     )
             )
-            WireCircularProgressIndicator(progressColor = MaterialTheme.wireColorScheme.badge)
+            if (type is SettingUpWireScreenType.Progress) {
+                WireCircularProgressIndicator(progressColor = MaterialTheme.wireColorScheme.badge)
+            }
             Text(
                 text = stringResource(messageResId),
                 style = MaterialTheme.wireTypography.body01,
@@ -89,13 +93,38 @@ fun SettingUpWireScreenContent(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding)
             )
+            if (type is SettingUpWireScreenType.Failure) {
+                WirePrimaryButton(
+                    onClick = type.onRetryClick,
+                    text = stringResource(type.retryButtonResId),
+                    fillMaxWidth = false,
+                    modifier = Modifier
+                        .padding(
+                            horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding,
+                            vertical = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding
+                        )
+                )
+            }
         }
     }
 }
 
-@Preview
-@Composable
-private fun MigrationScreenPreview() {
-    SettingUpWireScreenContent()
+sealed class SettingUpWireScreenType {
+    object Progress : SettingUpWireScreenType()
+    data class Failure(
+        @StringRes val retryButtonResId: Int = R.string.label_retry,
+        val onRetryClick: () -> Unit = {}
+    ) : SettingUpWireScreenType()
 }
 
+@Preview
+@Composable
+fun PreviewMigrationScreenProgress() {
+    SettingUpWireScreenContent(type = SettingUpWireScreenType.Progress)
+}
+
+@Preview
+@Composable
+fun PreviewMigrationScreenFailure() {
+    SettingUpWireScreenContent(type = SettingUpWireScreenType.Failure())
+}

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -22,10 +22,29 @@ package com.wire.android.ui.migration
 
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.R
+import com.wire.android.migration.MigrationData
 import com.wire.android.ui.common.SettingUpWireScreenContent
+import com.wire.android.ui.common.SettingUpWireScreenType
 
 @Composable
 fun MigrationScreen(viewModel: MigrationViewModel = hiltViewModel()) {
-    viewModel.init()
-    SettingUpWireScreenContent()
+    SettingUpWireScreenContent(
+        messageResId = when (val state = viewModel.state) {
+            MigrationState.Failed -> R.string.error_no_network_message
+            is MigrationState.InProgress -> when (state.type) {
+                MigrationData.Progress.Type.SERVER_CONFIGS -> R.string.migration_server_configs_message
+                MigrationData.Progress.Type.ACCOUNTS -> R.string.migration_accounts_message
+                MigrationData.Progress.Type.CLIENTS -> R.string.migration_clients_message
+                MigrationData.Progress.Type.USERS -> R.string.migration_users_message
+                MigrationData.Progress.Type.CONVERSATIONS -> R.string.migration_conversations_message
+                MigrationData.Progress.Type.MESSAGES -> R.string.migration_messages_message
+                MigrationData.Progress.Type.UNKNOWN -> R.string.migration_message_unknown
+            }
+        },
+        type = when (viewModel.state) {
+            is MigrationState.InProgress -> SettingUpWireScreenType.Progress
+            is MigrationState.Failed -> SettingUpWireScreenType.Failure(onRetryClick = viewModel::retry)
+        }
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationState.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.migration
+
+import com.wire.android.migration.MigrationData
+
+sealed class MigrationState {
+    data class InProgress(val type: MigrationData.Progress.Type) : MigrationState()
+    object Failed : MigrationState()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
@@ -20,10 +20,13 @@
 
 package com.wire.android.ui.migration
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
-import com.wire.android.migration.MigrationResult
+import com.wire.android.migration.MigrationData
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
@@ -44,19 +47,32 @@ class MigrationViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
 
-    fun init() {
+    var state: MigrationState by mutableStateOf(MigrationState.InProgress(MigrationData.Progress.Type.UNKNOWN))
+        private set
+
+    init {
         viewModelScope.launch(dispatchers.io()) {
             enqueueMigrationAndListenForStateChanges()
         }
     }
 
+    fun retry() {
+        // Flow collected in `enqueueMigrationAndListenForStateChanges` will still get updates for the newly enqueued work
+        workManager.enqueueMigrationWorker()
+        state = MigrationState.InProgress(MigrationData.Progress.Type.UNKNOWN)
+    }
+
     private suspend fun enqueueMigrationAndListenForStateChanges() {
         workManager.enqueueMigrationWorker().collect {
             when (it) {
-                is MigrationResult.Success -> navigateAfterMigration()
-                is MigrationResult.Failure -> {
-                    val failureType = it.type // TODO maybe show info and retry button in some cases?
+                is MigrationData.Result.Success -> navigateAfterMigration()
+                is MigrationData.Result.Failure -> {
+                    when (it.type) {
+                        MigrationData.Result.Failure.Type.NO_NETWORK -> state = MigrationState.Failed
+                        else -> navigateAfterMigration()
+                    }
                 }
+                is MigrationData.Progress -> state = MigrationState.InProgress(it.type)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="folder_label_protocol_details">Protocol details (beta)</string>
     <string name="label_user_blocked">Blocked</string>
     <string name="label_and">and</string>
+    <string name="label_retry">Retry</string>
     <!-- Content descriptions https://wearezeta.atlassian.net/wiki/spaces/AR/pages/122520039/Code+Style+Guideline#Content-description-strings -->
     <string name="content_description_app_logo">App Logo</string>
     <string name="content_description_reveal_password">Show password</string>
@@ -186,6 +187,13 @@
     <!-- Migration -->
     <string name="migration_title">Setting up Wire</string>
     <string name="migration_message">Please wait while we set up the app for you</string>
+    <string name="migration_message_unknown">Please wait while we migrate data for you</string>
+    <string name="migration_server_configs_message">Please wait while we migrate backends for you</string>
+    <string name="migration_accounts_message">Please wait while we migrate accounts for you</string>
+    <string name="migration_clients_message">Please wait while we migrate clients for you</string>
+    <string name="migration_users_message">Please wait while we migrate users for you</string>
+    <string name="migration_conversations_message">Please wait while we migrate conversations for you</string>
+    <string name="migration_messages_message">Please wait while we migrate messages for you</string>
     <string name="migration_cancel_title">Cancel migration</string>
     <string name="migration_cancel_message">Are you sure you want to close the application and cancel the ongoing migration?</string>
     <!-- Login -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3013" title="AR-3013" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3013</a>  Handle migration progress and network errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there's an error during the migration, the app doesn't do anything and becomes stuck on the migration screen.

### Solutions

Implement retry mechanism for network errors and let other errors complete the migration as there is nothing we can do with that, retrying won't have any effect.
Add progress steps to the migration to let user know what is being migrated at a given time.

### Testing

#### How to Test

Install the AR as an update to the scala app and perform the migration.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/215145272-001122f8-0dd9-45c7-992a-82d6d6561337.mp4

This video shows the UI changes - each step is delayed by 3s and there is a network error at the end to show the retry mechanism.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
