### PR TITLE
fix: not receiving messages on second account [AR-2867]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -125,9 +125,9 @@ class ConnectionPolicyManager @Inject constructor(
         userId: UserId
     ) {
         val isAppOnForeground = currentScreenManager.isAppOnForegroundFlow().first()
-        logger.d("$TAG hasInitialisedUI = $isAppOnForeground")
+        logger.d("$TAG isAppOnForeground = $isAppOnForeground")
         if (!isAppOnForeground) {
-            logger.d("$TAG $userId Downgrading policy as conditions to KEEP_ALIVE are not met")
+            logger.d("$TAG ${userId.toString().obfuscateId()} Downgrading policy as conditions to KEEP_ALIVE are not met")
             setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -79,12 +79,11 @@ class ConnectionPolicyManager @Inject constructor(
         CoroutineScope(dispatcherProvider.default()).launch {
             combine(
                 currentScreenManager.isAppOnForegroundFlow(),
-                currentSessionFlow(),
                 migrationManager.isMigrationCompletedFlow(),
-                ::Triple
-            ).collect { (isOnForeground, currentSession, isMigrationCompleted) ->
+                ::Pair
+            ).collect { (isOnForeground, isMigrationCompleted) ->
                 if (isMigrationCompleted)
-                    setPolicyForSessions(allValidSessions(), currentSession, isOnForeground)
+                    setPolicyForSessions(allValidSessions(), isOnForeground)
             }
         }
     }
@@ -125,39 +124,25 @@ class ConnectionPolicyManager @Inject constructor(
     private suspend fun UserSessionScope.downgradePolicyIfNeeded(
         userId: UserId
     ) {
-        val isCurrentSession = isCurrentSession(userId)
         val isAppOnForeground = currentScreenManager.isAppOnForegroundFlow().first()
-        logger.d("isCurrentSession = $isCurrentSession; hasInitialisedUI = $isCurrentSession")
-        val shouldKeepLivePolicy = isCurrentSession && isAppOnForeground
-        if (!shouldKeepLivePolicy) {
-            logger.d("$TAG Downgrading policy as conditions to KEEP_ALIVE are not met")
+        logger.d("$TAG hasInitialisedUI = $isAppOnForeground")
+        if (!isAppOnForeground) {
+            logger.d("$TAG $userId Downgrading policy as conditions to KEEP_ALIVE are not met")
             setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
         }
     }
 
-    private suspend fun isCurrentSession(userId: UserId): Boolean = coroutineScope.async {
-        val isCurrentSession = coreLogic.getGlobalScope().sessionRepository.currentSession().fold({
-            // Assume so in case of failure
-            true
-        }, {
-            it.userId == userId
-        })
-        return@async isCurrentSession
-    }.await()
-
     private suspend fun setPolicyForSessions(
         userIdList: List<QualifiedID>,
-        currentSessionUserId: QualifiedID?,
         wasUIInitialized: Boolean
     ) = userIdList.forEach { userId ->
-        val isCurrentSession = userId == currentSessionUserId
         val isWebSocketEnabled = coreLogic.getSessionScope(userId).getPersistentWebSocketStatus()
-        val connectionPolicy = if (isCurrentSession && wasUIInitialized) {
+        val connectionPolicy = if (wasUIInitialized) {
             ConnectionPolicy.KEEP_ALIVE
         } else {
-            if (!isWebSocketEnabled){
+            if (!isWebSocketEnabled) {
                 ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS
-            }else{
+            } else {
                 ConnectionPolicy.KEEP_ALIVE
             }
         }

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.sync.SyncManager
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
@@ -62,11 +61,10 @@ class ConnectionPolicyManagerTest {
     }
 
     @Test
-    fun givenCurrentlyActiveSessionAndInitialisedUI_whenHandlingPushNotification_thenShouldUpgradePolicyThenWait() = runTest {
+    fun givenInitialisedUI_whenHandlingPushNotification_thenShouldUpgradePolicyThenWait() = runTest {
         val user = USER_ID
 
         val (arrangement, connectionPolicyManager) = Arrangement()
-            .withCurrentSession(user)
             .withAppInTheForeground()
             .arrange()
 
@@ -79,53 +77,16 @@ class ConnectionPolicyManagerTest {
     }
 
     @Test
-    fun givenCurrentlyActiveSessionAndNotInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngrade() = runTest {
+    fun givenNotInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngrade() = runTest {
         val user = USER_ID
 
         val (arrangement, connectionPolicyManager) = Arrangement()
-            .withCurrentSession(user)
             .withAppInTheBackground()
             .arrange()
 
         connectionPolicyManager.handleConnectionOnPushNotification(user)
 
         coVerify(exactly = 1) {
-            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLiveOrFailure()
-            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
-        }
-    }
-
-    @Test
-    fun givenCurrentlyInactiveSessionAndInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngrade() = runTest {
-        val user = USER_ID
-
-        val (arrangement, connectionPolicyManager) = Arrangement()
-            .withCurrentSession(USER_ID_2)
-            .withAppInTheForeground()
-            .arrange()
-
-        connectionPolicyManager.handleConnectionOnPushNotification(user)
-
-        coVerify(exactly = 1) {
-            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
-            arrangement.syncManager.waitUntilLiveOrFailure()
-            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
-        }
-    }
-
-    @Test
-    fun givenNotCurrentAccountAndNotInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngradePolicy() = runTest {
-        val user = USER_ID
-
-        val (arrangement, connectionPolicyManager) = Arrangement()
-            .withCurrentSession(USER_ID_2)
-            .withAppInTheBackground()
-            .arrange()
-
-        connectionPolicyManager.handleConnectionOnPushNotification(user)
-
-        coVerifyOrder {
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
             arrangement.syncManager.waitUntilLiveOrFailure()
             arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2867" title="AR-2867" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2867</a>  Notifications don't show all notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When app is in foreground and we are logged to 2 accounts not current account doesn't receive all notifications

### Solutions

Disable downgrading connection policy by not current account

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test
1. Login in one device to 2 accounts
2. Create group with 3 users
3. Leave app in foreground
4. Type fast few messages from third user on web to group conversation
5. Notifications should contain same messages for both users


### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
