### PR TITLE
ci: fix kalium checkout race condition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,13 +155,14 @@ pipeline {
       }
     }
 
-    stage('Spawn Wrapper and Emulators') {
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
+
+    stage('Configure workspace and Emulators') {
       parallel {
-        stage('Fetch submodules') {
-          steps {
-            sh 'git submodule update --init --recursive'
-          }
-        }
 
         stage('Copy local.properties to Kalium') {
           steps {


### PR DESCRIPTION
There's a race condition between copying the `local.properties` to `kalium` and the actual checking out of `kalium`, which leads to a Git failure, as during checkout, the `kalium` folder is not empty

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Jenkins sometimes fails randomly.

### Causes

There's a race condition between copying the `local.properties` to `kalium` and the actual checking out of `kalium`, which leads to a Git failure, as during checkout, the `kalium` folder is not empty


### Solutions

Fetch submodules before finishing the configuration of the workspace (copying `local.properties` for example).

----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
