### PR TITLE
fix: skip annotations with negative offsets

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
@@ -85,6 +85,9 @@ fun LinkifyText(
     val annotatedString = buildAnnotatedString {
         append(textAsString)
         linkInfos.forEach {
+            if (it.end - it.start <= 0) {
+                return@forEach
+            }
             addStyle(
                 style = SpanStyle(
                     color = MaterialTheme.wireColorScheme.primary,
@@ -102,6 +105,9 @@ fun LinkifyText(
         }
         if (text is UIText.DynamicString && text.mentions.isNotEmpty()) {
             text.mentions.forEach {
+                if (it.length <= 0) {
+                    return@forEach
+                }
                 addStyle(
                     style = SpanStyle(
                         color = MaterialTheme.wireColorScheme.messageMentionText,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

String annotations with negative ranges are not supported.

### Solutions

Skip annotations with negative ranges

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution
**TODO: This needs a Test**

#### How to Test

Render a message generating a negative range annotation (e.g. a mention, with length < 0).

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
