### PR TITLE
fix: animation not smooth when expanding a system message

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -21,7 +21,9 @@
 package com.wire.android.ui.home.conversations
 
 import android.content.res.Resources
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -108,21 +110,26 @@ fun SystemMessageItem(message: SystemMessage) {
         Column {
             val context = LocalContext.current
             var expanded: Boolean by remember { mutableStateOf(false) }
-            Crossfade(targetState = expanded) {
-                Text(
-                    modifier = Modifier.defaultMinSize(minHeight = dimensions().spacing20x),
-                    style = MaterialTheme.wireTypography.body01,
-                    lineHeight = MaterialTheme.wireTypography.body02.lineHeight,
-                    text = message.annotatedString(
-                        res = context.resources,
-                        expanded = it,
-                        normalStyle = MaterialTheme.wireTypography.body01,
-                        boldStyle = MaterialTheme.wireTypography.body02,
-                        normalColor = MaterialTheme.wireColorScheme.secondaryText,
-                        boldColor = MaterialTheme.wireColorScheme.onBackground
-                    )
+            Text(
+                modifier = Modifier
+                    .defaultMinSize(minHeight = dimensions().spacing20x)
+                    .animateContentSize(
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioLowBouncy,
+                            stiffness = Spring.StiffnessMediumLow
+                        )
+                    ),
+                style = MaterialTheme.wireTypography.body01,
+                lineHeight = MaterialTheme.wireTypography.body02.lineHeight,
+                text = message.annotatedString(
+                    res = context.resources,
+                    expanded = expanded,
+                    normalStyle = MaterialTheme.wireTypography.body01,
+                    boldStyle = MaterialTheme.wireTypography.body02,
+                    normalColor = MaterialTheme.wireColorScheme.secondaryText,
+                    boldColor = MaterialTheme.wireColorScheme.onBackground
                 )
-            }
+            )
             if (message is SystemMessage.Knock) {
                 VerticalSpace.x8()
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Animation not smooth when expanding a system message

### Causes (Optional)

Jumping state change

### Solutions

Replace `CrossFade` to use `animateContentSize` with custom animationSpec

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Remove more than 4 participants from a group to see that show all button

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

https://user-images.githubusercontent.com/18124919/217764730-c9f629d0-be52-45b6-b4a9-665212b9e621.mp4


https://user-images.githubusercontent.com/18124919/217764767-d2d78751-13c9-4316-adfa-07daef7f7740.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
