### PR TITLE
fix: handle too many requests on 2fa request (AR-3365)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -103,32 +103,32 @@ class LoginEmailViewModel @Inject constructor(
                     replace = false
                 )
             }.let {
-                    when (it) {
-                        is AddAuthenticatedUserUseCase.Result.Failure -> {
-                            updateEmailLoginError(it.toLoginError())
-                            return@launch
-                        }
-
-                        is AddAuthenticatedUserUseCase.Result.Success -> it.userId
+                when (it) {
+                    is AddAuthenticatedUserUseCase.Result.Failure -> {
+                        updateEmailLoginError(it.toLoginError())
+                        return@launch
                     }
+
+                    is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
+            }
             withContext(dispatchers.io()) {
                 registerClient(
                     userId = storedUserId,
                     password = loginState.password.text,
                 )
             }.let {
-                    when (it) {
-                        is RegisterClientResult.Failure -> {
-                            updateEmailLoginError(it.toLoginError())
-                            return@launch
-                        }
+                when (it) {
+                    is RegisterClientResult.Failure -> {
+                        updateEmailLoginError(it.toLoginError())
+                        return@launch
+                    }
 
-                        is RegisterClientResult.Success -> {
-                            navigateAfterRegisterClientSuccess(storedUserId)
-                        }
+                    is RegisterClientResult.Success -> {
+                        navigateAfterRegisterClientSuccess(storedUserId)
                     }
                 }
+            }
         }
     }
 
@@ -180,7 +180,8 @@ class LoginEmailViewModel @Inject constructor(
             verifiableAction = VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
         )
         when (result) {
-            is RequestSecondFactorVerificationCodeUseCase.Result.Success -> {
+            is RequestSecondFactorVerificationCodeUseCase.Result.Success,
+            RequestSecondFactorVerificationCodeUseCase.Result.Failure.TooManyRequests -> {
                 secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
                     isCodeInputNecessary = true,
                     emailUsed = email,
@@ -188,7 +189,7 @@ class LoginEmailViewModel @Inject constructor(
                 updateEmailLoginError(LoginError.None)
             }
 
-            is RequestSecondFactorVerificationCodeUseCase.Result.Failure -> {
+            is RequestSecondFactorVerificationCodeUseCase.Result.Failure.Generic -> {
                 updateEmailLoginError(LoginError.DialogError.GenericError(result.cause))
             }
         }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -38,6 +38,7 @@ import com.wire.android.ui.authentication.login.LoginError
 import com.wire.android.ui.common.textfield.CodeFieldValue
 import com.wire.android.util.EMPTY
 import com.wire.android.util.newServerConfig
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.server.CommonApiVersionType
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -353,7 +354,35 @@ class LoginEmailViewModelTest {
     }
 
     @Test
-    fun `given login fails with missing 2fa and 2fa too many requests, when logging in, then should assume email was sent`() = runTest {
+    fun `given login fails with 2fa missing and 2fa request succeeds, when logging in, then should request user input`() = runTest {
+        val email = "some.email@example.org"
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA
+        coEvery { requestSecondFactorCodeUseCase(any(), any()) } returns RequestSecondFactorVerificationCodeUseCase.Result.Success
+        loginViewModel.onUserIdentifierChange(TextFieldValue(email))
+
+        loginViewModel.login()
+
+        loginViewModel.secondFactorVerificationCodeState.isCodeInputNecessary shouldBe true
+        coVerify(exactly = 1) { requestSecondFactorCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION) }
+    }
+
+    @Test
+    fun `given login fails with 2fa missing and 2fa request fails generically, when logging in, then should NOT request user input`() = runTest {
+        val email = "some.email@example.org"
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA
+        coEvery { requestSecondFactorCodeUseCase(any(), any()) } returns RequestSecondFactorVerificationCodeUseCase.Result.Failure.Generic(
+            CoreFailure.Unknown(null)
+        )
+        loginViewModel.onUserIdentifierChange(TextFieldValue(email))
+
+        loginViewModel.login()
+
+        loginViewModel.secondFactorVerificationCodeState.isCodeInputNecessary shouldBe false
+        coVerify(exactly = 1) { requestSecondFactorCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION) }
+    }
+
+    @Test
+    fun `given 2fa code request fails with too many requests, when logging in, then should request user input`() = runTest {
         val email = "some.email@example.org"
         coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA
         coEvery {
@@ -363,6 +392,7 @@ class LoginEmailViewModelTest {
 
         loginViewModel.login()
 
+        loginViewModel.secondFactorVerificationCodeState.isCodeInputNecessary shouldBe true
         coVerify(exactly = 1) { requestSecondFactorCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION) }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -353,6 +353,20 @@ class LoginEmailViewModelTest {
     }
 
     @Test
+    fun `given login fails with missing 2fa and 2fa too many requests, when logging in, then should assume email was sent`() = runTest {
+        val email = "some.email@example.org"
+        coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA
+        coEvery {
+            requestSecondFactorCodeUseCase(any(), any())
+        } returns RequestSecondFactorVerificationCodeUseCase.Result.Failure.TooManyRequests
+        loginViewModel.onUserIdentifierChange(TextFieldValue(email))
+
+        loginViewModel.login()
+
+        coVerify(exactly = 1) { requestSecondFactorCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION) }
+    }
+
+    @Test
     fun `given login fails with missing 2fa, when logging in, then should state 2FA input is needed`() = runTest {
         val email = "some.email@example.org"
         coEvery { loginUseCase(any(), any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials.Missing2FA

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -34,7 +34,7 @@ object AndroidNdk {
 object AndroidClient {
     const val appId = "com.wire.android"
     val versionCode = Versionizer().versionCode
-    const val versionName = "4.1.1"
+    const val versionName = "4.1.2"
     const val testRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3365" title="AR-3365" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3365</a>  Server error is shown if rate limit is reached after second login on 2FA backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there is a `TooManyRequests` response from the backend during 2FA code request, the user sees a generic ServerError

### Causes

Backend is very restrictive, and this happens often.

### Solutions

Rely on the new change in Kalium that returns a `TooManyRequests` result:
- https://github.com/wireapp/kalium/pull/1682

Because the backend returns it on a per-email basis, we can assume that the email was recently sent, and the code can be used. So from a UX point of view, we can handle as a success, and ask for the 2FA code input.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/1682

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
