### PR TITLE
feat: support 2fa on login (AR-3088)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
@@ -44,13 +44,12 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.authentication.ServerTitle
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
+import com.wire.android.ui.authentication.verificationcode.ResendCodeText
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
@@ -167,29 +166,6 @@ private fun CodeContent(
     } else if (state.error is CreateAccountCodeViewState.CodeError.TooManyDevicesError) {
         onRemoveDeviceOpen()
     }
-}
-
-@Composable
-private fun ResendCodeText(onResendCodePressed: () -> Unit, clickEnabled: Boolean) {
-    Text(
-        text = stringResource(R.string.create_account_code_resend),
-        style = MaterialTheme.wireTypography.body02.copy(
-            textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.primary
-        ),
-        textAlign = TextAlign.Center,
-        modifier = Modifier
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                enabled = clickEnabled,
-                onClick = onResendCodePressed
-            )
-            .padding(
-                horizontal = MaterialTheme.wireDimensions.spacing16x,
-                vertical = MaterialTheme.wireDimensions.spacing24x
-            )
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
@@ -21,8 +21,6 @@
 package com.wire.android.ui.authentication.create.code
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginError.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginError.kt
@@ -34,7 +34,7 @@ sealed class LoginError {
         object InvalidCredentialsError : DialogError()
         object ProxyError : DialogError()
         object InvalidSSOCookie : DialogError()
-        object InvalidCodeError : DialogError()
+        object InvalidSSOCodeError : DialogError()
         object UserAlreadyExists : DialogError()
         object PasswordNeededToRegisterClient : DialogError()
         data class SSOResultError constructor(val result: SSOFailureCodes) :

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavigationItem.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication.login
+
+enum class LoginNavigationItem(val route: String) {
+    MAIN_LOGIN_FORM_SELECTION("main_input"),
+    EMAIL_SECOND_FACTOR_INPUT("email_second_factor_input");
+
+    val itemName: String
+        get() = "${ROUTE_PREFIX}_$route"
+
+    companion object {
+        private const val ROUTE_PREFIX = "login"
+        fun fromRoute(fullRoute: String): LoginNavigationItem? = values().firstOrNull { it.itemName == fullRoute }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -265,7 +265,7 @@ fun LoginErrorDialog(
             )
         }
 
-        is LoginError.DialogError.InvalidCodeError -> LoginDialogErrorData(
+        is LoginError.DialogError.InvalidSSOCodeError -> LoginDialogErrorData(
             stringResource(R.string.login_error_invalid_credentials_title),
             stringResource(R.string.login_error_invalid_sso_code),
             onDialogDismiss

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui.authentication.login
 
 import androidx.annotation.VisibleForTesting
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -53,7 +52,6 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
-@ExperimentalMaterialApi
 @HiltViewModel
 @Suppress("TooManyFunctions")
 open class LoginViewModel @Inject constructor(
@@ -132,13 +130,15 @@ open class LoginViewModel @Inject constructor(
     suspend fun registerClient(
         userId: UserId,
         password: String?,
-        capabilities: List<ClientCapability>? = null
+        secondFactorVerificationCode: String? = null,
+        capabilities: List<ClientCapability>? = null,
     ): RegisterClientResult {
         val clientScope = clientScopeProviderFactory.create(userId).clientScope
         return clientScope.getOrRegister(
             RegisterClientUseCase.RegisterClientParam(
                 password = password,
-                capabilities = capabilities
+                capabilities = capabilities,
+                secondFactorVerificationCode = secondFactorVerificationCode
             )
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -55,7 +54,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.authentication.login.LoginError

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -77,13 +77,12 @@ import com.wire.android.util.CustomTabsHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LoginEmailScreen(
+    loginEmailViewModel: LoginEmailViewModel,
     scrollState: ScrollState = rememberScrollState()
 ) {
     val scope = rememberCoroutineScope()
-    val loginEmailViewModel: LoginEmailViewModel = hiltViewModel()
     val loginEmailState: LoginState = loginEmailViewModel.loginState
 
     clearAutofillTree()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -1,0 +1,146 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package com.wire.android.ui.authentication.login.email
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.R
+import com.wire.android.ui.authentication.verificationcode.VerificationCode
+import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
+import com.wire.android.ui.common.Logo
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.android.ui.common.textfield.CodeFieldValue
+import com.wire.android.ui.common.typography
+import com.wire.android.util.ui.UIText
+
+@Composable
+fun LoginEmailVerificationCodeScreen(
+    viewModel: LoginEmailViewModel = hiltViewModel()
+) = LoginEmailVerificationCodeContent(
+    viewModel.secondFactorVerificationCodeState,
+    viewModel.loginState.emailLoginLoading,
+    viewModel::onCodeChange,
+    viewModel::onCodeResend,
+    viewModel::onCodeVerificationBackPress
+)
+
+@Composable
+private fun LoginEmailVerificationCodeContent(
+    verificationCodeState: VerificationCodeState,
+    isLoading: Boolean,
+    onCodeChange: (CodeFieldValue) -> Unit,
+    onCodeResend: () -> Unit,
+    onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BackHandler { onBackPressed() }
+    ConstraintLayout(
+        modifier = modifier.fillMaxSize().padding(dimensions().spacing32x)
+    ) {
+        val (main, logo) = createRefs()
+        Logo(
+            modifier = Modifier.height(dimensions().spacing24x).constrainAs(logo) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                bottom.linkTo(parent.bottom)
+            }
+        )
+        MainContent(
+            codeState = verificationCodeState,
+            isLoading = isLoading,
+            onCodeChange = onCodeChange,
+            onResendCode = onCodeResend,
+            modifier = Modifier.constrainAs(main) {
+                top.linkTo(parent.top)
+                bottom.linkTo(logo.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                height = Dimension.fillToConstraints
+            }
+        )
+    }
+}
+
+@Composable
+private fun MainContent(
+    codeState: VerificationCodeState,
+    isLoading: Boolean,
+    onCodeChange: (CodeFieldValue) -> Unit,
+    onResendCode: () -> Unit,
+    modifier: Modifier = Modifier
+) = Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+    modifier = modifier
+) {
+    Text(
+        text = UIText.StringResource(R.string.second_factor_authentication_title).asString(),
+        style = typography().title01,
+        textAlign = TextAlign.Start
+    )
+    VerticalSpace.x24()
+    Text(
+        text = UIText.StringResource(
+            R.string.second_factor_authentication_instructions_label,
+            codeState.emailUsed
+        ).asString(),
+        style = typography().body01,
+        textAlign = TextAlign.Start
+    )
+    VerticalSpace.x32()
+    VerificationCode(
+        codeLength = codeState.codeLength,
+        currentCode = codeState.code.text,
+        isLoading = isLoading,
+        isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
+        onCodeChange = onCodeChange,
+        onResendCode = onResendCode,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun LoginEmailVerificationCodeScreenPreview() = LoginEmailVerificationCodeContent(
+    VerificationCodeState(
+        codeLength = 6,
+        code = CodeFieldValue(TextFieldValue("12"), false),
+        isCurrentCodeInvalid = false,
+        emailUsed = ""
+    ),
+    false,
+    {},
+    {},
+    {},
+)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -23,7 +23,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -23,6 +23,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
@@ -101,7 +102,7 @@ private fun MainContent(
     onResendCode: () -> Unit,
     modifier: Modifier = Modifier
 ) = Column(
-    horizontalAlignment = Alignment.CenterHorizontally,
+    horizontalAlignment = Alignment.Start,
     verticalArrangement = Arrangement.Center,
     modifier = modifier
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -78,9 +78,9 @@ class LoginEmailViewModel @Inject constructor(
 
             val secondFactorVerificationCode = secondFactorVerificationCodeState.code.text.text
             val loginResult = authScope.login(
-                loginState.userIdentifier.text,
-                loginState.password.text,
-                true,
+                userIdentifier = loginState.userIdentifier.text,
+                password = loginState.password.text,
+                shouldPersistClient = true,
                 secondFactorVerificationCode = secondFactorVerificationCode
             )
             if (loginResult !is AuthenticationResult.Success) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -20,7 +20,9 @@
 
 package com.wire.android.ui.authentication.login.email
 
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -32,17 +34,21 @@ import com.wire.android.ui.authentication.login.LoginError
 import com.wire.android.ui.authentication.login.LoginViewModel
 import com.wire.android.ui.authentication.login.toLoginError
 import com.wire.android.ui.authentication.login.updateEmailLoginEnabled
+import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
+import com.wire.android.ui.common.textfield.CodeFieldValue
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
+import com.wire.kalium.logic.data.auth.verification.VerifiableAction
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
+import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @Suppress("LongParameterList", "ComplexMethod")
-@ExperimentalMaterialApi
 @HiltViewModel
 class LoginEmailViewModel @Inject constructor(
     private val authScope: AutoVersionAuthScopeUseCase,
@@ -59,69 +65,56 @@ class LoginEmailViewModel @Inject constructor(
     authServerConfigProvider,
     userDataStoreProvider
 ) {
+
+    var secondFactorVerificationCodeState by mutableStateOf(
+        VerificationCodeState()
+    )
+
     @Suppress("LongMethod")
     fun login() {
         loginState = loginState.copy(emailLoginLoading = true, loginError = LoginError.None).updateEmailLoginEnabled()
         viewModelScope.launch {
-            val authScope = authScope(
-                AutoVersionAuthScopeUseCase.ProxyAuthentication.UsernameAndPassword(
-                    ProxyCredentials(loginState.proxyIdentifier.text, loginState.proxyPassword.text)
-                )
-            ).let {
-                loginState = loginState.copy(emailLoginLoading = false)
-                when (it) {
-                    is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
+            val authScope = resolveCurrentAuthScope() ?: return@launch
 
-                    is AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> {
-                        loginState = loginState.copy(loginError = LoginError.DialogError.ServerVersionNotSupported)
+            val secondFactorVerificationCode = secondFactorVerificationCodeState.code.text.text
+            val loginResult = authScope.login(
+                loginState.userIdentifier.text,
+                loginState.password.text,
+                true,
+                secondFactorVerificationCode = secondFactorVerificationCode
+            )
+            if (loginResult !is AuthenticationResult.Success) {
+                loginResult as AuthenticationResult.Failure
+                handleAuthenticationFailure(loginResult, authScope)
+                return@launch
+            }
+            val storedUserId = addAuthenticatedUser(
+                authTokens = loginResult.authData,
+                ssoId = loginResult.ssoID,
+                serverConfigId = loginResult.serverConfigId,
+                proxyCredentials = loginResult.proxyCredentials,
+                replace = false
+            ).let {
+                when (it) {
+                    is AddAuthenticatedUserUseCase.Result.Failure -> {
+                        updateEmailLoginError(it.toLoginError())
                         return@launch
                     }
-                    is AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion -> {
-                        loginState = loginState.copy(loginError = LoginError.DialogError.ClientUpdateRequired)
-                        return@launch
-                    }
-                    is AutoVersionAuthScopeUseCase.Result.Failure.Generic -> {
-                       loginState = loginState.copy(loginError = LoginError.DialogError.GenericError(it.genericFailure))
-                        return@launch
-                    }
+
+                    is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
             }
-
-            val loginResult = authScope.login(loginState.userIdentifier.text, loginState.password.text, true)
-                .let {
-                    when (it) {
-                        is AuthenticationResult.Failure -> {
-                            updateEmailLoginError(it.toLoginError())
-                            return@launch
-                        }
-
-                        is AuthenticationResult.Success -> {
-                            it
-                        }
-                    }
-                }
-            val storedUserId =
-                addAuthenticatedUser(
-                    authTokens = loginResult.authData,
-                    ssoId = loginResult.ssoID,
-                    serverConfigId = loginResult.serverConfigId,
-                    proxyCredentials = loginResult.proxyCredentials,
-                    replace = false
-                ).let {
-                    when (it) {
-                        is AddAuthenticatedUserUseCase.Result.Failure -> {
-                            updateEmailLoginError(it.toLoginError())
-                            return@launch
-                        }
-                        is AddAuthenticatedUserUseCase.Result.Success -> it.userId
-                    }
-                }
-            registerClient(storedUserId, loginState.password.text).let {
+            registerClient(
+                userId = storedUserId,
+                password = loginState.password.text,
+                secondFactorVerificationCode = secondFactorVerificationCode
+            ).let {
                 when (it) {
                     is RegisterClientResult.Failure -> {
                         updateEmailLoginError(it.toLoginError())
                         return@launch
                     }
+
                     is RegisterClientResult.Success -> {
                         navigateAfterRegisterClientSuccess(storedUserId)
                     }
@@ -130,8 +123,64 @@ class LoginEmailViewModel @Inject constructor(
         }
     }
 
+    private suspend fun resolveCurrentAuthScope(): AuthenticationScope? = authScope(
+        AutoVersionAuthScopeUseCase.ProxyAuthentication.UsernameAndPassword(
+            ProxyCredentials(loginState.proxyIdentifier.text, loginState.proxyPassword.text)
+        )
+    ).let {
+        loginState = loginState.copy(emailLoginLoading = false)
+        when (it) {
+            is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
+
+            is AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> {
+                loginState = loginState.copy(loginError = LoginError.DialogError.ServerVersionNotSupported)
+                return null
+            }
+
+            is AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion -> {
+                loginState = loginState.copy(loginError = LoginError.DialogError.ClientUpdateRequired)
+                return null
+            }
+
+            is AutoVersionAuthScopeUseCase.Result.Failure.Generic -> {
+                loginState = loginState.copy(loginError = LoginError.DialogError.GenericError(it.genericFailure))
+                return null
+            }
+        }
+    }
+
+    private suspend fun handleAuthenticationFailure(it: AuthenticationResult.Failure, authScope: AuthenticationScope) {
+        if (it is AuthenticationResult.Failure.InvalidCredentials.Missing2FA) {
+            loginState = loginState.updateEmailLoginEnabled()
+            request2FACode(authScope)
+        } else {
+            updateEmailLoginError(it.toLoginError())
+        }
+    }
+
+    private suspend fun request2FACode(authScope: AuthenticationScope) {
+        val email = loginState.userIdentifier.text.trim()
+        val result = authScope.requestSecondFactorVerificationCode(
+            email = email,
+            verifiableAction = VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+        )
+        when (result) {
+            is RequestSecondFactorVerificationCodeUseCase.Result.Success -> {
+                secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+                    isCodeSent = true,
+                    emailUsed = email,
+                )
+                loginState = loginState.copy(loginError = LoginError.None)
+            }
+
+            is RequestSecondFactorVerificationCodeUseCase.Result.Failure -> {
+                updateEmailLoginError(LoginError.DialogError.GenericError(result.cause))
+            }
+        }
+    }
+
     fun onUserIdentifierChange(newText: TextFieldValue) {
-        // in case an error is showing e.g. inline error is should be cleared
+        // in case an error is showing e.g. inline error it should be cleared
         if (loginState.loginError is LoginError.TextFieldError && newText != loginState.userIdentifier) {
             clearEmailLoginError()
         }
@@ -149,5 +198,28 @@ class LoginEmailViewModel @Inject constructor(
 
     fun onProxyPasswordChange(newText: TextFieldValue) {
         loginState = loginState.copy(proxyPassword = newText).updateEmailLoginEnabled()
+    }
+
+    fun onCodeChange(newValue: CodeFieldValue) {
+        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(code = newValue, isCurrentCodeInvalid = false)
+        if (newValue.isFullyFilled) {
+            login()
+        }
+    }
+
+    fun onCodeVerificationBackPress() {
+        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+            code = CodeFieldValue(TextFieldValue(""), false),
+            isCodeSent = false,
+            emailUsed = "",
+        )
+    }
+
+    fun onCodeResend() {
+        viewModelScope.launch {
+            resolveCurrentAuthScope()?.let {
+                request2FACode(it)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -150,11 +150,18 @@ class LoginEmailViewModel @Inject constructor(
     }
 
     private suspend fun handleAuthenticationFailure(it: AuthenticationResult.Failure, authScope: AuthenticationScope) {
-        if (it is AuthenticationResult.Failure.InvalidCredentials.Missing2FA) {
-            loginState = loginState.updateEmailLoginEnabled()
-            request2FACode(authScope)
-        } else {
-            updateEmailLoginError(it.toLoginError())
+        when (it) {
+            is AuthenticationResult.Failure.InvalidCredentials.Missing2FA -> {
+                loginState = loginState.updateEmailLoginEnabled()
+                request2FACode(authScope)
+            }
+
+            is AuthenticationResult.Failure.InvalidCredentials.Invalid2FA -> {
+                loginState = loginState.updateEmailLoginEnabled()
+                secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(isCurrentCodeInvalid = true)
+            }
+
+            else -> updateEmailLoginError(it.toLoginError())
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -187,7 +187,7 @@ class LoginSSOViewModel @Inject constructor(
 
 private fun SSOInitiateLoginResult.Failure.toLoginSSOError() = when (this) {
     SSOInitiateLoginResult.Failure.InvalidCodeFormat -> LoginError.TextFieldError.InvalidValue
-    SSOInitiateLoginResult.Failure.InvalidCode -> LoginError.DialogError.InvalidCodeError
+    SSOInitiateLoginResult.Failure.InvalidCode -> LoginError.DialogError.InvalidSSOCodeError
     is SSOInitiateLoginResult.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)
     SSOInitiateLoginResult.Failure.InvalidRedirect ->
         LoginError.DialogError.GenericError(CoreFailure.Unknown(IllegalArgumentException("Invalid Redirect")))

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package com.wire.android.ui.authentication.verificationcode
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import com.wire.android.R
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun ResendCodeText(onResendCodePressed: () -> Unit, clickEnabled: Boolean) {
+    Text(
+        text = stringResource(R.string.create_account_code_resend),
+        style = MaterialTheme.wireTypography.body02.copy(
+            textDecoration = TextDecoration.Underline,
+            color = MaterialTheme.colorScheme.primary
+        ),
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                enabled = clickEnabled,
+                onClick = onResendCodePressed
+            )
+            .padding(
+                horizontal = MaterialTheme.wireDimensions.spacing16x,
+                vertical = MaterialTheme.wireDimensions.spacing24x
+            )
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
@@ -56,7 +56,7 @@ fun VerificationCode(
     ) {
 
         val state = if (isCurrentCodeInvalid) WireTextFieldState.Error(
-            stringResource(id = R.string.create_account_code_error)
+            stringResource(id = R.string.second_factor_code_error)
         )
         else WireTextFieldState.Default
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package com.wire.android.ui.authentication.verificationcode
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
+import com.wire.android.R
+import com.wire.android.ui.common.progress.WireCircularProgressIndicator
+import com.wire.android.ui.common.textfield.CodeFieldValue
+import com.wire.android.ui.common.textfield.CodeTextField
+import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
+
+@Composable
+fun VerificationCode(
+    codeLength: Int,
+    currentCode: TextFieldValue,
+    isLoading: Boolean,
+    isCurrentCodeInvalid: Boolean,
+    onCodeChange: (CodeFieldValue) -> Unit,
+    onResendCode: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+
+        val state = if (isCurrentCodeInvalid) WireTextFieldState.Error(
+            stringResource(id = R.string.create_account_code_error)
+        )
+        else WireTextFieldState.Default
+
+        CodeTextField(
+            codeLength = codeLength,
+            value = currentCode,
+            state = state,
+            onValueChange = onCodeChange,
+            modifier = Modifier.focusRequester(focusRequester)
+        )
+
+        AnimatedVisibility(visible = isLoading) {
+            WireCircularProgressIndicator(
+                progressColor = MaterialTheme.wireColorScheme.primary,
+                size = MaterialTheme.wireDimensions.spacing24x,
+                modifier = Modifier.padding(vertical = MaterialTheme.wireDimensions.spacing16x)
+            )
+        }
+
+        ResendCodeText(
+            onResendCodePressed = onResendCode,
+            clickEnabled = !isLoading
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package com.wire.android.ui.authentication.verificationcode
+
+import androidx.compose.ui.text.input.TextFieldValue
+import com.wire.android.ui.common.textfield.CodeFieldValue
+
+data class VerificationCodeState(
+    val codeLength: Int = DEFAULT_VERIFICATION_CODE_LENGTH,
+    val emailUsed: String = "",
+    val isCodeSent: Boolean = false,
+    val code: CodeFieldValue = CodeFieldValue(TextFieldValue(""), false),
+    val isCurrentCodeInvalid: Boolean = false,
+) {
+    companion object {
+        const val DEFAULT_VERIFICATION_CODE_LENGTH = 6
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/common/Logo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/Logo.kt
@@ -21,10 +21,6 @@
 package com.wire.android.ui.common
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -32,21 +28,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.ui.theme.wireDimensions
 
 @Composable
-fun Logo() {
+fun Logo(modifier: Modifier = Modifier) {
     Image(
         painter = painterResource(id = R.drawable.ic_wire_logo),
         contentDescription = stringResource(id = R.string.content_description_app_logo),
         contentScale = ContentScale.Fit,
-        modifier = Modifier
-            .padding(
-                horizontal = MaterialTheme.wireDimensions.homeDrawerLogoHorizontalPadding,
-                vertical = MaterialTheme.wireDimensions.homeDrawerLogoVerticalPadding
-            )
-            .width(MaterialTheme.wireDimensions.homeDrawerLogoWidth)
-            .height(MaterialTheme.wireDimensions.homeDrawerLogoHeight),
+        modifier = modifier,
         colorFilter = ColorFilter.tint(colorsScheme().onSurface)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -95,7 +96,13 @@ fun HomeDrawer(
             )
 
     ) {
-        Logo()
+        Logo(
+            modifier = Modifier.padding(
+                horizontal = MaterialTheme.wireDimensions.homeDrawerLogoHorizontalPadding,
+                vertical = MaterialTheme.wireDimensions.homeDrawerLogoVerticalPadding
+            ).width(MaterialTheme.wireDimensions.homeDrawerLogoWidth)
+                .height(MaterialTheme.wireDimensions.homeDrawerLogoHeight)
+        )
 
         fun navigateAndCloseDrawer(item: Any) {
             when (item) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,9 @@
     <string name="conversation_history_wipe_explanation">According to your team\'s security
         settings, your conversation history has also been deleted.</string>
 
+    <!-- Second Factor Authentication -->
+    <string name="second_factor_authentication_title">Verify your account</string>
+    <string name="second_factor_authentication_instructions_label">Enter the verification code sent to the email %1$s</string>
     <!-- Remove Device -->
     <string name="remove_device_title">Remove a Device</string>
     <string name="remove_device_message">Remove one of your other devices to start using Wire on

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <!-- Second Factor Authentication -->
     <string name="second_factor_authentication_title">Verify your account</string>
     <string name="second_factor_authentication_instructions_label">Enter the verification code sent to the email %1$s</string>
+    <string name="second_factor_code_error">Invalid code, or maximum attempts exceeded. Please retry, or request another code</string>
     <!-- Remove Device -->
     <string name="remove_device_title">Remove a Device</string>
     <string name="remove_device_message">Remove one of your other devices to start using Wire on

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -174,7 +174,7 @@ class LoginEmailViewModelTest {
         val scheduler = TestCoroutineScheduler()
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
         coEvery {
-            loginUseCase(any(), any(), any(), any())
+            loginUseCase(any(), any(), any(), any(), any())
         } returns AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination
         coEvery {
             addAuthenticatedUserUseCase(any(), any(), any(), any())
@@ -197,7 +197,7 @@ class LoginEmailViewModelTest {
         val scheduler = TestCoroutineScheduler()
         val password = "abc"
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
-        coEvery { loginUseCase(any(), any(), any(), any()) } returns AuthenticationResult.Success(
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Success(
             AUTH_TOKEN,
             SSO_ID,
             SERVER_CONFIG.id,
@@ -211,7 +211,7 @@ class LoginEmailViewModelTest {
         loginViewModel.onPasswordChange(TextFieldValue(password))
 
         runTest { loginViewModel.login() }
-        coVerify(exactly = 1) { loginUseCase(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { loginUseCase(any(), any(), any(), any(), any()) }
         coVerify(exactly = 1) { getOrRegisterClientUseCase(any()) }
         coVerify(exactly = 1) {
             navigationManager.navigate(
@@ -228,7 +228,7 @@ class LoginEmailViewModelTest {
         val scheduler = TestCoroutineScheduler()
         val password = "abc"
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
-        coEvery { loginUseCase(any(), any(), any(), any()) } returns AuthenticationResult.Success(
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Success(
             AUTH_TOKEN,
             SSO_ID,
             SERVER_CONFIG.id,
@@ -242,7 +242,7 @@ class LoginEmailViewModelTest {
         loginViewModel.onPasswordChange(TextFieldValue(password))
 
         runTest { loginViewModel.login() }
-        coVerify(exactly = 1) { loginUseCase(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { loginUseCase(any(), any(), any(), any(), any()) }
         coVerify(exactly = 1) { getOrRegisterClientUseCase(any()) }
         coVerify(exactly = 1) {
             navigationManager.navigate(
@@ -257,7 +257,7 @@ class LoginEmailViewModelTest {
     @Test
     fun `given button is clicked, when login returns InvalidUserIdentifier error, then InvalidUserIdentifierError is passed`() {
         coEvery {
-            loginUseCase(any(), any(), any(), any())
+            loginUseCase(any(), any(), any(), any(), any())
         } returns AuthenticationResult.Failure.InvalidUserIdentifier
 
         runTest { loginViewModel.login() }
@@ -269,6 +269,7 @@ class LoginEmailViewModelTest {
     fun `given button is clicked, when login returns InvalidCredentials error, then InvalidCredentialsError is passed`() {
         coEvery {
             loginUseCase(
+                any(),
                 any(),
                 any(),
                 any(),
@@ -285,7 +286,7 @@ class LoginEmailViewModelTest {
     fun `given button is clicked, when login returns Generic error, then GenericError is passed`() {
         val networkFailure = NetworkFailure.NoNetworkConnection(null)
         coEvery {
-            loginUseCase(any(), any(), any(), any())
+            loginUseCase(any(), any(), any(), any(), any())
         } returns AuthenticationResult.Failure.Generic(networkFailure)
 
         runTest { loginViewModel.login() }
@@ -298,6 +299,7 @@ class LoginEmailViewModelTest {
     fun `given dialog is dismissed, when login returns DialogError, then hide error`() {
         coEvery {
             loginUseCase(
+                any(),
                 any(),
                 any(),
                 any(),
@@ -314,7 +316,7 @@ class LoginEmailViewModelTest {
 
     @Test
     fun `given button is clicked, when addAuthenticatedUser returns UserAlreadyExists error, then UserAlreadyExists is passed`() {
-        coEvery { loginUseCase(any(), any(), any(), any()) } returns AuthenticationResult.Success(
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Success(
             AUTH_TOKEN,
             SSO_ID,
             SERVER_CONFIG.id,

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -347,6 +347,16 @@ class LoginEmailViewModelTest {
     }
 
     @Test
+    fun `given login fails with invalid 2fa, when logging in, then should mark the current code as invalid`() = runTest {
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Invalid2FA
+        loginViewModel.onUserIdentifierChange(TextFieldValue("some.email@example.org"))
+
+        loginViewModel.login()
+
+        loginViewModel.secondFactorVerificationCodeState.isCurrentCodeInvalid shouldBe true
+    }
+
+    @Test
     fun `given 2fa is needed, when code is filled, then should login with entered code and navigate out of login`() = runTest {
         val email = "some.email@example.org"
         val code = "123456"

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -214,7 +214,7 @@ class LoginSSOViewModelTest {
 
         runTest { loginViewModel.login() }
 
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.InvalidCodeError::class
+        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.InvalidSSOCodeError::class
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3088" title="AR-3088" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3088</a>  2FA
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support 2FA on login and client registration.

### Solutions

For this PR: start supporting on Login.

For the next PR: client registration.

I intend to make a `SecondFactorInputViewModel` interface, so that both `LoginEmailViewModel` and other client registration related VMs can implement the same interface, and the same Composable can be used, as the behaviour should be exactly the same in all instances where 2FA might come into play.

To reduce PR size, I'll do this conversion to interface in the following PR.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

In a Team where `secondFactorAuthentication` is enabled, attempt to login.

An email will be sent to your account, and it must be inserted as in the screen recording below.

### Attachments

#### Light Theme recording

https://user-images.githubusercontent.com/9389043/225487000-261e0f40-c29a-48d6-8809-7de64d0db433.mp4

#### Dark Theme Screenshot

![2FA](https://user-images.githubusercontent.com/9389043/225486962-f772442f-86d2-4461-848a-77bdd0b65ed8.png)

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
