### PR TITLE
fix: file restricted team sharing assets crash [AR-2061]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptionButton.kt
@@ -27,17 +27,18 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 
 @Composable
-fun AdditionalOptionButton(isSelected: Boolean = false, onClick: () -> Unit) {
+fun AdditionalOptionButton(isSelected: Boolean = false, isEnabled: Boolean, onClick: () -> Unit) {
     WireSecondaryIconButton(
         onButtonClicked = onClick,
         iconResource = R.drawable.ic_add,
         contentDescription = R.string.content_description_attachment_item,
-        state = if (isSelected) WireButtonState.Selected else WireButtonState.Default,
+        state = if (!isEnabled) WireButtonState.Disabled
+        else if (isSelected) WireButtonState.Selected else WireButtonState.Default,
     )
 }
 
 @Preview
 @Composable
 fun PreviewAdditionalOptionButton() {
-    AdditionalOptionButton(isSelected = false, onClick = {})
+    AdditionalOptionButton(isSelected = false, isEnabled = false, onClick = {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
@@ -54,6 +54,7 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 fun MessageComposeActionsBox(
     transition: Transition<MessageComposeInputState>,
     isMentionActive: Boolean,
+    isFileSharingEnabled: Boolean,
     startMention: () -> Unit,
     onAdditionalOptionButtonClicked: () -> Unit,
     onPingClicked: () -> Unit,
@@ -74,6 +75,7 @@ fun MessageComposeActionsBox(
                         state.attachmentOptionsDisplayed,
                         isMentionActive,
                         state.isEditMessage,
+                        isFileSharingEnabled,
                         startMention,
                         onAdditionalOptionButtonClicked,
                         onPingClicked
@@ -89,6 +91,7 @@ private fun MessageComposeActions(
     attachmentOptionsDisplayed: Boolean,
     isMentionsSelected: Boolean,
     isEditMessage: Boolean,
+    isFileSharingEnabled: Boolean = true,
     startMention: () -> Unit,
     onAdditionalOptionButtonClicked: () -> Unit,
     onPingClicked: () -> Unit
@@ -103,7 +106,7 @@ private fun MessageComposeActions(
             .height(dimensions().spacing56x)
     ) {
         with(localFeatureVisibilityFlags) {
-            if (!isEditMessage) AdditionalOptionButton(attachmentOptionsDisplayed, onAdditionalOptionButtonClicked)
+            if (!isEditMessage) AdditionalOptionButton(attachmentOptionsDisplayed, isFileSharingEnabled, onAdditionalOptionButtonClicked)
             if (RichTextIcon) RichTextEditingAction()
             if (!isEditMessage && EmojiIcon) AddEmojiAction()
             if (!isEditMessage && GifIcon) AddGifAction()
@@ -177,7 +180,7 @@ fun PreviewMessageActionsBox() {
             .fillMaxWidth()
             .height(dimensions().spacing56x)
     ) {
-        AdditionalOptionButton(isSelected = false, onClick = {})
+        AdditionalOptionButton(isSelected = false, isEnabled = true, onClick = {})
         RichTextEditingAction()
         AddEmojiAction()
         AddGifAction()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -231,6 +231,7 @@ private fun MessageComposer(
                     MessageComposerInput(
                         transition = transition,
                         interactionAvailability = interactionAvailability,
+                        isFileSharingEnabled = isFileSharingEnabled,
                         securityClassificationType = securityClassificationType,
                         messageComposeInputState = messageComposerState.messageComposeInputState,
                         quotedMessageData = messageComposerState.quotedMessageData,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -76,6 +76,7 @@ internal fun MessageComposerInput(
     membersToMention: List<Contact>,
     actions: MessageComposerInputActions,
     inputFocusRequester: FocusRequester,
+    isFileSharingEnabled: Boolean,
 ) {
     when (interactionAvailability) {
         InteractionAvailability.BLOCKED_USER -> BlockedUserComposerInput()
@@ -90,6 +91,7 @@ internal fun MessageComposerInput(
                 membersToMention = membersToMention,
                 actions = actions,
                 inputFocusRequester = inputFocusRequester,
+                isFileSharingEnabled = isFileSharingEnabled
             )
         }
     }
@@ -105,6 +107,7 @@ private fun EnabledMessageComposerInput(
     membersToMention: List<Contact>,
     actions: MessageComposerInputActions,
     inputFocusRequester: FocusRequester,
+    isFileSharingEnabled: Boolean
 ) {
     Box {
         var currentSelectedLineIndex by remember { mutableStateOf(0) }
@@ -119,6 +122,7 @@ private fun EnabledMessageComposerInput(
                 onLineBottomCoordinateChange = { cursorCoordinateY = it },
                 actions = actions,
                 inputFocusRequester = inputFocusRequester,
+                isFileSharingEnabled = isFileSharingEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .let {
@@ -129,6 +133,7 @@ private fun EnabledMessageComposerInput(
             MessageComposeActionsBox(
                 transition = transition,
                 isMentionActive = membersToMention.isNotEmpty(),
+                isFileSharingEnabled = isFileSharingEnabled,
                 startMention = actions.startMention,
                 onAdditionalOptionButtonClicked = actions.onAdditionalOptionButtonClicked,
                 modifier = Modifier.background(colorsScheme().messageComposerBackgroundColor),
@@ -152,6 +157,7 @@ private fun MessageComposeInput(
     onLineBottomCoordinateChange: (Float) -> Unit,
     actions: MessageComposerInputActions,
     inputFocusRequester: FocusRequester,
+    isFileSharingEnabled: Boolean,
     modifier: Modifier
 ) {
     Column(
@@ -198,7 +204,8 @@ private fun MessageComposeInput(
             onLineBottomYCoordinateChanged = onLineBottomCoordinateChange,
             onAdditionalOptionButtonClicked = actions.onAdditionalOptionButtonClicked,
             onEditCancelButtonClicked = actions.onEditCancelButtonClicked,
-            onEditSaveButtonClicked = actions.onEditSaveButtonClicked
+            onEditSaveButtonClicked = actions.onEditSaveButtonClicked,
+            isFileSharingEnabled = isFileSharingEnabled,
         )
     }
 }
@@ -268,7 +275,8 @@ private fun generatePreviewWithState(state: MessageComposeInputState) {
         quotedMessageData = null,
         membersToMention = listOf(),
         actions = MessageComposerInputActions(),
-        inputFocusRequester = FocusRequester()
+        inputFocusRequester = FocusRequester(),
+        isFileSharingEnabled = true
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
@@ -67,6 +67,7 @@ fun MessageComposerInputRow(
     onAdditionalOptionButtonClicked: () -> Unit = { },
     onEditSaveButtonClicked: () -> Unit = { },
     onEditCancelButtonClicked: () -> Unit = { },
+    isFileSharingEnabled: Boolean = true,
 ) {
     Row(
         verticalAlignment = when (messageComposeInputState) {
@@ -79,7 +80,7 @@ fun MessageComposerInputRow(
             visible = { it is MessageComposeInputState.Inactive }
         ) {
             Box(modifier = Modifier.padding(start = dimensions().spacing8x)) {
-                AdditionalOptionButton(messageComposeInputState.attachmentOptionsDisplayed) {
+                AdditionalOptionButton(isSelected = messageComposeInputState.attachmentOptionsDisplayed, isEnabled = isFileSharingEnabled) {
                     onAdditionalOptionButtonClicked()
                 }
             }
@@ -185,24 +186,28 @@ fun PreviewMessageComposerInputRowInactive() {
     val state = MessageComposeInputState.Inactive()
     MessageComposerInputRow(updateTransition(targetState = state, label = ""), state)
 }
+
 @Preview
 @Composable
 fun PreviewMessageComposerInputRowActiveCollapsed() {
     val state = MessageComposeInputState.Active(size = MessageComposeInputSize.COLLAPSED)
     MessageComposerInputRow(updateTransition(targetState = state, label = ""), state)
 }
+
 @Preview
 @Composable
 fun PreviewMessageComposerInputRowActiveCollapsedSendEnabled() {
     val state = MessageComposeInputState.Active(messageText = TextFieldValue("text"), size = MessageComposeInputSize.COLLAPSED)
     MessageComposerInputRow(updateTransition(targetState = state, label = ""), state)
 }
+
 @Preview
 @Composable
 fun PreviewMessageComposerInputRowActiveExpanded() {
     val state = MessageComposeInputState.Active(size = MessageComposeInputSize.EXPANDED)
     MessageComposerInputRow(updateTransition(targetState = state, label = ""), state)
 }
+
 @Preview
 @Composable
 fun PreviewMessageComposerInputRowActiveEdit() {
@@ -212,6 +217,7 @@ fun PreviewMessageComposerInputRowActiveEdit() {
     )
     MessageComposerInputRow(updateTransition(targetState = state, label = ""), state)
 }
+
 @Preview
 @Composable
 fun PreviewMessageComposerInputRowActiveEditSaveEnabled() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,11 +534,6 @@
         <item quantity="one">You and 1 other person were added to the conversation</item>
         <item quantity="other">You and %1$d people were added to the conversation</item>
     </plurals>
-    <plurals name="last_message_other_added_self_user_and_others">
-        <item quantity="zero">You were added to the conversation</item>
-        <item quantity="one">You and 1 other person were added to the conversation</item>
-        <item quantity="other">You and %1$d people were added to the conversation</item>
-    </plurals>
     <plurals name="last_message_other_added_other_users">
         <item quantity="one">1 person was added to the conversation</item>
         <item quantity="other">%1$d people were added to the conversation</item>
@@ -549,11 +544,6 @@
         <item quantity="other">You removed %1$d people from the conversation</item>
     </plurals>
     <plurals name="last_message_other_removed_self_user">
-        <item quantity="zero">You were removed from the conversation</item>
-        <item quantity="one">You and 1 other person were removed from the conversation</item>
-        <item quantity="other">You and %1$d people were removed from the conversation</item>
-    </plurals>
-    <plurals name="last_message_other_removed_self_user_and_others">
         <item quantity="zero">You were removed from the conversation</item>
         <item quantity="one">You and 1 other person were removed from the conversation</item>
         <item quantity="other">You and %1$d people were removed from the conversation</item>
@@ -746,7 +736,7 @@
     <string name="prohibited_videos_message">Receiving videos is prohibited</string>
     <string name="prohibited_audio_message">Receiving audio messages is prohibited</string>
     <string name="prohibited_file_message">Receiving files is prohibited</string>
-    <string name="team_settings_changed">Team settings changed</string>
+    <string name="team_settings_changed">Team Settings Changed</string>
     <string name="sharing_files_enabled">Sharing and receiving files of any type is now enabled</string>
     <string name="sharing_files_disabled">Sharing and receiving files of any type is now disabled</string>
     <!--wire dropdown-->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2061" title="AR-2061" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2061</a>  [feature config] Wrong copy on dialog
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users that belong to teams whose file restricted flag is set to `false`, should not be able to share any type of asset. This holds true on our current implementation, however when clicking on the additional sharing options button, the app crashed, as we were trying to render an empty grid, causing a fatal exception.
Also capitalised the dialog title to match designs.

### Solutions
In order to avoid this situation, design decided to disable the additional options sharing button while the team sharing assets feature flag was disabled.

### Testing

#### How to Test

Try to login into a team that doesn't allow asset sharing. Navigate to any conversation, check that the additional options sharing button is disabled. 

### Attachments (Optional)


https://user-images.githubusercontent.com/2468164/225037285-95607c44-283c-4028-b344-9b070748fcd8.mov


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
