### PR TITLE
fix: DeepLink handling (AR-3202)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -180,6 +180,12 @@ class WireActivityViewModel @Inject constructor(
 
     @Suppress("ComplexMethod")
     fun handleDeepLink(intent: Intent?) {
+        if (shouldGoToMigration()) {
+            // means User is Logged in, but didn't finish the migration yet.
+            // so we need to finish migration first.
+            return
+        }
+
         viewModelScope.launch {
             val result = intent?.data?.let { deepLinkProcessor(it) }
             when {
@@ -187,7 +193,10 @@ class WireActivityViewModel @Inject constructor(
                 result is DeepLinkResult.MigrationLogin -> openMigrationLogin(result.userHandle)
                 result is DeepLinkResult.CustomServerConfig -> onCustomServerConfig(result)
 
-                shouldGoToMigration() || shouldGoToWelcome() -> {} // do nothing, this case is handled by startNavigationRoute()
+                shouldGoToWelcome() -> {
+                    // to handle the deepLinks above user needs to be Logged in
+                    // do nothing, navigating to Login is handled by startNavigationRoute()
+                }
 
                 isSharingIntent(intent) -> navigateToImportMediaScreen()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3202" title="AR-3202" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3202</a>  Redirect to another backend not working anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?
fix for Redirect to another backend not working anymore

### Issues

Switching to custom backEnd by deepLink does not work

### Causes (Optional)

While refactoring DeepLink handling I misunderstand the expected result. Thought if user is not logged in then we should not allow him to do anything.

### Solutions

Update DeepLink handling to accept SSOLogin, MigrationLogin and CustomServerConfig deepLinks even if user is not Logged in.
