### PR TITLE
fix: png not showing on web [AR-2925]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import androidx.work.WorkManager
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.util.DeviceLabel
+import com.wire.android.util.ImageUtil
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -98,9 +99,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -896,4 +897,8 @@ class UseCaseModule {
     @Provides
     fun provideResetSessionUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): ResetSessionUseCase =
         coreLogic.getSessionScope(currentAccount).messages.resetSession
+
+    @ViewModelScoped
+    @Provides
+    fun provideImageUtil(): ImageUtil = ImageUtil
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -54,7 +54,6 @@ import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
-import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
@@ -71,14 +70,14 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.functional.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import okio.Path
-import okio.buffer
+import javax.inject.Inject
+import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -211,7 +210,7 @@ class MessageComposerViewModel @Inject constructor(
                             else {
                                 val (imgWidth, imgHeight) =
                                     ImageUtil.extractImageWidthAndHeight(
-                                        kaliumFileSystem.source(attachmentBundle.dataPath).buffer().inputStream(),
+                                        attachmentBundle.dataPath.toString(),
                                         mimeType
                                     )
                                 val result = sendAssetMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -97,7 +97,8 @@ class MessageComposerViewModel @Inject constructor(
     private val updateConversationReadDateUseCase: UpdateConversationReadDateUseCase,
     private val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase,
     private val contactMapper: ContactMapper,
-    private val membersToMention: MembersToMentionUseCase
+    private val membersToMention: MembersToMentionUseCase,
+    private val imageUtil: ImageUtil
 ) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationViewState())
@@ -209,7 +210,7 @@ class MessageComposerViewModel @Inject constructor(
                             if (dataSize > IMAGE_SIZE_LIMIT_BYTES) onSnackbarMessage(ErrorMaxImageSize)
                             else {
                                 val (imgWidth, imgHeight) =
-                                    ImageUtil.extractImageWidthAndHeight(
+                                    imageUtil.extractImageWidthAndHeight(
                                         attachmentBundle.dataPath.toString(),
                                         mimeType
                                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -211,8 +211,8 @@ class MessageComposerViewModel @Inject constructor(
                             else {
                                 val (imgWidth, imgHeight) =
                                     imageUtil.extractImageWidthAndHeight(
-                                        attachmentBundle.dataPath.toString(),
-                                        mimeType
+                                        kaliumFileSystem,
+                                        attachmentBundle.dataPath
                                     )
                                 val result = sendAssetMessage(
                                     conversationId = conversationId,

--- a/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
@@ -28,8 +28,10 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
 import androidx.exifinterface.media.ExifInterface
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import okio.Path
+import okio.buffer
 import java.io.ByteArrayOutputStream
-import java.io.File
 import kotlin.math.ceil
 import kotlin.math.round
 import kotlin.math.sqrt
@@ -49,29 +51,11 @@ object ImageUtil {
     /**
      * Attempts to read the width and height of an image represented by the input parameter
      */
-    fun extractImageWidthAndHeight(path: String, mimeType: String): Pair<Int, Int> {
-        val isAnimated = mimeType.contains("gif") || mimeType.contains("webp")
-        if (isAnimated) {
-            BitmapFactory.decodeStream(File(path).inputStream()).let { bitmap ->
+    fun extractImageWidthAndHeight(kaliumFileSystem: KaliumFileSystem, imageDataPath: Path): Pair<Int, Int> {
+        kaliumFileSystem.source(imageDataPath).buffer().use { bufferedSource ->
+            BitmapFactory.decodeStream(bufferedSource.inputStream()).let { bitmap ->
                 return bitmap.width to bitmap.height
             }
-        } else {
-            val exifInterface = ExifInterface(File(path))
-            // we had a fallback to get the width and height from the file because the ExifInterface is not returning
-            // values after edit some images
-            val exifWidth: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0).let {
-                if (it != 0) {
-                    return@let it
-                }
-                BitmapFactory.decodeFile(path).width
-            }
-            val exifHeight: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0).let {
-                if (it != 0) {
-                    return@let it
-                }
-                BitmapFactory.decodeFile(path).height
-            }
-            return exifWidth to exifHeight
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
@@ -29,7 +29,7 @@ import android.graphics.Matrix
 import android.net.Uri
 import androidx.exifinterface.media.ExifInterface
 import java.io.ByteArrayOutputStream
-import java.io.InputStream
+import java.io.File
 import kotlin.math.ceil
 import kotlin.math.round
 import kotlin.math.sqrt
@@ -49,16 +49,28 @@ object ImageUtil {
     /**
      * Attempts to read the width and height of an image represented by the input parameter
      */
-    fun extractImageWidthAndHeight(imageDataInputStream: InputStream, mimeType: String): Pair<Int, Int> {
+    fun extractImageWidthAndHeight(path: String, mimeType: String): Pair<Int, Int> {
         val isAnimated = mimeType.contains("gif") || mimeType.contains("webp")
         if (isAnimated) {
-            BitmapFactory.decodeStream(imageDataInputStream).let { bitmap ->
+            BitmapFactory.decodeStream(File(path).inputStream()).let { bitmap ->
                 return bitmap.width to bitmap.height
             }
         } else {
-            val exifInterface = ExifInterface(imageDataInputStream)
-            val exifWidth: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0)
-            val exifHeight: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0)
+            val exifInterface = ExifInterface(File(path))
+            // we had a fallback to get the width and height from the file because the ExifInterface is not returning
+            // values after edit some images
+            val exifWidth: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0).let {
+                if (it != 0) {
+                    return@let it
+                }
+                BitmapFactory.decodeFile(path).width
+            }
+            val exifHeight: Int = exifInterface.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0).let {
+                if (it != 0) {
+                    return@let it
+                }
+                BitmapFactory.decodeFile(path).height
+            }
             return exifWidth to exifHeight
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -33,6 +33,7 @@ import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.MessageTime
 import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.util.ImageUtil
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure
@@ -75,8 +76,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
-import okio.Path
-import okio.buffer
 
 internal class ConversationsViewModelArrangement {
 
@@ -151,6 +150,9 @@ internal class ConversationsViewModelArrangement {
     private lateinit var contactMapper: ContactMapper
 
     @MockK
+    private lateinit var imageUtil: ImageUtil
+
+    @MockK
     private lateinit var membersToMention: MembersToMentionUseCase
 
     private val fakeKaliumFileSystem = FakeKaliumFileSystem()
@@ -172,7 +174,8 @@ internal class ConversationsViewModelArrangement {
             observeConversationInteractionAvailability = observeConversationInteractionAvailabilityUseCase,
             observeSecurityClassificationLabel = observeSecurityClassificationType,
             contactMapper = contactMapper,
-            membersToMention = membersToMention
+            membersToMention = membersToMention,
+            imageUtil = imageUtil
         )
     }
 
@@ -180,17 +183,13 @@ internal class ConversationsViewModelArrangement {
         coEvery { isFileSharingEnabledUseCase() } returns FileSharingStatus(null, null)
         coEvery { observeOngoingCallsUseCase() } returns emptyFlow()
         coEvery { observeEstablishedCallsUseCase() } returns emptyFlow()
+        coEvery { observeSecurityClassificationType(any()) } returns emptyFlow()
+        coEvery { imageUtil.extractImageWidthAndHeight(any(), any()) } returns (69 to 420)
         coEvery { observeConversationInteractionAvailabilityUseCase(any()) } returns flowOf(
             IsInteractionAvailableResult.Success(
                 InteractionAvailability.ENABLED
             )
         )
-    }
-
-    fun withStoredAsset(dataPath: Path, dataContent: ByteArray) = apply {
-        fakeKaliumFileSystem.sink(dataPath).buffer().use {
-            it.write(dataContent)
-        }
     }
 
     fun withSuccessfulSendAttachmentMessage() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -76,6 +76,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import okio.Path
+import okio.buffer
 
 internal class ConversationsViewModelArrangement {
 
@@ -184,12 +186,18 @@ internal class ConversationsViewModelArrangement {
         coEvery { observeOngoingCallsUseCase() } returns emptyFlow()
         coEvery { observeEstablishedCallsUseCase() } returns emptyFlow()
         coEvery { observeSecurityClassificationType(any()) } returns emptyFlow()
-        coEvery { imageUtil.extractImageWidthAndHeight(any(), any()) } returns (69 to 420)
+        coEvery { imageUtil.extractImageWidthAndHeight(any(), any()) } returns (1 to 1)
         coEvery { observeConversationInteractionAvailabilityUseCase(any()) } returns flowOf(
             IsInteractionAvailableResult.Success(
                 InteractionAvailability.ENABLED
             )
         )
+    }
+
+    fun withStoredAsset(dataPath: Path, dataContent: ByteArray) = apply {
+        fakeKaliumFileSystem.sink(dataPath).buffer().use {
+            it.write(dataContent)
+        }
     }
 
     fun withSuccessfulSendAttachmentMessage() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -173,6 +173,7 @@ class MessageComposerViewModelTest {
         val assetSize = assetContent.size.toLong()
         val (arrangement, viewModel) = ConversationsViewModelArrangement()
             .withSuccessfulViewModelInit()
+            .withStoredAsset(assetPath, assetContent)
             .withSuccessfulSendAttachmentMessage()
             .arrange()
         val mockedAttachment = AttachmentBundle(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -173,7 +173,6 @@ class MessageComposerViewModelTest {
         val assetSize = assetContent.size.toLong()
         val (arrangement, viewModel) = ConversationsViewModelArrangement()
             .withSuccessfulViewModelInit()
-            .withStoredAsset(assetPath, assetContent)
             .withSuccessfulSendAttachmentMessage()
             .arrange()
         val mockedAttachment = AttachmentBundle(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2925" title="AR-2925" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2925</a>  Png image file not accessible when send from android to web in the latest build
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

PNG not showing on web after sending from Android 

### Causes (Optional)

ExifInterface is not returning the tags after the image got edited so it fallback to default 0

### Solutions

check if the value is 0, so we get the value from BitmapFactory.decodeFile(path).width

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
