### PR TITLE
feat: self deleting message group options [AR-3226]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -1004,7 +1004,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideObserveSelfDeletingMessagesUseCase(
+    fun provideObserveSelfDeletionTimerSettingsForConversationUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): ObserveSelfDeletionTimerSettingsForConversationUseCase = coreLogic.getSessionScope(currentAccount).observeSelfDeletingMessages
@@ -1052,6 +1052,11 @@ class UseCaseModule {
     @Provides
     fun provideObserveGuestRoomLinkFeatureFlagUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).observeGuestRoomLinkFeatureFlag
+
+    @ViewModelScoped
+    @Provides
+    fun provideUpdateMessageTimerUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).conversations.updateMessageTimer
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -28,6 +28,7 @@ import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -48,6 +49,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidRemoteData
 import com.wire.kalium.logic.util.isGreaterThan
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 // TODO: splits mapping into more classes
 @Suppress("TooManyFunctions")
@@ -91,6 +93,32 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.NewConversationReceiptMode -> mapNewConversationReceiptMode(content)
         is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
         is MessageContent.HistoryLost -> mapConversationHistoryLost()
+        is MessageContent.ConversationMessageTimerChanged -> mapConversationTimerChanged(message.senderUserId, content, members)
+    }
+
+    private fun mapConversationTimerChanged(
+        senderUserId: UserId,
+        content: MessageContent.ConversationMessageTimerChanged,
+        userList: List<User>
+    ): UIMessageContent.SystemMessage {
+        val sender = userList.findUser(userId = senderUserId)
+        val authorName = toSystemMessageMemberName(
+            user = sender,
+            type = SelfNameType.ResourceTitleCase
+        )
+
+        return if (content.messageTimer != null) {
+            UIMessageContent.SystemMessage.ConversationMessageTimerActivated(
+                author = authorName,
+                isAuthorSelfUser = sender is SelfUser,
+                selfDeletionDuration = (content.messageTimer ?: 0L).milliseconds.toSelfDeletionDuration()
+            )
+        } else {
+            UIMessageContent.SystemMessage.ConversationMessageTimerDeactivated(
+                author = authorName,
+                isAuthorSelfUser = sender is SelfUser
+            )
+        }
     }
 
     private fun mapResetSession(

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -71,6 +71,7 @@ class MessageContentMapper @Inject constructor(
                     Message.Visibility.HIDDEN -> null // we don't want to show hidden message content in any way
                 }
             }
+
             is Message.System -> {
                 when (message.visibility) {
                     Message.Visibility.VISIBLE -> mapSystemMessage(message, userList)
@@ -96,6 +97,7 @@ class MessageContentMapper @Inject constructor(
         is MessageContent.ConversationMessageTimerChanged -> mapConversationTimerChanged(message.senderUserId, content, members)
     }
 
+    // TODO KBX cover with tests
     private fun mapConversationTimerChanged(
         senderUserId: UserId,
         content: MessageContent.ConversationMessageTimerChanged,
@@ -302,6 +304,7 @@ class MessageContentMapper @Inject constructor(
                         messageResourceProvider.sentAMessageWithContent, it
                     )
                 } ?: UIText.StringResource(R.string.sent_a_message_with_unknown_content)
+
                 is MessageContent.FailedDecryption -> UIText.StringResource(R.string.label_message_decryption_failure_message)
                 else -> UIText.StringResource(R.string.sent_a_message_with_unknown_content)
             },

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -100,7 +100,8 @@ class MigrationMapper @Inject constructor() {
                 lastModifiedDate = lastEventTime,
                 lastNotificationDate = lastEventTime,
                 creatorId = creatorId,
-                receiptMode = fromScalaReceiptMode(receiptMode)
+                receiptMode = fromScalaReceiptMode(receiptMode),
+                messageTimer = null
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -43,6 +43,7 @@ import com.wire.android.navigation.NavigationItemDestinationsRoutes.EDIT_DISPLAY
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.EDIT_EMAIL
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.EDIT_GUEST_ACCESS
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.EDIT_HANDLE
+import com.wire.android.navigation.NavigationItemDestinationsRoutes.EDIT_SELF_DELETING_MESSAGES
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.GROUP_CONVERSATION_ALL_PARTICIPANTS
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.GROUP_CONVERSATION_DETAILS
 import com.wire.android.navigation.NavigationItemDestinationsRoutes.HOME
@@ -85,6 +86,7 @@ import com.wire.android.ui.home.conversations.ConversationScreen
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsScreen
 import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessParams
 import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessScreen
+import com.wire.android.ui.home.conversations.details.editselfdeletingmessages.EditSelfDeletingMessagesScreen
 import com.wire.android.ui.home.conversations.details.metadata.EditConversationNameScreen
 import com.wire.android.ui.home.conversations.details.participants.GroupConversationAllParticipantsScreen
 import com.wire.android.ui.home.conversations.messagedetails.MessageDetailsScreen
@@ -411,6 +413,20 @@ enum class NavigationItem(
         }
     },
 
+    EditSelfDeletingMessages(
+        primaryRoute = EDIT_SELF_DELETING_MESSAGES,
+        canonicalRoute = "$EDIT_SELF_DELETING_MESSAGES?$EXTRA_CONVERSATION_ID={$EXTRA_CONVERSATION_ID}",
+        content = { EditSelfDeletingMessagesScreen() },
+        animationConfig = NavigationAnimationConfig.CustomAnimation(smoothSlideInFromRight(), smoothSlideOutFromLeft())
+    ) {
+        override fun getRouteWithArgs(arguments: List<Any>): String {
+            val conversationIdString: String = arguments.filterIsInstance<ConversationId>().firstOrNull()?.toString()
+                ?: "{$EXTRA_CONVERSATION_ID}"
+
+            return "$EDIT_SELF_DELETING_MESSAGES?$EXTRA_CONVERSATION_ID=$conversationIdString"
+        }
+    },
+
     OngoingCall(
         primaryRoute = ONGOING_CALL,
         canonicalRoute = "$ONGOING_CALL/{$EXTRA_CONVERSATION_ID}",
@@ -500,6 +516,7 @@ object NavigationItemDestinationsRoutes {
     const val CONVERSATION = "detailed_conversation_screen"
     const val EDIT_CONVERSATION_NAME = "edit_conversation_name_screen"
     const val EDIT_GUEST_ACCESS = "edit_guest_access_screen"
+    const val EDIT_SELF_DELETING_MESSAGES = "edit_self_deleting_messages_screen"
     const val GROUP_CONVERSATION_DETAILS = "group_conversation_details_screen"
     const val MESSAGE_DETAILS = "message_details_screen"
     const val GROUP_CONVERSATION_ALL_PARTICIPANTS = "group_conversation_all_participants_screen"

--- a/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
@@ -23,10 +23,11 @@ package com.wire.android.ui.common.divider
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.common.colorsScheme
 
 @Composable
-fun WireDivider() {
-    Divider(color = colorsScheme().divider, thickness = Dp.Hairline, modifier = Modifier)
+fun WireDivider(color: Color? = null) {
+    Divider(color = color ?: colorsScheme().divider, thickness = Dp.Hairline, modifier = Modifier)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
@@ -28,6 +28,6 @@ import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.common.colorsScheme
 
 @Composable
-fun WireDivider(color: Color? = null) {
-    Divider(color = color ?: colorsScheme().divider, thickness = Dp.Hairline, modifier = Modifier)
+fun WireDivider(color: Color = colorsScheme().divider) {
+    Divider(color = color, thickness = Dp.Hairline, modifier = Modifier)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/spacers/HorizontalSpace.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/spacers/HorizontalSpace.kt
@@ -29,6 +29,11 @@ import com.wire.android.ui.common.dimensions
 object HorizontalSpace {
 
     @Composable
+    fun x2() {
+        Spacer(Modifier.width(dimensions().spacing2x))
+    }
+
+    @Composable
     fun x8() {
         Spacer(Modifier.width(dimensions().spacing8x))
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -177,7 +177,7 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     private fun observeSelfDeletingMessagesStatus() = viewModelScope.launch {
-        observeSelfDeletingMessages(conversationId, includeSelfSettings = true).collect { selfDeletingStatus ->
+        observeSelfDeletingMessages(conversationId, considerSelfUserSettings = true).collect { selfDeletingStatus ->
             messageComposerViewState = messageComposerViewState.copy(selfDeletionTimer = selfDeletingStatus)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -177,7 +177,7 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     private fun observeSelfDeletingMessagesStatus() = viewModelScope.launch {
-        observeSelfDeletingMessages(conversationId).collect { selfDeletingStatus ->
+        observeSelfDeletingMessages(conversationId, includeSelfSettings = true).collect { selfDeletingStatus ->
             messageComposerViewState = messageComposerViewState.copy(selfDeletionTimer = selfDeletingStatus)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -399,7 +399,7 @@ private fun Username(username: String, modifier: Modifier = Modifier) {
 @Composable
 private fun MessageContent(
     message: UIMessage,
-    messageContent: UIMessageContent?,
+    messageContent: UIMessageContent.Regular?,
     audioMessagesState: Map<String, AudioState>,
     onAssetClick: Clickable,
     onImageClick: Clickable,
@@ -489,26 +489,9 @@ private fun MessageContent(
         }
 
         UIMessageContent.Deleted -> {}
-        is UIMessageContent.SystemMessage.MemberAdded -> {}
-        is UIMessageContent.SystemMessage.MemberJoined -> {}
-        is UIMessageContent.SystemMessage.MemberLeft -> {}
-        is UIMessageContent.SystemMessage.MemberRemoved -> {}
-        is UIMessageContent.SystemMessage.RenamedConversation -> {}
-        is UIMessageContent.SystemMessage.TeamMemberRemoved -> {}
-        is UIMessageContent.SystemMessage.CryptoSessionReset -> {}
-        is UIMessageContent.PreviewAssetMessage -> {}
-        is UIMessageContent.SystemMessage.MissedCall.YouCalled -> {}
-        is UIMessageContent.SystemMessage.MissedCall.OtherCalled -> {}
-        is UIMessageContent.SystemMessage.NewConversationReceiptMode -> {}
-        is UIMessageContent.SystemMessage.ConversationReceiptModeChanged -> {}
         null -> {
             throw NullPointerException("messageContent is null")
         }
-
-        is UIMessageContent.SystemMessage.Knock -> {}
-        is UIMessageContent.SystemMessage.HistoryLost -> {}
-        is UIMessageContent.SystemMessage.ConversationMessageTimerActivated -> {}
-        is UIMessageContent.SystemMessage.ConversationMessageTimerDeactivated -> {}
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -507,6 +507,8 @@ private fun MessageContent(
 
         is UIMessageContent.SystemMessage.Knock -> {}
         is UIMessageContent.SystemMessage.HistoryLost -> {}
+        is UIMessageContent.SystemMessage.ConversationMessageTimerActivated -> {}
+        is UIMessageContent.SystemMessage.ConversationMessageTimerDeactivated -> {}
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -165,17 +165,17 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.MissedCall.OtherCalled -> null
         is SystemMessage.MissedCall.YouCalled -> null
         is SystemMessage.Knock -> ColorFilter.tint(colorsScheme().primary)
-        is SystemMessage.MemberAdded -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.MemberJoined -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.MemberLeft -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.MemberRemoved -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.CryptoSessionReset -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.RenamedConversation -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.TeamMemberRemoved -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.ConversationReceiptModeChanged -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.HistoryLost -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.NewConversationReceiptMode -> ColorFilter.tint(colorsScheme().onBackground)
-        is SystemMessage.ConversationMessageTimerActivated -> ColorFilter.tint(colorsScheme().onBackground)
+        is SystemMessage.MemberAdded,
+        is SystemMessage.MemberJoined,
+        is SystemMessage.MemberLeft,
+        is SystemMessage.MemberRemoved,
+        is SystemMessage.CryptoSessionReset,
+        is SystemMessage.RenamedConversation,
+        is SystemMessage.TeamMemberRemoved,
+        is SystemMessage.ConversationReceiptModeChanged,
+        is SystemMessage.HistoryLost,
+        is SystemMessage.NewConversationReceiptMode,
+        is SystemMessage.ConversationMessageTimerActivated,
         is SystemMessage.ConversationMessageTimerDeactivated -> ColorFilter.tint(colorsScheme().onBackground)
     }
 }
@@ -315,11 +315,13 @@ fun SystemMessage.annotatedString(
                 author.asString(res),
                 memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
             )
+
         is SystemMessage.MemberRemoved ->
             arrayOf(
                 author.asString(res),
                 memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
             )
+
         is SystemMessage.MemberJoined -> arrayOf(author.asString(res))
         is SystemMessage.MemberLeft -> arrayOf(author.asString(res))
         is SystemMessage.MissedCall -> arrayOf(author.asString(res))
@@ -334,7 +336,8 @@ fun SystemMessage.annotatedString(
             author.asString(res),
             res.getString(R.string.label_system_message_activated),
             selfDeletionDuration.longLabel.asString(res)
-            )
+        )
+
         is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(
             author.asString(res),
             res.getString(R.string.label_system_message_deactivated)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -158,6 +158,7 @@ fun SystemMessageItem(message: UIMessage.System) {
     }
 }
 
+@Suppress("ComplexMethod")
 @Composable
 private fun getColorFilter(message: SystemMessage): ColorFilter? {
     return when (message) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -174,6 +174,8 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.ConversationReceiptModeChanged -> ColorFilter.tint(colorsScheme().onBackground)
         is SystemMessage.HistoryLost -> ColorFilter.tint(colorsScheme().onBackground)
         is SystemMessage.NewConversationReceiptMode -> ColorFilter.tint(colorsScheme().onBackground)
+        is SystemMessage.ConversationMessageTimerActivated -> ColorFilter.tint(colorsScheme().onBackground)
+        is SystemMessage.ConversationMessageTimerDeactivated -> ColorFilter.tint(colorsScheme().onBackground)
     }
 }
 
@@ -278,6 +280,8 @@ private val SystemMessage.expandable
         is SystemMessage.ConversationReceiptModeChanged -> false
         is SystemMessage.Knock -> false
         is SystemMessage.HistoryLost -> false
+        is SystemMessage.ConversationMessageTimerActivated -> false
+        is SystemMessage.ConversationMessageTimerDeactivated -> false
     }
 
 private fun List<String>.toUserNamesListString(res: Resources) = when {
@@ -325,6 +329,15 @@ fun SystemMessage.annotatedString(
         is SystemMessage.ConversationReceiptModeChanged -> arrayOf(author.asString(res), receiptMode.asString(res))
         is SystemMessage.Knock -> arrayOf(author.asString(res))
         is SystemMessage.HistoryLost -> arrayOf()
+        is SystemMessage.ConversationMessageTimerActivated -> arrayOf(
+            author.asString(res),
+            res.getString(R.string.label_system_message_activated),
+            selfDeletionDuration.longLabel.asString(res)
+            )
+        is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(
+            author.asString(res),
+            res.getString(R.string.label_system_message_deactivated)
+        )
     }
     return res.stringWithStyledArgs(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -293,7 +293,6 @@ private fun GroupConversationDetailsContent(
             bottomSheetEventsHandler.onClearConversationContent(it)
         }
     )
-
 }
 
 enum class GroupConversationDetailsTabItem(@StringRes override val titleResId: Int) : TabItem {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -319,4 +319,3 @@ fun PreviewGroupConversationDetails() {
         )
     }
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -415,7 +415,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
         }
     }
 
-    fun navigateSelfDeletingMessagesScreen() {
+    fun navigateToEditSelfDeletingMessagesScreen() {
         viewModelScope.launch {
             navigationManager.navigate(
                 command = NavigationCommand(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUs
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.Result
@@ -98,6 +99,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase,
     private val clearConversationContent: ClearConversationContentUseCase,
     private val updateConversationReceiptMode: UpdateConversationReceiptModeUseCase,
+    private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     override val savedStateHandle: SavedStateHandle,
     private val isMLSEnabled: IsMLSEnabledUseCase,
     qualifiedIdMapper: QualifiedIdMapper
@@ -143,7 +145,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 groupDetailsFlow,
                 isSelfAdminFlow,
                 getSelfTeam(),
-            ) { groupDetails, isSelfAnAdmin, selfTeam ->
+                observeSelfDeletionTimerSettingsForConversation(conversationId, includeSelfSettings = false),
+            ) { groupDetails, isSelfAnAdmin, selfTeam, selfDeletionTimer ->
 
                 val isSelfInOwnerTeam = selfTeam?.id != null && selfTeam.id == groupDetails.conversation.teamId?.value
 
@@ -173,7 +176,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isUpdatingGuestAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
                         mlsEnabled = isMLSEnabled(),
                         isReadReceiptAllowed = groupDetails.conversation.receiptMode == Conversation.ReceiptMode.ENABLED,
-                        isUpdatingReadReceiptAllowed = isUpdatingReadReceiptAllowed
+                        isUpdatingReadReceiptAllowed = isUpdatingReadReceiptAllowed,
+                        selfDeletionTimer = selfDeletionTimer
                     )
                 )
             }.collect {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -145,7 +145,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 groupDetailsFlow,
                 isSelfAdminFlow,
                 getSelfTeam(),
-                observeSelfDeletionTimerSettingsForConversation(conversationId, includeSelfSettings = false),
+                observeSelfDeletionTimerSettingsForConversation(conversationId, considerSelfUserSettings = false),
             ) { groupDetails, isSelfAnAdmin, selfTeam, selfDeletionTimer ->
 
                 val isSelfInOwnerTeam = selfTeam?.id != null && selfTeam.id == groupDetails.conversation.teamId?.value

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -415,6 +415,18 @@ class GroupConversationDetailsViewModel @Inject constructor(
         }
     }
 
+    fun navigateSelfDeletingMessagesScreen() {
+        viewModelScope.launch {
+            navigationManager.navigate(
+                command = NavigationCommand(
+                    destination = NavigationItem.EditSelfDeletingMessages.getRouteWithArgs(
+                        listOf(conversationId)
+                    )
+                )
+            )
+        }
+    }
+
     fun navigateToEditGuestAccessScreen() {
         if (groupOptionsState.value.isUpdatingAllowed) {
             viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -1,0 +1,152 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.R
+import com.wire.android.appLogger
+import com.wire.android.ui.common.divider.WireDivider
+import com.wire.android.ui.common.rememberTopBarElevationState
+import com.wire.android.ui.common.selectableBackground
+import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
+import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.extension.folderWithElements
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditSelfDeletingMessagesScreen(
+    editGuestAccessViewModel: EditSelfDeletingMessagesViewModel = hiltViewModel(),
+) {
+    val scrollState = rememberScrollState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = scrollState.rememberTopBarElevationState().value,
+                onNavigationPressed = editGuestAccessViewModel::navigateBack,
+                title = stringResource(id = R.string.self_deleting_messages_title)
+            )
+        }, snackbarHost = {
+            SwipeDismissSnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }) { internalPadding ->
+        Column {
+            LazyColumn(
+                modifier = Modifier
+                    .background(MaterialTheme.wireColorScheme.background)
+                    .padding(internalPadding)
+                    .weight(1F)
+                    .fillMaxSize()
+            ) {
+                with(editGuestAccessViewModel) {
+                    item {
+                        // TODO KBX
+                        SelfDeletingMessageOption(
+                            isSwitchEnabled = true,
+                            isSwitchVisible = true,
+                            switchState = editSelfDeletingMessagesState.isEnabled,
+                            isLoading = editSelfDeletingMessagesState.isLoading,
+                            onCheckedChange = ::updateSelfDeletingMessageOption
+                        )
+                    }
+                    if(editSelfDeletingMessagesState.isEnabled)
+                    folderWithElements(
+                        header = context.resources.getString(R.string.self_deleting_messages_folder_timer),
+                        items = SelfDeletionDuration.values().associateBy { it.name },
+                        divider = { WireDivider(color = MaterialTheme.wireColorScheme.outline) }
+                    ) { duration ->
+                        if (duration == SelfDeletionDuration.None) {
+                            Text(
+                                text = stringResource(id = R.string.automatically_delete_message_after),
+                                style = MaterialTheme.wireTypography.label04,
+                                color = MaterialTheme.wireColorScheme.secondaryText,
+                                textAlign = TextAlign.Start,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(color = MaterialTheme.wireColorScheme.surface)
+                                    .padding(all = MaterialTheme.wireDimensions.spacing16x)
+                            )
+                        } else {
+                            SelectableSelfDeletingItem(
+                                duration = duration,
+                                isSelected = editSelfDeletingMessagesState.currentlySelected == duration,
+                                onSelfDeletionDurationSelected = ::onSelectDuration
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+@Composable
+fun SelectableSelfDeletingItem(
+    duration: SelfDeletionDuration,
+    isSelected: Boolean,
+    onSelfDeletionDurationSelected: (SelfDeletionDuration) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectableBackground(isSelected, onClick = { onSelfDeletionDurationSelected(duration) })
+            .background(color = MaterialTheme.wireColorScheme.surface)
+            .padding(all = MaterialTheme.wireDimensions.spacing16x)
+    ) {
+        RadioButton(selected = isSelected, onClick = null)
+        HorizontalSpace.x8()
+        Text(
+            text = duration.longLabel.asString(),
+            style = MaterialTheme.wireTypography.body01,
+            color = MaterialTheme.wireColorScheme.onBackground
+        )
+    }
+
+}
+
+
+@Preview
+@Composable
+fun PreviewEditSelfDeletingMessagesScreen() {
+    EditSelfDeletingMessagesScreen()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -95,7 +95,7 @@ fun EditSelfDeletingMessagesScreen(
                             onCheckedChange = ::updateSelfDeletingMessageOption
                         )
                     }
-                    if (editSelfDeletingMessagesState.isEnabled)
+                    if (editSelfDeletingMessagesState.isEnabled) {
                         folderWithElements(
                             header = context.resources.getString(R.string.self_deleting_messages_folder_timer),
                             items = SelfDeletionDuration.values().associateBy { it.name },
@@ -120,6 +120,7 @@ fun EditSelfDeletingMessagesScreen(
                                 )
                             }
                         }
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -58,7 +58,7 @@ import com.wire.android.util.extension.folderWithElements
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditSelfDeletingMessagesScreen(
-    editGuestAccessViewModel: EditSelfDeletingMessagesViewModel = hiltViewModel(),
+    editSelfDeletingMessagesViewModel: EditSelfDeletingMessagesViewModel = hiltViewModel(),
 ) {
     val scrollState = rememberScrollState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -68,7 +68,7 @@ fun EditSelfDeletingMessagesScreen(
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = scrollState.rememberTopBarElevationState().value,
-                onNavigationPressed = editGuestAccessViewModel::navigateBack,
+                onNavigationPressed = editSelfDeletingMessagesViewModel::navigateBack,
                 title = stringResource(id = R.string.self_deleting_messages_title)
             )
         }, snackbarHost = {
@@ -85,11 +85,9 @@ fun EditSelfDeletingMessagesScreen(
                     .weight(1F)
                     .fillMaxSize()
             ) {
-                with(editGuestAccessViewModel) {
+                with(editSelfDeletingMessagesViewModel) {
                     item {
                         SelfDeletingMessageOption(
-                            isSwitchEnabled = true,
-                            isSwitchVisible = true,
                             switchState = editSelfDeletingMessagesState.isEnabled,
                             isLoading = editSelfDeletingMessagesState.isLoading,
                             onCheckedChange = ::updateSelfDeletingMessageOption

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -21,10 +21,19 @@
 package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.*
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -34,7 +43,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.selectableBackground
@@ -79,7 +87,6 @@ fun EditSelfDeletingMessagesScreen(
             ) {
                 with(editGuestAccessViewModel) {
                     item {
-                        // TODO KBX
                         SelfDeletingMessageOption(
                             isSwitchEnabled = true,
                             isSwitchVisible = true,
@@ -88,36 +95,35 @@ fun EditSelfDeletingMessagesScreen(
                             onCheckedChange = ::updateSelfDeletingMessageOption
                         )
                     }
-                    if(editSelfDeletingMessagesState.isEnabled)
-                    folderWithElements(
-                        header = context.resources.getString(R.string.self_deleting_messages_folder_timer),
-                        items = SelfDeletionDuration.values().associateBy { it.name },
-                        divider = { WireDivider(color = MaterialTheme.wireColorScheme.outline) }
-                    ) { duration ->
-                        if (duration == SelfDeletionDuration.None) {
-                            Text(
-                                text = stringResource(id = R.string.automatically_delete_message_after),
-                                style = MaterialTheme.wireTypography.label04,
-                                color = MaterialTheme.wireColorScheme.secondaryText,
-                                textAlign = TextAlign.Start,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(color = MaterialTheme.wireColorScheme.surface)
-                                    .padding(all = MaterialTheme.wireDimensions.spacing16x)
-                            )
-                        } else {
-                            SelectableSelfDeletingItem(
-                                duration = duration,
-                                isSelected = editSelfDeletingMessagesState.currentlySelected == duration,
-                                onSelfDeletionDurationSelected = ::onSelectDuration
-                            )
+                    if (editSelfDeletingMessagesState.isEnabled)
+                        folderWithElements(
+                            header = context.resources.getString(R.string.self_deleting_messages_folder_timer),
+                            items = SelfDeletionDuration.values().associateBy { it.name },
+                            divider = { WireDivider(color = MaterialTheme.wireColorScheme.outline) }
+                        ) { duration ->
+                            if (duration == SelfDeletionDuration.None) {
+                                Text(
+                                    text = stringResource(id = R.string.automatically_delete_message_after),
+                                    style = MaterialTheme.wireTypography.label04,
+                                    color = MaterialTheme.wireColorScheme.secondaryText,
+                                    textAlign = TextAlign.Start,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(color = MaterialTheme.wireColorScheme.surface)
+                                        .padding(all = MaterialTheme.wireDimensions.spacing16x)
+                                )
+                            } else {
+                                SelectableSelfDeletingItem(
+                                    duration = duration,
+                                    isSelected = editSelfDeletingMessagesState.currentlySelected == duration,
+                                    onSelfDeletionDurationSelected = ::onSelectDuration
+                                )
+                            }
                         }
-                    }
                 }
             }
         }
     }
-
 }
 
 @Composable
@@ -141,9 +147,7 @@ fun SelectableSelfDeletingItem(
             color = MaterialTheme.wireColorScheme.onBackground
         )
     }
-
 }
-
 
 @Preview
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesState.kt
@@ -28,4 +28,4 @@ data class EditSelfDeletingMessagesState(
     val selfDeletingDuration: Duration = Duration.ZERO,
     val isLoading: Boolean = true,
     val currentlySelected: SelfDeletionDuration? = null
-    )
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesState.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
+
+import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
+import kotlin.time.Duration
+
+data class EditSelfDeletingMessagesState(
+    val isEnabled: Boolean = false,
+    val selfDeletingDuration: Duration = Duration.ZERO,
+    val isLoading: Boolean = true,
+    val currentlySelected: SelfDeletionDuration? = null
+    )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -73,7 +73,7 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
     private fun observeSelfDeletingMessages() {
         viewModelScope.launch {
             combine(
-                observeSelfDeletionTimerSettingsForConversation(conversationId, includeSelfSettings = false),
+                observeSelfDeletionTimerSettingsForConversation(conversationId, considerSelfUserSettings = false),
                 observeConversationMembers(conversationId).map { it.isSelfAnAdmin },
                 ::Pair
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -1,0 +1,141 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
+import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+@Suppress("LongParameterList", "TooManyFunctions")
+class EditSelfDeletingMessagesViewModel @Inject constructor(
+    private val navigationManager: NavigationManager,
+    private val dispatcher: DispatcherProvider,
+    private val observeConversationMembers: ObserveParticipantsForConversationUseCase,
+    private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val updateMessageTimer: UpdateMessageTimerUseCase,
+    savedStateHandle: SavedStateHandle,
+    qualifiedIdMapper: QualifiedIdMapper,
+) : ViewModel() {
+
+    val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
+        checkNotNull(savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)) {
+            "No conversationId was provided via savedStateHandle to EditSelfDeletingMessagesViewModel"
+        }
+    )
+
+    var editSelfDeletingMessagesState by mutableStateOf(
+        EditSelfDeletingMessagesState()
+    )
+
+    init {
+        observeSelfDeletingMessages()
+    }
+
+    private fun observeSelfDeletingMessages() {
+        viewModelScope.launch {
+            val selfDeletingMessagesFlow = observeSelfDeletionTimerSettingsForConversation(conversationId, includeSelfSettings = false)
+                .distinctUntilChanged()
+                .flowOn(dispatcher.io())
+                .shareIn(this, SharingStarted.WhileSubscribed(), 1)
+
+            val isSelfAdminFlow = observeConversationMembers(conversationId)
+                .map { it.isSelfAnAdmin }
+                .distinctUntilChanged()
+
+            combine(
+                selfDeletingMessagesFlow,
+                isSelfAdminFlow
+            ) { selfDeletingMessages, isSelfAnAdmin ->
+                editSelfDeletingMessagesState = editSelfDeletingMessagesState.copy(
+                    isEnabled = selfDeletingMessages.isEnforcedByGroup,
+                    selfDeletingDuration = selfDeletingMessages.toDuration(),
+                    currentlySelected = selfDeletingMessages.toDuration().toSelfDeletionDuration()
+                )
+            }
+        }
+    }
+
+    fun updateSelfDeletingMessageOption(shouldBeEnabled: Boolean) {
+        // TODO KBX implement use case
+        viewModelScope.launch {
+            editSelfDeletingMessagesState = editSelfDeletingMessagesState.copy(
+                isLoading = true,
+                isEnabled = shouldBeEnabled
+            )
+            delay(2000)
+            editSelfDeletingMessagesState = editSelfDeletingMessagesState.copy(
+                isLoading = false
+            )
+        }
+
+    }
+
+    fun onSelectDuration(duration: SelfDeletionDuration) {
+        viewModelScope.launch {
+            val previousSelected = editSelfDeletingMessagesState.currentlySelected
+            editSelfDeletingMessagesState = editSelfDeletingMessagesState.copy(
+                isLoading = true,
+                currentlySelected = duration
+            )
+            editSelfDeletingMessagesState = when (updateMessageTimer(conversationId, duration.value.inWholeMilliseconds)) {
+                is UpdateMessageTimerUseCase.Result.Failure -> {
+                    editSelfDeletingMessagesState.copy(
+                        isLoading = true,
+                        currentlySelected = previousSelected
+                    )
+                }
+                UpdateMessageTimerUseCase.Result.Success -> {
+                    editSelfDeletingMessagesState.copy(
+                        isLoading = false
+                    )
+                }
+            }
+        }
+    }
+
+    fun navigateBack(args: Map<String, Boolean> = mapOf()) {
+        viewModelScope.launch { navigationManager.navigateBack(args) }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/SelfDeletingMessageOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/SelfDeletingMessageOption.kt
@@ -27,15 +27,13 @@ import com.wire.android.ui.home.conversations.details.options.GroupOptionWithSwi
 
 @Composable
 fun SelfDeletingMessageOption(
-    isSwitchEnabled: Boolean,
-    isSwitchVisible: Boolean,
     switchState: Boolean,
     isLoading: Boolean,
     onCheckedChange: (Boolean) -> Unit
 ) {
     GroupOptionWithSwitch(
-        switchClickable = isSwitchEnabled,
-        switchVisible = isSwitchVisible,
+        switchClickable = true,
+        switchVisible = true,
         switchState = switchState,
         onClick = onCheckedChange,
         isLoading = isLoading,
@@ -48,8 +46,6 @@ fun SelfDeletingMessageOption(
 @Composable
 fun PreviewGuestOption() {
     SelfDeletingMessageOption(
-        isSwitchEnabled = false,
-        isSwitchVisible = true,
         switchState = true,
         isLoading = false,
         onCheckedChange = {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/SelfDeletingMessageOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/SelfDeletingMessageOption.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.ui.home.conversations.details.options.GroupOptionWithSwitch
+
+@Composable
+fun SelfDeletingMessageOption(
+    isSwitchEnabled: Boolean,
+    isSwitchVisible: Boolean,
+    switchState: Boolean,
+    isLoading: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    GroupOptionWithSwitch(
+        switchClickable = isSwitchEnabled,
+        switchVisible = isSwitchVisible,
+        switchState = switchState,
+        onClick = onCheckedChange,
+        isLoading = isLoading,
+        title = R.string.self_deleting_messages_option,
+        subTitle = R.string.self_deleting_messages_option_description
+    )
+}
+
+@Preview
+@Composable
+fun PreviewGuestOption() {
+    SelfDeletingMessageOption(
+        isSwitchEnabled = false,
+        isSwitchVisible = true,
+        switchState = true,
+        isLoading = false,
+        onCheckedChange = {}
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -62,7 +62,7 @@ fun GroupConversationOptions(
     GroupConversationSettings(
         state = state,
         onGuestItemClicked = viewModel::navigateToEditGuestAccessScreen,
-        onSelfDeletingClicked = viewModel::navigateSelfDeletingMessagesScreen,
+        onSelfDeletingClicked = viewModel::navigateToEditSelfDeletingMessagesScreen,
         onServiceSwitchClicked = viewModel::onServicesUpdate,
         onReadReceiptSwitchClicked = viewModel::onReadReceiptUpdate,
         lazyListState = lazyListState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -126,14 +126,18 @@ fun GroupConversationSettings(
                 GroupConversationOptionsItem(
                     title = stringResource(id = R.string.conversation_options_self_deleting_messages_label),
                     subtitle = stringResource(id = R.string.conversation_options_self_deleting_messages_description),
-                    trailingOnText = if(state.selfDeletionTimer.isEnforced)
+                    trailingOnText = if (state.selfDeletionTimer.isEnforced)
                         "(${state.selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel.asString()})" else null,
-                    switchState = SwitchState.TextOnly(value = true),
+                    switchState = SwitchState.TextOnly(value = state.selfDeletionTimer.isEnforced),
                     arrowType = if (state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam)
                         ArrowType.TITLE_ALIGNED
                     else
                         ArrowType.NONE,
-                    clickable = Clickable(enabled = state.isUpdatingAllowed, onClick = onSelfDeletingClicked, onLongClick = {}),
+                    clickable = Clickable(
+                        enabled = state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam,
+                        onClick = onSelfDeletingClicked,
+                        onLongClick = {}
+                    ),
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -126,13 +126,17 @@ fun GroupConversationSettings(
                 GroupConversationOptionsItem(
                     title = stringResource(id = R.string.conversation_options_self_deleting_messages_label),
                     subtitle = stringResource(id = R.string.conversation_options_self_deleting_messages_description),
-                    trailingOnText = if (state.selfDeletionTimer.isEnforced)
-                        "(${state.selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel.asString()})" else null,
+                    trailingOnText = if (state.selfDeletionTimer.isEnforced) {
+                        "(${state.selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel.asString()})"
+                    } else {
+                        null
+                    },
                     switchState = SwitchState.TextOnly(value = state.selfDeletionTimer.isEnforced),
-                    arrowType = if (state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam)
+                    arrowType = if (state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam) {
                         ArrowType.TITLE_ALIGNED
-                    else
-                        ArrowType.NONE,
+                    } else {
+                        ArrowType.NONE
+                    },
                     clickable = Clickable(
                         enabled = state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam,
                         onClick = onSelfDeletingClicked,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.collectAsStateLifecycleAware
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
@@ -61,6 +62,7 @@ fun GroupConversationOptions(
     GroupConversationSettings(
         state = state,
         onGuestItemClicked = viewModel::navigateToEditGuestAccessScreen,
+        onSelfDeletingClicked = viewModel::navigateSelfDeletingMessagesScreen,
         onServiceSwitchClicked = viewModel::onServicesUpdate,
         onReadReceiptSwitchClicked = viewModel::onReadReceiptUpdate,
         lazyListState = lazyListState,
@@ -79,6 +81,7 @@ fun GroupConversationOptions(
 fun GroupConversationSettings(
     state: GroupConversationOptionsState,
     onGuestItemClicked: () -> Unit,
+    onSelfDeletingClicked: () -> Unit,
     onServiceSwitchClicked: (Boolean) -> Unit,
     onReadReceiptSwitchClicked: (Boolean) -> Unit,
     onEditGroupName: () -> Unit,
@@ -118,6 +121,22 @@ fun GroupConversationSettings(
             }
         }
         item { FolderHeader(name = stringResource(id = R.string.folder_label_messaging)) }
+        if (!state.selfDeletionTimer.isDisabled) {
+            item {
+                GroupConversationOptionsItem(
+                    title = stringResource(id = R.string.conversation_options_self_deleting_messages_label),
+                    subtitle = stringResource(id = R.string.conversation_options_self_deleting_messages_description),
+                    trailingOnText = if(state.selfDeletionTimer.isEnforced)
+                        "(${state.selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel.asString()})" else null,
+                    switchState = SwitchState.TextOnly(value = true),
+                    arrowType = if (state.isUpdatingAllowed && !state.selfDeletionTimer.isEnforcedByTeam)
+                        ArrowType.TITLE_ALIGNED
+                    else
+                        ArrowType.NONE,
+                    clickable = Clickable(enabled = state.isUpdatingAllowed, onClick = onSelfDeletingClicked, onLongClick = {}),
+                )
+            }
+        }
         item {
             ReadReceiptOption(
                 isSwitchEnabled = state.isUpdatingReadReceiptAllowed,
@@ -299,7 +318,7 @@ fun PreviewAdminTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = true
         ),
-        {}, {}, { }, {}
+        {}, {}, {}, {}, {}
     )
 }
 
@@ -316,7 +335,7 @@ fun PreviewGuestAdminTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = false
         ),
-        {}, {}, {}, {}
+        {}, {}, {}, {}, {}
     )
 }
 
@@ -333,7 +352,7 @@ fun PreviewMemberTeamGroupConversationOptions() {
             isServicesAllowed = true,
             isUpdatingGuestAllowed = false
         ),
-        {}, {}, { }, {}
+        {}, {}, {}, {}, {}
     )
 }
 
@@ -346,6 +365,6 @@ fun PreviewNormalGroupConversationOptions() {
             groupName = "Normal Group Conversation",
             areAccessOptionsAvailable = false
         ),
-        {}, {}, { }, {}
+        {}, {}, {}, {}, {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -137,7 +137,7 @@ fun ConversationOptionSwitch(
                 color = MaterialTheme.wireColorScheme.onBackground
             )
         }
-        if(trailingOnText != null) {
+        if (trailingOnText != null) {
             HorizontalSpace.x2()
             Text(
                 text = trailingOnText,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -46,6 +46,7 @@ import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.WireSwitch
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.clickable
+import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -55,6 +56,7 @@ fun GroupConversationOptionsItem(
     title: String,
     subtitle: String? = null,
     label: String? = null,
+    trailingOnText: String? = null,
     titleTrailingItem: (@Composable () -> Unit)? = null,
     footer: (@Composable () -> Unit)? = null,
     switchState: SwitchState = SwitchState.None,
@@ -99,7 +101,7 @@ fun GroupConversationOptionsItem(
                 if (titleTrailingItem != null) {
                     Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)) { titleTrailingItem() }
                 }
-                ConversationOptionSwitch(switchState)
+                ConversationOptionSwitch(switchState, trailingOnText)
 
                 if (arrowType == ArrowType.TITLE_ALIGNED) {
                     ArrowRight()
@@ -123,17 +125,27 @@ fun GroupConversationOptionsItem(
 
 @Composable
 fun ConversationOptionSwitch(
-    switchState: SwitchState
+    switchState: SwitchState,
+    trailingOnText: String?
 ) {
     if (switchState is SwitchState.Visible) {
         if (switchState.isOnOffVisible) {
+            HorizontalSpace.x8()
             Text(
                 text = stringResource(if (switchState.value) R.string.label_on else R.string.label_off),
                 style = MaterialTheme.wireTypography.body01,
-                color = MaterialTheme.wireColorScheme.onBackground,
-                modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)
+                color = MaterialTheme.wireColorScheme.onBackground
             )
         }
+        if(trailingOnText != null) {
+            HorizontalSpace.x2()
+            Text(
+                text = trailingOnText,
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.secondaryText,
+            )
+        }
+        HorizontalSpace.x8()
         if (switchState.isSwitchVisible) {
             WireSwitch(
                 checked = switchState.value,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -23,6 +23,7 @@ package com.wire.android.ui.home.conversations.details.options
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 
 data class GroupConversationOptionsState(
     val conversationId: ConversationId,
@@ -40,7 +41,8 @@ data class GroupConversationOptionsState(
     val loadingServicesOption: Boolean = false,
     val loadingReadReceiptOption: Boolean = false,
     val error: Error = Error.None,
-    val mlsEnabled: Boolean = false
+    val mlsEnabled: Boolean = false,
+    val selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled
 ) {
 
     sealed interface Error {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -30,6 +30,7 @@ import com.wire.android.ui.home.conversations.model.MessageStatus.DecryptionFail
 import com.wire.android.ui.home.conversations.model.MessageStatus.Deleted
 import com.wire.android.ui.home.conversations.model.MessageStatus.ReceiveFailure
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.uiMessageDateTime
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -279,6 +280,25 @@ sealed class UIMessageContent {
             R.drawable.ic_view,
             if (isAuthorSelfUser) R.string.label_system_message_read_receipt_changed_by_self
             else R.string.label_system_message_read_receipt_changed_by_other
+        )
+
+        data class ConversationMessageTimerActivated(
+            val author: UIText,
+            val isAuthorSelfUser: Boolean = false,
+            val selfDeletionDuration: SelfDeletionDuration
+        ) : SystemMessage(
+            R.drawable.ic_timer,
+            if (isAuthorSelfUser) R.string.label_system_message_conversation_message_timer_activated_by_self
+            else R.string.label_system_message_conversation_message_timer_activated_by_other
+        )
+
+        data class ConversationMessageTimerDeactivated(
+            val author: UIText,
+            val isAuthorSelfUser: Boolean = false,
+        ) : SystemMessage(
+            R.drawable.ic_timer,
+            if (isAuthorSelfUser) R.string.label_system_message_conversation_message_timer_deactivated_by_self
+            else R.string.label_system_message_conversation_message_timer_deactivated_by_other
         )
 
         class HistoryLost : SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)

--- a/app/src/main/kotlin/com/wire/android/util/extension/LazyListScope.kt
+++ b/app/src/main/kotlin/com/wire/android/util/extension/LazyListScope.kt
@@ -66,7 +66,7 @@ inline fun <T, K : Any> LazyListScope.folderWithElements(
                     .animateItemPlacement()
             ) {
                 factory(item.value)
-                if (index < list.lastIndex)
+                if (index <= list.lastIndex)
                     divider()
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,6 +532,12 @@
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
     <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_read_receipt_changed_by_other">%1$s turned read receipts %2$s for everyone</string>
+    <string name="label_system_message_conversation_message_timer_activated_by_self">%1$s %2$s the forced switching on for self-deleting messages (message timer: %3$s)</string>
+    <string name="label_system_message_conversation_message_timer_activated_by_other">%1$s %2$s the forced switching on for self-deleting messages (message timer: %3$s)</string>
+    <string name="label_system_message_activated">activated</string>
+    <string name="label_system_message_conversation_message_timer_deactivated_by_self">%1$s %2$s the forced switching on for self-deleting messages</string>
+    <string name="label_system_message_conversation_message_timer_deactivated_by_other">%1$s %2$s the forced switching on for self-deleting messages</string>
+    <string name="label_system_message_deactivated">deactivated</string>
     <string name="label_system_message_conversation_history_lost">You haven\'t used this device for a while. some messages may not appear here.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="conversation_participant_you_label">(You)</string>
     <string name="conversation_details_is_classified">SECURITY LEVEL: VS-NfD</string>
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
+    <string name="conversation_options_self_deleting_messages_label">Self-deleting messages</string>
+    <string name="conversation_options_self_deleting_messages_description">When this is on, all messages in this group will disappear after a certain time.</string>
     <string name="conversation_options_guests_label">Guests</string>
     <string name="conversation_details_guest_description">When this is ON, people from outside your team can join this conversation</string>
     <string name="conversation_options_guest_description">Turn this option ON to open this conversation to people outside your team, even if they don\'t have Wire.</string>
@@ -914,6 +916,14 @@
     <string name="join_conversation_via_deeplink_error_link_expired">The link to this group conversation expired or the conversation was set to private.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">The maximum number of participants in this conversation has been reached.</string>
     <string name="join_conversation_via_deeplink_error_general">Due to an error you could not be added to the group conversation.</string>
+
+    <!-- edit self-deleting messages -->
+    <string name="self_deleting_messages_title">Self-deleting Messages</string>
+    <string name="self_deleting_messages_option">Enforce message deletion</string>
+    <string name="self_deleting_messages_option_description">When this is on, all messages in this group will disappear after a certain time. This applies to all group participants.</string>
+    <string name="self_deleting_messages_folder_timer">Timer</string>
+    <string name="self_deleting_messages_folder_timer_description">Automatically delete messages after:</string>
+
     <!-- guest room link -->
     <string name="folder_label_guest_link">Guest link</string>
     <string name="guest_link_description">Invite others with a link to this conversation. Anyone with the link can join the conversation, even if they don’t have Wire.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -922,7 +922,6 @@
     <string name="self_deleting_messages_option">Enforce message deletion</string>
     <string name="self_deleting_messages_option_description">When this is on, all messages in this group will disappear after a certain time. This applies to all group participants.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
-    <string name="self_deleting_messages_folder_timer_description">Automatically delete messages after:</string>
 
     <!-- guest room link -->
     <string name="folder_label_guest_link">Guest link</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -47,7 +47,8 @@ object TestConversation {
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
-        receiptMode = Conversation.ReceiptMode.ENABLED
+        receiptMode = Conversation.ReceiptMode.ENABLED,
+        messageTimer = null
     )
     val SELF = Conversation(
         ID.copy(value = "SELF ID"),
@@ -63,7 +64,8 @@ object TestConversation {
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
-        receiptMode = Conversation.ReceiptMode.ENABLED
+        receiptMode = Conversation.ReceiptMode.ENABLED,
+        messageTimer = null
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -80,7 +82,8 @@ object TestConversation {
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
-        receiptMode = Conversation.ReceiptMode.ENABLED
+        receiptMode = Conversation.ReceiptMode.ENABLED,
+        messageTimer = null
     )
 
 
@@ -98,7 +101,8 @@ object TestConversation {
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
-        receiptMode = Conversation.ReceiptMode.ENABLED
+        receiptMode = Conversation.ReceiptMode.ENABLED,
+        messageTimer = null
     )
 
     val USER_1 = UserId("member1", "domainMember")
@@ -122,7 +126,8 @@ object TestConversation {
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         lastReadDate = "2022-03-30T15:36:00.000Z",
         creatorId = null,
-        receiptMode =  Conversation.ReceiptMode.ENABLED
+        receiptMode =  Conversation.ReceiptMode.ENABLED,
+        messageTimer = null
     )
 
 }

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -86,7 +86,6 @@ object TestConversation {
         messageTimer = null
     )
 
-
     fun one_on_one(convId: ConversationId) = Conversation(
         convId,
         "ONE_ON_ONE Name",
@@ -126,8 +125,7 @@ object TestConversation {
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         lastReadDate = "2022-03-30T15:36:00.000Z",
         creatorId = null,
-        receiptMode =  Conversation.ReceiptMode.ENABLED,
+        receiptMode = Conversation.ReceiptMode.ENABLED,
         messageTimer = null
     )
-
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -228,7 +228,7 @@ internal class MessageComposerViewModelArrangement {
         coEvery { observeEstablishedCallsUseCase() } returns emptyFlow()
         coEvery { observeSecurityClassificationType(any()) } returns emptyFlow()
         coEvery { imageUtil.extractImageWidthAndHeight(any(), any()) } returns (1 to 1)
-        coEvery { observeConversationSelfDeletionStatus(any()) } returns emptyFlow()
+        coEvery { observeConversationSelfDeletionStatus(any(), any()) } returns emptyFlow()
         coEvery { observeConversationInteractionAvailabilityUseCase(any()) } returns flowOf(
             IsInteractionAvailableResult.Success(
                 InteractionAvailability.ENABLED
@@ -276,7 +276,7 @@ internal class MessageComposerViewModelArrangement {
     }
 
     fun withObserveSelfDeletingStatus(expectedSelfDeletionTimer: SelfDeletionTimer) = apply {
-        coEvery { observeConversationSelfDeletionStatus(conversationId) } returns flowOf(expectedSelfDeletionTimer)
+        coEvery { observeConversationSelfDeletionStatus(conversationId, true) } returns flowOf(expectedSelfDeletionTimer)
     }
 
     fun withPersistSelfDeletionStatus() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -375,7 +375,7 @@ class MessageComposerViewModelTest {
         // When
 
         // Then
-        coVerify(exactly = 1) { arrangement.observeConversationSelfDeletionStatus.invoke(arrangement.conversationId) }
+        coVerify(exactly = 1) { arrangement.observeConversationSelfDeletionStatus.invoke(arrangement.conversationId, true) }
         assert(viewModel.messageComposerViewState.selfDeletionTimer is SelfDeletionTimer.Enabled)
         assert(viewModel.messageComposerViewState.selfDeletionTimer.toDuration() == expectedDuration)
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -49,6 +49,8 @@ import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUs
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
@@ -484,7 +486,8 @@ class GroupConversationDetailsViewModelTest {
                 accessRole = Conversation.defaultGroupAccessRoles.toMutableList().apply { add(Conversation.AccessRole.GUEST) },
                 lastReadDate = "2022-04-04T16:11:28.388Z",
                 creatorId = null,
-                receiptMode = Conversation.ReceiptMode.ENABLED
+                receiptMode = Conversation.ReceiptMode.ENABLED,
+                messageTimer = null
             ),
             legalHoldStatus = LegalHoldStatus.DISABLED,
             hasOngoingCall = false,
@@ -538,6 +541,8 @@ internal class GroupConversationDetailsViewModelArrangement {
     @MockK
     lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
 
+    lateinit var observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase
+
     @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
@@ -561,7 +566,8 @@ internal class GroupConversationDetailsViewModelArrangement {
             updateConversationMutedStatus = updateConversationMutedStatus,
             clearConversationContent = clearConversationContentUseCase,
             updateConversationReceiptMode = updateConversationReceiptMode,
-            isMLSEnabled = isMLSEnabledUseCase
+            isMLSEnabled = isMLSEnabledUseCase,
+            observeSelfDeletionTimerSettingsForConversation = observeSelfDeletionTimerSettingsForConversation
         )
     }
 
@@ -583,6 +589,7 @@ internal class GroupConversationDetailsViewModelArrangement {
             qualifiedIdMapper.fromStringToQualifiedID("conv_id@domain")
         } returns QualifiedID("conv_id", "domain")
         coEvery { updateConversationMutedStatus(any(), any(), any()) } returns ConversationUpdateStatusResult.Success
+        coEvery { observeSelfDeletionTimerSettingsForConversation(any(), any()) } returns flowOf(SelfDeletionTimer.Disabled)
     }
 
     fun withSavedStateConversationId(conversationId: ConversationId) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -541,6 +541,7 @@ internal class GroupConversationDetailsViewModelArrangement {
     @MockK
     lateinit var updateConversationReceiptMode: UpdateConversationReceiptModeUseCase
 
+    @MockK
     lateinit var observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase
 
     @MockK

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -316,7 +316,8 @@ class MediaGalleryViewModelTest {
                 access = listOf(Conversation.Access.INVITE),
                 accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER),
                 creatorId = null,
-                receiptMode = Conversation.ReceiptMode.ENABLED
+                receiptMode = Conversation.ReceiptMode.ENABLED,
+                messageTimer = null
             ),
             otherUser = OtherUser(
                 QualifiedID("other-user-id", "domain-id"),

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -149,7 +149,8 @@ internal class NewConversationViewModelArrangement {
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER),
             creatorId = null,
-            receiptMode = Conversation.ReceiptMode.ENABLED
+            receiptMode = Conversation.ReceiptMode.ENABLED,
+            messageTimer = null
         )
 
         val PUBLIC_USER = OtherUser(

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -434,7 +434,8 @@ class OtherUserProfileScreenViewModelTest {
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER),
             creatorId = null,
-            receiptMode = Conversation.ReceiptMode.ENABLED
+            receiptMode = Conversation.ReceiptMode.ENABLED,
+            messageTimer = null
         )
         val CONVERSATION_ROLE_DATA = ConversationRoleData(
             "some_name",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3226" title="AR-3226" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3226</a>  Self-deleting messages in group settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added option in conversation group settings for self deleting messages
- added edit self deleting messages conversation group screen
- system message for enable/disable group self deleting message timer change 

### Dependencies (Optional)

Needs releases with:

- [https://github.com/wireapp/kalium/pull/1718] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
