### PR TITLE
fix: SessionManagerImpl.serverConfig crash (AR-3289)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -366,6 +366,19 @@ class WireNotificationManager @Inject constructor(
                 if (currentScreen !is CurrentScreen.InBackground) {
                     flowOf(null)
                 } else {
+                    try {
+                        coreLogic
+                            .getSessionScope(userId)
+                            .calls
+                            .establishedCall()
+                            .map {
+                                it.firstOrNull()?.let { call ->
+                                    OngoingCallData(callNotificationManager.getNotificationTitle(call), call.conversationId, userId)
+                                }
+                            }
+                    } catch (e: IllegalArgumentException) {
+                        flowOf(null)
+                    }
                     coreLogic.getSessionScope(userId).calls
                         .establishedCall()
                         .map {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3289" title="AR-3289" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3289</a>  Playstore crash: com.wire.kalium.logic.network.SessionManagerImpl.serverConfig
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A crash visible on Play console

```
Exception java.lang.IllegalStateException:
  at com.wire.kalium.logic.network.SessionManagerImpl.serverConfig (SessionManagerImpl.java:110)
  at com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer$Companion.create (AuthenticatedNetworkContainer.java:185)
  at com.wire.kalium.logic.feature.UserSessionScopeProviderImpl.create (UserSessionScopeProviderImpl.java:185)
  at com.wire.kalium.logic.feature.UserSessionScopeProviderCommon$getOrCreate$1.invoke (UserSessionScopeProviderCommon.java:185)
  at com.wire.kalium.logic.feature.UserSessionScopeProviderCommon$getOrCreate$1.invoke (UserSessionScopeProviderCommon.java:185)
  at io.ktor.util.collections.ConcurrentMap$computeIfAbsent$1.invoke (ConcurrentMap.java)
  at io.ktor.util.collections.ConcurrentMap.computeIfAbsent$lambda$0 (ConcurrentMap.java)
  at java.util.concurrent.ConcurrentHashMap.computeIfAbsent (ConcurrentHashMap.java:1747)
```

It's happening on background, when we start observing established calls.

### Causes (Optional)

When observing established calls, we check  which API version to use. That check uses session for that and if the app did not manage to get it, an `IllegalStateException` will be thrown

At some point when the app in background(probably after migration), session is null which to crash the app because of `IllegalStateException`.

### Solutions

use Try catch to hande `IllegalStateException` exception

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
