### PR TITLE
fix: delete and remove edit options not using error color correctly [AR-3386]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -59,9 +60,10 @@ fun MenuBottomSheetItem(
     icon: @Composable () -> Unit,
     action: (@Composable () -> Unit)? = null,
     clickBlockParams: ClickBlockParams = ClickBlockParams(),
+    itemProvidedColor: Color = MaterialTheme.colorScheme.secondary,
     onItemClick: () -> Unit = {}
 ) {
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+    CompositionLocalProvider(LocalContentColor provides itemProvidedColor) {
         val clickable = remember(onItemClick, clickBlockParams) { Clickable(clickBlockParams = clickBlockParams, onClick = onItemClick) }
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -24,10 +24,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -164,102 +162,98 @@ internal fun ConversationMainSheetContent(
                                 conversationSheetContent.conversationId,
                                 conversationSheetContent.title,
                                 conversationSheetContent.conversationTypeDetail
-                        )
+                            )
                         )
                     }
                 )
             }
             if (conversationSheetContent.canBlockUser()) {
                 add {
-                    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
-                        MenuBottomSheetItem(
-                            icon = {
-                                MenuItemIcon(
-                                    id = R.drawable.ic_block,
-                                    contentDescription = stringResource(R.string.content_description_block_the_user),
+                    MenuBottomSheetItem(
+                        icon = {
+                            MenuItemIcon(
+                                id = R.drawable.ic_block,
+                                contentDescription = stringResource(R.string.content_description_block_the_user),
+                            )
+                        },
+                        itemProvidedColor = MaterialTheme.colorScheme.error,
+                        title = stringResource(R.string.label_block),
+                        clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+                        onItemClick = {
+                            blockUserClick(
+                                BlockUserDialogState(
+                                    userName = conversationSheetContent.title,
+                                    userId = (conversationSheetContent.conversationTypeDetail as ConversationTypeDetail.Private).userId
                                 )
-                            },
-                            title = stringResource(R.string.label_block),
-                            clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-                            onItemClick = {
-                                blockUserClick(
-                                    BlockUserDialogState(
-                                        userName = conversationSheetContent.title,
-                                        userId = (conversationSheetContent.conversationTypeDetail as ConversationTypeDetail.Private).userId
-                                    )
-                                )
-                            }
-                        )
-                    }
+                            )
+                        }
+                    )
                 }
             }
             if (conversationSheetContent.canUnblockUser()) {
                 add {
-                    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
-                        MenuBottomSheetItem(
-                            icon = {
-                                MenuItemIcon(
-                                    id = R.drawable.ic_block,
-                                    contentDescription = stringResource(R.string.content_description_unblock_the_user)
+                    MenuBottomSheetItem(
+                        icon = {
+                            MenuItemIcon(
+                                id = R.drawable.ic_block,
+                                contentDescription = stringResource(R.string.content_description_unblock_the_user)
+                            )
+                        },
+                        itemProvidedColor = MaterialTheme.colorScheme.onBackground,
+                        title = stringResource(R.string.label_unblock),
+                        onItemClick = {
+                            unblockUserClick(
+                                UnblockUserDialogState(
+                                    userName = conversationSheetContent.title,
+                                    userId = (conversationSheetContent.conversationTypeDetail as ConversationTypeDetail.Private).userId
                                 )
-                            },
-                            title = stringResource(R.string.label_unblock),
-                            onItemClick = {
-                                unblockUserClick(
-                                    UnblockUserDialogState(
-                                        userName = conversationSheetContent.title,
-                                        userId = (conversationSheetContent.conversationTypeDetail as ConversationTypeDetail.Private).userId
-                                    )
-                                )
-                            }
-                        )
-                    }
+                            )
+                        }
+                    )
                 }
             }
             if (conversationSheetContent.canLeaveTheGroup()) {
                 add {
-                    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
-                        MenuBottomSheetItem(
-                            icon = {
-                                MenuItemIcon(
-                                    id = R.drawable.ic_leave,
-                                    contentDescription = stringResource(R.string.content_description_leave_the_group),
+                    MenuBottomSheetItem(
+                        icon = {
+                            MenuItemIcon(
+                                id = R.drawable.ic_leave,
+                                contentDescription = stringResource(R.string.content_description_leave_the_group),
+                            )
+                        },
+                        itemProvidedColor = MaterialTheme.colorScheme.error,
+                        title = stringResource(R.string.label_leave_group),
+                        onItemClick = {
+                            leaveGroup(
+                                GroupDialogState(
+                                    conversationSheetContent.conversationId,
+                                    conversationSheetContent.title
                                 )
-                            },
-                            title = stringResource(R.string.label_leave_group),
-                            onItemClick = {
-                                leaveGroup(
-                                    GroupDialogState(
-                                        conversationSheetContent.conversationId,
-                                        conversationSheetContent.title
-                                    )
-                                )
-                            }
-                        )
-                    }
+                            )
+                        }
+                    )
                 }
             }
             if (conversationSheetContent.canDeleteGroup()) {
                 add {
-                    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
-                        MenuBottomSheetItem(
-                            icon = {
-                                MenuItemIcon(
-                                    id = R.drawable.ic_remove,
-                                    contentDescription = stringResource(R.string.content_description_delete_the_group),
+                    MenuBottomSheetItem(
+                        icon = {
+                            MenuItemIcon(
+                                id = R.drawable.ic_remove,
+                                contentDescription = stringResource(R.string.content_description_delete_the_group),
+                            )
+                        },
+                        title = stringResource(R.string.label_delete_group),
+                        itemProvidedColor = MaterialTheme.colorScheme.error,
+                        onItemClick = {
+                            deleteGroup(
+                                GroupDialogState(
+                                    conversationSheetContent.conversationId,
+                                    conversationSheetContent.title
                                 )
-                            },
-                            title = stringResource(R.string.label_delete_group),
-                            onItemClick = {
-                                deleteGroup(
-                                    GroupDialogState(
-                                        conversationSheetContent.conversationId,
-                                        conversationSheetContent.title
-                                    )
-                                )
-                            }
-                        )
-                    }
+                            )
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/DeleteItemMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/DeleteItemMenuOption.kt
@@ -17,10 +17,8 @@
  */
 package com.wire.android.ui.edit
 
-import androidx.compose.material.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
@@ -28,16 +26,15 @@ import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 
 @Composable
 fun DeleteItemMenuOption(onDeleteItemClick: () -> Unit) {
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
-        MenuBottomSheetItem(
-            icon = {
-                MenuItemIcon(
-                    id = R.drawable.ic_delete,
-                    contentDescription = stringResource(R.string.content_description_delete_the_message),
-                )
-            },
-            title = stringResource(R.string.label_delete),
-            onItemClick = onDeleteItemClick
-        )
-    }
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_delete,
+                contentDescription = stringResource(R.string.content_description_delete_the_message),
+            )
+        },
+        itemProvidedColor = MaterialTheme.colorScheme.error,
+        title = stringResource(R.string.label_delete),
+        onItemClick = onDeleteItemClick
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/OpenAssetExternallyOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/OpenAssetExternallyOption.kt
@@ -18,10 +18,7 @@
 
 package com.wire.android.ui.edit
 
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
@@ -29,15 +26,13 @@ import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 
 @Composable
 fun OpenAssetExternallyOption(onOpenClick: () -> Unit) =
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
-        MenuBottomSheetItem(
-            icon = {
-                MenuItemIcon(
-                    id = R.drawable.ic_view,
-                    contentDescription = stringResource(R.string.content_description_open_asset_icon),
-                )
-            },
-            title = stringResource(R.string.label_open_asset_externally),
-            onItemClick = onOpenClick
-        )
-    }
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_view,
+                contentDescription = stringResource(R.string.content_description_open_asset_icon),
+            )
+        },
+        title = stringResource(R.string.label_open_asset_externally),
+        onItemClick = onOpenClick
+    )

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -30,12 +30,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -193,30 +191,27 @@ fun EditGalleryMenuItems(
         add { ReplyMessageOption(onReplyItemClick = onImageReplied) }
         add { DownloadAssetExternallyOption(onDownloadClick = onDownloadImage) }
         add {
-            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
-                MenuBottomSheetItem(
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_share_file,
-                            contentDescription = stringResource(R.string.content_description_share_the_file),
-                        )
-                    },
-                    title = stringResource(R.string.label_share),
-                    onItemClick = onShareImage
-                )
-            }
-            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.error) {
-                MenuBottomSheetItem(
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_delete,
-                            contentDescription = stringResource(R.string.content_description_delete_the_message),
-                        )
-                    },
-                    title = stringResource(R.string.label_delete),
-                    onItemClick = onDeleteMessage
-                )
-            }
+            MenuBottomSheetItem(
+                icon = {
+                    MenuItemIcon(
+                        id = R.drawable.ic_share_file,
+                        contentDescription = stringResource(R.string.content_description_share_the_file),
+                    )
+                },
+                title = stringResource(R.string.label_share),
+                onItemClick = onShareImage
+            )
+            MenuBottomSheetItem(
+                icon = {
+                    MenuItemIcon(
+                        id = R.drawable.ic_delete,
+                        contentDescription = stringResource(R.string.content_description_delete_the_message),
+                    )
+                },
+                itemProvidedColor = MaterialTheme.colorScheme.error,
+                title = stringResource(R.string.label_delete),
+                onItemClick = onDeleteMessage
+            )
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3386" title="AR-3386" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3386</a>  On dark mode ui issue that message options are greyed out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On the last PR #1777 mistakenly we forgot to apply correct error color to special items such as delete, clear content, block, etc...

### Solutions
Added an extra `itemProvidedColor` field to `MenuBottomSheetItem` to correctly provide it by constructor and removed the manual tint on all individual menu items to provide it via parameter.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
|   <img width="455" alt="Captura de pantalla 2023-05-11 a las 12 54 28" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/af74c163-ebe7-403e-8a3d-9beee39c3757">|  <img width="452" alt="Captura de pantalla 2023-05-11 a las 13 02 17" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/4249a5fb-64ed-4eb7-a8f1-015c206d110b"> |

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
