### PR TITLE
fix(dev): saved files are not visible in downloads folder on lower Androids [AR-3120]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
     <uses-permission
             android:name="android.permission.WRITE_EXTERNAL_STORAGE"
             android:maxSdkVersion="28" />
+    <uses-permission
+            android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"
+            android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -22,6 +22,7 @@
 
 package com.wire.android.util
 
+import android.app.DownloadManager
 import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.ContentValues
@@ -95,11 +96,12 @@ private fun getTempWritableAttachmentUri(context: Context, attachmentPath: Path)
 
 private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedDataPath: Path, fileSize: Long): Uri? {
     val resolver = contentResolver
+    val mimeType = Uri.parse(downloadedDataPath.toString()).getMimeType(this@saveFileDataToDownloadsFolder)
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val contentValues = ContentValues().apply {
             // ContentResolver modifies the name if another file with the given name already exists, so we don't have to worry about it
             put(MediaStore.MediaColumns.DISPLAY_NAME, assetName.ifEmpty { ATTACHMENT_FILENAME })
-            put(MediaStore.MediaColumns.MIME_TYPE, Uri.parse(downloadedDataPath.toString()).getMimeType(this@saveFileDataToDownloadsFolder))
+            put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
             put(MediaStore.MediaColumns.SIZE, fileSize)
         }
         resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
@@ -109,7 +111,20 @@ private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedD
         // we need to find the next available name with copy counter by ourselves before copying
         val availableAssetName = findFirstUniqueName(downloadsDir, assetName.ifEmpty { ATTACHMENT_FILENAME })
         val destinationFile = File(downloadsDir, availableAssetName)
-        FileProvider.getUriForFile(this, authority, destinationFile)
+        val uri = FileProvider.getUriForFile(this, authority, destinationFile)
+        if (mimeType?.isNotEmpty() == true) {
+            val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            downloadManager.addCompletedDownload(
+                /* title = */ availableAssetName,
+                /* description = */ availableAssetName,
+                /* isMediaScannerScannable = */ true,
+                /* mimeType = */ mimeType,
+                /* path = */ destinationFile.absolutePath,
+                /* length = */ fileSize,
+                /* showNotification = */ false
+            )
+        }
+        uri
     }?.also { downloadedUri ->
         resolver.openOutputStream(downloadedUri).use { outputStream ->
             val brr = ByteArray(DATA_COPY_BUFFER_SIZE)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3120" title="AR-3120" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3120</a>  Saved files are not visible in downloads folder on lower Androids
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Files that are downloaded and user clicks on "save" should be copied to the "downloads" folder. They are actually copied, because the user can find them when navigating through the device's storage, but on lower Androids they can't be found in "downloads" category in a popular file manager apps or in the "downloads" app.

### Solutions

Use the `DownloadManager` to add the complete download and notify the system that there is a new file downloaded so it should update the list of downloads and should be available when for instance displaying all downloads with `ACTION_VIEW_DOWNLOADS`.

### Testing

#### How to Test

Download and click on "save" file, get the snackbar with the info that file was saved successfully. Tap on "show" and get navigated to the "downloads" folder and see if the saved file is visible there.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.