### PR TITLE
fix: [RC] check if the logging file exists before clearing its content

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
@@ -107,9 +107,11 @@ class LogFileWriter(private val logsDirectory: File) {
     }
 
     private fun clearActiveLoggingFileContent() {
-        val writer = PrintWriter(activeLoggingFile)
-        writer.print("")
-        writer.close()
+        if(activeLoggingFile.exists()) {
+            val writer = PrintWriter(activeLoggingFile)
+            writer.print("")
+            writer.close()
+        }
     }
 
     /**
@@ -144,11 +146,13 @@ class LogFileWriter(private val logsDirectory: File) {
         }?.forEach { it.delete() }
     }
 
+    private fun compressedFileName(currentDate: String, logFilesCount: Int): String = "${LOG_FILE_PREFIX}_${currentDate}_${logFilesCount}.gz"
+
     private fun compress(): Boolean {
         try {
             val logFilesCount = logsDirectory.listFiles()?.size
             val currentDate = logFileTimeFormat.format(Date())
-            val compressed = File(logsDirectory, "${LOG_FILE_PREFIX}_${currentDate}_${logFilesCount}.gz")
+            val compressed = File(logsDirectory, compressedFileName(currentDate, logFilesCount ?: 0))
             val zippedOutputStream = GZIPOutputStream(compressed.outputStream())
             val inputStream = activeLoggingFile.inputStream()
             inputStream.copyTo(zippedOutputStream, BYTE_ARRAY_SIZE)

--- a/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
@@ -107,7 +107,7 @@ class LogFileWriter(private val logsDirectory: File) {
     }
 
     private fun clearActiveLoggingFileContent() {
-        if(activeLoggingFile.exists()) {
+        if (activeLoggingFile.exists()) {
             val writer = PrintWriter(activeLoggingFile)
             writer.print("")
             writer.close()
@@ -146,7 +146,8 @@ class LogFileWriter(private val logsDirectory: File) {
         }?.forEach { it.delete() }
     }
 
-    private fun compressedFileName(currentDate: String, logFilesCount: Int): String = "${LOG_FILE_PREFIX}_${currentDate}_${logFilesCount}.gz"
+    private fun compressedFileName(currentDate: String, logFilesCount: Int): String =
+        "${LOG_FILE_PREFIX}_${currentDate}_$logFilesCount.gz"
 
     private fun compress(): Boolean {
         try {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

clicking delete log files crashes the app if logging was never enabled

### Solutions

check if the file exists before clearing its content

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
