### PR TITLE
fix: new group guest link creation AR-3188

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
@@ -162,7 +162,7 @@ class EditGuestAccessViewModel @Inject constructor(
 
         viewModelScope.launch {
             withContext(dispatcher.io()) {
-                if(!shouldEnableGuestAccess) {
+                if (!shouldEnableGuestAccess) {
                     removeGuestLink()
                 }
                 updateConversationAccessRole(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
@@ -162,6 +162,9 @@ class EditGuestAccessViewModel @Inject constructor(
 
         viewModelScope.launch {
             withContext(dispatcher.io()) {
+                if(!shouldEnableGuestAccess) {
+                    removeGuestLink()
+                }
                 updateConversationAccessRole(
                     conversationId = conversationId,
                     accessRoles = newAccessRoles,
@@ -174,7 +177,6 @@ class EditGuestAccessViewModel @Inject constructor(
                             isGuestAccessAllowed = !shouldEnableGuestAccess
                         )
                     )
-
                     is UpdateConversationAccessRoleUseCase.Result.Success -> Unit
                 }
                 updateState(editGuestAccessState.copy(isUpdatingGuestAccess = false))
@@ -222,6 +224,10 @@ class EditGuestAccessViewModel @Inject constructor(
     }
 
     fun onRevokeDialogConfirm() {
+        removeGuestLink()
+    }
+
+    private fun removeGuestLink() {
         updateState(editGuestAccessState.copy(shouldShowRevokeLinkConfirmationDialog = false, isRevokingLink = true))
         viewModelScope.launch {
             revokeGuestRoomLink(conversationId).also {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
@@ -261,15 +261,31 @@ abstract class SearchPeopleViewModel(
         }
     }
 
+    /**
+     * Do not under any circumstances call this function in a loop.
+     * It will cause the to emit a value each time. This in turn
+     * will result in synchronous execution of functions on the main
+     * thread like to use outdated values.
+     */
     fun addContactToGroup(contact: Contact) {
         viewModelScope.launch {
             selectedContactsFlow.emit(selectedContactsFlow.value + contact)
         }
     }
 
+    /**
+     * Do not under any circumstances call this function in a loop.
+     * It will cause the state to emit a value each time. This in turn
+     * will result in synchronous execution of functions on the main
+     * thread like to use outdated values.
+     * Use [removeContactsFromGroup] instead.
+     */
     fun removeContactFromGroup(contact: Contact) {
+        removeContactsFromGroup(setOf(contact))
+    }
+    fun removeContactsFromGroup(contacts: Set<Contact>) {
         viewModelScope.launch {
-            selectedContactsFlow.emit(selectedContactsFlow.value - contact)
+            selectedContactsFlow.emit(selectedContactsFlow.value - contacts)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
@@ -20,9 +20,6 @@
 
 package com.wire.android.ui.home.newconversation.groupOptions
 
-import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.Conversation.AccessRole.SERVICE
-
 data class GroupOptionState(
     val continueEnabled: Boolean = true,
     val isLoading: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
@@ -30,10 +30,6 @@ data class GroupOptionState(
     val isAllowServicesEnabled: Boolean = true,
     val isReadReceiptEnabled: Boolean = true,
     val showAllowGuestsDialog: Boolean = false,
-    val accessRoleState: MutableSet<Conversation.AccessRole> = Conversation
-        .defaultGroupAccessRoles
-        .toMutableSet()
-        .apply { add(Conversation.AccessRole.SERVICE) },
     val error: Error? = null
 ) {
     sealed interface Error {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -225,27 +225,13 @@ internal class NewConversationViewModelArrangement {
     }
 
     fun withGuestEnabled(isGuestModeEnabled: Boolean) = apply {
-        val newAccessRole: MutableSet<Conversation.AccessRole> = viewModel.groupOptionsState.accessRoleState.apply {
-            if (isGuestModeEnabled) {
-                add(Conversation.AccessRole.GUEST)
-                add(Conversation.AccessRole.NON_TEAM_MEMBER)
-            } else {
-                remove(Conversation.AccessRole.GUEST)
-                remove(Conversation.AccessRole.NON_TEAM_MEMBER)
-            }
-        }
         viewModel.groupOptionsState = viewModel
             .groupOptionsState
-            .copy(isAllowGuestEnabled = isGuestModeEnabled, accessRoleState = newAccessRole)
+            .copy(isAllowGuestEnabled = isGuestModeEnabled)
     }
 
     fun withServicesEnabled(areServicesEnabled: Boolean) = apply {
         viewModel.groupOptionsState = viewModel.groupOptionsState.copy(isAllowServicesEnabled = areServicesEnabled)
-        if (areServicesEnabled) {
-            viewModel.groupOptionsState.accessRoleState.add(Conversation.AccessRole.SERVICE)
-        } else {
-            viewModel.groupOptionsState.accessRoleState.remove(Conversation.AccessRole.SERVICE)
-        }
     }
 
     fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3188" title="AR-3188" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3188</a>  When we create a group on AR, we can not enable guestlinks
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. When creating a new group, the UI wasn't using the correct accessRoles
1. When creating a new group and disallowing guests, the UI would have a race where some guests could remain in the list of participants and fail group creation
1. When turning off guest access, guest links are not revoked and can't be revoked when access is disabled

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

1. Remove redundant state information, so that there is only 1 way of determining accessRoles
1. Bulk remove guests and avoid triggering state updates. The problem arises from a misunderstanding of how the `collect` operator works
1. When disabling guests, also revoke guest link

### Testing

#### How to Test

1. Create a a group with guests, check that you can create a guest link right after group creation
1. Start creating a group with guests, disallow guests before hitting continue and check that group creation worked
1. After creating a group with guests, edit guest access. Notice that the guest link is also revoked.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
