### PR TITLE
fix: starting persistent web socket service (AR-3139)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -160,6 +160,7 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
         <receiver
                 android:name=".ui.debugscreen.StartServiceReceiver"
                 android:enabled="true"

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -1,18 +1,10 @@
 package com.wire.android
 
 import com.wire.android.di.KaliumCoreLogic
-import com.wire.android.navigation.NavigationCommand
-import com.wire.android.navigation.NavigationItem
-import com.wire.android.navigation.NavigationManager
 import com.wire.android.notification.NotificationChannelsManager
-import com.wire.android.notification.WireNotificationManager
-import com.wire.android.services.ServicesManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -24,20 +16,15 @@ import javax.inject.Singleton
  * such as notifications or persistent web socket.
  */
 @Singleton
-@OptIn(ExperimentalCoroutinesApi::class)
 class GlobalObserversManager @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
-    private val notificationChannelsManager: NotificationChannelsManager,
-    private val notificationManager: WireNotificationManager,
-    private val servicesManager: ServicesManager,
-    private val navigationManager: NavigationManager
+    private val notificationChannelsManager: NotificationChannelsManager
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 
     fun observe() {
         scope.launch { observeAccountsToCreateChannels() }
-        scope.launch { observePersistentConnectionStatusToRunWebSocketAndNotifications() }
     }
 
     private suspend fun observeAccountsToCreateChannels() {
@@ -46,41 +33,5 @@ class GlobalObserversManager @Inject constructor(
             .collect { list ->
                 notificationChannelsManager.createUserNotificationChannels(list.map { it.first })
             }
-    }
-
-    private suspend fun observePersistentConnectionStatusToRunWebSocketAndNotifications() {
-        coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
-            when (result) {
-                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
-                    appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
-                }
-                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
-                    result.persistentWebSocketStatusListFlow.collect { statuses ->
-                        val usersToObserve = statuses
-                            .filter { !it.isPersistentWebSocketEnabled }
-                            .map { it.userId }
-
-                        notificationManager.observeNotificationsAndCallsWhileRunning(
-                            usersToObserve,
-                            scope
-                        ) { call -> openIncomingCall(call.conversationId) }
-
-                        if (statuses.any { it.isPersistentWebSocketEnabled }) {
-                            if (!servicesManager.isPersistentWebSocketServiceRunning()) {
-                                servicesManager.startPersistentWebSocketService()
-                            }
-                        } else {
-                            servicesManager.stopPersistentWebSocketService()
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun openIncomingCall(conversationId: ConversationId) {
-        scope.launch {
-            navigationManager.navigate(NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationId))))
-        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
@@ -23,6 +23,7 @@ package com.wire.android.services
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import javax.inject.Inject
@@ -57,7 +58,11 @@ class ServicesManager @Inject constructor(private val context: Context) {
         PersistentWebSocketService.isServiceStarted
 
     private fun startService(intent: Intent) {
-        context.startService(intent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent)
+        } else {
+            context.startService(intent)
+        }
     }
 
     private fun stopService(serviceClass: KClass<out Service>) {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -74,9 +74,13 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
-@AndroidEntryPoint
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalComposeUiApi::class,
+    ExperimentalCoroutinesApi::class
+)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@AndroidEntryPoint
 @Suppress("TooManyFunctions")
 class WireActivity : AppCompatActivity() {
 
@@ -97,6 +101,7 @@ class WireActivity : AppCompatActivity() {
         proximitySensorManager.initialize()
         lifecycle.addObserver(currentScreenManager)
         viewModel.handleDeepLink(intent)
+        viewModel.observePersistentConnectionStatus()
         setComposableContent()
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -96,7 +96,6 @@ class WireActivityViewModel @Inject constructor(
     private val servicesManager: ServicesManager,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
     private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
-    @KaliumCoreLogic private val coreLogic: CoreLogic
 ) : ViewModel() {
 
     private val navigationArguments = mutableMapOf<String, Any>(SERVER_CONFIG_ARG to ServerConfig.DEFAULT)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -38,6 +38,7 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.services.ServicesManager
 import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialogState
 import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.util.deeplink.DeepLinkProcessor
@@ -59,6 +60,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -81,6 +83,7 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class WireActivityViewModel @Inject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val dispatchers: DispatcherProvider,
     private val currentSessionFlow: CurrentSessionFlowUseCase,
     private val getServerConfigUseCase: GetServerConfigUseCase,
@@ -90,6 +93,7 @@ class WireActivityViewModel @Inject constructor(
     private val getSessions: GetSessionsUseCase,
     private val accountSwitch: AccountSwitchUseCase,
     private val migrationManager: MigrationManager,
+    private val servicesManager: ServicesManager,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
     private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
     @KaliumCoreLogic private val coreLogic: CoreLogic
@@ -473,6 +477,32 @@ class WireActivityViewModel @Inject constructor(
     fun appWasUpdate() {
         globalAppState = globalAppState.copy(updateAppDialog = false)
     }
+
+    fun observePersistentConnectionStatus() {
+        viewModelScope.launch {
+            coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+                when (result) {
+                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
+                        appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
+                    }
+
+                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                        result.persistentWebSocketStatusListFlow.collect { statuses ->
+
+                            if (statuses.any { it.isPersistentWebSocketEnabled }) {
+                                if (!servicesManager.isPersistentWebSocketServiceRunning()) {
+                                    servicesManager.startPersistentWebSocketService()
+                                }
+                            } else {
+                                servicesManager.stopPersistentWebSocketService()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
     companion object {
         private const val SERVER_CONFIG_ARG = "server_config"

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -503,7 +503,6 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-
     companion object {
         private const val SERVER_CONFIG_ARG = "server_config"
         private const val SSO_DEEPLINK_ARG = "sso_deeplink"

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.services.ServicesManager
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
@@ -40,7 +39,6 @@ import javax.inject.Inject
 @HiltViewModel
 class NetworkSettingsViewModel
 @Inject constructor(
-    private val servicesManager: ServicesManager,
     private val navigationManager: NavigationManager,
     private val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase,
     private val observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase,
@@ -80,13 +78,6 @@ class NetworkSettingsViewModel
                                                     persistentWebSocketStatus.isPersistentWebSocketEnabled
                                                 )
                                         }
-                                    }
-                                    if (it.map { it.isPersistentWebSocketEnabled }.contains(true)) {
-                                        if (!servicesManager.isPersistentWebSocketServiceRunning()) {
-                                            servicesManager.startPersistentWebSocketService()
-                                        }
-                                    } else {
-                                        servicesManager.stopPersistentWebSocketService()
                                     }
                                 }
                             }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -4,16 +4,10 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.framework.TestUser
-import com.wire.android.navigation.NavigationManager
 import com.wire.android.notification.NotificationChannelsManager
-import com.wire.android.notification.WireNotificationManager
-import com.wire.android.services.ServicesManager
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
-import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
-import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,86 +35,6 @@ class GlobalObserversManagerTest {
         coVerify(exactly = 1) { arrangement.notificationChannelsManager.createUserNotificationChannels(accs) }
     }
 
-    @Test
-    fun `given a valid account with persistent socket disabled, then listen for notifications and calls for it`() {
-        val statuses = listOf(PersistentWebSocketStatus(TestUser.SELF_USER.id, false))
-        val expectedUserIds = listOf(TestUser.SELF_USER.id)
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
-    }
-
-    @Test
-    fun `given a valid account with persistent socket enabled, then do not listen for notifications and calls for it`() {
-        val statuses = listOf(PersistentWebSocketStatus(TestUser.SELF_USER.id, true))
-        val expectedUserIds = listOf<UserId>()
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
-    }
-
-    @Test
-    fun `given valid accounts, then listen for notifications and calls only for those that have persistent socket disabled`() {
-        val statuses = listOf(
-            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
-            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
-        )
-        val expectedUserIds = listOf(TestUser.SELF_USER.id)
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(expectedUserIds, any(), any()) }
-    }
-
-    @Test
-    fun `given valid accounts, all with persistent socket disabled, then stop socket service`() {
-        val statuses = listOf(
-            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
-            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), false)
-        )
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 0) { arrangement.servicesManager.startPersistentWebSocketService() }
-        coVerify(exactly = 1) { arrangement.servicesManager.stopPersistentWebSocketService() }
-    }
-
-    @Test
-    fun `given valid accounts, at least one with persistent socket enabled, and socket service not running, then start service`() {
-        val statuses = listOf(
-            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
-            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
-        )
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .withIsPersistentWebSocketServiceRunning(false)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 1) { arrangement.servicesManager.startPersistentWebSocketService() }
-        coVerify(exactly = 0) { arrangement.servicesManager.stopPersistentWebSocketService() }
-    }
-
-    @Test
-    fun `given valid accounts, at least one with persistent socket enabled, and socket service running, then do not start service again`() {
-        val statuses = listOf(
-            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
-            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
-        )
-        val (arrangement, manager) = Arrangement()
-            .withPersistentWebSocketConnectionStatuses(statuses)
-            .withIsPersistentWebSocketServiceRunning(true)
-            .arrange()
-        manager.observe()
-        coVerify(exactly = 0) { arrangement.servicesManager.startPersistentWebSocketService() }
-        coVerify(exactly = 0) { arrangement.servicesManager.stopPersistentWebSocketService() }
-    }
-
     private class Arrangement {
 
         @MockK
@@ -129,23 +43,11 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var notificationChannelsManager: NotificationChannelsManager
 
-        @MockK
-        lateinit var notificationManager: WireNotificationManager
-
-        @MockK
-        lateinit var servicesManager: ServicesManager
-
-        @MockK
-        lateinit var navigationManager: NavigationManager
-
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
                 coreLogic = coreLogic,
-                notificationChannelsManager = notificationChannelsManager,
-                notificationManager = notificationManager,
-                servicesManager = servicesManager,
-                navigationManager = navigationManager
+                notificationChannelsManager = notificationChannelsManager
             )
         }
 
@@ -155,27 +57,11 @@ class GlobalObserversManagerTest {
 
             // Default empty values
             mockUri()
-
-            coEvery { notificationManager.observeNotificationsAndCallsWhileRunning(any(), any(), any()) } returns Unit
-            coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(listOf())
-            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
-                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(listOf()))
             every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
-            every { servicesManager.isPersistentWebSocketServiceRunning() } returns false
-            coEvery { navigationManager.navigate(any()) } returns Unit
         }
 
         fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
             coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(list)
-        }
-
-        fun withPersistentWebSocketConnectionStatuses(list: List<PersistentWebSocketStatus>): Arrangement = apply {
-            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
-                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(list))
-        }
-
-        fun withIsPersistentWebSocketServiceRunning(isRunning: Boolean): Arrangement = apply {
-            every { servicesManager.isPersistentWebSocketServiceRunning() } returns isRunning
         }
 
         fun arrange() = this to manager

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -33,22 +33,21 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.services.ServicesManager
+import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
 import com.wire.kalium.logic.feature.auth.AccountInfo
+import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
 import com.wire.kalium.logic.feature.conversation.JoinConversationViaCodeUseCase
-import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
@@ -622,9 +621,6 @@ class WireActivityViewModelTest {
         @MockK
         lateinit var observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase
 
-        @MockK
-        lateinit var coreLogic: CoreLogic
-
         private val viewModel by lazy {
             WireActivityViewModel(
                 coreLogic = coreLogic,
@@ -639,8 +635,7 @@ class WireActivityViewModelTest {
                 migrationManager = migrationManager,
                 servicesManager = servicesManager,
                 observeSyncStateUseCaseProviderFactory = observeSyncStateUseCaseProviderFactory,
-                observeIfAppUpdateRequired = observeIfAppUpdateRequired,
-                coreLogic = coreLogic
+                observeIfAppUpdateRequired = observeIfAppUpdateRequired
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3139" title="AR-3139" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3139</a>  Play Store Crash: PersistentWebSocketService.generateForegroundNotification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


(cherry picked from commit ddb8d66a64d1f5cb3af1da773a56961bc16351c3)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Sister PR of #1502
 
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
