### PR TITLE
fix: remove audio animation for the slider (RC)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -1,7 +1,5 @@
 package com.wire.android.ui.home.conversations.model.messagetypes.audio
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -92,7 +90,6 @@ private fun SuccessfulAudioMessage(
     onSliderPositionChange: (Float) -> Unit,
     onAudioMessageLongClick: (() -> Unit)? = null
 ) {
-    val stiffness = 5f
     val audioDuration by remember(currentPositionInMs) {
         mutableStateOf(
             AudioDuration(totalTimeInMs, currentPositionInMs)
@@ -115,13 +112,9 @@ private fun SuccessfulAudioMessage(
             state = if (audioMediaPlayingState is AudioMediaPlayingState.Fetching) WireButtonState.Disabled else WireButtonState.Default,
             onButtonClicked = onPlayButtonClick
         )
-        val progress by animateFloatAsState(
-            targetValue = audioDuration.currentPositionInMs.toFloat(),
-            animationSpec = spring(stiffness = stiffness)
-        )
 
         Slider(
-            value = progress,
+            value = audioDuration.currentPositionInMs.toFloat(),
             onValueChange = onSliderPositionChange,
             valueRange = 0f..if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f,
             colors = SliderDefaults.colors(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For audio messages, the slider is moving slowly when trying change it manually, making it a bad UX

### Causes (Optional)

Issue introduced by #1712

### Solutions

Removing that animation.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
