### PR TITLE
fix: disabled development api for staging environment [AR-3277]

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,7 +30,7 @@
         "logging_enabled": true,
         "safe_logging": false,
         "private_build": true,
-        "development_api_enabled": true,
+        "development_api_enabled": false,
         "mls_support_enabled": true,
         "firebasePushSenderId": "723990470614",
         "firebaseAppId": "1:723990470614:android:10cf802bfcc7bb71d28e77",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3277" title="AR-3277" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3277</a>  Username unavailable for all 1:1 conversations and conversation details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On development API (V4) there are responses with new structures which aren't handled by app.

### Causes (Optional)

Fetching users causes bug that we don't have information about users

### Solutions

Disable development api for staging
