### PR TITLE
fix(dev): banner padding issue and classified banners for calls (AR-3244)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -130,7 +130,8 @@ private fun OngoingCallContent(
         initialValue = sheetInitialValue
     ).also {
         LaunchedEffect(Unit) {
-            it.animateTo(sheetInitialValue) // same issue with expanded on other sheets, we need to use animateTo to fully expand programmatically
+            // Same issue with expanded on other sheets, we need to use animateTo to fully expand programmatically.
+            it.animateTo(sheetInitialValue)
         }
     }
 
@@ -221,7 +222,7 @@ private fun OngoingCallTopBar(
     )
 }
 
-//TODO(refactor) use CallOptionsControls to avoid duplication
+// TODO(refactor) use CallOptionsControls to avoid duplication
 @Composable
 private fun CallingControls(
     isMuted: Boolean,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -58,9 +59,10 @@ import com.wire.android.ui.calling.controlbuttons.SpeakerButton
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.participantsview.VerticalCallingPager
 import com.wire.android.ui.common.SecurityClassificationBanner
-import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.progress.WireCircularProgressIndicator
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.topappbar.CommonTopAppBar
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
 import com.wire.android.ui.common.topappbar.ConnectivityUIState
@@ -121,9 +123,17 @@ private fun OngoingCallContent(
     navigateBack: () -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit
 ) {
+
+    val sheetInitialValue =
+        if (classificationType == SecurityClassificationType.NONE) BottomSheetValue.Collapsed else BottomSheetValue.Expanded
     val sheetState = rememberBottomSheetState(
-        initialValue = if (classificationType == SecurityClassificationType.NONE) BottomSheetValue.Collapsed else BottomSheetValue.Expanded
-    )
+        initialValue = sheetInitialValue
+    ).also {
+        LaunchedEffect(Unit) {
+            it.animateTo(sheetInitialValue) // same issue with expanded on other sheets, we need to use animateTo to fully expand programmatically
+        }
+    }
+
     val scaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = sheetState
     )
@@ -251,6 +261,7 @@ private fun CallingControls(
             onHangUpButtonClicked = onHangUpCall
         )
     }
+    VerticalSpace.x8()
     SecurityClassificationBanner(classificationType)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3244" title="AR-3244" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3244</a>  Padding between classified banner and calling buttons is too small
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is no existing padding in `OngoingCallScreen` when we display the security banner.

### Solutions

Add a vertical space and use `animateTo`, to fully expand the sheet in case there is a classification security banner.

#### How to Test

Have a call in between anta, bella, chala and verify the spaced banner, added attachment to facilitate this.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
|  ![image](https://user-images.githubusercontent.com/5806454/229486989-1d62a2f7-412e-4493-ad05-a295899f0199.png) | ![banner-fix-vsnfd](https://user-images.githubusercontent.com/5806454/229487093-f951d8da-0488-40cc-9da6-73d6276deb74.png)  |


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
