### PR TITLE
feat: group panel read receipt toggle

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUs
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ObserveMessageReactionsUseCase
@@ -640,6 +641,14 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): UpdateConversationMutedStatusUseCase =
         coreLogic.getSessionScope(currentAccount).conversations.updateConversationMutedStatus
+
+    @ViewModelScoped
+    @Provides
+    fun provideUpdateConversationReceiptModeUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): UpdateConversationReceiptModeUseCase =
+        coreLogic.getSessionScope(currentAccount).conversations.updateConversationReceiptMode
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -340,7 +340,9 @@ class GroupConversationDetailsViewModel @Inject constructor(
     }
 
     private suspend fun updateConversationAccess(
-        enableGuestAndNonTeamMember: Boolean, enableServices: Boolean, conversationId: ConversationId
+        enableGuestAndNonTeamMember: Boolean,
+        enableServices: Boolean,
+        conversationId: ConversationId
     ) = updateConversationAccessRole(
         allowGuest = enableGuestAndNonTeamMember,
         allowNonTeamMember = enableGuestAndNonTeamMember,
@@ -396,7 +398,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
     }
 
     private suspend fun clearContentSnackbarResult(
-        clearContentResult: ClearConversationContentUseCase.Result, conversationTypeDetail: ConversationTypeDetail
+        clearContentResult: ClearConversationContentUseCase.Result,
+        conversationTypeDetail: ConversationTypeDetail
     ) {
         if (conversationTypeDetail is ConversationTypeDetail.Connection) throw IllegalStateException(
             "Unsupported conversation type to clear content, something went wrong?"

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -47,17 +47,20 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.uiText
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
+import com.wire.kalium.logic.feature.conversation.ConversationUpdateReceiptModeResult
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.Result
@@ -92,6 +95,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val removeMemberFromConversation: RemoveMemberFromConversationUseCase,
     private val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase,
     private val clearConversationContent: ClearConversationContentUseCase,
+    private val updateConversationReceiptMode: UpdateConversationReceiptModeUseCase,
     override val savedStateHandle: SavedStateHandle,
     qualifiedIdMapper: QualifiedIdMapper
 ) : GroupConversationParticipantsViewModel(
@@ -159,6 +163,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isServicesAllowed = groupDetails.conversation.isServicesAllowed(),
                         isUpdatingAllowed = isSelfAnAdmin,
                         isUpdatingGuestAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
+                        isReadReceiptAllowed = groupDetails.conversation.receiptMode == Conversation.ReceiptMode.ENABLED,
+                        isUpdatingReadReceiptAllowed = isSelfAnAdmin
                     )
                 )
             }.collect {}
@@ -221,6 +227,12 @@ class GroupConversationDetailsViewModel @Inject constructor(
             true -> updateServicesRemoteRequest(enableServices)
             false -> updateState(groupOptionsState.value.copy(changeServiceOptionConfirmationRequired = true))
         }
+    }
+
+    fun onReadReceiptUpdate(enableReadReceipt: Boolean) {
+        appLogger.i("[$TAG][onReadReceiptUpdate] - enableReadReceipt: $enableReadReceipt")
+        updateState(groupOptionsState.value.copy(loadingReadReceiptOption = true, isReadReceiptAllowed = enableReadReceipt))
+        updateReadReceiptRemoteRequest(enableReadReceipt)
     }
 
     fun onGuestDialogDismiss() {
@@ -297,6 +309,33 @@ class GroupConversationDetailsViewModel @Inject constructor(
             }
 
             updateState(groupOptionsState.value.copy(loadingServicesOption = false))
+        }
+    }
+
+    private fun updateReadReceiptRemoteRequest(enableReadReceipt: Boolean) {
+        viewModelScope.launch {
+            val result = withContext(dispatcher.io()) {
+                updateConversationReceiptMode(
+                    conversationId = conversationId,
+                    receiptMode = when (enableReadReceipt) {
+                        true -> Conversation.ReceiptMode.ENABLED
+                        else -> Conversation.ReceiptMode.DISABLED
+                    }
+                )
+            }
+
+            when (result) {
+                is ConversationUpdateReceiptModeResult.Failure -> updateState(
+                    groupOptionsState.value.copy(
+                        isReadReceiptAllowed = !enableReadReceipt,
+                        error = GroupConversationOptionsState.Error.UpdateReadReceiptError(result.cause)
+                    )
+                )
+
+                ConversationUpdateReceiptModeResult.Success -> Unit
+            }
+
+            updateState(groupOptionsState.value.copy(loadingReadReceiptOption = false))
         }
     }
 
@@ -407,6 +446,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     }
 
     companion object {
+        const val TAG = "GroupConversationDetailsViewModel"
         const val MAX_NUMBER_OF_PARTICIPANTS = 4
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -398,8 +398,9 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private suspend fun clearContentSnackbarResult(
         clearContentResult: ClearConversationContentUseCase.Result, conversationTypeDetail: ConversationTypeDetail
     ) {
-        if (conversationTypeDetail is ConversationTypeDetail.Connection)
-            throw IllegalStateException("Unsupported conversation type to clear content, something went wrong?")
+        if (conversationTypeDetail is ConversationTypeDetail.Connection) throw IllegalStateException(
+            "Unsupported conversation type to clear content, something went wrong?"
+        )
 
         if (clearContentResult is ClearConversationContentUseCase.Result.Failure) {
             showSnackBarMessage(UIText.StringResource(R.string.group_content_delete_failure))

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -449,5 +449,4 @@ class GroupConversationDetailsViewModel @Inject constructor(
         const val TAG = "GroupConversationDetailsViewModel"
         const val MAX_NUMBER_OF_PARTICIPANTS = 4
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -62,6 +62,7 @@ fun GroupConversationOptions(
         state = state,
         onGuestSwitchClicked = viewModel::onGuestUpdate,
         onServiceSwitchClicked = viewModel::onServicesUpdate,
+        onReadReceiptSwitchClicked = viewModel::onReadReceiptUpdate,
         lazyListState = lazyListState,
         onEditGroupName = viewModel::navigateToEditGroupName
     )
@@ -85,6 +86,7 @@ fun GroupConversationSettings(
     state: GroupConversationOptionsState,
     onGuestSwitchClicked: (Boolean) -> Unit,
     onServiceSwitchClicked: (Boolean) -> Unit,
+    onReadReceiptSwitchClicked: (Boolean) -> Unit,
     onEditGroupName: () -> Unit,
     lazyListState: LazyListState = rememberLazyListState(),
 ) {
@@ -120,6 +122,15 @@ fun GroupConversationSettings(
                     onCheckedChange = onServiceSwitchClicked
                 )
             }
+        }
+        item { FolderHeader(name = stringResource(id = R.string.folder_label_messaging))}
+        item {
+            ReadReceiptOption(
+                isSwitchEnabled = state.isUpdatingReadReceiptAllowed,
+                switchState = state.isReadReceiptAllowed,
+                isLoading = state.loadingReadReceiptOption,
+                onCheckedChange = onReadReceiptSwitchClicked
+            )
         }
         item {
             ConversationProtocolDetails(
@@ -233,6 +244,24 @@ private fun ServicesOption(
 }
 
 @Composable
+private fun ReadReceiptOption(
+    isSwitchEnabled: Boolean,
+    switchState: Boolean,
+    isLoading: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    GroupOptionWithSwitch(
+        switchClickable = isSwitchEnabled,
+        switchVisible = isSwitchEnabled,
+        switchState = switchState,
+        isLoading = isLoading,
+        onClick = onCheckedChange,
+        title = R.string.conversation_options_read_receipt_label,
+        subTitle = R.string.conversation_options_read_receipt_description
+    )
+}
+
+@Composable
 private fun GroupOptionWithSwitch(
     switchState: Boolean,
     switchClickable: Boolean,
@@ -307,7 +336,7 @@ fun PreviewAdminTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = true
         ),
-        {}, {}, { }
+        {}, {}, { }, {}
     )
 }
 
@@ -324,7 +353,7 @@ fun PreviewGuestAdminTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = false
         ),
-        {}, {}, { }
+        {}, {}, { }, {}
     )
 }
 
@@ -341,7 +370,7 @@ fun PreviewMemberTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = false
         ),
-        {}, {}, { }
+        {}, {}, { }, {}
     )
 }
 
@@ -354,7 +383,7 @@ fun PreviewNormalGroupConversationOptions() {
             groupName = "Normal Group Conversation",
             areAccessOptionsAvailable = false
         ),
-        {}, {}, { }
+        {}, {}, { }, {}
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -123,7 +123,7 @@ fun GroupConversationSettings(
                 )
             }
         }
-        item { FolderHeader(name = stringResource(id = R.string.folder_label_messaging))}
+        item { FolderHeader(name = stringResource(id = R.string.folder_label_messaging)) }
         item {
             ReadReceiptOption(
                 isSwitchEnabled = state.isUpdatingReadReceiptAllowed,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -31,12 +31,15 @@ data class GroupConversationOptionsState(
     val areAccessOptionsAvailable: Boolean = false,
     val isGuestAllowed: Boolean = false,
     val isServicesAllowed: Boolean = false,
+    val isReadReceiptAllowed: Boolean = false,
     val isUpdatingAllowed: Boolean = false,
     val isUpdatingGuestAllowed: Boolean = false,
+    val isUpdatingReadReceiptAllowed: Boolean = false,
     val changeGuestOptionConfirmationRequired: Boolean = false,
     val changeServiceOptionConfirmationRequired: Boolean = false,
     val loadingGuestOption: Boolean = false,
     val loadingServicesOption: Boolean = false,
+    val loadingReadReceiptOption: Boolean = false,
     val error: Error = Error.None,
 ) {
 
@@ -44,5 +47,6 @@ data class GroupConversationOptionsState(
         object None : Error
         class UpdateGuestError(val cause: CoreFailure) : Error
         class UpdateServicesError(val cause: CoreFailure) : Error
+        class UpdateReadReceiptError(val cause: CoreFailure) : Error
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="label_disable">Disable</string>
     <string name="folder_label_access">Access</string>
     <string name="folder_label_protocol_details">Protocol details (beta)</string>
+    <string name="folder_label_messaging">Messaging</string>
     <string name="label_user_blocked">Blocked</string>
     <string name="label_and">and</string>
     <string name="label_retry">Retry</string>
@@ -381,6 +382,8 @@
     <string name="delete_group_conversation_menu_item">Delete Group…</string>
     <string name="delete_group_conversation_dialog_title">Remove “%s”?</string>
     <string name="delete_group_conversation_dialog_description">The group will be removed from your conversations list on all devices. You will no longer be able to access the group and its content.</string>
+    <string name="conversation_options_read_receipt_label">Read receipts</string>
+    <string name="conversation_options_read_receipt_description">When this is on, people can see when their messages in this conversation are read.</string>
     <!-- Messages -->
     <string name="message_details_title">Message Details</string>
     <string name="message_details_reactions_tab">REACTIONS (%s)</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -42,11 +42,13 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
+import com.wire.kalium.logic.feature.conversation.ConversationUpdateReceiptModeResult
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
@@ -414,6 +416,36 @@ class GroupConversationDetailsViewModelTest {
         assertEquals(expected, viewModel.conversationSheetContent)
     }
 
+    @Test
+    fun `given receipt mode value enabled, when updating receipt mode, then value is propagated to screen state`() = runTest {
+        // given
+        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+            .withUpdateConversationReceiptModeReturningSuccess()
+            .arrange()
+        val receiptModeEnabled = true
+
+        // when
+        viewModel.onReadReceiptUpdate(enableReadReceipt = receiptModeEnabled)
+
+        // then
+        assertEquals(receiptModeEnabled, viewModel.groupOptionsState.value.isReadReceiptAllowed)
+    }
+
+    @Test
+    fun `given receipt mode value disabled, when updating receipt mode, then value is propagated to screen state`() = runTest {
+        // given
+        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+            .withUpdateConversationReceiptModeReturningSuccess()
+            .arrange()
+        val receiptModeEnabled = false
+
+        // when
+        viewModel.onReadReceiptUpdate(enableReadReceipt = receiptModeEnabled)
+
+        // then
+        assertEquals(receiptModeEnabled, viewModel.groupOptionsState.value.isReadReceiptAllowed)
+    }
+
     companion object {
         val dummyConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
         val testGroup = ConversationDetails.Group(
@@ -480,6 +512,9 @@ internal class GroupConversationDetailsViewModelArrangement {
     lateinit var clearConversationContentUseCase: ClearConversationContentUseCase
 
     @MockK
+    lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
+
+    @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     private val conversationDetailsChannel = Channel<ConversationDetails>(capacity = Channel.UNLIMITED)
@@ -500,7 +535,8 @@ internal class GroupConversationDetailsViewModelArrangement {
             savedStateHandle = savedStateHandle,
             qualifiedIdMapper = qualifiedIdMapper,
             updateConversationMutedStatus = updateConversationMutedStatus,
-            clearConversationContent = clearConversationContentUseCase
+            clearConversationContent = clearConversationContentUseCase,
+            updateConversationReceiptMode = updateConversationReceiptMode
         )
     }
 
@@ -544,6 +580,10 @@ internal class GroupConversationDetailsViewModelArrangement {
 
     suspend fun withSelfTeamUseCaseReturns(result: Team?) = apply {
         coEvery { getSelfTeamUseCase() } returns flowOf(result)
+    }
+
+    suspend fun withUpdateConversationReceiptModeReturningSuccess() = apply {
+        coEvery { updateConversationReceiptMode(any(), any()) } returns ConversationUpdateReceiptModeResult.Success
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -419,7 +419,7 @@ class GroupConversationDetailsViewModelTest {
     @Test
     fun `given receipt mode value enabled, when updating receipt mode, then value is propagated to screen state`() = runTest {
         // given
-        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+        val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()
             .withUpdateConversationReceiptModeReturningSuccess()
             .arrange()
         val receiptModeEnabled = true
@@ -429,12 +429,18 @@ class GroupConversationDetailsViewModelTest {
 
         // then
         assertEquals(receiptModeEnabled, viewModel.groupOptionsState.value.isReadReceiptAllowed)
+        coVerify(exactly = 1) {
+            arrangement.updateConversationReceiptMode(
+                conversationId = any(),
+                receiptMode = Conversation.ReceiptMode.ENABLED
+            )
+        }
     }
 
     @Test
     fun `given receipt mode value disabled, when updating receipt mode, then value is propagated to screen state`() = runTest {
         // given
-        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+        val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()
             .withUpdateConversationReceiptModeReturningSuccess()
             .arrange()
         val receiptModeEnabled = false
@@ -444,6 +450,12 @@ class GroupConversationDetailsViewModelTest {
 
         // then
         assertEquals(receiptModeEnabled, viewModel.groupOptionsState.value.isReadReceiptAllowed)
+        coVerify(exactly = 1) {
+            arrangement.updateConversationReceiptMode(
+                conversationId = any(),
+                receiptMode = Conversation.ReceiptMode.DISABLED
+            )
+        }
     }
 
     companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2451 - Admin panel: turn read receipts on/off](https://wearezeta.atlassian.net/browse/AR-2451)

### Issues

There was no way of updating conversation read receipt mode.

### Solutions

Creation of `UpdateConversationReceiptModeUseCase` to update conversation read receipt mode both locally and remotely.

### Dependencies (Optional)

Needs releases with:

- [X] [feat: group panel read receipt toggle #1420](https://github.com/wireapp/kalium/pull/1420)

### Testing

#### How to Test

- Open App
- Open Group Conversation you are an admin
- Open Group Settings and toggle Read Receipt ON or OFF
- Should reflect changes in web and in AR you will also see a system message.

### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5890660/215533631-ba3d4ed0-97dc-4401-bef1-06be7b66c791.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/5890660/215533638-426ab6ac-6a90-4d72-8660-6e1b11ba3985.png" width="200" height="400" />
