### PR TITLE
fix: incremental sync state flow buffer being overflowed [AR-3181]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -85,7 +85,9 @@ fun HomeScreen(
     conversationListViewModel: ConversationListViewModel = hiltViewModel(), // TODO: move required elements from this one to HomeViewModel?
 ) {
     homeViewModel.checkRequirements()
-    featureFlagNotificationViewModel.loadInitialSync()
+    LaunchedEffect(Unit) {
+        featureFlagNotificationViewModel.loadInitialSync()
+    }
     val homeScreenState = rememberHomeScreenState()
     val showNotificationsFlow = rememberRequestPushNotificationsPermissionFlow(
         onPermissionDenied = { /** TODO: Show a dialog rationale explaining why the permission is needed **/ })
@@ -121,8 +123,6 @@ fun HomeScreen(
             )
         }
     }
-
-    featureFlagNotificationViewModel.loadInitialSync()
 
     HomeContent(
         connectivityState = commonTopAppBarViewModel.connectivityState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -101,12 +101,14 @@ class FeatureFlagNotificationViewModel @Inject constructor(
     }
 
     private suspend fun setGuestRoomLinkFeatureFlag() {
-        observeGuestRoomLinkFeatureFlag().collect { guestRoomLinkStatus ->
-            guestRoomLinkStatus.isGuestRoomLinkEnabled?.let {
-                featureFlagState = featureFlagState.copy(isGuestRoomLinkEnabled = it)
-            }
-            guestRoomLinkStatus.isStatusChanged?.let {
-                featureFlagState = featureFlagState.copy(shouldShowGuestRoomLinkDialog = it)
+        viewModelScope.launch {
+            observeGuestRoomLinkFeatureFlag().collect { guestRoomLinkStatus ->
+                guestRoomLinkStatus.isGuestRoomLinkEnabled?.let {
+                    featureFlagState = featureFlagState.copy(isGuestRoomLinkEnabled = it)
+                }
+                guestRoomLinkStatus.isStatusChanged?.let {
+                    featureFlagState = featureFlagState.copy(shouldShowGuestRoomLinkDialog = it)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeat
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -68,19 +69,18 @@ class FeatureFlagNotificationViewModel @Inject constructor(
      */
     fun loadInitialSync() {
         viewModelScope.launch {
-            currentSessionUseCase().let {
-                when (it) {
+            currentSessionUseCase().let { currentSessionResult ->
+                when (currentSessionResult) {
                     is CurrentSessionResult.Failure -> {
                         appLogger.e("Failure while getting current session from FeatureFlagNotificationViewModel")
                     }
 
                     is CurrentSessionResult.Success -> {
-                        coreLogic.getSessionScope(it.accountInfo.userId).observeSyncState().collect { newState ->
-                            if (newState == SyncState.Live) {
-                                setFileSharingState(it.accountInfo.userId)
+                        coreLogic.getSessionScope(currentSessionResult.accountInfo.userId).observeSyncState()
+                            .firstOrNull { it == SyncState.Live }?.let {
+                                setFileSharingState(currentSessionResult.accountInfo.userId)
                                 setGuestRoomLinkFeatureFlag()
                             }
-                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -72,7 +72,9 @@ fun ImportMediaScreen(
 
 @Composable
 fun checkIfSharingIsEnabled(featureFlagNotificationViewModel: FeatureFlagNotificationViewModel) {
-    featureFlagNotificationViewModel.loadInitialSync()
+    LaunchedEffect(Unit) {
+        featureFlagNotificationViewModel.loadInitialSync()
+    }
 
     val fileSharingRestrictedDialogState = rememberVisibilityState<FileSharingRestrictedDialogState>()
     FileSharingRestrictedDialogContent(dialogState = fileSharingRestrictedDialogState)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3181" title="AR-3181" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3181</a>  App stuck in connecting state, no notification received
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is stuck on connecting because the sync state is not being emitted properly.

### Causes (Optional)

`emit()` can be suspended when the buffer is overflowed and the strategy is `SUSPEND` (it's like that by default). `FeatureFlagNotificationUseCase` is observing the incremental sync state in `loadInitialSync` and each time it becomes `LIVE` it executes two things: `setFileSharingState` which collects some data in another coroutine, and `setGuestRoomLinkFeatureFlag` which actually directly collects data from `isGuestRoomLinkEnabledFlow` which is a `SharedFlow`, so it means it never ends, so it waits here forever. What's more, this `loadInitialSync` is called twice every time the `HomeScreen` recomposes, and creates a new coroutine each time which means that after every recomposition there are two new blocking subscribers created, the buffer set to 64 can be easily overflowed in that situation.

### Solutions

Observe `isGuestRoomLinkEnabledFlow` in another coroutine in the `viewModelScope` and launch `loadInitialSync` only once for the `HomeScreen` and `ImportMediaScreen`.

### Testing

#### How to Test

Open and close the app multiple times or make the Home screen be recomposed multiple times, put the app in the background and receive a message.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
