### PR TITLE
chore: improve IDE support for composite builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 
-# Composite Builds + Hierarchical projects don't go well for KMM
-# https://youtrack.jetbrains.com/issue/KT-52172
-kotlin.mpp.hierarchicalStructureSupport=false
+# Support KMP Gradle Composite Builds - See https://youtrack.jetbrains.com/issue/KT-52172/
+kotlin.mpp.import.enableKgpDependencyResolution=true


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IDE support sucks at the moment when looking at Kalium:logic files inside Reloaded.

### Causes

Our structure (using Gradle Composite builds) wasn't officially supported by KMP.
It kinda is now on Kotlin 1.8.20, but it's behind a feature flag.
It should become the standard in Kotlin 1.9.0.

### Solutions

Enable the KGP Dependency resolution flag, as seen [here](https://youtrack.jetbrains.com/issue/KT-52172/Multiplatform-Support-composite-builds).

> **Note**: It requires IDEs based on IntelliJ 2023.1 or newer in order to see the improvments. So, either IntelliJ 2023.1, or 2023.1.1 EAP/RC, or the new [Android Studio Hedgehog](https://developer.android.com/studio/preview/features#2023.1.1).

> **Warning**: These IDEs do _**not**_ work with our Release/Candidate due to incompatibilities with Kotlin 1.8.10 or older.

### Dependencies

Needs releases with the PR on Kalium's side that also enable it:

- https://github.com/wireapp/kalium/pull/1684

### Testing

Manually tested.

### Attachments

Using IntelliJ 2023.1.1 RC open in `Reloaded` and looking at the class `RegisterClientUseCaseImpl`.

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/9389043/235164491-052c4a54-3daa-4e87-b60b-a395813ec273.png) | ![image](https://user-images.githubusercontent.com/9389043/235164547-c93b2511-bfae-4f06-bb8d-579b9db7b852.png) |

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
