### PR TITLE
chore: upgrade kotlin to 1.8.10

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,7 @@
  */
 
 private object Dependencies {
-    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"
     const val kluent = "org.amshove.kluent:kluent:1.68"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -71,7 +71,7 @@ object Repositories {
 
 object Libraries {
     object Versions {
-        const val kotlin = "1.7.21"
+        const val kotlin = "1.8.10"
         const val coroutines = "1.6.1-native-mt"
         const val jetpack = "1.1.0"
         const val constraintLayout = "2.1.4"
@@ -83,7 +83,7 @@ object Libraries {
         const val workManager = "2.7.1"
         const val fragment = "1.5.5"
         const val compose = "1.3.1"
-        const val composeCompiler = "1.3.2"
+        const val composeCompiler = "1.4.3"
         const val composeMaterial = "1.3.1"
         const val composeMaterial3 = "1.0.1"
         const val composeActivity = "1.6.1"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A newer version of Kotlin is available and the upgrade comes for free.
We should upgrade before the Reloaded code freeze so we don't differ much between `develop` and `release` and make our lives easier in the future.
A new version will be required for some features we're cooking and experimentation with new libraries.

### Solutions

Upgrade Kotlin to 1.8.10 (1.8.20 is still RC but should be coming out soon without breaking changes).

Upgrade the compose compiler to support 1.8.10;

### Dependencies

Needs the PR on Kalium's side too:

- https://github.com/wireapp/kalium/pull/1581

### Testing

All tests seem to pass on my machine.
The app using 1.8.10 is also working fine.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
