### PR TITLE
fix: (RC) personal user settings group read receipt (AR-3168)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -154,6 +154,11 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     selfRole = groupDetails.selfRole
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
+                val isUpdatingReadReceiptAllowed = if (selfTeam == null) {
+                    if (groupDetails.conversation.teamId != null) isSelfAnAdmin else false
+                } else {
+                    isSelfAnAdmin
+                }
 
                 updateState(
                     groupOptionsState.value.copy(
@@ -165,7 +170,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isUpdatingAllowed = isSelfAnAdmin,
                         isUpdatingGuestAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
                         isReadReceiptAllowed = groupDetails.conversation.receiptMode == Conversation.ReceiptMode.ENABLED,
-                        isUpdatingReadReceiptAllowed = isSelfAnAdmin
+                        isUpdatingReadReceiptAllowed = isUpdatingReadReceiptAllowed
                     )
                 )
             }.collect {}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -228,7 +228,7 @@ class GroupConversationDetailsViewModelTest {
                     .apply {
                         add(Conversation.AccessRole.SERVICE)
                         remove(Conversation.AccessRole.NON_TEAM_MEMBER)
-                           },
+                    },
                 access = Conversation.defaultGroupAccess
             )
         }
@@ -365,6 +365,106 @@ class GroupConversationDetailsViewModelTest {
             )
         }
     }
+
+    @Test
+    fun `given user has no teamId and conversation no teamId, when init group options, then read receipt toggle is disabled`() = runTest {
+        // given
+        // when
+        val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = null))
+        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+            .withUpdateConversationReceiptModeReturningSuccess()
+            .withConversationDetailUpdate(details)
+            .withSelfTeamUseCaseReturns(result = null)
+            .arrange()
+
+        // then
+        assertEquals(false, viewModel.groupOptionsState.value.isUpdatingReadReceiptAllowed)
+    }
+
+    @Test
+    fun `given user has no teamId, is admin and conversation has teamId, when init group options, then read receipt toggle is enabled`() =
+        runTest {
+            // given
+            val members = buildList {
+                for (i in 1..5) {
+                    add(testUIParticipant(i))
+                }
+            }
+            val conversationParticipantsData = ConversationParticipantsData(
+                participants = members.take(GroupConversationDetailsViewModel.MAX_NUMBER_OF_PARTICIPANTS),
+                allParticipantsCount = members.size,
+                isSelfAnAdmin = true
+            )
+            val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+
+            // when
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withUpdateConversationReceiptModeReturningSuccess()
+                .withConversationDetailUpdate(details)
+                .withConversationMembersUpdate(conversationParticipantsData)
+                .withSelfTeamUseCaseReturns(result = null)
+                .arrange()
+
+            // then
+            assertEquals(true, viewModel.groupOptionsState.value.isUpdatingReadReceiptAllowed)
+        }
+
+    @Test
+    fun `given user has no teamId, not admin and conversation has teamId, when init group options, then read receipt toggle is enabled`() =
+        runTest {
+            // given
+            val members = buildList {
+                for (i in 1..5) {
+                    add(testUIParticipant(i))
+                }
+            }
+            val conversationParticipantsData = ConversationParticipantsData(
+                participants = members.take(GroupConversationDetailsViewModel.MAX_NUMBER_OF_PARTICIPANTS),
+                allParticipantsCount = members.size,
+                isSelfAnAdmin = true
+            )
+            val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+
+            // when
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withUpdateConversationReceiptModeReturningSuccess()
+                .withConversationDetailUpdate(details)
+                .withConversationMembersUpdate(conversationParticipantsData)
+                .withSelfTeamUseCaseReturns(result = null)
+                .arrange()
+
+            // then
+            assertEquals(true, viewModel.groupOptionsState.value.isUpdatingReadReceiptAllowed)
+        }
+
+    @Test
+    fun `given user has teamId, is admin and conversation teamId, when init group options, then read receipt toggle is enabled`() =
+        runTest {
+            // given
+            val members = buildList {
+                for (i in 1..5) {
+                    add(testUIParticipant(i))
+                }
+            }
+            val conversationParticipantsData = ConversationParticipantsData(
+                participants = members.take(GroupConversationDetailsViewModel.MAX_NUMBER_OF_PARTICIPANTS),
+                allParticipantsCount = members.size,
+                isSelfAnAdmin = true
+            )
+            val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+            val selfTeam = Team("team_id", "team_name", "icon")
+
+            // when
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withUpdateConversationReceiptModeReturningSuccess()
+                .withConversationDetailUpdate(details)
+                .withConversationMembersUpdate(conversationParticipantsData)
+                .withSelfTeamUseCaseReturns(result = selfTeam)
+                .arrange()
+
+            // then
+            assertEquals(true, viewModel.groupOptionsState.value.isUpdatingReadReceiptAllowed)
+        }
 
     companion object {
         val dummyConversationId = ConversationId("some-dummy-value", "some.dummy.domain")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3168" title="AR-3168" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3168</a>  PlayTest 21.02 - Read receipts -> Personal user should't change read receipt settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Personal users without a team could toggle read receipt settings in a group conversation (if they were the owner).

### Causes (Optional)

Logic was missing some things.

### Solutions

Add logic for when we should enable the toggle.
Logic is as follow:

Account contains:
- [NO TEAM][CONVERSATION NO TEAM] = toggle disabled
- [NO TEAM][CONVERSATION HAS TEAM] = toggle based if user is group admin
- [TEAM] = toggle based if user is group admin

### Testing

#### How to Test

User needs to create a group from personal account with no team and also join another group where owner of group has a team and to become the admin of the group as well, then logic should follow.
