### PR TITLE
fix: Plurals translations

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -101,7 +101,7 @@ private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
     else -> UIText.StringResource(R.string.username_unavailable_label)
 }
 
-@Suppress("LongMethod", "ComplexMethod")
+@Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")
 fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
     return when (content) {
         is WithUser -> {
@@ -193,7 +193,11 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         !isSelfMessage && isSelfRemoved -> {
                             when (otherUsersSize) {
                                 0 -> UIText.StringResource(R.string.last_message_other_removed_only_self_user)
-                                else -> UIText.PluralResource(R.plurals.last_message_other_removed_self_user, otherUsersSize, otherUsersSize)
+                                else -> UIText.PluralResource(
+                                    R.plurals.last_message_other_removed_self_user,
+                                    otherUsersSize,
+                                    otherUsersSize
+                                )
                             }
                         }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -161,7 +161,10 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         }
 
                         !isSelfMessage && isSelfAdded -> {
-                            UIText.PluralResource(R.plurals.last_message_other_added_self_user, otherUsersSize, otherUsersSize)
+                            when (otherUsersSize) {
+                                0 -> UIText.StringResource(R.string.last_message_other_added_only_self_user)
+                                else -> UIText.PluralResource(R.plurals.last_message_other_added_self_user, otherUsersSize, otherUsersSize)
+                            }
                         }
 
                         else -> {
@@ -188,7 +191,10 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         }
 
                         !isSelfMessage && isSelfRemoved -> {
-                            UIText.PluralResource(R.plurals.last_message_other_removed_self_user, otherUsersSize, otherUsersSize)
+                            when (otherUsersSize) {
+                                0 -> UIText.StringResource(R.string.last_message_other_removed_only_self_user)
+                                else -> UIText.PluralResource(R.plurals.last_message_other_removed_self_user, otherUsersSize, otherUsersSize)
+                            }
                         }
 
                         else -> {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Wire
   ~ Copyright (C) 2023 Wire Swiss GmbH
   ~
@@ -514,8 +513,8 @@
         <item quantity="one">Sie haben 1 Person zur Unterhaltung hinzugefügt</item>
         <item quantity="other">Sie haben %1$d Personen zur Unterhaltung hinzugefügt</item>
     </plurals>
+    <string name="last_message_other_added_only_self_user">Sie wurden zur Unterhaltung hinzugefügt</string>
     <plurals name="last_message_other_added_self_user">
-        <item quantity="zero">Sie wurden zur Unterhaltung hinzugefügt</item>
         <item quantity="one">Sie und 1 weitere Person wurden zur Unterhaltung hinzugefügt</item>
         <item quantity="other">Sie und %1$d weitere Personen wurden zur Unterhaltung hinzugefügt</item>
     </plurals>
@@ -528,8 +527,8 @@
         <item quantity="one">Sie haben 1 Person aus der Unterhaltung entfernt</item>
         <item quantity="other">Sie haben %1$d Personen zur Unterhaltung entfernt</item>
     </plurals>
+    <string name="last_message_other_removed_only_self_user">Sie wurden aus der Unterhaltung entfernt</string>
     <plurals name="last_message_other_removed_self_user">
-        <item quantity="zero">Sie wurden aus der Unterhaltung entfernt</item>
         <item quantity="one">Sie und 1 weitere Person wurden aus der Unterhaltung entfernt</item>
         <item quantity="other">Sie und %1$d weitere Personen wurden aus der Unterhaltung entfernt</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,11 +522,11 @@
     <string name="label_system_message_receipt_mode_off">off</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
-        <item quantity="one">You added 1 person to the conversation</item>
+        <item quantity="one" >You added 1 person to the conversation</item>
         <item quantity="other">You added %1$d people to the conversation</item>
     </plurals>
+    <string name="last_message_other_added_only_self_user">You were added to the conversation</string>
     <plurals name="last_message_other_added_self_user">
-        <item quantity="zero">You were added to the conversation</item>
         <item quantity="one">You and 1 other person were added to the conversation</item>
         <item quantity="other">You and %1$d people were added to the conversation</item>
     </plurals>
@@ -534,13 +534,12 @@
         <item quantity="one">1 person was added to the conversation</item>
         <item quantity="other">%1$d people were added to the conversation</item>
     </plurals>
-
     <plurals name="last_message_self_removed_users">
         <item quantity="one">You removed 1 person from the conversation</item>
         <item quantity="other">You removed %1$d people from the conversation</item>
     </plurals>
+    <string name="last_message_other_removed_only_self_user">You were removed from the conversation</string>
     <plurals name="last_message_other_removed_self_user">
-        <item quantity="zero">You were removed from the conversation</item>
         <item quantity="one">You and 1 other person were removed from the conversation</item>
         <item quantity="other">You and %1$d people were removed from the conversation</item>
     </plurals>

--- a/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
@@ -227,9 +227,8 @@ class MessagePreviewContentMapperTest {
             )
 
             val uiPreviewMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.TextMessage>()
-            val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
-            previewString.count shouldBeEqualTo 0
-            previewString.resId shouldBeEqualTo R.plurals.last_message_other_removed_self_user
+            val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.StringResource>()
+            previewString.resId shouldBeEqualTo R.string.last_message_other_removed_only_self_user
         }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After contacting with Crowdin support team, I confirmed that they don't currently allow plural translations for cases where argument provided is 0/zero. 

### Solutions
I removed that case from the plural strings and added a finer handling of the strings. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
