### PR TITLE
fix: issue with wrong text color while in dark mode [AR-3386]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
@@ -29,9 +29,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,22 +61,24 @@ fun MenuBottomSheetItem(
     clickBlockParams: ClickBlockParams = ClickBlockParams(),
     onItemClick: () -> Unit = {}
 ) {
-    val clickable = remember(onItemClick, clickBlockParams) { Clickable(clickBlockParams = clickBlockParams, onClick = onItemClick) }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationBottomSheetItemHeight)
-            .fillMaxWidth()
-            .clickable(clickable)
-            .padding(MaterialTheme.wireDimensions.conversationBottomSheetItemPadding)
-    ) {
-        icon()
-        Spacer(modifier = Modifier.width(12.dp))
-        MenuItemTitle(title = title)
-        if (action != null) {
-            Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing12x))
-            Spacer(modifier = Modifier.weight(1f)) // combining both in one modifier doesn't work
-            action()
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+        val clickable = remember(onItemClick, clickBlockParams) { Clickable(clickBlockParams = clickBlockParams, onClick = onItemClick) }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationBottomSheetItemHeight)
+                .fillMaxWidth()
+                .clickable(clickable)
+                .padding(MaterialTheme.wireDimensions.conversationBottomSheetItemPadding)
+        ) {
+            icon()
+            Spacer(modifier = Modifier.width(12.dp))
+            MenuItemTitle(title = title)
+            if (action != null) {
+                Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing12x))
+                Spacer(modifier = Modifier.weight(1f)) // combining both in one modifier doesn't work
+                action()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
@@ -29,15 +29,13 @@ import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 
 @Composable
 fun DownloadAssetExternallyOption(onDownloadClick: () -> Unit) =
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
-        MenuBottomSheetItem(
-            icon = {
-                MenuItemIcon(
-                    id = R.drawable.ic_download,
-                    contentDescription = stringResource(R.string.content_description_download_icon),
-                )
-            },
-            title = stringResource(R.string.label_download),
-            onItemClick = onDownloadClick
-        )
-    }
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_download,
+                contentDescription = stringResource(R.string.content_description_download_icon),
+            )
+        },
+        title = stringResource(R.string.label_download),
+        onItemClick = onDownloadClick
+    )

--- a/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/DownloadAssetExternallyOption.kt
@@ -18,10 +18,7 @@
 
 package com.wire.android.ui.edit
 
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem

--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,58 +38,61 @@ fun ReactionOption(
     onReactionClick: (emoji: String) -> Unit,
     emojiFontSize: TextUnit = 28.sp
 ) {
-    Column {
-        Row {
-            Spacer(modifier = Modifier.width(dimensions().spacing8x))
-            Text(
-                ("${stringResource(R.string.label_reactions)} ${stringResource(id = R.string.label_more_comming_soon)}").uppercase(),
-                style = MaterialTheme.wireTypography.label01
-            )
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            listOf("❤️", "👍", "😁", "🙂", "☹️", "👎").forEach { emoji ->
-                CompositionLocalProvider(
-                    LocalMinimumTouchTargetEnforcement provides false
-                ) {
-                    Button(
-                        onClick = {
-                            // TODO remove when all emojis will be available
-                            if (emoji == "❤️") {
-                                // So we display the pretty emoji,
-                                // but we match the ugly one sent from other platforms
-                                val correctedEmoji = "❤"
-                                onReactionClick(correctedEmoji)
-                            }
-                        },
-                        modifier = Modifier
-                            .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
-                            // TODO remove when all emojis will be available
-                            .alpha(if (emoji == "❤️") 1F else 0.3F),
-                        contentPadding = PaddingValues(dimensions().spacing8x),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.wireColorScheme.surface,
-                            contentColor = MaterialTheme.wireColorScheme.secondaryButtonSelectedOutline
-                        )
+
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+        Column {
+            Row {
+                Spacer(modifier = Modifier.width(dimensions().spacing8x))
+                Text(
+                    ("${stringResource(R.string.label_reactions)} ${stringResource(id = R.string.label_more_comming_soon)}").uppercase(),
+                    style = MaterialTheme.wireTypography.label01
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                listOf("❤️", "👍", "😁", "🙂", "☹️", "👎").forEach { emoji ->
+                    CompositionLocalProvider(
+                        LocalMinimumTouchTargetEnforcement provides false
                     ) {
-                        Text(emoji, style = TextStyle(fontSize = emojiFontSize))
+                        Button(
+                            onClick = {
+                                // TODO remove when all emojis will be available
+                                if (emoji == "❤️") {
+                                    // So we display the pretty emoji,
+                                    // but we match the ugly one sent from other platforms
+                                    val correctedEmoji = "❤"
+                                    onReactionClick(correctedEmoji)
+                                }
+                            },
+                            modifier = Modifier
+                                .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
+                                // TODO remove when all emojis will be available
+                                .alpha(if (emoji == "❤️") 1F else 0.3F),
+                            contentPadding = PaddingValues(dimensions().spacing8x),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.wireColorScheme.surface,
+                                contentColor = MaterialTheme.wireColorScheme.secondaryButtonSelectedOutline
+                            )
+                        ) {
+                            Text(emoji, style = TextStyle(fontSize = emojiFontSize))
+                        }
                     }
                 }
-            }
-            IconButton(
-                onClick = {
-                    // TODO show more emojis
-                },
-                modifier = Modifier
-                    // TODO remove when all emojis will be available
-                    .alpha(0.1F),
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_more_emojis),
-                    contentDescription = stringResource(R.string.content_description_more_emojis)
-                )
+                IconButton(
+                    onClick = {
+                        // TODO show more emojis
+                    },
+                    modifier = Modifier
+                        // TODO remove when all emojis will be available
+                        .alpha(0.1F),
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_more_emojis),
+                        contentDescription = stringResource(R.string.content_description_more_emojis)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3386" title="AR-3386" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3386</a>  On dark mode ui issue that message options are greyed out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Dark mode was not showing correct text colors for menu items in bottom sheet.

### Causes (Optional)
We were not styling correctly menu items.

### Solutions

Apply the same style to all `MenuBottomSheetItem`s.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="457" alt="Captura de pantalla 2023-05-11 a las 10 53 04" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/40f696a6-1979-4b10-a2ce-c02218ff75eb"> |  <img width="442" alt="Captura de pantalla 2023-05-11 a las 10 44 17" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/8b0a8476-2d30-4dc1-a076-560cc8fa513c"> |

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
