### PR TITLE
feat: send message editions and handle error state [AR-2900]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -76,6 +76,7 @@ import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.GetNotificationsUseCase
 import com.wire.kalium.logic.feature.message.ObserveMessageReactionsUseCase
 import com.wire.kalium.logic.feature.message.ObserveMessageReceiptsUseCase
+import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
 import com.wire.kalium.logic.feature.message.SendKnockUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
@@ -451,6 +452,13 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): SendTextMessageUseCase = coreLogic.getSessionScope(currentAccount).messages.sendTextMessage
+
+    @ViewModelScoped
+    @Provides
+    fun provideSendEditTextMessageUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): SendEditTextMessageUseCase = coreLogic.getSessionScope(currentAccount).messages.sendEditTextMessage
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -144,6 +144,12 @@ class MessageMapper @Inject constructor(
     )
 
     private fun getMessageStatus(message: Message.Standalone) = when {
+        message.status == Message.Status.FAILED && message is Message.Regular && message.editStatus is Message.EditStatus.Edited ->
+            MessageStatus.EditSendFailure(
+                isoFormatter.fromISO8601ToTimeFormat(
+                    utcISO = (message.editStatus as Message.EditStatus.Edited).lastTimeStamp
+                )
+            )
         message.status == Message.Status.FAILED -> MessageStatus.SendFailure
         message.status == Message.Status.FAILED_REMOTELY -> MessageStatus.SendRemotelyFailure(message.conversationId.domain)
         message.visibility == Message.Visibility.DELETED -> MessageStatus.Deleted

--- a/app/src/main/kotlin/com/wire/android/ui/common/DeletedLabel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/DeletedLabel.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.common
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -49,6 +50,10 @@ fun StatusBox(
     Box(
         modifier = modifier
             .wrapContentSize()
+            .background(
+                color = MaterialTheme.wireColorScheme.surface,
+                shape = RoundedCornerShape(size = dimensions().spacing4x)
+            )
             .border(
                 BorderStroke(
                     width = 1.dp,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -78,6 +78,7 @@ import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewState
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.messagecomposer.MessageComposeInputState
@@ -177,6 +178,7 @@ fun ConversationScreen(
         onOpenProfile = conversationInfoViewModel::navigateToProfile,
         onMessageDetailsClick = conversationMessagesViewModel::openMessageDetails,
         onSendMessage = messageComposerViewModel::sendMessage,
+        onSendEditMessage = messageComposerViewModel::sendEditMessage,
         onDeleteMessage = messageComposerViewModel::showDeleteMessageDialog,
         onSendAttachment = messageComposerViewModel::sendAttachmentMessage,
         onDownloadAsset = conversationMessagesViewModel::downloadOrFetchAssetToInternalStorage,
@@ -280,6 +282,7 @@ private fun ConversationScreen(
     onOpenProfile: (String) -> Unit,
     onMessageDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onSendMessage: (String, List<UiMention>, String?) -> Unit,
+    onSendEditMessage: (EditMessageBundle) -> Unit,
     onDeleteMessage: (String, Boolean) -> Unit,
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onAudioClick: (String) -> Unit,
@@ -369,6 +372,7 @@ private fun ConversationScreen(
                         messageComposerInnerState = messageComposerInnerState,
                         messages = conversationMessagesViewState.messages,
                         onSendMessage = onSendMessage,
+                        onSendEditMessage = onSendEditMessage,
                         onSendAttachment = onSendAttachment,
                         onMentionMember = onMentionMember,
                         onDownloadAsset = onDownloadAsset,
@@ -405,6 +409,7 @@ private fun ConversationScreenContent(
     messageComposerInnerState: MessageComposerInnerState,
     messages: Flow<PagingData<UIMessage>>,
     onSendMessage: (String, List<UiMention>, String?) -> Unit,
+    onSendEditMessage: (EditMessageBundle) -> Unit,
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onMentionMember: (String?) -> Unit,
     onDownloadAsset: (String) -> Unit,
@@ -455,6 +460,7 @@ private fun ConversationScreenContent(
             }
             onSendMessage(message, mentions, messageId)
         },
+        onSendEditTextMessage = onSendEditMessage,
         onSendAttachment = {
             scope.launch {
                 lazyListState.scrollToItem(0)
@@ -608,6 +614,7 @@ fun PreviewConversationScreen() {
         onOpenProfile = { _ -> },
         onMessageDetailsClick = { _, _ -> },
         onSendMessage = { _, _, _ -> },
+        onSendEditMessage = { _ -> },
         onDeleteMessage = { _, _ -> },
         onSendAttachment = { },
         onDownloadAsset = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -51,6 +51,7 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
+import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.messagecomposer.UiMention
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.FileManager
@@ -70,6 +71,7 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationInteraction
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
 import com.wire.kalium.logic.feature.message.SendKnockUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
@@ -93,6 +95,7 @@ class MessageComposerViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
+    private val sendEditTextMessage: SendEditTextMessageUseCase,
     private val deleteMessage: DeleteMessageUseCase,
     private val dispatchers: DispatcherProvider,
     private val getSelfUserTeam: GetSelfTeamUseCase,
@@ -214,6 +217,17 @@ class MessageComposerViewModel @Inject constructor(
                 text = message,
                 mentions = mentions.map { it.intoMessageMention() },
                 quotedMessageId = quotedMessageId
+            )
+        }
+    }
+
+    fun sendEditMessage(editMessageBundle: EditMessageBundle) {
+        viewModelScope.launch {
+            sendEditTextMessage(
+                conversationId = conversationId,
+                originalMessageId = editMessageBundle.originalMessageId,
+                text = editMessageBundle.newContent,
+                mentions = editMessageBundle.newMentions.map { it.intoMessageMention() },
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -172,7 +172,7 @@ fun MessageItem(
                 }
 
                 if (message.sendingFailed) {
-                    MessageSendFailureWarning(messageHeader.messageStatus)
+                    MessageSendFailureWarning(messageHeader.messageStatus as MessageStatus.MessageSendFailureStatus)
                 }
             }
         }
@@ -385,21 +385,14 @@ private fun MessageContent(
 
 @Composable
 private fun MessageStatusLabel(messageStatus: MessageStatus) {
-    when (messageStatus) {
-        MessageStatus.Deleted,
-        is MessageStatus.Edited,
-        MessageStatus.ReceiveFailure -> StatusBox(messageStatus.text.asString())
-
-        is MessageStatus.DecryptionFailure,
-        is MessageStatus.SendRemotelyFailure, MessageStatus.SendFailure, MessageStatus.Untouched -> {
-            /** Don't display anything **/
-        }
+    messageStatus.badgeText?.let {
+        StatusBox(it.asString())
     }
 }
 
 @Composable
 private fun MessageSendFailureWarning(
-    messageStatus: MessageStatus
+    messageStatus: MessageStatus.MessageSendFailureStatus
     /* TODO: add onRetryClick handler */
 ) {
     val context = LocalContext.current
@@ -409,7 +402,7 @@ private fun MessageSendFailureWarning(
     ) {
         Column {
             Text(
-                text = messageStatus.text.asString(),
+                text = messageStatus.errorText.asString(),
                 style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
             )
             if (messageStatus is MessageStatus.SendRemotelyFailure) {
@@ -451,7 +444,7 @@ private fun MessageDecryptionFailure(
         Column {
             VerticalSpace.x4()
             Text(
-                text = decryptionStatus.text.asString(),
+                text = decryptionStatus.errorText.asString(),
                 style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.error)
             )
             Text(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -78,9 +78,7 @@ fun EditMessageMenuItems(
     val isAssetMessage = message.messageContent is UIMessageContent.AssetMessage
             || message.messageContent is UIMessageContent.ImageMessage
             || message.messageContent is UIMessageContent.AudioAssetMessage
-    val isEditableContent = message.messageContent is UIMessageContent.TextMessage
-
-    val isEditable = message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon && isEditableContent
+    val isEditable = message.isTextMessage && message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon
 
     val onCopyItemClick = remember(message) {
         {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -78,8 +78,9 @@ fun EditMessageMenuItems(
     val isAssetMessage = message.messageContent is UIMessageContent.AssetMessage
             || message.messageContent is UIMessageContent.ImageMessage
             || message.messageContent is UIMessageContent.AudioAssetMessage
+    val isEditableContent = message.messageContent is UIMessageContent.TextMessage
 
-    val isEditable = message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon && !isAssetMessage
+    val isEditable = message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon && isEditableContent
 
     val onCopyItemClick = remember(message) {
         {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/EditMessageBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/EditMessageBundle.kt
@@ -1,0 +1,9 @@
+package com.wire.android.ui.home.conversations.model
+
+import com.wire.android.ui.home.messagecomposer.UiMention
+
+data class EditMessageBundle(
+    val originalMessageId: String,
+    val newContent: String,
+    val newMentions: List<UiMention>,
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -29,7 +29,6 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.MessageStatus.DecryptionFailure
 import com.wire.android.ui.home.conversations.model.MessageStatus.Deleted
 import com.wire.android.ui.home.conversations.model.MessageStatus.ReceiveFailure
-import com.wire.android.ui.home.conversations.model.MessageStatus.SendFailure
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.uiMessageDateTime
@@ -48,8 +47,7 @@ data class UIMessage(
     val messageFooter: MessageFooter
 ) {
     val isDeleted: Boolean = messageHeader.messageStatus == Deleted
-    val sendingFailed: Boolean =
-        messageHeader.messageStatus == SendFailure || messageHeader.messageStatus is MessageStatus.SendRemotelyFailure
+    val sendingFailed: Boolean = messageHeader.messageStatus is MessageStatus.MessageSendFailureStatus
     val decryptionFailed: Boolean = messageHeader.messageStatus is DecryptionFailure
     val receivingFailed: Boolean = messageHeader.messageStatus == ReceiveFailure || decryptionFailed
     val isAvailable: Boolean = !isDeleted && !sendingFailed && !receivingFailed
@@ -79,19 +77,43 @@ data class MessageFooter(
     val ownReactions: Set<String> = emptySet()
 )
 
-sealed class MessageStatus(val text: UIText) {
-    object Untouched : MessageStatus(UIText.DynamicString(""))
-    object Deleted : MessageStatus(UIText.StringResource(R.string.deleted_message_text))
-    data class Edited(val formattedEditTimeStamp: String) :
-        MessageStatus(UIText.StringResource(R.string.label_message_status_edited_with_date, formattedEditTimeStamp))
+sealed class MessageStatus(
+    open val errorText: UIText? = null, // error description text shown below the content of the message
+    open val badgeText: UIText? = null, // text shown between tne user name and the content in the outlined box with a text inside
+) {
+    sealed class MessageSendFailureStatus : MessageStatus() {
+        abstract override val errorText: UIText
+    }
 
-    object SendFailure : MessageStatus(UIText.StringResource(R.string.label_message_sent_failure))
-    data class SendRemotelyFailure(val backendWithFailure: String) :
-        MessageStatus(UIText.StringResource(R.string.label_message_sent_remotely_failure, backendWithFailure))
+    object Untouched : MessageStatus()
+    object Deleted : MessageStatus() {
+        override val badgeText: UIText = UIText.StringResource(R.string.deleted_message_text)
+    }
 
-    object ReceiveFailure : MessageStatus(UIText.StringResource(R.string.label_message_receive_failure))
-    data class DecryptionFailure(val isDecryptionResolved: Boolean) :
-        MessageStatus(UIText.StringResource(R.string.label_message_decryption_failure_message))
+    data class Edited(val formattedEditTimeStamp: String) : MessageStatus() {
+        override val badgeText: UIText = UIText.StringResource(R.string.label_message_status_edited_with_date, formattedEditTimeStamp)
+    }
+
+    data class EditSendFailure(val formattedEditTimeStamp: String) : MessageSendFailureStatus() {
+        override val errorText: UIText = UIText.StringResource(R.string.label_message_edit_sent_failure)
+        override val badgeText: UIText = UIText.StringResource(R.string.label_message_status_edited_with_date, formattedEditTimeStamp)
+    }
+
+    object SendFailure : MessageSendFailureStatus() {
+        override val errorText: UIText = UIText.StringResource(R.string.label_message_sent_failure)
+    }
+
+    data class SendRemotelyFailure(val backendWithFailure: String) : MessageSendFailureStatus() {
+        override val errorText: UIText = UIText.StringResource(R.string.label_message_sent_remotely_failure, backendWithFailure)
+    }
+
+    object ReceiveFailure : MessageStatus() {
+        override val errorText: UIText = UIText.StringResource(R.string.label_message_receive_failure)
+    }
+
+    data class DecryptionFailure(val isDecryptionResolved: Boolean) : MessageStatus() {
+        override val errorText: UIText = UIText.StringResource(R.string.label_message_decryption_failure_message)
+    }
 }
 
 @Stable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -79,7 +79,7 @@ data class MessageFooter(
 
 sealed class MessageStatus(
     open val errorText: UIText? = null, // error description text shown below the content of the message
-    open val badgeText: UIText? = null, // text shown between tne user name and the content in the outlined box with a text inside
+    open val badgeText: UIText? = null, // text shown between the user name and the content in the outlined box with a text inside
 ) {
     sealed class MessageSendFailureStatus : MessageStatus() {
         abstract override val errorText: UIText

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -115,7 +115,8 @@ fun MessageComposer(
                         )
                     )
                 }
-                messageComposerState.toNewMessage(clearInput = true)
+                messageComposerState.focusManager.clearFocus()
+                messageComposerState.toInactive(clearInput = true)
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -62,6 +62,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.mention.MemberItemToMention
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptions
 import com.wire.android.ui.home.newconversation.model.Contact
@@ -75,6 +76,7 @@ fun MessageComposer(
     messageComposerState: MessageComposerInnerState,
     messageContent: @Composable () -> Unit,
     onSendTextMessage: (String, List<UiMention>, messageId: String?) -> Unit,
+    onSendEditTextMessage: (EditMessageBundle) -> Unit,
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onMentionMember: (String?) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
@@ -97,6 +99,23 @@ fun MessageComposer(
                 )
                 messageComposerState.quotedMessageData = null
                 messageComposerState.setMessageTextValue(TextFieldValue(""))
+            }
+        }
+
+        val onSendEditButtonClicked = remember {
+            {
+                (messageComposerState.messageComposeInputState as? MessageComposeInputState.Active)?.let {
+                    (it.type as? MessageComposeInputType.EditMessage)?.messageId
+                }?.let { originalMessageId ->
+                    onSendEditTextMessage(
+                        EditMessageBundle(
+                            originalMessageId = originalMessageId,
+                            newContent = messageComposerState.messageComposeInputState.messageText.text,
+                            messageComposerState.mentions,
+                        )
+                    )
+                }
+                messageComposerState.toNewMessage(clearInput = true)
             }
         }
 
@@ -129,6 +148,7 @@ fun MessageComposer(
             onSendAttachmentClicked = onSendAttachmentClicked,
             securityClassificationType = securityClassificationType,
             onSendButtonClicked = onSendButtonClicked,
+            onEditSaveButtonClicked = onSendEditButtonClicked,
             onMentionPicked = onMentionPicked,
             onPingClicked = onPingClicked,
             tempWritableImageUri = tempWritableImageUri,
@@ -153,6 +173,7 @@ private fun MessageComposer(
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
     onSendButtonClicked: () -> Unit,
+    onEditSaveButtonClicked: () -> Unit,
     onMentionPicked: (Contact) -> Unit,
     onPingClicked: () -> Unit
 ) {
@@ -168,7 +189,8 @@ private fun MessageComposer(
             Column(
                 Modifier
                     .fillMaxWidth()
-                    .height(currentScreenHeight)) {
+                    .height(currentScreenHeight)
+            ) {
 
                 // when MessageComposer is composed for the first time we do not know the height until users opens the keyboard
                 var keyboardHeight: KeyboardHeight by remember { mutableStateOf(KeyboardHeight.NotKnown) }
@@ -257,10 +279,7 @@ private fun MessageComposer(
                                     messageComposerState.toActive()
                                     messageComposerState.showAttachmentOptions()
                                 },
-                                onEditSaveButtonClicked = {
-                                    // TODO: replace with proper implementation
-                                    onMessageComposerError(ConversationSnackbarMessages.MessageEditNotYetSupported)
-                                },
+                                onEditSaveButtonClicked = onEditSaveButtonClicked,
                                 onEditCancelButtonClicked = {
                                     messageComposerState.focusManager.clearFocus()
                                     messageComposerState.toInactive(clearInput = true)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -177,14 +177,6 @@ data class MessageComposerInnerState(
         inputFocusRequester.requestFocus()
     }
 
-    fun toNewMessage(clearInput: Boolean = false) {
-        messageComposeInputState = MessageComposeInputState.Active(
-            messageText = if (clearInput) TextFieldValue("") else messageComposeInputState.messageText,
-            type = MessageComposeInputType.NewMessage()
-        )
-        inputFocusRequester.requestFocus()
-    }
-
     fun showAttachmentOptions() = changeAttachmentOptionsVisibility(true)
     fun hideAttachmentOptions() = changeAttachmentOptionsVisibility(false)
     private fun changeAttachmentOptionsVisibility(newValue: Boolean) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -173,6 +173,15 @@ data class MessageComposerInnerState(
             messageText = TextFieldValue(text = originalText, selection = TextRange(originalText.length)),
             type = MessageComposeInputType.EditMessage(messageId, originalText)
         )
+        quotedMessageData = null
+        inputFocusRequester.requestFocus()
+    }
+
+    fun toNewMessage(clearInput: Boolean = false) {
+        messageComposeInputState = MessageComposeInputState.Active(
+            messageText = if (clearInput) TextFieldValue("") else messageComposeInputState.messageText,
+            type = MessageComposeInputType.NewMessage()
+        )
         inputFocusRequester.requestFocus()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="label_membership_service">Service</string>
     <string name="label_user_deleted">Deleted</string>
     <string name="label_message_sent_failure">Message could not be sent due to connectivity issues.</string>
+    <string name="label_message_edit_sent_failure">The edited message could not be sent due to connectivity issues.</string>
     <string name="label_message_sent_remotely_failure">Message could not be sent, as the backend %s appears to be offline.</string>
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -67,6 +67,7 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationInteraction
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
 import com.wire.kalium.logic.feature.message.SendKnockUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
@@ -118,6 +119,9 @@ internal class ConversationsViewModelArrangement {
 
     @MockK
     lateinit var sendTextMessage: SendTextMessageUseCase
+
+    @MockK
+    lateinit var sendEditTextMessage: SendEditTextMessageUseCase
 
     @MockK
     lateinit var sendAssetMessage: ScheduleNewAssetMessageUseCase
@@ -184,6 +188,7 @@ internal class ConversationsViewModelArrangement {
             navigationManager = navigationManager,
             qualifiedIdMapper = qualifiedIdMapper,
             sendTextMessage = sendTextMessage,
+            sendEditTextMessage = sendEditTextMessage,
             sendAssetMessage = sendAssetMessage,
             deleteMessage = deleteMessage,
             dispatchers = TestDispatcherProvider(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2900" title="AR-2900" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-2900</a>  Create a new use case to handle message editing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, there is no logic implemented for sending message editions.

### Solutions

Use created use case for sending message editions, change the composer state to inactive after sending the edit (like on designs), add new `MessageStatus.EditSendFailure` which combines both text types (error label and status box).

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/1583

### Testing

#### How to Test

Send a message, long-click on that message and choose "edit", modify the content and send it.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/225684549-5504631c-3bcc-4310-b5cc-29e0733c31aa.mp4

<img src="https://user-images.githubusercontent.com/30429749/225695775-8786c81b-234f-4f67-addb-620da09039b2.png"  width="360">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
