### PR TITLE
fix: remove read messages after migration [AR-3237] develop

### DIFF
--- a/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrationManagerTest.kt
@@ -34,6 +34,7 @@ import com.wire.android.migration.feature.MigrateUsersUseCase
 import com.wire.android.migration.userDatabase.ScalaConversationData
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
@@ -133,6 +134,9 @@ class MigrationManagerTest {
         lateinit var globalDataStore: GlobalDataStore
 
         @MockK
+        lateinit var coreLogic: CoreLogic
+
+        @MockK
         lateinit var migrateServerConfigUseCase: MigrateServerConfigUseCase
 
         @MockK
@@ -166,6 +170,7 @@ class MigrationManagerTest {
         private val manager: MigrationManager by lazy {
             MigrationManager(
                 applicationContext,
+                coreLogic,
                 globalDataStore,
                 migrateServerConfigUseCase,
                 migrateActiveAccounts,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3237" title="AR-3237" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3237</a>  Conversations are being unread after migration when they were read before
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

RC reference: https://github.com/wireapp/wire-android-reloaded/pull/1581