### PR TITLE
feat: offline backends - users metadata (AR-3124)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/MoreOptionIcon.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/MoreOptionIcon.kt
@@ -23,17 +23,20 @@ package com.wire.android.ui.common
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.wire.android.R
+import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 
 @Composable
 fun MoreOptionIcon(
     onButtonClicked: () -> Unit,
+    state: WireButtonState = WireButtonState.Default,
     modifier: Modifier = Modifier
 ) {
     WireSecondaryIconButton(
         onButtonClicked = onButtonClicked,
         iconResource = R.drawable.ic_more,
         contentDescription = R.string.content_description_show_more_options,
+        state = state,
         modifier = modifier
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
@@ -91,7 +91,8 @@ fun HighlightName(
         Text(
             text = name,
             style = MaterialTheme.wireTypography.title02.copy(
-                color = if (name.isUnknownUser()) MaterialTheme.wireColorScheme.secondaryText else MaterialTheme.wireTypography.title02.color
+                color = if (name.isUnknownUser()) MaterialTheme.wireColorScheme.secondaryText
+                else MaterialTheme.wireTypography.title02.color
             ),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -102,4 +103,3 @@ fun HighlightName(
 
 @Composable
 private fun String.isUnknownUser() = this == stringResource(id = R.string.username_unavailable_label)
-

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
@@ -29,12 +29,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
+import com.wire.android.R
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.EMPTY
 import com.wire.android.util.MatchQueryResult
 import com.wire.android.util.QueryMatchExtractor
 import kotlinx.coroutines.launch
@@ -57,7 +60,7 @@ fun HighlightName(
             )
         }
     }
-    if (highlightIndexes.isNotEmpty()) {
+    if (searchQuery != String.EMPTY && highlightIndexes.isNotEmpty()) {
         Text(
             buildAnnotatedString {
                 withStyle(
@@ -87,10 +90,16 @@ fun HighlightName(
     } else {
         Text(
             text = name,
-            style = MaterialTheme.wireTypography.title02,
+            style = MaterialTheme.wireTypography.title02.copy(
+                color = if (name.isUnknownUser()) MaterialTheme.wireColorScheme.secondaryText else MaterialTheme.wireTypography.title02.color
+            ),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = modifier
         )
     }
 }
+
+@Composable
+private fun String.isUnknownUser() = this == stringResource(id = R.string.username_unavailable_label)
+

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.model.UserAvatarData
@@ -53,6 +52,7 @@ import com.wire.android.ui.home.conversations.search.SearchResultState
 import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.extension.folderWithElements
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -147,8 +147,10 @@ private fun ContactItem(
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = if (isMetadataNotAvailable) name else stringResource(R.string.username_unavailable_label),
-                    style = MaterialTheme.wireTypography.title02.copy(),
+                    text = if (isMetadataNotAvailable) stringResource(R.string.username_unavailable_label) else name,
+                    style = MaterialTheme.wireTypography.title02.copy(
+                        color = if (isMetadataNotAvailable) MaterialTheme.wireColorScheme.secondaryText else MaterialTheme.wireTypography.title02.color
+                    ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(weight = 1f, fill = false)
@@ -164,7 +166,7 @@ private fun ContactItem(
             Box(
                 modifier = Modifier
                     .wrapContentWidth()
-                    .padding(end = 8.dp)
+                    .padding(end = dimensions().spacing8x)
             ) {
                 ArrowRightIcon(Modifier.align(Alignment.TopEnd))
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -108,9 +108,9 @@ fun ContactsScreen(
             SearchFailureBox(failureMessage = allKnownContactResult.failureString)
         }
 
-        //TODO: what to do when user has no contacts ?
+        // TODO: what to do when user has no contacts ?
         SearchResultState.EmptyResult -> {
-
+            /*NO OP*/
         }
     }
 }
@@ -149,7 +149,8 @@ private fun ContactItem(
                 Text(
                     text = if (isMetadataNotAvailable) stringResource(R.string.username_unavailable_label) else name,
                     style = MaterialTheme.wireTypography.title02.copy(
-                        color = if (isMetadataNotAvailable) MaterialTheme.wireColorScheme.secondaryText else MaterialTheme.wireTypography.title02.color
+                        color = if (isMetadataNotAvailable) MaterialTheme.wireColorScheme.secondaryText
+                        else MaterialTheme.wireTypography.title02.color
                     ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -94,7 +95,8 @@ fun ContactsScreen(
                                 belongsToGroup = contactsAddedToGroup.contains(this),
                                 addToGroup = { onAddToGroup(this) },
                                 removeFromGroup = { onRemoveFromGroup(this) },
-                                openUserProfile = { onOpenUserProfile(this) }
+                                openUserProfile = { onOpenUserProfile(this) },
+                                isMetadataNotAvailable = isMetadataEmpty()
                             )
                         }
                     }
@@ -123,6 +125,7 @@ private fun ContactItem(
     addToGroup: () -> Unit,
     removeFromGroup: () -> Unit,
     openUserProfile: () -> Unit,
+    isMetadataNotAvailable: Boolean = false
 ) {
     val clickable = remember {
         Clickable(
@@ -144,8 +147,8 @@ private fun ContactItem(
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = name,
-                    style = MaterialTheme.wireTypography.title02,
+                    text = if (isMetadataNotAvailable) name else stringResource(R.string.username_unavailable_label),
+                    style = MaterialTheme.wireTypography.title02.copy(),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(weight = 1f, fill = false)

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/model/Contact.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/model/Contact.kt
@@ -32,4 +32,8 @@ data class Contact(
     val label: String = "",
     val connectionState: ConnectionState,
     val membership: Membership
-)
+) {
+    fun isMetadataEmpty(): Boolean {
+        return name.isEmpty()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
+import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset.UserAvatarAsset
@@ -60,6 +61,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ifNotEmpty
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
@@ -130,7 +132,7 @@ fun UserProfileInfo(
                     }
             ) {
                 Text(
-                    text = fullName,
+                    text = fullName.ifBlank { UIText.StringResource(R.string.username_unavailable_label).asString() },
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     style = MaterialTheme.wireTypography.title02,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -136,7 +136,7 @@ fun UserProfileInfo(
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     style = MaterialTheme.wireTypography.title02,
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = if (fullName.isNotBlank()) MaterialTheme.colorScheme.onBackground else MaterialTheme.wireColorScheme.labelText
                 )
                 Text(
                     text = userName.ifNotEmpty { "@$userName" },

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -21,6 +21,8 @@
 package com.wire.android.ui.userprofile.other
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -30,10 +32,13 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.wire.android.BuildConfig
 import com.wire.android.R
@@ -44,12 +49,42 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.theme.wireColorScheme
-import com.wire.android.util.CustomTabsHelper
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 
 @Composable
 fun OtherUserDevicesScreen(
+    lazyListState: LazyListState = rememberLazyListState(),
+    state: OtherUserProfileState,
+    onDeviceClick: (Device) -> Unit
+) {
+    if (state.otherUserDevices.isEmpty()) {
+        OtherUserEmptyDevicesContent()
+    } else {
+        OtherUserDevicesContent(lazyListState, state, onDeviceClick)
+    }
+}
+
+@Composable
+private fun OtherUserEmptyDevicesContent() {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = dimensions().spacing56x),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = stringResource(id = R.string.label_client_key_fingerprint_not_available).lowercase().capitalize(),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText)
+        )
+    }
+}
+
+@Composable
+private fun OtherUserDevicesContent(
     lazyListState: LazyListState = rememberLazyListState(),
     state: OtherUserProfileState,
     onDeviceClick: (Device) -> Unit
@@ -74,7 +109,7 @@ fun OtherUserDevicesScreen(
                             tag = "learn_more",
                             annotation = supportUrl,
                             onClick = {
-                                CustomTabsHelper.launchUrl(context, supportUrl)
+                                com.wire.android.util.CustomTabsHelper.launchUrl(context, supportUrl)
                             }
                         )
                     ),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 
@@ -108,9 +109,7 @@ private fun OtherUserDevicesContent(
                             text = stringResource(id = R.string.label_learn_more),
                             tag = "learn_more",
                             annotation = supportUrl,
-                            onClick = {
-                                com.wire.android.util.CustomTabsHelper.launchUrl(context, supportUrl)
-                            }
+                            onClick = { CustomTabsHelper.launchUrl(context, supportUrl) }
                         )
                     ),
                     modifier = Modifier.padding(all = dimensions().spacing16x),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
@@ -81,7 +81,6 @@ fun OtherUserProfileDetails(
     }
 }
 
-
 @Composable
 private fun UserDetailInformation(
     title: String,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
@@ -53,7 +53,14 @@ fun OtherUserProfileDetails(
         state = lazyListState,
         modifier = Modifier.fillMaxSize()
     ) {
-        if (state.email.isNotEmpty())
+        item(key = "user_details_domain") {
+            UserDetailInformation(
+                title = stringResource(R.string.settings_myaccount_domain),
+                value = state.userId.domain,
+                onCopy = null
+            )
+        }
+        if (state.email.isNotEmpty()) {
             item(key = "user_details_email") {
                 UserDetailInformation(
                     title = stringResource(R.string.email_label),
@@ -61,7 +68,8 @@ fun OtherUserProfileDetails(
                     onCopy = { otherUserProfileScreenState.copy(it, context) }
                 )
             }
-        if (state.phone.isNotEmpty())
+        }
+        if (state.phone.isNotEmpty()) {
             item(key = "user_details_phone") {
                 UserDetailInformation(
                     title = stringResource(R.string.phone_label),
@@ -69,6 +77,7 @@ fun OtherUserProfileDetails(
                     onCopy = { otherUserProfileScreenState.copy(it, context) }
                 )
             }
+        }
     }
 }
 
@@ -77,7 +86,7 @@ fun OtherUserProfileDetails(
 private fun UserDetailInformation(
     title: String,
     value: String,
-    onCopy: (String) -> Unit
+    onCopy: ((String) -> Unit)?
 ) {
     RowItemTemplate(
         modifier = Modifier.padding(horizontal = dimensions().spacing8x),
@@ -95,7 +104,7 @@ private fun UserDetailInformation(
                 text = value
             )
         },
-        actions = { CopyButton(onCopyClicked = { onCopy(value) }) },
+        actions = { onCopy?.let { CopyButton(onCopyClicked = { onCopy(value) }) } },
         clickable = Clickable(enabled = false) {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
@@ -92,7 +92,7 @@ fun OtherUserProfileGroup(
                 value = AnnotatedString(state.groupState!!.role.name.asString()),
                 isSelfAdmin = state.groupState.isSelfAdmin,
                 openChangeRoleBottomSheet = openChangeRoleBottomSheet,
-                isRoleEditable = state.membership.allowsRoleEdition()
+                isRoleEditable = state.membership.allowsRoleEdition() && !state.isMetadataEmpty()
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -68,6 +68,7 @@ import com.wire.android.ui.common.MoreOptionIcon
 import com.wire.android.ui.common.TabItem
 import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
+import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.dialogs.BlockUserDialogContent
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
@@ -305,7 +306,10 @@ private fun TopBarHeader(
         elevation = elevation,
         actions = {
             if (state.connectionState in listOf(ConnectionState.ACCEPTED, ConnectionState.BLOCKED)) {
-                MoreOptionIcon(openConversationBottomSheet)
+                MoreOptionIcon(
+                    onButtonClicked = openConversationBottomSheet,
+                    state = if (state.isMetadataEmpty()) WireButtonState.Disabled else WireButtonState.Default
+                )
             }
         }
     )
@@ -434,7 +438,7 @@ private fun ContentFooter(
         ) {
             Box(modifier = Modifier.padding(all = dimensions().spacing16x)) {
                 // TODO show open conversation button for service bots after AR-2135
-                if (state.membership != Membership.Service) {
+                if (!state.isMetadataEmpty() && state.membership != Membership.Service) {
                     OtherUserConnectionActionButton(
                         state.connectionState,
                         footerEventsHandler::onSendConnectionRequest,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -72,6 +72,10 @@ data class OtherUserProfileState(
             )
         )
     }
+
+    fun isMetadataEmpty(): Boolean {
+        return fullName.isEmpty() || userName.isEmpty()
+    }
 }
 
 data class OtherUserProfileGroupState(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,7 +380,7 @@
     <string name="member_name_you_label_titlecase">You</string>
     <string name="member_name_you_label_lowercase">you</string>
     <string name="label_add_participants">Add Participants</string>
-    <string name="username_unavailable_label">Username unavailable</string>
+    <string name="username_unavailable_label">Name not available</string>
     <string name="conversation_details_title">Conversation Details</string>
     <string name="conversation_details_options_tab">OPTIONS</string>
     <string name="conversation_details_participants_tab">PARTICIPANTS</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3124" title="AR-3124" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-3124</a>  [Android] Implement UX for missing conversation and user metadata
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support displaying/ hiding and restrict options for users that we don't have metadata for.
This is done in, other user profile, participants lists and conversations list.

### Solution

If a backend is down, and we only have ids of these remote users we present a better user experience.

### Dependencies (Optional)

https://github.com/wireapp/kalium/pull/1698

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5806454/236427127-0c41f7d9-f721-4b5a-ab32-f37c7258cbe3.png" width="300"/>

<img src="https://user-images.githubusercontent.com/5806454/236427144-ffb6d24a-809b-47d6-9a30-ae02e6bd396a.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
