### PR TITLE
fix(frida): handle role edit option for federated users 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/Membership.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/Membership.kt
@@ -34,4 +34,6 @@ enum class Membership(@StringRes val stringResourceId: Int) {
     None(-1)
 }
 
-fun Membership.hasLabel(): Boolean = stringResourceId != -1;
+fun Membership.hasLabel(): Boolean = stringResourceId != -1
+
+fun Membership.allowsRoleEdition() = this != Membership.Federated && this != Membership.Service

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
@@ -39,10 +39,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.RowItemTemplate
-import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.SurfaceBackgroundWrapper
 import com.wire.android.ui.common.button.WireButton
+import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversationslist.model.allowsRoleEdition
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
@@ -90,6 +91,7 @@ fun OtherUserProfileGroup(
                 label = stringResource(id = R.string.user_profile_group_role),
                 value = AnnotatedString(state.groupState!!.role.name.asString()),
                 isSelfAdmin = state.groupState.isSelfAdmin,
+                isRoleEditable = state.membership.allowsRoleEdition(),
                 openChangeRoleBottomSheet = openChangeRoleBottomSheet
             )
         }
@@ -100,7 +102,7 @@ fun OtherUserProfileGroup(
 private fun UserGroupDetailsInformation(
     title: AnnotatedString,
     isSelfAdmin: Boolean,
-    onRemoveFromConversation: () -> Unit,
+    onRemoveFromConversation: () -> Unit
 ) {
     SurfaceBackgroundWrapper {
         Column(modifier = Modifier.padding(horizontal = dimensions().spacing16x)) {
@@ -108,7 +110,7 @@ private fun UserGroupDetailsInformation(
             Text(
                 style = MaterialTheme.wireTypography.body01,
                 color = MaterialTheme.wireColorScheme.labelText,
-                text = title,
+                text = title
             )
             Spacer(modifier = Modifier.height(dimensions().spacing16x))
             if (isSelfAdmin) {
@@ -116,7 +118,7 @@ private fun UserGroupDetailsInformation(
                     text = stringResource(id = R.string.user_profile_group_remove_button),
                     minHeight = dimensions().spacing32x,
                     fillMaxWidth = false,
-                    onClick = onRemoveFromConversation,
+                    onClick = onRemoveFromConversation
                 )
                 Spacer(modifier = Modifier.height(dimensions().spacing16x))
             }
@@ -130,6 +132,7 @@ private fun UserRoleInformation(
     value: AnnotatedString,
     clickable: Clickable = Clickable(enabled = false) {},
     isSelfAdmin: Boolean,
+    isRoleEditable: Boolean,
     openChangeRoleBottomSheet: () -> Unit
 ) {
     RowItemTemplate(
@@ -149,7 +152,7 @@ private fun UserRoleInformation(
             )
         },
         actions = {
-            if (isSelfAdmin) {
+            if (isSelfAdmin && isRoleEditable) {
                 EditButton(onEditClicked = openChangeRoleBottomSheet)
             }
         },


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We can edit the role of the user, even if there is no possible for them to execute operations as their new role.

### Causes (Optional)

Failing admin operations for users on different domains

### Solutions

Check if the user is a member of the same domain, and only then, the user admin can elevate/change the role of the target user.

### Attachments

https://user-images.githubusercontent.com/5806454/234564259-718da3dd-c67e-4314-9670-feb54b400ef5.mov

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Context: Log in a federated environment, have a group conversation with users from other backends.
Expected: Me as an admin I cannot edit the role of user if is on a different domain (aka, federated)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
