### PR TITLE
fix: no self deletion status for asset saved externally

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -366,7 +366,7 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     fun updateSelfDeletingMessages(newSelfDeletionTimer: SelfDeletionTimer) = viewModelScope.launch {
-        messageComposerViewState.copy(selfDeletionTimer = newSelfDeletionTimer)
+        messageComposerViewState = messageComposerViewState.copy(selfDeletionTimer = newSelfDeletionTimer)
         persistNewSelfDeletingStatus(conversationId, newSelfDeletionTimer)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -268,7 +268,9 @@ fun MessageExpireLabel(messageContent: UIMessageContent?, timeLeft: String) {
 
         is UIMessageContent.AssetMessage -> {
             StatusBox(
-                statusText = if (messageContent.downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY) stringResource(
+                statusText = if (messageContent.downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY
+                    || messageContent.downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                ) stringResource(
                     R.string.self_deleting_message_time_left,
                     timeLeft
                 )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -72,7 +72,6 @@ import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
 import com.wire.kalium.logic.feature.message.SendKnockUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
-import com.wire.kalium.logic.feature.selfdeletingMessages.ConversationSelfDeletionStatus
 import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerForConversationUseCase
 import com.wire.kalium.logic.feature.selfdeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -72,6 +72,10 @@ import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
 import com.wire.kalium.logic.feature.message.SendKnockUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ConversationSelfDeletionStatus
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerForConversationUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.PersistNewSelfDeletionTimerUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
@@ -182,6 +186,12 @@ internal class MessageComposerViewModelArrangement {
     @MockK
     private lateinit var enqueueMessageSelfDeletionUseCase: EnqueueMessageSelfDeletionUseCase
 
+    @MockK
+    lateinit var observeConversationSelfDeletionStatus: ObserveSelfDeletionTimerForConversationUseCase
+
+    @MockK
+    lateinit var persistSelfDeletionStatus: PersistNewSelfDeletionTimerUseCase
+
     private val fakeKaliumFileSystem = FakeKaliumFileSystem()
 
     private val viewModel by lazy {
@@ -207,7 +217,9 @@ internal class MessageComposerViewModelArrangement {
             pingRinger = pingRinger,
             sendKnockUseCase = sendKnockUseCase,
             fileManager = fileManager,
-            enqueueMessageSelfDeletionUseCase = enqueueMessageSelfDeletionUseCase
+            enqueueMessageSelfDeletionUseCase = enqueueMessageSelfDeletionUseCase,
+            observeSelfDeletingMessages = observeConversationSelfDeletionStatus,
+            persistNewSelfDeletingStatus = persistSelfDeletionStatus
         )
     }
 
@@ -217,6 +229,7 @@ internal class MessageComposerViewModelArrangement {
         coEvery { observeEstablishedCallsUseCase() } returns emptyFlow()
         coEvery { observeSecurityClassificationType(any()) } returns emptyFlow()
         coEvery { imageUtil.extractImageWidthAndHeight(any(), any()) } returns (1 to 1)
+        coEvery { observeConversationSelfDeletionStatus(any()) } returns emptyFlow()
         coEvery { observeConversationInteractionAvailabilityUseCase(any()) } returns flowOf(
             IsInteractionAvailableResult.Success(
                 InteractionAvailability.ENABLED
@@ -261,6 +274,14 @@ internal class MessageComposerViewModelArrangement {
 
     fun withSaveToExternalMediaStorage(resultFileName: String?) = apply {
         coEvery { fileManager.saveToExternalMediaStorage(any(), any(), any(), any(), any()) } returns resultFileName
+    }
+
+    fun withObserveSelfDeletingStatus(expectedSelfDeletionTimer: SelfDeletionTimer) = apply {
+        coEvery { observeConversationSelfDeletionStatus(conversationId) } returns flowOf(expectedSelfDeletionTimer)
+    }
+
+    fun withPersistSelfDeletionStatus() = apply {
+        coEvery { persistSelfDeletionStatus(any(), any()) } returns Unit
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -28,7 +28,6 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.UriAsset
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import io.mockk.coVerify

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -28,7 +28,9 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,6 +40,8 @@ import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
@@ -338,5 +342,42 @@ class MessageComposerViewModelTest {
         // Then
         coVerify(exactly = 1) { arrangement.sendKnockUseCase.invoke(any(), any()) }
         verify(exactly = 1) { arrangement.pingRinger.ping(any(), isReceivingPing = false) }
+    }
+
+    @Test
+    fun `given that a user updates the self-deleting message timer, when invoked, then the timer gets successfully updated`() = runTest {
+        // Given
+        val expectedDuration = 1.toDuration(DurationUnit.HOURS)
+        val expectedTimer = SelfDeletionTimer.Enabled(expectedDuration)
+        val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withPersistSelfDeletionStatus()
+            .arrange()
+
+        // When
+        viewModel.updateSelfDeletingMessages(expectedTimer)
+
+        // Then
+        coVerify(exactly = 1) { arrangement.persistSelfDeletionStatus.invoke(arrangement.conversationId, expectedTimer) }
+        assert(viewModel.messageComposerViewState.selfDeletionTimer is SelfDeletionTimer.Enabled)
+        assert(viewModel.messageComposerViewState.selfDeletionTimer.toDuration() == expectedDuration)
+    }
+
+    @Test
+    fun `given a valid observed enforced self-deleting message timer, when invoked, then the timer gets successfully updated`() = runTest {
+        // Given
+        val expectedDuration = 1.toDuration(DurationUnit.DAYS)
+        val expectedTimer = SelfDeletionTimer.Enabled(expectedDuration)
+        val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withObserveSelfDeletingStatus(expectedTimer)
+            .arrange()
+
+        // When
+
+        // Then
+        coVerify(exactly = 1) { arrangement.observeConversationSelfDeletionStatus.invoke(arrangement.conversationId) }
+        assert(viewModel.messageComposerViewState.selfDeletionTimer is SelfDeletionTimer.Enabled)
+        assert(viewModel.messageComposerViewState.selfDeletionTimer.toDuration() == expectedDuration)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Currently whenever we user decides to the save asset after downloading it, the self deletion timer is not displayed anymore but just self-deleting information label, even though the timer is ticking.

### Causes (Optional)

- We just checked for SAVED_INTERNALLY status.

### Solutions

- Check for SAVED_EXTERNALLY as well.
### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
