### PR TITLE
fix: (dev) call hang up button from notification (AR-2982)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -120,7 +120,7 @@ fun endOngoingCallPendingIntent(context: Context, conversationId: String, userId
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        END_ONGOING_CALL_REQUEST_CODE,
+        getRequestCode(conversationId, END_ONGOING_CALL_REQUEST_CODE),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -131,7 +131,7 @@ fun declineCallPendingIntent(context: Context, conversationId: String, userId: S
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        DECLINE_CALL_REQUEST_CODE,
+        getRequestCode(conversationId, DECLINE_CALL_REQUEST_CODE),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -177,11 +177,11 @@ fun openAppPendingIntent(context: Context): PendingIntent {
 }
 
 private const val MESSAGE_NOTIFICATIONS_SUMMARY_REQUEST_CODE = 0
-private const val DECLINE_CALL_REQUEST_CODE = 1
+private const val DECLINE_CALL_REQUEST_CODE = "decline_call_"
 private const val OPEN_INCOMING_CALL_REQUEST_CODE = 2
 private const val FULL_SCREEN_REQUEST_CODE = 3
 private const val OPEN_ONGOING_CALL_REQUEST_CODE = 4
-private const val END_ONGOING_CALL_REQUEST_CODE = 5
+private const val END_ONGOING_CALL_REQUEST_CODE = "hang_up_call_"
 private const val OPEN_MESSAGE_REQUEST_CODE_PREFIX = "open_message_"
 private const val OPEN_OTHER_USER_PROFILE_CODE_PREFIX = "open_other_user_profile_"
 private const val CALL_REQUEST_CODE_PREFIX = "call_"

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
@@ -58,7 +58,7 @@ class EndOngoingCallReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
-        appLogger.i("CallNotificationDismissReceiver: onReceive, conversationId: $conversationId")
+        appLogger.i("EndOngoingCallReceiver: onReceive, conversationId: $conversationId")
 
         coroutineScope.launch() {
             val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2982" title="AR-2982" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2982</a>  Playtest 20.01 - Hang up button doesn't work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Hang up call button from ongoing call notification doesn't work.

### Causes (Optional)

Static request code for notification action

### Solutions

Make request code for `hang up` and `decline` call in notification dynamic (to include call conversation id) so Android doesn't cache wrong data for ongoing call hang up button.

#### How to Test

- Open App
- Receive/Start Call
- Put App in Background
- Click Hang Up from notification
- Call should end as expected

