### PR TITLE
fix(rc): perform migration right after the app update [AR-3075]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -151,6 +151,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+                android:name=".migration.UpdateReceiver"
+                android:enabled="true"
+                android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
         <service
                 android:name=".services.PersistentWebSocketService"
                 android:exported="false"/>

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,10 +42,9 @@ class GlobalObserversManager @Inject constructor(
 
     private suspend fun observeAccountsToCreateChannels() {
         coreLogic.getGlobalScope().observeValidAccounts()
-            .onStart { emit(listOf()) }
             .distinctUntilChanged()
             .collect { list ->
-                notificationChannelsManager.createNotificationChannels(list.map { it.first })
+                notificationChannelsManager.createUserNotificationChannels(list.map { it.first })
             }
     }
 

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -1,0 +1,88 @@
+package com.wire.android
+
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.notification.NotificationChannelsManager
+import com.wire.android.notification.WireNotificationManager
+import com.wire.android.services.ServicesManager
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * This is a helper class used to collect the necessary data and perform the actions required in order for the app to function properly,
+ * such as notifications or persistent web socket.
+ */
+@Singleton
+@OptIn(ExperimentalCoroutinesApi::class)
+class GlobalObserversManager @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    private val notificationChannelsManager: NotificationChannelsManager,
+    private val notificationManager: WireNotificationManager,
+    private val servicesManager: ServicesManager,
+    private val navigationManager: NavigationManager
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
+    
+    fun observe() {
+        scope.launch { observeAccountsToCreateChannels() }
+        scope.launch { observePersistentConnectionStatusToRunWebSocketAndNotifications() }
+    }
+
+    private suspend fun observeAccountsToCreateChannels() {
+        coreLogic.getGlobalScope().observeValidAccounts()
+            .onStart { emit(listOf()) }
+            .distinctUntilChanged()
+            .collect { list ->
+                notificationChannelsManager.createNotificationChannels(list.map { it.first })
+            }
+    }
+
+    private suspend fun observePersistentConnectionStatusToRunWebSocketAndNotifications() {
+        coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+            when (result) {
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
+                    appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
+                }
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                    result.persistentWebSocketStatusListFlow.collect { statuses ->
+                        val usersToObserve = statuses
+                            .filter { !it.isPersistentWebSocketEnabled }
+                            .map { it.userId }
+
+                        notificationManager.observeNotificationsAndCallsWhileRunning(
+                            usersToObserve,
+                            scope
+                        ) { call -> openIncomingCall(call.conversationId) }
+
+                        if (statuses.any { it.isPersistentWebSocketEnabled }) {
+                            if (!servicesManager.isPersistentWebSocketServiceRunning()) {
+                                servicesManager.startPersistentWebSocketService()
+                            }
+                        } else {
+                            servicesManager.stopPersistentWebSocketService()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun openIncomingCall(conversationId: ConversationId) {
+        scope.launch {
+            navigationManager.navigate(NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationId))))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -29,8 +29,15 @@ import co.touchlab.kermit.platformLogWriter
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.notification.NotificationChannelsManager
+import com.wire.android.notification.WireNotificationManager
+import com.wire.android.services.ServicesManager
 import com.wire.android.util.DataDogLogger
 import com.wire.android.util.LogFileWriter
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.isGoogleServicesAvailable
 import com.wire.android.util.getGitBuildId
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
@@ -39,27 +46,42 @@ import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // App wide global logger, carefully initialized when our application is "onCreate"
 var appLogger: KaliumLogger = KaliumLogger.disabled()
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidApp
 class WireApplication : Application(), Configuration.Provider {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
-
     @Inject
     lateinit var logFileWriter: LogFileWriter
-
     @Inject
     lateinit var connectionPolicyManager: ConnectionPolicyManager
-
     @Inject
     lateinit var wireWorkerFactory: WireWorkerFactory
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+    @Inject
+    lateinit var notificationChannelsManager: NotificationChannelsManager
+    @Inject
+    lateinit var notificationManager: WireNotificationManager
+    @Inject
+    lateinit var navigationManager: NavigationManager
+    @Inject
+    lateinit var servicesManager: ServicesManager
 
     override fun getWorkManagerConfiguration(): Configuration {
         return Configuration.Builder()
@@ -87,6 +109,8 @@ class WireApplication : Application(), Configuration.Provider {
 
         // TODO: Can be handled in one of Sync steps
         coreLogic.updateApiVersionsScheduler.schedulePeriodicApiVersionUpdate()
+
+        initObservers()
     }
 
     private fun enableStrictMode() {
@@ -110,6 +134,52 @@ class WireApplication : Application(), Configuration.Provider {
                 // .penaltyDeath() TODO: add it later after fixing reported violations
                 .build()
         )
+    }
+
+    private fun initObservers() {
+        MainScope().launch(dispatchers.io()) {
+            coreLogic.getGlobalScope().observeValidAccounts()
+                .onStart { emit(listOf()) }
+                .distinctUntilChanged()
+                .collect { list ->
+                    notificationChannelsManager.createNotificationChannels(list.map { it.first })
+                }
+        }
+        MainScope().launch(dispatchers.io()) {
+            coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+                when (result) {
+                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
+                        appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
+                    }
+                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                        result.persistentWebSocketStatusListFlow.collect { statuses ->
+                            val usersToObserve = statuses
+                                .filter { !it.isPersistentWebSocketEnabled }
+                                .map { it.userId }
+
+                            notificationManager.observeNotificationsAndCallsWhileRunning(
+                                usersToObserve,
+                                MainScope()
+                            ) { call -> openIncomingCall(call.conversationId) }
+
+                            if (statuses.any { it.isPersistentWebSocketEnabled }) {
+                                if (!servicesManager.isPersistentWebSocketServiceRunning()) {
+                                    servicesManager.startPersistentWebSocketService()
+                                }
+                            } else {
+                                servicesManager.stopPersistentWebSocketService()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun openIncomingCall(conversationId: ConversationId) {
+        MainScope().launch {
+            navigationManager.navigate(NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationId))))
+        }
     }
 
     private fun initializeApplicationLoggingFrameworks() {

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -25,7 +25,6 @@ import androidx.work.Data
 import androidx.work.workDataOf
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.migration.failure.MigrationFailure
 import com.wire.android.migration.feature.MigrateActiveAccountsUseCase
 import com.wire.android.migration.feature.MigrateClientsDataUseCase
 import com.wire.android.migration.feature.MigrateConversationsUseCase
@@ -35,16 +34,13 @@ import com.wire.android.migration.feature.MigrateUsersUseCase
 import com.wire.android.migration.util.ScalaDBNameProvider
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.failure.ServerConfigFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.functional.onSuccess
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -96,25 +92,23 @@ class MigrationManager @Inject constructor(
         coroutineScope: CoroutineScope,
         updateProgress: suspend (MigrationData.Progress) -> Unit,
         migrationDispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(2)
-    ): MigrationData.Result {
-        migrateServerConfig().map {
-            appLogger.d("$TAG - Step 1 - Migrating accounts")
-            migrateActiveAccounts(it)
-        }.mapLeft(::migrationFailure)
-            .onSuccess { (migratedAccounts, isFederated) ->
-                updateProgress(MigrationData.Progress(MigrationData.Progress.Type.ACCOUNTS))
-                onAccountsMigrated(migratedAccounts, isFederated, coroutineScope, migrationDispatcher).also {
-                    appLogger.d("User migration done Result $it")
-                }
+    ): MigrationData.Result =
+        migrateServerConfig()
+            .map {
+                appLogger.d("$TAG - Step 1 - Migrating accounts")
+                migrateActiveAccounts(it)
             }
-            .onFailure {
-                if (it != MigrationData.Result.Failure.Type.NO_NETWORK) {
-                    globalDataStore.setMigrationCompleted() // only for network errors we show the info and "retry" button to the user
+            .fold(
+                {
+                    migrationFailure(it)
+                }, { (migratedAccounts, isFederated) ->
+                    updateProgress(MigrationData.Progress(MigrationData.Progress.Type.ACCOUNTS))
+                    onAccountsMigrated(migratedAccounts, isFederated, coroutineScope, migrationDispatcher).also {
+                        appLogger.d("User migration done Result $it")
+                    }
+                    MigrationData.Result.Success
                 }
-                return MigrationData.Result.Failure(it)
-            }
-        return MigrationData.Result.Success
-    }
+            )
 
     private suspend fun onAccountsMigrated(
         migratedAccounts: Map<String, Either<CoreFailure, UserId>>,
@@ -153,13 +147,9 @@ class MigrationManager @Inject constructor(
         return resultAcc.toMap()
     }
 
-    private fun migrationFailure(failure: CoreFailure): MigrationData.Result.Failure.Type = when (failure) {
-        is NetworkFailure.NoNetworkConnection -> MigrationData.Result.Failure.Type.NO_NETWORK
-        is StorageFailure.DataNotFound -> MigrationData.Result.Failure.Type.DATA_NOT_FOUND
-        is ServerConfigFailure.UnknownServerVersion -> MigrationData.Result.Failure.Type.UNKNOWN_SERVER_VERSION
-        is ServerConfigFailure.NewServerVersion -> MigrationData.Result.Failure.Type.TOO_NEW_VERSION
-        is MigrationFailure.InvalidRefreshToken -> MigrationData.Result.Failure.Type.UNKNOWN
-        else -> MigrationData.Result.Failure.Type.UNKNOWN
+    private fun migrationFailure(failure: CoreFailure): MigrationData.Result = when (failure) {
+        is NetworkFailure.NoNetworkConnection -> MigrationData.Result.Failure
+        else -> MigrationData.Result.Success
     }
 
     companion object {
@@ -177,25 +167,9 @@ sealed class MigrationData {
 
     sealed class Result : MigrationData() {
         object Success : Result()
-        data class Failure(val type: Type) : Result() {
-            enum class Type { UNKNOWN_SERVER_VERSION, TOO_NEW_VERSION, DATA_NOT_FOUND, NO_NETWORK, UNKNOWN; }
-            companion object {
-                const val KEY_FAILURE_TYPE = "failure_type"
-            }
-        }
+        object Failure : Result()
     }
 }
-
-fun MigrationData.Result.Failure.Type.toData(): Data = workDataOf(MigrationData.Result.Failure.KEY_FAILURE_TYPE to this.name)
-
-fun Data.getMigrationFailure(): MigrationData.Result.Failure.Type = this.getString(MigrationData.Result.Failure.KEY_FAILURE_TYPE)
-    ?.let {
-        try {
-            MigrationData.Result.Failure.Type.valueOf(it)
-        } catch (e: IllegalArgumentException) {
-            null
-        }
-    } ?: MigrationData.Result.Failure.Type.UNKNOWN
 
 fun MigrationData.Progress.Type.toData(): Data = workDataOf(MigrationData.Progress.KEY_PROGRESS_TYPE to this.name)
 

--- a/app/src/main/kotlin/com/wire/android/migration/UpdateReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/UpdateReceiver.kt
@@ -1,0 +1,40 @@
+package com.wire.android.migration
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.WorkManager
+import com.wire.android.BuildConfig
+import com.wire.android.appLogger
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.workmanager.worker.enqueueMigrationWorker
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class UpdateReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+    @Inject
+    lateinit var migrationManager: MigrationManager
+    @Inject
+    lateinit var workManager: WorkManager
+
+    private val scope by lazy {
+        CoroutineScope(SupervisorJob() + dispatcherProvider.io())
+    }
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        appLogger.i("App updated to ${BuildConfig.VERSION_NAME}")
+        scope.launch {
+            if (migrationManager.shouldMigrate()) {
+                appLogger.i("Migration worker enqueued")
+                workManager.enqueueMigrationWorker()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -67,7 +67,7 @@ class NotificationChannelsManager @Inject constructor(
      * Use it on logout.
      */
     fun deleteChannelGroup(userId: UserId) {
-        appLogger.i("${TAG}: deleting notification channels for ${userId.toString().obfuscateId()} user")
+        appLogger.i("$TAG: deleting notification channels for ${userId.toString().obfuscateId()} user")
         notificationManagerCompat.deleteNotificationChannelGroup(NotificationConstants.getChanelGroupIdForUser(userId))
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -138,8 +138,6 @@ class NotificationChannelsManager @Inject constructor(
         notificationManagerCompat.createNotificationChannel(notificationChannel)
     }
 
-    fun shouldCreateChannel(channelId: String): Boolean = notificationManagerCompat.getNotificationChannel(channelId) == null
-
     /**
      * Tricky bug: No documentation whatsoever, but these values affect how the system cancels or not the vibration of the notification
      * on different Android OS levels, probably channel creation related.

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -48,14 +48,11 @@ class NotificationChannelsManager @Inject constructor(
         )
     }
 
-    fun createNotificationChannels(allUsers: List<SelfUser>) {
-        appLogger.i("${TAG}: creating all the channels for ${allUsers.size} users")
+    // Creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
+    fun createUserNotificationChannels(allUsers: List<SelfUser>) {
+        appLogger.i("${TAG}: creating all the notification channels for ${allUsers.size} users")
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
-        // creating regular NotificationChannels, that are common for all users and shouldn't be grouped.
-        createRegularChannel(NotificationConstants.WEB_SOCKET_CHANNEL_ID, NotificationConstants.WEB_SOCKET_CHANNEL_NAME)
-
-        // creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
         allUsers.forEach { user ->
             val groupId = createNotificationChannelGroup(user.id, user.handle ?: user.name ?: user.id.value)
 

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -33,8 +33,10 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants.PERSISTENT_NOTIFICATION_ID
 import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_ID
+import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_NAME
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -76,6 +78,9 @@ class PersistentWebSocketService : Service() {
 
     @Inject
     lateinit var navigationManager: NavigationManager
+
+    @Inject
+    lateinit var notificationChannelsManager: NotificationChannelsManager
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -135,7 +140,11 @@ class PersistentWebSocketService : Service() {
     }
 
     private fun generateForegroundNotification() {
-        val notification: Notification = Notification.Builder(this, WEB_SOCKET_CHANNEL_ID)
+        if (notificationChannelsManager.shouldCreateChannel(WEB_SOCKET_CHANNEL_ID)) {
+            appLogger.i("${NotificationChannelsManager.TAG}: creating PersistentWebSocketService notification channel")
+            notificationChannelsManager.createRegularChannel(WEB_SOCKET_CHANNEL_ID, WEB_SOCKET_CHANNEL_NAME)
+        }
+        val notification: Notification = NotificationCompat.Builder(this, WEB_SOCKET_CHANNEL_ID)
             .setContentTitle("${resources.getString(R.string.app_name)} ${resources.getString(R.string.settings_service_is_running)}")
             .setSmallIcon(R.drawable.websocket_notification_icon_small)
             .setContentIntent(openAppPendingIntent(this))

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -99,6 +99,7 @@ class PersistentWebSocketService : Service() {
                     is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
                         appLogger.e("Failure while fetching persistent web socket status flow from service")
                     }
+
                     is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
                         result.persistentWebSocketStatusListFlow.collect { statuses ->
 
@@ -140,10 +141,8 @@ class PersistentWebSocketService : Service() {
     }
 
     private fun generateForegroundNotification() {
-        if (notificationChannelsManager.shouldCreateChannel(WEB_SOCKET_CHANNEL_ID)) {
-            appLogger.i("${NotificationChannelsManager.TAG}: creating PersistentWebSocketService notification channel")
-            notificationChannelsManager.createRegularChannel(WEB_SOCKET_CHANNEL_ID, WEB_SOCKET_CHANNEL_NAME)
-        }
+        notificationChannelsManager.createRegularChannel(WEB_SOCKET_CHANNEL_ID, WEB_SOCKET_CHANNEL_NAME)
+
         val notification: Notification = NotificationCompat.Builder(this, WEB_SOCKET_CHANNEL_ID)
             .setContentTitle("${resources.getString(R.string.app_name)} ${resources.getString(R.string.settings_service_is_running)}")
             .setSmallIcon(R.drawable.websocket_notification_icon_small)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -113,7 +113,6 @@ class WireActivityViewModel @Inject constructor(
             }
         }.distinctUntilChanged().flowOn(dispatchers.io()).shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
 
-
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -37,9 +37,6 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.notification.NotificationChannelsManager
-import com.wire.android.notification.WireNotificationManager
-import com.wire.android.services.ServicesManager
 import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialogState
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
@@ -57,8 +54,6 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
-import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
-import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,7 +66,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -86,18 +80,13 @@ class WireActivityViewModel @Inject constructor(
     val currentSessionFlow: CurrentSessionFlowUseCase,
     private val getServerConfigUseCase: GetServerConfigUseCase,
     private val deepLinkProcessor: DeepLinkProcessor,
-    private val notificationManager: WireNotificationManager,
     private val navigationManager: NavigationManager,
     private val authServerConfigProvider: AuthServerConfigProvider,
     private val getSessions: GetSessionsUseCase,
     private val accountSwitch: AccountSwitchUseCase,
-    private val observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase,
     private val migrationManager: MigrationManager,
-    private val servicesManager: ServicesManager,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
-    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
-    private val observeValidAccounts: ObserveValidAccountsUseCase,
-    private val notificationChannelsManager: NotificationChannelsManager
+    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase
 ) : ViewModel() {
 
     private val navigationArguments = mutableMapOf<String, Any>(SERVER_CONFIG_ARG to ServerConfig.DEFAULT)
@@ -129,43 +118,6 @@ class WireActivityViewModel @Inject constructor(
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
 
     init {
-        viewModelScope.launch(dispatchers.io()) {
-            observeValidAccounts()
-                .onStart { emit(listOf()) }
-                .distinctUntilChanged()
-                .collect { list ->
-                    notificationChannelsManager.createNotificationChannels(list.map { it.first })
-                }
-        }
-        viewModelScope.launch(dispatchers.io()) {
-            observePersistentWebSocketConnectionStatus().let { result ->
-                when (result) {
-                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
-                        appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
-                    }
-                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
-                        result.persistentWebSocketStatusListFlow.collect { statuses ->
-                            val usersToObserve = statuses
-                                .filter { !it.isPersistentWebSocketEnabled }
-                                .map { it.userId }
-
-                            notificationManager.observeNotificationsAndCallsWhileRunning(
-                                usersToObserve,
-                                viewModelScope
-                            ) { call -> openIncomingCall(call.conversationId) }
-
-                            if (statuses.any { it.isPersistentWebSocketEnabled }) {
-                                if (!servicesManager.isPersistentWebSocketServiceRunning()) {
-                                    servicesManager.startPersistentWebSocketService()
-                                }
-                            } else {
-                                servicesManager.stopPersistentWebSocketService()
-                            }
-                        }
-                    }
-                }
-            }
-        }
         viewModelScope.launch(dispatchers.io()) {
             observeUserId
                 .flatMapLatest {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
@@ -25,24 +25,27 @@ import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.lifecycle.asFlow
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkRequest.MIN_BACKOFF_MILLIS
 import androidx.work.WorkerParameters
+import androidx.work.await
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.migration.MigrationData
 import com.wire.android.migration.MigrationManager
-import com.wire.android.migration.getMigrationFailure
 import com.wire.android.migration.getMigrationProgress
 import com.wire.android.migration.toData
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.openAppPendingIntent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.coroutineScope
@@ -61,9 +64,9 @@ class MigrationWorker
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result = coroutineScope {
-        when (val migrationResult = migrationManager.migrate(this, { setProgress(it.type.toData()) })) {
+        when (migrationManager.migrate(this, { setProgress(it.type.toData()) })) {
             is MigrationData.Result.Success -> Result.success()
-            is MigrationData.Result.Failure -> Result.failure(migrationResult.type.toData())
+            is MigrationData.Result.Failure -> Result.retry()
         }
     }
 
@@ -86,6 +89,7 @@ class MigrationWorker
             .setContentTitle(applicationContext.getString(R.string.migration_title))
             .setContentText(applicationContext.getString(R.string.migration_message))
             .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setContentIntent(openAppPendingIntent(applicationContext))
             .build()
 
         return ForegroundInfo(NotificationConstants.MIGRATION_NOTIFICATION_ID, notification)
@@ -96,20 +100,30 @@ class MigrationWorker
     }
 }
 
-fun WorkManager.enqueueMigrationWorker(): Flow<MigrationData> {
+suspend fun WorkManager.enqueueMigrationWorker(): Flow<MigrationData> {
     val request = OneTimeWorkRequestBuilder<MigrationWorker>()
         .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
         .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+        .setConstraints(
+            Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+        )
         .build()
-    enqueueUniqueWork(MigrationWorker.NAME, ExistingWorkPolicy.KEEP, request)
+    val isAlreadyRunning = getWorkInfosForUniqueWork(MigrationWorker.NAME).await().let { it.firstOrNull()?.state == WorkInfo.State.RUNNING }
+    enqueueUniqueWork(
+        MigrationWorker.NAME,
+        if (isAlreadyRunning) ExistingWorkPolicy.KEEP else ExistingWorkPolicy.REPLACE,
+        request
+    )
     return getWorkInfosForUniqueWorkLiveData(MigrationWorker.NAME).asFlow().map {
         it.first().let { workInfo ->
             when (workInfo.state) {
                 WorkInfo.State.SUCCEEDED -> MigrationData.Result.Success
-                WorkInfo.State.FAILED -> MigrationData.Result.Failure(workInfo.outputData.getMigrationFailure())
-                WorkInfo.State.CANCELLED -> MigrationData.Result.Failure(workInfo.outputData.getMigrationFailure())
+                WorkInfo.State.FAILED -> MigrationData.Result.Failure
+                WorkInfo.State.CANCELLED -> MigrationData.Result.Failure
                 WorkInfo.State.RUNNING -> MigrationData.Progress(workInfo.progress.getMigrationProgress())
-                WorkInfo.State.ENQUEUED -> null
+                WorkInfo.State.ENQUEUED -> MigrationData.Result.Failure
                 WorkInfo.State.BLOCKED -> null
             }
         }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
@@ -38,7 +38,6 @@ import androidx.work.WorkRequest.MIN_BACKOFF_MILLIS
 import androidx.work.WorkerParameters
 import androidx.work.await
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.migration.MigrationData
 import com.wire.android.migration.MigrationManager
 import com.wire.android.migration.getMigrationProgress
@@ -72,13 +71,10 @@ class MigrationWorker
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
 
-        if (notificationChannelsManager.shouldCreateChannel(NotificationConstants.OTHER_CHANNEL_ID)) {
-            appLogger.i("${NotificationChannelsManager.TAG}: creating Other Essential Actions notification channel")
-            notificationChannelsManager.createRegularChannel(
-                NotificationConstants.OTHER_CHANNEL_ID,
-                NotificationConstants.OTHER_CHANNEL_NAME
-            )
-        }
+        notificationChannelsManager.createRegularChannel(
+            NotificationConstants.OTHER_CHANNEL_ID,
+            NotificationConstants.OTHER_CHANNEL_NAME
+        )
 
         val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.OTHER_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon_small)

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -27,7 +27,6 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.WireNotificationManager
@@ -59,13 +58,10 @@ class NotificationFetchWorker
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
 
-        if (notificationChannelsManager.shouldCreateChannel(NotificationConstants.MESSAGE_SYNC_CHANNEL_ID)) {
-            appLogger.i("${NotificationChannelsManager.TAG}: creating Message Synchronization notification channel")
-            notificationChannelsManager.createRegularChannel(
-                NotificationConstants.MESSAGE_SYNC_CHANNEL_ID,
-                NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME
-            )
-        }
+        notificationChannelsManager.createRegularChannel(
+            NotificationConstants.MESSAGE_SYNC_CHANNEL_ID,
+            NotificationConstants.MESSAGE_SYNC_CHANNEL_NAME
+        )
 
         val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.MESSAGE_SYNC_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon_small)

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -1,0 +1,185 @@
+package com.wire.android
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.config.mockUri
+import com.wire.android.framework.TestUser
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.notification.NotificationChannelsManager
+import com.wire.android.notification.WireNotificationManager
+import com.wire.android.services.ServicesManager
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class GlobalObserversManagerTest {
+
+    @Test
+    fun `given few valid accounts, then notificationChannels creating is called`() {
+        val accs = listOf(
+            TestUser.SELF_USER,
+            TestUser.SELF_USER.copy(id = TestUser.USER_ID.copy(value = "something else"))
+        )
+        val (arrangement, manager) = Arrangement()
+            .withValidAccounts(accs.map { it to null })
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(listOf()) }
+        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(accs) }
+    }
+
+    @Test
+    fun `given a valid account with persistent socket disabled, then listen for notifications and calls for it`() {
+        val statuses = listOf(PersistentWebSocketStatus(TestUser.SELF_USER.id, false))
+        val expectedUserIds = listOf(TestUser.SELF_USER.id)
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
+    }
+
+    @Test
+    fun `given a valid account with persistent socket enabled, then do not listen for notifications and calls for it`() {
+        val statuses = listOf(PersistentWebSocketStatus(TestUser.SELF_USER.id, true))
+        val expectedUserIds = listOf<UserId>()
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
+    }
+
+    @Test
+    fun `given valid accounts, then listen for notifications and calls only for those that have persistent socket disabled`() {
+        val statuses = listOf(
+            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
+            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
+        )
+        val expectedUserIds = listOf(TestUser.SELF_USER.id)
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
+    }
+
+    @Test
+    fun `given valid accounts, all with persistent socket disabled, then stop socket service`() {
+        val statuses = listOf(
+            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
+            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), false)
+        )
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.servicesManager.startPersistentWebSocketService() }
+        coVerify(exactly = 1) { arrangement.servicesManager.stopPersistentWebSocketService() }
+    }
+
+    @Test
+    fun `given valid accounts, at least one with persistent socket enabled, and socket service not running, then start service`() {
+        val statuses = listOf(
+            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
+            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
+        )
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .withIsPersistentWebSocketServiceRunning(false)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.servicesManager.startPersistentWebSocketService() }
+        coVerify(exactly = 0) { arrangement.servicesManager.stopPersistentWebSocketService() }
+    }
+
+    @Test
+    fun `given valid accounts, at least one with persistent socket enabled, and socket service running, then do not start service again`() {
+        val statuses = listOf(
+            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
+            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
+        )
+        val (arrangement, manager) = Arrangement()
+            .withPersistentWebSocketConnectionStatuses(statuses)
+            .withIsPersistentWebSocketServiceRunning(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.servicesManager.startPersistentWebSocketService() }
+        coVerify(exactly = 0) { arrangement.servicesManager.stopPersistentWebSocketService() }
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var coreLogic: CoreLogic
+
+        @MockK
+        lateinit var notificationChannelsManager: NotificationChannelsManager
+
+        @MockK
+        lateinit var notificationManager: WireNotificationManager
+
+        @MockK
+        lateinit var servicesManager: ServicesManager
+
+        @MockK
+        lateinit var navigationManager: NavigationManager
+
+
+        private val manager by lazy {
+            GlobalObserversManager(
+                dispatcherProvider = TestDispatcherProvider(),
+                coreLogic = coreLogic,
+                notificationChannelsManager = notificationChannelsManager,
+                notificationManager = notificationManager,
+                servicesManager = servicesManager,
+                navigationManager = navigationManager
+            )
+        }
+
+        init {
+            // Tests setup
+            MockKAnnotations.init(this, relaxUnitFun = true)
+
+            // Default empty values
+            mockUri()
+
+            coEvery { notificationManager.observeNotificationsAndCallsWhileRunning(any(), any(), any()) } returns Unit
+            coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(listOf())
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(listOf()))
+            every { notificationChannelsManager.createNotificationChannels(any()) } returns Unit
+            every { servicesManager.isPersistentWebSocketServiceRunning() } returns false
+            coEvery { navigationManager.navigate(any()) } returns Unit
+        }
+
+        fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
+            coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(list)
+        }
+
+        fun withPersistentWebSocketConnectionStatuses(list: List<PersistentWebSocketStatus>): Arrangement = apply {
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(list))
+        }
+
+        fun withIsPersistentWebSocketServiceRunning(isRunning: Boolean): Arrangement = apply {
+            every { servicesManager.isPersistentWebSocketServiceRunning() } returns isRunning
+        }
+
+        fun arrange() = this to manager
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class GlobalObserversManagerTest {
 
     @Test
-    fun `given few valid accounts, then notificationChannels creating is called`() {
+    fun `given few valid accounts, then create user-specific notification channels`() {
         val accs = listOf(
             TestUser.SELF_USER,
             TestUser.SELF_USER.copy(id = TestUser.USER_ID.copy(value = "something else"))
@@ -38,8 +38,7 @@ class GlobalObserversManagerTest {
             .withValidAccounts(accs.map { it to null })
             .arrange()
         manager.observe()
-        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(listOf()) }
-        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(accs) }
+        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createUserNotificationChannels(accs) }
     }
 
     @Test
@@ -162,7 +161,7 @@ class GlobalObserversManagerTest {
             coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(listOf())
             coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
                     ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(listOf()))
-            every { notificationChannelsManager.createNotificationChannels(any()) } returns Unit
+            every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
             every { servicesManager.isPersistentWebSocketServiceRunning() } returns false
             coEvery { navigationManager.navigate(any()) } returns Unit
         }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -138,7 +138,6 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var navigationManager: NavigationManager
 
-
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -467,9 +467,7 @@ class WireActivityViewModelTest {
         }
 
         fun arrange() = this to viewModel
-
     }
-
 
     companion object {
         val TEST_ACCOUNT_INFO = AccountInfo.Valid(UserId("user_id", "domain.de"))

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -27,22 +27,16 @@ import com.wire.android.config.mockUri
 import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.di.ObserveSyncStateUseCaseProvider
 import com.wire.android.feature.AccountSwitchUseCase
-import com.wire.android.framework.TestUser
 import com.wire.android.migration.MigrationManager
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.notification.NotificationChannelsManager
-import com.wire.android.notification.WireNotificationManager
-import com.wire.android.services.ServicesManager
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.team.Team
-import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
 import com.wire.kalium.logic.feature.auth.AccountInfo
@@ -51,8 +45,6 @@ import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
-import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
-import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -388,21 +380,6 @@ class WireActivityViewModelTest {
         assertEquals(true, viewModel.globalAppState.updateAppDialog)
     }
 
-    @Test
-    fun `given few valid accounts, then notificationChannels creating is called`() {
-        val accs = listOf(
-            TestUser.SELF_USER,
-            TestUser.SELF_USER.copy(id = TestUser.USER_ID.copy(value = "something else"))
-        )
-        val (arrangement, _) = Arrangement()
-            .withSomeCurrentSession()
-            .withValidAccounts(accs.map { it to null })
-            .arrange()
-
-        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(listOf()) }
-        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createNotificationChannels(accs) }
-    }
-
     private class Arrangement {
         init {
             // Tests setup
@@ -413,19 +390,12 @@ class WireActivityViewModelTest {
             coEvery { currentSessionFlow() } returns flowOf()
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
             coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
-            coEvery { notificationManager.observeNotificationsAndCallsWhileRunning(any(), any(), any()) } returns Unit
             coEvery { navigationManager.navigate(any()) } returns Unit
-            coEvery { observePersistentWebSocketConnectionStatus() } returns
-                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
-                        flowOf(listOf())
-                    )
             coEvery { getSessionsUseCase.invoke() }
             coEvery { migrationManager.shouldMigrate() } returns false
             every { observeSyncStateUseCaseProviderFactory.create(any()).observeSyncState } returns observeSyncStateUseCase
             every { observeSyncStateUseCase() } returns emptyFlow()
             coEvery { observeIfAppUpdateRequired(any()) } returns flowOf(false)
-            every { notificationChannelsManager.createNotificationChannels(any()) } returns Unit
-            coEvery { observeValidAccounts() } returns flowOf(listOf())
         }
 
         @MockK
@@ -438,13 +408,7 @@ class WireActivityViewModelTest {
         lateinit var deepLinkProcessor: DeepLinkProcessor
 
         @MockK
-        lateinit var notificationManager: WireNotificationManager
-
-        @MockK
         lateinit var navigationManager: NavigationManager
-
-        @MockK
-        lateinit var observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase
 
         @MockK
         lateinit var getSessionsUseCase: GetSessionsUseCase
@@ -465,16 +429,7 @@ class WireActivityViewModelTest {
         private lateinit var observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory
 
         @MockK
-        lateinit var servicesManager: ServicesManager
-
-        @MockK
         lateinit var observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase
-
-        @MockK
-        lateinit var observeValidAccounts: ObserveValidAccountsUseCase
-
-        @MockK
-        lateinit var notificationChannelsManager: NotificationChannelsManager
 
         private val viewModel by lazy {
             WireActivityViewModel(
@@ -482,18 +437,13 @@ class WireActivityViewModelTest {
                 currentSessionFlow = currentSessionFlow,
                 getServerConfigUseCase = getServerConfigUseCase,
                 deepLinkProcessor = deepLinkProcessor,
-                notificationManager = notificationManager,
                 navigationManager = navigationManager,
                 authServerConfigProvider = authServerConfigProvider,
-                observePersistentWebSocketConnectionStatus = observePersistentWebSocketConnectionStatus,
                 getSessions = getSessionsUseCase,
                 accountSwitch = switchAccount,
                 migrationManager = migrationManager,
                 observeSyncStateUseCaseProviderFactory = observeSyncStateUseCaseProviderFactory,
-                servicesManager = servicesManager,
-                observeIfAppUpdateRequired = observeIfAppUpdateRequired,
-                observeValidAccounts = observeValidAccounts,
-                notificationChannelsManager = notificationChannelsManager
+                observeIfAppUpdateRequired = observeIfAppUpdateRequired
             )
         }
 
@@ -514,10 +464,6 @@ class WireActivityViewModelTest {
 
         fun withAppUpdateRequired(result: Boolean): Arrangement = apply {
             coEvery { observeIfAppUpdateRequired(any()) } returns flowOf(result)
-        }
-
-        fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
-            coEvery { observeValidAccounts() } returns flowOf(list)
         }
 
         fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3075" title="AR-3075" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3075</a>  Perform migration from scala right after the update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After the app update from the scala to AR, we check and execute the migration process only after the user opens the app (`WireActivityViewModel` checks and opens `MigrationScreen` which schedules the `MigrationWorker`). This creates the situation where if the update happened in the background, the user can even be not aware of that, then he/she won't see any notification until he/she opens the app and completes the migration.

### Solutions

Schedule the migration right after the update, by creating a broadcast receiver which listens to the `MY_PACKAGE_REPLACED` actions. The worker is scheduled in the way that it will retry again if it failed because of the network error but will start only if the connection is restored. The app can be opened even during the migration process - view model listens to the current state of the worker, the user is able also to retry manually the migration if it failed because of the network issue.
Migration worker results are simplified because it returns failure only when there's a network error so now every `Failure` means network problem.
Necessary observers (for notifications and persistent web socket) are moved to a dedicated manager and started in `WireApplication` instead of `WireActivityViewModel` so it doesn't live in a lifecycle of Activity but the whole Application.
Creating a channel for web socket is moved to the service right before creating the notification, so there is no "global" channel that's created independently.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Update the app from the scala to AR and don't open it, the migration should be performed automatically.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/216694259-deea1fdb-0bc0-433f-9aeb-e9f9b3da54fe.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
