### PR TITLE
fix: make login and sync loading smoother [AR-3001]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -74,8 +74,9 @@ class RegisterDeviceViewModel @Inject constructor(
     }
 
     fun onPasswordChange(newText: TextFieldValue) {
-        if (state.password != newText)
+        if (state.password != newText) {
             updateState(state.copy(password = newText, error = RegisterDeviceError.None, continueEnabled = newText.text.isNotEmpty()))
+        }
     }
 
     fun onErrorDismiss() {
@@ -129,8 +130,9 @@ class RegisterDeviceViewModel @Inject constructor(
         navigationManager.navigate(NavigationCommand(NavigationItem.RemoveDevices.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
 
     private suspend fun navigateAfterRegisterClientSuccess() =
-        if (userDataStore.initialSyncCompleted.first())
+        if (userDataStore.initialSyncCompleted.first()) {
             navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
-        else
+        } else {
             navigationManager.navigate(NavigationCommand(NavigationItem.InitialSync.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
+        }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
@@ -21,11 +21,14 @@
 package com.wire.android.ui.initialsync
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.ui.common.SettingUpWireScreenContent
 
 @Composable
 fun InitialSyncScreen(viewModel: InitialSyncViewModel = hiltViewModel()) {
     SettingUpWireScreenContent()
-    viewModel.waitUntilSyncIsCompleted()
+    LaunchedEffect(Unit) {
+        viewModel.waitUntilSyncIsCompleted()
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
@@ -34,7 +34,9 @@ import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -47,12 +49,12 @@ class InitialSyncViewModel @Inject constructor(
 ) : ViewModel() {
 
     fun waitUntilSyncIsCompleted() {
-        viewModelScope.launch(dispatchers.io()) {
-            observeSyncState().collect { syncState ->
-                if (syncState is SyncState.Live) {
-                    userDataStoreProvider.getOrCreate(userId).setInitialSyncCompleted()
-                    navigateToConvScreen()
-                }
+        viewModelScope.launch {
+            withContext(dispatchers.io()) {
+                observeSyncState().firstOrNull { it is SyncState.Live }
+            }?.let {
+                userDataStoreProvider.getOrCreate(userId).setInitialSyncCompleted()
+                navigateToConvScreen()
             }
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -23,6 +23,7 @@ package com.wire.android.ui.authentication.devices.register
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.mockUri
+import com.wire.android.datastore.UserDataStore
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
@@ -39,9 +40,11 @@ import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
@@ -66,6 +69,9 @@ class RegisterDeviceViewModelTest {
     @MockK
     private lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
 
+    @MockK
+    lateinit var userDataStore: UserDataStore
+
     private lateinit var registerDeviceViewModel: RegisterDeviceViewModel
 
     @BeforeEach
@@ -73,11 +79,13 @@ class RegisterDeviceViewModelTest {
         MockKAnnotations.init(this)
         mockUri()
         coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(true)
+        every { userDataStore.initialSyncCompleted } returns flowOf(true)
         registerDeviceViewModel =
             RegisterDeviceViewModel(
                 navigationManager,
                 registerClientUseCase,
-                isPasswordRequiredUseCase
+                isPasswordRequiredUseCase,
+                userDataStore
             )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -25,6 +25,7 @@ package com.wire.android.ui.authentication.login.email
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.AuthServerConfigProvider
@@ -149,7 +150,8 @@ class LoginEmailViewModelTest {
             savedStateHandle,
             navigationManager,
             authServerConfigProvider,
-            userDataStoreProvider
+            userDataStoreProvider,
+            TestDispatcherProvider()
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3001" title="AR-3001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3001</a>  Loading spinner on setting up Wire Screen is not visible on android 9
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Loading state UI is frozen during initial sync on Android 9. 
Loading state when logging in is wrong and progress disappears after a split second. 

### Solutions

Login:
Remove turning off the loading flag on login screen right after the first call and let it be visible throughout the whole login flow. 
Execute all important actions on IO to not block the main thread and let the loading be as smooth as possible.

Initial sync:
Call `waitUntilSyncIsCompleted` in `LaunchedEffect` with `Unit` key to make sure it's executed only once.
Change `collect` to `firstOrNull` to not collect items when it's not needed anymore.

Register device:
Open "initial sync" screen also after registering a device if the sync hasn't been done yet.

### Testing

#### How to Test

Login and sync to see the difference.

### Attachments (Optional)

Before:

https://user-images.githubusercontent.com/30429749/226672004-8a9bc044-ed0d-4469-848e-8d92229a41f8.mp4

<br />
<br />

After:

https://user-images.githubusercontent.com/30429749/226672139-fc92e0b5-e631-48b9-8ee8-71bdff36ed30.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
