### PR TITLE
feat: read only profiles lock for avatar and display name (AR-2186)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -92,6 +92,7 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
@@ -776,6 +777,13 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): IsPasswordRequiredUseCase = coreLogic.getSessionScope(currentAccount).users.isPasswordRequired
+
+    @ViewModelScoped
+    @Provides
+    fun provideIsReadOnlyAccountUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): IsReadOnlyAccountUseCase = coreLogic.getSessionScope(currentAccount).users.isReadOnlyAccount
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/AccountDetailsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/AccountDetailsItem.kt
@@ -29,10 +29,10 @@ sealed class AccountDetailsItem(
     val title: UIText.StringResource,
     open val text: String,
     val navigationItem: NavigationItem,
-    open val clickable: Clickable
+    open val clickable: Clickable?
 ) {
 
-    data class DisplayName(override val text: String, override val clickable: Clickable) : AccountDetailsItem(
+    data class DisplayName(override val text: String, override val clickable: Clickable?) : AccountDetailsItem(
         title = UIText.StringResource(R.string.settings_myaccount_display_name),
         text = text,
         navigationItem = NavigationItem.EditDisplayName,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -81,7 +81,11 @@ fun MyAccountScreen(
 private fun mapToUISections(viewModel: MyAccountViewModel, state: MyAccountState): List<AccountDetailsItem> {
     return with(state) {
         listOfNotNull(
-            if (fullName.isNotBlank()) DisplayName(fullName, Clickable { viewModel.navigateToChangeDisplayName() }) else null,
+            if (fullName.isNotBlank()) {
+                DisplayName(fullName, clickableActionIfPossible(state.isReadOnlyAccount) { viewModel.navigateToChangeDisplayName() })
+            } else {
+                null
+            },
             if (userName.isNotBlank()) Username("@$userName") else null,
             if (email.isNotBlank()) Email(email) else null,
             if (teamName.isNotBlank()) Team(teamName) else null,
@@ -89,6 +93,9 @@ private fun mapToUISections(viewModel: MyAccountViewModel, state: MyAccountState
         )
     }
 }
+
+private fun clickableActionIfPossible(shouldDisableAction: Boolean, action: () -> Unit) =
+    if (shouldDisableAction) null else Clickable { action.invoke() }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -139,7 +146,7 @@ fun MyAccountContent(
             folderWithElements(
                 header = context.getString(R.string.settings_myaccount_title),
                 items = accountDetailItems.associateBy { it.title.toString() },
-                factory = { item ->
+                factory = { item: AccountDetailsItem ->
                     RowItemTemplate(
                         title = {
                             Text(
@@ -156,11 +163,11 @@ fun MyAccountContent(
                             )
                         },
                         actions = {
-                            if (item.clickable.enabled) {
+                            if (item.clickable?.enabled == true) {
                                 Icons.Filled.ChevronRight.Icon().invoke()
                             }
                         },
-                        clickable = item.clickable
+                        clickable = item.clickable ?: Clickable(false)
                     )
                 }
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
@@ -26,5 +26,6 @@ data class MyAccountState(
     val email: String = "",
     val teamName: String = "",
     val domain: String = "",
-    val changePasswordUrl: String? = null
+    val changePasswordUrl: String? = null,
+    val isReadOnlyAccount: Boolean = true
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -41,15 +41,16 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
@@ -58,6 +59,7 @@ class MyAccountViewModel @Inject constructor(
     private val getSelfTeam: GetSelfTeamUseCase,
     private val serverConfig: SelfServerConfigUseCase,
     private val isPasswordRequired: IsPasswordRequiredUseCase,
+    private val isReadOnlyAccount: IsReadOnlyAccountUseCase,
     private val navigationManager: NavigationManager,
     private val dispatchers: DispatcherProvider
 ) : SavedStateViewModel(savedStateHandle) {
@@ -69,6 +71,13 @@ class MyAccountViewModel @Inject constructor(
         viewModelScope.launch {
             fetchSelfUser()
             loadPasswordChangeContextIfPossible()
+            fetchIsReadOnlyAccount()
+        }
+    }
+
+    private suspend fun fetchIsReadOnlyAccount() {
+        viewModelScope.launch {
+            myAccountState = myAccountState.copy(isReadOnlyAccount = isReadOnlyAccount())
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -119,7 +119,7 @@ private fun SelfUserProfileContent(
     onMessageShown: () -> Unit = {},
     onMaxAccountReachedDialogDismissed: () -> Unit = {},
     onOtherAccountClick: (UserId) -> Unit = {},
-    isUserInCall: () -> Boolean,
+    isUserInCall: () -> Boolean
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -173,7 +173,8 @@ private fun SelfUserProfileContent(
                             userName = userName,
                             teamName = teamName,
                             onUserProfileClick = onChangeUserProfilePicture,
-                            editableState = if (state.isReadOnlyAccount) EditableState.NotEditable else EditableState.IsEditable(onEditClick),
+                            editableState = if (state.isReadOnlyAccount) EditableState.NotEditable
+                            else EditableState.IsEditable(onEditClick)
                         )
                     }
                     stickyHeader {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -173,7 +173,7 @@ private fun SelfUserProfileContent(
                             userName = userName,
                             teamName = teamName,
                             onUserProfileClick = onChangeUserProfilePicture,
-                            editableState = EditableState.IsEditable(onEditClick),
+                            editableState = if (state.isReadOnlyAccount) EditableState.NotEditable else EditableState.IsEditable(onEditClick),
                         )
                     }
                     stickyHeader {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
@@ -21,11 +21,11 @@
 package com.wire.android.ui.userprofile.self
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.userprofile.self.SelfUserProfileViewModel.ErrorCodes
 import com.wire.android.ui.userprofile.self.dialog.StatusDialogData
 import com.wire.android.ui.userprofile.self.model.OtherAccount
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 
 data class SelfUserProfileState @OptIn(ExperimentalMaterial3Api::class) constructor(
     val avatarAsset: UserAvatarAsset? = null,
@@ -38,4 +38,5 @@ data class SelfUserProfileState @OptIn(ExperimentalMaterial3Api::class) construc
     val statusDialogData: StatusDialogData? = null, // null means no dialog to display
     val isAvatarLoading: Boolean = false,
     val maxAccountsReached: Boolean = false,
+    val isReadOnlyAccount: Boolean = true
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -54,11 +54,13 @@ import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -69,7 +71,6 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 // Suppress for now after removing mockMethodForAvatar it should not complain
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -93,6 +94,7 @@ class SelfUserProfileViewModel @Inject constructor(
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val accountSwitch: AccountSwitchUseCase,
     private val endCall: EndCallUseCase,
+    private val isReadOnlyAccount: IsReadOnlyAccountUseCase,
     private val notificationChannelsManager: NotificationChannelsManager
 ) : ViewModel() {
 
@@ -105,6 +107,13 @@ class SelfUserProfileViewModel @Inject constructor(
         viewModelScope.launch {
             fetchSelfUser()
             observeEstablishedCall()
+            fetchIsReadOnlyAccount()
+        }
+    }
+
+    private suspend fun fetchIsReadOnlyAccount() {
+        viewModelScope.launch {
+            userProfileState = userProfileState.copy(isReadOnlyAccount = isReadOnlyAccount())
         }
     }
 
@@ -249,7 +258,7 @@ class SelfUserProfileViewModel @Inject constructor(
 
     fun changeStatus(status: UserAvailabilityStatus) {
         setNotShowStatusRationaleAgainIfNeeded(status)
-        //TODO add the broadcast message to inform everyone about the self user new status
+        // TODO add the broadcast message to inform everyone about the self user new status
         viewModelScope.launch { updateStatus(status) }
         dismissStatusDialog()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -112,9 +112,7 @@ class SelfUserProfileViewModel @Inject constructor(
     }
 
     private suspend fun fetchIsReadOnlyAccount() {
-        viewModelScope.launch {
-            userProfileState = userProfileState.copy(isReadOnlyAccount = isReadOnlyAccount())
-        }
+        userProfileState = userProfileState.copy(isReadOnlyAccount = isReadOnlyAccount())
     }
 
     private fun observeEstablishedCall() {
@@ -152,7 +150,7 @@ class SelfUserProfileViewModel @Inject constructor(
                         completePicture?.let { updateUserAvatar(it) }
 
                         // Update user data state
-                        userProfileState = SelfUserProfileState(
+                        userProfileState = userProfileState.copy(
                             status = availabilityStatus,
                             fullName = name.orEmpty(),
                             userName = handle.orEmpty(),

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase.Result.Success
+import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import io.mockk.Called
 import io.mockk.MockKAnnotations
@@ -102,6 +103,9 @@ class MyAccountViewModelTest {
         lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
 
         @MockK
+        lateinit var isReadOnlyAccountUseCase: IsReadOnlyAccountUseCase
+
+        @MockK
         private lateinit var savedStateHandle: SavedStateHandle
 
         val viewModel by lazy {
@@ -111,6 +115,7 @@ class MyAccountViewModelTest {
                 getSelfTeamUseCase,
                 selfServerConfigUseCase,
                 isPasswordRequiredUseCase,
+                isReadOnlyAccountUseCase,
                 navigationManager,
                 TestDispatcherProvider()
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2186" title="AR-2186" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2186</a>  [AR] Lock display name of SCIM users (1.6)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to handle checks for read only profiles, namely, users that are provided.
In simple words, users not managed by wire, their profiles are readonly.

### Depends on

The Kalium PR is https://github.com/wireapp/kalium/pull/1540

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
