### PR TITLE
fix: [RC] migration after update is not starting after update from 4.0.1

### DIFF
--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
@@ -19,9 +19,9 @@ class ShouldTriggerMigrationForUserUserCase @Inject constructor(
         .first().let { migrationStatus ->
             when (migrationStatus) {
                 UserMigrationStatus.Completed,
-                UserMigrationStatus.NotStarted -> return@let false
+                UserMigrationStatus.NoNeed -> return@let false
 
-                UserMigrationStatus.NoNeed,
+                UserMigrationStatus.NotStarted,
                 null -> checkForScalaDB(userId)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/userDatabase/ShouldTriggerMigrationForUserUserCase.kt
@@ -18,9 +18,12 @@ class ShouldTriggerMigrationForUserUserCase @Inject constructor(
     suspend operator fun invoke(userId: UserId) = globalDataStore.getUserMigrationStatus(userId.value)
         .first().let { migrationStatus ->
             when (migrationStatus) {
+                // if the user has already been migrated, we don't need to do it again
                 UserMigrationStatus.Completed,
                 UserMigrationStatus.NoNeed -> return@let false
 
+                // if the user has not been migrated yet, we check if the database exists
+                // also check when null since it can mean the migration is done on 4.0.1
                 UserMigrationStatus.NotStarted,
                 null -> checkForScalaDB(userId)
             }

--- a/app/src/test/kotlin/com/wire/android/migration/ShouldTriggerMigrationForUserUserCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/ShouldTriggerMigrationForUserUserCaseTest.kt
@@ -74,6 +74,34 @@ class ShouldTriggerMigrationForUserUserCaseTest {
         verify(exactly = 0) { arrangement.applicationContext.getDatabasePath(userId.value) }
     }
 
+    @Test
+    fun givenNull_whenGettingMigrationStatus_thenCheckForScalaDB() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withUserMigrationStatus(null)
+            .withUserHaveAValidDB()
+            .arrange()
+
+        val userId = UserId("userId", "domain")
+        assertTrue(useCase(userId))
+
+        verify(exactly = 1) { arrangement.globalDataStore.getUserMigrationStatus(userId.value) }
+        verify(exactly = 1) { arrangement.applicationContext.getDatabasePath(userId.value) }
+    }
+
+    @Test
+    fun givenNull_whenGettingMigrationStatusAndScalaDBDoesNotExists_thenCheckForScalaDB() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withUserMigrationStatus(null)
+            .withUserDoesNotHaveScalaDB()
+            .arrange()
+
+        val userId = UserId("userId", "domain")
+        assertFalse(useCase(userId))
+
+        verify(exactly = 1) { arrangement.globalDataStore.getUserMigrationStatus(userId.value) }
+        verify(exactly = 1) { arrangement.applicationContext.getDatabasePath(userId.value) }
+        coVerify(exactly = 1) { arrangement.globalDataStore.setUserMigrationStatus(userId.value, UserMigrationStatus.NoNeed) }
+    }
 
     private class Arrangement {
         init {
@@ -100,7 +128,7 @@ class ShouldTriggerMigrationForUserUserCaseTest {
             every { applicationContext.getDatabasePath(any()) } returns dbFile
         }
 
-        fun withUserMigrationStatus(status: UserMigrationStatus) = apply {
+        fun withUserMigrationStatus(status: UserMigrationStatus?) = apply {
             every { globalDataStore.getUserMigrationStatus(any()) } returns flowOf(status)
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

migration after update is not starting after update from 4.0.1

### Solutions

fix the logic to decide if the app should migrate or not

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
