### PR TITLE
fix: missing messages after migration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def defineFlavor() {
     } else if(branchName == "internal") {
         return 'Internal'
     }
-    return 'Staging'
+    return 'Prod'
 }
 
 def defineBuildType() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def defineFlavor() {
     } else if(branchName == "internal") {
         return 'Internal'
     }
-    return 'Prod'
+    return 'Staging'
 }
 
 def defineBuildType() {

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -60,7 +60,7 @@ class MigrationMapper @Inject constructor() {
     }
 
     private fun toQualifiedId(remoteId: String, domain: String?, selfUserId: UserId): QualifiedID {
-        val actualDomain = if(domain.isNullOrEmpty()) {
+        val actualDomain = if (domain.isNullOrEmpty()) {
             selfUserId.domain
         } else {
             domain

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.migration
 
+import androidx.annotation.VisibleForTesting
 import com.wire.android.migration.globalDatabase.ScalaSsoIdEntity
 import com.wire.android.migration.userDatabase.ScalaConversationData
 import com.wire.android.migration.userDatabase.ScalaMessageData
@@ -27,9 +28,6 @@ import com.wire.android.migration.userDatabase.ScalaUserData
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Access
-import com.wire.kalium.logic.data.conversation.Conversation.AccessRole.NON_TEAM_MEMBER
-import com.wire.kalium.logic.data.conversation.Conversation.AccessRole.SERVICE
-import com.wire.kalium.logic.data.conversation.Conversation.AccessRole.TEAM_MEMBER
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.Conversation.Type
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -59,7 +57,8 @@ class MigrationMapper @Inject constructor() {
         )
     }
 
-    private fun toQualifiedId(remoteId: String, domain: String?, selfUserId: UserId): QualifiedID {
+    @VisibleForTesting
+    fun toQualifiedId(remoteId: String, domain: String?, selfUserId: UserId): QualifiedID {
         val actualDomain = if (domain.isNullOrEmpty()) {
             selfUserId.domain
         } else {
@@ -95,7 +94,7 @@ class MigrationMapper @Inject constructor() {
                 protocol = ProtocolInfo.Proteus,
                 mutedStatus = mapMutedStatus(mutedStatus),
                 access = mapAccess(access),
-                accessRole = listOf(TEAM_MEMBER, NON_TEAM_MEMBER, SERVICE),
+                accessRole = emptyList(),
                 removedBy = null,
                 lastReadDate = conversationLastReadTime,
                 lastModifiedDate = lastEventTime,

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -109,9 +109,9 @@ class MigrateActiveAccountsUseCase @Inject constructor(
     }
 
     private fun isDataComplete(serverConfig: ServerConfig, activeAccount: ScalaActiveAccountsEntity): Boolean {
-        val isDomainExist = (!activeAccount.domain.isNullOrBlank()) or (serverConfig.metaData.domain != null)
-        val isAccessTokenExist = activeAccount.accessToken != null
-        return isDomainExist and isAccessTokenExist
+        val isDomainPresent = (!activeAccount.domain.isNullOrBlank()) or (serverConfig.metaData.domain != null)
+        val isAccessTokenPresent = activeAccount.accessToken != null
+        return isDomainPresent and isAccessTokenPresent
     }
 
     private suspend fun handleMissingData(

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -62,7 +62,12 @@ class MigrateActiveAccountsUseCase @Inject constructor(
             val authTokensEither: Either<CoreFailure, AuthTokens> = if (isDataComplete) {
                 // when the data is complete it means the user has a domain and an access token
                 // which make the following double bang operator safe
-                val domain = activeAccount.domain ?: serverConfig.metaData.domain!!
+                val domain = if (!activeAccount.domain.isNullOrBlank()) {
+                    activeAccount.domain
+                } else {
+                    serverConfig.metaData.domain!!
+                }
+
                 val userId = UserId(activeAccount.id, domain)
                 Either.Right(
                     AuthTokens(
@@ -104,7 +109,7 @@ class MigrateActiveAccountsUseCase @Inject constructor(
     }
 
     private fun isDataComplete(serverConfig: ServerConfig, activeAccount: ScalaActiveAccountsEntity): Boolean {
-        val isDomainExist = (activeAccount.domain != null) or (serverConfig.metaData.domain != null)
+        val isDomainExist = (!activeAccount.domain.isNullOrBlank()) or (serverConfig.metaData.domain != null)
         val isAccessTokenExist = activeAccount.accessToken != null
         return isDomainExist and isAccessTokenExist
     }
@@ -122,9 +127,9 @@ class MigrateActiveAccountsUseCase @Inject constructor(
         }
     }
 
-        data class Result(val userIds: Map<String, Either<AccountMigrationFailure, UserId>>, val isFederationEnabled: Boolean)
+    data class Result(val userIds: Map<String, Either<AccountMigrationFailure, UserId>>, val isFederationEnabled: Boolean)
 
-        data class AccountMigrationFailure(val userName: String?, val userHandle: String?, val cause: CoreFailure)
+    data class AccountMigrationFailure(val userName: String?, val userHandle: String?, val cause: CoreFailure)
 
     private companion object {
         const val REFRESH_TOKEN_PREFIX = "zuid="

--- a/app/src/test/kotlin/com/wire/android/migration/MigrationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrationMapperTest.kt
@@ -30,7 +30,7 @@ class MigrationMapperTest {
     }
 
     @Test
-    fun givenNonEmptyStringDomain_whenMappingIdFromScala_thenUserDomain() {
+    fun givenNonEmptyStringDomain_whenMappingIdFromScala_thenKeepTheDomainFromScala() {
         val scalaId = "123-321_123"
         val domain = "domain.com"
         val selfUser = UserId("self_id", "self_domain")

--- a/app/src/test/kotlin/com/wire/android/migration/MigrationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/migration/MigrationMapperTest.kt
@@ -1,0 +1,43 @@
+package com.wire.android.migration
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
+import org.amshove.kluent.internal.assertEquals
+import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class MigrationMapperTest {
+
+    private lateinit var migrationMapper: MigrationMapper
+    @BeforeEach
+    fun setUp() {
+        migrationMapper = MigrationMapper()
+    }
+
+    @Test
+    fun givenEmptyStringDomain_whenMappingIdFromScala_thenUserSelfDomain() {
+        val scalaId = "123-321_123"
+        val domain = ""
+        val selfUser = UserId("self_id", "self_domain")
+
+        val expected = QualifiedID(scalaId, selfUser.domain)
+        migrationMapper.toQualifiedId(scalaId, domain, selfUser).also {
+            assertEquals(expected, it)
+        }
+    }
+
+    @Test
+    fun givenNonEmptyStringDomain_whenMappingIdFromScala_thenUserDomain() {
+        val scalaId = "123-321_123"
+        val domain = "domain.com"
+        val selfUser = UserId("self_id", "self_domain")
+
+        val expected = QualifiedID(scalaId, domain)
+        migrationMapper.toQualifiedId(scalaId, domain, selfUser).also {
+            assertEquals(expected, it)
+        }
+    }
+}


### PR DESCRIPTION
…lf ID

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

missing message after migraiton from scala

### Causes (Optional)

one of the scala versions is setting the domain value as an empty string in the DB instead of null.
the migration code set the domain as the user self domain if the DB version is too old (before federation) but in this case the scala is randomly setting the domain (for some it is correct for others it is an empty string)

### Solutions

for new user:
- check the domain when mapping and user the user self domain in case of null or blank

for efected users:
- the fix will be from kalium in form of DB migration that lookup the corrupted IDs (user and conversations IDs) and fixes it by appending the user self domain to it

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/1702/

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
