### PR TITLE
fix: stuck in 2fa when account has too many devices (AR-3317)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -125,7 +125,7 @@ private fun LoginContent(
             )
         }
     }
-    val targetRoute: String = if (loginEmailViewModel.secondFactorVerificationCodeState.isCodeSent) {
+    val targetRoute: String = if (loginEmailViewModel.secondFactorVerificationCodeState.isCodeInputNecessary) {
         LoginNavigationItem.EMAIL_SECOND_FACTOR_INPUT.route
     } else {
         LoginNavigationItem.MAIN_LOGIN_FORM_SELECTION.route

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -122,7 +122,7 @@ private fun MainContent(
     VerticalSpace.x32()
     VerificationCode(
         codeLength = codeState.codeLength,
-        currentCode = codeState.code.text,
+        currentCode = codeState.codeInput.text,
         isLoading = isLoading,
         isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
         onCodeChange = onCodeChange,
@@ -135,7 +135,7 @@ private fun MainContent(
 internal fun LoginEmailVerificationCodeScreenPreview() = LoginEmailVerificationCodeContent(
     VerificationCodeState(
         codeLength = 6,
-        code = CodeFieldValue(TextFieldValue("12"), false),
+        codeInput = CodeFieldValue(TextFieldValue("12"), false),
         isCurrentCodeInvalid = false,
         emailUsed = ""
     ),

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -79,7 +79,7 @@ class LoginEmailViewModel @Inject constructor(
         viewModelScope.launch {
             val authScope = withContext(dispatchers.io()) { resolveCurrentAuthScope() } ?: return@launch
 
-            val secondFactorVerificationCode = secondFactorVerificationCodeState.code.text.text
+            val secondFactorVerificationCode = secondFactorVerificationCodeState.codeInput.text.text
             val loginResult = withContext(dispatchers.io()) {
                 authScope.login(
                     userIdentifier = loginState.userIdentifier.text,
@@ -93,6 +93,7 @@ class LoginEmailViewModel @Inject constructor(
                 handleAuthenticationFailure(loginResult, authScope)
                 return@launch
             }
+            secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(isCodeInputNecessary = false)
             val storedUserId = withContext(dispatchers.io()) {
                 addAuthenticatedUser(
                     authTokens = loginResult.authData,
@@ -181,7 +182,7 @@ class LoginEmailViewModel @Inject constructor(
         when (result) {
             is RequestSecondFactorVerificationCodeUseCase.Result.Success -> {
                 secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
-                    isCodeSent = true,
+                    isCodeInputNecessary = true,
                     emailUsed = email,
                 )
                 updateEmailLoginError(LoginError.None)
@@ -215,7 +216,7 @@ class LoginEmailViewModel @Inject constructor(
     }
 
     fun onCodeChange(newValue: CodeFieldValue) {
-        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(code = newValue, isCurrentCodeInvalid = false)
+        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(codeInput = newValue, isCurrentCodeInvalid = false)
         if (newValue.isFullyFilled) {
             login()
         }
@@ -223,8 +224,8 @@ class LoginEmailViewModel @Inject constructor(
 
     fun onCodeVerificationBackPress() {
         secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
-            code = CodeFieldValue(TextFieldValue(""), false),
-            isCodeSent = false,
+            codeInput = CodeFieldValue(TextFieldValue(""), false),
+            isCodeInputNecessary = false,
             emailUsed = "",
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
@@ -25,8 +25,8 @@ import com.wire.android.ui.common.textfield.CodeFieldValue
 data class VerificationCodeState(
     val codeLength: Int = DEFAULT_VERIFICATION_CODE_LENGTH,
     val emailUsed: String = "",
-    val isCodeSent: Boolean = false,
-    val code: CodeFieldValue = CodeFieldValue(TextFieldValue(""), false),
+    val isCodeInputNecessary: Boolean = false,
+    val codeInput: CodeFieldValue = CodeFieldValue(TextFieldValue(""), false),
     val isCurrentCodeInvalid: Boolean = false,
 ) {
     companion object {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -353,6 +353,18 @@ class LoginEmailViewModelTest {
     }
 
     @Test
+    fun `given login fails with missing 2fa, when logging in, then should state 2FA input is needed`() = runTest {
+        val email = "some.email@example.org"
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA
+        coEvery { requestSecondFactorCodeUseCase(any(), any()) } returns RequestSecondFactorVerificationCodeUseCase.Result.Success
+        loginViewModel.onUserIdentifierChange(TextFieldValue(email))
+
+        loginViewModel.login()
+
+        loginViewModel.secondFactorVerificationCodeState.isCodeInputNecessary shouldBe true
+    }
+
+    @Test
     fun `given login fails with invalid 2fa, when logging in, then should mark the current code as invalid`() = runTest {
         coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Invalid2FA
         loginViewModel.onUserIdentifierChange(TextFieldValue("some.email@example.org"))
@@ -389,6 +401,7 @@ class LoginEmailViewModelTest {
     fun `given 2fa login succeeds and registration fails, when code is filled, then should no longer require input`() = runTest {
         val email = "some.email@example.org"
         val code = "123456"
+
         coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Success(
             AUTH_TOKEN,
             SSO_ID,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3317" title="AR-3317" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3317</a>  Can't login with 2FA on bund-next environments anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Once login succeeds (2FA is correct), but the client registration fails due to any reason, the user is stuck in the 2FA input screen.

### Causes

The state is not updated to stop requesting user input after successful login.

### Solutions

1. Rename the `isCodeSent` (_i.e._ 2fa code is sent to the email, waiting user input), to something more meaningful: `isCodeInputNecessary`. Self explanatory.
2. Update `isCodeInputNecessary` to `false` as soon as the login succeeds. Doesn't matter if other steps fail or not, at leas the 2FA part did its job and properly collected a valid 2FA code.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
