### PR TITLE
chore: handle snackbar using UIText for connection requests

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleViewModel.kt
@@ -288,6 +288,7 @@ abstract class SearchPeopleViewModel(
     fun removeContactFromGroup(contact: Contact) {
         removeContactsFromGroup(setOf(contact))
     }
+
     fun removeContactsFromGroup(contacts: Set<Contact>) {
         viewModelScope.launch {
             selectedContactsFlow.emit(selectedContactsFlow.value - contacts)
@@ -326,5 +327,4 @@ sealed class SearchResult {
 
 sealed class SearchPeopleMessageType(override val uiText: UIText) : SnackBarMessage {
     object SuccessConnectionSentRequest : SearchPeopleMessageType(UIText.StringResource(R.string.connection_request_sent))
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -29,14 +29,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.wire.android.R
 import com.wire.android.navigation.rememberTrackingAnimatedNavController
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
-import com.wire.android.ui.home.conversations.search.NewConversationSnackbarState
 import com.wire.android.ui.home.conversations.search.SearchPeopleRouter
 import com.wire.android.ui.home.newconversation.common.NewConversationNavigationItem
 import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionScreen
@@ -48,11 +48,6 @@ fun NewConversationRouter() {
     val newConversationViewModel: NewConversationViewModel = hiltViewModel()
     val newConversationNavController = rememberTrackingAnimatedNavController() { NewConversationNavigationItem.fromRoute(it)?.itemName }
     val snackbarHostState = remember { SnackbarHostState() }
-
-    handleSnackBarMessage(
-        snackbarHostState,
-        newConversationViewModel.snackbarMessageState
-    ) { newConversationViewModel.clearSnackbarMessage() }
 
     Scaffold(
         snackbarHost = {
@@ -114,26 +109,12 @@ fun NewConversationRouter() {
             )
         }
     }
-}
 
-@Composable
-private fun handleSnackBarMessage(
-    snackbarHostState: SnackbarHostState,
-    conversationListSnackBarState: NewConversationSnackbarState,
-    onMessageShown: () -> Unit
-) {
-    conversationListSnackBarState.let { messageType ->
-        val message = when (messageType) {
-            is NewConversationSnackbarState.SuccessSendConnectionRequest ->
-                stringResource(id = R.string.connection_request_sent)
+    val context = LocalContext.current
 
-            NewConversationSnackbarState.None -> ""
-        }
-        LaunchedEffect(messageType) {
-            if (messageType != NewConversationSnackbarState.None) {
-                snackbarHostState.showSnackbar(message)
-                onMessageShown()
-            }
+    LaunchedEffect(Unit) {
+        newConversationViewModel.infoMessage.collect {
+            snackbarHostState.showSnackbar(it.asString(context.resources))
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -33,8 +33,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.wire.android.R
 import com.wire.android.navigation.rememberTrackingAnimatedNavController
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.home.conversations.search.SearchPeopleRouter
@@ -46,7 +44,11 @@ import com.wire.android.ui.home.newconversation.newgroup.NewGroupScreen
 @Composable
 fun NewConversationRouter() {
     val newConversationViewModel: NewConversationViewModel = hiltViewModel()
-    val newConversationNavController = rememberTrackingAnimatedNavController() { NewConversationNavigationItem.fromRoute(it)?.itemName }
+    val newConversationNavController = rememberTrackingAnimatedNavController() {
+        NewConversationNavigationItem.fromRoute(
+        it
+    )?.itemName
+    }
     val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
@@ -55,7 +57,8 @@ fun NewConversationRouter() {
                 hostState = snackbarHostState,
                 modifier = Modifier.fillMaxWidth()
             )
-        }) { internalPadding ->
+        }
+    ) { internalPadding ->
         NavHost(
             navController = newConversationNavController,
             startDestination = NewConversationNavigationItem.SearchListNavHostScreens.route,
@@ -67,7 +70,9 @@ fun NewConversationRouter() {
                     SearchPeopleRouter(
                         searchAllPeopleViewModel = newConversationViewModel,
                         onGroupSelectionSubmitAction = {
-                            newConversationNavController.navigate(NewConversationNavigationItem.NewGroupNameScreen.route)
+                            newConversationNavController.navigate(
+                                NewConversationNavigationItem.NewGroupNameScreen.route
+                            )
                         }
                     )
                 }
@@ -81,7 +86,9 @@ fun NewConversationRouter() {
                         onGroupNameChange = newConversationViewModel::onGroupNameChange,
                         onContinuePressed = {
                             if (newConversationViewModel.newGroupState.isSelfTeamMember == true) {
-                                newConversationNavController.navigate(NewConversationNavigationItem.GroupOptionsScreen.route)
+                                newConversationNavController.navigate(
+                                    NewConversationNavigationItem.GroupOptionsScreen.route
+                                )
                             } else {
                                 newConversationViewModel.createGroup()
                             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Cancelling request does not show the send request icon

This is a cherry pick , Original PR : https://github.com/wireapp/wire-android-reloaded/pull/1570/files

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
