### PR TITLE
fix: crash when starting a foreground service(AR-3028)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -53,9 +53,7 @@ class NotificationChannelsManager @Inject constructor(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
         // creating regular NotificationChannels, that are common for all users and shouldn't be grouped.
-        createRegularChannel(NotificationConstants.OTHER_CHANNEL_ID, NotificationConstants.OTHER_CHANNEL_NAME)
         createRegularChannel(NotificationConstants.WEB_SOCKET_CHANNEL_ID, NotificationConstants.WEB_SOCKET_CHANNEL_NAME)
-        createRegularChannel(NotificationConstants.MESSAGE_SYNC_CHANNEL_ID, NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME)
 
         // creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
         allUsers.forEach { user ->
@@ -134,7 +132,7 @@ class NotificationChannelsManager @Inject constructor(
         notificationManagerCompat.createNotificationChannel(notificationChannel)
     }
 
-    private fun createRegularChannel(channelId: String, channelName: String) {
+    fun createRegularChannel(channelId: String, channelName: String) {
         val notificationChannel = NotificationChannelCompat
             .Builder(channelId, NotificationManagerCompat.IMPORTANCE_HIGH)
             .setName(channelName)
@@ -142,6 +140,8 @@ class NotificationChannelsManager @Inject constructor(
 
         notificationManagerCompat.createNotificationChannel(notificationChannel)
     }
+
+    fun shouldCreateChannel(channelId: String): Boolean = notificationManagerCompat.getNotificationChannel(channelId) == null
 
     /**
      * Tricky bug: No documentation whatsoever, but these values affect how the system cancels or not the vibration of the notification
@@ -153,6 +153,6 @@ class NotificationChannelsManager @Inject constructor(
     companion object {
         private fun getChanelGroupNameForUser(userName: String): String = userName
 
-        private const val TAG = "NotificationChannelsManager"
+        const val TAG = "NotificationChannelsManager"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -78,11 +78,11 @@ class OngoingCallService : Service() {
 
             scope.launch {
                 coreLogic.getSessionScope(userId).calls.establishedCall().collect { establishedCall ->
-                        if (establishedCall.isEmpty()) {
-                            appLogger.i("$TAG: stopSelf. Reason: call was ended")
-                            stopSelf()
-                        }
+                    if (establishedCall.isEmpty()) {
+                        appLogger.i("$TAG: stopSelf. Reason: call was ended")
+                        stopSelf()
                     }
+                }
             }
 
             generateForegroundNotification(callName, conversationIdString, userId)

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -26,6 +26,7 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.migration.MigrationManager
+import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.workmanager.worker.MigrationWorker
 import com.wire.android.workmanager.worker.NotificationFetchWorker
@@ -38,6 +39,7 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 class WireWorkerFactory @Inject constructor(
     private val wireNotificationManager: WireNotificationManager,
+    private val notificationChannelsManager: NotificationChannelsManager,
     private val migrationManager: MigrationManager,
     @KaliumCoreLogic
     private val coreLogic: CoreLogic
@@ -49,11 +51,10 @@ class WireWorkerFactory @Inject constructor(
                 WrapperWorkerFactory(coreLogic, WireForegroundNotificationDetailsProvider)
                     .createWorker(appContext, workerClassName, workerParameters)
             NotificationFetchWorker::class.java.canonicalName ->
-                NotificationFetchWorker(appContext, workerParameters, wireNotificationManager)
+                NotificationFetchWorker(appContext, workerParameters, wireNotificationManager, notificationChannelsManager)
             MigrationWorker::class.java.canonicalName ->
-                MigrationWorker(appContext, workerParameters, migrationManager)
+                MigrationWorker(appContext, workerParameters, migrationManager, notificationChannelsManager)
             else -> null
         }
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -27,6 +27,8 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.wire.android.R
+import com.wire.android.appLogger
+import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.WireNotificationManager
 import dagger.assisted.Assisted
@@ -40,6 +42,7 @@ class NotificationFetchWorker
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wireNotificationManager: WireNotificationManager,
+    private val notificationChannelsManager: NotificationChannelsManager
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         const val USER_ID_INPUT_DATA = "worker_user_id_input_data"
@@ -55,6 +58,15 @@ class NotificationFetchWorker
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
+
+        if (notificationChannelsManager.shouldCreateChannel(NotificationConstants.MESSAGE_SYNC_CHANNEL_ID)) {
+            appLogger.i("${NotificationChannelsManager.TAG}: creating Message Synchronization notification channel")
+            notificationChannelsManager.createRegularChannel(
+                NotificationConstants.MESSAGE_SYNC_CHANNEL_ID,
+                NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME
+            )
+        }
+
         val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.MESSAGE_SYNC_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon_small)
             .setAutoCancel(true)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3028" title="AR-3028" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3028</a>  Exception android.app.RemoteServiceException:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is crashing when a foreground service starts.

```
Exception android.app.RemoteServiceException: Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: null
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2141)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:237)
  at android.app.ActivityThread.main (ActivityThread.java:8016)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1076)
```

### Causes (Optional)

This is happening because we are starting a foreground service(that will start an ongoing notification) before creating the corresponding notification channel.

Mainly happening in `NotificationFetchWorker` when syncing old messages while the app in the background.

### Solutions

Move channels creation inside `NotificationFetchWorker` and `MigrationWorker` and before passing the notification to the service to be sure that we already have a channel.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Testing it is a bit tricky since you need a Samsung, Huawei or Redmi device and be faster since you need to perform sync before creating the notification channel.

- Make sure that you don't have any notification channel created by going into app info --> notifications
- Don't use the app for some time to be sure that you will have to sync the app on next opening 
- Open and close the app while sync is performing
- The app will crash at that time when it's in background (if not that means `Message Synchronisation` channel is created).

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
