### PR TITLE
fix: [DEV] call frozen dev (AR-2944)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -82,14 +82,18 @@ class OngoingCallViewModel @OptIn(ExperimentalCoroutinesApi::class)
 
     fun requestVideoStreams(participants: List<UICallParticipant>) {
         viewModelScope.launch {
-            participants.filter {
-                it.isCameraOn || it.isSharingScreen
-            }.also {
-                val clients: List<CallClient> = participants.map {
-                    CallClient(it.id.toString(), it.clientId)
+            participants
+                .filter {
+                    it.isCameraOn || it.isSharingScreen
                 }
-                requestVideoStreams(conversationId, clients)
-            }
+                .also {
+                    if (it.isNotEmpty()) {
+                        val clients: List<CallClient> = it.map { uiParticipant ->
+                            CallClient(uiParticipant.id.toString(), uiParticipant.clientId)
+                        }
+                        requestVideoStreams(conversationId, clients)
+                    }
+                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantsTiles.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantsTiles.kt
@@ -73,16 +73,11 @@ fun VerticalCallingPager(
                     val participantsWithCameraOn by rememberUpdatedState(participants.count { it.isCameraOn })
                     val participantsWithScreenShareOn by rememberUpdatedState(participants.count { it.isSharingScreen })
 
-                    // Request video stream when someone turns camera on/off
-                    LaunchedEffect(participantsWithCameraOn) {
-                        requestVideoStreams(participantsChunkedList[pagerState.currentPage])
-                    }
-                    // Request video stream when someone starts sharing screen
-                    LaunchedEffect(participantsWithScreenShareOn) {
-                        requestVideoStreams(participantsChunkedList[pagerState.currentPage])
-                    }
-                    // Request video stream when swiping to a different page on the grid
-                    LaunchedEffect(pagerState.currentPage) {
+                    LaunchedEffect(
+                        participantsWithCameraOn, // Request video stream when someone turns camera on/off
+                        participantsWithScreenShareOn, // Request video stream when someone starts sharing screen
+                        pagerState.currentPage // Request video stream when swiping to a different page on the grid
+                    ) {
                         requestVideoStreams(participantsChunkedList[pagerState.currentPage])
                     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2944" title="AR-2944" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2944</a>  Call is frozen and hang up button doesn't work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While in an Ongoing Call (specially when in screen) we would be sending many requests for video streams (even when not needed).

### Causes (Optional)

- (from AR) Missing some checks and not correctly using the filtered list of clients
- (from AVS) seems like when sending multiple requests for video streams it also loads our SFT servers and its not good :)

### Solutions

- Group `LaunchedEffect` usage into just one so we can take advantage of Coroutine from itself, so when something (camera, screenshare or video grid changes) happens simultaneously, we will cancel whatever was there and send it only once instead of multiple times as well.
- Make correct usage of filtered client list to request video streams
- Make sure we are not requesting video streams when there is no need (empty client list)

### Testing

#### How to Test

- Join a call with more than 8 participants (to have 2 pages of participants) or just change:
   `MAX_TILES_PER_PAGE = 8` to `2` and `MAX_ITEMS_FOR_ONE_ON_ONE_VIEW = 3` to `2` and can test with your own accounts.
- wait for videos/screenshares to be received and scroll through pages of call participants
- everything should work as expected