### PR TITLE
fix: serialization of sync requests qualified ids (SQPIT-1614)

### DIFF
--- a/zmessaging/src/test/scala/com/waz/model/sync/SyncRequestSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/sync/SyncRequestSpec.scala
@@ -1,0 +1,115 @@
+package com.waz.model.sync
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.model.sync.SyncRequest._
+import com.waz.model.sync._
+import com.waz.model.{ConversationRole, ConvId, QualifiedId, UserId}
+import org.json.JSONObject
+
+class SyncRequestSpec extends AndroidFreeSpec {
+
+  private val testUserId = "asd"
+  private val testDomain = "123"
+  private val testSetOfIds = Set[QualifiedId](QualifiedId(UserId(testUserId), testDomain))
+
+  feature("SyncClientsBatch (de)serialization") {
+
+    val sampleJson = s"""{"cmd":"sync-user-clients-batch","qualified_ids":[{"id":"$testUserId","domain":"$testDomain"}]}"""
+
+    scenario("Serializing a request") {
+      SyncRequest.Encoder(SyncClientsBatch(testSetOfIds)).toString shouldEqual sampleJson
+    }
+
+    scenario("Deserializing a request") {
+      val jsonObject = new JSONObject(sampleJson)
+
+      SyncRequest.Decoder(jsonObject) shouldEqual SyncClientsBatch(testSetOfIds)
+    }
+
+    scenario("Serializing and Deserializing should match original value") {
+      val request = SyncClientsBatch(testSetOfIds)
+      val serialized = SyncRequest.Encoder(request).toString
+
+      val deserialized = SyncRequest.Decoder(new JSONObject(serialized))
+
+      deserialized shouldEqual request
+    }
+  }
+
+  feature("SyncQualifiedUsers (de)serialization") {
+
+    val sampleJson = s"""{"cmd":"sync-qualified-users","qualified_ids":[{"id":"$testUserId","domain":"$testDomain"}]}"""
+
+    scenario("Serializing a request") {
+      SyncRequest.Encoder(SyncQualifiedUsers(testSetOfIds)).toString shouldEqual sampleJson
+    }
+
+    scenario("Deserializing a request") {
+      val jsonObject = new JSONObject(sampleJson)
+
+      SyncRequest.Decoder(jsonObject) shouldEqual SyncQualifiedUsers(testSetOfIds)
+    }
+
+    scenario("Serializing and Deserializing should match original value") {
+      val request = SyncQualifiedUsers(testSetOfIds)
+      val serialized = SyncRequest.Encoder(request).toString
+
+      val deserialized = SyncRequest.Decoder(new JSONObject(serialized))
+
+      deserialized shouldEqual request
+    }
+  }
+
+  feature("SyncQualifiedSearchResults (de)serialization") {
+
+    val sampleJson = s"""{"cmd":"sync-qualified-search-results","qualified_ids":[{"id":"$testUserId","domain":"$testDomain"}]}"""
+
+    scenario("Serializing a request") {
+      SyncRequest.Encoder(SyncQualifiedSearchResults(testSetOfIds)).toString shouldEqual sampleJson
+    }
+
+    scenario("Deserializing a request") {
+      val jsonObject = new JSONObject(sampleJson)
+
+      SyncRequest.Decoder(jsonObject) shouldEqual SyncQualifiedSearchResults(testSetOfIds)
+    }
+
+    scenario("Serializing and Deserializing should match original value") {
+      val request = SyncQualifiedSearchResults(testSetOfIds)
+      val serialized = SyncRequest.Encoder(request).toString
+
+      val deserialized = SyncRequest.Decoder(new JSONObject(serialized))
+
+      deserialized shouldEqual request
+    }
+  }
+
+  feature("PostQualifiedConvJoin (de)serialization") {
+
+    val testConversationRole = ConversationRole.AdminRole
+    val testConvId = ConvId("123")
+
+    val sampleJson =
+      s"""{"cmd":"post-qualified-conv-join","conv":"${testConvId.str}","users":[{"id":"$testUserId","domain":"$testDomain"}],"conversation_role":"${testConversationRole.label}"}"""
+
+    scenario("Serializing a request") {
+      SyncRequest.Encoder(PostQualifiedConvJoin(testConvId, testSetOfIds, testConversationRole)).toString shouldEqual sampleJson
+    }
+
+    scenario("Deserializing a request") {
+      val jsonObject = new JSONObject(sampleJson)
+
+      SyncRequest.Decoder(jsonObject) shouldEqual PostQualifiedConvJoin(testConvId, testSetOfIds, testConversationRole)
+    }
+
+    scenario("Serializing and Deserializing should match original value") {
+      val request = PostQualifiedConvJoin(testConvId, testSetOfIds, testConversationRole)
+      val serialized = SyncRequest.Encoder(request).toString
+
+      val deserialized = SyncRequest.Decoder(new JSONObject(serialized))
+
+      deserialized shouldEqual request
+    }
+  }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-1614" title="SQPIT-1614" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQPIT-1614</a>  Android Scala: Sending messages not possible and sync banner always shows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When attempting to deserialize some `SyncRequests`, an error similar to this one would show up:

```
Error `org.json.JSONException: Value Set({"id":"asd","domain":"123"}) at qualified_ids of type 
java.lang.String cannot be converted to JSONArray` when decoding sync job json: 
{"cmd":"sync-user-clients-batch","qualified_ids":"Set({\"id\":\"asd\",\"domain\":\"123\"})"}
```

Thank you @e-lisa and @marcoconti83 for the detective work, log collection and processing which led to this find.

### Causes

When serialising sets of qualified ids, instead of mapping to a JSONArray, it was just adding the set to the JSONObject, causing it to serialise using `obj.toString()`.

### Implications

This would also result in a `SyncRequest` of `Unknown` type, as a JSONException would be thrown, as seen [on this line](https://github.com/wireapp/wire-android/blob/4fd07c298d71ad067519b2f21c177019ef57b3c7/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala#L564).

Following the flow, the [`SyncHandler` would return a `Failure`](https://github.com/wireapp/wire-android/blob/0e0b3eb6cc0b906599f5d1d9ed7cdb0031eae3d5/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala#L374) when asked to handle this "`Unknown`" event.

Which would trigger [the "Failed permanently with error" log message](https://github.com/wireapp/wire-android/blob/4fd07c298d71ad067519b2f21c177019ef57b3c7/app/src/main/scala/com/waz/background/WorkManagerSyncRequestService.scala#L233).

Not completely sure of the implications of this failure to the lifecycle of the application after this, but I can keep digging if needed.

In any case, this is definitely a failure that needs handling.

### Solutions

Map the `set` of `QualifiedId` to a `JSONArray`, and then append this `JSONArray` to the desired `JSONObject` when serialising.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
