### PR TITLE
fix: camera is turned on by default after leaving and re-joing a call (AR-3194)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -58,7 +58,6 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
@@ -71,6 +70,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -149,9 +149,7 @@ class SharedCallingViewModel @Inject constructor(
     private suspend fun observeScreenState() {
         currentScreenManager.observeCurrentScreen(viewModelScope).collect {
             if (it == CurrentScreen.InBackground) {
-                pauseVideo()
-            } else if (it == CurrentScreen.OngoingCallScreen(conversationId)) {
-                unPauseVideo()
+                stopVideo()
             }
         }
     }
@@ -213,8 +211,7 @@ class SharedCallingViewModel @Inject constructor(
         sharedFlow.first()?.let { call ->
             callState = callState.copy(
                 callStatus = call.status,
-                callerName = call.callerName,
-                isCameraOn = call.isCameraOn
+                callerName = call.callerName
             )
         }
     }
@@ -234,7 +231,7 @@ class SharedCallingViewModel @Inject constructor(
 
     fun navigateBack() {
         viewModelScope.launch {
-            pauseVideo()
+            stopVideo()
             navigationManager.navigateBack()
         }
     }
@@ -299,19 +296,12 @@ class SharedCallingViewModel @Inject constructor(
         }
     }
 
-    fun pauseVideo() {
+    fun stopVideo() {
         viewModelScope.launch {
             if (callState.isCameraOn) {
-                updateVideoState(conversationId, VideoState.PAUSED)
-            }
-        }
-    }
-
-    private fun unPauseVideo() {
-        viewModelScope.launch {
-            // We should turn on video only for established call
-            if (callState.isCameraOn && callState.participants.isNotEmpty()) {
-                updateVideoState(conversationId, VideoState.STARTED)
+                callState = callState.copy(isCameraOn = false, isSpeakerOn = false)
+                clearVideoPreview()
+                turnLoudSpeakerOff()
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -77,7 +77,7 @@ fun ParticipantTile(
 ) {
     Surface(
         modifier = modifier,
-        color = colorsScheme().callingParticipantTileBackgroundColor ,
+        color = colorsScheme().callingParticipantTileBackgroundColor,
         shape = RoundedCornerShape(dimensions().corner6x)
     ) {
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -244,26 +244,27 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an video call, when pauseVideo is called, then clear the video preview and update video state to PAUSED`() {
+    fun `given a video call, when stopping video, then clear Video Preview and turn off speaker`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = true)
         coEvery { setVideoPreview(any(), any()) } returns Unit
-        coEvery { updateVideoState(any(), any()) } returns Unit
+        coEvery { turnLoudSpeakerOff() } returns Unit
 
-        runTest { sharedCallingViewModel.pauseVideo() }
+        runTest { sharedCallingViewModel.stopVideo() }
 
-        coVerify(exactly = 1) { updateVideoState(any(), VideoState.PAUSED) }
+        coVerify(exactly = 1) { setVideoPreview(any(), any()) }
+        coVerify(exactly = 1) { turnLoudSpeakerOff() }
     }
 
     @Test
-    fun `given an audio call, when pauseVideo is called, then do not pause the video`() {
+    fun `given an audio call, when stopVideo is invoked, then do not do anything`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = false)
         coEvery { setVideoPreview(any(), any()) } returns Unit
-        coEvery { updateVideoState(any(), any()) } returns Unit
+        coEvery { turnLoudSpeakerOff() } returns Unit
 
-        runTest { sharedCallingViewModel.pauseVideo() }
+        runTest { sharedCallingViewModel.stopVideo() }
 
         coVerify(inverse = true) { setVideoPreview(any(), any()) }
-        coVerify(inverse = true) { updateVideoState(any(), VideoState.PAUSED) }
+        coVerify(inverse = true) { turnLoudSpeakerOff() }
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3194" title="AR-3194" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3194</a>  Video still enabled when leaving a call when video was enabled and joining it again
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

camera is turned on by default after leaving and re-joing a call immediately.

### Causes (Optional)

It a race condition where the camera state didn't change yet from true to false and we join again the same call.
So the app takes true as camera state.

### Solutions

- Remove observing camera state on `init`.
- Stop camera when the app is in background. 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
