### PR TITLE
fix(dev): federation classified banner displayed after leaving or user deleted (AR-3264)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/BlockedUserComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/BlockedUserComposerInput.kt
@@ -40,9 +40,10 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.stringWithStyledArgs
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 @Composable
-fun BlockedUserComposerInput() {
+fun BlockedUserComposerInput(securityClassificationType: SecurityClassificationType) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -74,4 +75,5 @@ fun BlockedUserComposerInput() {
                 .padding(start = dimensions().spacing16x)
         )
     }
+    MessageComposerClassifiedBanner(securityClassificationType = securityClassificationType)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/DeletedUserComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/DeletedUserComposerInput.kt
@@ -39,9 +39,10 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.stringWithStyledArgs
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 @Composable
-fun DeletedUserComposerInput() {
+fun DeletedUserComposerInput(securityClassificationType: SecurityClassificationType) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -72,4 +73,5 @@ fun DeletedUserComposerInput() {
                 .padding(start = dimensions().spacing16x)
         )
     }
+    MessageComposerClassifiedBanner(securityClassificationType = securityClassificationType)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
@@ -21,9 +21,8 @@
 package com.wire.android.ui.home.messagecomposer
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -41,18 +40,15 @@ fun MessageComposerClassifiedBanner(
 ) {
     val isClassifiedConversation = securityClassificationType != SecurityClassificationType.NONE
     if (isClassifiedConversation) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxWidth()
                 .background(color = colorsScheme().backgroundVariant)
                 .padding(paddingValues)
         ) {
-
-            Box(Modifier.fillMaxWidth()) {
-                VerticalSpace.x8()
-                SecurityClassificationBanner(securityClassificationType = securityClassificationType)
-            }
+            VerticalSpace.x8()
+            SecurityClassificationBanner(securityClassificationType = securityClassificationType)
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
@@ -39,15 +39,16 @@ fun MessageComposerClassifiedBanner(
     securityClassificationType: SecurityClassificationType,
     paddingValues: PaddingValues = PaddingValues()
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(color = colorsScheme().backgroundVariant)
-            .padding(paddingValues)
-    ) {
-        val isClassifiedConversation = securityClassificationType != SecurityClassificationType.NONE
-        if (isClassifiedConversation) {
+    val isClassifiedConversation = securityClassificationType != SecurityClassificationType.NONE
+    if (isClassifiedConversation) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = colorsScheme().backgroundVariant)
+                .padding(paddingValues)
+        ) {
+
             Box(Modifier.fillMaxWidth()) {
                 VerticalSpace.x8()
                 SecurityClassificationBanner(securityClassificationType = securityClassificationType)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerClassifiedBanner.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.messagecomposer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.wire.android.ui.common.SecurityClassificationBanner
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
+
+@Composable
+fun MessageComposerClassifiedBanner(
+    securityClassificationType: SecurityClassificationType,
+    paddingValues: PaddingValues = PaddingValues()
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = colorsScheme().backgroundVariant)
+            .padding(paddingValues)
+    ) {
+        val isClassifiedConversation = securityClassificationType != SecurityClassificationType.NONE
+        if (isClassifiedConversation) {
+            Box(Modifier.fillMaxWidth()) {
+                VerticalSpace.x8()
+                SecurityClassificationBanner(securityClassificationType = securityClassificationType)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -79,9 +80,10 @@ internal fun MessageComposerInput(
     isFileSharingEnabled: Boolean,
 ) {
     when (interactionAvailability) {
-        InteractionAvailability.BLOCKED_USER -> BlockedUserComposerInput()
-        InteractionAvailability.DELETED_USER -> DeletedUserComposerInput()
-        InteractionAvailability.NOT_MEMBER, InteractionAvailability.DISABLED -> {}
+        InteractionAvailability.BLOCKED_USER -> BlockedUserComposerInput(securityClassificationType)
+        InteractionAvailability.DELETED_USER -> DeletedUserComposerInput(securityClassificationType)
+        InteractionAvailability.NOT_MEMBER, InteractionAvailability.DISABLED ->
+            MessageComposerClassifiedBanner(securityClassificationType, PaddingValues(vertical = dimensions().spacing16x))
         InteractionAvailability.ENABLED -> {
             EnabledMessageComposerInput(
                 transition = transition,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3264" title="AR-3264" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3264</a>  When I leave or get removed from a conversation the classified banner for that conversation is not displayed anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When leaving a conversation, or a user is blocked, or user deleted. The classified banner was not showing.

### Solutions

Display the component for other interactivity cases on the message composer


### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5806454/229838280-c9dc132d-ed25-41a0-a20d-ce37b6f2ad90.png" width="300" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
