### PR TITLE
feat: Broadcast self availability status to others (AR-1750)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -256,7 +256,6 @@ class SelfUserProfileViewModel @Inject constructor(
 
     fun changeStatus(status: UserAvailabilityStatus) {
         setNotShowStatusRationaleAgainIfNeeded(status)
-        // TODO add the broadcast message to inform everyone about the self user new status
         viewModelScope.launch { updateStatus(status) }
         dismissStatusDialog()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1750" title="AR-1750" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1750</a>  Broadcast self user status to other users/ clients
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

Broadcast my Availability status changes to other users. 
In fact - just applying kalium changes (all the magic was done there)
