### PR TITLE
chore: adding readme section for contributing to language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,12 @@ It might be that after cloning the Android Reloaded project, some build issues a
 - There is a valid SDK path on your `local.properties` AND `kalium/local.properties` files pointing to the Android SDK folder. In Mac, that folder can be usually found under `sdk.dir=/Users/YOUR_USER_FOLDER/Library/Android/sdk`. The IDE **will not** create `kalium/local.properties` automatically, so you might want to copy/paste the one in the project root
 - When you've already started working on the project adding some commits, it might occur that your local build breaks, if that is the case, make sure you've updated the `kalium` submodule reference by running: `git submodule update --remote --merge`
 
-## Happy coding!!!
+## Contributing
+
+If you want to help Wire to speak more languages, please refer to our [site](https://support.wire.com/hc/en-us/articles/202856874-Language-support), to see the official list of supported languages and those who are open to contribute.
+
+To do so, you will find instructions there, but you can do the following:
+
+1. Create a [Crowdin account](https://crowdin.com/).
+2. Request access to add translations in our [project](https://crowdin.com/project/wire-android-reloaded).
+3. Translate away.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Because of the following PR, it's better to make things more clear for contributors.
https://github.com/wireapp/wire-android-reloaded/pull/1643

### Solutions

Adds section to the readme file, dedicated to contributing to translations.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
