### PR TITLE
fix: On join ringtone is played many times when the call got established (AR-3419)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import javax.inject.Inject
@@ -74,14 +75,14 @@ class InitiatingCallViewModel @Inject constructor(
 
     private suspend fun observeStartedCall() {
         observeEstablishedCalls()
+            .map { calls -> calls.map { it.conversationId } }
             .distinctUntilChanged()
-            .collect { calls ->
-                calls
-                    .find { call ->
-                        call.conversationId == conversationId
-                    }?.let {
-                        onCallEstablished()
-                    }
+            .collect { conversationIds ->
+                conversationIds.find { convId ->
+                    convId == conversationId
+                }?.let {
+                    onCallEstablished()
+                }
             }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3419" title="AR-3419" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3419</a>  On join ringtone is played many times when the call is established
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On join ringtone is played many times when the call got established
Sometimes the screen is flashing when the call got established

### Causes (Optional)

The flow returning established call can emit more than a value (when participants list is changed) causing to call oncallEstablished many times

### Solutions

map the flow to get only conversationIds

### Attachments (Optional)

Before

https://github.com/wireapp/wire-android-reloaded/assets/18124919/20c71506-3676-4a9b-81e9-cb653407822b


After

https://github.com/wireapp/wire-android-reloaded/assets/18124919/16995d9d-508c-494f-bc7c-b9d8b16933af



----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
