### PR TITLE
fix(rc): NPE crash after configuration changes [AR-3290]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.SharedFlow
 
 class NavigationManager {
 
-    private val _navigateState = MutableSharedFlow<NavigationCommand?>(1)
+    private val _navigateState = MutableSharedFlow<NavigationCommand?>()
     private val _navigateBack = MutableSharedFlow<Map<String, Any>>()
     var navigateState: SharedFlow<NavigationCommand?> = _navigateState
     var navigateBack: SharedFlow<Map<String, Any>> = _navigateBack


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3290" title="AR-3290" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3290</a>  Playstore crash: com.wire.android.navigation.NavigationUtilsKt.navigateToItem
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Same as https://github.com/wireapp/wire-android-reloaded/pull/1755

### Issues

Sometimes the NullPointerException occurs when trying to execute `navigateToItem`.

### Causes (Optional)

When configuration changes (for instance screen size changes), the whole WireActivity's composable is being recomposed and new `navController` is created, but the app doesn't use the updated one in NavigationManager's Flows that it collects. Also, if there's already any `NavigationCommand` to be executed, it makes the navigation even before the graph is fully recreated, which causes the NullPointerException.

### Solutions

Remove `replay` parameter from `navigationManager.navigateState` as it shouldn't be replayed, the navigation's state is  persisted by the `navController` itself, `NavigationManager` only passes the `NavigationCommand`s which are to be executed and shouldn't keep any values to be replayed, especially when `navigationManager.navigateBack` is not replayed, causing the app to navigate again after recomposition to a destination which shouldn't be open anymore.
Split effects in the `setUpNavigation` function as it contains parts of code intended for different things and should have different keys. First one is observing the navigation events `Flow`s which are launched in the given `scope` so each time the `scope` changes it should relaunch it. Second one is responsible for listening to the destination changes, so the key should be the `navController` so that listeners are registered to the proper one after it's updated and unregistered properly when disposed.
Simplify the `WireActivity` main composable, it doesn't need to consist of the `Scaffold`, ensure the correct sequence to build navigation graph properly, pass `onComplete` as a reference instead of creating unstable lambda which causes unneeded recompositions.

### Testing

#### How to Test

Open the app, navigate to some screen, go back, change the screen size and see if the app crashes.

### Attachments (Optional)

#### Before

https://user-images.githubusercontent.com/30429749/236261093-0481e4ed-78c2-401f-9c84-7a50c6ddeae0.mp4


#### After

https://user-images.githubusercontent.com/30429749/236261157-e5fe2430-03c4-4205-8608-a15c92e5b31b.mp4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.