### PR TITLE
fix: infinite vibration when receiving ping (AR-3208)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/PingRinger.kt
+++ b/app/src/main/kotlin/com/wire/android/media/PingRinger.kt
@@ -71,10 +71,10 @@ class PingRinger @Inject constructor(private val context: Context) {
                 if (ringerMode == AudioManager.RINGER_MODE_VIBRATE) {
                     appLogger.i("Starting vibration")
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        it.vibrate(VibrationEffect.createWaveform(VIBRATE_PATTERN, VibrationEffect.EFFECT_DOUBLE_CLICK))
+                        it.vibrate(VibrationEffect.createWaveform(VIBRATE_PATTERN, VibrationEffect.DEFAULT_AMPLITUDE))
                     } else {
                         @Suppress("DEPRECATION")
-                        it.vibrate(VIBRATE_PATTERN, VibrationEffect.EFFECT_DOUBLE_CLICK)
+                        it.vibrate(VIBRATE_PATTERN, VibrationEffect.DEFAULT_AMPLITUDE)
                     }
                 } else {
                     appLogger.i("Skipping vibration")
@@ -84,6 +84,6 @@ class PingRinger @Inject constructor(private val context: Context) {
     }
 
     companion object {
-        private val VIBRATE_PATTERN = longArrayOf(0, 1000, 1000)
+        private val VIBRATE_PATTERN: LongArray = longArrayOf(0L, 1000L, 1000L, 1000L)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3208" title="AR-3208" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3208</a>  Ping user when has vibration mode, put into infinite vibration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When phone was in vibration mode and received Ping message, it would vibrate infinitely.

### Causes (Optional)

`VibrationEffect` and `VIBRATION_PATTERN` was misleading.

### Solutions

- Force vibration to execute only once | `VibrationEffect.DEFAULT_AMPLITUDE`
- Add an extra fake vibration pattern as last value is ignored | `longArrayOf(0L, 1000L, 1000L, 1000L)` as we only want it to vibrate twice.

### Testing

#### How to Test

- Put App in Vibration Mode
- Receive Ping message WHILE inside the conversation
- Phone should vibrate only twice