### PR TITLE
fix(rc): federated user data is not refreshed (AR-3249)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -188,7 +188,7 @@ fun OtherProfileScreenContent(
         derivedStateOf {
             listOfNotNull(
                 state.groupState?.let { OtherUserProfileTabItem.GROUP },
-                OtherUserProfileTabItem.DETAILS,
+                state.hasValidDetailsInformation().let { hasInfo -> if (hasInfo) OtherUserProfileTabItem.DETAILS else null },
                 OtherUserProfileTabItem.DEVICES
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -60,6 +60,12 @@ data class OtherUserProfileState(
         } ?: this
     }
 
+    /**
+     * This serves the purpose to hide the details tab in case there is no data to show.
+     * Ie. Public users don't have email for privacy reasons, so no need to show the tab.
+     */
+    fun hasValidDetailsInformation() = email.isNotBlank()
+
     companion object {
         val PREVIEW = OtherUserProfileState(
             userId = UserId("some_user", "domain.com"),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3249" title="AR-3249" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3249</a>  Federation - not possible to access user data of federated user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In federated environments, data for users is not refreshed

### Causes (Optional)

We are not getting updates for names, and in case a backend is down, that info is never refreshed.
Having cases where we don't have anything to show.

### Solutions

- Work done in linked kalium PR
- Also, if we don't have data to show in the details tab, as requested by Design team.

### Dependency

https://github.com/wireapp/kalium/pull/1609

### Testing

#### Test Coverage (Optional) 

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
