### PR TITLE
fix: removing devices design review adjustment (AR-2963)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -95,17 +95,17 @@ private fun DeviceItemContent(
 ) {
     Row(
         verticalAlignment = Alignment.Top,
-        modifier = if (background != null) Modifier.background(color = background) else Modifier
+        modifier = (if (background != null) Modifier.background(color = background) else Modifier)
+            .clickable(enabled = isWholeItemClickable) {
+                if (isWholeItemClickable) {
+                    onRemoveDeviceClick?.invoke(device)
+                }
+            }
     ) {
         Row(
             modifier = Modifier
                 .padding(MaterialTheme.wireDimensions.removeDeviceItemPadding)
                 .weight(1f)
-                .clickable(enabled = isWholeItemClickable) {
-                    if (isWholeItemClickable) {
-                        onRemoveDeviceClick?.invoke(device)
-                    }
-                }
         ) {
             Icon(
                 modifier = Modifier.shimmerPlaceholder(visible = placeholder),
@@ -200,7 +200,7 @@ private fun DeviceItemTexts(device: Device, placeholder: Boolean, isDebug: Boole
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun PreviewDeviceItem() {
     Box(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.authentication.devices
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -42,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,6 +54,7 @@ import com.wire.android.R
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.getMinTouchMargins
+import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.shimmerPlaceholder
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -66,6 +69,7 @@ fun DeviceItem(
     background: Color? = null,
     leadingIcon: @Composable (() -> Unit),
     leadingIconBorder: Dp = 1.dp,
+    isWholeItemClickable: Boolean = false,
     onRemoveDeviceClick: ((Device) -> Unit)? = null
 ) {
     DeviceItemContent(
@@ -74,7 +78,8 @@ fun DeviceItem(
         background = background,
         leadingIcon = leadingIcon,
         leadingIconBorder = leadingIconBorder,
-        onRemoveDeviceClick = onRemoveDeviceClick
+        onRemoveDeviceClick = onRemoveDeviceClick,
+        isWholeItemClickable = isWholeItemClickable
     )
 }
 
@@ -85,7 +90,8 @@ private fun DeviceItemContent(
     background: Color? = null,
     leadingIcon: @Composable (() -> Unit),
     leadingIconBorder: Dp,
-    onRemoveDeviceClick: ((Device) -> Unit)?
+    onRemoveDeviceClick: ((Device) -> Unit)?,
+    isWholeItemClickable: Boolean
 ) {
     Row(
         verticalAlignment = Alignment.Top,
@@ -95,6 +101,11 @@ private fun DeviceItemContent(
             modifier = Modifier
                 .padding(MaterialTheme.wireDimensions.removeDeviceItemPadding)
                 .weight(1f)
+                .clickable(enabled = isWholeItemClickable) {
+                    if (isWholeItemClickable) {
+                        onRemoveDeviceClick?.invoke(device)
+                    }
+                }
         ) {
             Icon(
                 modifier = Modifier.shimmerPlaceholder(visible = placeholder),
@@ -119,8 +130,7 @@ private fun DeviceItemContent(
             }
         if (!placeholder && onRemoveDeviceClick != null) {
             WireSecondaryButton(
-                modifier = Modifier
-                    .testTag("remove device button"),
+                modifier = Modifier.testTag("remove device button"),
                 onClick = { onRemoveDeviceClick(device) },
                 leadingIcon = leadingIcon,
                 fillMaxWidth = false,
@@ -128,7 +138,10 @@ private fun DeviceItemContent(
                 minWidth = MaterialTheme.wireDimensions.buttonSmallMinSize.width,
                 shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.buttonSmallCornerSize),
                 contentPadding = PaddingValues(0.dp),
-                borderWidth = leadingIconBorder
+                borderWidth = leadingIconBorder,
+                colors = wireSecondaryButtonColors().copy(
+                    enabled = background ?: MaterialTheme.wireColorScheme.secondaryButtonEnabled
+                )
             )
         }
     }
@@ -187,7 +200,7 @@ private fun DeviceItemTexts(device: Device, placeholder: Boolean, isDebug: Boole
     )
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun PreviewDeviceItem() {
     Box(modifier = Modifier.fillMaxWidth()) {
@@ -195,7 +208,7 @@ fun PreviewDeviceItem() {
             device = Device(),
             placeholder = false,
             background = null,
-            {}
+            { Icon(painter = painterResource(id = R.drawable.ic_remove), contentDescription = "") }
         ) {}
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -143,7 +143,7 @@ class DeviceDetailsViewModel @Inject constructor(
 
     fun navigateBack() {
         viewModelScope.launch {
-            navigationManager.navigate(NavigationCommand(NavigationItem.SelfDevices.getRouteWithArgs(), BackStackMode.REMOVE_CURRENT))
+            navigationManager.navigate(NavigationCommand(NavigationItem.SelfDevices.getRouteWithArgs(), BackStackMode.UPDATE_EXISTED))
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -138,7 +138,8 @@ private fun LazyListScope.folderDeviceItems(
             placeholder = false,
             onRemoveDeviceClick = onDeviceClick,
             leadingIcon = Icons.Filled.ChevronRight.Icon(),
-            leadingIconBorder = 0.dp
+            leadingIconBorder = 0.dp,
+            isWholeItemClickable = true
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
@@ -77,8 +76,7 @@ class SelfDevicesViewModel @Inject constructor(
         viewModelScope.launch {
             navigationManager.navigate(
                 NavigationCommand(
-                    NavigationItem.DeviceDetails.getRouteWithArgs(listOf(device.clientId)),
-                    BackStackMode.REMOVE_CURRENT
+                    NavigationItem.DeviceDetails.getRouteWithArgs(listOf(device.clientId))
                 )
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2963" title="AR-2963" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2963</a>  Delete a device from the devices list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After design review, we are addressing some small issues regarding user interaction and navigation while removing devices.
- Making the entire row clickable
- Navigation after success

### Testing

No needed, as these changes address styling and user interaction

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
