### PR TITLE
fix: mention from web [AR-3376]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
+import kotlin.math.min
 
 @Suppress("ComplexMethod")
 @Composable
@@ -107,7 +108,7 @@ fun LinkifyText(
             }
             if (text is UIText.DynamicString && text.mentions.isNotEmpty()) {
                 text.mentions.forEach {
-                    if (it.length <= 0 || (it.start + it.length) >= textAsString.length) {
+                    if (it.length <= 0) {
                         return@forEach
                     }
                     addStyle(
@@ -117,13 +118,13 @@ fun LinkifyText(
                             background = if (it.isSelfMention) primaryVariant else Color.Unspecified
                         ),
                         start = it.start,
-                        end = it.start + it.length
+                        end = min(it.start + it.length, textAsString.length)
                     )
                     addStringAnnotation(
                         tag = "mentionTag",
                         annotation = it.userId.toString(),
                         start = it.start,
-                        end = it.start + it.length
+                        end = min(it.start + it.length, textAsString.length)
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
-import kotlin.math.min
 
 @Suppress("ComplexMethod")
 @Composable
@@ -108,7 +107,7 @@ fun LinkifyText(
             }
             if (text is UIText.DynamicString && text.mentions.isNotEmpty()) {
                 text.mentions.forEach {
-                    if (it.length <= 0) {
+                    if (it.length <= 0 || it.start >= length || it.start + it.length > length) {
                         return@forEach
                     }
                     addStyle(
@@ -118,13 +117,13 @@ fun LinkifyText(
                             background = if (it.isSelfMention) primaryVariant else Color.Unspecified
                         ),
                         start = it.start,
-                        end = min(it.start + it.length, textAsString.length)
+                        end = it.start + it.length
                     )
                     addStringAnnotation(
                         tag = "mentionTag",
                         annotation = it.userId.toString(),
                         start = it.start,
-                        end = min(it.start + it.length, textAsString.length)
+                        end = it.start + it.length
                     )
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3376" title="AR-3376" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3376</a>  Mentions - If i mention a guest account from web, on ar it is broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed handling mention from web

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

| Before | After |
| ----------- | ------------ |
| ![before](https://user-images.githubusercontent.com/13151239/236431120-fd6727e5-3f52-4143-9c2c-e61302d93ef4.jpeg) | ![after](https://user-images.githubusercontent.com/13151239/236431157-2dd1f913-879b-4aac-9bbd-9ce417a631df.jpeg) |

