### PR TITLE
chore: increase VS-NFD banner visibility (AR-2610)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
@@ -20,22 +20,29 @@
 
 package com.wire.android.ui.common
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
@@ -45,22 +52,30 @@ fun SecurityClassificationBanner(
     modifier: Modifier = Modifier
 ) {
     if (securityClassificationType != SecurityClassificationType.NONE) {
-        Divider()
-        Row(
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .background(getBackgroundColorFor(securityClassificationType))
-                .height(dimensions().spacing24x)
-                .fillMaxWidth()
-        ) {
-            Text(
-                text = getTextFor(securityClassificationType),
-                color = getColorTextFor(securityClassificationType),
-                style = MaterialTheme.wireTypography.label03
-            )
+        Column {
+            Divider(color = getDividerColorFor(securityClassificationType))
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = modifier
+                    .background(getBackgroundColorFor(securityClassificationType))
+                    .height(dimensions().spacing24x)
+                    .fillMaxWidth()
+            ) {
+                Icon(
+                    painter = getIconFor(securityClassificationType),
+                    tint = getColorTextFor(securityClassificationType),
+                    contentDescription = getTextFor(securityClassificationType),
+                    modifier = Modifier.padding(end = dimensions().spacing8x)
+                )
+                Text(
+                    text = getTextFor(securityClassificationType),
+                    color = getColorTextFor(securityClassificationType),
+                    style = MaterialTheme.wireTypography.label03
+                )
+            }
+            Divider(color = getDividerColorFor(securityClassificationType))
         }
-        Divider()
     }
 }
 
@@ -76,27 +91,57 @@ private fun getTextFor(securityClassificationType: SecurityClassificationType): 
 @Composable
 private fun getBackgroundColorFor(securityClassificationType: SecurityClassificationType): Color {
     return if (securityClassificationType == SecurityClassificationType.CLASSIFIED) {
-        colorsScheme().surface
+        colorsScheme().classifiedBannerBackgroundColor
     } else {
-        colorsScheme().onSurface
+        colorsScheme().unclassifiedBannerBackgroundColor
     }
 }
 
 @Composable
 private fun getColorTextFor(securityClassificationType: SecurityClassificationType): Color {
     return if (securityClassificationType == SecurityClassificationType.CLASSIFIED) {
-        colorsScheme().onSurface
+        colorsScheme().classifiedBannerForegroundColor
     } else {
-        colorsScheme().surface
+        colorsScheme().unclassifiedBannerForegroundColor
     }
 }
 
-@Preview(showBackground = true)
+@Composable
+private fun getDividerColorFor(securityClassificationType: SecurityClassificationType): Color {
+    return if (securityClassificationType == SecurityClassificationType.CLASSIFIED) {
+        colorsScheme().classifiedBannerForegroundColor
+    } else {
+        colorsScheme().unclassifiedBannerBackgroundColor
+    }
+}
+
+@Composable
+private fun getIconFor(securityClassificationType: SecurityClassificationType): Painter {
+    return if (securityClassificationType == SecurityClassificationType.CLASSIFIED) {
+        painterResource(id = R.drawable.ic_check_tick)
+    } else {
+        painterResource(id = R.drawable.ic_info)
+    }
+}
+
+@Preview(
+    name = "Classified Indication - Light Mode",
+    showBackground = true
+)
+@Preview(
+    name = "Classified Indication - Dark Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    showBackground = true
+)
 @Composable
 fun PreviewClassifiedIndicator() {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        SecurityClassificationBanner(securityClassificationType = SecurityClassificationType.CLASSIFIED)
-        Divider()
-        SecurityClassificationBanner(securityClassificationType = SecurityClassificationType.NOT_CLASSIFIED)
+    WireTheme {
+        Surface {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                SecurityClassificationBanner(securityClassificationType = SecurityClassificationType.CLASSIFIED)
+                Divider()
+                SecurityClassificationBanner(securityClassificationType = SecurityClassificationType.NOT_CLASSIFIED)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -94,7 +94,11 @@ data class WireColorScheme(
     val connectivityBarOngoingCallBackgroundColor: Color,
     val connectivityBarIssueBackgroundColor: Color,
     val messageComposerBackgroundColor: Color,
-    val messageComposerEditBackgroundColor: Color
+    val messageComposerEditBackgroundColor: Color,
+    val classifiedBannerBackgroundColor: Color,
+    val classifiedBannerForegroundColor: Color,
+    val unclassifiedBannerBackgroundColor: Color,
+    val unclassifiedBannerForegroundColor: Color
 ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
         primary = primary,
@@ -219,7 +223,11 @@ private val LightWireColorScheme = WireColorScheme(
     connectivityBarOngoingCallBackgroundColor = WireColorPalette.LightGreen500,
     connectivityBarIssueBackgroundColor = WireColorPalette.LightBlue500,
     messageComposerBackgroundColor = Color.White,
-    messageComposerEditBackgroundColor = WireColorPalette.LightBlue50
+    messageComposerEditBackgroundColor = WireColorPalette.LightBlue50,
+    classifiedBannerBackgroundColor = WireColorPalette.LightGreen50,
+    classifiedBannerForegroundColor = WireColorPalette.LightGreen500,
+    unclassifiedBannerBackgroundColor = WireColorPalette.LightRed600,
+    unclassifiedBannerForegroundColor = Color.White
 )
 
 // Dark WireColorScheme
@@ -318,7 +326,11 @@ private val DarkWireColorScheme = WireColorScheme(
     connectivityBarOngoingCallBackgroundColor = WireColorPalette.DarkGreen700,
     connectivityBarIssueBackgroundColor = WireColorPalette.LightBlue500,
     messageComposerBackgroundColor = WireColorPalette.Gray100,
-    messageComposerEditBackgroundColor = WireColorPalette.DarkBlue800
+    messageComposerEditBackgroundColor = WireColorPalette.DarkBlue800,
+    classifiedBannerBackgroundColor = WireColorPalette.DarkGreen900,
+    classifiedBannerForegroundColor = WireColorPalette.DarkGreen500,
+    unclassifiedBannerBackgroundColor = WireColorPalette.DarkRed500,
+    unclassifiedBannerForegroundColor = Color.Black
 )
 
 @PackagePrivate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2610" title="AR-2610" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2610</a>  Increase visibility on VS-NFD banner
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

VS-NFD banner needed visibility increase.

### Solutions

Increase visibility on VS-NDF banners by changing its color and properly applying them on Light and Dark Mode.

### Testing

#### How to Test

Verify this screens for the banner on Light/Dark Mode:
- Conversation
- Other user Profile (Connected)
- Other user Profile (Not Connected)
- Incoming Call
- Outgoing Call

### Attachments (Optional)

| Light Mode | Dark Mode |
| ----------- | ------------ |
| <img src="https://user-images.githubusercontent.com/5890660/225273458-165e2f1a-3077-408f-aa1f-2bd8af7b188e.png" width="200" height="400" alt="connected" />  | <img src="https://user-images.githubusercontent.com/5890660/225273535-fb039fbd-fd47-4ab0-9d45-7438b80cac4e.png" width="200" height="400" alt="dark_connected" />  |
| <img src="https://user-images.githubusercontent.com/5890660/225273478-605ca9c6-92bd-440f-9891-e72d44be8734.png" width="200" height="400" alt="not_connected" />  | <img src="https://user-images.githubusercontent.com/5890660/225273544-80b08cea-9f6d-46c5-a73a-296b4fdb9a42.png" width="200" height="400" alt="dark_not_connected" />  |
| <img src="https://user-images.githubusercontent.com/5890660/225273485-a259375b-10eb-4579-915a-a72035b0db7f.png" width="200" height="400" alt="conversation" />  | <img src="https://user-images.githubusercontent.com/5890660/225273556-d5f663ab-d7d7-4542-9ae4-bcab816fd3a5.png" width="200" height="400" alt="dark_conversation" />  |
| <img src="https://user-images.githubusercontent.com/5890660/225273490-73c9b9a7-2a07-4511-9d12-649555e395a3.png" width="200" height="400" alt="incoming_call" />  |  <img src="https://user-images.githubusercontent.com/5890660/225273550-2e448289-9086-4000-9817-15f68eae5553.png" width="200" height="400" alt="dark_incoming_call" /> |
| <img src="https://user-images.githubusercontent.com/5890660/225273498-6e44e974-a3b1-4254-a841-c69c825c8ef3.png" width="200" height="400" alt="outgoing_call" />  | <img src="https://user-images.githubusercontent.com/5890660/225273555-1f8530c0-51c7-409e-a7cf-8d2838ae5252.png" width="200" height="400" alt="dark_outgoing_call" />  |
| <img src="https://user-images.githubusercontent.com/5890660/225306459-33092b96-318b-499d-9f6d-ec9b8515d09c.png" width="200" height="400" alt="conversation_unclassified" />  |  <img src="https://user-images.githubusercontent.com/5890660/225306446-6306c838-2d8d-4785-b5ec-54dcb2584155.png" width="200" height="400" alt="dark_conversation_unclassified" /> |