### PR TITLE
fix: do not send empty 2fa code on client registration

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -107,7 +107,6 @@ class LoginEmailViewModel @Inject constructor(
             registerClient(
                 userId = storedUserId,
                 password = loginState.password.text,
-                secondFactorVerificationCode = secondFactorVerificationCode
             ).let {
                 when (it) {
                     is RegisterClientResult.Failure -> {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -381,6 +381,27 @@ class LoginEmailViewModelTest {
         coVerify(exactly = 1) { navigationManager.navigate(any()) }
     }
 
+    @Test
+    fun `given 2fa is needed, when code is filled, then should register client without explicit 2fa code`() = runTest {
+        val email = "some.email@example.org"
+        val code = "123456"
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Success(
+            AUTH_TOKEN,
+            SSO_ID,
+            SERVER_CONFIG.id,
+            null
+        )
+        coEvery { addAuthenticatedUserUseCase(any(), any(), any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
+        coEvery { navigationManager.navigate(any()) } returns Unit
+        coEvery { getOrRegisterClientUseCase(any()) } returns RegisterClientResult.Success(CLIENT)
+        every { userDataStoreProvider.getOrCreate(any()).initialSyncCompleted } returns flowOf(true)
+
+        loginViewModel.onUserIdentifierChange(TextFieldValue(email))
+        loginViewModel.onCodeChange(CodeFieldValue(TextFieldValue(code), true))
+
+        coVerify(exactly = 1) { getOrRegisterClientUseCase(match { it.secondFactorVerificationCode == null }) }
+    }
+
     companion object {
         val CLIENT_ID = ClientId("test")
         val CLIENT = Client(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users get a failure on login

### Causes

Reloaded is passing an empty 2FA code when registering clients.

### Solutions

Do not pass any 2FA code to Kalium, as Reloaded shouldn't pass any 2FA code explicitly after logging in, as Kalium manages that anyway.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
