### PR TITLE
chore: add IntelliJ's automatic copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ captures/
 # Allow project icon
 !.idea/icon.png
 
+# Allow automatic IntelliJ's automatic copyright
+!.idea/copyright/**
+
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
 #*.jks

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,13 @@
+<component name="CopyrightManager">
+  <settings default="wire-swiss-gmbh">
+    <module2copyright>
+      <element module="Production" copyright="wire-swiss-gmbh" />
+      <element module="Tests" copyright="wire-swiss-gmbh" />
+      <element module="All" copyright="wire-swiss-gmbh" />
+    </module2copyright>
+    <LanguageOptions name="Kotlin" />
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>

--- a/.idea/copyright/wire_swiss_gmbh.xml
+++ b/.idea/copyright/wire_swiss_gmbh.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Wire&#10;Copyright (C) &amp;#36;today.year Wire Swiss GmbH&#10;&#10;This program is free software: you can redistribute it and/or modify&#10;it under the terms of the GNU General Public License as published by&#10;the Free Software Foundation, either version 3 of the License, or&#10;(at your option) any later version.&#10;&#10;This program is distributed in the hope that it will be useful,&#10;but WITHOUT ANY WARRANTY; without even the implied warranty of&#10;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the&#10;GNU General Public License for more details.&#10;&#10;You should have received a copy of the GNU General Public License&#10;along with this program. If not, see http://www.gnu.org/licenses/." />
+    <option name="myName" value="wire-swiss-gmbh" />
+  </copyright>
+</component>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our IDEs do not add the copyright notice automatically when creating new files in Reloaded. (It's currently only working in Kalium)

### Causes

Oops

### Solutions

Copy the same settings from Kalium and bring them over.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
