### PR TITLE
fix: text field not cleared after sending message (RC)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -112,12 +112,16 @@ internal fun WireTextField(
         BasicTextField(
             value = value,
             onValueChange = {
-                updatedText = if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
-                    else it
+                updatedText = if (singleLine || maxLines == 1) {
+                    it.copy(it.text.replace("\n", ""))
+                } else it
 
-                updatedText = if (updatedText.text.length > maxTextLength)
-                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(updatedText.text.length - 1))
-                else updatedText
+                if (updatedText.text.length > maxTextLength) {
+                    updatedText = TextFieldValue(
+                        text = updatedText.text.take(maxTextLength),
+                        selection = TextRange(updatedText.text.length - 1)
+                    )
+                }
 
                 onValueChange(updatedText)
             },

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -110,16 +110,16 @@ internal fun WireTextField(
         if (labelText != null)
             Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
         BasicTextField(
-            value = text,
+            value = value,
             onValueChange = {
-                onValueChange(
-                    if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
+                text = if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
                     else it
-                )
 
                 text = if (it.text.length > maxTextLength)
                     TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length - 1))
                 else it
+
+                onValueChange(text)
             },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
             keyboardOptions = keyboardOptions,

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -104,7 +104,7 @@ internal fun WireTextField(
     onLineBottomYCoordinateChanged: (Float) -> Unit = { },
 ) {
     val enabled = state !is WireTextFieldState.Disabled
-    var text by remember { mutableStateOf(value) }
+    var updatedText by remember { mutableStateOf(value) }
 
     Column(modifier = modifier) {
         if (labelText != null)
@@ -112,14 +112,14 @@ internal fun WireTextField(
         BasicTextField(
             value = value,
             onValueChange = {
-                text = if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
+                updatedText = if (singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
                     else it
 
-                text = if (it.text.length > maxTextLength)
-                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(it.text.length - 1))
-                else it
+                updatedText = if (updatedText.text.length > maxTextLength)
+                    TextFieldValue(text = it.text.take(maxTextLength), selection = TextRange(updatedText.text.length - 1))
+                else updatedText
 
-                onValueChange(text)
+                onValueChange(updatedText)
             },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
             keyboardOptions = keyboardOptions,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

TextField not cleared after sending a message.

### Causes (Optional)

`text` variable in remembering the old value and we are assigning it to the textField value

### Solutions

Assign textField value the value passed in param


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Write a message and send it, you should not see the sent message in the TextField


### Attachments (Optional)

In the video I set the limit to 10 

https://user-images.githubusercontent.com/18124919/222213052-01334f74-16f8-428b-8736-41a3c3351c4e.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
