### PR TITLE
fix: single unread event in conversation last message [AR-3003]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -43,9 +43,9 @@ fun MessagePreview?.toUIPreview(unreadEventCount: UnreadEventCount): UILastMessa
         unreadEventCount.isEmpty() -> uiLastMessageContent()
         // when there are only unread message events also show last message
         unreadEventCount.size == 1 && unreadEventCount.keys.first() == UnreadEventType.MESSAGE -> uiLastMessageContent()
-        // for the rest of one type events show last message only where their count equals one
+        // for the one type events show last message only where their count equals one
         unreadEventCount.size == 1 && unreadEventCount.values.first() == 1 -> uiLastMessageContent()
-        // for the rest take 2 most prioritized events with count to last message
+        // for the rest take 1 or 2 most prioritized events with count to last message
         else -> multipleUnreadEventsToLastMessage(unreadEventCount)
     }
 }
@@ -91,8 +91,13 @@ private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount
         }.associate { it }
 
     val first = unreadContentTexts.values.first()
-    val second = unreadContentTexts.values.elementAt(1)
-    return UILastMessageContent.MultipleMessage(listOf(first, second))
+    return if (unreadContentTexts.entries.size > 1) {
+        val second = unreadContentTexts.values.elementAt(1)
+        UILastMessageContent.MultipleMessage(listOf(first, second))
+    } else {
+        UILastMessageContent.TextMessage(MessageBody(first))
+    }
+
 }
 
 private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -97,7 +97,6 @@ private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount
     } else {
         UILastMessageContent.TextMessage(MessageBody(first))
     }
-
 }
 
 private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -38,61 +38,61 @@ fun MessagePreview?.toUIPreview(unreadEventCount: UnreadEventCount): UILastMessa
         return UILastMessageContent.None
     }
 
-    val sortedUnreadContent = unreadEventCount
-        .toSortedMap()
-
-    // we want to show last message content instead of counter when there are only one type of unread events
-    if (sortedUnreadContent.isNotEmpty()) {
-        val unreadContentTexts = sortedUnreadContent
-            .mapNotNull { type ->
-                when (type.key) {
-                    UnreadEventType.KNOCK -> UnreadEventType.KNOCK to UIText.PluralResource(
-                        R.plurals.unread_event_knock,
-                        type.value,
-                        type.value
-                    )
-
-                    UnreadEventType.MISSED_CALL -> UnreadEventType.MISSED_CALL to UIText.PluralResource(
-                        R.plurals.unread_event_call,
-                        type.value,
-                        type.value
-                    )
-
-                    UnreadEventType.MENTION -> UnreadEventType.MENTION to UIText.PluralResource(
-                        R.plurals.unread_event_mention,
-                        type.value,
-                        type.value
-                    )
-
-                    UnreadEventType.REPLY -> UnreadEventType.REPLY to UIText.PluralResource(
-                        R.plurals.unread_event_reply,
-                        type.value,
-                        type.value
-                    )
-
-                    UnreadEventType.MESSAGE -> UnreadEventType.MESSAGE to UIText.PluralResource(
-                        R.plurals.unread_event_message,
-                        type.value,
-                        type.value
-                    )
-
-                    UnreadEventType.IGNORED -> null
-                    null -> null
-                }
-            }.associate { it }
-        if (unreadContentTexts.size > 1) {
-            val first = unreadContentTexts.values.first()
-            val second = unreadContentTexts.values.elementAt(1)
-            return UILastMessageContent.MultipleMessage(listOf(first, second))
-        } else if (unreadContentTexts.isNotEmpty()) {
-            val unreadContent = unreadContentTexts.entries.first()
-            if (unreadContent.key != UnreadEventType.MESSAGE) {
-                return UILastMessageContent.TextMessage(MessageBody(unreadContent.value))
-            }
-        }
+    return when {
+        // when unread event count is empty show last message
+        unreadEventCount.isEmpty() -> uiLastMessageContent()
+        // when there are only unread message events also show last message
+        unreadEventCount.size == 1 && unreadEventCount.keys.first() == UnreadEventType.MESSAGE -> uiLastMessageContent()
+        // for the rest of one type events show last message only where their count equals one
+        unreadEventCount.size == 1 && unreadEventCount.values.first() == 1 -> uiLastMessageContent()
+        // for the rest take 2 most prioritized events with count to last message
+        else -> multipleUnreadEventsToLastMessage(unreadEventCount)
     }
+}
 
-    return uiLastMessageContent()
+private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount): UILastMessageContent {
+    val unreadContentTexts = unreadEventCount
+        .toSortedMap()
+        .mapNotNull { type ->
+            when (type.key) {
+                UnreadEventType.KNOCK -> UnreadEventType.KNOCK to UIText.PluralResource(
+                    R.plurals.unread_event_knock,
+                    type.value,
+                    type.value
+                )
+
+                UnreadEventType.MISSED_CALL -> UnreadEventType.MISSED_CALL to UIText.PluralResource(
+                    R.plurals.unread_event_call,
+                    type.value,
+                    type.value
+                )
+
+                UnreadEventType.MENTION -> UnreadEventType.MENTION to UIText.PluralResource(
+                    R.plurals.unread_event_mention,
+                    type.value,
+                    type.value
+                )
+
+                UnreadEventType.REPLY -> UnreadEventType.REPLY to UIText.PluralResource(
+                    R.plurals.unread_event_reply,
+                    type.value,
+                    type.value
+                )
+
+                UnreadEventType.MESSAGE -> UnreadEventType.MESSAGE to UIText.PluralResource(
+                    R.plurals.unread_event_message,
+                    type.value,
+                    type.value
+                )
+
+                UnreadEventType.IGNORED -> null
+                null -> null
+            }
+        }.associate { it }
+
+    val first = unreadContentTexts.values.first()
+    val second = unreadContentTexts.values.elementAt(1)
+    return UILastMessageContent.MultipleMessage(listOf(first, second))
 }
 
 private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -52,7 +52,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
     val DUMMY_ASSET_REMOTE_DATA = AssetContent.RemoteData(
         otrKey = ByteArray(0),
@@ -79,7 +80,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
 
     fun buildAssetMessage(assetContent: AssetContent) = Message.Regular(
@@ -90,7 +92,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
 
     val MEMBER_REMOVED_MESSAGE = Message.System(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3003" title="AR-3003" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3003</a>  Add an icon for missed events in the conversation list item
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When there was only one type of unread event with counter equal to one there was message for example `1 mention` instead of `Someone mentioned you`. So I fixed and simplified logic to be more understandable. 


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
