### PR TITLE
fix: show reply message when quoted message is not available [AR-3238]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -59,6 +59,8 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.messages.QuotedMessage
+import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle
+import com.wire.android.ui.home.conversations.messages.QuotedUnavailable
 import com.wire.android.ui.home.conversations.messages.ReactionPill
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageFooter
@@ -69,6 +71,7 @@ import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.RestrictedAssetMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.RestrictedGenericFileMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.audio.AudioMessage
@@ -369,7 +372,10 @@ private fun MessageContent(
         is UIMessageContent.TextMessage -> {
             messageContent.messageBody.quotedMessage?.let {
                 VerticalSpace.x4()
-                QuotedMessage(it)
+                when (it) {
+                    is UIQuotedMessage.UIQuotedData -> QuotedMessage(it)
+                    UIQuotedMessage.UnavailableData -> QuotedUnavailable(QuotedMessageStyle.COMPLETE)
+                }
                 VerticalSpace.x4()
             }
             MessageBody(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
@@ -56,7 +57,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle.COMPLETE
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle.PREVIEW
-import com.wire.android.ui.home.conversations.model.QuotedMessageUIData
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
 
@@ -84,15 +85,15 @@ enum class QuotedMessageStyle {
 
 @Composable
 internal fun QuotedMessage(
-    messageData: QuotedMessageUIData,
+    messageData: UIQuotedMessage.UIQuotedData,
     style: QuotedMessageStyle = COMPLETE,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {}
 ) {
     when (val quotedContent = messageData.quotedContent) {
-        QuotedMessageUIData.Invalid -> QuotedInvalid(style)
+        UIQuotedMessage.UIQuotedData.Invalid -> QuotedInvalid(style)
 
-        is QuotedMessageUIData.GenericAsset -> QuotedGenericAsset(
+        is UIQuotedMessage.UIQuotedData.GenericAsset -> QuotedGenericAsset(
             senderName = messageData.senderName,
             originalDateTimeText = messageData.originalMessageDateDescription,
             assetName = quotedContent.assetName,
@@ -101,7 +102,7 @@ internal fun QuotedMessage(
             startContent = startContent
         )
 
-        is QuotedMessageUIData.DisplayableImage -> QuotedImage(
+        is UIQuotedMessage.UIQuotedData.DisplayableImage -> QuotedImage(
             senderName = messageData.senderName,
             asset = quotedContent.displayable,
             originalDateTimeText = messageData.originalMessageDateDescription,
@@ -110,14 +111,14 @@ internal fun QuotedMessage(
             startContent = startContent
         )
 
-        QuotedMessageUIData.Deleted -> QuotedDeleted(
+        UIQuotedMessage.UIQuotedData.Deleted -> QuotedDeleted(
             senderName = messageData.senderName,
             originalDateDescription = messageData.originalMessageDateDescription,
             modifier = modifier,
             style = style,
         )
 
-        is QuotedMessageUIData.Text -> QuotedText(
+        is UIQuotedMessage.UIQuotedData.Text -> QuotedText(
             text = quotedContent.value,
             editedTimeDescription = messageData.editedTimeDescription,
             originalDateTimeDescription = messageData.originalMessageDateDescription,
@@ -127,7 +128,7 @@ internal fun QuotedMessage(
             startContent = startContent
         )
 
-        is QuotedMessageUIData.AudioMessage -> QuotedAudioMessage(
+        is UIQuotedMessage.UIQuotedData.AudioMessage -> QuotedAudioMessage(
             senderName = messageData.senderName,
             originalDateTimeText = messageData.originalMessageDateDescription,
             modifier = modifier,
@@ -139,7 +140,7 @@ internal fun QuotedMessage(
 
 @Composable
 fun QuotedMessagePreview(
-    quotedMessageData: QuotedMessageUIData,
+    quotedMessageData: UIQuotedMessage.UIQuotedData,
     onCancelReply: () -> Unit
 ) {
     QuotedMessage(quotedMessageData, style = PREVIEW) {
@@ -252,7 +253,14 @@ private fun QuotedMessageTopRow(
 }
 
 @Composable
-private fun QuotedInvalid(style: QuotedMessageStyle) {
+fun QuotedUnavailable(style: QuotedMessageStyle) {
+    QuotedMessageContent(stringResource(R.string.username_unavailable_label), style = style, centerContent = {
+        MainContentText(stringResource(R.string.label_quote_invalid_or_not_found), fontStyle = FontStyle.Italic)
+    })
+}
+
+@Composable
+fun QuotedInvalid(style: QuotedMessageStyle) {
     QuotedMessageContent(null, style = style, centerContent = {
         StatusBox(stringResource(R.string.label_quote_invalid_or_not_found))
     })
@@ -379,13 +387,14 @@ fun QuotedAudioMessage(
 }
 
 @Composable
-private fun MainContentText(text: String) {
+private fun MainContentText(text: String, fontStyle: FontStyle = FontStyle.Normal) {
     Text(
         text = text,
         style = typography().subline01,
         maxLines = TEXT_QUOTE_MAX_LINES,
         overflow = TextOverflow.Ellipsis,
-        color = colorsScheme().secondaryText
+        color = colorsScheme().secondaryText,
+        fontStyle = fontStyle
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -74,13 +74,13 @@ fun PreviewMessageWithReply() {
             messageContent = UIMessageContent.TextMessage(
                 MessageBody(
                     message = UIText.DynamicString("Sure, go ahead!"),
-                    quotedMessage = QuotedMessageUIData(
+                    quotedMessage = UIQuotedMessage.UIQuotedData(
                         messageId = "asdoij",
                         senderId = previewUserId,
                         senderName = UIText.DynamicString("John Doe"),
                         originalMessageDateDescription = UIText.StringResource(R.string.label_quote_original_message_date, "10:30"),
                         editedTimeDescription = UIText.StringResource(R.string.label_message_status_edited_with_date, "10:32"),
-                        quotedContent = QuotedMessageUIData.Text("Hey, can I call right now?")
+                        quotedContent = UIQuotedMessage.UIQuotedData.Text("Hey, can I call right now?")
                     )
                 )
             )
@@ -245,4 +245,29 @@ fun PreviewMessageWithSystemMessage() {
             )
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewMessagesWithUnavailableQuotedMessage() {
+    MessageItem(
+        message = mockMessageWithText.copy(
+            messageContent = UIMessageContent.TextMessage(
+                MessageBody(
+                    message = UIText.DynamicString("Confirmed"),
+                    quotedMessage = UIQuotedMessage.UnavailableData
+                )
+            )
+        ),
+        onLongClicked = {},
+        onAssetMessageClicked = {},
+        onImageMessageClicked = { _, _ -> },
+        onOpenProfile = { _ -> },
+        onReactionClicked = { _, _ -> },
+        onResetSessionClicked = { _, _ -> },
+        onChangeAudioPosition = { _, _ -> },
+        onAudioClick = {},
+        audioMessagesState = emptyMap(),
+        onSelfDeletingMessageRead = {}
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -269,35 +269,40 @@ sealed class UIMessageContent {
 
 data class MessageBody(
     val message: UIText,
-    val quotedMessage: QuotedMessageUIData? = null
+    val quotedMessage: UIQuotedMessage? = null
 )
 
-data class QuotedMessageUIData(
-    val messageId: String,
-    val senderId: UserId,
-    val senderName: UIText,
-    val originalMessageDateDescription: UIText,
-    val editedTimeDescription: UIText?,
-    val quotedContent: Content
-) {
+sealed class UIQuotedMessage {
 
-    sealed interface Content
+    object UnavailableData : UIQuotedMessage()
 
-    data class Text(val value: String) : Content
+    data class UIQuotedData(
+        val messageId: String,
+        val senderId: UserId,
+        val senderName: UIText,
+        val originalMessageDateDescription: UIText,
+        val editedTimeDescription: UIText?,
+        val quotedContent: Content
+    ) : UIQuotedMessage() {
 
-    data class GenericAsset(
-        val assetName: String?,
-        val assetMimeType: String
-    ) : Content
+        sealed interface Content
 
-    data class DisplayableImage(
-        val displayable: ImageAsset.PrivateAsset
-    ) : Content
+        data class Text(val value: String) : Content
 
-    object AudioMessage : Content
+        data class GenericAsset(
+            val assetName: String?,
+            val assetMimeType: String
+        ) : Content
 
-    object Deleted : Content
-    object Invalid : Content
+        data class DisplayableImage(
+            val displayable: ImageAsset.PrivateAsset
+        ) : Content
+
+        object AudioMessage : Content
+
+        object Deleted : Content
+        object Invalid : Content
+    }
 }
 
 enum class MessageSource {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -40,9 +40,9 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.appLogger
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
-import com.wire.android.ui.home.conversations.model.QuotedMessageUIData
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.DEFAULT_FILE_MIME_TYPE
@@ -109,7 +109,7 @@ data class MessageComposerInnerState(
 
     var mentions by mutableStateOf(listOf<UiMention>())
 
-    var quotedMessageData: QuotedMessageUIData? by mutableStateOf(null)
+    var quotedMessageData: UIQuotedMessage.UIQuotedData? by mutableStateOf(null)
 
     fun setMessageTextValue(text: TextFieldValue) {
         updateMentionsIfNeeded(text)
@@ -146,7 +146,7 @@ data class MessageComposerInnerState(
             start = messageComposeInputState.messageText.currentMentionStartIndex(),
             length = contact.name.length + 1, // +1 cause there is an "@" before it
             userId = UserId(contact.id, contact.domain),
-            handler = String.MENTION_SYMBOL + contact.name
+            handler = String.MENTION_SYMBOL + contact.name,
         )
 
         insertMentionIntoText(mention)
@@ -301,24 +301,24 @@ data class MessageComposerInnerState(
         val authorId = uiMessage.messageHeader.userId ?: return
 
         val content = when (val content = uiMessage.messageContent) {
-            is UIMessageContent.AssetMessage -> QuotedMessageUIData.GenericAsset(
+            is UIMessageContent.AssetMessage -> UIQuotedMessage.UIQuotedData.GenericAsset(
                 assetName = content.assetName,
                 assetMimeType = content.assetExtension
             )
 
-            is UIMessageContent.RestrictedAsset -> QuotedMessageUIData.GenericAsset(
+            is UIMessageContent.RestrictedAsset -> UIQuotedMessage.UIQuotedData.GenericAsset(
                 assetName = content.assetName,
                 assetMimeType = content.mimeType
             )
 
-            is UIMessageContent.TextMessage -> QuotedMessageUIData.Text(
+            is UIMessageContent.TextMessage -> UIQuotedMessage.UIQuotedData.Text(
                 value = content.messageBody.message.asString(context.resources)
             )
 
-            is UIMessageContent.AudioAssetMessage -> QuotedMessageUIData.AudioMessage
+            is UIMessageContent.AudioAssetMessage -> UIQuotedMessage.UIQuotedData.AudioMessage
 
             is UIMessageContent.ImageMessage -> content.asset?.let {
-                QuotedMessageUIData.DisplayableImage(displayable = content.asset)
+                UIQuotedMessage.UIQuotedData.DisplayableImage(displayable = content.asset)
             }
 
             else -> {
@@ -327,7 +327,7 @@ data class MessageComposerInnerState(
             }
         }
         content?.let { quotedContent ->
-            quotedMessageData = QuotedMessageUIData(
+            quotedMessageData = UIQuotedMessage.UIQuotedData(
                 messageId = uiMessage.messageHeader.messageId,
                 senderId = authorId,
                 senderName = authorName,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -58,7 +58,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.messages.QuotedMessagePreview
-import com.wire.android.ui.home.conversations.model.QuotedMessageUIData
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
@@ -72,7 +72,7 @@ internal fun MessageComposerInput(
     interactionAvailability: InteractionAvailability,
     securityClassificationType: SecurityClassificationType,
     messageComposeInputState: MessageComposeInputState,
-    quotedMessageData: QuotedMessageUIData?,
+    quotedMessageData: UIQuotedMessage.UIQuotedData?,
     membersToMention: List<Contact>,
     actions: MessageComposerInputActions,
     inputFocusRequester: FocusRequester,
@@ -103,7 +103,7 @@ private fun EnabledMessageComposerInput(
     transition: Transition<MessageComposeInputState>,
     securityClassificationType: SecurityClassificationType,
     messageComposeInputState: MessageComposeInputState,
-    quotedMessageData: QuotedMessageUIData?,
+    quotedMessageData: UIQuotedMessage.UIQuotedData?,
     membersToMention: List<Contact>,
     actions: MessageComposerInputActions,
     inputFocusRequester: FocusRequester,
@@ -151,7 +151,7 @@ private fun EnabledMessageComposerInput(
 private fun MessageComposeInput(
     transition: Transition<MessageComposeInputState>,
     messageComposeInputState: MessageComposeInputState,
-    quotedMessageData: QuotedMessageUIData?,
+    quotedMessageData: UIQuotedMessage.UIQuotedData?,
     securityClassificationType: SecurityClassificationType,
     onSelectedLineIndexChange: (Int) -> Unit,
     onLineBottomCoordinateChange: (Float) -> Unit,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="conversations_calls_tab_title">Calls</string>
     <string name="conversations_mentions_tab_title">Mentions</string>
     <string name="sent_a_message_with_content">sent a message with %s content</string>
+    <string name="sent_a_message_with_unknown_content">sent a message with unknown content</string>
     <string name="new_group_title">New Group</string>
     <string name="new_group_description">Up to 500 people can join a group conversation.</string>
     <string name="group_name_title">Group Name</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3238" title="AR-3238" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3238</a>  Reply to a message I don't have access to, does not look like a reply anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

RC PR reference: https://github.com/wireapp/wire-android-reloaded/pull/1597