### PR TITLE
fix: empty user profile [AR-3236]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -140,7 +140,12 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val userId: QualifiedID = savedStateHandle.get<String>(EXTRA_USER_ID)!!.toQualifiedID(qualifiedIdMapper)
     private val conversationId: QualifiedID? = savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)?.toQualifiedID(qualifiedIdMapper)
 
-    var state: OtherUserProfileState by mutableStateOf(OtherUserProfileState(userId = userId, conversationId = conversationId))
+    var state: OtherUserProfileState by mutableStateOf(OtherUserProfileState(
+        userId = userId,
+        conversationId = conversationId,
+        isDataLoading = true,
+        isAvatarLoading = true
+    ))
     var requestInProgress: Boolean by mutableStateOf(false)
 
     private val _infoMessage = MutableSharedFlow<UIText>()
@@ -150,8 +155,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     val closeBottomSheet = _closeBottomSheet.asSharedFlow()
 
     init {
-        state = state.copy(isDataLoading = true, isAvatarLoading = true)
-
         observeUserInfoAndUpdateViewState()
         persistClients()
         setClassificationType()
@@ -490,7 +493,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     private fun setClassificationType() {
         viewModelScope.launch {
-            state = state.copy(securityClassificationType = getOtherUserSecurityClassificationLabel(userId))
+            val result = getOtherUserSecurityClassificationLabel(userId)
+            state = state.copy(securityClassificationType = result)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3236" title="AR-3236" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3236</a>  User Profile of unconnected user is empty when accessing it from conversation list or any other place
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Updating the state asynchronously was causing problems on the other user profile screen. 

### Causes (Optional)

Sometimes when user opens other user profile screen the screen is in infinite loading state

### Solutions

Don't await for suspend function inside the `state.copy()`
