### PR TITLE
feat: add ping sound (AR-3121)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -20,8 +20,10 @@
 
 package com.wire.android.notification
 
+import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.media.PingRinger
 import com.wire.android.services.ServicesManager
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
@@ -32,6 +34,7 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
+import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.message.MarkMessagesAsNotifiedUseCase
@@ -69,7 +72,8 @@ class WireNotificationManager @Inject constructor(
     private val callNotificationManager: CallNotificationManager,
     private val connectionPolicyManager: ConnectionPolicyManager,
     private val servicesManager: ServicesManager,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val pingRinger: PingRinger
 ) {
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.default())
@@ -365,6 +369,11 @@ class WireNotificationManager @Inject constructor(
                     userId,
                     newNotifications
                 )
+
+                verifyIfShouldPlayPingSound(
+                    currentScreen = currentScreenState.value,
+                    notifications = newNotifications
+                )
                 val userName = selfUserNameState.value
 
                 // combining all the data that is necessary for Notifications into small data class,
@@ -446,6 +455,27 @@ class WireNotificationManager @Inject constructor(
             coreLogic.getSessionScope(it)
                 .conversations
                 .markConnectionRequestAsNotified(connectionRequestUserId)
+        }
+    }
+
+    private fun verifyIfShouldPlayPingSound(
+        currentScreen: CurrentScreen,
+        notifications: List<LocalNotificationConversation>
+    ) {
+        if (currentScreen is CurrentScreen.Conversation) {
+            val conversationId = currentScreen.id
+            val containsPingMessage = notifications
+                .filter { it.id == conversationId }
+                .any {
+                    it.messages.any { message -> message is LocalNotificationMessage.Knock }
+                }
+
+            if (containsPingMessage) {
+                pingRinger.ping(
+                    resource = R.raw.ping_from_them,
+                    isReceivingPing = true
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -370,7 +370,7 @@ class WireNotificationManager @Inject constructor(
                     newNotifications
                 )
 
-                verifyIfShouldPlayPingSound(
+                playPingSoundIfNeeded(
                     currentScreen = currentScreenState.value,
                     notifications = newNotifications
                 )
@@ -458,16 +458,15 @@ class WireNotificationManager @Inject constructor(
         }
     }
 
-    private fun verifyIfShouldPlayPingSound(
+    private fun playPingSoundIfNeeded(
         currentScreen: CurrentScreen,
         notifications: List<LocalNotificationConversation>
     ) {
         if (currentScreen is CurrentScreen.Conversation) {
             val conversationId = currentScreen.id
             val containsPingMessage = notifications
-                .filter { it.id == conversationId }
                 .any {
-                    it.messages.any { message -> message is LocalNotificationMessage.Knock }
+                    it.id == conversationId && it.messages.any { message -> message is LocalNotificationMessage.Knock }
                 }
 
             if (containsPingMessage) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3121" title="AR-3121" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3121</a>  Ping sound in conversation screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When in conversation screen and user received ping, no sounds was played.

### Causes (Optional)

Not implemented.

### Solutions

Add the verification for if a message is Ping(`Knock`) and play the ping sound.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open App
- Open Conversation
- MAKE SURE YOU HAVE SOUND ON
- Receive Ping
- Ping sound should be played
