### PR TITLE
chore: Add logs when opening MessageDetails screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -200,6 +200,7 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     fun openMessageDetails(messageId: String, isSelfMessage: Boolean) {
+        appLogger.i("[$TAG][openMessageDetails] - isSelfMessage: $isSelfMessage")
         viewModelScope.launch {
             navigationManager.navigate(
                 command = NavigationCommand(
@@ -243,4 +244,8 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     // endregion
+
+    private companion object {
+        const val TAG = "ConversationMessagesViewModel"
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add log to when user opens `MessageDetails` screen in order to be able to use it to show reports of screen usage.
