### PR TITLE
chore: add debug setting for enabling encrypted proteus storage

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 // App wide global logger, carefully initialized when our application is "onCreate"
@@ -198,8 +199,14 @@ class WireApplication : Application(), Configuration.Provider {
             .build()
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
+        val extraInfo = mapOf(
+            Pair("encrypted_proteus_storage_enabled", runBlocking {
+                globalDataStore.isEncryptedProteusStorageEnabled().first()
+            })
+        )
+
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
-        Datadog.setUserInfo(id = getDeviceId()?.sha256())
+        Datadog.setUserInfo(id = getDeviceId()?.sha256(), extraInfo = extraInfo)
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -200,9 +200,9 @@ class WireApplication : Application(), Configuration.Provider {
 
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         val extraInfo = mapOf(
-            Pair("encrypted_proteus_storage_enabled", runBlocking {
+           "encrypted_proteus_storage_enabled" to runBlocking {
                 globalDataStore.isEncryptedProteusStorageEnabled().first()
-            })
+            }
         )
 
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)

--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Suppress("TooManyFunctions")
 @Singleton
 class GlobalDataStore @Inject constructor(@ApplicationContext private val context: Context) {
 
@@ -64,7 +65,8 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         context.dataStore.edit { it[IS_LOGGING_ENABLED] = enabled }
     }
 
-    fun isEncryptedProteusStorageEnabled(): Flow<Boolean> = getBooleanPreference(IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED, BuildConfig.ENCRYPT_PROTEUS_STORAGE)
+    fun isEncryptedProteusStorageEnabled(): Flow<Boolean> =
+        getBooleanPreference(IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED, BuildConfig.ENCRYPT_PROTEUS_STORAGE)
 
     suspend fun setEncryptedProteusStorageEnabled(enabled: Boolean) {
         context.dataStore.edit { it[IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED] = enabled }
@@ -74,7 +76,8 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         context.dataStore.edit { it[MIGRATION_COMPLETED] = true }
     }
 
-    suspend fun isWelcomeScreenPresented(): Boolean = getBooleanPreference(WELCOME_SCREEN_PRESENTED, false).firstOrNull() ?: false
+    suspend fun isWelcomeScreenPresented(): Boolean =
+        getBooleanPreference(WELCOME_SCREEN_PRESENTED, false).firstOrNull() ?: false
 
     suspend fun setWelcomeScreenPresented() {
         context.dataStore.edit { it[WELCOME_SCREEN_PRESENTED] = true }

--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -44,6 +44,7 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         private val MIGRATION_COMPLETED = booleanPreferencesKey("migration_completed")
         private val WELCOME_SCREEN_PRESENTED = booleanPreferencesKey("welcome_screen_presented")
         private val IS_LOGGING_ENABLED = booleanPreferencesKey("is_logging_enabled")
+        private val IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED = booleanPreferencesKey("is_encrypted_proteus_storage_enabled")
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
     }
 
@@ -61,6 +62,12 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
     fun isLoggingEnabled(): Flow<Boolean> = getBooleanPreference(IS_LOGGING_ENABLED, BuildConfig.LOGGING_ENABLED)
     suspend fun setLoggingEnabled(enabled: Boolean) {
         context.dataStore.edit { it[IS_LOGGING_ENABLED] = enabled }
+    }
+
+    fun isEncryptedProteusStorageEnabled(): Flow<Boolean> = getBooleanPreference(IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED, BuildConfig.ENCRYPT_PROTEUS_STORAGE)
+
+    suspend fun setEncryptedProteusStorageEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED] = enabled }
     }
 
     suspend fun setMigrationCompleted() {

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -22,18 +22,21 @@ package com.wire.android.di
 
 import android.os.Build
 import com.wire.android.BuildConfig
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 @Module
 @InstallIn(SingletonComponent::class)
 class KaliumConfigsModule {
 
     @Provides
-    fun provideKaliumConfigs(): KaliumConfigs {
+    fun provideKaliumConfigs(globalDataStore: GlobalDataStore): KaliumConfigs {
         return KaliumConfigs(
             isChangeEmailEnabled = BuildConfig.ALLOW_CHANGE_OF_EMAIL,
             isLoggingEnabled = BuildConfig.LOGGING_ENABLED,
@@ -52,7 +55,7 @@ class KaliumConfigsModule {
             lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD,
             isMLSSupportEnabled = BuildConfig.MLS_SUPPORT_ENABLED,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
-            encryptProteusStorage = BuildConfig.ENCRYPT_PROTEUS_STORAGE
+            encryptProteusStorage = runBlocking { globalDataStore.isEncryptedProteusStorageEnabled().first() }
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreen.kt
@@ -76,6 +76,7 @@ fun DebugScreen() {
         navigateBack = debugScreenViewModel::navigateBack,
         onForceLatestDevelopmentApiChange = debugScreenViewModel::forceUpdateApiVersions,
         restartSlowSyncForRecovery = debugScreenViewModel::restartSlowSyncForRecovery,
+        enableEncryptedProteusStorage = debugScreenViewModel::enableEncryptedProteusStorage
     )
 }
 
@@ -88,7 +89,8 @@ fun DebugContent(
     onDeleteLogs: () -> Unit,
     navigateBack: () -> Unit,
     onForceLatestDevelopmentApiChange: () -> Unit,
-    restartSlowSyncForRecovery: () -> Unit
+    restartSlowSyncForRecovery: () -> Unit,
+    enableEncryptedProteusStorage: () -> Unit
 ) {
     val scrollState = rememberScrollState()
 
@@ -114,6 +116,17 @@ fun DebugContent(
                 mlsErrorMessage = debugScreenState.mlsErrorMessage,
                 restartSlowSyncForRecovery = restartSlowSyncForRecovery
             )
+
+            if (BuildConfig.PRIVATE_BUILD) {
+                ProteusOptions(
+                    isEncryptedStorageEnabled = debugScreenState.isEncryptedProteusStorageEnabled,
+                    onEncryptedStorageEnabledChange = { enabled ->
+                        if (enabled) {
+                            enableEncryptedProteusStorage()
+                        }
+                    }
+                )
+            }
 
             LogOptions(
                 deviceId = debugContentState.deviceId,
@@ -169,6 +182,21 @@ private fun MlsOptions(
                 )
             )
         }
+    }
+}
+
+@Composable
+private fun ProteusOptions(
+    isEncryptedStorageEnabled: Boolean,
+    onEncryptedStorageEnabledChange: (Boolean) -> Unit,
+) {
+    Column {
+        FolderHeader(stringResource(R.string.label_proteus_option_title))
+
+        EnableEncryptedProteusStorageSwitch(
+            isEnabled = isEncryptedStorageEnabled,
+            onCheckedChange = onEncryptedStorageEnabledChange
+        )
     }
 }
 
@@ -262,6 +290,32 @@ private fun EnableLoggingSwitch(
             WireSwitch(
                 checked = isEnabled,
                 onCheckedChange = onCheckedChange,
+                modifier = Modifier.padding(end = dimensions().spacing16x)
+            )
+        }
+    )
+}
+
+@Composable
+private fun EnableEncryptedProteusStorageSwitch(
+    isEnabled: Boolean = false,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    RowItemTemplate(
+        title = {
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = stringResource(R.string.label_enable_encrypted_proteus_storage),
+                modifier = Modifier.padding(start = dimensions().spacing8x)
+            )
+        },
+        actions = {
+            WireSwitch(
+                checked = isEnabled,
+                onCheckedChange = onCheckedChange,
+                enabled = !isEnabled,
                 modifier = Modifier.padding(end = dimensions().spacing16x)
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debugscreen/DebugScreenViewModel.kt
@@ -44,6 +44,7 @@ import javax.inject.Inject
 
 data class DebugScreenState(
     val isLoggingEnabled: Boolean = false,
+    val isEncryptedProteusStorageEnabled: Boolean = false,
     val currentClientId: String = String.EMPTY,
     val keyPackagesCount: Int = 0,
     val mslClientId: String = String.EMPTY,
@@ -70,6 +71,7 @@ class DebugScreenViewModel
 
     init {
         observeLoggingState()
+        observeEncryptedProteusStorageState()
         observeMlsMetadata()
         observeCurrentClientId()
     }
@@ -78,6 +80,14 @@ class DebugScreenViewModel
         viewModelScope.launch {
             globalDataStore.isLoggingEnabled().collect {
                 state = state.copy(isLoggingEnabled = it)
+            }
+        }
+    }
+
+    private fun observeEncryptedProteusStorageState() {
+        viewModelScope.launch {
+            globalDataStore.isEncryptedProteusStorageEnabled().collect {
+                state = state.copy(isEncryptedProteusStorageEnabled = it)
             }
         }
     }
@@ -136,6 +146,12 @@ class DebugScreenViewModel
         } else {
             logFileWriter.stop()
             CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED, logWriters = arrayOf(DataDogLogger, platformLogWriter()))
+        }
+    }
+
+    fun enableEncryptedProteusStorage() {
+        viewModelScope.launch {
+            globalDataStore.setEncryptedProteusStorageEnabled(true)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -768,6 +768,8 @@
     <string name="label_restart_slowsync_for_recovery">Restart SlowSync for Recovery</string>
     <string name="label_mls_option_title">MLS DATA</string>
     <string name="label_enable_logging">Enable Logging</string>
+    <string name="label_proteus_option_title">Proteus</string>
+    <string name="label_enable_encrypted_proteus_storage">Enable encrypted proteus storage</string>
     <string name="label_debug_title">Debug</string>
     <string name="label_client_option_title">Client ID</string>
     <string name="label_device_id">Device ID: %1$s</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add a debug setting for enabling encrypted proteus storage. 

After enabling this setting we'll migrate to use the Core Crypto proteus implementation on the next app launch. This action is not reversible so once you've enabled this setting you can't turn it off again.

I've also added an additional user info field to data dog: `encrypted_proteus_storage_enabled` so that we know if a CC proteus client was involved in a decryption error.

This setting is only available on private builds.

### Attachments

![image](https://user-images.githubusercontent.com/7156/220381941-593bdac9-ca19-491f-ab66-c5a2b3528337.png)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
