### PR TITLE
fix: empty bottom sheet remains open after closing message details screen [AR-3145]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -80,9 +80,10 @@ class ConversationScreenState(
         coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Expanded) }
     }
 
-    fun hideEditContextMenu() {
+    fun hideEditContextMenu(onComplete: () -> Unit = {}) {
         coroutineScope.launch {
             modalBottomSheetState.animateTo(ModalBottomSheetValue.Hidden)
+            onComplete()
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -62,7 +62,7 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 @Composable
 fun EditMessageMenuItems(
     message: UIMessage,
-    hideEditMessageMenu: () -> Unit,
+    hideEditMessageMenu: (OnComplete) -> Unit,
     onCopyClick: (text: String) -> Unit,
     onDeleteClick: (messageId: String, isMyMessage: Boolean) -> Unit,
     onReactionClick: (messageId: String, emoji: String) -> Unit,
@@ -81,41 +81,48 @@ fun EditMessageMenuItems(
 
     val onCopyItemClick = remember(message) {
         {
-            hideEditMessageMenu()
-            onCopyClick((message.messageContent as UIMessageContent.TextMessage).messageBody.message.asString(localContext.resources))
+            hideEditMessageMenu() {
+                onCopyClick((message.messageContent as UIMessageContent.TextMessage).messageBody.message.asString(localContext.resources))
+            }
         }
     }
     val onDeleteItemClick = remember(message) {
         {
-            hideEditMessageMenu()
-            onDeleteClick(message.messageHeader.messageId, message.isMyMessage)
+            hideEditMessageMenu() {
+                onDeleteClick(message.messageHeader.messageId, message.isMyMessage)
+            }
         }
     }
     val onReactionItemClick = remember(message) {
         { emoji: String ->
-            hideEditMessageMenu()
-            onReactionClick(message.messageHeader.messageId, emoji)
+            hideEditMessageMenu() {
+                onReactionClick(message.messageHeader.messageId, emoji)
+            }
         }
     }
     val onReplyItemClick = remember(message) {
         {
-            hideEditMessageMenu()
-            onReplyClick(message)
+            hideEditMessageMenu() {
+                onReplyClick(message)
+            }
+
         }
     }
     val onDetailsItemClick = remember(message) {
         {
-            hideEditMessageMenu()
-            onDetailsClick(message.messageHeader.messageId, message.isMyMessage)
+            hideEditMessageMenu() {
+                onDetailsClick(message.messageHeader.messageId, message.isMyMessage)
+            }
         }
     }
     val onEditItemClick = remember(message) {
         {
-            hideEditMessageMenu()
-            onEditClick(
-                message.messageHeader.messageId,
-                (message.messageContent as UIMessageContent.TextMessage).messageBody.message.asString(localContext.resources)
-            )
+            hideEditMessageMenu() {
+                onEditClick(
+                    message.messageHeader.messageId,
+                    (message.messageContent as UIMessageContent.TextMessage).messageBody.message.asString(localContext.resources)
+                )
+            }
         }
     }
 
@@ -273,3 +280,5 @@ private fun MessageDetails(
         onItemClick = onMessageDetailsClick
     )
 }
+
+typealias OnComplete = () -> Unit

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -105,7 +105,6 @@ fun EditMessageMenuItems(
             hideEditMessageMenu() {
                 onReplyClick(message)
             }
-
         }
     }
     val onDetailsItemClick = remember(message) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3145" title="AR-3145" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3145</a>  PlayTest 17.02 - Read Receipt -> After closing the message details screen, the empty bottom sheet remains open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After closing the message details screen, the empty bottom sheet remains open.

### Causes (Optional)

Animation is launched at the same time as the navigation happens so the state isn't changed and remains open after navigating back, but the message id is already cleared, so it's empty.

### Solutions

Previously the app waited until the closing animation is completed, so such logic was restored (we can change the duration of this animation if we want).

### Testing

#### How to Test

Long tap on message to open bottom sheet, choose the message details, close the message details screen.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/222788931-96acbae4-0fc4-4d31-94c0-641180128ac1.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
