### PR TITLE
fix(dev): NavBackStackEntry crash on HomeScreen [AR-3286]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -44,10 +44,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.wire.android.R
@@ -207,18 +209,28 @@ fun HomeContent(
                                 }
                             },
                             content = {
-                                NavHost(
-                                    navController = navController,
-                                    // For now we only support Conversations screen
-                                    startDestination = HomeNavigationItem.Conversations.route
-                                ) {
-                                    HomeNavigationItem.values()
-                                        .forEach { item ->
-                                            composable(
-                                                route = item.route,
-                                                content = item.content(homeStateHolder)
-                                            )
-                                        }
+                                /**
+                                 * This "if" is a workaround, otherwise it can crash because of the SubcomposeLayout's nature.
+                                 * We need to communicate to the sub-compositions when they are to be disposed by the parent and ignore
+                                 * compositions in the round they are to be disposed. More here:
+                                 * https://github.com/google/accompanist/issues/1487
+                                 * https://issuetracker.google.com/issues/268422136
+                                 * https://issuetracker.google.com/issues/254645321
+                                 */
+                                if (LocalLifecycleOwner.current.lifecycle.currentState != Lifecycle.State.DESTROYED) {
+                                    NavHost(
+                                        navController = navController,
+                                        // For now we only support Conversations screen
+                                        startDestination = HomeNavigationItem.Conversations.route
+                                    ) {
+                                        HomeNavigationItem.values()
+                                            .forEach { item ->
+                                                composable(
+                                                    route = item.route,
+                                                    content = item.content(homeStateHolder)
+                                                )
+                                            }
+                                    }
                                 }
                             },
                             floatingActionButton = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3286" title="AR-3286" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3286</a>  Playstore crash: You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes we get a crash "You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed" with the stack trace leading to the `HomeScreen`.

### Causes (Optional)

We use `Scaffold`, `ModalBottomSheetLayout` and `ModalDrawer` on `HomeScreen`, all of them use `SubcomposeLayout` underneath (`BoxWithConstraints` also uses it). This layout breaks a little the usual order of actions for the composables by registering a separate sub-composition for that element which happens independently and after the parent's composition, sometimes even if the value that's required is already destroyed (`NavBackStackEntry` in this case).

More detailed explanation is here: https://wearezeta.atlassian.net/browse/ACOL-105

### Solutions

According to the Google's response:

> To fix this would require,
> 1. Ensuring all composition is performed in strict dependency order (parent first, sub-compositions after parents).
> 2. Communicate to the sub-compositions when they are to be disposed by the parent and ignore compositions in the round they are to be disposed.

The workaround in this case is to not allow recomposing the `NavHost` if we already know that the `NavBackStackEntry` has been already destroyed.

### Testing

#### How to Test

Open the app, navigate to the specific conversation and then spam "back" arrow button from the top bar, it should close the app without any crash. That's the only way that I found to reproduce this crash.

### Notes (Optional)

- We should find a way to disallow the ability to click "back" arrow button multiple times, because right now it schedules a "back" navigation every time so the user can close the app by clicking multiple times - it should be possible to only go back one level from a particular screen.
- We should also consider reducing the number of nested navigations that we have, on `HomeScreen` `NavHost` is currently not needed at all so it only increases complexity without any major benefit.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
