### PR TITLE
fix: show deleted regular message [AR-3278]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -26,8 +26,8 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -61,15 +61,21 @@ class MessageContentMapper @Inject constructor(
         message: Message.Standalone,
         userList: List<User>
     ): UIMessageContent? {
-        return when (message.visibility) {
-            Message.Visibility.VISIBLE ->
-                return when (message) {
-                    is Message.Regular -> mapRegularMessage(message, userList.findUser(message.senderUserId))
-                    is Message.System -> mapSystemMessage(message, userList)
+        return when (message) {
+            is Message.Regular -> {
+                when (message.visibility) {
+                    Message.Visibility.VISIBLE -> mapRegularMessage(message, userList.findUser(message.senderUserId))
+                    Message.Visibility.DELETED -> UIMessageContent.Deleted // for deleted , there is a state label displayed only
+                    Message.Visibility.HIDDEN -> null // we don't want to show hidden message content in any way
                 }
-
-            Message.Visibility.DELETED, // for deleted, there is a state label displayed only
-            Message.Visibility.HIDDEN -> null // we don't want to show hidden nor deleted message content in any way
+            }
+            is Message.System -> {
+                when (message.visibility) {
+                    Message.Visibility.VISIBLE -> mapSystemMessage(message, userList)
+                    Message.Visibility.DELETED,
+                    Message.Visibility.HIDDEN -> null // we don't want to show hidden nor deleted message content in any way
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -37,7 +37,6 @@ import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.Visibility.HIDDEN
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
@@ -102,36 +101,26 @@ class MessageMapper @Inject constructor(
         } else {
             MessageFooter(message.id)
         }
-
-        // System messages don't have header so without the content there is nothing to be displayed.
-        // Also hidden messages should not be displayed, as well preview images
+        
         return when (content) {
             is UIMessageContent.Regular -> {
-                if (message.visibility == HIDDEN) {
-                    null
-                } else {
-                    UIMessage.Regular(
-                        messageContent = content,
-                        source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
-                        header = provideMessageHeader(sender, message),
-                        messageFooter = footer,
-                        userAvatarData = getUserAvatarData(sender),
-                        expirationStatus = provideExpirationData(message),
-                    )
-                }
+                UIMessage.Regular(
+                    messageContent = content,
+                    source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
+                    header = provideMessageHeader(sender, message),
+                    messageFooter = footer,
+                    userAvatarData = getUserAvatarData(sender),
+                    expirationStatus = provideExpirationData(message),
+                )
             }
             is UIMessageContent.SystemMessage ->
-                if (message.visibility == HIDDEN) {
-                    null
-                } else {
-                    UIMessage.System(
-                        messageContent = content,
-                        source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
-                        header = provideMessageHeader(sender, message),
-                    )
-                }
+                UIMessage.System(
+                    messageContent = content,
+                    source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
+                    header = provideMessageHeader(sender, message),
+                )
             null -> null
-            UIMessageContent.PreviewAssetMessage -> null
+            UIMessageContent.PreviewAssetMessage -> null // Preview images messages should not be displayed
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -101,7 +101,7 @@ class MessageMapper @Inject constructor(
         } else {
             MessageFooter(message.id)
         }
-        
+
         return when (content) {
             is UIMessageContent.Regular -> {
                 UIMessage.Regular(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -428,7 +428,7 @@ private fun MessageContent(
                 onAudioMessageLongClick = onLongClick
             )
         }
-
+        UIMessageContent.Deleted -> {}
         is UIMessageContent.SystemMessage.MemberAdded -> {}
         is UIMessageContent.SystemMessage.MemberJoined -> {}
         is UIMessageContent.SystemMessage.MemberLeft -> {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -165,6 +165,8 @@ sealed class UIMessageContent {
 
     data class TextMessage(val messageBody: MessageBody) : Regular()
 
+    object Deleted : Regular()
+
     data class RestrictedAsset(
         val mimeType: String,
         val assetSizeInBytes: Long,

--- a/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/EncodedMessageContentMapperTest.kt
@@ -28,6 +28,7 @@ import com.wire.android.framework.TestConversation
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestMessage.buildAssetMessage
 import com.wire.android.framework.TestUser
+import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIMessageContent.AssetMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent.PreviewAssetMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent.SystemMessage
@@ -304,7 +305,7 @@ class EncodedMessageContentMapperTest {
         val resultContentHidden = mapper.fromMessage(hiddenMessage, listOf())
         // Then
         assertTrue(resultContentVisible != null)
-        assertTrue(resultContentDeleted == null)
+        assertTrue(resultContentDeleted == UIMessageContent.Deleted)
         assertTrue(resultContentHidden == null)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3278" title="AR-3278" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3278</a>  Deleted label not visible anymore, instead message is gone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Regular messages with null content and delete visibility was ignored to show on messages list

### Causes (Optional)

Deleted messages was not showing on conversation screen

### Solutions

We were checking twice message visibility in mappers so I changed it to have it in one place and added new content type for regular message to make it more readable
