### PR TITLE
fix: not observing to edit changes to enable save edit button [AR-3399]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageInputRow.kt
@@ -130,7 +130,8 @@ fun MessageComposerInputRow(
             AnimatedVisibility(messageComposeInputState.isEditMessage) {
                 MessageEditActions(
                     onEditSaveButtonClicked = onEditSaveButtonClicked,
-                    onEditCancelButtonClicked = onEditCancelButtonClicked
+                    onEditCancelButtonClicked = onEditCancelButtonClicked,
+                    editButtonEnabled = messageComposeInputState.editSaveButtonEnabled
                 )
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3399" title="AR-3399" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3399</a>  PlayTest 09.05 - Edit option was greyed out on message options for both dark and normal modes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Edit button was not being enabled when changing the text while editing.

### Causes (Optional)
Probably a leftover when solving conflicts on previous PR's.

### Solutions

Fix it!
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
