### PR TITLE
fix: camera is turned on by default after leaving and re-joing a call (AR-3194) (release)

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -244,26 +244,27 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an video call, when pauseVideo is called, then clear the video preview and update video state to PAUSED`() {
+    fun `given a video call, when stopping video, then clear Video Preview and turn off speaker`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = true)
         coEvery { setVideoPreview(any(), any()) } returns Unit
-        coEvery { updateVideoState(any(), any()) } returns Unit
+        coEvery { turnLoudSpeakerOff() } returns Unit
 
-        runTest { sharedCallingViewModel.pauseVideo() }
+        runTest { sharedCallingViewModel.stopVideo() }
 
-        coVerify(exactly = 1) { updateVideoState(any(), VideoState.PAUSED) }
+        coVerify(exactly = 1) { setVideoPreview(any(), any()) }
+        coVerify(exactly = 1) { turnLoudSpeakerOff() }
     }
 
     @Test
-    fun `given an audio call, when pauseVideo is called, then do not pause the video`() {
+    fun `given an audio call, when stopVideo is invoked, then do not do anything`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = false)
         coEvery { setVideoPreview(any(), any()) } returns Unit
-        coEvery { updateVideoState(any(), any()) } returns Unit
+        coEvery { turnLoudSpeakerOff() } returns Unit
 
-        runTest { sharedCallingViewModel.pauseVideo() }
+        runTest { sharedCallingViewModel.stopVideo() }
 
         coVerify(inverse = true) { setVideoPreview(any(), any()) }
-        coVerify(inverse = true) { updateVideoState(any(), VideoState.PAUSED) }
+        coVerify(inverse = true) { turnLoudSpeakerOff() }
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3194" title="AR-3194" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3194</a>  Video still enabled when leaving a call when video was enabled and joining it again
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Same PR as #1598 to be merged into RC branch 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
