### PR TITLE
feat: support application id customization (AR-3334)

### DIFF
--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -65,12 +65,12 @@ object Default {
 }
 
 fun NamedDomainObjectContainer<ApplicationProductFlavor>.createAppFlavour(
-    applicationId: String,
+    flavorApplicationId: String,
     flavour: ProductFlavors
 ) {
     create(flavour.buildName) {
         dimension = flavour.dimensions
-        applicationId = flavour.applicationId
+        applicationId = flavorApplicationId
         versionNameSuffix = "-${flavour.buildName}"
         resValue("string", "app_name", flavour.appName)
         manifestPlaceholders.apply {
@@ -153,14 +153,22 @@ android {
     flavorDimensions(FlavorDimensions.DEFAULT)
     productFlavors {
         fun createFlavor(flavor: ProductFlavors) {
-            val applicationId = buildtimeConfiguration.flavorMap[flavor.buildName]!![FeatureConfigs.APPLICATION_ID]!!
-            createAppFlavour(applicationId, flavor)
+            val flavorName = flavor.buildName
+            val flavorSpecificMap = buildtimeConfiguration.flavorMap[flavorName]
+            requireNotNull(flavorSpecificMap) {
+                "Missing configs in json file for the flavor '$flavorName'"
+            }
+            val flavorApplicationId = flavorSpecificMap[FeatureConfigs.APPLICATION_ID.value] as? String
+            requireNotNull(flavorApplicationId) {
+                "Missing application ID definition for the flavor '$flavorName'"
+            }
+            createAppFlavour(flavorApplicationId, flavor)
         }
         createFlavor(ProductFlavors.Dev)
-        createFlavour(ProductFlavors.Staging)
-        createFlavour(ProductFlavors.Beta)
-        createFlavour(ProductFlavors.Internal)
-        createFlavour(ProductFlavors.Production)
+        createFlavor(ProductFlavors.Staging)
+        createFlavor(ProductFlavors.Beta)
+        createFlavor(ProductFlavors.Internal)
+        createFlavor(ProductFlavors.Production)
     }
 
 

--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
     "flavors": {
         "prod": {
+            "application_id": "com.wire",
             "developer_features_enabled": false,
             "logging_enabled": false,
             "application_is_private_build": false,
@@ -8,6 +9,7 @@
             "mls_support_enabled": false
         },
         "dev": {
+            "application_id": "com.waz.zclient.dev",
             "developer_features_enabled": true,
             "logging_enabled": true,
             "application_is_private_build": true,
@@ -26,6 +28,7 @@
             "default_backend_title": "wire-staging"
         },
         "staging": {
+            "application_id": "com.waz.zclient.dev",
             "developer_features_enabled": true,
             "logging_enabled": true,
             "application_is_private_build": true,
@@ -44,6 +47,7 @@
             "default_backend_title": "wire-staging"
         },
         "beta": {
+            "application_id": "com.wire.android.internal",
             "developer_features_enabled": true,
             "logging_enabled": true,
             "application_is_private_build": true,
@@ -51,6 +55,7 @@
             "mls_support_enabled": false
         },
         "internal": {
+            "application_id": "com.wire.internal",
             "developer_features_enabled": true,
             "logging_enabled": true,
             "application_is_private_build": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3334" title="AR-3334" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3334</a>  Implement correct bundle IDs for custom builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Customers using whitelabel apps need to be able to customise the app ID.

Currently, it's all hardcoded in our `variants.kt` file, for each flavour.

### Solutions

Removed the hardcoded values from `variants.gradle.kt` and moved the application id definitions to the `default.json` file to define the app ID of each flavour.

This way we can use the same mechanism for customisation already being used to personalise other build settings (with a `custom.json` file).

### Testing

Manually tested.

#### How to test

Play around with the `default.json` file changing the `application_id` and build the different flavours to see the outcome.

### Attachments

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
