### PR TITLE
fix: not receiving incoming calls

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -1,9 +1,14 @@
 package com.wire.android
 
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
+import com.wire.android.navigation.NavigationManager
 import com.wire.android.notification.NotificationChannelsManager
+import com.wire.android.notification.WireNotificationManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -19,6 +24,8 @@ import javax.inject.Singleton
 class GlobalObserversManager @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
+    private val notificationManager: WireNotificationManager,
+    private val navigationManager: NavigationManager,
     private val notificationChannelsManager: NotificationChannelsManager
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
@@ -32,6 +39,19 @@ class GlobalObserversManager @Inject constructor(
             .distinctUntilChanged()
             .collect { list ->
                 notificationChannelsManager.createUserNotificationChannels(list.map { it.first })
+                list.map {
+                    it.first.id
+                }.run {
+                    notificationManager.observeNotificationsAndCallsWhileRunning(this, scope) {
+                        openIncomingCall(it.conversationId)
+                    }
+                }
             }
+    }
+
+    private fun openIncomingCall(conversationId: ConversationId) {
+        scope.launch {
+            navigationManager.navigate(NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationId))))
+        }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -4,7 +4,9 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.framework.TestUser
+import com.wire.android.navigation.NavigationManager
 import com.wire.android.notification.NotificationChannelsManager
+import com.wire.android.notification.WireNotificationManager
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
@@ -23,16 +25,17 @@ import org.junit.jupiter.api.extension.ExtendWith
 class GlobalObserversManagerTest {
 
     @Test
-    fun `given few valid accounts, then create user-specific notification channels`() {
-        val accs = listOf(
+    fun `given few valid accounts, when starting observing accounts, then create user-specific notification channels`() {
+        val accounts = listOf(
             TestUser.SELF_USER,
             TestUser.SELF_USER.copy(id = TestUser.USER_ID.copy(value = "something else"))
         )
         val (arrangement, manager) = Arrangement()
-            .withValidAccounts(accs.map { it to null })
+            .withValidAccounts(accounts.map { it to null })
             .arrange()
         manager.observe()
-        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createUserNotificationChannels(accs) }
+        coVerify(exactly = 1) { arrangement.notificationChannelsManager.createUserNotificationChannels(accounts) }
+        coVerify(exactly = 1) { arrangement.notificationManager.observeNotificationsAndCallsWhileRunning(any(), any(), any()) }
     }
 
     private class Arrangement {
@@ -43,11 +46,19 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var notificationChannelsManager: NotificationChannelsManager
 
+        @MockK
+        lateinit var notificationManager: WireNotificationManager
+
+        @MockK
+        lateinit var navigationManager: NavigationManager
+
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
                 coreLogic = coreLogic,
-                notificationChannelsManager = notificationChannelsManager
+                notificationChannelsManager = notificationChannelsManager,
+                notificationManager = notificationManager,
+                navigationManager = navigationManager
             )
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are not getting incoming calls and notifications

### Causes (Optional)

`observeNotificationsAndCallsWhileRunning` was called when Observing persistent websocket config. But this was removed in this PR #1510

### Solutions

Observe notifications and calls in a GlobalObserver, independently from persistent websocket config

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
