### PR TITLE
fix: check if user is logged in after migraion error

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
@@ -145,7 +145,7 @@ class MigrationViewModel @Inject constructor(
 
     private suspend fun navigateToLogin(userHandle: String) {
         navigationManager.navigate(
-            NavigationCommand(NavigationItem.Login.getRouteWithArgs(listOf(userHandle)))
+            NavigationCommand(NavigationItem.Login.getRouteWithArgs(listOf(userHandle)), BackStackMode.CLEAR_WHOLE)
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationViewModel.kt
@@ -41,6 +41,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import com.wire.android.appLogger
+import com.wire.android.di.CurrentAccount
 import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
@@ -78,7 +79,16 @@ class MigrationViewModel @Inject constructor(
     fun accountLogin(userHandle: String) {
         viewModelScope.launch {
             migrationManager.dismissMigrationFailureNotification()
-            navigateToLogin(userHandle)
+            when (getCurrentSession()) {
+                is CurrentSessionResult.Failure.Generic,
+                CurrentSessionResult.Failure.SessionNotFound -> navigateToLogin(userHandle)
+                is CurrentSessionResult.Success -> navigationManager.navigate(
+                    NavigationCommand(
+                        NavigationItem.Home.getRouteWithArgs(),
+                        BackStackMode.CLEAR_WHOLE
+                    )
+                )
+            }
         }
     }
 
@@ -134,7 +144,8 @@ class MigrationViewModel @Inject constructor(
     }
 
     private suspend fun navigateToLogin(userHandle: String) {
-        navigationManager.navigate(NavigationCommand(NavigationItem.Login.getRouteWithArgs(listOf(userHandle)))
+        navigationManager.navigate(
+            NavigationCommand(NavigationItem.Login.getRouteWithArgs(listOf(userHandle)))
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

after the recent change to migration with crash on failure, the status screen will try to navigate to the login screen even if the user is already logged in

### Solutions

check if there is a current session before navigating to login screen

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
