### PR TITLE
fix: issue not identifying correctly already consumed intents [AR-3377] [AR-3387]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -190,9 +190,9 @@ class WireActivity : AppCompatActivity() {
 
         DisposableEffect(navController) {
             val updateScreenSettingsListener = NavController.OnDestinationChangedListener { controller, _, _ ->
-                    currentKeyboardController?.hide()
-                    updateScreenSettings(controller)
-                }
+                currentKeyboardController?.hide()
+                updateScreenSettings(controller)
+            }
             navController.addOnDestinationChangedListener(updateScreenSettingsListener)
             navController.addOnDestinationChangedListener(currentScreenManager)
 
@@ -403,11 +403,13 @@ class WireActivity : AppCompatActivity() {
         if (intent == null
             || intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0
             || savedInstanceState?.getBoolean(HANDLED_DEEPLINK_FLAG, false) == true
+            || intent.getBooleanExtra(HANDLED_DEEPLINK_FLAG, false)
         ) {
             return
+        } else {
+            viewModel.handleDeepLink(intent)
+            intent.putExtra(HANDLED_DEEPLINK_FLAG, true)
         }
-
-        viewModel.handleDeepLink(intent)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -396,6 +396,7 @@ class WireActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
     }
 
+    @Suppress("ComplexCondition")
     private fun handleDeepLink(
         intent: Intent?,
         savedInstanceState: Bundle? = null


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3377" title="AR-3377" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3377</a>  PlayTest 02.05 - After sharing an image, while opening a deeplink on the background there is share image screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently there is a buggy behavior in the app causing that if we open it via a navigation deeplink (message notification, or by importing media from other apps), when sending the app to background and resuming it, the initial navigation screen shown when handling the deeplink will pop up again.

### Solutions

Add an extra value on the intent once the user has handled the initial intent and check if it was already set when handling new intents. If so, we don't handle it again.

### Attachments (Optional)
| Before | After |
| ----------- | ------------ |
| <video src= "https://github.com/wireapp/wire-android-reloaded/assets/2468164/5bc2e8de-2782-4ace-8f80-db9b56b69d4a"/> | <video src= "https://github.com/wireapp/wire-android-reloaded/assets/2468164/7db5baa0-b543-470f-b324-da1fdb015c33" /> |


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
