### PR TITLE
fix(develop): fixed text color for both self and other users mentions [AR-3011]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
@@ -113,7 +113,7 @@ fun LinkifyText(
                     addStyle(
                         style = SpanStyle(
                             fontWeight = typography().body02.fontWeight,
-                            color = if (it.isSelfMention) onPrimaryVariant else primary,
+                            color = onPrimaryVariant,
                             background = if (it.isSelfMention) primaryVariant else Color.Unspecified
                         ),
                         start = it.start,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3011" title="AR-3011" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3011</a>  Blue colour of mentions in dark mode is different than blue of links
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Text color for mentions in dark mode was differing between self mentions and other users mentions. This PR unifies both cases.

### Attachments (Optional)
| Before | After |
| ----------- | ------------ |
|  <img width="402" alt="Captura de pantalla 2023-04-03 a las 17 59 15" src="https://user-images.githubusercontent.com/2468164/229565378-553b923c-5885-403d-a774-9c80f09b71cc.png"> |   <img width="400" alt="Captura de pantalla 2023-04-03 a las 18 01 28" src="https://user-images.githubusercontent.com/2468164/229565400-dc173f8a-4c54-4be2-a9bf-ac673f994227.png">|

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
