### PR TITLE
fix: refactor dialogs handling logic in `ConversationScreen`

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -46,13 +46,14 @@ import com.wire.android.navigation.getBackNavArgs
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorDeletingMessage
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsStates
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.UiMention
+import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -119,11 +120,10 @@ class MessageComposerViewModel @Inject constructor(
         private set
 
     var tempWritableImageUri: Uri? = null
-        private set
 
     // TODO: should be moved to ConversationMessagesViewModel?
-    var deleteMessageDialogsState: DeleteMessageDialogsState by mutableStateOf(
-        DeleteMessageDialogsState.States(
+    var deleteMessageDialogsState: DeleteMessageDialogsStates by mutableStateOf(
+        DeleteMessageDialogsStates(
             forYourself = DeleteMessageDialogActiveState.Hidden,
             forEveryone = DeleteMessageDialogActiveState.Hidden
         )
@@ -337,8 +337,8 @@ class MessageComposerViewModel @Inject constructor(
             }
         }
 
-    private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) =
-        (deleteMessageDialogsState as? DeleteMessageDialogsState.States)?.let { deleteMessageDialogsState = newValue(it) }
+    private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsStates) -> DeleteMessageDialogsStates) =
+        deleteMessageDialogsState.let { deleteMessageDialogsState = newValue(it) }
 
     fun updateConversationReadDate(utcISO: String) {
         viewModelScope.launch(dispatchers.io()) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialog.kt
@@ -31,32 +31,34 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.util.dialogErrorStrings
 
 @Composable
-internal fun DeleteMessageDialog(state: DeleteMessageDialogsState, actions: DeleteMessageDialogHelper) {
-
-    if (state is DeleteMessageDialogsState.States) {
-        when {
-            state.forEveryone is DeleteMessageDialogActiveState.Visible -> {
-                DeleteMessageDialog(
-                    state = state.forEveryone,
-                    onDialogDismiss = actions::onDeleteDialogDismissed,
-                    onDeleteForMe = actions::showDeleteMessageForYourselfDialog,
-                    onDeleteForEveryone = actions::onDeleteMessage,
-                )
-                if (state.forEveryone.error is DeleteMessageError.GenericError) {
-                    DeleteMessageErrorDialog(state.forEveryone.error, actions::clearDeleteMessageError)
-                }
+internal fun DeleteMessageDialog(
+    state: DeleteMessageDialogsStates,
+    actions: DeleteMessageDialogHelper,
+    extraOnDismissActions: () -> Unit = {}
+) {
+    when {
+        state.forEveryone is DeleteMessageDialogActiveState.Visible -> {
+            DeleteMessageDialog(
+                state = state.forEveryone,
+                onDialogDismiss = actions::onDeleteDialogDismissed,
+                onDeleteForMe = actions::showDeleteMessageForYourselfDialog,
+                onDeleteForEveryone = actions::onDeleteMessage,
+            )
+            if (state.forEveryone.error is DeleteMessageError.GenericError) {
+                DeleteMessageErrorDialog(state.forEveryone.error, actions::clearDeleteMessageError)
             }
-            state.forYourself is DeleteMessageDialogActiveState.Visible -> {
+        }
 
-                if (state.forYourself.error is DeleteMessageError.GenericError) {
-                    DeleteMessageErrorDialog(state.forYourself.error, actions::clearDeleteMessageError)
-                } else {
-                    DeleteMessageForYourselfDialog(
-                        state = state.forYourself,
-                        onDialogDismiss = actions::onDeleteDialogDismissed,
-                        onDeleteForMe = actions::onDeleteMessage
-                    )
-                }
+        state.forYourself is DeleteMessageDialogActiveState.Visible -> {
+
+            if (state.forYourself.error is DeleteMessageError.GenericError) {
+                DeleteMessageErrorDialog(state.forYourself.error, actions::clearDeleteMessageError)
+            } else {
+                DeleteMessageForYourselfDialog(
+                    state = state.forYourself,
+                    onDialogDismiss = actions::onDeleteDialogDismissed,
+                    onDeleteForMe = actions::onDeleteMessage
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogHelper.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 class DeleteMessageDialogHelper(
     val scope: CoroutineScope,
     val conversationId: QualifiedID,
-    private val updateDeleteDialogState: ((DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) -> Unit,
+    private val updateDeleteDialogState: ((DeleteMessageDialogsStates) -> DeleteMessageDialogsStates) -> Unit,
     private val deleteMessage: suspend (String, Boolean) -> Unit
 ) {
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogsState.kt
@@ -23,14 +23,10 @@ package com.wire.android.ui.home.conversations.delete
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
-sealed class DeleteMessageDialogsState {
-    data class States(
-        val forEveryone: DeleteMessageDialogActiveState,
-        val forYourself: DeleteMessageDialogActiveState
-    ) : DeleteMessageDialogsState()
-
-    data class Error(val coreFailure: CoreFailure) : DeleteMessageDialogsState()
-}
+data class DeleteMessageDialogsStates(
+    val forEveryone: DeleteMessageDialogActiveState,
+    val forYourself: DeleteMessageDialogActiveState
+)
 
 sealed class DeleteMessageDialogActiveState {
     object Hidden : DeleteMessageDialogActiveState()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogType.kt
@@ -14,12 +14,17 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- *
  */
 
-package com.wire.android.ui.home.conversations
+package com.wire.android.ui.home.conversations.dialogs
 
 enum class ConversationScreenDialogType {
-    ONGOING_ACTIVE_CALL, NO_CONNECTIVITY, CALLING_FEATURE_UNAVAILABLE, NONE
+    ONGOING_ACTIVE_CALL,
+    NO_CONNECTIVITY,
+    CALLING_FEATURE_UNAVAILABLE,
+    JOIN_CALL_ANYWAY,
+    DELETE_MESSAGE,
+    DOWNLOADED_ASSET,
+    ASSET_TOO_LARGE,
+    NONE
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogs.kt
@@ -1,0 +1,148 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.dialogs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialog
+import com.wire.android.ui.common.dialogs.calling.JoinAnywayDialog
+import com.wire.android.ui.common.dialogs.calling.OngoingActiveCallDialog
+import com.wire.android.ui.common.error.CoreFailureErrorDialog
+import com.wire.android.ui.home.conversations.AssetTooLargeDialog
+import com.wire.android.ui.home.conversations.AssetTooLargeDialogState
+import com.wire.android.ui.home.conversations.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState.Visible
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.ASSET_TOO_LARGE
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.CALLING_FEATURE_UNAVAILABLE
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.DELETE_MESSAGE
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.DOWNLOADED_ASSET
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.JOIN_CALL_ANYWAY
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.NONE
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.NO_CONNECTIVITY
+import com.wire.android.ui.home.conversations.dialogs.ConversationScreenDialogType.ONGOING_ACTIVE_CALL
+import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.messages.DownloadedAssetDialogVisibilityState.Displayed
+import com.wire.kalium.logic.NetworkFailure
+
+/**
+ * This class is meant to handle the visibility of the different dialogs that can be displayed in the conversation screen. Each dialog can
+ * have its own internal state and logic (or not)
+ */
+@Composable
+fun ConversationScreenDialogs(
+    conversationCallViewModel: ConversationCallViewModel,
+    messageComposerViewModel: MessageComposerViewModel,
+    currentConversationScreenDialog: ConversationScreenDialogType,
+    conversationMessagesViewModel: ConversationMessagesViewModel,
+    updateDialogType: (ConversationScreenDialogType) -> Unit
+) {
+
+    LaunchedEffect(conversationMessagesViewModel.conversationViewState.downloadedAssetDialogState) {
+        if (conversationMessagesViewModel.conversationViewState.downloadedAssetDialogState is Displayed) {
+            updateDialogType(DOWNLOADED_ASSET)
+        }
+    }
+
+    LaunchedEffect(conversationCallViewModel.conversationCallViewState.shouldShowJoinAnywayDialog) {
+        if (conversationCallViewModel.conversationCallViewState.shouldShowJoinAnywayDialog) {
+            updateDialogType(JOIN_CALL_ANYWAY)
+        }
+    }
+
+    LaunchedEffect(messageComposerViewModel.deleteMessageDialogsState) {
+        val showDeleteMessageDialog = messageComposerViewModel.deleteMessageDialogsState.forEveryone is Visible
+                || messageComposerViewModel.deleteMessageDialogsState.forYourself is Visible
+        if (showDeleteMessageDialog) {
+            updateDialogType(DELETE_MESSAGE)
+        }
+    }
+
+    LaunchedEffect(messageComposerViewModel.messageComposerViewState) {
+        if (messageComposerViewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Visible) {
+            updateDialogType(ASSET_TOO_LARGE)
+        }
+    }
+
+
+    when (currentConversationScreenDialog) {
+        ONGOING_ACTIVE_CALL -> {
+            OngoingActiveCallDialog(onJoinAnyways = {
+                conversationCallViewModel.navigateToInitiatingCallScreen()
+                updateDialogType(NONE)
+            }, onDialogDismiss = {
+                updateDialogType(NONE)
+            })
+        }
+
+        NO_CONNECTIVITY -> {
+            CoreFailureErrorDialog(coreFailure = NetworkFailure.NoNetworkConnection(null)) {
+                updateDialogType(NONE)
+            }
+        }
+
+        CALLING_FEATURE_UNAVAILABLE -> {
+            CallingFeatureUnavailableDialog(onDialogDismiss = {
+                updateDialogType(NONE)
+            })
+        }
+
+        JOIN_CALL_ANYWAY -> {
+            JoinAnywayDialog(
+                onDismiss = {
+                    conversationCallViewModel.dismissJoinCallAnywayDialog()
+                    updateDialogType(NONE)
+                },
+                onConfirm = conversationCallViewModel::joinAnyway
+            )
+        }
+
+        DELETE_MESSAGE -> {
+            DeleteMessageDialog(
+                state = messageComposerViewModel.deleteMessageDialogsState,
+                actions = messageComposerViewModel.deleteMessageHelper,
+                extraOnDismissActions = { updateDialogType(NONE) }
+            )
+        }
+
+        DOWNLOADED_ASSET -> {
+            DownloadedAssetDialog(
+                downloadedAssetDialogState = conversationMessagesViewModel.conversationViewState.downloadedAssetDialogState,
+                onSaveFileToExternalStorage = conversationMessagesViewModel::downloadAssetExternally,
+                onOpenFileWithExternalApp = conversationMessagesViewModel::downloadAndOpenAsset,
+                hideOnAssetDownloadedDialog = {
+                    conversationMessagesViewModel.hideOnAssetDownloadedDialog()
+                    updateDialogType(NONE)
+                }
+            )
+        }
+
+        ASSET_TOO_LARGE -> {
+            AssetTooLargeDialog(
+                dialogState = messageComposerViewModel.messageComposerViewState.assetTooLargeDialogState,
+                hideDialog = {
+                    messageComposerViewModel.hideAssetTooLargeError()
+                    updateDialogType(NONE)
+                }
+            )
+        }
+
+        NONE -> {}
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/ConversationScreenDialogs.kt
@@ -43,7 +43,10 @@ import com.wire.kalium.logic.NetworkFailure
 
 /**
  * This class is meant to handle the visibility of the different dialogs that can be displayed in the conversation screen. Each dialog can
- * have its own internal state and logic (or not)
+ * have its own internal state and logic (or not) to decide the actions of their buttons, and internal navigation. However, this class is
+ * ultimately responsible to decide which dialog should be displayed. Otherwise, if we keep adding more dialogs, we might end up showing two
+ * or more dialogs at the same time by mistake.
+ * TODO: We should consider creating a unified VM or interactor component instead of passing all these VMs as parameters to this class.
  */
 @Composable
 fun ConversationScreenDialogs(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/dialogs/DownloadedAssetDialog.kt
@@ -14,11 +14,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- *
  */
 
-package com.wire.android.ui.home.conversations
+package com.wire.android.ui.home.conversations.dialogs
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -37,7 +37,7 @@ import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsStates
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.startFileShareIntent
@@ -208,8 +208,8 @@ class MediaGalleryViewModel @Inject constructor(
         }
     }
 
-    private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) {
-        (mediaGalleryViewState.deleteMessageDialogsState as? DeleteMessageDialogsState.States)?.let {
+    private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsStates) -> DeleteMessageDialogsStates) {
+        (mediaGalleryViewState.deleteMessageDialogsState as? DeleteMessageDialogsStates)?.let {
             mediaGalleryViewState = mediaGalleryViewState.copy(deleteMessageDialogsState = newValue(it))
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
@@ -22,12 +22,12 @@ package com.wire.android.ui.home.gallery
 
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsStates
 
 data class MediaGalleryViewState(
     val screenTitle: String? = null,
     val onSnackbarMessage: MediaGallerySnackbarMessages? = null,
-    val deleteMessageDialogsState: DeleteMessageDialogsState = DeleteMessageDialogsState.States(
+    val deleteMessageDialogsState: DeleteMessageDialogsStates = DeleteMessageDialogsStates(
         forYourself = DeleteMessageDialogActiveState.Hidden,
         forEveryone = DeleteMessageDialogActiveState.Hidden
     )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -24,7 +24,7 @@ import androidx.core.net.toUri
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsStates
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.UriAsset
@@ -54,7 +54,7 @@ class MessageComposerViewModelTest {
         viewModel.showDeleteMessageDialog("", true)
 
         // Then
-        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
+        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsStates(
             forYourself = DeleteMessageDialogActiveState.Hidden,
             forEveryone = DeleteMessageDialogActiveState.Visible("", viewModel.conversationId)
         )
@@ -71,7 +71,7 @@ class MessageComposerViewModelTest {
         viewModel.showDeleteMessageDialog("", false)
 
         // Then
-        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
+        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsStates(
             forYourself = DeleteMessageDialogActiveState.Visible("", viewModel.conversationId),
             forEveryone = DeleteMessageDialogActiveState.Hidden
         )
@@ -88,7 +88,7 @@ class MessageComposerViewModelTest {
         viewModel.deleteMessageHelper.showDeleteMessageForYourselfDialog("")
 
         // Then
-        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
+        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsStates(
             forYourself = DeleteMessageDialogActiveState.Visible("", viewModel.conversationId),
             forEveryone = DeleteMessageDialogActiveState.Hidden
         )
@@ -103,7 +103,7 @@ class MessageComposerViewModelTest {
         viewModel.deleteMessageHelper.onDeleteDialogDismissed()
 
         // Then
-        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
+        viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsStates(
             forYourself = DeleteMessageDialogActiveState.Hidden, forEveryone = DeleteMessageDialogActiveState.Hidden
         )
     }
@@ -140,7 +140,7 @@ class MessageComposerViewModelTest {
         viewModel.deleteMessageHelper.onDeleteMessage("messageId", true)
 
         // Then
-        val expectedState = DeleteMessageDialogsState.States(
+        val expectedState = DeleteMessageDialogsStates(
             DeleteMessageDialogActiveState.Hidden,
             DeleteMessageDialogActiveState.Hidden
         )
@@ -223,11 +223,11 @@ class MessageComposerViewModelTest {
         val mockedUri = UriAsset("mocked_image.jpeg".toUri(), false)
 
         // When
-            viewModel.attachmentPicked(mockedUri)
+        viewModel.attachmentPicked(mockedUri)
 
-            // Then
-            coVerify(inverse = true) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
-            assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
+        // Then
+        coVerify(inverse = true) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
+        assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
     }
 
     @Test
@@ -247,11 +247,11 @@ class MessageComposerViewModelTest {
             val mockedUri = UriAsset("mocked_image.jpeg".toUri(), false)
 
             // When
-                viewModel.attachmentPicked(mockedUri)
+            viewModel.attachmentPicked(mockedUri)
 
-                // Then
-                coVerify(inverse = true) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
-                assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
+            // Then
+            coVerify(inverse = true) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
+            assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
         }
 
     @Test
@@ -318,11 +318,11 @@ class MessageComposerViewModelTest {
         )
 
         // When
-            viewModel.sendAttachmentMessage(mockedAttachment)
+        viewModel.sendAttachmentMessage(mockedAttachment)
 
-            // Then
-            coVerify(exactly = 1) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
-            assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Hidden)
+        // Then
+        coVerify(exactly = 1) { arrangement.sendAssetMessage.invoke(any(), any(), any(), any(), any(), any(), any()) }
+        assert(viewModel.messageComposerViewState.assetTooLargeDialogState is AssetTooLargeDialogState.Hidden)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -28,7 +28,7 @@ import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsStates
 import com.wire.android.util.FileManager
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure
@@ -163,8 +163,8 @@ class MediaGalleryViewModelTest {
 
         // Then
         val deleteMessageDialogsState = viewModel.mediaGalleryViewState.deleteMessageDialogsState
-        assert(deleteMessageDialogsState is DeleteMessageDialogsState.States)
-        assert((deleteMessageDialogsState as DeleteMessageDialogsState.States).forEveryone is DeleteMessageDialogActiveState.Visible)
+        assert(deleteMessageDialogsState is DeleteMessageDialogsStates)
+        assert((deleteMessageDialogsState as DeleteMessageDialogsStates).forEveryone is DeleteMessageDialogActiveState.Visible)
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Conversation screen is growing in size. It needs some code rearranging, so I started moving all the code related with dialogs from `ConversationScreen` to its own dedicated class, and respecting their internal bindings with every individual VM that each dialog interacts with.

### Solutions

Ideally, in the close future, we could improve this approach by creating a dedicated VM or Interactor that will be representing the bridge between the conversation view and all the different smaller views/VM's.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### How to Test
Just trigger any of the situations where these dialogs will show up (picked asset too large, click on asset message, trying to join a call while on other, deleting messages...)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
