### PR TITLE
fix: animate progress bar

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -92,6 +92,7 @@ private fun SuccessfulAudioMessage(
     onSliderPositionChange: (Float) -> Unit,
     onAudioMessageLongClick: (() -> Unit)? = null
 ) {
+    val stiffness = 5f
     val audioDuration by remember(currentPositionInMs) {
         mutableStateOf(
             AudioDuration(totalTimeInMs, currentPositionInMs)
@@ -116,7 +117,7 @@ private fun SuccessfulAudioMessage(
         )
         val progress by animateFloatAsState(
             targetValue = audioDuration.currentPositionInMs.toFloat(),
-            animationSpec = spring(stiffness = 5f)
+            animationSpec = spring(stiffness = stiffness)
         )
 
         Slider(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -1,5 +1,7 @@
 package com.wire.android.ui.home.conversations.model.messagetypes.audio
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -112,9 +114,13 @@ private fun SuccessfulAudioMessage(
             state = if (audioMediaPlayingState is AudioMediaPlayingState.Fetching) WireButtonState.Disabled else WireButtonState.Default,
             onButtonClicked = onPlayButtonClick
         )
+        val progress by animateFloatAsState(
+            targetValue = audioDuration.currentPositionInMs.toFloat(),
+            animationSpec = spring(stiffness = 5f)
+        )
 
         Slider(
-            value = audioDuration.currentPositionInMs.toFloat(),
+            value = progress,
             onValueChange = onSliderPositionChange,
             valueRange = 0f..if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f,
             colors = SliderDefaults.colors(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -95,7 +95,6 @@ fun CreateBackupDialog(
     onDismissDialog: () -> Unit
 ) {
     val progress by animateFloatAsState(targetValue = createBackupProgress)
-
     WireDialog(
         title = stringResource(R.string.backup_dialog_create_backup_title),
         onDismiss = onDismissDialog,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.ui.home.settings.backup.dialog.create
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -93,6 +94,8 @@ fun CreateBackupDialog(
     onSaveBackup: () -> Unit,
     onDismissDialog: () -> Unit
 ) {
+    val progress by animateFloatAsState(targetValue = createBackupProgress)
+
     WireDialog(
         title = stringResource(R.string.backup_dialog_create_backup_title),
         onDismiss = onDismissDialog,
@@ -124,7 +127,7 @@ fun CreateBackupDialog(
                 }
             }
             VerticalSpace.x16()
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth(), progress = createBackupProgress)
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth(), progress = progress)
             VerticalSpace.x16()
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.home.settings.backup.dialog.restore
 
 import android.net.Uri
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -120,6 +121,8 @@ fun RestoreProgressDialog(
     onOpenConversation: () -> Unit,
     onCancelBackupRestore: () -> Unit
 ) {
+    val progress by animateFloatAsState(targetValue = restoreProgress)
+    
     WireDialog(
         title = stringResource(R.string.backup_dialog_restoring_backup_title),
         onDismiss = {
@@ -147,7 +150,7 @@ fun RestoreProgressDialog(
                 }
             }
             VerticalSpace.x16()
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth(), progress = restoreProgress)
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth(), progress = progress)
             VerticalSpace.x16()
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -122,7 +122,6 @@ fun RestoreProgressDialog(
     onCancelBackupRestore: () -> Unit
 ) {
     val progress by animateFloatAsState(targetValue = restoreProgress)
-    
     WireDialog(
         title = stringResource(R.string.backup_dialog_restoring_backup_title),
         onDismiss = {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating/restoring backups and playing audio, the progress bar looks pretty bland

### Solutions

Add some animations there making it much neater
 
### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Restore/Create a backup
- Or play an audio

### Attachments (Optional)

####  Before:

https://user-images.githubusercontent.com/18124919/234280512-250b018a-9ac0-4662-bf58-7c563ea33a0d.mp4


https://user-images.githubusercontent.com/18124919/234280539-d681924f-831d-4442-bbf4-17225cdc21ab.mp4


####  After

https://user-images.githubusercontent.com/18124919/234280847-11217579-d0ef-4d75-a98e-ee775c045e5f.mp4


https://user-images.githubusercontent.com/18124919/234281590-a2e4198c-594e-44d3-b36e-eddcd1ac08b9.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
