### PR TITLE
fix(rc): handle migration errors properly [AR-3078]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,10 @@
                 <data
                         android:host="incoming-call"
                         android:scheme="wire"/>
+
+                <data
+                        android:host="migration-login"
+                        android:scheme="wire" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -20,11 +20,18 @@
 
 package com.wire.android.migration
 
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.text.Spanned
+import androidx.core.app.NotificationCompat
+import androidx.core.text.toSpanned
 import androidx.work.Data
 import androidx.work.workDataOf
+import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.migration.failure.MigrationFailure
 import com.wire.android.migration.feature.MigrateActiveAccountsUseCase
 import com.wire.android.migration.feature.MigrateClientsDataUseCase
 import com.wire.android.migration.feature.MigrateConversationsUseCase
@@ -32,15 +39,22 @@ import com.wire.android.migration.feature.MigrateMessagesUseCase
 import com.wire.android.migration.feature.MigrateServerConfigUseCase
 import com.wire.android.migration.feature.MigrateUsersUseCase
 import com.wire.android.migration.util.ScalaDBNameProvider
+import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.util.ui.stringWithBoldArgs
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.EncryptionFailure
+import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.ProteusFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.isLeft
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.functional.onFailure
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -67,7 +81,8 @@ class MigrationManager @Inject constructor(
     private val migrateClientsData: MigrateClientsDataUseCase,
     private val migrateUsers: MigrateUsersUseCase,
     private val migrateConversations: MigrateConversationsUseCase,
-    private val migrateMessages: MigrateMessagesUseCase
+    private val migrateMessages: MigrateMessagesUseCase,
+    private val notificationManager: NotificationManager
 ) {
     private fun isScalaDBPresent(): Boolean =
         applicationContext.getDatabasePath(ScalaDBNameProvider.globalDB()).let { it.isFile && it.exists() }
@@ -93,58 +108,100 @@ class MigrationManager @Inject constructor(
         coroutineScope: CoroutineScope,
         updateProgress: suspend (MigrationData.Progress) -> Unit,
         migrationDispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(2)
-    ): MigrationData.Result =
-        migrateServerConfig()
+    ): MigrationData.Result {
+        updateProgress(MigrationData.Progress(MigrationData.Progress.Type.ACCOUNTS))
+        return migrateServerConfig()
             .map {
                 appLogger.d("$TAG - Step 1 - Migrating accounts")
                 migrateActiveAccounts(it)
             }
+            .map { it.userIds.values.toList() to it.isFederationEnabled }
             .fold(
-                {
-                    migrationFailure(it)
-                }, { (migratedAccounts, isFederated) ->
-                    updateProgress(MigrationData.Progress(MigrationData.Progress.Type.ACCOUNTS))
-                    onAccountsMigrated(migratedAccounts, isFederated, coroutineScope, migrationDispatcher).also {
-                        appLogger.d("User migration done Result $it")
+                { failure ->
+                    when (failure) {
+                        is NetworkFailure -> MigrationData.Result.Failure.NoNetwork
+                        else -> MigrationData.Result.Failure.Account.Any
                     }
-                    MigrationData.Result.Success
+                }, { (migratedAccounts, isFederated) ->
+
+                    val accountsSucceeded = migratedAccounts.filter { it.isRight() }.map { (it as Either.Right).value }
+                    val accountsFailed = migratedAccounts.filter { it.isLeft() }.map { (it as Either.Left).value }
+                    if (accountsFailed.any { it.cause is NetworkFailure }) {
+                        MigrationData.Result.Failure.NoNetwork
+                    } else {
+                        val results = onAccountsMigrated(
+                            accountsSucceeded,
+                            isFederated,
+                            coroutineScope,
+                            migrationDispatcher,
+                            updateProgress
+                        ).values
+                        val dataFailed = results.filter { it.isLeft() }.map { (it as Either.Left).value }
+                        when {
+                            dataFailed.any { it is NetworkFailure } -> MigrationData.Result.Failure.NoNetwork
+                            accountsFailed.size > 1 -> MigrationData.Result.Failure.Account.Any
+                            accountsFailed.size == 1 -> accountsFailed.first().let {
+                                if (it.userName?.isNotEmpty() == true && it.userHandle?.isNotEmpty() == true)
+                                    MigrationData.Result.Failure.Account.Specific(it.userName, it.userHandle)
+                                else MigrationData.Result.Failure.Account.Any
+                            }
+                            dataFailed.isNotEmpty() ->
+                                MigrationData.Result.Failure.Messages(dataFailed.joinToString { it.getErrorCode().toString() })
+                            else -> MigrationData.Result.Success
+                        }
+                    }
                 }
-            )
+            ).also {
+                when (it) {
+                    is MigrationData.Result.Failure.Account.Specific -> showAccountSpecificNotification(it.userName, it.userHandle)
+                    is MigrationData.Result.Failure.Account.Any -> showAccountAnyNotification()
+                    is MigrationData.Result.Failure.Messages -> showMessagesNotification(it.errorCode)
+                    else -> {}
+                }
+            }
+    }
+
+    private fun CoreFailure.getErrorCode(): Int = when(this) {
+        is MigrationFailure.ClientNotRegistered -> 1
+        is MigrationFailure.InvalidRefreshToken -> 2
+        is StorageFailure -> 3
+        is NetworkFailure -> 4
+        is EncryptionFailure -> 5
+        is ProteusFailure -> 6
+        is MLSFailure -> 7
+        else -> 0
+    }
 
     private suspend fun onAccountsMigrated(
-        migratedAccounts: Map<String, Either<CoreFailure, UserId>>,
+        migratedAccounts: List<UserId>,
         isFederated: Boolean,
         coroutineScope: CoroutineScope,
         migrationDispatcher: CoroutineDispatcher,
+        updateProgress: suspend (MigrationData.Progress) -> Unit,
     ): Map<String, Either<CoreFailure, Unit>> {
         val resultAcc: ConcurrentMap<String, Either<CoreFailure, Unit>> = ConcurrentHashMap()
-
-        val migrationJobs: List<Job> = migratedAccounts.map { it ->
+        updateProgress(MigrationData.Progress(MigrationData.Progress.Type.MESSAGES))
+        val migrationJobs: List<Job> = migratedAccounts.map { userId ->
             coroutineScope.launch(migrationDispatcher) {
-                if (it.value.isRight()) {
-                    val userid = (it.value as Either.Right).value
-                    appLogger.d("$TAG - Step 2 - Migrating clients for $userid")
-                    migrateClientsData(userid, isFederated).onFailure { failure ->
-                        appLogger.e("$TAG - Step 2 - Migrating clients for $userid failed reason $failure")
-                    }
-                    appLogger.d("$TAG - Step 3 - Migrating users for $userid")
-                    migrateUsers(userid).flatMap {
-                        appLogger.d("$TAG - Step 4 - Migrating conversations for $userid")
-                        migrateConversations(it)
-                    }.flatMap {
-                        appLogger.d("$TAG - Step 5 - Migrating messages for $userid")
-                        migrateMessages(userid, it, coroutineScope).let { failedConversations ->
-                            if (failedConversations.isEmpty()) {
-                                Either.Right(Unit)
-                            } else {
-                                Either.Left(failedConversations.values.first())
-                            }
+                appLogger.d("$TAG - Step 2 - Migrating clients for $userId")
+                migrateClientsData(userId, isFederated).onFailure { failure ->
+                    appLogger.e("$TAG - Step 2 - Migrating clients for $userId failed reason $failure")
+                }
+                appLogger.d("$TAG - Step 3 - Migrating users for $userId")
+                migrateUsers(userId).flatMap {
+                    appLogger.d("$TAG - Step 4 - Migrating conversations for $userId")
+                    migrateConversations(it)
+                }.flatMap {
+                    appLogger.d("$TAG - Step 5 - Migrating messages for $userId")
+                    migrateMessages(userId, it, coroutineScope).let { failedConversations ->
+                        if (failedConversations.isEmpty()) {
+                            Either.Right(Unit)
+                        } else {
+                            Either.Left(failedConversations.values.first())
                         }
-                    }.also {
-                        resultAcc[userid.value] = it
                     }
-                } else {
-                    resultAcc[it.key] = it.value as Either.Left
+                }.also {
+                    resultAcc[userId.value] = it
                 }
             }
         }
@@ -154,9 +211,41 @@ class MigrationManager @Inject constructor(
         return resultAcc.toMap()
     }
 
-    private fun migrationFailure(failure: CoreFailure): MigrationData.Result = when (failure) {
-        is NetworkFailure.NoNetworkConnection -> MigrationData.Result.Failure
-        else -> MigrationData.Result.Success
+    private fun showMigrationFailureNotification(message: Spanned, pendingIntent: PendingIntent) {
+        val notification = NotificationCompat.Builder(applicationContext, NotificationConstants.OTHER_CHANNEL_ID)
+            .setSmallIcon(R.drawable.notification_icon_small)
+            .setAutoCancel(true)
+            .setSilent(false)
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .setContentTitle(applicationContext.getString(R.string.welcome_migration_dialog_title))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setContentIntent(pendingIntent)
+            .build()
+        notificationManager.notify(NotificationConstants.MIGRATION_ERROR_NOTIFICATION_ID, notification)
+    }
+
+    private fun showAccountAnyNotification() {
+        val message = applicationContext.resources.getString(R.string.migration_login_required).toSpanned()
+        showMigrationFailureNotification(message, openAppPendingIntent(applicationContext)) // TODO: open directly login screen
+    }
+
+    private fun showAccountSpecificNotification(userName: String, userHandle: String) {
+        val message = applicationContext.resources.stringWithBoldArgs(
+            R.string.migration_login_required_specific_account,
+            applicationContext.resources.getString(R.string.migration_login_required_specific_account_name, userName, userHandle)
+        )
+        showMigrationFailureNotification(message, openAppPendingIntent(applicationContext)) // TODO: open directly login screen
+    }
+
+    private fun showMessagesNotification(errorCode: String) {
+        val message = applicationContext.resources.getString(R.string.migration_messages_failure, errorCode).toSpanned()
+        showMigrationFailureNotification(message, openAppPendingIntent(applicationContext))
+    }
+
+    fun dismissMigrationFailureNotification() {
+        notificationManager.cancel(NotificationConstants.MIGRATION_ERROR_NOTIFICATION_ID)
     }
 
     companion object {
@@ -166,15 +255,35 @@ class MigrationManager @Inject constructor(
 
 sealed class MigrationData {
     data class Progress(val type: Type) : MigrationData() {
-        enum class Type { SERVER_CONFIGS, ACCOUNTS, CLIENTS, USERS, CONVERSATIONS, MESSAGES, UNKNOWN; }
+        enum class Type { ACCOUNTS, MESSAGES, UNKNOWN; }
         companion object {
             const val KEY_PROGRESS_TYPE = "progress_type"
+            val steps = listOf(Type.ACCOUNTS, Type.MESSAGES) // migration steps in order
         }
     }
 
     sealed class Result : MigrationData() {
         object Success : Result()
-        object Failure : Result()
+        sealed class Failure : Result() {
+            object NoNetwork : Failure()
+            sealed class Account : Failure() {
+                data class Specific(val userName: String, val userHandle: String) : Account()
+                object Any : Account()
+            }
+
+            data class Messages(val errorCode: String) : Failure()
+
+            companion object {
+                const val KEY_FAILURE_TYPE = "failure_type"
+                const val FAILURE_TYPE_NO_NETWORK = "failure_no_network"
+                const val FAILURE_TYPE_ACCOUNT_ANY = "failure_account_any"
+                const val FAILURE_TYPE_ACCOUNT_SPECIFIC = "failure_account_specific"
+                const val FAILURE_TYPE_MESSAGES = "failure_messages"
+                const val KEY_FAILURE_USER_NAME = "failure_user_name"
+                const val KEY_FAILURE_USER_HANDLE = "failure_user_handle"
+                const val KEY_FAILURE_ERROR_CODE = "failure_error_code"
+            }
+        }
     }
 }
 
@@ -188,3 +297,38 @@ fun Data.getMigrationProgress(): MigrationData.Progress.Type = this.getString(Mi
             null
         }
     } ?: MigrationData.Progress.Type.UNKNOWN
+
+fun MigrationData.Result.Failure.toData(): Data = when (this) {
+    is MigrationData.Result.Failure.Account.Any -> workDataOf(
+        MigrationData.Result.Failure.KEY_FAILURE_TYPE to MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_ANY,
+    )
+
+    is MigrationData.Result.Failure.Account.Specific -> workDataOf(
+        MigrationData.Result.Failure.KEY_FAILURE_TYPE to MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_SPECIFIC,
+        MigrationData.Result.Failure.KEY_FAILURE_USER_NAME to this.userName,
+        MigrationData.Result.Failure.KEY_FAILURE_USER_HANDLE to this.userHandle,
+    )
+
+    is MigrationData.Result.Failure.Messages -> workDataOf(
+        MigrationData.Result.Failure.KEY_FAILURE_TYPE to MigrationData.Result.Failure.FAILURE_TYPE_MESSAGES,
+        MigrationData.Result.Failure.KEY_FAILURE_ERROR_CODE to this.errorCode
+    )
+
+    MigrationData.Result.Failure.NoNetwork -> workDataOf(
+        MigrationData.Result.Failure.KEY_FAILURE_TYPE to MigrationData.Result.Failure.FAILURE_TYPE_NO_NETWORK
+    )
+}
+
+fun Data.getMigrationFailure(): MigrationData.Result.Failure = when (this.getString(MigrationData.Result.Failure.KEY_FAILURE_TYPE)) {
+    MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_ANY -> MigrationData.Result.Failure.Account.Any
+    MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_SPECIFIC -> MigrationData.Result.Failure.Account.Specific(
+        this.getString(MigrationData.Result.Failure.KEY_FAILURE_USER_NAME) ?: "",
+        this.getString(MigrationData.Result.Failure.KEY_FAILURE_USER_NAME) ?: "",
+    )
+
+    MigrationData.Result.Failure.FAILURE_TYPE_MESSAGES -> MigrationData.Result.Failure.Messages(
+        this.getString(MigrationData.Result.Failure.KEY_FAILURE_ERROR_CODE) ?: ""
+    )
+
+    else -> MigrationData.Result.Failure.NoNetwork
+}

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -44,6 +44,8 @@ import com.wire.android.migration.util.ScalaDBNameProvider
 import com.wire.kalium.logger.obfuscateId
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.notification.openMigrationLoginPendingIntent
+import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.stringWithBoldArgs
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.EncryptionFailure
@@ -283,7 +285,7 @@ class MigrationManager @Inject constructor(
 
     private fun showAccountAnyNotification() {
         val message = applicationContext.resources.getString(R.string.migration_login_required).toSpanned()
-        showMigrationFailureNotification(message, openAppPendingIntent(applicationContext)) // TODO: open directly login screen
+        showMigrationFailureNotification(message, openMigrationLoginPendingIntent(applicationContext, String.EMPTY))
     }
 
     private fun showAccountSpecificNotification(userName: String, userHandle: String) {
@@ -291,7 +293,7 @@ class MigrationManager @Inject constructor(
             R.string.migration_login_required_specific_account,
             applicationContext.resources.getString(R.string.migration_login_required_specific_account_name, userName, userHandle)
         )
-        showMigrationFailureNotification(message, openAppPendingIntent(applicationContext)) // TODO: open directly login screen
+        showMigrationFailureNotification(message, openMigrationLoginPendingIntent(applicationContext, userHandle))
     }
 
     private fun showMessagesNotification(errorCode: String) {
@@ -377,7 +379,7 @@ fun Data.getMigrationFailure(): MigrationData.Result.Failure = when (this.getStr
     MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_ANY -> MigrationData.Result.Failure.Account.Any
     MigrationData.Result.Failure.FAILURE_TYPE_ACCOUNT_SPECIFIC -> MigrationData.Result.Failure.Account.Specific(
         this.getString(MigrationData.Result.Failure.KEY_FAILURE_USER_NAME) ?: "",
-        this.getString(MigrationData.Result.Failure.KEY_FAILURE_USER_NAME) ?: "",
+        this.getString(MigrationData.Result.Failure.KEY_FAILURE_USER_HANDLE) ?: "",
     )
 
     MigrationData.Result.Failure.FAILURE_TYPE_MESSAGES -> MigrationData.Result.Failure.Messages(

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -75,7 +75,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("LongParameterList", "TooGenericExceptionCaught")
+@Suppress("LongParameterList", "TooGenericExceptionCaught", "TooManyFunctions")
 @Singleton
 class MigrationManager @Inject constructor(
     @ApplicationContext private val applicationContext: Context,
@@ -186,6 +186,7 @@ class MigrationManager @Inject constructor(
         }
     }
 
+    @Suppress("MagicNumber")
     private fun CoreFailure.getErrorCode(): Int = when(this) {
         is MigrationFailure.ClientNotRegistered -> 1
         is MigrationFailure.InvalidRefreshToken -> 2
@@ -197,6 +198,7 @@ class MigrationManager @Inject constructor(
         else -> 0
     }
 
+    @Suppress("NestedBlockDepth")
     private suspend fun onAccountsMigrated(
         migratedAccounts: List<Either<MigrateActiveAccountsUseCase.AccountMigrationFailure, UserId>>,
         isFederated: Boolean,

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -25,6 +25,7 @@ import com.wire.android.migration.MigrationMapper
 import com.wire.android.migration.failure.MigrationFailure
 import com.wire.android.migration.globalDatabase.ScalaActiveAccountsEntity
 import com.wire.android.migration.globalDatabase.ScalaAppDataBaseProvider
+import com.wire.android.migration.userDatabase.ScalaUserDatabaseProvider
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -34,6 +35,7 @@ import com.wire.kalium.logic.feature.auth.AuthTokens
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.mapLeft
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,10 +43,11 @@ import javax.inject.Singleton
 class MigrateActiveAccountsUseCase @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val scalaGlobalDB: ScalaAppDataBaseProvider,
+    private val scalaUserDB: ScalaUserDatabaseProvider,
     private val mapper: MigrationMapper
 ) {
     suspend operator fun invoke(serverConfig: ServerConfig): Result {
-        val resultAcc: MutableMap<String, Either<CoreFailure, UserId>> = mutableMapOf()
+        val resultAcc: MutableMap<String, Either<AccountMigrationFailure, UserId>> = mutableMapOf()
         val scalaAccountList = scalaGlobalDB.scalaAccountsDAO.activeAccounts()
 
         repeat(scalaAccountList.size) { index ->
@@ -52,7 +55,6 @@ class MigrateActiveAccountsUseCase @Inject constructor(
                 scalaAccountList[index].copy(
                     refreshToken = scalaAccountList[index].refreshToken.removePrefix(REFRESH_TOKEN_PREFIX)
                 )
-
             val isDataComplete = isDataComplete(serverConfig, activeAccount)
             val ssoId = activeAccount.ssoId?.let { ssoId -> mapper.fromScalaSsoID(ssoId) }
             val authTokensEither: Either<CoreFailure, AuthTokens> = if (isDataComplete) {
@@ -89,6 +91,9 @@ class MigrateActiveAccountsUseCase @Inject constructor(
                     is AddAuthenticatedUserUseCase.Result.Failure.Generic -> Either.Left(addAccountResult.genericFailure)
                     else -> Either.Right(authTokens.userId)
                 }
+            }.mapLeft {
+                val userData = scalaUserDB.userDAO(activeAccount.id)?.users(listOf(activeAccount.id))?.firstOrNull()
+                AccountMigrationFailure(userData?.name, userData?.handle, it)
             }
             resultAcc[activeAccount.id] = accountResult
         }
@@ -114,7 +119,9 @@ class MigrateActiveAccountsUseCase @Inject constructor(
         }
     }
 
-    data class Result(val userIds: Map<String, Either<CoreFailure, UserId>>, val isFederationEnabled: Boolean)
+    data class Result(val userIds: Map<String, Either<AccountMigrationFailure, UserId>>, val isFederationEnabled: Boolean)
+
+    data class AccountMigrationFailure(val userName: String?, val userHandle: String?, val cause: CoreFailure)
 
     private companion object {
         const val REFRESH_TOKEN_PREFIX = "zuid="

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -35,6 +35,8 @@ import com.wire.kalium.logic.feature.auth.AuthTokens
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapLeft
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -92,7 +94,7 @@ class MigrateActiveAccountsUseCase @Inject constructor(
                     else -> Either.Right(authTokens.userId)
                 }
             }.mapLeft {
-                val userData = scalaUserDB.userDAO(activeAccount.id)?.users(listOf(activeAccount.id))?.firstOrNull()
+                val userData = scalaUserDB.userDAO(activeAccount.id).map { it.users(listOf(activeAccount.id)) }.getOrNull()?.firstOrNull()
                 AccountMigrationFailure(userData?.name, userData?.handle, it)
             }
             resultAcc[activeAccount.id] = accountResult

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateClientsDataUseCase.kt
@@ -52,7 +52,7 @@ class MigrateClientsDataUseCase @Inject constructor(
    @Suppress("ReturnCount")
     suspend operator fun invoke(userId: UserId, isFederated: Boolean): Either<CoreFailure, Unit> {
 
-        val clientId = scalaUserDBProvider.clientDAO(userId)?.clientInfo()?.clientId?.let { ClientId(it) }
+        val clientId = scalaUserDBProvider.clientDAO(userId.value)?.clientInfo()?.clientId?.let { ClientId(it) }
             ?: return Either.Left(StorageFailure.DataNotFound)
 
         // move crypto box files
@@ -131,7 +131,7 @@ class MigrateClientsDataUseCase @Inject constructor(
                 .map { file -> file.name.substringBefore("_") to file }
             val sessionUserIds = filesWithoutDomain.map { (userId, _) -> userId }.distinct()
             val sessionUsers = sessionUserIds.chunked(SESSION_USER_IDS_CHUNK_SIZE)
-                .map { scalaUserDBProvider.userDAO(userId)?.users(it) ?: listOf() }
+                .map { scalaUserDBProvider.userDAO(userId.value)?.users(it) ?: listOf() }
                 .flatten()
                 .associateBy { it.id }
             filesWithoutDomain.forEach { (sessionUserId, file) ->

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateConversationsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateConversationsUseCase.kt
@@ -48,7 +48,7 @@ class MigrateConversationsUseCase @Inject constructor(
     // and in that case leaving it as group will not be an issue
     suspend operator fun invoke(userIds: List<UserId>): Either<CoreFailure, Map<UserId, List<ScalaConversationData>>> =
         userIds.foldToEitherWhileRight(mapOf()) { userId, acc ->
-            val conversations = scalaUserDatabase.conversationDAO(userId)?.conversations() ?: listOf()
+            val conversations = scalaUserDatabase.conversationDAO(userId.value)?.conversations() ?: listOf()
             if (conversations.isNotEmpty()) {
                 val mappedConversations = conversations.mapNotNull { scalaConversation ->
                     mapper.fromScalaConversationToConversation(scalaConversation, userId)

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateMessagesUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateMessagesUseCase.kt
@@ -27,7 +27,6 @@ import com.wire.android.migration.userDatabase.ScalaUserDatabaseProvider
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
@@ -45,8 +44,8 @@ class MigrateMessagesUseCase @Inject constructor(
     ): Map<String, CoreFailure> {
         val errorsAcc: MutableMap<String, CoreFailure> = mutableMapOf()
 
-        val messageDAO = scalaUserDatabase.messageDAO(userId)
-        val userDAO = scalaUserDatabase.userDAO(userId)
+        val messageDAO = scalaUserDatabase.messageDAO(userId.value)
+        val userDAO = scalaUserDatabase.userDAO(userId.value)
 
         // iterate over all conversations and migrate messages
         // if any error occurs, add it to the errors accumulator

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateUsersUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateUsersUseCase.kt
@@ -37,7 +37,7 @@ class MigrateUsersUseCase @Inject constructor(
     private val mapper: MigrationMapper
 ) {
     suspend operator fun invoke(userId: UserId): Either<CoreFailure, UserId> {
-        val users = scalaUserDatabase.userDAO(userId)?.allUsers() ?: listOf()
+        val users = scalaUserDatabase.userDAO(userId.value)?.allUsers() ?: listOf()
         val selfScalaUser = users.first { it.id == userId.value && it.domain == userId.domain }
         val mappedUsers = users.map { scalaUser ->
             mapper.fromScalaUserToUser(scalaUser, selfScalaUser.id, selfScalaUser.domain, selfScalaUser.teamId, userId)

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaUserDatabaseProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ScalaUserDatabaseProvider.kt
@@ -24,7 +24,6 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import com.wire.android.migration.util.ScalaDBNameProvider
 import com.wire.android.migration.util.openDatabaseIfExists
-import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -39,10 +38,10 @@ import javax.inject.Singleton
 class ScalaUserDatabaseProvider @Inject constructor(
     @ApplicationContext private val applicationContext: Context
 ) {
-    private val _dbs: ConcurrentMap<UserId, Pair<ScalaUserDatabase, CoroutineDispatcher>?> by lazy { ConcurrentHashMap() }
+    private val _dbs: ConcurrentMap<String, Pair<ScalaUserDatabase, CoroutineDispatcher>?> by lazy { ConcurrentHashMap() }
 
     @Synchronized
-    fun db(userId: UserId): Pair<ScalaUserDatabase, CoroutineDispatcher>? {
+    fun db(userId: String): Pair<ScalaUserDatabase, CoroutineDispatcher>? {
         return _dbs.getOrPut(userId) {
             val dbName = ScalaDBNameProvider.userDB(userId)
             applicationContext.openDatabaseIfExists(dbName)?.let {
@@ -52,10 +51,10 @@ class ScalaUserDatabaseProvider @Inject constructor(
         }
     }
 
-    fun clientDAO(userId: UserId): ScalaClientDAO? = db(userId)?.let { ScalaClientDAO(it.first, it.second) }
-    fun conversationDAO(userId: UserId): ScalaConversationDAO? = db(userId)?.let { ScalaConversationDAO(it.first, it.second) }
-    fun messageDAO(userId: UserId): ScalaMessageDAO? = db(userId)?.let { ScalaMessageDAO(it.first, it.second) }
-    fun userDAO(userId: UserId): ScalaUserDAO? = db(userId)?.let { ScalaUserDAO(it.first, it.second) }
+    fun clientDAO(userId: String): ScalaClientDAO? = db(userId)?.let { ScalaClientDAO(it.first, it.second) }
+    fun conversationDAO(userId: String): ScalaConversationDAO? = db(userId)?.let { ScalaConversationDAO(it.first, it.second) }
+    fun messageDAO(userId: String): ScalaMessageDAO? = db(userId)?.let { ScalaMessageDAO(it.first, it.second) }
+    fun userDAO(userId: String): ScalaUserDAO? = db(userId)?.let { ScalaUserDAO(it.first, it.second) }
 }
 
 typealias ScalaUserDatabase = SQLiteDatabase

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
@@ -19,7 +19,7 @@ class ShouldTriggerMigrationForUserUserCase @Inject constructor(
         .first().let { migrationStatus ->
             if (migrationStatus != UserMigrationStatus.NotStarted) return@let false
 
-            applicationContext.getDatabasePath(ScalaDBNameProvider.userDB(userId))
+            applicationContext.getDatabasePath(ScalaDBNameProvider.userDB(userId.value))
                 .let { it.isFile && it.exists() }
                 .also {
                     // if the user database does not exists, we can't migrate it

--- a/app/src/main/kotlin/com/wire/android/migration/util/ScalaDBNameProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/util/ScalaDBNameProvider.kt
@@ -20,11 +20,9 @@
 
 package com.wire.android.migration.util
 
-import com.wire.kalium.logic.data.user.UserId
-
 object ScalaDBNameProvider {
     fun globalDB() = SCALA_GLOBAL_DATABASE_NAME
-    fun userDB(userId: UserId) = userId.value
+    fun userDB(userId: String) = userId
 
     private const val SCALA_GLOBAL_DATABASE_NAME = "ZGlobal.db"
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -132,13 +132,25 @@ enum class NavigationItem(
 
     Login(
         primaryRoute = LOGIN,
-        canonicalRoute = LOGIN,
+        canonicalRoute = "$LOGIN?$EXTRA_USER_HANDLE={$EXTRA_USER_HANDLE}",
         content = { contentParams ->
             val ssoLoginResult = contentParams.arguments.filterIsInstance<DeepLinkResult.SSOLogin>().firstOrNull()
             LoginScreen(ssoLoginResult)
         },
+        deepLinks = listOf(
+            navDeepLink {
+                uriPattern = "${DeepLinkProcessor.DEEP_LINK_SCHEME}://" +
+                        "${DeepLinkProcessor.MIGRATION_LOGIN_HOST}/" +
+                        "{$EXTRA_USER_HANDLE}"
+            }
+        ),
         animationConfig = NavigationAnimationConfig.CustomAnimation(smoothSlideInFromRight(), smoothSlideOutFromLeft())
-    ),
+    ) {
+        override fun getRouteWithArgs(arguments: List<Any>): String {
+            val userHandleString: String = arguments.filterIsInstance<String>().firstOrNull()?.toString() ?: "{$EXTRA_USER_HANDLE}"
+            return "$LOGIN?$EXTRA_USER_HANDLE=$userHandleString"
+        }
+    },
 
     CreateTeam(
         primaryRoute = CREATE_TEAM,
@@ -456,6 +468,7 @@ object NavigationItemDestinationsRoutes {
 
 const val EXTRA_USER_ID = "extra_user_id"
 const val EXTRA_USER_DOMAIN = "extra_user_domain"
+const val EXTRA_USER_HANDLE = "extra_user_handle"
 
 const val EXTRA_CONVERSATION_ID = "extra_conversation_id"
 const val EXTRA_CREATE_ACCOUNT_FLOW_TYPE = "extra_create_account_flow_type"

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.notification
 
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 
 //TODO: The names need to be localisable
@@ -53,6 +52,7 @@ object NotificationConstants {
     val PERSISTENT_NOTIFICATION_ID = "wire_persistent_web_socket_notification".hashCode()
     val MESSAGE_SYNC_NOTIFICATION_ID = "wire_notification_fetch_notification".hashCode()
     val MIGRATION_NOTIFICATION_ID = "wire_migration_notification".hashCode()
+    val MIGRATION_ERROR_NOTIFICATION_ID = "wire_migration_error_notification".hashCode()
 
     // MessagesSummaryNotification ID depends on User, use fun getMessagesSummaryId(userId: UserId) to get it
     private const val MESSAGE_SUMMARY_ID_STRING = "wire_messages_summary_notification"

--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -166,6 +166,23 @@ private fun openOngoingCallIntent(context: Context, conversationId: String) =
             .build()
     }
 
+private fun openMigrationLoginIntent(context: Context, userHandle: String) =
+    Intent(context.applicationContext, WireActivity::class.java).apply {
+        data = Uri.Builder()
+            .scheme(DeepLinkProcessor.DEEP_LINK_SCHEME)
+            .authority(DeepLinkProcessor.MIGRATION_LOGIN_HOST)
+            .appendPath(userHandle)
+            .build()
+    }
+
+fun openMigrationLoginPendingIntent(context: Context, userHandle: String): PendingIntent =
+    PendingIntent.getActivity(
+        context.applicationContext,
+        OPEN_MIGRATION_LOGIN_REQUEST_CODE,
+        openMigrationLoginIntent(context, userHandle),
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    )
+
 fun openAppPendingIntent(context: Context): PendingIntent {
     val appIntent = Intent(context.applicationContext, WireActivity::class.java)
     return PendingIntent.getActivity(
@@ -181,6 +198,7 @@ private const val DECLINE_CALL_REQUEST_CODE = "decline_call_"
 private const val OPEN_INCOMING_CALL_REQUEST_CODE = 2
 private const val FULL_SCREEN_REQUEST_CODE = 3
 private const val OPEN_ONGOING_CALL_REQUEST_CODE = 4
+private const val OPEN_MIGRATION_LOGIN_REQUEST_CODE = 5
 private const val END_ONGOING_CALL_REQUEST_CODE = "hang_up_call_"
 private const val OPEN_MESSAGE_REQUEST_CODE_PREFIX = "open_message_"
 private const val OPEN_OTHER_USER_PROFILE_CODE_PREFIX = "open_other_user_profile_"

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -165,6 +165,7 @@ class WireActivityViewModel @Inject constructor(
         else -> NavigationItem.Home.getRouteWithArgs()
     }
 
+    @Suppress("ComplexMethod")
     fun handleDeepLink(intent: Intent?) {
         intent?.data?.let { deepLink ->
             when (val result = deepLinkProcessor(deepLink, viewModelScope)) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 
 data class LoginState(
     val userIdentifier: TextFieldValue = TextFieldValue(""),
+    val userIdentifierEnabled: Boolean = true,
     val password: TextFieldValue = TextFieldValue(""),
     val ssoCode: TextFieldValue = TextFieldValue(""),
     val proxyIdentifier: TextFieldValue = TextFieldValue(""),

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -148,7 +148,8 @@ private fun LoginEmailContent(
                 error = when (loginState.loginError) {
                     LoginError.TextFieldError.InvalidValue -> stringResource(R.string.login_error_invalid_user_identifier)
                     else -> null
-                }
+                },
+                isEnabled = loginState.userIdentifierEnabled
             )
             PasswordInput(
                 modifier = Modifier
@@ -202,6 +203,7 @@ private fun UserIdentifierInput(
     userIdentifier: TextFieldValue,
     error: String?,
     onUserIdentifierChange: (TextFieldValue) -> Unit,
+    isEnabled: Boolean,
 ) {
     AutoFillTextField(
         autofillTypes = listOf(AutofillType.EmailAddress, AutofillType.Username),
@@ -209,7 +211,11 @@ private fun UserIdentifierInput(
         onValueChange = onUserIdentifierChange,
         placeholderText = stringResource(R.string.login_user_identifier_placeholder),
         labelText = stringResource(R.string.login_user_identifier_label),
-        state = if (error != null) WireTextFieldState.Error(error) else WireTextFieldState.Default,
+        state = when {
+            !isEnabled -> WireTextFieldState.Disabled
+            error != null -> WireTextFieldState.Error(error)
+            else -> WireTextFieldState.Default
+        },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         modifier = modifier.testTag("emailField")
     )

--- a/app/src/main/kotlin/com/wire/android/ui/common/SettingUpWireScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SettingUpWireScreenContent.kt
@@ -22,14 +22,19 @@ package com.wire.android.ui.common
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -37,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,59 +57,87 @@ import com.wire.android.ui.theme.wireTypography
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingUpWireScreenContent(
-    @StringRes titleResId: Int = R.string.migration_title,
-    @StringRes messageResId: Int = R.string.migration_message,
+    @StringRes topBarTitleResId: Int = R.string.migration_title,
     @DrawableRes iconResId: Int = R.drawable.ic_migration,
+    title: String? = null,
+    message: AnnotatedString = AnnotatedString(stringResource(R.string.migration_message)),
     type: SettingUpWireScreenType = SettingUpWireScreenType.Progress
 ) {
     Scaffold(
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = 0.dp,
-                title = stringResource(titleResId),
+                title = stringResource(topBarTitleResId),
                 navigationIconType = null,
             )
         }
     ) { internalPadding ->
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            Image(
-                painter = painterResource(iconResId),
-                contentDescription = "",
-                contentScale = ContentScale.Inside,
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
                 modifier = Modifier
-                    .padding(
-                        horizontal = MaterialTheme.wireDimensions.welcomeImageHorizontalPadding,
-                        vertical = MaterialTheme.wireDimensions.welcomeVerticalSpacing
-                    )
-            )
-            if (type is SettingUpWireScreenType.Progress) {
-                WireCircularProgressIndicator(progressColor = MaterialTheme.wireColorScheme.badge)
-            }
-            Text(
-                text = stringResource(messageResId),
-                style = MaterialTheme.wireTypography.body01,
-                color = MaterialTheme.wireColorScheme.secondaryText,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding)
-            )
-            if (type is SettingUpWireScreenType.Failure) {
-                WirePrimaryButton(
-                    onClick = type.onRetryClick,
-                    text = stringResource(type.retryButtonResId),
-                    fillMaxWidth = false,
+                    .fillMaxWidth()
+                    .weight(weight = 1f, fill = true)
+            ) {
+                Image(
+                    painter = painterResource(iconResId),
+                    contentDescription = "",
+                    contentScale = ContentScale.Inside,
                     modifier = Modifier
                         .padding(
-                            horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding,
-                            vertical = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding
+                            horizontal = MaterialTheme.wireDimensions.welcomeImageHorizontalPadding,
+                            vertical = MaterialTheme.wireDimensions.welcomeVerticalSpacing
                         )
                 )
+                AnimatedVisibility(visible = type is SettingUpWireScreenType.Progress) {
+                    WireCircularProgressIndicator(progressColor = MaterialTheme.wireColorScheme.badge)
+                }
+                AnimatedVisibility(visible = title?.isNotEmpty() == true) {
+                    Text(
+                        text = title ?: "",
+                        style = MaterialTheme.wireTypography.body02,
+                        color = MaterialTheme.wireColorScheme.onBackground,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .animateContentSize()
+                            .padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding)
+                    )
+                }
+
+                Text(
+                    text = message,
+                    style = MaterialTheme.wireTypography.body01,
+                    color = MaterialTheme.wireColorScheme.secondaryText,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .animateContentSize()
+                        .padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding)
+                )
+            }
+
+            Box(modifier = Modifier.animateContentSize()) {
+                if (type is SettingUpWireScreenType.Failure) {
+                    Surface(
+                        shadowElevation = MaterialTheme.wireDimensions.topBarShadowElevation,
+                        color = MaterialTheme.wireColorScheme.background,
+                    ) {
+                        Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
+                            WirePrimaryButton(
+                                onClick = (type as? SettingUpWireScreenType.Failure)?.onButtonClick ?: {},
+                                text = (type as? SettingUpWireScreenType.Failure)?.buttonTextResId?.let { stringResource(it) },
+                                fillMaxWidth = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -112,15 +146,15 @@ fun SettingUpWireScreenContent(
 sealed class SettingUpWireScreenType {
     object Progress : SettingUpWireScreenType()
     data class Failure(
-        @StringRes val retryButtonResId: Int = R.string.label_retry,
-        val onRetryClick: () -> Unit = {}
+        @StringRes val buttonTextResId: Int = R.string.label_retry,
+        val onButtonClick: () -> Unit = {}
     ) : SettingUpWireScreenType()
 }
 
 @Preview
 @Composable
 fun PreviewMigrationScreenProgress() {
-    SettingUpWireScreenContent(type = SettingUpWireScreenType.Progress)
+    SettingUpWireScreenContent(type = SettingUpWireScreenType.Progress, title = "Step 1/2")
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -36,6 +36,7 @@ import com.wire.android.ui.common.SettingUpWireScreenContent
 import com.wire.android.ui.common.SettingUpWireScreenType
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.stringWithStyledArgs
 
 @Composable
@@ -48,7 +49,7 @@ private fun MigrationScreenContent(
     state: MigrationState,
     retry: () -> Unit = {},
     finish: () -> Unit = {},
-    accountLogin: (String?) -> Unit = {}
+    accountLogin: (String) -> Unit = {}
 ) {
     SettingUpWireScreenContent(
         message = state.message(),
@@ -61,7 +62,7 @@ private fun MigrationScreenContent(
             )
             is MigrationState.Failed.Account.Any -> SettingUpWireScreenType.Failure(
                 buttonTextResId = R.string.label_continue,
-                onButtonClick = { accountLogin(null) }
+                onButtonClick = { accountLogin(String.EMPTY) }
             )
             is MigrationState.Failed.Account.Specific -> SettingUpWireScreenType.Failure(
                 buttonTextResId = R.string.label_continue,

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -51,41 +51,8 @@ private fun MigrationScreenContent(
     accountLogin: (String?) -> Unit = {}
 ) {
     SettingUpWireScreenContent(
-        message = when (state) {
-            is MigrationState.InProgress -> when (state.type) {
-                MigrationData.Progress.Type.ACCOUNTS -> AnnotatedString(stringResource(R.string.migration_accounts_message))
-                MigrationData.Progress.Type.MESSAGES -> AnnotatedString(stringResource(R.string.migration_messages_message))
-                MigrationData.Progress.Type.UNKNOWN -> AnnotatedString(stringResource(R.string.migration_message_unknown))
-            }
-            is MigrationState.Failed.NoNetwork -> buildAnnotatedString {
-                withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
-                    append(stringResource(R.string.error_no_network_message))
-                }
-            }
-            is MigrationState.Failed.Messages -> buildAnnotatedString {
-                withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
-                    append(stringResource(R.string.migration_messages_failure, state.errorCode))
-                }
-            }
-            is MigrationState.Failed.Account.Any -> AnnotatedString(stringResource(R.string.migration_login_required))
-            is MigrationState.Failed.Account.Specific -> LocalContext.current.resources.stringWithStyledArgs(
-                stringResId = R.string.migration_login_required_specific_account,
-                normalStyle = MaterialTheme.wireTypography.body01,
-                argsStyle = MaterialTheme.wireTypography.body02,
-                normalColor = MaterialTheme.wireColorScheme.secondaryText,
-                argsColor = MaterialTheme.wireColorScheme.secondaryText,
-                stringResource(R.string.migration_login_required_specific_account_name, state.userName, state.userHandle)
-            )
-        },
-        title = when (state) {
-            is MigrationState.Failed -> null
-            is MigrationState.InProgress -> {
-                MigrationData.Progress.steps.indexOf(state.type).let { stepNumber ->
-                    if (stepNumber >= 0) stringResource(R.string.migration_title_step, stepNumber + 1, MigrationData.Progress.steps.size)
-                    else null
-                }
-            }
-        },
+        message = state.message(),
+        title = state.title(),
         type = when (state) {
             is MigrationState.InProgress -> SettingUpWireScreenType.Progress
             is MigrationState.Failed.NoNetwork -> SettingUpWireScreenType.Failure(
@@ -106,6 +73,45 @@ private fun MigrationScreenContent(
             )
         }
     )
+}
+
+@Composable
+private fun MigrationState.message() = when (this) {
+    is MigrationState.InProgress -> when (this.type) {
+        MigrationData.Progress.Type.ACCOUNTS -> AnnotatedString(stringResource(R.string.migration_accounts_message))
+        MigrationData.Progress.Type.MESSAGES -> AnnotatedString(stringResource(R.string.migration_messages_message))
+        MigrationData.Progress.Type.UNKNOWN -> AnnotatedString(stringResource(R.string.migration_message_unknown))
+    }
+    is MigrationState.Failed.NoNetwork -> buildAnnotatedString {
+        withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
+            append(stringResource(R.string.error_no_network_message))
+        }
+    }
+    is MigrationState.Failed.Messages -> buildAnnotatedString {
+        withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
+            append(stringResource(R.string.migration_messages_failure, this@message.errorCode))
+        }
+    }
+    is MigrationState.Failed.Account.Any -> AnnotatedString(stringResource(R.string.migration_login_required))
+    is MigrationState.Failed.Account.Specific -> LocalContext.current.resources.stringWithStyledArgs(
+        stringResId = R.string.migration_login_required_specific_account,
+        normalStyle = MaterialTheme.wireTypography.body01,
+        argsStyle = MaterialTheme.wireTypography.body02,
+        normalColor = MaterialTheme.wireColorScheme.secondaryText,
+        argsColor = MaterialTheme.wireColorScheme.secondaryText,
+        stringResource(R.string.migration_login_required_specific_account_name, this.userName, this.userHandle)
+    )
+}
+
+@Composable
+private fun MigrationState.title() = when (this) {
+    is MigrationState.Failed -> null
+    is MigrationState.InProgress -> {
+        MigrationData.Progress.steps.indexOf(this.type).let { stepNumber ->
+            if (stepNumber >= 0) stringResource(R.string.migration_title_step, stepNumber + 1, MigrationData.Progress.steps.size)
+            else null
+        }
+    }
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -20,31 +20,116 @@
 
 package com.wire.android.ui.migration
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.migration.MigrationData
 import com.wire.android.ui.common.SettingUpWireScreenContent
 import com.wire.android.ui.common.SettingUpWireScreenType
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.stringWithStyledArgs
 
 @Composable
 fun MigrationScreen(viewModel: MigrationViewModel = hiltViewModel()) {
+    MigrationScreenContent(viewModel.state, viewModel::retry, viewModel::finish, viewModel::accountLogin)
+}
+
+@Composable
+private fun MigrationScreenContent(
+    state: MigrationState,
+    retry: () -> Unit = {},
+    finish: () -> Unit = {},
+    accountLogin: (String?) -> Unit = {}
+) {
     SettingUpWireScreenContent(
-        messageResId = when (val state = viewModel.state) {
-            MigrationState.Failed -> R.string.error_no_network_message
+        message = when (state) {
             is MigrationState.InProgress -> when (state.type) {
-                MigrationData.Progress.Type.SERVER_CONFIGS -> R.string.migration_server_configs_message
-                MigrationData.Progress.Type.ACCOUNTS -> R.string.migration_accounts_message
-                MigrationData.Progress.Type.CLIENTS -> R.string.migration_clients_message
-                MigrationData.Progress.Type.USERS -> R.string.migration_users_message
-                MigrationData.Progress.Type.CONVERSATIONS -> R.string.migration_conversations_message
-                MigrationData.Progress.Type.MESSAGES -> R.string.migration_messages_message
-                MigrationData.Progress.Type.UNKNOWN -> R.string.migration_message_unknown
+                MigrationData.Progress.Type.ACCOUNTS -> AnnotatedString(stringResource(R.string.migration_accounts_message))
+                MigrationData.Progress.Type.MESSAGES -> AnnotatedString(stringResource(R.string.migration_messages_message))
+                MigrationData.Progress.Type.UNKNOWN -> AnnotatedString(stringResource(R.string.migration_message_unknown))
+            }
+            is MigrationState.Failed.NoNetwork -> buildAnnotatedString {
+                withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
+                    append(stringResource(R.string.error_no_network_message))
+                }
+            }
+            is MigrationState.Failed.Messages -> buildAnnotatedString {
+                withStyle(SpanStyle(color = MaterialTheme.wireColorScheme.error)) {
+                    append(stringResource(R.string.migration_messages_failure, state.errorCode))
+                }
+            }
+            is MigrationState.Failed.Account.Any -> AnnotatedString(stringResource(R.string.migration_login_required))
+            is MigrationState.Failed.Account.Specific -> LocalContext.current.resources.stringWithStyledArgs(
+                stringResId = R.string.migration_login_required_specific_account,
+                normalStyle = MaterialTheme.wireTypography.body01,
+                argsStyle = MaterialTheme.wireTypography.body02,
+                normalColor = MaterialTheme.wireColorScheme.secondaryText,
+                argsColor = MaterialTheme.wireColorScheme.secondaryText,
+                stringResource(R.string.migration_login_required_specific_account_name, state.userName, state.userHandle)
+            )
+        },
+        title = when (state) {
+            is MigrationState.Failed -> null
+            is MigrationState.InProgress -> {
+                MigrationData.Progress.steps.indexOf(state.type).let { stepNumber ->
+                    if (stepNumber >= 0) stringResource(R.string.migration_title_step, stepNumber + 1, MigrationData.Progress.steps.size)
+                    else null
+                }
             }
         },
-        type = when (viewModel.state) {
+        type = when (state) {
             is MigrationState.InProgress -> SettingUpWireScreenType.Progress
-            is MigrationState.Failed -> SettingUpWireScreenType.Failure(onRetryClick = viewModel::retry)
+            is MigrationState.Failed.NoNetwork -> SettingUpWireScreenType.Failure(
+                buttonTextResId = R.string.label_retry,
+                onButtonClick = retry
+            )
+            is MigrationState.Failed.Account.Any -> SettingUpWireScreenType.Failure(
+                buttonTextResId = R.string.label_continue,
+                onButtonClick = { accountLogin(null) }
+            )
+            is MigrationState.Failed.Account.Specific -> SettingUpWireScreenType.Failure(
+                buttonTextResId = R.string.label_continue,
+                onButtonClick = { accountLogin(state.userHandle) }
+            )
+            is MigrationState.Failed.Messages -> SettingUpWireScreenType.Failure(
+                buttonTextResId = R.string.label_continue,
+                onButtonClick = finish
+            )
         }
     )
+}
+
+@Preview
+@Composable
+fun PreviewMigrationScreenInProgress() {
+    MigrationScreenContent(state = MigrationState.InProgress(MigrationData.Progress.Type.ACCOUNTS))
+}
+@Preview
+@Composable
+fun PreviewMigrationScreenFailedNoNetwork() {
+    MigrationScreenContent(state = MigrationState.Failed.NoNetwork)
+}
+@Preview
+@Composable
+fun PreviewMigrationScreenFailedAccountAny() {
+    MigrationScreenContent(state = MigrationState.Failed.Account.Any)
+}
+@Preview
+@Composable
+fun PreviewMigrationScreenFailedAccountSpecific() {
+    MigrationScreenContent(state = MigrationState.Failed.Account.Specific(userName = "name", userHandle = "@handle"))
+}
+@Preview
+@Composable
+fun PreviewMigrationScreenFailedMessages() {
+    MigrationScreenContent(state = MigrationState.Failed.Messages(errorCode = "123"))
 }

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationState.kt
@@ -24,5 +24,12 @@ import com.wire.android.migration.MigrationData
 
 sealed class MigrationState {
     data class InProgress(val type: MigrationData.Progress.Type) : MigrationState()
-    object Failed : MigrationState()
+    sealed class Failed : MigrationState() {
+        object NoNetwork : Failed()
+        sealed class Account : Failed() {
+            data class Specific(val userName: String, val userHandle: String) : Account()
+            object Any : Account()
+        }
+        data class Messages(val errorCode: String) : Failed()
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
@@ -75,7 +75,7 @@ class MigrationViewModel @Inject constructor(
         state = MigrationState.InProgress(MigrationData.Progress.Type.UNKNOWN)
     }
 
-    fun accountLogin(userHandle: String?) {
+    fun accountLogin(userHandle: String) {
         viewModelScope.launch {
             migrationManager.dismissMigrationFailureNotification()
             navigateToLogin(userHandle)
@@ -130,8 +130,8 @@ class MigrationViewModel @Inject constructor(
         }
     }
 
-    private suspend fun navigateToLogin(userHandle: String?) {
-        // TODO: pass user handle to be pre-filled on the email login screen
-        navigationManager.navigate(NavigationCommand(NavigationItem.Login.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
+    private suspend fun navigateToLogin(userHandle: String) {
+        navigationManager.navigate(NavigationCommand(NavigationItem.Login.getRouteWithArgs(listOf(userHandle)))
+        )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -25,6 +25,7 @@ import androidx.annotation.VisibleForTesting
 import com.wire.android.appLogger
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
@@ -50,6 +51,7 @@ sealed class DeepLinkResult {
     data class OngoingCall(val conversationsId: ConversationId) : DeepLinkResult()
     data class OpenConversation(val conversationsId: ConversationId) : DeepLinkResult()
     data class OpenOtherUserProfile(val userId: QualifiedID) : DeepLinkResult()
+    data class MigrationLogin(val userHandle: String) : DeepLinkResult()
 }
 
 @Singleton
@@ -66,6 +68,7 @@ class DeepLinkProcessor @Inject constructor(
         ONGOING_CALL_DEEPLINK_HOST -> getOngoingCallDeepLinkResult(uri)
         CONVERSATION_DEEPLINK_HOST -> getOpenConversationDeepLinkResult(uri, scope)
         OTHER_USER_PROFILE_DEEPLINK_HOST -> getOpenOtherUserProfileDeepLinkResult(uri)
+        MIGRATION_LOGIN_HOST -> getOpenMigrationLoginDeepLinkResult(uri)
         else -> DeepLinkResult.Unknown
     }
 
@@ -99,6 +102,12 @@ class DeepLinkProcessor @Inject constructor(
     private fun getOpenOtherUserProfileDeepLinkResult(uri: Uri): DeepLinkResult =
         uri.lastPathSegment?.toQualifiedID(qualifiedIdMapper)?.let {
             DeepLinkResult.OpenOtherUserProfile(it)
+        } ?: DeepLinkResult.Unknown
+
+    private fun getOpenMigrationLoginDeepLinkResult(uri: Uri): DeepLinkResult =
+        uri.lastPathSegment?.let {
+            if (it == MIGRATION_LOGIN_HOST) DeepLinkResult.MigrationLogin(String.EMPTY)
+            else DeepLinkResult.MigrationLogin(it)
         } ?: DeepLinkResult.Unknown
 
     private fun getCustomServerConfigDeepLinkResult(uri: Uri) = uri.getQueryParameter(SERVER_CONFIG_PARAM)?.let {
@@ -147,6 +156,7 @@ class DeepLinkProcessor @Inject constructor(
         const val ONGOING_CALL_DEEPLINK_HOST = "ongoing-call"
         const val CONVERSATION_DEEPLINK_HOST = "conversation"
         const val OTHER_USER_PROFILE_DEEPLINK_HOST = "other-user-profile"
+        const val MIGRATION_LOGIN_HOST = "migration-login"
 
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
@@ -21,6 +21,7 @@
 package com.wire.android.util.ui
 
 import android.content.res.Resources
+import android.text.SpannedString
 import androidx.annotation.StringRes
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
@@ -33,10 +34,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
-import com.wire.android.ui.common.colorsScheme
+import androidx.core.text.bold
+import androidx.core.text.buildSpannedString
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 
+// To be used in Composables when we have access to the styles and colors.
 @Suppress("LongParameterList", "SpreadOperator")
 fun Resources.stringWithStyledArgs(
     @StringRes stringResId: Int,
@@ -52,6 +55,21 @@ fun Resources.stringWithStyledArgs(
     return buildAnnotatedString {
         string.split(STYLE_SEPARATOR).forEachIndexed { index, text ->
             withStyle(if (index % 2 == 0) normalSpanStyle else boldSpanStyle) { append(text) }
+        }
+    }
+}
+
+// To be used outside of Composables, e.g. in notifications.
+@Suppress("LongParameterList", "SpreadOperator")
+fun Resources.stringWithBoldArgs(
+    @StringRes stringResId: Int,
+    vararg formatArgs: String
+): SpannedString {
+    val string = this.getString(stringResId, *formatArgs.map { it.bold() }.toTypedArray())
+    return buildSpannedString {
+        string.split(STYLE_SEPARATOR).forEachIndexed { index, text ->
+            if (index % 2 == 0) append(text)
+            else bold { append(text) }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/SingleUserMigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/SingleUserMigrationWorker.kt
@@ -5,11 +5,9 @@ import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.lifecycle.asFlow
 import androidx.work.BackoffPolicy
-import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
-import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
@@ -21,6 +19,7 @@ import androidx.work.workDataOf
 import com.wire.android.R
 import com.wire.android.migration.MigrationData
 import com.wire.android.migration.MigrationManager
+import com.wire.android.migration.getMigrationFailure
 import com.wire.android.migration.getMigrationProgress
 import com.wire.android.migration.toData
 import com.wire.android.notification.NotificationChannelsManager
@@ -100,10 +99,10 @@ suspend fun WorkManager.enqueueSingleUserMigrationWorker(userId: UserId): Flow<M
         it.first().let { workInfo ->
             when (workInfo.state) {
                 WorkInfo.State.SUCCEEDED -> MigrationData.Result.Success
-                WorkInfo.State.FAILED -> MigrationData.Result.Failure
-                WorkInfo.State.CANCELLED -> MigrationData.Result.Failure
+                WorkInfo.State.FAILED -> workInfo.outputData.getMigrationFailure()
+                WorkInfo.State.CANCELLED -> workInfo.outputData.getMigrationFailure()
                 WorkInfo.State.RUNNING -> MigrationData.Progress(workInfo.progress.getMigrationProgress())
-                WorkInfo.State.ENQUEUED -> MigrationData.Result.Failure
+                WorkInfo.State.ENQUEUED -> workInfo.outputData.getMigrationFailure()
                 WorkInfo.State.BLOCKED -> null
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="migration_title_updated">Setting up Wire</string>
     <string name="migration_login_required">In order to migrate your messages from the old version of Wire, you need to log in to your account.</string>
     <string name="migration_login_required_specific_account">In order to migrate your messages from the old version of Wire, you need to log in to your account %s.</string>
-    <string name="migration_login_required_specific_account_name">“%1$s (%2$s)“</string>
+    <string name="migration_login_required_specific_account_name">“%1$s (@%2$s)“</string>
     <string name="migration_messages_failure">Unfortunately, not all messages and conversations could not be migrated due to incompatibility with the older version of Wire (error code: %s)</string>
     <string name="migration_cancel_title">Cancel migration</string>
     <string name="migration_cancel_message">Are you sure you want to close the application and cancel the ongoing migration?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,12 +188,15 @@
     <string name="migration_title">Setting up Wire</string>
     <string name="migration_message">Please wait while we set up the app for you</string>
     <string name="migration_message_unknown">Please wait while we migrate data for you</string>
-    <string name="migration_server_configs_message">Please wait while we migrate backends for you</string>
-    <string name="migration_accounts_message">Please wait while we migrate accounts for you</string>
-    <string name="migration_clients_message">Please wait while we migrate clients for you</string>
-    <string name="migration_users_message">Please wait while we migrate users for you</string>
-    <string name="migration_conversations_message">Please wait while we migrate conversations for you</string>
-    <string name="migration_messages_message">Please wait while we migrate messages for you</string>
+    <string name="migration_accounts_message">Migrating your accounts...</string>
+    <string name="migration_messages_message">Migrating your messages...</string>
+    <string name="migration_title_step">Step %1$d/%2$d</string>
+    <string name="migration_title_almost_done">Almost done!</string>
+    <string name="migration_title_updated">Setting up Wire</string>
+    <string name="migration_login_required">In order to migrate your messages from the old version of Wire, you need to log in to your account.</string>
+    <string name="migration_login_required_specific_account">In order to migrate your messages from the old version of Wire, you need to log in to your account %s.</string>
+    <string name="migration_login_required_specific_account_name">“%1$s (%2$s)“</string>
+    <string name="migration_messages_failure">Unfortunately, not all messages and conversations could not be migrated due to incompatibility with the older version of Wire (error code: %s)</string>
     <string name="migration_cancel_title">Cancel migration</string>
     <string name="migration_cancel_message">Are you sure you want to close the application and cancel the ongoing migration?</string>
     <!-- Login -->

--- a/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.migration
 
+import android.app.NotificationManager
 import android.content.Context
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.datastore.GlobalDataStore
@@ -155,6 +156,9 @@ class MigrationManagerTest {
         @MockK
         lateinit var markUsersAsNeedToBeMigrated: MarkUsersAsNeedToBeMigrated
 
+        @MockK
+        lateinit var notificationManager: NotificationManager
+
         val coroutineScope: CoroutineScope = TestScope()
 
         val coroutineDispatcher = StandardTestDispatcher()
@@ -169,7 +173,8 @@ class MigrationManagerTest {
                 migrateUsers,
                 migrateConversations,
                 migrateMessages,
-                markUsersAsNeedToBeMigrated
+                markUsersAsNeedToBeMigrated,
+                notificationManager
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3078" title="AR-3078" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3078</a>  Notification / info screen for migration errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there's an error during first two steps of the migration, it can fail and the user won't know about it until he opens the app and sees that it requires logging in.

### Solutions

Handle errors during first and second step of the migration as "Account" errors which require logging in - show the proper screen if the migration happens when the app is open and notification to make sure user is aware of that and can take action as soon as possible. Handle errors during further steps by showing a warning on screen and on notification in case it happened in the background informing that there may be some messages missing after the migration.
Network errors during any step are handled the same as now - by showing error screen with "retry" button and rescheduling the worker to try again when the network is back.

### Attachments

https://user-images.githubusercontent.com/30429749/221368155-6b8efab4-6972-4e20-9f2b-2cb1248719bd.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
