### PR TITLE
feat: Move conversation to first unread message (AR-2998)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.conversation.AddMemberToConversationUseCase
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
@@ -1048,7 +1049,7 @@ class UseCaseModule {
     fun provideEnqueueMessageSelfDeletionUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
-    ): EnqueueMessageSelfDeletionUseCase = coreLogic.getSessionScope(currentAccount).enqueueMessageSelfDeletionUseCase
+    ): EnqueueMessageSelfDeletionUseCase = coreLogic.getSessionScope(currentAccount).messages.enqueueMessageSelfDeletion
 
     @ViewModelScoped
     @Provides
@@ -1073,4 +1074,13 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): UpdateEmailUseCase =
         coreLogic.getSessionScope(currentAccount).users.updateEmail
+
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetConversationUnreadEventsCountUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): GetConversationUnreadEventsCountUseCase =
+        coreLogic.getSessionScope(currentAccount).conversations.getConversationUnreadEventsCountUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -1103,7 +1103,6 @@ class UseCaseModule {
     ): UpdateEmailUseCase =
         coreLogic.getSessionScope(currentAccount).users.updateEmail
 
-
     @ViewModelScoped
     @Provides
     fun provideGetConversationUnreadEventsCountUseCase(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -379,6 +379,7 @@ private fun ConversationScreen(
                         audioMessagesState = conversationMessagesViewState.audioMessagesState,
                         isFileSharingEnabled = messageComposerViewState.isFileSharingEnabled,
                         lastUnreadMessageInstant = conversationMessagesViewState.firstUnreadInstant,
+                        unreadEventCount = conversationMessagesViewState.firstuUnreadEventIndex,
                         conversationState = messageComposerViewState,
                         messageComposerInnerState = messageComposerInnerState,
                         messages = conversationMessagesViewState.messages,
@@ -414,6 +415,7 @@ private fun ConversationScreenContent(
     membersToMention: List<Contact>,
     isFileSharingEnabled: Boolean,
     lastUnreadMessageInstant: Instant?,
+    unreadEventCount: Int,
     conversationState: MessageComposerViewState,
     audioMessagesState: Map<String, AudioState>,
     messageComposerInnerState: MessageComposerInnerState,
@@ -440,9 +442,8 @@ private fun ConversationScreenContent(
 
     val lazyPagingMessages = messages.collectAsLazyPagingItems()
 
-    val lazyListState = rememberSaveable(lazyPagingMessages, saver = LazyListState.Saver) {
-        // TODO: Autoscroll to last unread message
-        LazyListState(0)
+    val lazyListState = rememberSaveable(unreadEventCount, lazyPagingMessages, saver = LazyListState.Saver) {
+        LazyListState(unreadEventCount)
     }
 
     MessageComposer(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -59,6 +59,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCase
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
@@ -73,6 +74,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import okio.Path
 import javax.inject.Inject
+import kotlin.math.max
 
 @HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -89,7 +91,8 @@ class ConversationMessagesViewModel @Inject constructor(
     private val getMessageForConversation: GetMessagesForConversationUseCase,
     private val toggleReaction: ToggleReactionUseCase,
     private val resetSession: ResetSessionUseCase,
-    private val conversationAudioMessagePlayer: ConversationAudioMessagePlayer
+    private val conversationAudioMessagePlayer: ConversationAudioMessagePlayer,
+    private val getConversationUnreadEventsCountUseCase: GetConversationUnreadEventsCountUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationMessagesViewState())
@@ -107,6 +110,7 @@ class ConversationMessagesViewModel @Inject constructor(
         loadLastMessageInstant()
         observeAudioPlayerState()
     }
+
     private fun observeAudioPlayerState() {
         viewModelScope.launch {
             conversationAudioMessagePlayer.observableAudioMessagesState.collect {
@@ -118,11 +122,19 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     private fun loadPaginatedMessages() = viewModelScope.launch {
-        val paginatedMessagesFlow = getMessageForConversation(conversationId)
+        val lastReadIndex = when (val result = getConversationUnreadEventsCountUseCase(conversationId)) {
+            is GetConversationUnreadEventsCountUseCase.Result.Success -> result.amount.toInt()
+            is GetConversationUnreadEventsCountUseCase.Result.Failure -> 0
+        }
+
+        val paginatedMessagesFlow = getMessageForConversation(conversationId, lastReadIndex)
             .flowOn(dispatchers.io())
             .cachedIn(this)
 
-        conversationViewState = conversationViewState.copy(messages = paginatedMessagesFlow)
+        conversationViewState = conversationViewState.copy(
+            messages = paginatedMessagesFlow,
+            firstuUnreadEventIndex = max(lastReadIndex - 1, 0)
+        )
     }
 
     private fun loadLastMessageInstant() = viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -92,7 +92,7 @@ class ConversationMessagesViewModel @Inject constructor(
     private val toggleReaction: ToggleReactionUseCase,
     private val resetSession: ResetSessionUseCase,
     private val conversationAudioMessagePlayer: ConversationAudioMessagePlayer,
-    private val getConversationUnreadEventsCountUseCase: GetConversationUnreadEventsCountUseCase
+    private val getConversationUnreadEventsCount: GetConversationUnreadEventsCountUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationMessagesViewState())
@@ -122,7 +122,7 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     private fun loadPaginatedMessages() = viewModelScope.launch {
-        val lastReadIndex = when (val result = getConversationUnreadEventsCountUseCase(conversationId)) {
+        val lastReadIndex = when (val result = getConversationUnreadEventsCount(conversationId)) {
             is GetConversationUnreadEventsCountUseCase.Result.Success -> result.amount.toInt()
             is GetConversationUnreadEventsCountUseCase.Result.Failure -> 0
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -31,6 +31,7 @@ import kotlinx.datetime.Instant
 data class ConversationMessagesViewState(
     val messages: Flow<PagingData<UIMessage>> = emptyFlow(),
     val firstUnreadInstant: Instant? = null,
+    val firstuUnreadEventIndex: Int = 0,
     val downloadedAssetDialogState: DownloadedAssetDialogVisibilityState = DownloadedAssetDialogVisibilityState.Hidden,
     val audioMessagesState: Map<String, AudioState> = emptyMap()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import java.lang.Integer.max
 import javax.inject.Inject
 
 class GetMessagesForConversationUseCase @Inject constructor(
@@ -45,11 +46,11 @@ class GetMessagesForConversationUseCase @Inject constructor(
 ) {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    suspend operator fun invoke(conversationId: ConversationId): Flow<PagingData<UIMessage>> {
+    suspend operator fun invoke(conversationId: ConversationId, lastReadIndex: Int): Flow<PagingData<UIMessage>> {
         val pagingConfig = PagingConfig(
             pageSize = PAGE_SIZE,
             prefetchDistance = PREFETCH_DISTANCE,
-            initialLoadSize = INITIAL_LOAD_SIZE
+            initialLoadSize = max(INITIAL_LOAD_SIZE, lastReadIndex + PREFETCH_DISTANCE)
         )
         return getMessages(
             conversationId,
@@ -66,7 +67,7 @@ class GetMessagesForConversationUseCase @Inject constructor(
 
     private companion object {
         const val PAGE_SIZE = 20
-        const val INITIAL_LOAD_SIZE = 50
-        const val PREFETCH_DISTANCE = 30
+        const val INITIAL_LOAD_SIZE = 10
+        const val PREFETCH_DISTANCE = 5
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
@@ -67,7 +67,7 @@ class GetMessagesForConversationUseCase @Inject constructor(
 
     private companion object {
         const val PAGE_SIZE = 20
-        const val INITIAL_LOAD_SIZE = 10
-        const val PREFETCH_DISTANCE = 5
+        const val INITIAL_LOAD_SIZE = 50
+        const val PREFETCH_DISTANCE = 30
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateDownloadStatusResult
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
@@ -101,6 +102,9 @@ class ConversationMessagesViewModelArrangement {
     @MockK
     lateinit var conversationAudioMessagePlayer: ConversationAudioMessagePlayer
 
+    @MockK
+    lateinit var getConversationUnreadEventsCount: GetConversationUnreadEventsCountUseCase
+
     private val viewModel: ConversationMessagesViewModel by lazy {
         ConversationMessagesViewModel(
             navigationManager,
@@ -115,7 +119,8 @@ class ConversationMessagesViewModelArrangement {
             getMessagesForConversationUseCase,
             toggleReaction,
             resetSession,
-            conversationAudioMessagePlayer
+            conversationAudioMessagePlayer,
+            getConversationUnreadEventsCount
         )
     }
 
@@ -128,7 +133,8 @@ class ConversationMessagesViewModelArrangement {
             qualifiedIdMapper.fromStringToQualifiedID("some-dummy-value@some.dummy.domain")
         } returns QualifiedID("some-dummy-value", "some.dummy.domain")
         coEvery { observeConversationDetails(any()) } returns flowOf()
-        coEvery { getMessagesForConversationUseCase(any()) } returns messagesChannel.consumeAsFlow()
+        coEvery { getMessagesForConversationUseCase(any(), any()) } returns messagesChannel.consumeAsFlow()
+        coEvery { getConversationUnreadEventsCount(any()) } returns GetConversationUnreadEventsCountUseCase.Result.Success(0L)
         coEvery { updateAssetMessageDownloadStatus(any(), any(), any()) } returns UpdateDownloadStatusResult.Success
     }
 
@@ -144,6 +150,10 @@ class ConversationMessagesViewModelArrangement {
         every { fileManager.openWithExternalApp(any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
         }
+    }
+
+    fun withConversationUnreadEventsCount(result: GetConversationUnreadEventsCountUseCase.Result) = apply {
+        coEvery { getConversationUnreadEventsCount(any()) } returns result
     }
 
     fun withGetMessageByIdReturning(message: Message) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -27,8 +27,10 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestMessage.GENERIC_ASSET_CONTENT
 import com.wire.android.ui.home.conversations.mockUITextMessage
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -145,6 +147,24 @@ class ConversationMessagesViewModelTest {
         coVerify(exactly = 1) {
             arrangement.toggleReaction(arrangement.conversationId, messageId, reaction)
         }
+    }
+
+    @Test
+    fun `given getting UnreadEventsCount failed, then messages requested anyway`() = runTest {
+        val (arrangement, _) = ConversationMessagesViewModelArrangement()
+            .withConversationUnreadEventsCount(GetConversationUnreadEventsCountUseCase.Result.Failure(StorageFailure.DataNotFound))
+            .arrange()
+
+        coVerify(exactly = 1) { arrangement.getMessagesForConversationUseCase(any(), 0) }
+    }
+
+    @Test
+    fun `given getting UnreadEventsCount succeed, then messages requested with corresponding lastReadIndex`() = runTest {
+        val (arrangement, _) = ConversationMessagesViewModelArrangement()
+            .withConversationUnreadEventsCount(GetConversationUnreadEventsCountUseCase.Result.Success(12))
+            .arrange()
+
+        coVerify(exactly = 1) { arrangement.getMessagesForConversationUseCase(any(), 12) }
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,11 @@
  *
  *
  */
+pluginManagement {
+    repositories {
+        mavenCentral()
+    }
+}
 
 //Include all the existent modules in the project
 rootDir


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2998" title="AR-2998" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-2998</a>  When opening a conversation set focus to the oldest unread message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

When opening the conversation messages list scroll to the first (the oldest) unread message

### Dependencies (Optional)

Needs releases with:

After merging kalium PR https://github.com/wireapp/kalium/pull/1714

### Testing

#### How to Test

- receive a lot of messages in some conversation
- open that conversation
Expected result: 
messages list will be scrolled to the oldest unread message. 

- receive more then 50 messages in some conversation 
(`50` is a defaulted page size in messages pager)
- open that conversation
Expected result: 
messages list will be scrolled to the oldest unread message. 

### Attachments (Optional)


https://github.com/wireapp/wire-android-reloaded/assets/6539347/873cfdf7-638e-4780-a05d-73a5700d92fe

