### PR TITLE
fix(rc): saving files to downloads folder and empty asset names on older Androids [AR-2985] [AR-2984]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
     <uses-permission
             android:name="android.permission.READ_EXTERNAL_STORAGE"
             android:maxSdkVersion="32"/>
+    <uses-permission
+            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+            android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -21,12 +21,12 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.util.permission.rememberWriteStorageRequestFlow
 import com.wire.kalium.logic.util.fileExtension
 import okio.Path
 
@@ -37,13 +37,16 @@ fun DownloadedAssetDialog(
     onOpenFileWithExternalApp: (Path, String?) -> Unit,
     hideOnAssetDownloadedDialog: () -> Unit
 ) {
-    val context = LocalContext.current
-
     if (downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed) {
         val assetName = downloadedAssetDialogState.assetName
         val assetDataPath = downloadedAssetDialogState.assetDataPath
         val assetSize = downloadedAssetDialogState.assetSize
         val messageId = downloadedAssetDialogState.messageId
+
+        val onSaveFileWriteStorageRequest = rememberWriteStorageRequestFlow(
+            onGranted = { onSaveFileToExternalStorage(assetName, assetDataPath, assetSize, messageId) },
+            onDenied = { /** TODO: Show a dialog rationale explaining why the permission is needed **/ }
+        )
 
         WireDialog(
             title = assetName,
@@ -58,7 +61,7 @@ fun DownloadedAssetDialog(
             optionButton1Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_save_text),
                 type = WireDialogButtonType.Primary,
-                onClick = { onSaveFileToExternalStorage(assetName, assetDataPath, assetSize, messageId) }
+                onClick = onSaveFileWriteStorageRequest::launch
             ),
             dismissButtonProperties = WireDialogButtonProperties(
                 text = stringResource(R.string.label_cancel),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -168,9 +168,9 @@ class ConversationMessagesViewModel @Inject constructor(
     fun onSaveFile(assetName: String, assetDataPath: Path, assetSize: Long, messageId: String) {
         viewModelScope.launch {
             withContext(dispatchers.io()) {
-                fileManager.saveToExternalStorage(assetName, assetDataPath, assetSize) {
+                fileManager.saveToExternalStorage(assetName, assetDataPath, assetSize) { savedFileName: String? ->
                     updateAssetMessageDownloadStatus(Message.DownloadStatus.SAVED_EXTERNALLY, conversationId, messageId)
-                    onFileSavedToExternalStorage(assetName)
+                    onFileSavedToExternalStorage(savedFileName)
                     hideOnAssetDownloadedDialog()
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
+import com.wire.android.util.permission.rememberWriteStorageRequestFlow
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +58,14 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
     val uiState = mediaGalleryViewModel.mediaGalleryViewState
     val mediaGalleryScreenState = rememberMediaGalleryScreenState()
     val scope = rememberCoroutineScope()
+
+    val onSaveImageWriteStorageRequest = rememberWriteStorageRequestFlow(
+        onGranted = {
+            mediaGalleryScreenState.showContextualMenu(false)
+            mediaGalleryViewModel.saveImageToExternalStorage()
+        }, onDenied = {
+            // TODO
+        })
 
     with(uiState) {
         MenuModalSheetLayout(
@@ -67,10 +76,7 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
                     mediaGalleryScreenState.showContextualMenu(false)
                     mediaGalleryViewModel.deleteCurrentImage()
                 },
-                onDownloadImage = {
-                    mediaGalleryScreenState.showContextualMenu(false)
-                    mediaGalleryViewModel.saveImageToExternalStorage()
-                }
+                onDownloadImage = onSaveImageWriteStorageRequest::launch
             ),
             content = {
                 Scaffold(
@@ -151,8 +157,6 @@ private fun getSnackbarMessage(messageCode: MediaGallerySnackbarMessages, resour
     }
     return msg to actionLabel
 }
-
-
 
 @Composable
 fun EditGalleryMenuItems(

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -36,7 +36,6 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.getCurrentParsedDateTime
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -59,7 +58,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MediaGalleryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val wireSessionImageLoader: WireSessionImageLoader,
+    wireSessionImageLoader: WireSessionImageLoader,
     qualifiedIdMapper: QualifiedIdMapper,
     private val navigationManager: NavigationManager,
     private val getConversationDetails: ObserveConversationDetailsUseCase,
@@ -123,7 +122,7 @@ class MediaGalleryViewModel @Inject constructor(
                 val imageData = getImageData(imageAssetId.conversationId, imageAssetId.messageId).await()
                 if (imageData is Success) {
                     fileManager.saveToExternalStorage(imageData.assetName, imageData.decodedAssetPath, imageData.assetSize) {
-                        onImageSavedToExternalStorage()
+                        onImageSavedToExternalStorage(it)
                     }
                 } else {
                     onSaveError()
@@ -138,8 +137,8 @@ class MediaGalleryViewModel @Inject constructor(
         }
     }
 
-    private fun onImageSavedToExternalStorage() {
-        onSnackbarMessage(MediaGallerySnackbarMessages.OnImageDownloaded())
+    private fun onImageSavedToExternalStorage(fileName: String?) {
+        onSnackbarMessage(MediaGallerySnackbarMessages.OnImageDownloaded(fileName))
     }
 
     internal fun onSaveError() {

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -36,10 +36,12 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
         assetName: String,
         assetDataPath: Path,
         assetDataSize: Long,
-        onFileSaved: suspend () -> Unit
-    ) {
+        dispatcher: DispatcherProvider = DefaultDispatcherProvider(),
+        onFileSaved: suspend (String?) -> Unit
+    ): Unit = withContext(dispatcher.io()) {
         saveFileToDownloadsFolder(assetName, assetDataPath, assetDataSize, context)
-        onFileSaved()
+            ?.let { context.getFileName(it) }
+            .also { onFileSaved(it) }
     }
 
     fun openWithExternalApp(assetDataPath: Path, assetExtension: String?, onError: () -> Unit) {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -29,6 +29,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.os.Environment
 import android.os.Environment.DIRECTORY_DOWNLOADS
 import android.provider.MediaStore
 import android.provider.OpenableColumns
@@ -36,12 +37,15 @@ import android.provider.Settings
 import android.webkit.MimeTypeMap
 import androidx.annotation.AnyRes
 import androidx.annotation.NonNull
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.FileProvider
 import com.wire.android.appLogger
 import com.wire.android.util.ImageUtil.ImageSizeClass
 import com.wire.android.util.ImageUtil.ImageSizeClass.Medium
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.util.buildFileName
+import com.wire.kalium.logic.util.splitFileExtensionAndCopyCounter
 import kotlinx.coroutines.withContext
 import okio.Path
 import okio.Path.Companion.toPath
@@ -93,14 +97,18 @@ private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedD
     val resolver = contentResolver
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, assetName)
+            // ContentResolver modifies the name if another file with the given name already exists, so we don't have to worry about it
+            put(MediaStore.MediaColumns.DISPLAY_NAME, assetName.ifEmpty { ATTACHMENT_FILENAME })
             put(MediaStore.MediaColumns.MIME_TYPE, Uri.parse(downloadedDataPath.toString()).getMimeType(this@saveFileDataToDownloadsFolder))
             put(MediaStore.MediaColumns.SIZE, fileSize)
         }
         resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
     } else {
         val authority = getProviderAuthority()
-        val destinationFile = File(getExternalFilesDir(DIRECTORY_DOWNLOADS), assetName)
+        val downloadsDir = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS)
+        // we need to find the next available name with copy counter by ourselves before copying
+        val availableAssetName = findFirstUniqueName(downloadsDir, assetName.ifEmpty { ATTACHMENT_FILENAME })
+        val destinationFile = File(downloadsDir, availableAssetName)
         FileProvider.getUriForFile(this, authority, destinationFile)
     }?.also { downloadedUri ->
         resolver.openOutputStream(downloadedUri).use { outputStream ->
@@ -176,9 +184,8 @@ fun Context.startFileShareIntent(path: String) {
     startActivity(shareIntent)
 }
 
-fun saveFileToDownloadsFolder(assetName: String, assetDataPath: Path, assetDataSize: Long, context: Context) {
+fun saveFileToDownloadsFolder(assetName: String, assetDataPath: Path, assetDataSize: Long, context: Context): Uri? =
     context.saveFileDataToDownloadsFolder(assetName, assetDataPath, assetDataSize)
-}
 
 fun Context.multipleFileSharingIntent(uris: ArrayList<Uri>): Intent {
 
@@ -264,8 +271,19 @@ fun Context.getGitBuildId(): String = runCatching {
     }
 }.getOrDefault("")
 
-fun Context.getProviderAuthority() = "${packageName}.provider"
+fun Context.getProviderAuthority() = "$packageName.provider"
 
-private const val TEMP_IMG_ATTACHMENT_FILENAME = "temp_img_attachment.jpg"
-private const val TEMP_VIDEO_ATTACHMENT_FILENAME = "temp_video_attachment.mp4"
+@VisibleForTesting
+fun findFirstUniqueName(dir: File, desiredName: String): String {
+    var currentName: String = desiredName
+    while (File(dir, currentName).exists()) {
+        val (nameWithoutCopyCounter, copyCounter, extension) = currentName.splitFileExtensionAndCopyCounter()
+        currentName = buildFileName(nameWithoutCopyCounter, extension, copyCounter + 1)
+    }
+    return currentName
+}
+
+private const val ATTACHMENT_FILENAME = "attachment"
+private const val TEMP_IMG_ATTACHMENT_FILENAME = "image_attachment.jpg"
+private const val TEMP_VIDEO_ATTACHMENT_FILENAME = "video_attachment.mp4"
 private const val DATA_COPY_BUFFER_SIZE = 2048

--- a/app/src/main/kotlin/com/wire/android/util/permission/WriteStorageRequestFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/WriteStorageRequestFlow.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.util.permission
+
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.content.Context
+import android.os.Build
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.wire.android.util.extension.checkPermission
+
+class WriteStorageRequestFlow(
+    private val context: Context,
+    private val actionIfAlreadyGranted: () -> Unit,
+    private val accessFilePermissionLauncher: ManagedActivityResultLauncher<String, Boolean>
+) {
+    fun launch() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            if (context.checkPermission(WRITE_EXTERNAL_STORAGE)) {
+                actionIfAlreadyGranted()
+            } else {
+                accessFilePermissionLauncher.launch(WRITE_EXTERNAL_STORAGE)
+            }
+        } else {
+            actionIfAlreadyGranted()
+        }
+    }
+}
+
+@Composable
+fun rememberWriteStorageRequestFlow(onGranted: () -> Unit, onDenied: () -> Unit): WriteStorageRequestFlow {
+    val context = LocalContext.current
+    val requestWriteStoragePermissionLauncher: ManagedActivityResultLauncher<String, Boolean> =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) onGranted()
+            else onDenied()
+        }
+    return remember { WriteStorageRequestFlow(context, onGranted, requestWriteStoragePermissionLauncher) }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -160,7 +160,7 @@ class ConversationMessagesViewModelArrangement {
         messageId: String
     ) = apply {
         viewModel.showOnAssetDownloadedDialog(assetName, assetDataPath, assetSize, messageId)
-        coEvery { fileManager.saveToExternalStorage(any(), any(), any(), any()) }.answers {
+        coEvery { fileManager.saveToExternalStorage(any(), any(), any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -91,7 +91,7 @@ class ConversationMessagesViewModelTest {
             viewModel.onSaveFile(assetName, assetDataPath, 1L, messageId)
 
             // Then
-            coVerify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any(), any()) }
+            coVerify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any(), any(), any()) }
             assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.Hidden)
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -103,7 +103,7 @@ class MediaGalleryViewModelTest {
         // Then
         coVerify(exactly = 1) {
             arrangement.getImageData.invoke(mockedConversation.conversation.id, viewModel.imageAssetId.messageId)
-            arrangement.fileManager.saveToExternalStorage(any(), dummyDataPath, mockedImage.size.toLong(), any())
+            arrangement.fileManager.saveToExternalStorage(any(), dummyDataPath, mockedImage.size.toLong(), any(), any())
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.util
+
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class FileUtilTest {
+
+    @TempDir
+    val tempDir = File("temp-dir")
+
+    @Test
+    fun `given file does not exist when finding first unique name in directory then return this name`() {
+        val desired = "abc.jpg"
+        val expected = "abc.jpg"
+
+        val result = findFirstUniqueName(tempDir, desired)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given file already exists when finding unique name in directory then return next available name`() {
+        File(tempDir, "abc.jpg").createNewFile()
+        val desired = "abc.jpg"
+        val expected = "abc (1).jpg"
+
+        val result = findFirstUniqueName(tempDir, desired)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given file and its copies already exist when finding unique name in directory then return next available name`() {
+        File(tempDir, "abc.jpg").createNewFile()
+        File(tempDir, "abc (1).jpg").createNewFile()
+        File(tempDir, "abc (2).jpg").createNewFile()
+        val desired = "abc.jpg"
+        val expected = "abc (3).jpg"
+
+        val result = findFirstUniqueName(tempDir, desired)
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2985" title="AR-2985" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2985</a>  Can't save files on android 9
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Copy of already approved one for `develop`: https://github.com/wireapp/wire-android-reloaded/pull/1386

### Issues

- Crash when saving files. [AR-2984](https://wearezeta.atlassian.net/browse/AR-2984)
- Not possible to save files on Android 9. [AR-2985](https://wearezeta.atlassian.net/browse/AR-2985)

### Causes (Optional)

- Crash is probably because of the empty asset name, it would explain why there's an error saying that it's a directory and not a file. Asset names actually are only optional so it can happen.
- For Android older than Q (29), we get downloads directory as `getExternalFilesDir(DIRECTORY_DOWNLOADS)` but this actually creates "downloads" directory inside the private "files" directory for our app instead of returning the public "downloads" folder.
Another thing it that on newer Androids, system automatically handles the case of duplicates, so if you want to add to "downloads" a file that already exists, it will rename it so you can have both, but on older versions we need to do it ourselves otherwise the file will be overwritten.


### Solutions

- Provide some generic file name "attachment" when the asset name is empty.
- Use `Environment.getExternalStoragePublicDirectory` instead to get the public "downloads" directory.
- Ask for `WRITE_EXTERNAL_STORAGE` permission.
- Check and find an unique name if the file already exists in the given directory to not overwrite - add copy counter to the file name like this: `filename (2).jpg`.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/1435

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Try to save attachment to the "downloads" directory on Android 9.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[AR-2984]: https://wearezeta.atlassian.net/browse/AR-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2985]: https://wearezeta.atlassian.net/browse/AR-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ