### PR TITLE
fix: Missed notifications on spamming (AR-2867)

### DIFF
--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -330,18 +330,37 @@ class WireNotificationManagerTest {
         }
 
     @Test
-    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUser_shouldSkipNotification() = runTest(dispatcherProvider.main()) {
+    fun givenASingleUserId_whenNotificationReceivedAndNoSuchUser_shouldSkipNotification() = runTest(dispatcherProvider.main()) {
         val otherAuthSession = provideAccountInfo("other_id")
         val userId = otherAuthSession.userId
         val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
             .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
-            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN)).withIncomingCalls(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground).arrange()
+            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
+            .withIncomingCalls(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground)
+            .arrange()
 
         manager.fetchAndShowNotificationsOnce(userId.value)
         advanceUntilIdle()
 
         coVerify(exactly = 0) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
+    }
+
+    @Test
+    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUserButExistOnThatDevice_shouldCheckNotification() = runTest(dispatcherProvider.main()) {
+        val otherAuthSession = provideAccountInfo("other_id")
+        val userId = otherAuthSession.userId
+        val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+            .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN, otherAuthSession)))
+            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
+            .withIncomingCalls(listOf())
+            .withCurrentScreen(CurrentScreen.InBackground)
+            .arrange()
+
+        manager.fetchAndShowNotificationsOnce(userId.value)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -347,21 +347,22 @@ class WireNotificationManagerTest {
     }
 
     @Test
-    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUserButExistOnThatDevice_shouldCheckNotification() = runTest(dispatcherProvider.main()) {
-        val otherAuthSession = provideAccountInfo("other_id")
-        val userId = otherAuthSession.userId
-        val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
-            .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN, otherAuthSession)))
-            .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
-            .withIncomingCalls(listOf())
-            .withCurrentScreen(CurrentScreen.InBackground)
-            .arrange()
+    fun givenASingleUserId_whenNotificationReceivedAndNotCurrentUserButExistOnThatDevice_shouldCheckNotification() =
+        runTest(dispatcherProvider.main()) {
+            val otherAuthSession = provideAccountInfo("other_id")
+            val userId = otherAuthSession.userId
+            val (arrangement, manager) = Arrangement().withMessageNotifications(listOf())
+                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN, otherAuthSession)))
+                .withCurrentUserSession(provideCurrentValidUserSession(TEST_AUTH_TOKEN))
+                .withIncomingCalls(listOf())
+                .withCurrentScreen(CurrentScreen.InBackground)
+                .arrange()
 
-        manager.fetchAndShowNotificationsOnce(userId.value)
-        advanceUntilIdle()
+            manager.fetchAndShowNotificationsOnce(userId.value)
+            advanceUntilIdle()
 
-        coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
-    }
+            coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(userId) }
+        }
 
     @Test
     fun givenSomeEstablishedCalls_whenAppIsNotVisible_thenOngoingCallServiceRun() = runTestWithCancellation(dispatcherProvider.main()) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2867" title="AR-2867" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2867</a>  Notifications don't show all notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

When we receive new messages really quick (spamming with 2-3 messages per second), some notifications are missed.

### Causes (Optional)

When the push comes we launch the coroutine job for syncing and observing the notifications and calls + there is an algorithm to check if such a job is already running and do not start a new if yes. 
The problem was in call observation: because of some limitations in AVS  we need some time to get an Event about a call from our BE, then go to AVS and ask if such a call is active yet. Because of it we have a workaround that observes calls for 8 seconds. 

So when somebody spams us, new pushes come, but the new sync job is not started as the app thinks that it's already running, cause the 8-seconds workaround is a part of that job. So what do we get: job is running, but the sync is not => losing the notifications. 

### Solutions

Extract 8-seconds workaround for calls from the sync-job to the separate job.
