### PR TITLE
chore: set max message length to type to 8000 characters (AR-2716) (develop)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -114,8 +114,9 @@ internal fun WireTextField(
             value = text,
             onValueChange = {
                 onValueChange(
-                    if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
-                    else it
+                    if (singleLine || maxLines == 1) {
+                        it.copy(it.text.replace("\n", ""))
+                    } else it
                 )
 
                 text = if (it.text.length > maxTextLength) {
@@ -215,10 +216,11 @@ private fun InnerText(
             trailingIcon != null -> trailingIcon
             else -> state.icon()?.Icon(Modifier.padding(horizontal = 16.dp))
         }
-        if (leadingIcon != null)
+        if (leadingIcon != null) {
             Box(contentAlignment = Alignment.Center) {
                 Tint(contentColor = colors.iconColor(state).value, content = leadingIcon)
             }
+        }
         Box(Modifier.weight(1f)) {
             val padding = Modifier.padding(
                 start = if (leadingIcon == null) 16.dp else 0.dp,

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -107,8 +107,9 @@ internal fun WireTextField(
     var text by remember { mutableStateOf(value) }
 
     Column(modifier = modifier) {
-        if (labelText != null)
+        if (labelText != null) {
             Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
+        }
         BasicTextField(
             value = text,
             onValueChange = {
@@ -117,9 +118,9 @@ internal fun WireTextField(
                     else it
                 )
 
-                text = if (it.text.length > maxTextLength)
+                text = if (it.text.length > maxTextLength) {
                     TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length - 1))
-                else it
+                } else it
             },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
             keyboardOptions = keyboardOptions,
@@ -182,13 +183,14 @@ fun Label(
             color = colors.labelColor(state, interactionSource).value,
             modifier = Modifier.padding(bottom = 4.dp, end = 4.dp)
         )
-        if (labelMandatoryIcon)
+        if (labelMandatoryIcon) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_input_mandatory),
                 tint = colors.labelMandatoryColor(state).value,
                 contentDescription = "",
                 modifier = Modifier.padding(top = 2.dp)
             )
+        }
     }
 }
 
@@ -223,7 +225,7 @@ private fun InnerText(
                 end = if (trailingOrStateIcon == null) 16.dp else 0.dp,
                 top = 2.dp, bottom = 2.dp
             )
-            if (value.text.isEmpty() && placeholderText != null)
+            if (value.text.isEmpty() && placeholderText != null) {
                 Text(
                     text = placeholderText,
                     style = placeholderTextStyle,
@@ -232,6 +234,7 @@ private fun InnerText(
                         .fillMaxWidth()
                         .then(padding)
                 )
+            }
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -241,10 +244,11 @@ private fun InnerText(
                 innerTextField()
             }
         }
-        if (trailingOrStateIcon != null)
+        if (trailingOrStateIcon != null) {
             Box(contentAlignment = Alignment.Center) {
                 Tint(contentColor = colors.iconColor(state).value, content = trailingOrStateIcon)
             }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -46,7 +46,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
@@ -55,6 +58,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
@@ -78,6 +82,7 @@ internal fun WireTextField(
     readOnly: Boolean = false,
     singleLine: Boolean = true,
     maxLines: Int = 1,
+    maxTextLength: Int = 8000,
     keyboardOptions: KeyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences, autoCorrect = true),
     keyboardActions: KeyboardActions = KeyboardActions(),
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -99,17 +104,22 @@ internal fun WireTextField(
     onLineBottomYCoordinateChanged: (Float) -> Unit = { },
     ) {
     val enabled = state !is WireTextFieldState.Disabled
+    var text by remember { mutableStateOf(value) }
 
     Column(modifier = modifier) {
         if (labelText != null)
             Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
         BasicTextField(
-            value = value,
+            value = text,
             onValueChange = {
                 onValueChange(
                     if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
                     else it
                 )
+
+                text = if(it.text.length > maxTextLength)
+                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length-1))
+                else it
             },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
             keyboardOptions = keyboardOptions,

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -102,7 +102,7 @@ internal fun WireTextField(
     modifier: Modifier = Modifier,
     onSelectedLineIndexChanged: (Int) -> Unit = { },
     onLineBottomYCoordinateChanged: (Float) -> Unit = { },
-    ) {
+) {
     val enabled = state !is WireTextFieldState.Disabled
     var text by remember { mutableStateOf(value) }
 
@@ -117,8 +117,8 @@ internal fun WireTextField(
                     else it
                 )
 
-                text = if(it.text.length > maxTextLength)
-                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length-1))
+                text = if (it.text.length > maxTextLength)
+                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length - 1))
                 else it
             },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2716" title="AR-2716" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2716</a>  Character limit for sending a message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Same PR as #1512 to merge into develop

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
