### PR TITLE
fix: [RC] Open conversation on notification tap (AR-2999)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -267,7 +267,8 @@ enum class NavigationItem(
             navDeepLink {
                 uriPattern = "${DeepLinkProcessor.DEEP_LINK_SCHEME}://" +
                         "${DeepLinkProcessor.CONVERSATION_DEEPLINK_HOST}/" +
-                        "{$EXTRA_CONVERSATION_ID}"
+                        "{$EXTRA_CONVERSATION_ID}/" +
+                        "{$EXTRA_USER_ID}"
             }
         ),
         content = { ConversationScreen(backNavArgs = it.navBackStackEntry.savedStateHandle.getBackNavArgs()) },

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -70,7 +70,7 @@ enum class CommentResId(@StringRes val value: Int) {
 fun LocalNotificationConversation.intoNotificationConversation(): NotificationConversation {
 
     val notificationMessages = this.messages.map { it.intoNotificationMessage() }.sortedBy { it.time }
-    val lastMessageTime = this.messages.maxOfOrNull { Instant.parse(it.time).toEpochMilliseconds() } ?: 0
+    val lastMessageTime = this.messages.maxOfOrNull { it.time.toEpochMilliseconds() } ?: 0
 
     return NotificationConversation(
         id = id.toString(),
@@ -85,7 +85,7 @@ fun LocalNotificationConversation.intoNotificationConversation(): NotificationCo
 fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
 
     val notificationMessageAuthor = NotificationMessageAuthor(author.name, null) // TODO image
-    val notificationMessageTime = Instant.parse(time).toEpochMilliseconds()
+    val notificationMessageTime = time.toEpochMilliseconds()
 
     return when (this) {
         is LocalNotificationMessage.Text -> NotificationMessage.Text(

--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -37,7 +37,8 @@ fun messagePendingIntent(context: Context, conversationId: String, userId: Strin
         data = Uri.Builder()
             .scheme(DeepLinkProcessor.DEEP_LINK_SCHEME)
             .authority(DeepLinkProcessor.CONVERSATION_DEEPLINK_HOST)
-            .appendPath(conversationId).appendPath(userId)
+            .appendPath(conversationId)
+            .appendPath(userId)
             .build()
     }
     val requestCode = getRequestCode(conversationId, OPEN_MESSAGE_REQUEST_CODE_PREFIX)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -216,9 +216,9 @@ class WireActivityViewModel @Inject constructor(
 
     fun handleDeepLink(intent: Intent?) {
         intent?.data?.let { deepLink ->
-            viewModelScope.launch {
-                when (val result = deepLinkProcessor(deepLink)) {
-                    is DeepLinkResult.CustomServerConfig -> loadServerConfig(result.url)?.let { serverLinks ->
+            when (val result = deepLinkProcessor(deepLink, viewModelScope)) {
+                is DeepLinkResult.CustomServerConfig -> runBlocking {
+                    loadServerConfig(result.url)?.let { serverLinks ->
                         globalAppState = globalAppState.copy(
                             customBackendDialog = CustomBEDeeplinkDialogState(
                                 shouldShowDialog = true,
@@ -227,50 +227,50 @@ class WireActivityViewModel @Inject constructor(
                         )
                         navigationArguments.put(SERVER_CONFIG_ARG, serverLinks)
                     }
+                }
 
-                    is DeepLinkResult.SSOLogin -> navigationArguments.put(SSO_DEEPLINK_ARG, result)
+                is DeepLinkResult.SSOLogin -> navigationArguments.put(SSO_DEEPLINK_ARG, result)
 
-                    is DeepLinkResult.IncomingCall -> {
-                        if (isLaunchedFromHistory(intent)) {
-                            // We don't need to handle deepLink, if activity was launched from history.
-                            // For example: user opened app by deepLink, then closed it by back button click,
-                            // then open the app from the "Recent Apps"
-                            appLogger.i("IncomingCall deepLink launched from the history")
-                        } else {
-                            navigationArguments.put(INCOMING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
-                        }
+                is DeepLinkResult.IncomingCall -> {
+                    if (isLaunchedFromHistory(intent)) {
+                        // We don't need to handle deepLink, if activity was launched from history.
+                        // For example: user opened app by deepLink, then closed it by back button click,
+                        // then open the app from the "Recent Apps"
+                        appLogger.i("IncomingCall deepLink launched from the history")
+                    } else {
+                        navigationArguments.put(INCOMING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
                     }
+                }
 
-                    is DeepLinkResult.OngoingCall -> {
-                        if (isLaunchedFromHistory(intent)) {
-                            // We don't need to handle deepLink, if activity was launched from history.
-                            // For example: user opened app by deepLink, then closed it by back button click,
-                            // then open the app from the "Recent Apps"
-                            appLogger.i("IncomingCall deepLink launched from the history")
-                        } else {
-                            navigationArguments.put(ONGOING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
-                        }
+                is DeepLinkResult.OngoingCall -> {
+                    if (isLaunchedFromHistory(intent)) {
+                        // We don't need to handle deepLink, if activity was launched from history.
+                        // For example: user opened app by deepLink, then closed it by back button click,
+                        // then open the app from the "Recent Apps"
+                        appLogger.i("IncomingCall deepLink launched from the history")
+                    } else {
+                        navigationArguments.put(ONGOING_CALL_CONVERSATION_ID_ARG, result.conversationsId)
                     }
+                }
 
-                    is DeepLinkResult.OpenConversation -> {
-                        if (isLaunchedFromHistory(intent)) {
-                            appLogger.i("OpenConversation deepLink launched from the history")
-                        } else {
-                            navigationArguments.put(OPEN_CONVERSATION_ID_ARG, result.conversationsId)
-                        }
+                is DeepLinkResult.OpenConversation -> {
+                    if (isLaunchedFromHistory(intent)) {
+                        appLogger.i("OpenConversation deepLink launched from the history")
+                    } else {
+                        navigationArguments.put(OPEN_CONVERSATION_ID_ARG, result.conversationsId)
                     }
+                }
 
-                    is DeepLinkResult.OpenOtherUserProfile -> {
-                        if (isLaunchedFromHistory(intent)) {
-                            appLogger.i("OpenOtherUserProfile deepLink launched from the history")
-                        } else {
-                            navigationArguments.put(OPEN_OTHER_USER_PROFILE_ARG, result.userId)
-                        }
+                is DeepLinkResult.OpenOtherUserProfile -> {
+                    if (isLaunchedFromHistory(intent)) {
+                        appLogger.i("OpenOtherUserProfile deepLink launched from the history")
+                    } else {
+                        navigationArguments.put(OPEN_OTHER_USER_PROFILE_ARG, result.userId)
                     }
+                }
 
-                    DeepLinkResult.Unknown -> {
-                        appLogger.e("unknown deeplink result $result")
-                    }
+                DeepLinkResult.Unknown -> {
+                    appLogger.e("unknown deeplink result $result")
                 }
             }
         }

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.minutes
 
@@ -473,6 +474,7 @@ class WireNotificationManagerTest {
 
     companion object {
         private val TEST_SERVER_CONFIG: ServerConfig = newServerConfig(1)
+        private val TEST_INSTANT = Instant.fromEpochMilliseconds(123_456_789L)
         private val TEST_AUTH_TOKEN = provideAccountInfo()
 
         private fun provideAccountInfo(userId: String = "user_id"): AccountInfo {
@@ -503,7 +505,7 @@ class WireNotificationManagerTest {
         )
 
         private fun provideLocalNotificationMessage(): LocalNotificationMessage = LocalNotificationMessage.Text(
-            LocalNotificationMessageAuthor("author", null), "", "testing text"
+            LocalNotificationMessageAuthor("author", null), TEST_INSTANT, "testing text"
         )
 
         private fun provideUserId() = UserId("value", "domain")

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -412,7 +412,7 @@ class WireActivityViewModelTest {
             mockUri()
             coEvery { currentSessionFlow() } returns flowOf()
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
-            coEvery { deepLinkProcessor(any()) } returns DeepLinkResult.Unknown
+            coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
             coEvery { notificationManager.observeNotificationsAndCallsWhileRunning(any(), any(), any()) } returns Unit
             coEvery { navigationManager.navigate(any()) } returns Unit
             coEvery { observePersistentWebSocketConnectionStatus() } returns
@@ -508,7 +508,7 @@ class WireActivityViewModelTest {
         }
 
         fun withDeepLinkResult(result: DeepLinkResult): Arrangement {
-            coEvery { deepLinkProcessor(any()) } returns result
+            coEvery { deepLinkProcessor(any(), any()) } returns result
             return this
         }
 

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -57,7 +57,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a valid remote config deeplink, returns CustomServerConfig object`() = runTest {
         setupWithRemoteConfigDeeplink(FAKE_REMOTE_SERVER_URL)
-        val result = deepLinkProcessor(uri)
+        val result = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.CustomServerConfig::class.java, result)
         assertEquals(DeepLinkResult.CustomServerConfig(url = FAKE_REMOTE_SERVER_URL), result)
     }
@@ -65,7 +65,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a remote config deeplink with null parameters, returns DeeplinkResult-Unknown `() = runTest {
         setupWithRemoteConfigDeeplink(null)
-        val result = deepLinkProcessor(uri)
+        val result = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.Unknown::class.java, result)
         assertEquals(DeepLinkResult.Unknown, result)
     }
@@ -73,7 +73,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a valid success sso login deeplink, returns SSOLogin-Success object`() = runTest {
         setupWithSSOLoginSuccessDeeplink(FAKE_COOKIE, FAKE_REMOTE_SERVER_ID)
-        val result = deepLinkProcessor(uri)
+        val result = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.SSOLogin.Success::class.java, result)
         assertEquals(DeepLinkResult.SSOLogin.Success(FAKE_COOKIE, FAKE_REMOTE_SERVER_ID), result)
     }
@@ -81,7 +81,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a sso login success deeplink with null parameters, returns SSOLogin-Failure with unknown error`() = runTest {
         setupWithSSOLoginSuccessDeeplink(null, null)
-        val loginSuccessNullResult = deepLinkProcessor(uri)
+        val loginSuccessNullResult = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, loginSuccessNullResult)
         assertEquals(
             DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByCode(SSOFailureCodes.SSOServerErrorCode.UNKNOWN)),
@@ -92,7 +92,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a valid failed sso login deeplink, returns SSOLogin-Failure object`() = runTest {
         setupWithSSOLoginFailureDeeplink(FAKE_ERROR)
-        val result = deepLinkProcessor(uri)
+        val result = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, result)
         assertEquals(DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByLabel(FAKE_ERROR)), result)
     }
@@ -100,7 +100,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a sso login failure deeplink with null parameters, returns SSOLogin-Failure with unknown error`() = runTest {
         setupWithSSOLoginFailureDeeplink(null)
-        val loginFailureNullResult = deepLinkProcessor(uri)
+        val loginFailureNullResult = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, loginFailureNullResult)
         assertEquals(
             DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByCode(SSOFailureCodes.SSOServerErrorCode.UNKNOWN)),
@@ -111,7 +111,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a incoming call deeplink, returns IncomingCall with conversationId`() = runTest {
         setupWithIncomingCallDeepLink()
-        val incomingCallResult = deepLinkProcessor(uri)
+        val incomingCallResult = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.IncomingCall::class.java, incomingCallResult)
         assertEquals(
             DeepLinkResult.IncomingCall(ConversationId("some_value", "some_domain")),
@@ -122,7 +122,7 @@ class DeepLinkProcessorTest {
     @Test
     fun `given a invalid deeplink, returns Unknown object`() = runTest {
         setupWithInvalidDeeplink()
-        val result = deepLinkProcessor(uri)
+        val result = deepLinkProcessor(uri, this)
         assertInstanceOf(DeepLinkResult.Unknown::class.java, result)
         assertEquals(DeepLinkResult.Unknown, result)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2999" title="AR-2999" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2999</a>  Tapping on notification directs user to conversation list screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Tap on notification opens Conversation list, should open Conversation 

### Causes (Optional)

1. After adding notification for multiple accounts: deeplink that is used on notification tap was changed (upended by `userId`) but Deeplink in navigation was not updated 
2. when the app is running deeplink handling became `suspend` and launched in a new coroutine. So when the app checks deeplink handling result it's not updated yet.

### Solutions

1. update Conversation screen deeplink scheme 
2. run deeplink handling in the same coroutine 


