### PR TITLE
chore: disable back button for incoming and outgoing call screens

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.calling.incoming
 
 import android.view.View
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -125,7 +126,9 @@ private fun IncomingCallContent(
     onVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit
 ) {
-
+    BackHandler {
+        // DO NOTHING
+    }
     val scaffoldState = rememberBottomSheetScaffoldState()
 
     BottomSheetScaffold(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.calling.initiating
 
 import android.view.View
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -81,6 +82,10 @@ private fun InitiatingCallContent(
     onVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit
 ) {
+    BackHandler {
+        // DO NOTHING
+    }
+
     val scaffoldState = rememberBottomSheetScaffoldState()
 
     BottomSheetScaffold(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
@@ -50,7 +50,6 @@ import com.wire.android.ui.calling.controlbuttons.CallOptionsControls
 import com.wire.android.ui.calling.controlbuttons.HangUpButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 
 @Composable


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When pressing on back button in incoming/outgoing call screen, the screen got dismissed but the call still ongoing.

### Causes (Optional)

We are not handling this case yet 

### Solutions

Disable back button until we handle this case.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
