### PR TITLE
feat: support resource customization

### DIFF
--- a/buildSrc/src/main/kotlin/customization/BuildTimeConfiguration.kt
+++ b/buildSrc/src/main/kotlin/customization/BuildTimeConfiguration.kt
@@ -1,5 +1,12 @@
 package customization
 
+import java.io.File
+
+data class BuildTimeConfiguration(
+    val flavorSettings: NormalizedFlavorSettings,
+    val customResourceOverrideDirectory: File?
+)
+
 data class NormalizedFlavorSettings(
     val flavorMap: Map<String, Map<String, Any?>>
 )

--- a/buildSrc/src/main/kotlin/customization/FeatureFlags.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureFlags.kt
@@ -18,7 +18,7 @@
  */
 package customization
 
-import scripts.Variants_gradle.ProductFlavors
+import flavor.ProductFlavors
 
 /**
  * By convention use the prefix FEATURE_ for every

--- a/buildSrc/src/main/kotlin/customization/ResourcesOverrider.kt
+++ b/buildSrc/src/main/kotlin/customization/ResourcesOverrider.kt
@@ -1,0 +1,26 @@
+package customization
+
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
+import flavor.ProductFlavors
+import java.io.File
+
+fun BaseExtension.overrideResourcesForAllFlavors(
+    customResourcesRootDir: File
+) {
+
+    sourceSets {
+        ProductFlavors.all.forEach {
+            getByName(it.buildName).apply {
+                val resDir = (res as DefaultAndroidSourceDirectorySet).srcDirs.first()
+                println("Copying files from '${customResourcesRootDir.absolutePath}' into '${resDir.absolutePath}'")
+
+                customResourcesRootDir.walkTopDown().filter { !it.isDirectory }.forEach { customContent ->
+                    val relativePath = customContent.relativeTo(customResourcesRootDir).path
+                    val targetFile = File(resDir, relativePath)
+                    customContent.copyTo(targetFile, overwrite = true)
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/flavor/ProductFlavors.kt
+++ b/buildSrc/src/main/kotlin/flavor/ProductFlavors.kt
@@ -1,0 +1,31 @@
+package flavor
+
+object FlavorDimensions {
+    const val DEFAULT = "default"
+}
+
+sealed class ProductFlavors(
+    val buildName: String,
+    val appName: String,
+    val dimensions: String = FlavorDimensions.DEFAULT,
+    val shareduserId: String = ""
+) {
+    override fun toString(): String = this.buildName
+
+    object Dev : ProductFlavors("dev", "Wire Dev")
+    object Staging : ProductFlavors("staging", "Wire Staging")
+
+    object Beta : ProductFlavors("beta", "Wire Beta")
+    object Internal : ProductFlavors("internal", "Wire Internal")
+    object Production : ProductFlavors("prod", "Wire", shareduserId = "com.waz.userid")
+
+    companion object {
+        val all: Collection<ProductFlavors> = setOf(
+            Dev,
+            Staging,
+            Beta,
+            Internal,
+            Production,
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -134,9 +134,7 @@ android {
 
     flavorDimensions(FlavorDimensions.DEFAULT)
 
-    val buildtimeConfiguration = getBuildtimeConfiguration(rootDir = rootDir,
-        Customization.CustomizationOption.FromFile(rootProject.file("custom/custom-reloaded.json"))
-    )
+    val buildtimeConfiguration = getBuildtimeConfiguration(rootDir = rootDir)
     val flavorMap = buildtimeConfiguration.flavorSettings.flavorMap
 
     productFlavors {

--- a/buildSrc/src/test/kotlin/customization/CustomizationTest.kt
+++ b/buildSrc/src/test/kotlin/customization/CustomizationTest.kt
@@ -63,7 +63,7 @@ class CustomizationTest {
             Customization.CustomizationOption.DefaultOnly
         )
 
-        result.flavorMap["dev"]!!["foo"] shouldBeEqualTo "default"
+        result.flavorSettings.flavorMap["dev"]!!["foo"] shouldBeEqualTo "default"
     }
 
     @Test
@@ -94,6 +94,6 @@ class CustomizationTest {
             Customization.CustomizationOption.FromFile(customFile)
         )
 
-        result.flavorMap["dev"]!!["foo"] shouldBeEqualTo "custom"
+        result.flavorSettings.flavorMap["dev"]!!["foo"] shouldBeEqualTo "custom"
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Customers with custom builds need some resources to be overriden.

### Solutions

Check if the customization directory also contains a `resources` directory inside of it.
If it does, grab all files from inside the `resources` directory and copy them into `res` of each flavor, keeping the file structure.

#### Example:
```
-custom/
 |-resources/
 | |-mipmap/
 |   |-file1.png
 | |-file2.png
  -
```

- `file2.png` will be copied to `res/file2.png`
- `file1.png` will be copied to `res/mipmap/file1.png`

This is applied to all flavors. It doesn't allow flavor-specific resources for custom builds. A new custom build is needed in order to do it.

### Testing

Tested manually.

Coverage will be added Soon™.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Force a customized build by adding a `custom.json` file:

```kotlin
val buildtimeConfiguration = getBuildtimeConfiguration(rootDir = rootDir,
    Customization.CustomizationOption.FromFile(rootProject.file("custom/custom-reloaded.json"))
)
```
Add a `resources` directory beside the `custom-reloaded.json` file.
Its content will be copied to all flavours.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
