### PR TITLE
fix: last remaining issues from import media features [AR-2445][AR-2198][AR-2198]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -318,6 +318,7 @@ private fun ConversationScreen(
                 onShareAsset = {
                     conversationScreenState.selectedMessage?.messageHeader?.messageId?.let {
                         conversationMessagesViewModel.shareAsset(context, it)
+                        conversationScreenState.hideEditContextMenu()
                     }
                 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -74,10 +74,10 @@ fun EditMessageMenuItems(
     val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
     val localContext = LocalContext.current
     val isCopyable = message.isTextMessage
-    val isEditable = message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon
     val isAvailable = message.isAvailable
     val isAssetMessage =
         message.messageContent is UIMessageContent.AssetMessage || message.messageContent is UIMessageContent.ImageMessage
+    val isEditable = message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon && !isAssetMessage
 
     val onCopyItemClick = remember(message) {
         {

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -78,6 +78,7 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
                 },
                 onDownloadImage = onSaveImageWriteStorageRequest::launch,
                 onShareImage = {
+                    mediaGalleryScreenState.showContextualMenu(false)
                     mediaGalleryViewModel.shareAsset(context)
                 }
             ),

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -153,7 +153,7 @@ fun ImportMediaContent(importMediaViewModel: ImportMediaViewModel) {
                             }
                         }
                     }
-                    Divider(color = colorsScheme().outline, thickness = 1.dp)
+                    Divider(color = colorsScheme().outline, thickness = 1.dp, modifier = Modifier.padding(top = dimensions().spacing12x))
                     Box(Modifier.padding(dimensions().spacing6x)) {
                         SearchTopBar(
                             isSearchActive = searchBarState.isSearchActive,
@@ -200,6 +200,7 @@ fun ImportMediaContent(importMediaViewModel: ImportMediaViewModel) {
             }
         )
     }
+    BackHandler { importMediaViewModel.navigateBack() }
     SnackBarMessage(importMediaViewModel.infoMessage, snackbarHostState)
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
@@ -225,7 +225,9 @@ class ImportMediaViewModel @Inject constructor(
         return matchingConversations
     }
 
-    fun navigateBack() = viewModelScope.launch(dispatchers.main()) { navigationManager.navigateBack() }
+    fun navigateBack() = viewModelScope.launch(dispatchers.main()) {
+        navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.REMOVE_CURRENT))
+    }
 
     suspend fun handleReceivedDataFromSharingIntent(activity: AppCompatActivity) {
         val incomingIntent = ShareCompat.IntentReader(activity)
@@ -296,13 +298,14 @@ class ImportMediaViewModel @Inject constructor(
                 appLogger.d("Triggered sendAssetMessage job # ${jobs.size} -- path ${importedAsset.dataPath} -- isImage $isImage")
             }
             jobs.joinAll()
-            navigationManager.navigate(
-                command = NavigationCommand(
-                    NavigationItem.Conversation.getRouteWithArgs(listOf(conversation.conversationId)),
-                    backStackMode = BackStackMode.CLEAR_WHOLE
-                )
-            )
+            navigateToConversation(conversation.conversationId)
         }
+    }
+
+    private suspend fun navigateToConversation(conversationId: ConversationId) {
+        // We add the Home fragment to the back stack so that we can navigate back to it when we press the back button
+        navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.REMOVE_CURRENT))
+        navigationManager.navigate(NavigationCommand(NavigationItem.Conversation.getRouteWithArgs(listOf(conversationId))))
     }
 
     fun currentSelectedConversationsCount() = if (importMediaState.importedAssets.isNotEmpty()) {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -22,7 +22,7 @@
 
 package com.wire.android.util
 
-import android.R
+import com.wire.android.R
 import android.app.DownloadManager
 import android.content.ActivityNotFoundException
 import android.content.ContentResolver
@@ -96,7 +96,7 @@ suspend fun Uri.toDrawable(context: Context, dispatcher: DispatcherProvider = De
     }
 }
 
-private fun defaultGalleryIcon(context: Context) = ContextCompat.getDrawable(context, R.drawable.ic_menu_gallery)
+private fun defaultGalleryIcon(context: Context) = ContextCompat.getDrawable(context, R.drawable.ic_gallery)
 
 fun getTempWritableAttachmentUri(context: Context, attachmentPath: Path): Uri {
     val file = attachmentPath.toFile()
@@ -210,7 +210,7 @@ fun Context.startFileShareIntent(path: String) {
     shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     shareIntent.putExtra(
         Intent.EXTRA_SUBJECT,
-        "Sharing Log from Wire"
+        resources.getString(R.string.export_media_subject_title)
     )
 
     shareIntent.putExtra(Intent.EXTRA_STREAM, fileURI)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,10 +387,11 @@
     <string name="delete_group_conversation_dialog_title">Remove “%s”?</string>
     <string name="delete_group_conversation_dialog_description">The group will be removed from your conversations list on all devices. You will no longer be able to access the group and its content.</string>
 
-    <!-- Import External Media -->
+    <!-- Import/Export External Media -->
     <string name="import_media_content_title">Share With Wire</string>
     <string name="import_media_searchbar_title">Search for conversation</string>
     <string name="import_media_send_button_title">Send</string>
+    <string name="export_media_subject_title">Sharing Media from Wire</string>
 
     <!--Read receipts -->
     <string name="conversation_options_read_receipt_label">Read receipts</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2445" title="AR-2445" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2445</a>  Export media from conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Series of minor remaining issues from import media screen and plugin to share media within the app.


#### How to Test

- Check that after importing media into the app, user can navigate back to the Home screen.
- Check that `Share` option is visible only for assets and it is placed right above from delete asset option.
- Check that contextual menu is hidden after sharing asset to external apps.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
