### PR TITLE
fix(rc): more NavBackStackEntry crashes (hopefully) [AR-3137][AR-3193]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -98,7 +98,8 @@ class WireActivity : AppCompatActivity() {
 
         viewModel.handleDeepLink(intent)
         viewModel.observePersistentConnectionStatus()
-        setComposableContent()
+        val startDestination = viewModel.startNavigationRoute()
+        setComposableContent(startDestination)
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -108,7 +109,7 @@ class WireActivity : AppCompatActivity() {
         super.onNewIntent(intent)
     }
 
-    private fun setComposableContent() {
+    private fun setComposableContent(startDestination: String) {
         setContent {
             CompositionLocalProvider(
                 LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
@@ -117,16 +118,19 @@ class WireActivity : AppCompatActivity() {
                 WireTheme {
                     val scope = rememberCoroutineScope()
                     val navController = rememberTrackingAnimatedNavController() { NavigationItem.fromRoute(it)?.itemName }
-                    val startDestination = viewModel.startNavigationRoute()
-                    Scaffold {
-                        NavigationGraph(navController = navController, startDestination, viewModel.navigationArguments())
-                    }
-                    setUpNavigation(navController, scope)
-
+                    setUpNavigationGraph(startDestination, navController, scope)
                     handleDialogs()
                 }
             }
         }
+    }
+
+    @Composable
+    fun setUpNavigationGraph(startDestination: String, navController: NavHostController, scope: CoroutineScope) {
+        Scaffold {
+            NavigationGraph(navController = navController, startDestination, viewModel.navigationArguments())
+        }
+        setUpNavigation(navController, scope)
     }
 
     @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -129,6 +129,10 @@ fun ConversationScreen(
         messageComposerViewModel.checkPendingActions()
     }
 
+    LaunchedEffect(Unit) {
+        conversationInfoViewModel.observeConversationDetails()
+    }
+
     when (showDialog.value) {
         ConversationScreenDialogType.ONGOING_ACTIVE_CALL -> {
             OngoingActiveCallDialog(onJoinAnyways = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -78,8 +78,17 @@ class ConversationInfoViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             selfUserId = observerSelfUser().first().id
-            observeConversationDetails(conversationId).collect(::handleConversationDetailsResult)
         }
+    }
+
+    /*
+        If this would be collected in the scope of this ViewModel (in `init` for instance) then there would be a race condition.
+        [MessageComposerViewModel] handles the navigating back after removing a group and here it would navigate to home if the group
+        is removed without back params indicating that the user actually have just done that. The info about the group being removed
+        could appear before the back navigation params. That's why it's being observed in the `LaunchedEffect` in the Composable.
+    */
+    suspend fun observeConversationDetails() {
+        observeConversationDetails(conversationId).collect(::handleConversationDetailsResult)
     }
 
     private suspend fun handleConversationDetailsResult(conversationDetailsResult: ObserveConversationDetailsUseCase.Result) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -171,10 +171,11 @@ class ConversationInfoViewModel @Inject constructor(
         is ConversationDetails.OneOne -> conversationDetails.otherUser.name.orEmpty()
         else -> conversationDetails.conversation.name.orEmpty()
     }.let {
-        if (it.isNotEmpty()) it.toUIText()
-        else
-            if (it.isEmpty() && isConversationUnavailable) UIText.StringResource(R.string.username_unavailable_label)
-            else UIText.StringResource(R.string.member_name_deleted_label)
+        when {
+            it.isNotEmpty() -> it.toUIText()
+            it.isEmpty() && isConversationUnavailable -> UIText.StringResource(R.string.username_unavailable_label)
+            else -> UIText.StringResource(R.string.member_name_deleted_label)
+        }
     }
 
     fun navigateToDetails() = viewModelScope.launch(dispatchers.default()) {
@@ -209,7 +210,6 @@ class ConversationInfoViewModel @Inject constructor(
                     else -> navigateToOtherProfile(userId)
                 }
             }
-
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -85,16 +85,16 @@ class ConversationInfoViewModelArrangement {
         every {
             qualifiedIdMapper.fromStringToQualifiedID("some-dummy-value@some.dummy.domain")
         } returns QualifiedID("some-dummy-value", "some.dummy.domain")
-    }
-
-    suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
         coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow().map {
             ObserveConversationDetailsUseCase.Result.Success(it)
         }
-        conversationDetailsChannel.send(conversationDetails)
+    }
+
+    suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
         coEvery {
             qualifiedIdMapper.fromStringToQualifiedID("id@domain")
         } returns QualifiedID("id", "domain")
+        conversationDetailsChannel.send(conversationDetails)
     }
 
     suspend fun withSelfUser() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
@@ -36,6 +36,8 @@ import com.wire.kalium.logic.data.user.UserId
 import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
@@ -112,14 +114,17 @@ class ConversationInfoViewModelTest {
         coEvery {
             arrangement.qualifiedIdMapper.fromStringToQualifiedID("other@domain")
         } returns QualifiedID("other", "domain")
-
-        // When
-        viewModel.navigateToProfile(userId.toString())
-        // Then
-        coVerify(exactly = 1) {
-            arrangement.navigationManager.navigate(
-                NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId, arrangement.conversationId)))
-            )
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When
+            viewModel.navigateToProfile(userId.toString())
+            // Then
+            coVerify(exactly = 1) {
+                arrangement.navigationManager.navigate(
+                    NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId, arrangement.conversationId)))
+                )
+            }
+            cancel()
         }
     }
 
@@ -133,13 +138,16 @@ class ConversationInfoViewModelTest {
             )
             .withSelfUser()
             .arrange()
-
-        // When - Then
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
-        assertEquals(
-            oneToOneConversationDetails.otherUser.name,
-            (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
-        )
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When - Then
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
+            assertEquals(
+                oneToOneConversationDetails.otherUser.name,
+                (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
+            )
+            cancel()
+        }
     }
 
     @Test
@@ -152,9 +160,12 @@ class ConversationInfoViewModelTest {
             )
             .withSelfUser()
             .arrange()
-
-        // When - Then
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.StringResource)
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When - Then
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.StringResource)
+            cancel()
+        }
     }
 
     @Test
@@ -165,13 +176,16 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
             .withSelfUser()
             .arrange()
-
-        // When - Then
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
-        assertEquals(
-            groupConversationDetails.conversation.name,
-            (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
-        )
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When - Then
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
+            assertEquals(
+                groupConversationDetails.conversation.name,
+                (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
+            )
+            cancel()
+        }
     }
 
     @Test
@@ -185,21 +199,26 @@ class ConversationInfoViewModelTest {
             )
             .withSelfUser()
             .arrange()
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When - Then
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
+            assertEquals(
+                firstConversationDetails.conversation.name,
+                (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
+            )
 
-        // When - Then
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
-        assertEquals(
-            firstConversationDetails.conversation.name,
-            (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
-        )
+            // When - Then
+            arrangement.withConversationDetailUpdate(conversationDetails = secondConversationDetails)
+            advanceUntilIdle()
 
-        // When - Then
-        arrangement.withConversationDetailUpdate(conversationDetails = secondConversationDetails)
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
-        assertEquals(
-            secondConversationDetails.conversation.name,
-            (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
-        )
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.DynamicString)
+            assertEquals(
+                secondConversationDetails.conversation.name,
+                (viewModel.conversationInfoViewState.conversationName as UIText.DynamicString).value
+            )
+            cancel()
+        }
     }
 
     @Test
@@ -225,9 +244,12 @@ class ConversationInfoViewModelTest {
             )
             .withSelfUser()
             .arrange()
-
-        // When - Then
-        assert(viewModel.conversationInfoViewState.conversationName is UIText.StringResource)
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            // When - Then
+            assert(viewModel.conversationInfoViewState.conversationName is UIText.StringResource)
+            cancel()
+        }
     }
 
     @Test
@@ -239,9 +261,13 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(conversationDetails = conversationDetails)
             .withSelfUser()
             .arrange()
-        val actualAvatar = viewModel.conversationInfoViewState.conversationAvatar
-        // When - Then
-        assert(actualAvatar is ConversationAvatar.OneOne)
-        assertEquals(otherUserAvatar, (actualAvatar as ConversationAvatar.OneOne).avatarAsset?.userAssetId)
+        launch { viewModel.observeConversationDetails() }.run {
+            advanceUntilIdle()
+            val actualAvatar = viewModel.conversationInfoViewState.conversationAvatar
+            // When - Then
+            assert(actualAvatar is ConversationAvatar.OneOne)
+            assertEquals(otherUserAvatar, (actualAvatar as ConversationAvatar.OneOne).avatarAsset?.userAssetId)
+            cancel()
+        }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3137" title="AR-3137" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3137</a>  Play Store Crash: You cannot access the NavBackStackEntry
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There are still some `NavBackStackEntry` crashes, encountered sometimes when the user removes the group on the group details screen or gets logged out because their account has been removed.

### Solutions

Moved the setting of the start destination/initial screen higher, out of the composable to be determined only once when the Activity is being created and not change because of any recomposition because it can mess up the `NavHost` and back stack.
Start observing conversation details changes in the `ConversationScreen` composable scope, previously it was collecting throughout the whole lifetime of the `ConversationInfoViewModel`, but there are two ViewModels that use the same back navigation param, so there was a race condition, because `MessageComposerViewModel` handles the conversation removal but `ConversationInfoViewModel` also navigates to Home when it detects that such conversation doesn't exist and if it processed this removal before the back navigation params were passed, it could navigate to Home and then the app tried to also navigate back.

### Testing

#### How to Test

Try to remove a group or remove the user from another client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
