### PR TITLE
fix: wrong wording for enable receipts in German [AR-2980]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -138,7 +138,8 @@ class MessageContentMapper @Inject constructor(
             receiptMode = when (content.receiptMode) {
                 true -> UIText.StringResource(R.string.label_system_message_receipt_mode_on)
                 else -> UIText.StringResource(R.string.label_system_message_receipt_mode_off)
-            }
+            },
+            isAuthorSelfUser = sender is SelfUser
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -189,8 +189,9 @@ sealed class UIMessageContent {
 
         data class ConversationReceiptModeChanged(
             val author: UIText,
-            val receiptMode: UIText
-        ) : SystemMessage(R.drawable.ic_view, R.string.label_system_message_read_receipt_changed)
+            val receiptMode: UIText,
+            val isAuthorSelfUser: Boolean = false
+        ) : SystemMessage(R.drawable.ic_view, if (isAuthorSelfUser) R.string.label_system_message_read_receipt_changed_by_self else R.string.label_system_message_read_receipt_changed_by_other)
 
         class HistoryLost :
             SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -191,7 +191,11 @@ sealed class UIMessageContent {
             val author: UIText,
             val receiptMode: UIText,
             val isAuthorSelfUser: Boolean = false
-        ) : SystemMessage(R.drawable.ic_view, if (isAuthorSelfUser) R.string.label_system_message_read_receipt_changed_by_self else R.string.label_system_message_read_receipt_changed_by_other)
+        ) : SystemMessage(
+            R.drawable.ic_view,
+            if (isAuthorSelfUser) R.string.label_system_message_read_receipt_changed_by_self
+            else R.string.label_system_message_read_receipt_changed_by_other
+        )
 
         class HistoryLost :
             SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -77,7 +77,7 @@ class BackupAndRestoreViewModel
     internal lateinit var latestImportedBackupTempPath: Path
 
     fun createBackup(password: String) = viewModelScope.launch(dispatcher.main()) {
-        // TODO: Find a way to update the create progress more faithfully. For now we will just show this small delays to mimic the
+        // TODO: Find a way to update the creation progress more faithfully. For now we will just show this small delays to mimic the
         //  progress also for small backups
         updateCreationProgress(PROGRESS_25)
         delay(SMALL_DELAY)

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -494,7 +494,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -492,7 +492,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -491,7 +491,8 @@
     <string name="label_system_message_team_member_left">%1$s wurde aus dem Team entfernt</string>
     <string name="label_system_message_user_not_available">Dieser Benutzer ist nicht mehr verfügbar</string>
     <string name="label_system_message_new_conversation_receipt_mode">Lesebestätigungen sind %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s haben Lesebestätigungen für alle %2$sgeschaltet</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s haben Lesebestätigungen für alle %2$sgeschaltet</string>
+    <string name="label_system_message_read_receipt_changed_by_other">%1$s hat Lesebestätigungen für alle %2$sgeschaltet</string>
     <string name="label_system_message_conversation_history_lost">DIESES GERÄT WURDE FÜR EINE WEILE NICHT BENUTZT. EINIGE MELDUNGEN WERDEN HIER VIELLEICHT NICHT ANGEZEIGT.</string>
     <string name="label_system_message_receipt_mode_on">ein</string>
     <string name="label_system_message_receipt_mode_off">aus</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -492,7 +492,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -489,7 +489,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -489,7 +489,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -492,7 +492,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -491,7 +491,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -492,7 +492,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -491,7 +491,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -490,7 +490,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -492,7 +492,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -489,7 +489,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -489,7 +489,7 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -509,7 +509,8 @@
     <string name="label_system_message_team_member_left">%1$s was removed from the team</string>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
-    <string name="label_system_message_read_receipt_changed">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_read_receipt_changed_by_other">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_conversation_history_lost">You haven\'t used this device for a while. some messages may not appear here.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2980" title="AR-2980" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2980</a>  System notification in german for read receipts has wrong wording
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

String copies for disabling/enabling read receipts in groups were reading wrongly for German language as it was using the same one for the slef user and other users.

### Solutions
Use 2 different localised copies, and pass a boolean indicating whether the action was triggered by self or other user.

### Attachments (Optional)
<img width="426" alt="Captura de pantalla 2023-02-27 a las 14 06 36" src="https://user-images.githubusercontent.com/2468164/221572671-ac7beec0-e1b0-40ec-a36e-c57aaede9ff1.png">


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
