### PR TITLE
fix: images sent from Xiaomi devices not returning correct mimeType [AR-3143]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -27,7 +27,6 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.util.permission.rememberWriteStorageRequestFlow
-import com.wire.kalium.logic.util.fileExtension
 import okio.Path
 
 @Composable
@@ -56,7 +55,7 @@ fun DownloadedAssetDialog(
             optionButton2Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_open_text),
                 type = WireDialogButtonType.Primary,
-                onClick = { onOpenFileWithExternalApp(assetDataPath, assetName.fileExtension()) }
+                onClick = { onOpenFileWithExternalApp(assetDataPath, assetName) }
             ),
             optionButton1Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_save_text),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -166,7 +166,6 @@ class ConversationMessagesViewModel @Inject constructor(
         }
         val assetContent = messageContent.value
         assetDataPath(conversationId, messageId)?.run {
-
             showOnAssetDownloadedDialog(assetContent.name ?: "", first, assetContent.sizeInBytes, messageId)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -165,17 +165,16 @@ class ConversationMessagesViewModel @Inject constructor(
             return
         }
         val assetContent = messageContent.value
-        val resultData = assetDataPath(conversationId, messageId)
+        assetDataPath(conversationId, messageId)?.run {
 
-        if (resultData != null) {
-            showOnAssetDownloadedDialog(assetContent.name ?: "", resultData, assetContent.sizeInBytes, messageId)
+            showOnAssetDownloadedDialog(assetContent.name ?: "", first, assetContent.sizeInBytes, messageId)
         }
     }
 
-    fun onOpenFileWithExternalApp(assetDataPath: Path, assetExtension: String?) {
+    fun onOpenFileWithExternalApp(assetDataPath: Path, assetName: String?) {
         viewModelScope.launch {
             withContext(dispatchers.io()) {
-                fileManager.openWithExternalApp(assetDataPath, assetExtension) { onOpenFileError() }
+                fileManager.openWithExternalApp(assetDataPath, assetName) { onOpenFileError() }
                 hideOnAssetDownloadedDialog()
             }
         }
@@ -244,14 +243,16 @@ class ConversationMessagesViewModel @Inject constructor(
 
     fun shareAsset(context: Context, messageId: String) {
         viewModelScope.launch {
-            context.startFileShareIntent(assetDataPath(conversationId, messageId).toString())
+            assetDataPath(conversationId, messageId)?.run {
+                context.startFileShareIntent(first, second)
+            }
         }
     }
 
-    private suspend fun assetDataPath(conversationId: QualifiedID, messageId: String): Path? =
+    private suspend fun assetDataPath(conversationId: QualifiedID, messageId: String): Pair<Path, String>? =
         getMessageAsset(conversationId, messageId).await().run {
             return when (this) {
-                is MessageAssetResult.Success -> decodedAssetPath
+                is MessageAssetResult.Success -> decodedAssetPath to assetName
                 else -> null
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -100,14 +100,16 @@ class MediaGalleryViewModel @Inject constructor(
 
     fun shareAsset(context: Context) {
         viewModelScope.launch {
-            context.startFileShareIntent(assetDataPath(imageAssetId.conversationId, imageAssetId.messageId).toString())
+            assetDataPath(imageAssetId.conversationId, imageAssetId.messageId)?.run {
+                context.startFileShareIntent(first, second)
+            }
         }
     }
 
-    private suspend fun assetDataPath(conversationId: QualifiedID, messageId: String): Path? =
+    private suspend fun assetDataPath(conversationId: QualifiedID, messageId: String): Pair<Path, String>? =
         getImageData(conversationId, messageId).await().run {
             return when (this) {
-                is Success -> decodedAssetPath
+                is Success -> decodedAssetPath to assetName
                 else -> null
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -47,7 +47,6 @@ import com.wire.kalium.logic.feature.backup.RestoreBackupResult.BackupRestoreFai
 import com.wire.kalium.logic.feature.backup.RestoreBackupUseCase
 import com.wire.kalium.logic.feature.backup.VerifyBackupResult
 import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
-import com.wire.kalium.logic.util.fileExtension
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -105,7 +104,7 @@ class BackupAndRestoreViewModel
     fun saveBackup() = viewModelScope.launch(dispatcher.main()) {
         latestCreatedBackup?.let { backupData ->
             withContext(dispatcher.io()) {
-                fileManager.shareWithExternalApp(backupData.path, backupData.assetName.fileExtension()) {}
+                fileManager.shareWithExternalApp(backupData.path, backupData.assetName) {}
             }
         }
         state = BackupAndRestoreState.INITIAL_STATE

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
@@ -34,7 +34,7 @@ import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.getMetaDataFromUri
+import com.wire.android.util.getMetadataFromUri
 import com.wire.android.util.getMimeType
 import com.wire.android.util.isImageFile
 import com.wire.android.util.parcelableArrayList
@@ -323,7 +323,7 @@ class ImportMediaViewModel @Inject constructor(
         uri: Uri
     ): ImportedMediaAsset? = withContext(dispatchers.io()) {
         val assetKey = UUID.randomUUID().toString()
-        val fileMetadata = uri.getMetaDataFromUri(context)
+        val fileMetadata = uri.getMetadataFromUri(context)
         val tempAssetPath = kaliumFileSystem.tempFilePath(assetKey)
         val mimeType = fileMetadata.mimeType.ifEmpty { importedAssetMimeType }
         when {

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
@@ -254,7 +254,7 @@ class ImportMediaViewModel @Inject constructor(
 
     private suspend fun handleSingleIntent(incomingIntent: ShareCompat.IntentReader, activity: AppCompatActivity) {
         incomingIntent.stream?.let { uri ->
-            incomingIntent.type?.let { mimeType ->
+            uri.getMimeType(activity)?.let { mimeType ->
                 handleImportedAsset(activity, mimeType, uri)?.let { importedAsset ->
                     importMediaState = importMediaState.copy(importedAssets = mutableListOf(importedAsset))
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaViewModel.kt
@@ -319,12 +319,13 @@ class ImportMediaViewModel @Inject constructor(
 
     private suspend fun handleImportedAsset(
         context: Context,
-        mimeType: String,
+        importedAssetMimeType: String,
         uri: Uri
     ): ImportedMediaAsset? = withContext(dispatchers.io()) {
         val assetKey = UUID.randomUUID().toString()
         val fileMetadata = uri.getMetaDataFromUri(context)
         val tempAssetPath = kaliumFileSystem.tempFilePath(assetKey)
+        val mimeType = fileMetadata.mimeType.ifEmpty { importedAssetMimeType }
         when {
             isAboveLimit(isImageFile(mimeType), fileMetadata.size) -> null
             isImageFile(mimeType) -> {

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -45,12 +45,12 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
             .also { onFileSaved(it) }
     }
 
-    fun openWithExternalApp(assetDataPath: Path, assetExtension: String?, onError: () -> Unit) {
-        openAssetFileWithExternalApp(assetDataPath, context, assetExtension, onError)
+    fun openWithExternalApp(assetDataPath: Path, assetName: String?, onError: () -> Unit) {
+        openAssetFileWithExternalApp(assetDataPath, context, assetName, onError)
     }
 
-    fun shareWithExternalApp(assetDataPath: Path, assetExtension: String?, onError: () -> Unit) {
-        shareAssetFileWithExternalApp(assetDataPath, context, assetExtension, onError)
+    fun shareWithExternalApp(assetDataPath: Path, assetName: String?, onError: () -> Unit) {
+        shareAssetFileWithExternalApp(assetDataPath, context, assetName, onError)
     }
 
     suspend fun copyToTempPath(uri: Uri, tempCachePath: Path, dispatcher: DispatcherProvider = DefaultDispatcherProvider()): Long =

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -302,9 +302,15 @@ inline fun <reified T : Parcelable> Intent.parcelableArrayList(key: String): Arr
 fun Uri.getMetaDataFromUri(context: Context): FileMetaData {
     context.contentResolver.query(this, null, null, null, null)?.use { cursor ->
         if (cursor.moveToFirst()) {
-            val displayName = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME))
-            val fileMimeType = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE))
-            val size = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE))
+            val displayName = cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME).let { idx ->
+                if (idx > -1) cursor.getString(idx) else ""
+            }
+            val fileMimeType = cursor.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE).let { index ->
+                if (index > -1) cursor.getString(index) else ""
+            }
+            val size = cursor.getColumnIndex(MediaStore.MediaColumns.SIZE).let { index ->
+                if (index > -1) cursor.getLong(index) else 0L
+            }
             return FileMetaData(displayName, size, fileMimeType)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -271,7 +271,7 @@ fun openAssetFileWithExternalApp(assetDataPath: Path, context: Context, assetNam
 fun shareAssetFileWithExternalApp(assetDataPath: Path, context: Context, assetName: String?, onError: () -> Unit) {
     try {
         val assetUri = context.pathToUri(assetDataPath, assetName)
-        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(assetName)
+        val mimeType = assetUri.getMimeType(context)
         // Set intent and launch
         val intent = Intent()
         intent.apply {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -302,16 +302,16 @@ inline fun <reified T : Parcelable> Intent.parcelableArrayList(key: String): Arr
 fun Uri.getMetaDataFromUri(context: Context): FileMetaData {
     context.contentResolver.query(this, null, null, null, null)?.use { cursor ->
         if (cursor.moveToFirst()) {
-            val displayName =
-                cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME))
+            val displayName = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME))
+            val fileMimeType = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE))
             val size = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE))
-            return FileMetaData(displayName, size)
+            return FileMetaData(displayName, size, fileMimeType)
         }
     }
     return FileMetaData()
 }
 
-data class FileMetaData(val name: String = "", val size: Long = 0L)
+data class FileMetaData(val name: String = "", val size: Long = 0L, val mimeType: String = "")
 
 fun isImageFile(mimeType: String?): Boolean {
     return mimeType != null && mimeType.startsWith("image/")

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
@@ -45,7 +45,6 @@ import com.wire.kalium.logic.feature.backup.RestoreBackupResult.Failure
 import com.wire.kalium.logic.feature.backup.RestoreBackupUseCase
 import com.wire.kalium.logic.feature.backup.VerifyBackupResult
 import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
-import com.wire.kalium.logic.util.fileExtension
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -141,7 +140,7 @@ class BackupAndRestoreViewModelTest {
         coVerify(exactly = 1) {
             arrangement.fileManager.shareWithExternalApp(
                 storedBackup.path,
-                storedBackup.assetName.fileExtension(),
+                storedBackup.assetName,
                 any()
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3143" title="AR-3143" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3143</a>  PlayTest 17.02 - Share asset -> Name of asset changes to its id
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When importing image assets from certain manufacturers, i.e. Xiaomi, sometimes these images were being mapped as generic assets. The reason behing this buggy behavior was that the mimeType derived from the imported asset Intent was partially wrong (`image/x`), causing AR to not take it as a valid image asset to be displayed.
- Also, when sharing assets to external apps, we were not specifying any display name, therefore, the FileProvider was taking the asset identifier as the default one.

### Solutions
- Unify the way of fetching the mimeType on imported assets, and prioritising the information of the internal content metadata db of the device instead of the mimeType provided by the sharing intent, which is more prone to throw inaccurate data.
- Pass over the asset name to be used as the asset display name.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
