### PR TITLE
fix: initial status bar color

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -74,7 +74,7 @@ private fun ConnectivityStatusBar(
     val isVisible = connectivityInfo !is ConnectivityUIState.Info.None
 
     // So it keeps the current colour while the animation is collapsing the bar
-    val initialColour = MaterialTheme.wireColorScheme.connectivityBarOngoingCallBackgroundColor
+    val initialColour = MaterialTheme.wireColorScheme.primary
     var lastVisibleBackgroundColor by remember {
         mutableStateOf(initialColour)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed initial status bar color from green one to blue one because syncing status (blue) mostly appears when app starts

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
