### PR TITLE
fix: Revert "fix: Plurals translations (#1543)"

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -101,7 +101,7 @@ private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
     else -> UIText.StringResource(R.string.username_unavailable_label)
 }
 
-@Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")
+@Suppress("LongMethod", "ComplexMethod")
 fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
     return when (content) {
         is WithUser -> {
@@ -161,10 +161,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         }
 
                         !isSelfMessage && isSelfAdded -> {
-                            when (otherUsersSize) {
-                                0 -> UIText.StringResource(R.string.last_message_other_added_only_self_user)
-                                else -> UIText.PluralResource(R.plurals.last_message_other_added_self_user, otherUsersSize, otherUsersSize)
-                            }
+                            UIText.PluralResource(R.plurals.last_message_other_added_self_user, otherUsersSize, otherUsersSize)
                         }
 
                         else -> {
@@ -191,14 +188,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                         }
 
                         !isSelfMessage && isSelfRemoved -> {
-                            when (otherUsersSize) {
-                                0 -> UIText.StringResource(R.string.last_message_other_removed_only_self_user)
-                                else -> UIText.PluralResource(
-                                    R.plurals.last_message_other_removed_self_user,
-                                    otherUsersSize,
-                                    otherUsersSize
-                                )
-                            }
+                            UIText.PluralResource(R.plurals.last_message_other_removed_self_user, otherUsersSize, otherUsersSize)
                         }
 
                         else -> {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Wire
   ~ Copyright (C) 2023 Wire Swiss GmbH
   ~
@@ -513,8 +514,8 @@
         <item quantity="one">Sie haben 1 Person zur Unterhaltung hinzugefügt</item>
         <item quantity="other">Sie haben %1$d Personen zur Unterhaltung hinzugefügt</item>
     </plurals>
-    <string name="last_message_other_added_only_self_user">Sie wurden zur Unterhaltung hinzugefügt</string>
     <plurals name="last_message_other_added_self_user">
+        <item quantity="zero">Sie wurden zur Unterhaltung hinzugefügt</item>
         <item quantity="one">Sie und 1 weitere Person wurden zur Unterhaltung hinzugefügt</item>
         <item quantity="other">Sie und %1$d weitere Personen wurden zur Unterhaltung hinzugefügt</item>
     </plurals>
@@ -527,8 +528,8 @@
         <item quantity="one">Sie haben 1 Person aus der Unterhaltung entfernt</item>
         <item quantity="other">Sie haben %1$d Personen zur Unterhaltung entfernt</item>
     </plurals>
-    <string name="last_message_other_removed_only_self_user">Sie wurden aus der Unterhaltung entfernt</string>
     <plurals name="last_message_other_removed_self_user">
+        <item quantity="zero">Sie wurden aus der Unterhaltung entfernt</item>
         <item quantity="one">Sie und 1 weitere Person wurden aus der Unterhaltung entfernt</item>
         <item quantity="other">Sie und %1$d weitere Personen wurden aus der Unterhaltung entfernt</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -526,11 +526,11 @@
     <string name="label_system_message_receipt_mode_off">off</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
-        <item quantity="one" >You added 1 person to the conversation</item>
+        <item quantity="one">You added 1 person to the conversation</item>
         <item quantity="other">You added %1$d people to the conversation</item>
     </plurals>
-    <string name="last_message_other_added_only_self_user">You were added to the conversation</string>
     <plurals name="last_message_other_added_self_user">
+        <item quantity="zero">You were added to the conversation</item>
         <item quantity="one">You and 1 other person were added to the conversation</item>
         <item quantity="other">You and %1$d people were added to the conversation</item>
     </plurals>
@@ -538,12 +538,13 @@
         <item quantity="one">1 person was added to the conversation</item>
         <item quantity="other">%1$d people were added to the conversation</item>
     </plurals>
+
     <plurals name="last_message_self_removed_users">
         <item quantity="one">You removed 1 person from the conversation</item>
         <item quantity="other">You removed %1$d people from the conversation</item>
     </plurals>
-    <string name="last_message_other_removed_only_self_user">You were removed from the conversation</string>
     <plurals name="last_message_other_removed_self_user">
+        <item quantity="zero">You were removed from the conversation</item>
         <item quantity="one">You and 1 other person were removed from the conversation</item>
         <item quantity="other">You and %1$d people were removed from the conversation</item>
     </plurals>

--- a/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
@@ -227,8 +227,9 @@ class MessagePreviewContentMapperTest {
             )
 
             val uiPreviewMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.TextMessage>()
-            val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.StringResource>()
-            previewString.resId shouldBeEqualTo R.string.last_message_other_removed_only_self_user
+            val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
+            previewString.count shouldBeEqualTo 0
+            previewString.resId shouldBeEqualTo R.plurals.last_message_other_removed_self_user
         }
 
     @Test


### PR DESCRIPTION
This reverts commit bce11edd8fbde17728e020ae881ece5c42e2cb22.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Zero quantity string copies was not supported in Crowdin for translation, hence I had to remove these changes I added in the past. However, after contacting Crowdin support team, they told me they just enabled a special processor and they would like me to test whether this is working or not, therefore the revert.

### Solutions
Revert the changes so that `zero` can also be translated with the same key copy via Crowdin website.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
