### PR TITLE
feat: other user profile screen classified security banner (AR-2702)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
@@ -108,9 +109,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -994,4 +995,12 @@ class UseCaseModule {
     @Provides
     fun provideMarkGuestLinkFeatureFlagAsNotChangedUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).markGuestLinkFeatureFlagAsNotChanged
+
+    @ViewModelScoped
+    @Provides
+    fun getOtherUserSecurityClassificationLabelUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): GetOtherUserSecurityClassificationLabelUseCase =
+        coreLogic.getSessionScope(currentAccount).getOtherUserSecurityClassificationLabel
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
@@ -42,7 +42,7 @@ import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 @Composable
 fun SecurityClassificationBanner(
     securityClassificationType: SecurityClassificationType,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     if (securityClassificationType != SecurityClassificationType.NONE) {
         Divider()
@@ -99,5 +99,4 @@ fun PreviewClassifiedIndicator() {
         Divider()
         SecurityClassificationBanner(securityClassificationType = SecurityClassificationType.NOT_CLASSIFIED)
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -47,10 +47,12 @@ import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.Icon
+import com.wire.android.ui.common.SecurityClassificationBanner
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
-import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.progress.WireCircularProgressIndicator
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -58,6 +60,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ifNotEmpty
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 @Composable
 fun UserProfileInfo(
@@ -70,7 +73,8 @@ fun UserProfileInfo(
     onUserProfileClick: (() -> Unit)? = null,
     editableState: EditableState,
     modifier: Modifier = Modifier,
-    connection: ConnectionState = ConnectionState.ACCEPTED
+    connection: ConnectionState = ConnectionState.ACCEPTED,
+    securityClassificationType: SecurityClassificationType
 ) {
     Column(
         horizontalAlignment = CenterHorizontally,
@@ -129,14 +133,14 @@ fun UserProfileInfo(
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     style = MaterialTheme.wireTypography.title02,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = MaterialTheme.colorScheme.onBackground
                 )
                 Text(
                     text = userName.ifNotEmpty { "@$userName" },
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.wireTypography.body02,
                     maxLines = 1,
-                    color = MaterialTheme.wireColorScheme.labelText,
+                    color = MaterialTheme.wireColorScheme.labelText
                 )
                 UserBadge(membership, connection, topPadding = dimensions().spacing8x)
             }
@@ -171,6 +175,10 @@ fun UserProfileInfo(
                 )
             }
         }
+        if (securityClassificationType != SecurityClassificationType.NONE) {
+            VerticalSpace.x8()
+            SecurityClassificationBanner(securityClassificationType = securityClassificationType)
+        }
     }
 }
 
@@ -191,7 +199,7 @@ private fun TeamInformation(modifier: Modifier, teamName: String) {
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         style = MaterialTheme.wireTypography.label01,
-        color = MaterialTheme.colorScheme.onBackground,
+        color = MaterialTheme.colorScheme.onBackground
     )
 }
 
@@ -199,7 +207,6 @@ sealed class EditableState {
     object NotEditable : EditableState()
     class IsEditable(val onEditClick: () -> Unit) : EditableState()
 }
-
 
 @Preview
 @Composable
@@ -212,6 +219,7 @@ fun PreviewUserProfileInfo() {
         fullName = "fullName",
         onUserProfileClick = {},
         teamName = "Wire",
-        connection = ConnectionState.ACCEPTED
+        connection = ConnectionState.ACCEPTED,
+        securityClassificationType = SecurityClassificationType.CLASSIFIED
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -322,7 +322,8 @@ private fun TopBarCollapsing(state: OtherUserProfileState) {
             membership = state.membership,
             editableState = EditableState.NotEditable,
             modifier = Modifier.padding(bottom = dimensions().spacing16x),
-            connection = state.connectionState
+            connection = state.connectionState,
+            securityClassificationType = state.securityClassificationType
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -89,6 +89,7 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -130,6 +131,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val getOtherUserClients: GetOtherUserClientsUseCase,
     private val persistOtherUserClients: PersistOtherUserClientsUseCase,
     private val clearConversationContentUseCase: ClearConversationContentUseCase,
+    private val getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase,
     savedStateHandle: SavedStateHandle,
     qualifiedIdMapper: QualifiedIdMapper
 ) : ViewModel(), OtherUserProfileEventsHandler, OtherUserProfileBottomSheetEventsHandler, OtherUserProfileFooterEventsHandler {
@@ -151,6 +153,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
         observeUserInfoAndUpdateViewState()
         persistClients()
+        setClassificationType()
     }
 
     private fun persistClients() {
@@ -468,6 +471,12 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             )
         )
     }
+    private fun setClassificationType() {
+        viewModelScope.launch {
+            state = state.copy(securityClassificationType = getOtherUserSecurityClassificationLabel(userId))
+        }
+    }
+
 
     override fun navigateBack() = viewModelScope.launch { navigationManager.navigateBack() }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -97,6 +97,8 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusU
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Date
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -106,8 +108,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Date
-import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -272,7 +272,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                     state = state.copy(connectionState = ConnectionState.IGNORED)
                     navigationManager.navigateBack(
                         mapOf(
-                            EXTRA_CONNECTION_IGNORED_USER_NAME to state.userName,
+                            EXTRA_CONNECTION_IGNORED_USER_NAME to state.userName
                         )
                     )
                 }
@@ -284,8 +284,9 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         viewModelScope.launch {
             if (conversationId != null) {
                 updateMemberRole(conversationId, userId, role).also {
-                    if (it is UpdateConversationMemberRoleResult.Failure)
+                    if (it is UpdateConversationMemberRoleResult.Failure) {
                         closeBottomSheetAndShowInfoMessage(ChangeGroupRoleError)
+                    }
                 }
             }
         }
@@ -306,8 +307,9 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 )
             }
 
-            if (response is RemoveMemberFromConversationUseCase.Result.Failure)
+            if (response is RemoveMemberFromConversationUseCase.Result.Failure) {
                 closeBottomSheetAndShowInfoMessage(RemoveConversationMemberError)
+            }
 
             requestInProgress = false
         }
@@ -402,8 +404,9 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         clearContentResult: ClearConversationContentUseCase.Result,
         conversationTypeDetail: ConversationTypeDetail
     ) {
-        if (conversationTypeDetail is ConversationTypeDetail.Connection)
+        if (conversationTypeDetail is ConversationTypeDetail.Connection) {
             throw IllegalStateException("Unsupported conversation type to clear content, something went wrong?")
+        }
 
         if (clearContentResult is ClearConversationContentUseCase.Result.Failure) {
             closeBottomSheetAndShowInfoMessage(OtherUserProfileInfoMessageType.ConversationContentDeleteFailure)
@@ -471,12 +474,12 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             )
         )
     }
+
     private fun setClassificationType() {
         viewModelScope.launch {
             state = state.copy(securityClassificationType = getOtherUserSecurityClassificationLabel(userId))
         }
     }
-
 
     override fun navigateBack() = viewModelScope.launch { navigationManager.navigateBack() }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.BotService
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 data class OtherUserProfileState(
     val userId: UserId,
@@ -49,7 +50,8 @@ data class OtherUserProfileState(
     val botService: BotService? = null,
     val conversationSheetContent: ConversationSheetContent? = null,
     val otherUserClients: List<OtherUserClient> = listOf(),
-    val blockingState: BlockingState = BlockingState.CAN_NOT_BE_BLOCKED
+    val blockingState: BlockingState = BlockingState.CAN_NOT_BE_BLOCKED,
+    val securityClassificationType: SecurityClassificationType = SecurityClassificationType.NONE
 ) {
     fun updateMuteStatus(status: MutedConversationStatus): OtherUserProfileState {
         return conversationSheetContent?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -81,6 +81,7 @@ import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialogState
 import com.wire.android.ui.userprofile.self.model.OtherAccount
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -174,7 +175,8 @@ private fun SelfUserProfileContent(
                             teamName = teamName,
                             onUserProfileClick = onChangeUserProfilePicture,
                             editableState = if (state.isReadOnlyAccount) EditableState.NotEditable
-                            else EditableState.IsEditable(onEditClick)
+                            else EditableState.IsEditable(onEditClick),
+                            securityClassificationType = SecurityClassificationType.NONE
                         )
                     }
                     stickyHeader {

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -50,6 +50,7 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -127,6 +128,9 @@ internal class OtherUserProfileViewModelArrangement {
     @MockK
     lateinit var clearConversationContent: ClearConversationContentUseCase
 
+    @MockK
+    lateinit var getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase
+
     private val viewModel by lazy {
         OtherUserProfileScreenViewModel(
             navigationManager,
@@ -148,6 +152,7 @@ internal class OtherUserProfileViewModelArrangement {
             otherUserClients,
             persistOtherUserClientsUseCase,
             clearConversationContent,
+            getOtherUserSecurityClassificationLabel,
             savedStateHandle,
             qualifiedIdMapper
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2702" title="AR-2702" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-2702</a>  No classified banners displayed on other users Profile Page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to implement security classification banner for other user profile screen.

### Solutions

Consume the use case that returns the security classification label for a given user id and reuse the Compose component that displays the banner.

### Attachments


<img src="https://user-images.githubusercontent.com/5806454/222514327-af86d1f0-8950-43c5-a31d-48a472a22b63.png" width="300" />

<img src="https://user-images.githubusercontent.com/5806454/222514348-449af56f-b6ed-44a7-ac01-566738536f07.png" width="300" />


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
