### PR TITLE
fix: [RC] Add callback to handle deeplink only when Navigation Graph is done (AR-3290)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
@@ -28,7 +28,12 @@ import com.google.accompanist.navigation.animation.composable
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun NavigationGraph(navController: NavHostController, startDestination: String, appInitialArgs: List<Any> = emptyList()) {
+fun NavigationGraph(
+    navController: NavHostController,
+    startDestination: String,
+    appInitialArgs: List<Any> = emptyList(),
+    onComplete: () -> Unit
+) {
     AnimatedNavHost(navController, startDestination) {
         NavigationItem.values().onEach { item ->
             composable(
@@ -39,5 +44,6 @@ fun NavigationGraph(navController: NavHostController, startDestination: String, 
                 exitTransition = { item.animationConfig.exitTransition }
             )
         }
+        onComplete()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -27,6 +27,7 @@ import com.wire.android.appLogger
 
 @ExperimentalMaterial3Api
 internal fun NavController.navigateToItem(command: NavigationCommand) {
+    appLogger.d("[$TAG] -> command: ${command.destination}")
     currentBackStackEntry?.savedStateHandle?.remove<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
     navigate(command.destination) {
         when (command.backStackMode) {
@@ -91,3 +92,5 @@ fun String.getPrimaryRoute(): String {
     }
     return primaryRoute
 }
+
+private const val TAG = "NavigationUtils"

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -104,10 +104,11 @@ class WireActivity : AppCompatActivity() {
         proximitySensorManager.initialize()
         lifecycle.addObserver(currentScreenManager)
 
-        handleDeepLink(intent, savedInstanceState)
         viewModel.observePersistentConnectionStatus()
         val startDestination = viewModel.startNavigationRoute()
-        setComposableContent(startDestination)
+        setComposableContent(startDestination) {
+            handleDeepLink(intent, savedInstanceState)
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -118,7 +119,10 @@ class WireActivity : AppCompatActivity() {
         super.onNewIntent(intent)
     }
 
-    private fun setComposableContent(startDestination: String) {
+    private fun setComposableContent(
+        startDestination: String,
+        onComplete: () -> Unit
+    ) {
         setContent {
             CompositionLocalProvider(
                 LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
@@ -128,7 +132,7 @@ class WireActivity : AppCompatActivity() {
                 WireTheme {
                     val scope = rememberCoroutineScope()
                     val navController = rememberTrackingAnimatedNavController { NavigationItem.fromRoute(it)?.itemName }
-                    setUpNavigationGraph(startDestination, navController, scope)
+                    setUpNavigationGraph(startDestination, navController, scope) { onComplete() }
                     handleDialogs()
                 }
             }
@@ -136,9 +140,19 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    fun setUpNavigationGraph(startDestination: String, navController: NavHostController, scope: CoroutineScope) {
+    fun setUpNavigationGraph(
+        startDestination: String,
+        navController: NavHostController,
+        scope: CoroutineScope,
+        onComplete: () -> Unit
+    ) {
         Scaffold {
-            NavigationGraph(navController = navController, startDestination)
+            NavigationGraph(
+                navController = navController,
+                startDestination = startDestination
+            ) {
+                onComplete()
+            }
         }
         setUpNavigation(navController, scope)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3290" title="AR-3290" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3290</a>  Playstore crash: com.wire.android.navigation.NavigationUtilsKt.navigateToItem
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-3290 - com.wire.android.navigation.NavigationUtilsKt.navigateToItem ](https://wearezeta.atlassian.net/browse/AR-3290)

### Issues

Sometimes while handling some screen through deeplinks (from notifications for example when you receive a message or an incoming call) the app would handle it before having the navigation graph fully built.

### Solutions

Added a callback to when navigation graph is fully built to only then handle deeplinks.

### Testing

#### How to Test

Currently not very able to test unless you force the issue (fully commenting the creation of the navigation graph)

### Notes (Optional)

Also added a log on `NavigationUtils.NavController.navigateToItem(..)` to show which screen is being opened, in case this fix doesn't end up fixing the whole issue we will at least know from where the navigation is coming from.
