### PR TITLE
feat: pt1. offline backends - displaying failed to send message errors (AR-3122)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -145,6 +145,7 @@ class MessageMapper @Inject constructor(
 
     private fun getMessageStatus(message: Message.Standalone) = when {
         message.status == Message.Status.FAILED -> MessageStatus.SendFailure
+        message.status == Message.Status.FAILED_REMOTELY -> MessageStatus.SendRemotelyFailure(message.conversationId.domain)
         message.visibility == Message.Visibility.DELETED -> MessageStatus.Deleted
         message is Message.Regular && message.editStatus is Message.EditStatus.Edited ->
             MessageStatus.Edited(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -104,8 +103,8 @@ fun MessageItem(
             Spacer(Modifier.padding(start = dimensions().spacing8x - fullAvatarOuterPadding))
 
             val isProfileRedirectEnabled =
-                message.messageHeader.userId != null
-                        && !(message.messageHeader.isSenderDeleted || message.messageHeader.isSenderUnavailable)
+                message.messageHeader.userId != null &&
+                    !(message.messageHeader.isSenderDeleted || message.messageHeader.isSenderUnavailable)
 
             val avatarClickable = remember {
                 Clickable(enabled = isProfileRedirectEnabled) {
@@ -127,8 +126,8 @@ fun MessageItem(
                             Clickable(enabled = true, onClick = {
                                 onAssetMessageClicked(message.messageHeader.messageId)
                             }, onLongClick = {
-                                onLongClicked(message)
-                            })
+                                    onLongClicked(message)
+                                })
                         }
 
                         val currentOnImageClick = remember {
@@ -138,8 +137,8 @@ fun MessageItem(
                                     message.messageSource == MessageSource.Self
                                 )
                             }, onLongClick = {
-                                onLongClicked(message)
-                            })
+                                    onLongClicked(message)
+                                })
                         }
                         val onLongClick = remember { { onLongClicked(message) } }
 
@@ -164,7 +163,7 @@ fun MessageItem(
                 }
 
                 if (message.sendingFailed) {
-                    MessageSendFailureWarning()
+                    MessageSendFailureWarning(messageHeader.messageStatus)
                 }
             }
         }
@@ -173,7 +172,7 @@ fun MessageItem(
 
 @Composable
 private fun Modifier.customizeMessageBackground(
-    message: UIMessage,
+    message: UIMessage
 ) = run {
     if (message.sendingFailed || message.receivingFailed) {
         background(MaterialTheme.wireColorScheme.messageErrorBackgroundColor)
@@ -182,7 +181,7 @@ private fun Modifier.customizeMessageBackground(
 
 @Composable
 private fun MessageHeader(
-    messageHeader: MessageHeader,
+    messageHeader: MessageHeader
 ) {
     with(messageHeader) {
         Column {
@@ -352,32 +351,48 @@ private fun MessageStatusLabel(messageStatus: MessageStatus) {
         MessageStatus.ReceiveFailure -> StatusBox(messageStatus.text.asString())
 
         is MessageStatus.DecryptionFailure,
-        MessageStatus.SendFailure, MessageStatus.Untouched -> {
+        is MessageStatus.SendRemotelyFailure, MessageStatus.SendFailure, MessageStatus.Untouched -> {
             /** Don't display anything **/
         }
     }
 }
 
 @Composable
-private fun MessageSendFailureWarning() {
+private fun MessageSendFailureWarning(
+    messageStatus: MessageStatus
+    /* TODO: add onRetryClick handler */
+) {
+    val context = LocalContext.current
+    val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more) // todo: change later tbd.
     CompositionLocalProvider(
         LocalTextStyle provides MaterialTheme.typography.labelSmall
     ) {
-        Row {
+        Column {
             Text(
-                text = MessageStatus.SendFailure.text.asString(),
+                text = messageStatus.text.asString(),
                 style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
             )
-            Spacer(Modifier.width(dimensions().spacing4x))
-//      todo to uncomment this after we have the functionality of resend the message
-//              Text(
-//                modifier = Modifier.fillMaxWidth(),
-//                style = LocalTextStyle.current.copy(
-//                    color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
-//                    textDecoration = TextDecoration.Underline
-//                ),
-//                text = stringResource(R.string.label_try_again),
-//            )
+            if (messageStatus is MessageStatus.SendRemotelyFailure) {
+                Text(
+                    modifier = Modifier
+                        .clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
+                    style = LocalTextStyle.current.copy(
+                        color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    text = stringResource(R.string.label_learn_more)
+                )
+            }
+            // TODO: re-enable when we have a retry mechanism
+//            VerticalSpace.x4()
+//            Row {
+//                WireSecondaryButton(
+//                    text = stringResource(R.string.label_retry),
+//                    onClick = { /* TODO */ },
+//                    minHeight = dimensions().spacing32x,
+//                    fillMaxWidth = false
+//                )
+//            }
         }
     }
 }
@@ -406,7 +421,7 @@ private fun MessageDecryptionFailure(
                     color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
                     textDecoration = TextDecoration.Underline
                 ),
-                text = stringResource(R.string.label_learn_more),
+                text = stringResource(R.string.label_learn_more)
             )
             VerticalSpace.x4()
             Text(
@@ -419,7 +434,7 @@ private fun MessageDecryptionFailure(
                         text = stringResource(R.string.label_reset_session),
                         onClick = { messageHeader.userId?.let { userId -> onResetSessionClicked(userId, messageHeader.clientId?.value) } },
                         minHeight = dimensions().spacing32x,
-                        fillMaxWidth = false,
+                        fillMaxWidth = false
                     )
                 }
             } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -363,7 +363,7 @@ private fun MessageSendFailureWarning(
     /* TODO: add onRetryClick handler */
 ) {
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more) // todo: change later tbd.
+    val learnMoreUrl = stringResource(R.string.url_message_details_offline_backends_learn_more)
     CompositionLocalProvider(
         LocalTextStyle provides MaterialTheme.typography.labelSmall
     ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -48,7 +48,8 @@ data class UIMessage(
     val messageFooter: MessageFooter
 ) {
     val isDeleted: Boolean = messageHeader.messageStatus == Deleted
-    val sendingFailed: Boolean = messageHeader.messageStatus == SendFailure
+    val sendingFailed: Boolean =
+        messageHeader.messageStatus == SendFailure || messageHeader.messageStatus is MessageStatus.SendRemotelyFailure
     val decryptionFailed: Boolean = messageHeader.messageStatus is DecryptionFailure
     val receivingFailed: Boolean = messageHeader.messageStatus == ReceiveFailure || decryptionFailed
     val isAvailable: Boolean = !isDeleted && !sendingFailed && !receivingFailed
@@ -75,7 +76,7 @@ data class MessageHeader(
 data class MessageFooter(
     val messageId: String,
     val reactions: Map<String, Int> = emptyMap(),
-    val ownReactions: Set<String> = emptySet(),
+    val ownReactions: Set<String> = emptySet()
 )
 
 sealed class MessageStatus(val text: UIText) {
@@ -85,6 +86,9 @@ sealed class MessageStatus(val text: UIText) {
         MessageStatus(UIText.StringResource(R.string.label_message_status_edited_with_date, formattedEditTimeStamp))
 
     object SendFailure : MessageStatus(UIText.StringResource(R.string.label_message_sent_failure))
+    data class SendRemotelyFailure(val backendWithFailure: String) :
+        MessageStatus(UIText.StringResource(R.string.label_message_sent_remotely_failure, backendWithFailure))
+
     object ReceiveFailure : MessageStatus(UIText.StringResource(R.string.label_message_receive_failure))
     data class DecryptionFailure(val isDecryptionResolved: Boolean) :
         MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
@@ -143,7 +147,8 @@ sealed class UIMessageContent {
     ) : UIMessageContent() {
 
         data class Knock(val author: UIText) : SystemMessage(
-            R.drawable.ic_ping, R.string.label_message_knock
+            R.drawable.ic_ping,
+            R.string.label_message_knock
         )
 
         data class MemberAdded(
@@ -212,7 +217,7 @@ data class QuotedMessageUIData(
 
     data class GenericAsset(
         val assetName: String?,
-        val assetMimeType: String,
+        val assetMimeType: String
     ) : Content
 
     data class DisplayableImage(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/en-us/articles/6655706999581-What-s-new-on-Android-</string>
     <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/212053645-Like-a-message</string>
     <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/360000665277-Activate-or-deactivate-read-receipts</string>
+    <string name="url_message_details_offline_backends_learn_more" translatable="false">https://support.wire.com/hc/articles/9357718008093-Backend</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,8 @@
     <string name="label_membership_external">External</string>
     <string name="label_membership_service">Service</string>
     <string name="label_user_deleted">Deleted</string>
-    <string name="label_message_sent_failure">Message could not be sent.</string>
+    <string name="label_message_sent_failure">Message could not be sent due to connectivity issues.</string>
+    <string name="label_message_sent_remotely_failure">Message could not be sent, as the backend %s appears to be offline.</string>
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3122" title="AR-3122" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3122</a>  [Android] Implement UI for sending messages when a remote backend is offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This work is part of a series of PR's that will be covering "sending messages" while some backends or recipients are not available due to federation, connectivity issues, so this will allow a user to:

- Sent even if it some of the participants are owned by a backend that is offline.
- See why some of the users were not able to receive the message and why.

This part 1, focus on handling the new error detail federation and persisting that failure to cover own backend unavailability and others backend unavailability, this covers the messages copy adjustment and remote backend errors.

The next step is to re-enable the retry button for resending a failed message

### Dependencies (Optional)

https://github.com/wireapp/kalium/pull/1493

Needs releases with:

- [x] GitHub link to other pull request

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5806454/219082134-47f161b2-7054-4260-9421-e09608bc5089.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
