### PR TITLE
fix(rc): mentions are lost after edit [AR-3299]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -36,6 +36,8 @@ import com.wire.android.ui.edit.ReplyMessageOption
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
+import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.message.mention.MessageMention
 
 @Composable
 fun EditMessageMenuItems(
@@ -46,7 +48,7 @@ fun EditMessageMenuItems(
     onReactionClick: (messageId: String, emoji: String) -> Unit,
     onReplyClick: (message: UIMessage) -> Unit,
     onDetailsClick: (messageId: String, isMyMessage: Boolean) -> Unit,
-    onEditClick: (messageId: String, originalText: String) -> Unit,
+    onEditClick: (messageId: String, originalText: String, originalMentions: List<MessageMention>) -> Unit,
     onShareAsset: () -> Unit,
 ): List<@Composable () -> Unit> {
     val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
@@ -96,10 +98,13 @@ fun EditMessageMenuItems(
     val onEditItemClick = remember(message) {
         {
             hideEditMessageMenu {
-                onEditClick(
-                    message.messageHeader.messageId,
-                    (message.messageContent as UIMessageContent.TextMessage).messageBody.message.asString(localContext.resources)
-                )
+                with(message.messageContent as UIMessageContent.TextMessage) {
+                    onEditClick(
+                        message.messageHeader.messageId,
+                        messageBody.message.asString(localContext.resources),
+                        if (messageBody.message is UIText.DynamicString) messageBody.message.mentions else listOf()
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -107,7 +107,7 @@ fun MessageComposer(
                         EditMessageBundle(
                             originalMessageId = originalMessageId,
                             newContent = messageComposerState.messageComposeInputState.messageText.text,
-                            messageComposerState.mentions,
+                            newMentions = messageComposerState.mentions,
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -172,11 +172,12 @@ data class MessageComposerInnerState(
         }
     }
 
-    fun toEditMessage(messageId: String, originalText: String) {
+    fun toEditMessage(messageId: String, originalText: String, originalMentions: List<MessageMention>) {
         messageComposeInputState = MessageComposeInputState.Active(
             messageText = TextFieldValue(text = originalText, selection = TextRange(originalText.length)),
             type = MessageComposeInputType.EditMessage(messageId, originalText)
         )
+        mentions = originalMentions.map { it.toUiMention(originalText) }
         quotedMessageData = null
         inputFocusRequester.requestFocus()
     }
@@ -363,6 +364,13 @@ data class UiMention(
 ) {
     fun intoMessageMention() = MessageMention(start, length, userId, false) // TODO Gonzo check if it's ok
 }
+
+fun MessageMention.toUiMention(originalText: String) = UiMention(
+    start = this.start,
+    length = this.length,
+    userId = this.userId,
+    handler = originalText.substring(start, start + length)
+)
 
 class AttachmentInnerState(val context: Context) {
     var attachmentState by mutableStateOf<AttachmentState>(AttachmentState.NotPicked)

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerStateTest.kt
@@ -202,7 +202,7 @@ class MessageComposerInnerStateTest {
         val originalMessageText = "original message text"
         val state = createState(context, focusManager, focusRequester)
         state.setMessageTextValue(textFieldValueWithSelection("start text"))
-        state.toEditMessage("message-id", originalMessageText)
+        state.toEditMessage("message-id", originalMessageText, listOf())
         assert(state.messageComposeInputState.isEditMessage)
         assertEquals(originalMessageText, state.messageComposeInputState.messageText.text)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3299" title="AR-3299" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3299</a>  PlayTest 12.04 - If you edit a mention, it is not a mention anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Same as https://github.com/wireapp/wire-android-reloaded/pull/1695

### Issues

If you edit a message with a mention, it stops being mention and becomes a regular text.

### Solutions

Pass mentions along with original text and put them into `MessageComposerInnerState.mentions` list when the state is being changed to "update text".

### Testing

#### How to Test

Send a message with a mention, edit this message keeping the original mention, save the edit and see if the mention is still highlighted.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/233422975-9ff7c117-2a93-49a9-916d-ac1bcf0b9be0.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
