### PR TITLE
fix: exit animation for ongoing call screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.navigation
 
+import androidx.compose.animation.fadeOut
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -382,7 +383,7 @@ enum class NavigationItem(
         canonicalRoute = "$ONGOING_CALL/{$EXTRA_CONVERSATION_ID}",
         content = { OngoingCallScreen() },
         screenMode = ScreenMode.WAKE_UP,
-        animationConfig = NavigationAnimationConfig.CustomAnimation(null, shrinkOutFromView())
+        animationConfig = NavigationAnimationConfig.CustomAnimation(null, fadeOut())
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String = routeWithConversationIdArg(arguments)
     },


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Use fade out animation when leaving ongoing call screen 

Before

https://user-images.githubusercontent.com/18124919/228845440-a7df92b4-7ff0-4b2a-88be-a5be42c1739d.mp4

After

https://user-images.githubusercontent.com/18124919/228845753-b96934fa-a5c5-45bb-b4a2-e4c43060e818.mp4

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
