### PR TITLE
chore: build dev flavour in addition to staging on PRs

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,0 +1,40 @@
+name: "Build App"
+
+on:
+  workflow_call:
+    inputs:
+      flavour:
+        required: false
+        type: string
+
+jobs:
+  build-app:
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive # Needed in order to fetch Kalium sources for building
+        fetch-depth: 0
+    - name: Build
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./gradlew assembleBetaDebug -p ./ --no-daemon
+        cp app/build/outputs/apk/beta/debug/com.wire.*.apk wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
+    - name: Upload APK
+      if: success()
+      uses: actions/upload-artifact@v3
+      with:
+          name: wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
+          path: ./wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
+    - name: Post link to apk
+      if: success()
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.run_id }}"
+        gh pr comment "${{github.head_ref}}" --body "Build available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
+

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       flavour:
-        required: false
+        required: true
         type: string
 
 jobs:
@@ -16,19 +16,28 @@ jobs:
       with:
         submodules: recursive # Needed in order to fetch Kalium sources for building
         fetch-depth: 0
-    - name: Build
+    - name: Build beta flavour
+      if: ${{ inputs.flavour == 'beta-debug' }}
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         ./gradlew assembleBetaDebug -p ./ --no-daemon
-        cp app/build/outputs/apk/beta/debug/com.wire.*.apk wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
+        cp app/build/outputs/apk/beta/debug/com.wire.*.apk wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
+    - name: Build dev flavour
+      if: ${{ inputs.flavour == 'dev-debug' }}
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./gradlew assembleDevDebug -p ./ --no-daemon
+        cp app/build/outputs/apk/dev/debug/com.wire.*.apk wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
     - name: Upload APK
       if: success()
       uses: actions/upload-artifact@v3
       with:
-          name: wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
-          path: ./wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
+          name: wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
+          path: ./wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
     - name: Post link to apk
       if: success()
       env:
@@ -36,5 +45,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.run_id }}"
-        gh pr comment "${{github.head_ref}}" --body "Build available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
+        gh pr comment "${{github.head_ref}}" --body "Build (${{inputs.flavour}}) available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
 

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -82,10 +82,17 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
-  build-staging:
+  build-beta:
     if: ${{ github.event_name == 'pull_request' }}
     needs: [unit-tests]
     uses: ./.github/workflows/build-app.yml
     with:
-      flavour: "staging"
+      flavour: "beta-debug"
+
+  build-dev:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [unit-tests]
+    uses: ./.github/workflows/build-app.yml
+    with:
+      flavour: "dev-debug"
 

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -82,35 +82,10 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
-  build-app:
+  build-staging:
     if: ${{ github.event_name == 'pull_request' }}
     needs: [unit-tests]
-    runs-on: buildjet-8vcpu-ubuntu-2204
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive # Needed in order to fetch Kalium sources for building
-        fetch-depth: 0
-    - name: Build
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        ./gradlew assembleBetaDebug -p ./ --no-daemon
-        cp app/build/outputs/apk/beta/debug/com.wire.*.apk wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
-    - name: Upload APK
-      if: success()
-      uses: actions/upload-artifact@v3
-      with:
-          name: wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
-          path: ./wire-android-beta-debug-pr-${{ github.event.pull_request.number }}.apk
-    - name: Post link to apk
-      if: success()
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.run_id }}"
-        gh pr comment "${{github.head_ref}}" --body "Build available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
+    uses: ./.github/workflows/build-app.yml
+    with:
+      flavour: "staging"
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Create a dev flavour apk artifact in addition to the beta flavour apk.

### Solutions

* Extract `build-app` job into a re-usable workflow
* Introduce `build-dev` and `build-beta` jobs using the build app workflow.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
