### PR TITLE
feat: offline backends - handling list-prekeys failed to list messages (AR-3122)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -49,6 +49,8 @@ import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidRemoteData
 import com.wire.kalium.logic.util.isGreaterThan
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import javax.inject.Inject
 
 // TODO: splits mapping into more classes
@@ -305,10 +307,12 @@ class MessageContentMapper @Inject constructor(
         return when (deliveryStatus) {
             is DeliveryStatus.PartialDelivery -> DeliveryStatusContent.PartialDelivery(
                 failedRecipients = deliveryStatus.recipientsFailedDelivery
-                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) },
+                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
+                    .toPersistentList(),
                 noClients = deliveryStatus.recipientsFailedWithNoClients
                     .groupBy { it.domain }
                     .mapValues { (_, userIds) -> userIds.map { UIText.DynamicString(userList.findUser(userId = it)?.name.orEmpty()) } }
+                    .toPersistentMap()
             )
             is DeliveryStatus.CompleteDelivery, null -> DeliveryStatusContent.CompleteDelivery
         }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -301,13 +301,13 @@ class MessageContentMapper @Inject constructor(
         }
     }
 
-    // todo(fed): do the mapping here?
     private fun mapRecipientsFailure(userList: List<User>, deliveryStatus: DeliveryStatus?): DeliveryStatusContent {
         return when (deliveryStatus) {
             is DeliveryStatus.PartialDelivery -> DeliveryStatusContent.PartialDelivery(
                 failedRecipients = deliveryStatus.recipientsFailedDelivery
                     .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) },
-                noClients = deliveryStatus.recipientsFailedWithNoClients.groupBy { it.domain }
+                noClients = deliveryStatus.recipientsFailedWithNoClients
+                    .groupBy { it.domain }
                     .mapValues { (_, userIds) -> userIds.map { UIText.DynamicString(userList.findUser(userId = it)?.name.orEmpty()) } }
             )
             is DeliveryStatus.CompleteDelivery, null -> DeliveryStatusContent.CompleteDelivery

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -301,15 +301,14 @@ class MessageContentMapper @Inject constructor(
         }
     }
 
+    // todo(fed): do the mapping here?
     private fun mapRecipientsFailure(userList: List<User>, deliveryStatus: DeliveryStatus?): DeliveryStatusContent {
         return when (deliveryStatus) {
             is DeliveryStatus.PartialDelivery -> DeliveryStatusContent.PartialDelivery(
                 failedRecipients = deliveryStatus.recipientsFailedDelivery
-                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
-                    .filter { it.value.isNotEmpty() },
-                noClients = deliveryStatus.recipientsFailedWithNoClients
-                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
-                    .filter { it.value.isNotEmpty() }
+                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) },
+                noClients = deliveryStatus.recipientsFailedWithNoClients.groupBy { it.domain }
+                    .mapValues { (_, userIds) -> userIds.map { UIText.DynamicString(userList.findUser(userId = it)?.name.orEmpty()) } }
             )
             is DeliveryStatus.CompleteDelivery, null -> DeliveryStatusContent.CompleteDelivery
         }
@@ -440,7 +439,7 @@ class AssetMessageContentMetadata(val assetMessageContent: AssetContent) {
         }
 
     fun isDisplayableImage(): Boolean = isDisplayableImageMimeType(assetMessageContent.mimeType) &&
-        imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
+            imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
 }
 
 // TODO: should we keep it here ?

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -303,11 +303,11 @@ class MessageContentMapper @Inject constructor(
     private fun mapRecipientsFailure(userList: List<User>, deliveryStatus: DeliveryStatus?): DeliveryStatusContent {
         return when (deliveryStatus) {
             is DeliveryStatus.PartialDelivery -> DeliveryStatusContent.PartialDelivery(
-                failedRecipients = deliveryStatus.recipientsFailedDelivery.map { userId ->
-                    userList.findUser(userId = userId)?.name.orUnknownName()
-                },
-                noClients = deliveryStatus.recipientsFailedWithNoClients.map { userId ->
-                    userList.findUser(userId = userId)?.name.orUnknownName()
+                failedRecipients = deliveryStatus.recipientsFailedDelivery
+                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
+                    .filter { it.value.isNotEmpty() },
+                noClients = deliveryStatus.recipientsFailedWithNoClients.groupBy { it.domain }.map {
+                    UIText.DynamicString(it.value.joinToString(prefix = "${it.value.size} "){ it.domain })
                 }
             )
             is DeliveryStatus.CompleteDelivery, null -> DeliveryStatusContent.CompleteDelivery

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -56,7 +56,7 @@ import javax.inject.Inject
 class MessageContentMapper @Inject constructor(
     private val messageResourceProvider: MessageResourceProvider,
     private val wireSessionImageLoader: WireSessionImageLoader,
-    private val isoFormatter: ISOFormatter,
+    private val isoFormatter: ISOFormatter
 ) {
 
     fun fromMessage(
@@ -152,7 +152,7 @@ class MessageContentMapper @Inject constructor(
     }
 
     private fun mapTeamMemberRemovedMessage(
-        content: MessageContent.TeamMemberRemoved,
+        content: MessageContent.TeamMemberRemoved
     ): UIMessageContent.SystemMessage = UIMessageContent.SystemMessage.TeamMemberRemoved(content)
 
     private fun mapConversationRenamedMessage(
@@ -251,7 +251,7 @@ class MessageContentMapper @Inject constructor(
 
     private fun mapAudio(
         assetContent: AssetContent,
-        metadata: AssetContent.AssetMetadata.Audio,
+        metadata: AssetContent.AssetMetadata.Audio
     ): UIMessageContent {
         with(assetContent) {
             return UIMessageContent.AudioAssetMessage(
@@ -285,7 +285,8 @@ class MessageContentMapper @Inject constructor(
                 is MessageContent.Text -> UIText.DynamicString(content.value, content.mentions)
                 is MessageContent.Unknown -> content.typeName?.let {
                     UIText.StringResource(
-                        messageResourceProvider.sentAMessageWithContent, it
+                        messageResourceProvider.sentAMessageWithContent,
+                        it
                     )
                 } ?: UIText.StringResource(R.string.sent_a_message_with_unknown_content)
                 is MessageContent.FailedDecryption -> UIText.StringResource(R.string.label_message_decryption_failure_message)
@@ -306,9 +307,9 @@ class MessageContentMapper @Inject constructor(
                 failedRecipients = deliveryStatus.recipientsFailedDelivery
                     .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
                     .filter { it.value.isNotEmpty() },
-                noClients = deliveryStatus.recipientsFailedWithNoClients.groupBy { it.domain }.map {
-                    UIText.DynamicString(it.value.joinToString(prefix = "${it.value.size} "){ it.domain })
-                }
+                noClients = deliveryStatus.recipientsFailedWithNoClients
+                    .map { userId -> UIText.DynamicString(userList.findUser(userId = userId)?.name.orEmpty()) }
+                    .filter { it.value.isNotEmpty() }
             )
             is DeliveryStatus.CompleteDelivery, null -> DeliveryStatusContent.CompleteDelivery
         }
@@ -439,7 +440,7 @@ class AssetMessageContentMetadata(val assetMessageContent: AssetContent) {
         }
 
     fun isDisplayableImage(): Boolean = isDisplayableImageMimeType(assetMessageContent.mimeType) &&
-            imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
+        imgWidth.isGreaterThan(0) && imgHeight.isGreaterThan(0)
 }
 
 // TODO: should we keep it here ?

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -112,7 +113,12 @@ internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: D
                     if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
                         Text(
                             text = partialDeliveryFailureContent.noClients.entries.map {
-                                stringResource(R.string.label_message_partial_delivery_x_participants_from_backend, it.value.size, it.key)
+                                pluralStringResource(
+                                    R.plurals.label_message_partial_delivery_x_participants_from_backend,
+                                    it.value.size,
+                                    it.value.size,
+                                    it.key
+                                )
                             }.joinToString(", ") + stringResource(
                                 R.string.label_message_partial_delivery_participants_wont_deliver,
                                 String.EMPTY
@@ -151,7 +157,7 @@ private fun SingleUserDeliveryFailure(
     Column {
         Text(
             text = stringResource(
-                id = R.string.label_message_partial_delivery_participants_wont_deliver,
+                id = R.string.label_message_partial_delivery_participants_deliver_later,
                 partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
             ),
             textAlign = TextAlign.Start

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -75,56 +75,80 @@ internal fun MessageSendFailureWarning(
 
 @Composable
 internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: DeliveryStatusContent.PartialDelivery) {
-    val resources = LocalContext.current.resources
+    val context = LocalContext.current
+    val resources = context.resources
     var expanded: Boolean by remember { mutableStateOf(false) }
     CompositionLocalProvider(
         LocalTextStyle provides MaterialTheme.typography.labelSmall.copy(color = MaterialTheme.wireColorScheme.error)
     ) {
-        Column {
-            Text(
-                text = stringResource(
-                    id = R.string.label_message_partial_delivery_participants_count,
-                    partialDeliveryFailureContent.totalUsersWithFailures
-                ),
-                textAlign = TextAlign.Start
-            )
-            VerticalSpace.x4()
-            if (expanded) {
-                if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
-                    // map to domain count
-                    Text(
-                        text = stringResource(
-                            id = R.string.label_message_partial_delivery_participants_wont_deliver,
-                            partialDeliveryFailureContent.noClients.joinToString(", ") { it.asString(resources) }
-                        ),
-                        textAlign = TextAlign.Start
-                    )
-                }
-                if (partialDeliveryFailureContent.failedRecipients.isNotEmpty()) {
-                    // ignore users without metadata
-                    Text(
-                        text = stringResource(
-                            id = R.string.label_message_partial_delivery_participants_deliver_later,
-                            partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
-                        ),
-                        textAlign = TextAlign.Start
-                    )
-                }
-            }
-            VerticalSpace.x4()
-            if (partialDeliveryFailureContent.expandable) {
-                WireSecondaryButton(
-                    onClick = { expanded = !expanded },
-                    text = stringResource(if (expanded) R.string.label_hide_details else R.string.label_show_details),
-                    fillMaxWidth = false,
-                    minHeight = dimensions().spacing32x,
-                    minWidth = dimensions().spacing40x,
-                    shape = RoundedCornerShape(size = dimensions().corner12x),
-                    contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
-                    modifier = Modifier
-                        .padding(top = dimensions().spacing4x)
-                        .height(height = dimensions().spacing32x)
+        if (partialDeliveryFailureContent.onlyOneUser) {
+            val learnMoreUrl = stringResource(R.string.url_message_details_offline_backends_learn_more)
+            Column {
+                Text(
+                    text = stringResource(
+                        id = R.string.label_message_partial_delivery_participants_deliver_later,
+                        partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
+                    ),
+                    textAlign = TextAlign.Start
                 )
+                Text(
+                    modifier = Modifier
+                        .clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
+                    style = LocalTextStyle.current.copy(
+                        color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    text = stringResource(R.string.label_learn_more)
+                )
+                VerticalSpace.x4()
+            }
+        } else {
+            Column {
+                Text(
+                    text = stringResource(
+                        id = R.string.label_message_partial_delivery_participants_count,
+                        partialDeliveryFailureContent.totalUsersWithFailures
+                    ),
+                    textAlign = TextAlign.Start
+                )
+                VerticalSpace.x4()
+                if (expanded) {
+                    if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
+                        // map to domain count
+                        Text(
+                            text = stringResource(
+                                id = R.string.label_message_partial_delivery_participants_wont_deliver,
+                                partialDeliveryFailureContent.noClients.joinToString(", ") { it.asString(resources) }
+                            ),
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                    if (partialDeliveryFailureContent.failedRecipients.isNotEmpty()) {
+                        // ignore users without metadata
+                        Text(
+                            text = stringResource(
+                                id = R.string.label_message_partial_delivery_participants_deliver_later,
+                                partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
+                            ),
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                }
+                VerticalSpace.x4()
+                if (partialDeliveryFailureContent.expandable) {
+                    WireSecondaryButton(
+                        onClick = { expanded = !expanded },
+                        text = stringResource(if (expanded) R.string.label_hide_details else R.string.label_show_details),
+                        fillMaxWidth = false,
+                        minHeight = dimensions().spacing32x,
+                        minWidth = dimensions().spacing40x,
+                        shape = RoundedCornerShape(size = dimensions().corner12x),
+                        contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
+                        modifier = Modifier
+                            .padding(top = dimensions().spacing4x)
+                            .height(height = dimensions().spacing32x)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -91,6 +91,7 @@ internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: D
             VerticalSpace.x4()
             if (expanded) {
                 if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
+                    // map to domain count
                     Text(
                         text = stringResource(
                             id = R.string.label_message_partial_delivery_participants_wont_deliver,
@@ -100,6 +101,7 @@ internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: D
                     )
                 }
                 if (partialDeliveryFailureContent.failedRecipients.isNotEmpty()) {
+                    // ignore users without metadata
                     Text(
                         text = stringResource(
                             id = R.string.label_message_partial_delivery_participants_deliver_later,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -80,69 +80,77 @@ internal fun MessageSendFailureWarning(
 @Composable
 internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: DeliveryStatusContent.PartialDelivery) {
     val resources = LocalContext.current.resources
-    var expanded: Boolean by remember { mutableStateOf(false) }
     CompositionLocalProvider(
         LocalTextStyle provides MaterialTheme.typography.labelSmall.copy(color = MaterialTheme.wireColorScheme.error)
     ) {
         if (partialDeliveryFailureContent.isSingleUserFailure) {
             SingleUserDeliveryFailure(partialDeliveryFailureContent, resources)
         } else {
-            Column {
+            MultiUserDeliveryFailure(partialDeliveryFailureContent, resources)
+        }
+    }
+}
+
+@Composable
+private fun MultiUserDeliveryFailure(
+    partialDeliveryFailureContent: DeliveryStatusContent.PartialDelivery,
+    resources: Resources
+) {
+    var expanded: Boolean by remember { mutableStateOf(false) }
+    Column {
+        Text(
+            text = stringResource(
+                id = R.string.label_message_partial_delivery_participants_count,
+                partialDeliveryFailureContent.totalUsersWithFailures
+            ),
+            textAlign = TextAlign.Start
+        )
+        VerticalSpace.x4()
+        if (expanded) {
+            if (partialDeliveryFailureContent.filteredRecipientsFailure.isNotEmpty()) {
                 Text(
                     text = stringResource(
-                        id = R.string.label_message_partial_delivery_participants_count,
-                        partialDeliveryFailureContent.totalUsersWithFailures
+                        id = R.string.label_message_partial_delivery_participants_deliver_later,
+                        partialDeliveryFailureContent.filteredRecipientsFailure
+                            .filter {
+                                !it.asString(resources).contentEquals(resources.getString(R.string.username_unavailable_label))
+                            }
+                            .joinToString(", ") { it.asString(resources) }
                     ),
                     textAlign = TextAlign.Start
                 )
-                VerticalSpace.x4()
-                if (expanded) {
-                    if (partialDeliveryFailureContent.filteredRecipientsFailure.isNotEmpty()) {
-                        Text(
-                            text = stringResource(
-                                id = R.string.label_message_partial_delivery_participants_deliver_later,
-                                partialDeliveryFailureContent.filteredRecipientsFailure
-                                    .filter {
-                                        !it.asString(resources).contentEquals(resources.getString(R.string.username_unavailable_label))
-                                    }
-                                    .joinToString(", ") { it.asString(resources) }
-                            ),
-                            textAlign = TextAlign.Start
-                        )
-                    }
-                    if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
-                        Text(
-                            text = partialDeliveryFailureContent.noClients.entries.map {
-                                pluralStringResource(
-                                    R.plurals.label_message_partial_delivery_x_participants_from_backend,
-                                    it.value.size,
-                                    it.value.size,
-                                    it.key
-                                )
-                            }.joinToString(", ") + stringResource(
-                                R.string.label_message_partial_delivery_participants_wont_deliver,
-                                String.EMPTY
-                            ),
-                            textAlign = TextAlign.Start
-                        )
-                    }
-                }
-                VerticalSpace.x4()
-                if (partialDeliveryFailureContent.expandable) {
-                    WireSecondaryButton(
-                        onClick = { expanded = !expanded },
-                        text = stringResource(if (expanded) R.string.label_hide_details else R.string.label_show_details),
-                        fillMaxWidth = false,
-                        minHeight = dimensions().spacing32x,
-                        minWidth = dimensions().spacing40x,
-                        shape = RoundedCornerShape(size = dimensions().corner12x),
-                        contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
-                        modifier = Modifier
-                            .padding(top = dimensions().spacing4x)
-                            .height(height = dimensions().spacing32x)
-                    )
-                }
             }
+            if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
+                Text(
+                    text = partialDeliveryFailureContent.noClients.entries.map {
+                        pluralStringResource(
+                            R.plurals.label_message_partial_delivery_x_participants_from_backend,
+                            it.value.size,
+                            it.value.size,
+                            it.key
+                        )
+                    }.joinToString(", ") + stringResource(
+                        R.string.label_message_partial_delivery_participants_wont_deliver,
+                        String.EMPTY
+                    ),
+                    textAlign = TextAlign.Start
+                )
+            }
+        }
+        VerticalSpace.x4()
+        if (partialDeliveryFailureContent.expandable) {
+            WireSecondaryButton(
+                onClick = { expanded = !expanded },
+                text = stringResource(if (expanded) R.string.label_hide_details else R.string.label_show_details),
+                fillMaxWidth = false,
+                minHeight = dimensions().spacing32x,
+                minWidth = dimensions().spacing40x,
+                shape = RoundedCornerShape(size = dimensions().corner12x),
+                contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
+                modifier = Modifier
+                    .padding(top = dimensions().spacing4x)
+                    .height(height = dimensions().spacing32x)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -31,6 +31,7 @@ import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.UserId
 
 @Composable
@@ -86,7 +87,7 @@ internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: D
             Column {
                 Text(
                     text = stringResource(
-                        id = R.string.label_message_partial_delivery_participants_deliver_later,
+                        id = R.string.label_message_partial_delivery_participants_wont_deliver,
                         partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
                     ),
                     textAlign = TextAlign.Start
@@ -114,21 +115,25 @@ internal fun MessageSentPartialDeliveryFailures(partialDeliveryFailureContent: D
                 VerticalSpace.x4()
                 if (expanded) {
                     if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
-                        // map to domain count
                         Text(
-                            text = stringResource(
-                                id = R.string.label_message_partial_delivery_participants_wont_deliver,
-                                partialDeliveryFailureContent.noClients.joinToString(", ") { it.asString(resources) }
+                            text = partialDeliveryFailureContent.noClients.entries.map {
+                                stringResource(R.string.label_message_partial_delivery_x_participants_from_backend, it.value.size, it.key)
+                            }.joinToString(", ") + stringResource(
+                                R.string.label_message_partial_delivery_participants_wont_deliver,
+                                String.EMPTY
                             ),
                             textAlign = TextAlign.Start
                         )
                     }
                     if (partialDeliveryFailureContent.failedRecipients.isNotEmpty()) {
-                        // ignore users without metadata
                         Text(
                             text = stringResource(
                                 id = R.string.label_message_partial_delivery_participants_deliver_later,
-                                partialDeliveryFailureContent.failedRecipients.joinToString(", ") { it.asString(resources) }
+                                partialDeliveryFailureContent.failedRecipients
+                                    .filter {
+                                        !it.asString(resources).contentEquals(resources.getString(R.string.username_unavailable_label))
+                                    }
+                                    .joinToString(", ") { it.asString(resources) }
                             ),
                             textAlign = TextAlign.Start
                         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -38,6 +38,11 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlin.time.Duration
 
 sealed class UIMessage(
@@ -346,11 +351,11 @@ data class MessageTime(val utcISO: String) {
 @Stable
 sealed interface DeliveryStatusContent {
     class PartialDelivery(
-        val failedRecipients: List<UIText> = emptyList(),
-        val noClients: Map<String, List<UIText>> = emptyMap(),
+        val failedRecipients: ImmutableList<UIText> = persistentListOf(),
+        val noClients: ImmutableMap<String, List<UIText>> = persistentMapOf(),
     ) : DeliveryStatusContent {
         private val usersWithNoClients by lazy { noClients.values.flatten() }
-        val filteredRecipientsFailure by lazy { failedRecipients.filter { it !in usersWithNoClients } }
+        val filteredRecipientsFailure by lazy { failedRecipients.filter { it !in usersWithNoClients }.toImmutableList() }
         val isSingleUserFailure by lazy { totalUsersWithFailures == 1 }
         val totalUsersWithFailures by lazy { (failedRecipients + usersWithNoClients).distinct().count() }
         val hasFailures: Boolean

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -349,10 +349,10 @@ sealed interface DeliveryStatusContent {
         val failedRecipients: List<UIText> = emptyList(),
         val noClients: Map<String, List<UIText>> = emptyMap(),
     ) : DeliveryStatusContent {
-
-        val totalUsersWithFailures by lazy { (failedRecipients + noClients.values.flatten()).distinct().count() }
-        val onlyOneUser by lazy { totalUsersWithFailures == 1 }
-
+        private val usersWithNoClients by lazy { noClients.values.flatten() }
+        val filteredRecipientsFailure by lazy { failedRecipients.filter { it !in usersWithNoClients } }
+        val isSingleUserFailure by lazy { totalUsersWithFailures == 1 }
+        val totalUsersWithFailures by lazy { (failedRecipients + usersWithNoClients).distinct().count() }
         val hasFailures: Boolean
             get() = totalUsersWithFailures > 0
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -343,13 +343,14 @@ data class MessageTime(val utcISO: String) {
     val formattedDate = utcISO.uiMessageDateTime() ?: ""
 }
 
+@Stable
 sealed interface DeliveryStatusContent {
     class PartialDelivery(
         val failedRecipients: List<UIText> = emptyList(),
-        val noClients: List<UIText> = emptyList(),
+        val noClients: Map<String, List<UIText>> = emptyMap(),
     ) : DeliveryStatusContent {
 
-        val totalUsersWithFailures by lazy { (failedRecipients + noClients).distinct().count() }
+        val totalUsersWithFailures by lazy { (failedRecipients + noClients.values.flatten()).distinct().count() }
         val onlyOneUser by lazy { totalUsersWithFailures == 1 }
 
         val hasFailures: Boolean

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -346,11 +346,11 @@ data class MessageTime(val utcISO: String) {
 sealed interface DeliveryStatusContent {
     class PartialDelivery(
         val failedRecipients: List<UIText> = emptyList(),
-        val noClients: List<UIText> = emptyList()
+        val noClients: List<UIText> = emptyList(),
     ) : DeliveryStatusContent {
 
-        val totalUsersWithFailures: Int
-            get() = failedRecipients.size + noClients.size
+        val totalUsersWithFailures by lazy { (failedRecipients + noClients).distinct().count() }
+        val onlyOneUser by lazy { totalUsersWithFailures == 1 }
 
         val hasFailures: Boolean
             get() = totalUsersWithFailures > 0

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,10 +47,13 @@
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
     <string name="label_message_knock">%s pinged</string>
-    <string name="label_message_partial_delivery_participants_count"><b>%1$d</b> participants had issues receiving this message.</string>
-    <string name="label_message_partial_delivery_participants_wont_deliver"><b>%s</b> will not receive this message.</string>
-    <string name="label_message_partial_delivery_participants_deliver_later"><b>%s</b> will receive the message later.</string>
-    <string name="label_message_partial_delivery_x_participants_from_backend"><b>%d participants from %s</b></string>
+    <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
+    <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
+    <string name="label_message_partial_delivery_participants_deliver_later">%s will get your message later.</string>
+    <plurals name="label_message_partial_delivery_x_participants_from_backend">
+        <item quantity="one">1 participant from %2$s</item>
+        <item quantity="other">%1$d participants from %2$s</item>
+    </plurals>
     <string name="label_try_again">Try again</string>
     <string name="label_reset_session">Reset Session</string>
     <string name="label_reset_session_success">Session successfully reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="label_message_partial_delivery_participants_count">%1$d participants had issues receiving this message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s will not receive this message.</string>
     <string name="label_message_partial_delivery_participants_deliver_later">%s will receive the message later.</string>
+    <string name="label_message_partial_delivery_x_participants_from_backend">%d participants from %s</string>
     <string name="label_try_again">Try again</string>
     <string name="label_reset_session">Reset Session</string>
     <string name="label_reset_session_success">Session successfully reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,10 +47,10 @@
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
     <string name="label_message_knock">%s pinged</string>
-    <string name="label_message_partial_delivery_participants_count">%1$d participants had issues receiving this message.</string>
-    <string name="label_message_partial_delivery_participants_wont_deliver">%s will not receive this message.</string>
-    <string name="label_message_partial_delivery_participants_deliver_later">%s will receive the message later.</string>
-    <string name="label_message_partial_delivery_x_participants_from_backend">%d participants from %s</string>
+    <string name="label_message_partial_delivery_participants_count"><b>%1$d</b> participants had issues receiving this message.</string>
+    <string name="label_message_partial_delivery_participants_wont_deliver"><b>%s</b> will not receive this message.</string>
+    <string name="label_message_partial_delivery_participants_deliver_later"><b>%s</b> will receive the message later.</string>
+    <string name="label_message_partial_delivery_x_participants_from_backend"><b>%d participants from %s</b></string>
     <string name="label_try_again">Try again</string>
     <string name="label_reset_session">Reset Session</string>
     <string name="label_reset_session_success">Session successfully reset</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3122" title="AR-3122" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3122</a>  [Android] Implement UI for sending messages when a remote backend is offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
UI part handling of: https://github.com/wireapp/kalium/pull/1662

GOAL: Handling the prekeys failed to list case, persistence, and mapping message option for `client_mismatch_strategy`.

For more context, you can have a look at the PR linked above but in a "tweet":
We are implementing offline backend support, so this adds the partial delivery handling when some clients are not possible to get. Making use of new fields in the backend and using `client_mismatch_strategy`

### Causes (Optional)

Now when a message it's not able to get prekeys for a client, will include those users into the mismatch strategy and display it as an error message for partial delivery.

### Solutions

Handling the UI according to mocks https://www.figma.com/file/UgKehvwIbiIiQ2CCEdsVuf/Android?node-id=32174-258789&t=KA8Xg9YlWzzBVwqA-0

### Dependencies (Optional)

https://github.com/wireapp/kalium/pull/1662

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

WIP

- [ ] I have added automated test to this contribution

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5806454/235160121-25712e46-41c1-48f1-9104-1f11106fd0ef.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
