### PR TITLE
fix: Fix crash when no logged in user

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -119,8 +119,11 @@ class WireActivity : AppCompatActivity() {
                 WireTheme {
                     val scope = rememberCoroutineScope()
                     val navController = rememberTrackingAnimatedNavController { NavigationItem.fromRoute(it)?.itemName }
-                    val isSharingIntent = ShareCompat.IntentReader(this).isShareIntent
-                    setUpNavigationGraph(viewModel.startNavigationRoute(isSharingIntent = isSharingIntent), navController, scope)
+                    setUpNavigationGraph(
+                        viewModel.startNavigationRoute(hasSharingIntent = ShareCompat.IntentReader(this).isShareIntent),
+                        navController,
+                        scope
+                    )
                     handleDialogs()
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -56,10 +56,6 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialog
-import com.wire.android.ui.common.dialogs.FileSharingRestrictedDialogContent
-import com.wire.android.ui.common.dialogs.FileSharingRestrictedDialogState
-import com.wire.android.ui.common.visbility.rememberVisibilityState
-import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
 import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
@@ -95,8 +91,6 @@ class WireActivity : AppCompatActivity() {
 
     val viewModel: WireActivityViewModel by viewModels()
 
-    val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -104,7 +98,6 @@ class WireActivity : AppCompatActivity() {
         lifecycle.addObserver(currentScreenManager)
         viewModel.handleDeepLink(intent)
         setComposableContent()
-        checkSharingStateIntent()
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -126,40 +119,12 @@ class WireActivity : AppCompatActivity() {
                 WireTheme {
                     val scope = rememberCoroutineScope()
                     val navController = rememberTrackingAnimatedNavController { NavigationItem.fromRoute(it)?.itemName }
-                    if (!isThereSharingIntent()) {
-                        setUpNavigationGraph(viewModel.startNavigationRoute(), navController, scope)
-                    } else {
-                        setUpNavigationGraph(viewModel.startNavigationRoute(NavigationItem.ImportMedia), navController, scope)
-                    }
+                    val isSharingIntent = ShareCompat.IntentReader(this).isShareIntent
+                    setUpNavigationGraph(viewModel.startNavigationRoute(isSharingIntent = isSharingIntent), navController, scope)
                     handleDialogs()
                 }
             }
         }
-    }
-
-    private fun checkSharingStateIntent() {
-        val incomingIntent = ShareCompat.IntentReader(this)
-        if (incomingIntent.isShareIntent) {
-            featureFlagNotificationViewModel.updateSharingStateIfNeeded()
-        }
-    }
-
-    @Composable
-    private fun isThereSharingIntent(): Boolean {
-        val fileSharingRestrictedDialogState = rememberVisibilityState<FileSharingRestrictedDialogState>()
-        FileSharingRestrictedDialogContent(
-            dialogState = fileSharingRestrictedDialogState
-        )
-        if (featureFlagNotificationViewModel.featureFlagState.showFileSharingRestrictedDialog) {
-            fileSharingRestrictedDialogState.show(
-                fileSharingRestrictedDialogState.savedState ?: FileSharingRestrictedDialogState
-            )
-        }
-        if (featureFlagNotificationViewModel.featureFlagState.openImportMediaScreen) {
-            return true
-        }
-
-        return false
     }
 
     @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -451,7 +451,7 @@ class WireActivityViewModel @Inject constructor(
             }
         }
     }
-    
+
     private fun shouldGoToMigration(): Boolean = runBlocking {
         migrationManager.shouldMigrate()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -168,9 +168,10 @@ class WireActivityViewModel @Inject constructor(
 
     fun navigationArguments() = navigationArguments.values.toList()
 
-    fun startNavigationRoute(navigationItem: NavigationItem? = null): String = when {
+    fun startNavigationRoute(navigationItem: NavigationItem? = null, isSharingIntent: Boolean = false): String = when {
         shouldGoToMigration() -> NavigationItem.Migration.getRouteWithArgs()
         shouldGoToWelcome() -> NavigationItem.Welcome.getRouteWithArgs()
+        isSharingIntent -> NavigationItem.ImportMedia.getRouteWithArgs()
         navigationItem != null -> navigationItem.getRouteWithArgs()
         else -> NavigationItem.Home.getRouteWithArgs()
     }
@@ -180,7 +181,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     fun handleDeepLink(intent: Intent?) {
-        if (isSharingIntent(intent)) {
+        if (!shouldGoToWelcome() && isSharingIntent(intent)) {
             navigateToImportMediaScreen()
         } else {
             intent?.data?.let { deepLink ->
@@ -205,6 +206,7 @@ class WireActivityViewModel @Inject constructor(
                                 navigationArguments[SERVER_CONFIG_ARG] = serverLinks
                             }
                         }
+
                         is DeepLinkResult.SSOLogin -> navigationArguments[SSO_DEEPLINK_ARG] = result
 
                         is DeepLinkResult.IncomingCall -> navigationArguments[INCOMING_CALL_CONVERSATION_ID_ARG] = result.conversationsId

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -24,7 +24,6 @@ import android.content.Intent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.app.ShareCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
@@ -452,8 +451,7 @@ class WireActivityViewModel @Inject constructor(
             }
         }
     }
-
-
+    
     private fun shouldGoToMigration(): Boolean = runBlocking {
         migrationManager.shouldMigrate()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
@@ -23,6 +23,5 @@ package com.wire.android.ui.home
 data class FeatureFlagState(
     val showFileSharingDialog: Boolean = false,
     val isFileSharingEnabledState: Boolean = true,
-    val showFileSharingRestrictedDialog: Boolean = false,
-    val openImportMediaScreen: Boolean = false
+    val showFileSharingRestrictedDialog: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -86,7 +86,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
         viewModelScope.launch {
             coreLogic.getSessionScope(userId).observeFileSharingStatus().collect {
                 if (it.isFileSharingEnabled != null) {
-                    featureFlagState = featureFlagState.copy(isFileSharingEnabledState = it.isFileSharingEnabled!!)
+                    featureFlagState = featureFlagState.copy(isFileSharingEnabledState = false)
                 }
                 if (it.isStatusChanged != null && it.isStatusChanged!!) {
                     featureFlagState = featureFlagState.copy(showFileSharingDialog = it.isStatusChanged!!)
@@ -120,11 +120,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
         // correctly for some strange reason.
         runBlocking {
             if (checkNumberOfSessions() > 0) {
-                featureFlagState = if (!featureFlagState.isFileSharingEnabledState) {
-                    featureFlagState.copy(showFileSharingRestrictedDialog = true)
-                } else {
-                    featureFlagState.copy(openImportMediaScreen = true, showFileSharingRestrictedDialog = false)
-                }
+                featureFlagState = featureFlagState.copy(showFileSharingRestrictedDialog = featureFlagState.isFileSharingEnabledState)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -84,12 +84,12 @@ class FeatureFlagNotificationViewModel @Inject constructor(
 
     private fun setFileSharingState(userId: UserId) {
         viewModelScope.launch {
-            coreLogic.getSessionScope(userId).observeFileSharingStatus().collect {
-                if (it.isFileSharingEnabled != null) {
-                    featureFlagState = featureFlagState.copy(isFileSharingEnabledState = false)
+            coreLogic.getSessionScope(userId).observeFileSharingStatus().collect { fileSharingStatus ->
+                fileSharingStatus.isFileSharingEnabled?.let {
+                    featureFlagState = featureFlagState.copy(isFileSharingEnabledState = it)
                 }
-                if (it.isStatusChanged != null && it.isStatusChanged!!) {
-                    featureFlagState = featureFlagState.copy(showFileSharingDialog = it.isStatusChanged!!)
+                fileSharingStatus.isStatusChanged?.let {
+                    featureFlagState = featureFlagState.copy(showFileSharingDialog = it)
                 }
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After the merge of https://github.com/wireapp/wire-android-reloaded/pull/1399 we started noticing a series of crashes when launching the app with no authenticated user. 

### Causes (Optional)

The cause of the crash was that we were lazily initialising the `FeatureFlagNotificationViewModel` upon app start inside the `WireActivity`. And this VM was also referencing the `MarkFileSharingChangeAsNotifiedUseCase` whose scope required a valid user session. 

### Solutions

Therefore, we decided to decouple it from the initial logic, and check manually whether there was a valid user session AND the received intent was a sharing one before navigation to the `ImportMediaScreen`. Only once these requirements were met, we could call the `FeatureFlagNotificationViewModel`.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
