### PR TITLE
fix: allow to send knock message when offline [AR-3162]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActionsBox.kt
@@ -165,7 +165,7 @@ private fun AddMentionAction(isSelected: Boolean, addMentionAction: () -> Unit) 
 private fun PingAction(onPingClicked: () -> Unit) {
     WireSecondaryIconButton(
         onButtonClicked = onPingClicked,
-        clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+        clickBlockParams = ClickBlockParams(blockWhenSyncing = false, blockWhenConnecting = false),
         iconResource = R.drawable.ic_ping,
         contentDescription = R.string.content_description_ping_everyone
     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3162" title="AR-3162" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3162</a>  PlayTest 21.02 - Ping -> If sending a Ping fails, there should be a warning
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending pings was disabled when app is offline.

### Causes (Optional)

Sending ping should have similar behaviour as sending text messages and it should show error message under the sent message

### Solutions

Enable sending ping message while offline because rest of error handling is already implemented for system messages

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
| ![before1](https://user-images.githubusercontent.com/13151239/235688240-be8989ce-406a-4984-a374-2fb3dc2fc811.jpeg) | ![after1](https://user-images.githubusercontent.com/13151239/235688289-30fdeff1-cb14-4b5c-8ce0-92ed228169fe.jpeg)  |



