### PR TITLE
chore: upgrade kotlin to 1.8.20

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,13 +19,13 @@
  */
 
 private object Dependencies {
-    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
+    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"
     const val kluent = "org.amshove.kluent:kluent:1.68"
     const val hilt = "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
     const val spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.1.2"
-    const val junit5 = "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.1"
+    const val junit5 = "de.mannodermaus.gradle.plugins:android-junit5:1.9.0.0-SNAPSHOT"
     const val grgit = "org.ajoberstar.grgit:grgit-core:5.0.0-rc.3"
 }
 
@@ -39,6 +39,7 @@ repositories {
     mavenLocal()
     google()
     mavenCentral()
+    maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -71,7 +71,7 @@ object Repositories {
 
 object Libraries {
     object Versions {
-        const val kotlin = "1.8.10"
+        const val kotlin = "1.8.20"
         const val coroutines = "1.6.1-native-mt"
         const val jetpack = "1.1.0"
         const val constraintLayout = "2.1.4"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -83,7 +83,7 @@ object Libraries {
         const val workManager = "2.8.1"
         const val fragment = "1.5.6"
         const val compose = "1.3.1"
-        const val composeCompiler = "1.4.3"
+        const val composeCompiler = "1.4.6"
         const val composeMaterial = "1.3.1"
         const val composeMaterial3 = "1.0.1"
         const val composeActivity = "1.6.1"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IDEs based on IntelliJ 2023 can't perform Gradle Sync.
Kotlin has a new version.

### Causes

There's some incompatibility when using Composite builds + Multiplatform projects + Kotlin < 1.8.20 + new IDE versions.

### Solutions

Bump Kotlin to 1.9.20

There was an issue with the plugin we use in order to add Junit 5 support for Android, as [reported here](https://github.com/mannodermaus/android-junit5/issues/296).
Bumping to the new SNAPSHOT version fixes it.
Not great using a SNAPSHOT version, but at least we make new IDEs work.

Worst case scenarios we can take out Junit5 from the project and stick with Google's official support.

> **Note**: This PR also bumps Kalium version to the latest `develop`.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
