### PR TITLE
fix(develop): Add download and open menu options for different types of assets [AR-3180][AR-3007]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -137,20 +137,11 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                             )
                         )
 
-                    AssetType.ASSET ->
+                    AssetType.GENERIC_ASSET ->
                         UILastMessageContent.SenderWithMessage(
                             userUIText, UIText.StringResource(
                                 if (isSelfMessage) R.string.last_message_self_user_shared_asset
                                 else R.string.last_message_other_user_shared_asset
-                            )
-                        )
-
-                    AssetType.FILE ->
-                        UILastMessageContent.SenderWithMessage(
-                            userUIText,
-                            UIText.StringResource(
-                                if (isSelfMessage) R.string.last_message_self_user_shared_file
-                                else R.string.last_message_other_user_shared_file
                             )
                         )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.edit
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+
+@Composable
+fun DownloadAssetExternallyOption(onDownloadClick: () -> Unit) =
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+        MenuBottomSheetItem(
+            icon = {
+                MenuItemIcon(
+                    id = R.drawable.ic_download,
+                    contentDescription = stringResource(R.string.content_description_download_icon),
+                )
+            },
+            title = stringResource(R.string.label_download),
+            onItemClick = onDownloadClick
+        )
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/OpenAssetExternallyOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/OpenAssetExternallyOption.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.edit
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+
+@Composable
+fun OpenAssetExternallyOption(onOpenClick: () -> Unit) =
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+        MenuBottomSheetItem(
+            icon = {
+                MenuItemIcon(
+                    id = R.drawable.ic_view,
+                    contentDescription = stringResource(R.string.content_description_open_asset_icon),
+                )
+            },
+            title = stringResource(R.string.label_open_asset_externally),
+            onItemClick = onOpenClick
+        )
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -183,8 +183,6 @@ fun ConversationScreen(
         onDeleteMessage = messageComposerViewModel::showDeleteMessageDialog,
         onSendAttachment = messageComposerViewModel::sendAttachmentMessage,
         onAssetItemClicked = conversationMessagesViewModel::downloadOrFetchAssetAndShowDialog,
-        onDownloadAssetExternallyClicked = conversationMessagesViewModel::downloadAssetExternally,
-        onOpenAssetClicked = conversationMessagesViewModel::downloadAndOpenAsset,
         onImageFullScreenMode = { message, isSelfMessage ->
             messageComposerViewModel.navigateToGallery(message.messageHeader.messageId, isSelfMessage)
             conversationMessagesViewModel.updateImageOnFullscreenMode(message)
@@ -296,8 +294,6 @@ private fun ConversationScreen(
     onAudioClick: (String) -> Unit,
     onChangeAudioPosition: (String, Int) -> Unit,
     onAssetItemClicked: (String) -> Unit,
-    onDownloadAssetExternallyClicked: (String) -> Unit,
-    onOpenAssetClicked: (String) -> Unit,
     onImageFullScreenMode: (UIMessage, Boolean) -> Unit,
     onOpenOngoingCallScreen: () -> Unit,
     onStartCall: () -> Unit,
@@ -645,8 +641,6 @@ fun PreviewConversationScreen() {
         onDeleteMessage = { _, _ -> },
         onSendAttachment = { },
         onAssetItemClicked = { },
-        onOpenAssetClicked = { _ -> },
-        onDownloadAssetExternallyClicked = { _ -> },
         onImageFullScreenMode = { _, _ -> },
         onOpenOngoingCallScreen = { },
         onStartCall = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
@@ -21,13 +21,13 @@
 package com.wire.android.ui.home.conversations
 
 import com.wire.android.model.ImageAsset.UserAvatarAsset
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
-import okio.Path
 import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
 data class ConversationViewState(
@@ -44,13 +44,13 @@ sealed class ConversationAvatar {
 
 sealed class DownloadedAssetDialogVisibilityState {
     object Hidden : DownloadedAssetDialogVisibilityState()
-    data class Displayed(val assetName: String, val assetDataPath: Path, val assetSize: Long, val messageId: String) :
-        DownloadedAssetDialogVisibilityState()
+    data class Displayed(val assetData: AssetBundle, val messageId: String) : DownloadedAssetDialogVisibilityState()
 }
 
 sealed class ConversationDetailsData {
     object None : ConversationDetailsData()
     data class OneOne(val otherUserId: UserId, val connectionState: ConnectionState, val isBlocked: Boolean, val isDeleted: Boolean) :
         ConversationDetailsData()
+
     data class Group(val conversationId: QualifiedID) : ConversationDetailsData()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -27,23 +27,20 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.util.permission.rememberWriteStorageRequestFlow
-import okio.Path
 
 @Composable
 fun DownloadedAssetDialog(
     downloadedAssetDialogState: DownloadedAssetDialogVisibilityState,
-    onSaveFileToExternalStorage: (String, Path, Long, String) -> Unit,
-    onOpenFileWithExternalApp: (Path, String?) -> Unit,
+    onSaveFileToExternalStorage: (String) -> Unit,
+    onOpenFileWithExternalApp: (String) -> Unit,
     hideOnAssetDownloadedDialog: () -> Unit
 ) {
     if (downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed) {
-        val assetName = downloadedAssetDialogState.assetName
-        val assetDataPath = downloadedAssetDialogState.assetDataPath
-        val assetSize = downloadedAssetDialogState.assetSize
+        val assetName = downloadedAssetDialogState.assetData.fileName
         val messageId = downloadedAssetDialogState.messageId
 
         val onSaveFileWriteStorageRequest = rememberWriteStorageRequestFlow(
-            onGranted = { onSaveFileToExternalStorage(assetName, assetDataPath, assetSize, messageId) },
+            onGranted = { onSaveFileToExternalStorage(messageId) },
             onDenied = { /** TODO: Show a dialog rationale explaining why the permission is needed **/ }
         )
 
@@ -55,7 +52,7 @@ fun DownloadedAssetDialog(
             optionButton2Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_open_text),
                 type = WireDialogButtonType.Primary,
-                onClick = { onOpenFileWithExternalApp(assetDataPath, assetName) }
+                onClick = { onOpenFileWithExternalApp(messageId) }
             ),
             optionButton1Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_save_text),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -285,7 +285,9 @@ class MessageComposerViewModel @Inject constructor(
                             }
                         }
 
-                        AttachmentType.AUDIO -> TODO()
+                        AttachmentType.AUDIO -> {
+                            // TODO()
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -49,7 +49,7 @@ import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.Error
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
-import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.messagecomposer.UiMention
@@ -230,11 +230,11 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     @Suppress("MagicNumber")
-    fun sendAttachmentMessage(attachmentBundle: AttachmentBundle?) {
+    fun sendAttachmentMessage(attachmentBundle: AssetBundle?) {
         viewModelScope.launch {
             withContext(dispatchers.io()) {
                 attachmentBundle?.run {
-                    when (attachmentType) {
+                    when (assetType) {
                         AttachmentType.IMAGE -> {
                             if (dataSize > getAssetSizeLimit(isImage = true)) onSnackbarMessage(ErrorMaxImageSize)
                             else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -111,14 +111,14 @@ fun EditMessageMenuItems(
     val onDownloadAssetClick = remember(message) {
         {
             hideEditMessageMenu {
-                onDownloadAsset(message.messageHeader.messageId)
+                onDownloadAsset(message.header.messageId)
             }
         }
     }
     val onOpenAssetClick = remember(message) {
         {
             hideEditMessageMenu {
-                onOpenAsset(message.messageHeader.messageId)
+                onOpenAsset(message.header.messageId)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -111,7 +111,7 @@ fun EditMessageMenuItems(
     val onDownloadAssetClick = remember(message) {
         {
             hideEditMessageMenu {
-                onDownloadAsset(message.messageHeader.messageId,)
+                onDownloadAsset(message.messageHeader.messageId)
             }
         }
     }
@@ -142,8 +142,8 @@ fun EditMessageMenuItems(
                 }
             }
             add { ReplyMessageOption(onReplyItemClick) }
-            if (isAssetMessage) { DownloadAssetExternallyOption(onDownloadAssetClick) }
-            if (isGenericAsset) { OpenAssetExternallyOption(onOpenAssetClick) }
+            if (isAssetMessage) add { DownloadAssetExternallyOption(onDownloadAssetClick) }
+            if (isGenericAsset) add { OpenAssetExternallyOption(onOpenAssetClick) }
             if (isEditable) {
                 add {
                     MenuBottomSheetItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+import com.wire.android.ui.edit.DownloadAssetExternallyOption
 import com.wire.android.ui.edit.MessageDetailsMenuOption
+import com.wire.android.ui.edit.OpenAssetExternallyOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -48,6 +50,8 @@ fun EditMessageMenuItems(
     onDetailsClick: (messageId: String, isMyMessage: Boolean) -> Unit,
     onEditClick: (messageId: String, originalText: String) -> Unit,
     onShareAsset: () -> Unit,
+    onDownloadAsset: (messageId: String) -> Unit,
+    onOpenAsset: (messageId: String) -> Unit,
 ): List<@Composable () -> Unit> {
     val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
     val localContext = LocalContext.current
@@ -57,6 +61,7 @@ fun EditMessageMenuItems(
             || message.messageContent is UIMessageContent.ImageMessage
             || message.messageContent is UIMessageContent.AudioAssetMessage
     val isEditable = message.isTextMessage && message.isMyMessage && localFeatureVisibilityFlags.MessageEditIcon
+    val isGenericAsset = message.messageContent is UIMessageContent.AssetMessage
 
     val onCopyItemClick = remember(message) {
         {
@@ -103,6 +108,20 @@ fun EditMessageMenuItems(
             }
         }
     }
+    val onDownloadAssetClick = remember(message) {
+        {
+            hideEditMessageMenu {
+                onDownloadAsset(message.messageHeader.messageId,)
+            }
+        }
+    }
+    val onOpenAssetClick = remember(message) {
+        {
+            hideEditMessageMenu {
+                onOpenAsset(message.messageHeader.messageId)
+            }
+        }
+    }
 
     return buildList {
         if (isAvailable) {
@@ -123,6 +142,8 @@ fun EditMessageMenuItems(
                 }
             }
             add { ReplyMessageOption(onReplyItemClick) }
+            if (isAssetMessage) { DownloadAssetExternallyOption(onDownloadAssetClick) }
+            if (isGenericAsset) { OpenAssetExternallyOption(onOpenAssetClick) }
             if (isEditable) {
                 add {
                     MenuBottomSheetItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
@@ -25,18 +25,18 @@ import com.wire.kalium.logic.data.asset.isDisplayableImageMimeType
 import okio.Path
 
 /**
- * Represents an attachment part of a message to be sent
+ * Represents a set of metadata information of an asset message
  */
-data class AttachmentBundle(
+data class AssetBundle(
     val mimeType: String,
     val dataPath: Path,
     val dataSize: Long,
     val fileName: String,
-    val attachmentType: AttachmentType
+    val assetType: AttachmentType
 )
 
 enum class AttachmentType {
-    // TODO: Add audio or video later on
+    // TODO: Add video or any other sort of specific asset type later on
     IMAGE, GENERIC_FILE, AUDIO;
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -48,6 +48,7 @@ import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
+import com.wire.android.ui.edit.DownloadAssetExternallyOption
 import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
@@ -190,19 +191,8 @@ fun EditGalleryMenuItems(
         add { ReactionOption(onReactionClick = onReactionClick) }
         add { MessageDetailsMenuOption(onMessageDetailsClick = onMessageDetails) }
         add { ReplyMessageOption(onReplyItemClick = onImageReplied) }
+        add { DownloadAssetExternallyOption(onDownloadClick = onDownloadImage) }
         add {
-            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
-                MenuBottomSheetItem(
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_download,
-                            contentDescription = stringResource(R.string.content_description_download_icon),
-                        )
-                    },
-                    title = stringResource(R.string.label_download),
-                    onItemClick = onDownloadImage
-                )
-            }
             CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
                 MenuBottomSheetItem(
                     icon = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -57,7 +57,7 @@ import com.wire.android.ui.common.KeyboardHelper
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.mention.MemberItemToMention
-import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptions
@@ -73,7 +73,7 @@ fun MessageComposer(
     messageContent: @Composable () -> Unit,
     onSendTextMessage: (String, List<UiMention>, messageId: String?) -> Unit,
     onSendEditTextMessage: (EditMessageBundle) -> Unit,
-    onSendAttachment: (AttachmentBundle?) -> Unit,
+    onSendAttachment: (AssetBundle?) -> Unit,
     onMentionMember: (String?) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
     isFileSharingEnabled: Boolean,
@@ -117,7 +117,7 @@ fun MessageComposer(
         }
 
         val onSendAttachmentClicked = remember {
-            { attachmentBundle: AttachmentBundle? ->
+            { attachmentBundle: AssetBundle? ->
                 onSendAttachment(attachmentBundle)
                 messageComposerState.hideAttachmentOptions()
             }
@@ -165,7 +165,7 @@ private fun MessageComposer(
     interactionAvailability: InteractionAvailability,
     membersToMention: List<Contact>,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
-    onSendAttachmentClicked: (AttachmentBundle?) -> Unit,
+    onSendAttachmentClicked: (AssetBundle?) -> Unit,
     securityClassificationType: SecurityClassificationType,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.appLogger
-import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.QuotedMessageUIData
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -379,7 +379,7 @@ class AttachmentInnerState(val context: Context) {
             } else {
                 fileManager.copyToTempPath(attachmentUri, fullTempAssetPath)
             }
-            val attachment = AttachmentBundle(mimeType, fullTempAssetPath, assetSize, assetFileName, attachmentType)
+            val attachment = AssetBundle(mimeType, fullTempAssetPath, assetSize, assetFileName, attachmentType)
             AttachmentState.Picked(attachment)
         } catch (e: IOException) {
             appLogger.e("There was an error while obtaining the file from disk", e)
@@ -461,6 +461,6 @@ sealed class MessageComposeInputType {
 
 sealed class AttachmentState {
     object NotPicked : AttachmentState()
-    class Picked(val attachmentBundle: AttachmentBundle) : AttachmentState()
+    class Picked(val attachmentBundle: AssetBundle) : AttachmentState()
     object Error : AttachmentState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -49,7 +49,7 @@ import com.wire.android.ui.common.AttachmentButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorPickingAttachment
-import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.messagecomposer.AttachmentInnerState
 import com.wire.android.ui.home.messagecomposer.AttachmentState
 import com.wire.android.ui.theme.wireColorScheme
@@ -69,7 +69,7 @@ import okio.Path.Companion.toPath
 @Composable
 fun AttachmentOptions(
     attachmentInnerState: AttachmentInnerState,
-    onSendAttachment: (AttachmentBundle?) -> Unit,
+    onSendAttachment: (AssetBundle?) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
@@ -96,7 +96,7 @@ fun AttachmentOptions(
 @Composable
 private fun AttachmentOptionsComponent(
     attachmentInnerState: AttachmentInnerState,
-    onSendAttachment: (AttachmentBundle?) -> Unit,
+    onSendAttachment: (AssetBundle?) -> Unit,
     onError: (ConversationSnackbarMessages) -> Unit,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
@@ -158,7 +158,7 @@ private fun calculateGridParams(minPadding: Dp, minColumnWidth: Dp, fullWidth: D
 @Composable
 private fun configureStateHandling(
     attachmentInnerState: AttachmentInnerState,
-    onSendAttachment: (AttachmentBundle?) -> Unit,
+    onSendAttachment: (AssetBundle?) -> Unit,
     onError: (ConversationSnackbarMessages) -> Unit
 ) {
     when (val state = attachmentInnerState.attachmentState) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -547,16 +547,14 @@
     <item quantity="one">1 Person wurde aus der Unterhaltung entfernt</item>
     <item quantity="other">%1$d Personen wurden aus der Unterhaltung entfernt</item>
   </plurals>
-  <string name="last_message_self_user_shared_asset">haben eine Mediendatei geteilt</string>
-  <string name="last_message_other_user_shared_asset">hat eine Mediendatei geteilt</string>
+  <string name="last_message_self_user_shared_asset">haben eine Datei geteilt</string>
+  <string name="last_message_other_user_shared_asset">hat eine Datei geteilt</string>
   <string name="last_message_self_user_shared_image">haben ein Bild geteilt.</string>
   <string name="last_message_other_user_shared_image">hat ein Bild geteilt.</string>
   <string name="last_message_self_user_shared_video">haben ein Video geteilt.</string>
   <string name="last_message_other_user_shared_video">hat ein Video geteilt.</string>
   <string name="last_message_self_user_shared_audio">haben eine Audionachricht geteilt.</string>
   <string name="last_message_other_user_shared_audio">hat eine Audionachricht geteilt.</string>
-  <string name="last_message_self_user_shared_file">haben eine Datei geteilt.</string>
-  <string name="last_message_other_user_shared_file">hat eine Datei geteilt.</string>
   <string name="last_message_self_user_knock">haben gepingt.</string>
   <string name="last_message_other_user_knock">hat gepingt.</string>
   <string name="last_message_call">hat angerufen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="label_update">Update</string>
     <string name="label_close">Close</string>
     <string name="label_download">Download</string>
+    <string name="label_open_asset_externally">Open</string>
     <string name="label_show">Show</string>
     <string name="label_show_all">Show All</string>
     <string name="label_show_less">Show Less</string>
@@ -78,6 +79,7 @@
     <string name="content_description_muted_conversation">Muted conversation</string>
     <string name="content_description_check">Check mark</string>
     <string name="content_description_download_icon">Download icon</string>
+    <string name="content_description_open_asset_icon">Open icon</string>
     <string name="content_description_add_to_favourite">Add to Favorites</string>
     <string name="content_description_move_to_folder">Move to folder</string>
     <string name="content_description_move_to_archive">Move to archive</string>
@@ -559,16 +561,14 @@
         <item quantity="one">1 person was removed from the conversation</item>
         <item quantity="other">%1$d people were removed from the conversation</item>
     </plurals>
-    <string name="last_message_self_user_shared_asset">shared media asset</string>
-    <string name="last_message_other_user_shared_asset">shared media asset</string>
+    <string name="last_message_self_user_shared_asset">shared a file.</string>
+    <string name="last_message_other_user_shared_asset">shared a file.</string>
     <string name="last_message_self_user_shared_image">shared an image.</string>
     <string name="last_message_other_user_shared_image">shared an image.</string>
     <string name="last_message_self_user_shared_video">shared a video.</string>
     <string name="last_message_other_user_shared_video">shared a video.</string>
     <string name="last_message_self_user_shared_audio">shared an audio message.</string>
     <string name="last_message_other_user_shared_audio">shared an audio message.</string>
-    <string name="last_message_self_user_shared_file">shared a file.</string>
-    <string name="last_message_other_user_shared_file">shared a file.</string>
     <string name="last_message_self_user_knock">pinged.</string>
     <string name="last_message_other_user_knock">pinged.</string>
     <string name="last_message_call">called.</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -72,6 +72,15 @@ object TestMessage {
         Message.UploadStatus.NOT_UPLOADED,
         Message.DownloadStatus.NOT_DOWNLOADED
     )
+    val GENERIC_ASSET_CONTENT = AssetContent(
+        0L,
+        "name",
+        "application/zip",
+        null,
+        DUMMY_ASSET_REMOTE_DATA,
+        Message.UploadStatus.NOT_UPLOADED,
+        Message.DownloadStatus.NOT_DOWNLOADED
+    )
     val ASSET_MESSAGE = Message.Regular(
         id = "messageID",
         content = MessageContent.Asset(ASSET_IMAGE_CONTENT),

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companio
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.IMAGE_SIZE_LIMIT_BYTES
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
-import com.wire.android.ui.home.conversations.model.AttachmentBundle
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.kalium.logic.data.team.Team
 import io.mockk.coVerify
@@ -155,7 +155,7 @@ class MessageComposerViewModelTest {
             .withSuccessfulSendAttachmentMessage()
             .withGetAssetSizeLimitUseCase(false, 25000000)
             .arrange()
-        val mockedAttachment = AttachmentBundle(
+        val mockedAttachment = AssetBundle(
             "file/x-zip", "Mocked-data-path".toPath(), 1L, "mocked_file.zip", AttachmentType.GENERIC_FILE
         )
 
@@ -179,7 +179,7 @@ class MessageComposerViewModelTest {
             .withSuccessfulSendAttachmentMessage()
             .withGetAssetSizeLimitUseCase(true, 15000000)
             .arrange()
-        val mockedAttachment = AttachmentBundle(
+        val mockedAttachment = AssetBundle(
             "image/jpeg", assetPath, assetSize, assetName, AttachmentType.IMAGE
         )
 
@@ -213,7 +213,7 @@ class MessageComposerViewModelTest {
             .withSuccessfulSendAttachmentMessage()
             .withGetAssetSizeLimitUseCase(true, 15000000)
             .arrange()
-        val mockedAttachment = AttachmentBundle(
+        val mockedAttachment = AssetBundle(
             "image/jpeg", "some-data-path".toPath(), IMAGE_SIZE_LIMIT_BYTES + 1L, "mocked_image.jpeg", AttachmentType.IMAGE
         )
 
@@ -236,7 +236,7 @@ class MessageComposerViewModelTest {
                 .withSuccessfulSendAttachmentMessage()
                 .withGetAssetSizeLimitUseCase(false, 15000000)
                 .arrange()
-            val mockedAttachment = AttachmentBundle(
+            val mockedAttachment = AssetBundle(
                 "file/x-zip",
                 "some-data-path".toPath(),
                 ASSET_SIZE_DEFAULT_LIMIT_BYTES + 1L,
@@ -264,7 +264,7 @@ class MessageComposerViewModelTest {
             .withGetAssetSizeLimitUseCase(false, 100000000)
             .withTeamUser(userTeam)
             .arrange()
-        val mockedAttachment = AttachmentBundle(
+        val mockedAttachment = AssetBundle(
             "file/x-zip", "some-data-path".toPath(), ASSET_SIZE_DEFAULT_LIMIT_BYTES + 1L, "mocked_asset.jpeg", AttachmentType.GENERIC_FILE
         )
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -51,7 +51,7 @@ class ConversationMessagesViewModelTest {
             .withGetMessageByIdReturning(message)
             .arrange()
 
-        viewModel.downloadOrFetchAssetToInternalStorage(message.id)
+        viewModel.downloadOrFetchAssetAndShowDialog(message.id)
 
         coVerify(exactly = 1) { arrangement.getMessageById(arrangement.conversationId, message.id) }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -25,13 +25,15 @@ import androidx.paging.map
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.TestMessage
+import com.wire.android.framework.TestMessage.GENERIC_ASSET_CONTENT
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState
 import com.wire.android.ui.home.conversations.mockUITextMessage
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.util.fileExtension
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import org.amshove.kluent.shouldBeEqualTo
@@ -47,6 +49,7 @@ class ConversationMessagesViewModelTest {
     fun `given an message ID, when downloading or fetching into internal storage, then should get message details by ID`() = runTest {
         val message = TestMessage.ASSET_MESSAGE
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withObservableAudioMessagesState(flowOf())
             .withGetMessageAssetUseCaseReturning("path".toPath(), 42L)
             .withGetMessageByIdReturning(message)
             .arrange()
@@ -62,13 +65,22 @@ class ConversationMessagesViewModelTest {
         val messageId = "mocked-msg-id"
         val assetName = "mocked-asset-name.zip"
         val assetDataPath = "asset-data-path".toPath()
+        val assetMimeType = "application/zip"
+        val assetSize = 8192L
+        val message = TestMessage.ASSET_MESSAGE.copy(
+            id = messageId,
+            content = MessageContent.Asset(GENERIC_ASSET_CONTENT.copy(name = assetName, mimeType = assetMimeType, sizeInBytes = assetSize))
+        )
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
-            .withSuccessfulOpenAssetMessage(assetName, assetDataPath, 1L, messageId)
+            .withGetMessageByIdReturning(message)
+            .withObservableAudioMessagesState(flowOf())
+            .withGetMessageAssetUseCaseReturning(assetDataPath, assetSize)
+            .withSuccessfulOpenAssetMessage(assetMimeType, assetName, assetDataPath, assetSize, messageId)
             .arrange()
 
         // When
         assert(viewModel.conversationViewState.downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed)
-        viewModel.onOpenFileWithExternalApp(assetDataPath, assetName.fileExtension())
+        viewModel.downloadAndOpenAsset(messageId)
 
         // Then
         verify(exactly = 1) { arrangement.fileManager.openWithExternalApp(any(), any(), any()) }
@@ -81,14 +93,23 @@ class ConversationMessagesViewModelTest {
             // Given
             val messageId = "mocked-msg-id"
             val assetName = "mocked-asset-name.zip"
-            val assetDataPath = "asset-data-path".toPath()
+            val dataPath = "asset-data-path".toPath()
+            val mimeType = "application/zip"
+            val assetSize = 42L
+            val message = TestMessage.ASSET_MESSAGE.copy(
+                id = messageId,
+                content = MessageContent.Asset(GENERIC_ASSET_CONTENT.copy(name = assetName, mimeType = mimeType, sizeInBytes = assetSize))
+            )
             val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
-                .withSuccessfulSaveAssetMessage(assetName, assetDataPath, 1L, messageId)
+                .withObservableAudioMessagesState(flowOf())
+                .withGetMessageByIdReturning(message)
+                .withGetMessageAssetUseCaseReturning(dataPath, assetSize)
+                .withSuccessfulSaveAssetMessage(mimeType, assetName, dataPath, assetSize, messageId)
                 .arrange()
 
             // When
             assert(viewModel.conversationViewState.downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed)
-            viewModel.onSaveFile(assetName, assetDataPath, 1L, messageId)
+            viewModel.downloadAssetExternally(messageId)
 
             // Then
             coVerify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any(), any(), any()) }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3180" title="AR-3180" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3180</a>  Align assets context menus from conversation view and gallery view have the same options (follow-up to AR-3008)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, if a user wanted to open or download an image or generic asset, we had to either click on the image and download it from the `GalleryScreen` or click on the placeholder, and then decide whether to open or save externally that asset from a dialog. For audio messages, we had no way to download it externally.

### Solutions

- I added 2 new contextual menu options depending on the type of asset that we are long tapping (image, audio or generic asset).
- I also refactored the way that we have to download and open assets externally inside the `ConversationMessagesViewModel` class


### Dependencies (Optional)

Needs releases with:

- [x] GitHub link to other pull request
- https://github.com/wireapp/kalium/pull/1608

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)

https://user-images.githubusercontent.com/2468164/228590501-e143bb13-1f07-4dbe-80d0-5bbaf13f09c3.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
