### PR TITLE
fix: revoke guest link when disabling guest access

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
@@ -152,7 +152,11 @@ class EditGuestAccessViewModel @Inject constructor(
                         )
                     )
 
-                    is UpdateConversationAccessRoleUseCase.Result.Success -> Unit
+                    is UpdateConversationAccessRoleUseCase.Result.Success -> {
+                        if (!shouldEnableGuestAccess) {
+                            revokeGuestRoomLink(conversationId)
+                        }
+                    }
                 }
                 updateState(editGuestAccessState.copy(isUpdatingGuestAccess = false))
             }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -139,7 +139,55 @@ class EditGuestAccessViewModelTest {
     }
 
     @Test
-    fun `given guest access is activated, when trying to enable guest access, then display dialog before disabling guest access`() {
+    fun `given updateConversationAccessRole use case runs successfully, when trying to disable guest access, then disable guest access`() =
+        runTest {
+            editGuestAccessViewModel.editGuestAccessState = editGuestAccessViewModel.editGuestAccessState.copy(isGuestAccessAllowed = true)
+            coEvery {
+                updateConversationAccessRoleUseCase(any(), any(), any(), any())
+            } returns UpdateConversationAccessRoleUseCase.Result.Success
+
+            coEvery {
+                revokeGuestRoomLink(any())
+            } returns RevokeGuestRoomLinkResult.Success
+
+            editGuestAccessViewModel.onGuestDialogConfirm()
+
+            coVerify(exactly = 1) {
+                updateConversationAccessRoleUseCase(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                revokeGuestRoomLink(any())
+            }
+            assertEquals(
+                false,
+                editGuestAccessViewModel.editGuestAccessState.isGuestAccessAllowed
+            )
+        }
+
+    @Test
+    fun `given a failure when running updateConversationAccessRole, when trying to disable guest access, then do not disable guest access`() =
+        runTest {
+            editGuestAccessViewModel.editGuestAccessState = editGuestAccessViewModel.editGuestAccessState.copy(isGuestAccessAllowed = true)
+            coEvery {
+                updateConversationAccessRoleUseCase(any(), any(), any(), any())
+            } returns UpdateConversationAccessRoleUseCase.Result.Failure(CoreFailure.MissingClientRegistration)
+
+            editGuestAccessViewModel.onGuestDialogConfirm()
+
+            coVerify(exactly = 1) {
+                updateConversationAccessRoleUseCase(any(), any(), any(), any())
+            }
+            coVerify(inverse = true) {
+                revokeGuestRoomLink(any())
+            }
+            assertEquals(
+                true,
+                editGuestAccessViewModel.editGuestAccessState.isGuestAccessAllowed
+            )
+        }
+
+    @Test
+    fun `given guest access is activated, when trying to disable guest access, then display dialog before disabling guest access`() {
         editGuestAccessViewModel.editGuestAccessState =
             editGuestAccessViewModel.editGuestAccessState.copy(isGuestAccessAllowed = true)
 
@@ -157,7 +205,7 @@ class EditGuestAccessViewModelTest {
             generateGuestRoomLink(any())
         } returns GenerateGuestRoomLinkResult.Success
 
-        editGuestAccessViewModel.onGuestDialogConfirm()
+        editGuestAccessViewModel.onGenerateGuestRoomLink()
 
         coVerify(exactly = 1) {
             generateGuestRoomLink(any())
@@ -171,7 +219,7 @@ class EditGuestAccessViewModelTest {
             generateGuestRoomLink(any())
         } returns GenerateGuestRoomLinkResult.Failure(CoreFailure.MissingClientRegistration)
 
-        editGuestAccessViewModel.onGuestDialogConfirm()
+        editGuestAccessViewModel.onGenerateGuestRoomLink()
 
         coVerify(exactly = 1) {
             generateGuestRoomLink(any())

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -165,7 +165,7 @@ class EditGuestAccessViewModelTest {
         }
 
     @Test
-    fun `given a failure when running updateConversationAccessRole, when trying to disable guest access, then do not disable guest access`() =
+    fun `given a failure running updateConversationAccessRole, when trying to disable guest access, then do not disable guest access`() =
         runTest {
             editGuestAccessViewModel.editGuestAccessState = editGuestAccessViewModel.editGuestAccessState.copy(isGuestAccessAllowed = true)
             coEvery {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Disabling guest access does not remove guest link

### Solutions

call revokeGuestLinkUseCase when disabling guest access

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
