### PR TITLE
fix: member joined system message is missing after joining conversati…

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -178,7 +178,7 @@ class MessageContentMapper @Inject constructor(
         return when (content) {
             is Added ->
                 if (isAuthorSelfAction) {
-                    null // we don't want to show "You added you to the conversation"
+                    UIMessageContent.SystemMessage.MemberJoined(author = authorName, isSelfTriggered = isSelfTriggered)
                 } else {
                     UIMessageContent.SystemMessage.MemberAdded(
                         author = authorName,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -364,6 +364,7 @@ private fun MessageContent(
         }
 
         is UIMessageContent.SystemMessage.MemberAdded -> {}
+        is UIMessageContent.SystemMessage.MemberJoined -> {}
         is UIMessageContent.SystemMessage.MemberLeft -> {}
         is UIMessageContent.SystemMessage.MemberRemoved -> {}
         is UIMessageContent.SystemMessage.RenamedConversation -> {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -260,7 +260,7 @@ private fun List<UIText>.limitUserNamesList(res: Resources, threshold: Int): Lis
             .plus(res.getQuantityString(R.plurals.label_system_message_x_more, moreCount, moreCount))
     }
 
-@Suppress("LongParameterList", "SpreadOperator")
+@Suppress("LongParameterList", "SpreadOperator", "ComplexMethod")
 fun SystemMessage.annotatedString(
     res: Resources,
     expanded: Boolean,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -158,6 +158,7 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.MissedCall.YouCalled -> null
         is SystemMessage.Knock -> ColorFilter.tint(colorsScheme().primary)
         is SystemMessage.MemberAdded -> ColorFilter.tint(colorsScheme().onBackground)
+        is SystemMessage.MemberJoined -> ColorFilter.tint(colorsScheme().onBackground)
         is SystemMessage.MemberLeft -> ColorFilter.tint(colorsScheme().onBackground)
         is SystemMessage.MemberRemoved -> ColorFilter.tint(colorsScheme().onBackground)
         is SystemMessage.CryptoSessionReset -> ColorFilter.tint(colorsScheme().onBackground)
@@ -232,6 +233,7 @@ private val SystemMessage.expandable
     get() = when (this) {
         is SystemMessage.MemberAdded -> this.memberNames.size > EXPANDABLE_THRESHOLD
         is SystemMessage.MemberRemoved -> this.memberNames.size > EXPANDABLE_THRESHOLD
+        is SystemMessage.MemberJoined -> false
         is SystemMessage.MemberLeft -> false
         is SystemMessage.MissedCall -> false
         is SystemMessage.RenamedConversation -> false
@@ -278,6 +280,7 @@ fun SystemMessage.annotatedString(
                 author.asString(res),
                 memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
             )
+        is SystemMessage.MemberJoined -> arrayOf(author.asString(res))
         is SystemMessage.MemberLeft -> arrayOf(author.asString(res))
         is SystemMessage.MissedCall -> arrayOf(author.asString(res))
         is SystemMessage.RenamedConversation -> arrayOf(author.asString(res), additionalContent)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -192,6 +192,15 @@ sealed class UIMessageContent {
             if (isSelfTriggered) R.string.label_system_message_added_by_self else R.string.label_system_message_added_by_other
         )
 
+        data class MemberJoined(
+            val author: UIText,
+            val isSelfTriggered: Boolean = false
+        ) : SystemMessage(
+            R.drawable.ic_add,
+            if (isSelfTriggered) R.string.label_system_message_joined_the_conversation_by_self
+            else R.string.label_system_message_joined_the_conversation_by_other
+        )
+
         data class MemberRemoved(
             val author: UIText,
             val memberNames: List<UIText>,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -928,4 +928,6 @@
     <string name="new_device_dialog_other_user_title">Your account “%1$s (@%2$s)” was used on:</string>
     <string name="new_device_dialog_other_user_message">%1$s\nFrom: %2$s \n\nIf you didn’t do this, remove the device (navigate to “Manage Devices” in the Settings section of this account), and reset your password.</string>
     <string name="new_device_dialog_other_user_btn">Switch Account</string>
+    <string name="label_system_message_joined_the_conversation_by_self">%1$s joined the conversation</string>
+    <string name="label_system_message_joined_the_conversation_by_other">%1$s joined the conversation</string>
 </resources>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -52,7 +52,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
     val DUMMY_ASSET_REMOTE_DATA = AssetContent.RemoteData(
         otrKey = ByteArray(0),
@@ -79,7 +80,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
 
     fun buildAssetMessage(assetContent: AssetContent) = Message.Regular(
@@ -90,7 +92,8 @@ object TestMessage {
         senderUserId = UserId("user-id", "domain"),
         senderClientId = ClientId("client-id"),
         status = Message.Status.SENT,
-        editStatus = Message.EditStatus.NotEdited
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
     )
 
     val MEMBER_REMOVED_MESSAGE = Message.System(

--- a/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
@@ -162,7 +162,10 @@ class EncodedMessageContentMapperTest {
                     resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.name &&
                     resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.name
         )
-        assertTrue(resultContentAddedSelf == null)
+        assertTrue(
+            resultContentAddedSelf is SystemMessage.MemberJoined &&
+                    resultContentAddedSelf.author.asString(arrangement.resources) == member1.name
+        )
         assertTrue(
             resultOtherMissedCall is SystemMessage.MissedCall &&
                     resultOtherMissedCall.author.asString(arrangement.resources) == TestUser.OTHER_USER.name


### PR DESCRIPTION
…on with a guest link

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

self invoked member joined system messages were hidden to avoid displaying something like `You added You to the conversation`

### Solutions

map self invoked member joined to the correct message type 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
