### PR TITLE
fix(conversation): hide conversation protocol info when MLS is disabled

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -66,6 +66,7 @@ import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.Result
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -98,6 +99,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val clearConversationContent: ClearConversationContentUseCase,
     private val updateConversationReceiptMode: UpdateConversationReceiptModeUseCase,
     override val savedStateHandle: SavedStateHandle,
+    private val isMLSEnabled: IsMLSEnabledUseCase,
     qualifiedIdMapper: QualifiedIdMapper
 ) : GroupConversationParticipantsViewModel(
     savedStateHandle, navigationManager, observeConversationMembers, qualifiedIdMapper
@@ -169,6 +171,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isServicesAllowed = groupDetails.conversation.isServicesAllowed(),
                         isUpdatingAllowed = isSelfAnAdmin,
                         isUpdatingGuestAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
+                        mlsEnabled = isMLSEnabled(),
                         isReadReceiptAllowed = groupDetails.conversation.receiptMode == Conversation.ReceiptMode.ENABLED,
                         isUpdatingReadReceiptAllowed = isUpdatingReadReceiptAllowed
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -126,10 +126,12 @@ fun GroupConversationSettings(
                 onCheckedChange = onReadReceiptSwitchClicked
             )
         }
-        item {
-            ConversationProtocolDetails(
-                protocolInfo = state.protocolInfo
-            )
+        if (state.mlsEnabled) {
+            item {
+                ConversationProtocolDetails(
+                    protocolInfo = state.protocolInfo
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -40,6 +40,7 @@ data class GroupConversationOptionsState(
     val loadingServicesOption: Boolean = false,
     val loadingReadReceiptOption: Boolean = false,
     val error: Error = Error.None,
+    val mlsEnabled: Boolean = false
 ) {
 
     sealed interface Error {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -535,6 +535,7 @@ internal class GroupConversationDetailsViewModelArrangement {
     @MockK
     lateinit var isMLSEnabledUseCase: IsMLSEnabledUseCase
 
+    @MockK
     lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
 
     @MockK
@@ -559,6 +560,7 @@ internal class GroupConversationDetailsViewModelArrangement {
             qualifiedIdMapper = qualifiedIdMapper,
             updateConversationMutedStatus = updateConversationMutedStatus,
             clearConversationContent = clearConversationContentUseCase,
+            updateConversationReceiptMode = updateConversationReceiptMode,
             isMLSEnabled = isMLSEnabledUseCase
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -52,6 +52,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeU
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -532,7 +533,7 @@ internal class GroupConversationDetailsViewModelArrangement {
     lateinit var clearConversationContentUseCase: ClearConversationContentUseCase
 
     @MockK
-    lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
+    lateinit var isMLSEnabledUseCase: IsMLSEnabledUseCase
 
     @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
@@ -556,7 +557,7 @@ internal class GroupConversationDetailsViewModelArrangement {
             qualifiedIdMapper = qualifiedIdMapper,
             updateConversationMutedStatus = updateConversationMutedStatus,
             clearConversationContent = clearConversationContentUseCase,
-            updateConversationReceiptMode = updateConversationReceiptMode
+            isMLSEnabled = isMLSEnabledUseCase
         )
     }
 
@@ -570,6 +571,7 @@ internal class GroupConversationDetailsViewModelArrangement {
         coEvery { observerSelfUser() } returns flowOf(TestUser.SELF_USER)
         coEvery { observeParticipantsForConversationUseCase(any(), any()) } returns flowOf()
         coEvery { getSelfTeamUseCase() } returns flowOf(null)
+        coEvery { isMLSEnabledUseCase() } returns true
         coEvery {
             qualifiedIdMapper.fromStringToQualifiedID("some-dummy-value@some.dummy.domain")
         } returns QualifiedID("some-dummy-value", "some.dummy.domain")

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -48,6 +48,7 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
@@ -533,6 +534,8 @@ internal class GroupConversationDetailsViewModelArrangement {
 
     @MockK
     lateinit var isMLSEnabledUseCase: IsMLSEnabledUseCase
+
+    lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
 
     @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -48,7 +48,6 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
If the MLS is disabled, the protocol info in the conversation details must be hidden as well.

#### How to Test
If the MLS is disabled, in the Group conversation details, you must not see the Protocol Info

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
