### PR TITLE
fix: move revoke guest link to remove guest access use case [AR-3310]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -165,7 +165,7 @@ fun EditGuestAccessScreen(
         }
         if (editGuestAccessState.shouldShowRevokeLinkConfirmationDialog) {
             RevokeGuestConfirmationDialog(
-                onConfirm = ::onRevokeDialogConfirm, onDialogDismiss = ::onRevokeDialogDismiss
+                onConfirm = ::removeGuestLink, onDialogDismiss = ::onRevokeDialogDismiss
             )
         }
         if (editGuestAccessState.isFailedToGenerateGuestRoomLink) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
@@ -156,15 +156,12 @@ class EditGuestAccessViewModel @Inject constructor(
                 guestAllowed = shouldEnableGuestAccess,
                 servicesAllowed = editGuestAccessState.isServicesAccessAllowed,
                 nonTeamMembersAllowed = shouldEnableGuestAccess // Guest access controls non-team member access
-                )
+            )
         val newAccess = Conversation
             .accessFor(shouldEnableGuestAccess)
 
         viewModelScope.launch {
             withContext(dispatcher.io()) {
-                if (!shouldEnableGuestAccess) {
-                    removeGuestLink()
-                }
                 updateConversationAccessRole(
                     conversationId = conversationId,
                     accessRoles = newAccessRoles,
@@ -223,13 +220,9 @@ class EditGuestAccessViewModel @Inject constructor(
         editGuestAccessState = editGuestAccessState.copy(shouldShowRevokeLinkConfirmationDialog = false)
     }
 
-    fun onRevokeDialogConfirm() {
-        removeGuestLink()
-    }
-
-    private fun removeGuestLink() {
-        updateState(editGuestAccessState.copy(shouldShowRevokeLinkConfirmationDialog = false, isRevokingLink = true))
+    fun removeGuestLink() {
         viewModelScope.launch {
+            updateState(editGuestAccessState.copy(shouldShowRevokeLinkConfirmationDialog = false, isRevokingLink = true))
             revokeGuestRoomLink(conversationId).also {
                 if (it is RevokeGuestRoomLinkResult.Failure) {
                     updateState(editGuestAccessState.copy(isFailedToRevokeGuestRoomLink = true))

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -190,7 +190,7 @@ class EditGuestAccessViewModelTest {
             revokeGuestRoomLink(any())
         } returns RevokeGuestRoomLinkResult.Success
 
-        editGuestAccessViewModel.onRevokeDialogConfirm()
+        editGuestAccessViewModel.removeGuestLink()
 
         coVerify(exactly = 1) {
             revokeGuestRoomLink(any())
@@ -204,7 +204,7 @@ class EditGuestAccessViewModelTest {
             revokeGuestRoomLink(any())
         } returns RevokeGuestRoomLinkResult.Failure(CoreFailure.MissingClientRegistration)
 
-        editGuestAccessViewModel.onRevokeDialogConfirm()
+        editGuestAccessViewModel.removeGuestLink()
 
         coVerify(exactly = 1) {
             revokeGuestRoomLink(any())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3310" title="AR-3310" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3310</a>  Removing guests did not remove all guests (in UI only?)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

RC: https://github.com/wireapp/wire-android-reloaded/pull/1694