### PR TITLE
feat: add self deletion mechanism for import screen [AR-3294]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
@@ -25,9 +25,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -40,22 +42,25 @@ fun ModalSheetHeaderItem(header: MenuModalSheetHeader = MenuModalSheetHeader.Gon
         MenuModalSheetHeader.Gone -> {
             Spacer(modifier = Modifier.height(dimensions().modalBottomSheetNoHeaderVerticalPadding))
         }
+
         is MenuModalSheetHeader.Visible -> {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(
-                    start = dimensions().modalBottomSheetHeaderHorizontalPadding,
-                    end = dimensions().modalBottomSheetHeaderHorizontalPadding,
-                    top = dimensions().modalBottomSheetHeaderVerticalPadding,
-                    bottom = header.customBottomPadding ?: dimensions().modalBottomSheetHeaderVerticalPadding
-                )
-            ) {
-                header.leadingIcon()
-                Spacer(modifier = Modifier.width(dimensions().spacing8x))
-                Text(
-                    text = header.title,
-                    style = MaterialTheme.wireTypography.title02
-                )
+            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.secondary) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(
+                        start = dimensions().modalBottomSheetHeaderHorizontalPadding,
+                        end = dimensions().modalBottomSheetHeaderHorizontalPadding,
+                        top = dimensions().modalBottomSheetHeaderVerticalPadding,
+                        bottom = header.customBottomPadding ?: dimensions().modalBottomSheetHeaderVerticalPadding
+                    )
+                ) {
+                    header.leadingIcon()
+                    Spacer(modifier = Modifier.width(dimensions().spacing8x))
+                    Text(
+                        text = header.title,
+                        style = MaterialTheme.wireTypography.title02
+                    )
+                }
             }
         }
     }
@@ -63,7 +68,7 @@ fun ModalSheetHeaderItem(header: MenuModalSheetHeader = MenuModalSheetHeader.Gon
 
 sealed class MenuModalSheetHeader {
 
-    data class Visible (
+    data class Visible(
         val title: String,
         val leadingIcon: @Composable () -> Unit = {},
         val customBottomPadding: Dp? = null

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -95,30 +95,30 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
                     mediaGalleryScreenState.showContextualMenu(false)
                     mediaGalleryViewModel.onMessageDetailsClicked()
                 }
-            ),
-            content = {
-                Scaffold(
-                    topBar = {
-                        MediaGalleryScreenTopAppBar(
-                            title = screenTitle ?: stringResource(R.string.media_gallery_default_title_name),
-                            onCloseClick = mediaGalleryViewModel::navigateBack,
-                            onOptionsClick = { mediaGalleryScreenState.showContextualMenu(true) }
-                        )
-                    },
-                    content = { internalPadding ->
-                        Box(modifier = Modifier.padding(internalPadding)) {
-                            MediaGalleryContent(mediaGalleryViewModel, mediaGalleryScreenState)
-                        }
-                    },
-                    snackbarHost = {
-                        SwipeDismissSnackbarHost(
-                            hostState = mediaGalleryScreenState.snackbarHostState,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    },
-                )
-            }
-        )
+            )
+        ) {
+            Scaffold(
+                topBar = {
+                    MediaGalleryScreenTopAppBar(
+                        title = screenTitle
+                            ?: stringResource(R.string.media_gallery_default_title_name),
+                        onCloseClick = mediaGalleryViewModel::navigateBack,
+                        onOptionsClick = { mediaGalleryScreenState.showContextualMenu(true) }
+                    )
+                },
+                content = { internalPadding ->
+                    Box(modifier = Modifier.padding(internalPadding)) {
+                        MediaGalleryContent(mediaGalleryViewModel, mediaGalleryScreenState)
+                    }
+                },
+                snackbarHost = {
+                    SwipeDismissSnackbarHost(
+                        hostState = mediaGalleryScreenState.snackbarHostState,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                },
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -238,11 +238,11 @@ fun PreviewSelectParticipantsButtonsRowDisabledButton() {
 @Preview
 @Composable
 fun PreviewSendButtonsRowDisabledButton() {
-    SendContentButton(mainButtonText = "Send", count = 0) {}
+    SendContentButton(mainButtonText = "Send", count = 0, onMainButtonClick = {}) {}
 }
 
 @Preview
 @Composable
 fun PreviewSendButtonsRowEnabledButton() {
-    SendContentButton(mainButtonText = "Send", count = 1) {}
+    SendContentButton(mainButtonText = "Send", count = 1, onMainButtonClick = {}) {}
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -21,29 +21,35 @@
 package com.wire.android.ui.home.newconversation.common
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
-import com.wire.android.ui.common.button.IconAlignment
+import com.wire.android.ui.common.button.WireButtonColors
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.button.wirePrimaryButtonColors
+import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireColorScheme
@@ -75,100 +81,56 @@ fun SelectParticipantsButtonsAlwaysEnabled(
 }
 
 @Composable
-fun SelectParticipantsButtonsRow(
-    selectedParticipantsCount: Int = 0,
-    mainButtonText: String,
-    elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
-    modifier: Modifier = Modifier
-        .padding(horizontal = dimensions().spacing16x)
-        .height(dimensions().groupButtonHeight)
-        .fillMaxWidth(),
-    onMainButtonClick: () -> Unit,
-    onMoreButtonIcon: @Composable (() -> Unit)? = null,
-) {
-    SelectParticipantsButtonsRow(
-        selectedParticipantsCount = selectedParticipantsCount,
-        mainButtonText = mainButtonText,
-        shouldAllowNoSelectionContinue = false,
-        elevation = elevation,
-        modifier = modifier,
-        onMoreButtonIcon = onMoreButtonIcon,
-        onMainButtonClick = onMainButtonClick
-    )
-}
-
-@Composable
 fun SendContentButton(
     mainButtonText: String,
     count: Int,
-    selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled,
+    mainButtonColors: WireButtonColors = wirePrimaryButtonColors(),
     onMainButtonClick: () -> Unit,
+    selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled,
     onSelfDeletionTimerClicked: () -> Unit,
 ) {
     val isSelfDeletionEnabled = selfDeletionTimer !is SelfDeletionTimer.Disabled
-    Row(modifier = Modifier.fillMaxWidth()) {
-        SelectParticipantsButtonsRow(
-            showTotalSelectedItemsCount = false,
-            selectedParticipantsCount = count,
-            leadingIcon = {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_send),
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = dimensions().spacing12x),
-                    colorFilter = ColorFilter.tint(
-                        if (count > 0) colorsScheme().onPrimaryButtonEnabled else colorsScheme().onPrimaryButtonDisabled
-                    )
-                )
-            },
-            mainButtonText = mainButtonText,
-            shouldAllowNoSelectionContinue = false,
-            onMainButtonClick = onMainButtonClick,
-            onMoreButtonIcon = {
-                if (isSelfDeletionEnabled) {
-                    Spacer(modifier = Modifier.width(dimensions().spacing4x))
-                    SelfDeletionTimerButton(
-                        selfDeletionTimer = selfDeletionTimer,
-                        modifier = Modifier.size(dimensions().spacing16x).weight(1f),
-                        onSelfDeletionTimerClicked = onSelfDeletionTimerClicked
-                    )
-                }
-            }
-        )
-    }
-}
-
-@Composable
-fun SelfDeletionTimerButton(
-    selfDeletionTimer: SelfDeletionTimer,
-    modifier: Modifier = Modifier,
-    onSelfDeletionTimerClicked: () -> Unit) {
-    val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.userDuration != ZERO
-    WireSecondaryButton(
+    SelectParticipantsButtonsRow(
+        showTotalSelectedItemsCount = false,
+        selectedParticipantsCount = count,
         leadingIcon = {
             Image(
-                painter = painterResource(id = R.drawable.ic_timer),
+                painter = painterResource(id = R.drawable.ic_send),
                 contentDescription = null,
-                modifier = Modifier.size(dimensions().spacing16x),
+                modifier = Modifier.padding(end = dimensions().spacing12x),
                 colorFilter = ColorFilter.tint(
-                    if (isSelected) colorsScheme().onPrimaryButtonEnabled else colorsScheme().onPrimaryButtonDisabled
+                    when {
+                        selfDeletionTimer.toDuration() > ZERO -> colorsScheme().primaryButtonEnabled
+                        count > 0 -> colorsScheme().onPrimaryButtonEnabled
+                        else -> colorsScheme().onPrimaryButtonDisabled
+                    }
                 )
             )
         },
-        leadingIconAlignment = IconAlignment.Center,
-        onClick = onSelfDeletionTimerClicked,
-        modifier = modifier
-            .padding(horizontal = dimensions().spacing16x)
-            .fillMaxWidth()
+        mainButtonColors = mainButtonColors,
+        mainButtonText = mainButtonText,
+        shouldAllowNoSelectionContinue = false,
+        onMainButtonClick = onMainButtonClick,
+        onMoreButtonIcon = {
+            if (isSelfDeletionEnabled) {
+                SelfDeletionTimerButton(
+                    selfDeletionTimer = selfDeletionTimer,
+                    onSelfDeletionTimerClicked = onSelfDeletionTimerClicked,
+                    isDisabled = count == 0
+                )
+            }
+        }
     )
 }
 
 @Composable
-private fun SelectParticipantsButtonsRow(
+fun SelectParticipantsButtonsRow(
     showTotalSelectedItemsCount: Boolean = true,
     leadingIcon: @Composable (() -> Unit)? = null,
     selectedParticipantsCount: Int = 0,
     mainButtonText: String,
     shouldAllowNoSelectionContinue: Boolean = true,
+    mainButtonColors: WireButtonColors = wirePrimaryButtonColors(),
     elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
     modifier: Modifier = Modifier,
     onMainButtonClick: () -> Unit,
@@ -190,20 +152,57 @@ private fun SelectParticipantsButtonsRow(
                 text = buttonText,
                 leadingIcon = leadingIcon,
                 onClick = onMainButtonClick,
-                state = computeButtonState(selectedParticipantsCount, shouldAllowNoSelectionContinue),
+                colors = mainButtonColors,
+                state = computeMainButtonState(selectedParticipantsCount, shouldAllowNoSelectionContinue),
                 clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-                modifier = Modifier.weight(1f),
-                fillMaxWidth = onMoreButtonIcon == null
+                modifier = Modifier
+                    .weight(1f)
             )
             if (onMoreButtonIcon != null) {
-                Spacer(Modifier.width(dimensions().spacing8x))
                 onMoreButtonIcon()
             }
         }
     }
 }
 
-private fun computeButtonState(count: Int = 0, shouldAllowNoSelectionContinue: Boolean): WireButtonState {
+@Composable
+fun SelfDeletionTimerButton(
+    selfDeletionTimer: SelfDeletionTimer,
+    modifier: Modifier = Modifier,
+    isDisabled: Boolean,
+    onSelfDeletionTimerClicked: () -> Unit
+) {
+    val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.userDuration != ZERO
+    Box(
+        modifier = modifier
+            .padding(start = dimensions().spacing16x)
+            .size(dimensions().spacing48x)
+            .clip(RoundedCornerShape(size = dimensions().onMoreOptionsButtonCornerRadius))
+            .background(
+                color = if (isSelected) colorsScheme().onSecondaryButtonSelected else colorsScheme().secondaryButtonEnabled,
+            )
+    ) {
+        WireSecondaryButton(
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_timer),
+                    contentDescription = stringResource(id = R.string.content_description_self_deletion_selector_button),
+                    colorFilter = ColorFilter.tint(
+                        if (isSelected) colorsScheme().secondaryButtonSelected else colorsScheme().onSecondaryButtonEnabled
+                    ),
+                )
+            },
+            state = if (isDisabled) WireButtonState.Disabled else WireButtonState.Default,
+            colors = wireSecondaryButtonColors().copy(
+                enabled = Color.Transparent
+            ),
+            onClick = onSelfDeletionTimerClicked,
+            shape = RoundedCornerShape(size = dimensions().onMoreOptionsButtonCornerRadius),
+        )
+    }
+}
+
+private fun computeMainButtonState(count: Int = 0, shouldAllowNoSelectionContinue: Boolean): WireButtonState {
     return when {
         shouldAllowNoSelectionContinue -> WireButtonState.Default
         count > 0 -> WireButtonState.Default
@@ -227,15 +226,4 @@ fun PreviewSelectParticipantsButtonsRowWithoutMoreButton() {
 @Composable
 fun PreviewSelectParticipantsButtonsRowDisabledButton() {
     SelectParticipantsButtonsRow(selectedParticipantsCount = 0, mainButtonText = "Continue", onMainButtonClick = {})
-}
-
-@Preview
-@Composable
-fun PreviewSendContentButtons() {
-    SendContentButton(
-        mainButtonText = "Send",
-        count = 0,
-        selfDeletionTimer = SelfDeletionTimer.Enabled(ZERO),
-        onMainButtonClick = {},
-        onSelfDeletionTimerClicked = {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -89,7 +89,7 @@ fun SendContentButton(
     selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled,
     onSelfDeletionTimerClicked: () -> Unit,
 ) {
-    val isSelfDeletionEnabled = selfDeletionTimer !is SelfDeletionTimer.Disabled
+    val isSelfDeletionButtonVisible = selfDeletionTimer is SelfDeletionTimer.Enabled
     SelectParticipantsButtonsRow(
         showTotalSelectedItemsCount = false,
         selectedParticipantsCount = count,
@@ -112,7 +112,7 @@ fun SendContentButton(
         shouldAllowNoSelectionContinue = false,
         onMainButtonClick = onMainButtonClick,
         onMoreButtonIcon = {
-            if (isSelfDeletionEnabled) {
+            if (isSelfDeletionButtonVisible) {
                 SelfDeletionTimerButton(
                     selfDeletionTimer = selfDeletionTimer,
                     onSelfDeletionTimerClicked = onSelfDeletionTimerClicked,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -37,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
@@ -62,7 +60,7 @@ fun SelectParticipantsButtonsAlwaysEnabled(
         .padding(horizontal = dimensions().spacing16x)
         .height(dimensions().groupButtonHeight)
         .fillMaxWidth(),
-    onMoreButtonClick: (() -> Unit)? = null,
+    onMoreButtonIcon: @Composable (() -> Unit)? = null,
     onMainButtonClick: () -> Unit,
 ) {
     SelectParticipantsButtonsRow(
@@ -71,7 +69,7 @@ fun SelectParticipantsButtonsAlwaysEnabled(
         shouldAllowNoSelectionContinue = true,
         elevation = elevation,
         modifier = modifier,
-        onMoreButtonClick = onMoreButtonClick,
+        onMoreButtonIcon = onMoreButtonIcon,
         onMainButtonClick = onMainButtonClick
     )
 }
@@ -85,8 +83,8 @@ fun SelectParticipantsButtonsRow(
         .padding(horizontal = dimensions().spacing16x)
         .height(dimensions().groupButtonHeight)
         .fillMaxWidth(),
-    onMoreButtonClick: (() -> Unit)? = null,
     onMainButtonClick: () -> Unit,
+    onMoreButtonIcon: @Composable (() -> Unit)? = null,
 ) {
     SelectParticipantsButtonsRow(
         selectedParticipantsCount = selectedParticipantsCount,
@@ -94,7 +92,7 @@ fun SelectParticipantsButtonsRow(
         shouldAllowNoSelectionContinue = false,
         elevation = elevation,
         modifier = modifier,
-        onMoreButtonClick = onMoreButtonClick,
+        onMoreButtonIcon = onMoreButtonIcon,
         onMainButtonClick = onMainButtonClick
     )
 }
@@ -105,36 +103,45 @@ fun SendContentButton(
     count: Int,
     selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled,
     onMainButtonClick: () -> Unit,
-    onMoreButtonClick: () -> Unit,
+    onSelfDeletionTimerClicked: () -> Unit,
 ) {
     val isSelfDeletionEnabled = selfDeletionTimer !is SelfDeletionTimer.Disabled
-    SelectParticipantsButtonsRow(
-        showTotalSelectedItemsCount = false,
-        selectedParticipantsCount = count,
-        leadingIcon = {
-            Image(
-                painter = painterResource(id = R.drawable.ic_send),
-                contentDescription = null,
-                modifier = Modifier.padding(end = dimensions().spacing12x),
-                colorFilter = ColorFilter.tint(
-                    if (count > 0) colorsScheme().onPrimaryButtonEnabled else colorsScheme().onPrimaryButtonDisabled
+    Row(modifier = Modifier.fillMaxWidth()) {
+        SelectParticipantsButtonsRow(
+            showTotalSelectedItemsCount = false,
+            selectedParticipantsCount = count,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_send),
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = dimensions().spacing12x),
+                    colorFilter = ColorFilter.tint(
+                        if (count > 0) colorsScheme().onPrimaryButtonEnabled else colorsScheme().onPrimaryButtonDisabled
+                    )
                 )
-            )
-        },
-        mainButtonText = mainButtonText,
-        onMoreButtonLeadingIcon = {
-            if (isSelfDeletionEnabled) {
-                SelfDeletionTimerButton(selfDeletionTimer)
+            },
+            mainButtonText = mainButtonText,
+            shouldAllowNoSelectionContinue = false,
+            onMainButtonClick = onMainButtonClick,
+            onMoreButtonIcon = {
+                if (isSelfDeletionEnabled) {
+                    Spacer(modifier = Modifier.width(dimensions().spacing4x))
+                    SelfDeletionTimerButton(
+                        selfDeletionTimer = selfDeletionTimer,
+                        modifier = Modifier.size(dimensions().spacing16x).weight(1f),
+                        onSelfDeletionTimerClicked = onSelfDeletionTimerClicked
+                    )
+                }
             }
-        },
-        shouldAllowNoSelectionContinue = false,
-        onMainButtonClick = onMainButtonClick,
-        onMoreButtonClick = onMoreButtonClick,
-    )
+        )
+    }
 }
 
 @Composable
-fun SelfDeletionTimerButton(selfDeletionTimer: SelfDeletionTimer) {
+fun SelfDeletionTimerButton(
+    selfDeletionTimer: SelfDeletionTimer,
+    modifier: Modifier = Modifier,
+    onSelfDeletionTimerClicked: () -> Unit) {
     val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.userDuration != ZERO
     WireSecondaryButton(
         leadingIcon = {
@@ -148,10 +155,9 @@ fun SelfDeletionTimerButton(selfDeletionTimer: SelfDeletionTimer) {
             )
         },
         leadingIconAlignment = IconAlignment.Center,
-        onClick = {},
-        modifier = Modifier
+        onClick = onSelfDeletionTimerClicked,
+        modifier = modifier
             .padding(horizontal = dimensions().spacing16x)
-            .height(dimensions().groupButtonHeight)
             .fillMaxWidth()
     )
 }
@@ -164,12 +170,9 @@ private fun SelectParticipantsButtonsRow(
     mainButtonText: String,
     shouldAllowNoSelectionContinue: Boolean = true,
     elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
-    modifier: Modifier = Modifier
-        .padding(horizontal = dimensions().spacing16x)
-        .height(dimensions().groupButtonHeight),
-    onMoreButtonLeadingIcon: @Composable (() -> Unit)? = null,
-    onMoreButtonClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
     onMainButtonClick: () -> Unit,
+    onMoreButtonIcon: @Composable (() -> Unit)? = null,
 ) {
     Surface(
         color = MaterialTheme.wireColorScheme.background,
@@ -178,7 +181,9 @@ private fun SelectParticipantsButtonsRow(
         Row(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier,
+            modifier = modifier
+                .padding(horizontal = dimensions().spacing16x)
+                .height(dimensions().groupButtonHeight),
         ) {
             val buttonText = if (showTotalSelectedItemsCount) "$mainButtonText ($selectedParticipantsCount)" else mainButtonText
             WirePrimaryButton(
@@ -187,23 +192,12 @@ private fun SelectParticipantsButtonsRow(
                 onClick = onMainButtonClick,
                 state = computeButtonState(selectedParticipantsCount, shouldAllowNoSelectionContinue),
                 clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                fillMaxWidth = onMoreButtonIcon == null
             )
-            if (onMoreButtonClick != null) {
+            if (onMoreButtonIcon != null) {
                 Spacer(Modifier.width(dimensions().spacing8x))
-                WireSecondaryButton(
-                    onClick = onMoreButtonClick,
-                    leadingIcon = onMoreButtonLeadingIcon ?: {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_more),
-                            contentDescription = stringResource(R.string.content_description_right_arrow),
-                            modifier = Modifier
-                                .size(dimensions().wireIconButtonSize)
-                        )
-                    },
-                    leadingIconAlignment = IconAlignment.Center,
-                    fillMaxWidth = false
-                )
+                onMoreButtonIcon()
             }
         }
     }
@@ -220,7 +214,7 @@ private fun computeButtonState(count: Int = 0, shouldAllowNoSelectionContinue: B
 @Preview
 @Composable
 fun PreviewSelectParticipantsButtonsRow() {
-    SelectParticipantsButtonsRow(selectedParticipantsCount = 3, mainButtonText = "Continue", onMainButtonClick = {}, onMoreButtonClick = {})
+    SelectParticipantsButtonsRow(selectedParticipantsCount = 3, mainButtonText = "Continue", onMainButtonClick = {}, onMoreButtonIcon = {})
 }
 
 @Preview
@@ -237,12 +231,11 @@ fun PreviewSelectParticipantsButtonsRowDisabledButton() {
 
 @Preview
 @Composable
-fun PreviewSendButtonsRowDisabledButton() {
-    SendContentButton(mainButtonText = "Send", count = 0, onMainButtonClick = {}) {}
-}
-
-@Preview
-@Composable
-fun PreviewSendButtonsRowEnabledButton() {
-    SendContentButton(mainButtonText = "Send", count = 1, onMainButtonClick = {}) {}
+fun PreviewSendContentButtons() {
+    SendContentButton(
+        mainButtonText = "Send",
+        count = 0,
+        selfDeletionTimer = SelfDeletionTimer.Enabled(ZERO),
+        onMainButtonClick = {},
+        onSelfDeletionTimerClicked = {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -116,7 +116,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
         }
     }
 
-    private suspend fun observeTeamSettingsSelfDeletionStatus(userId: UserId) {
+    private fun observeTeamSettingsSelfDeletionStatus(userId: UserId) {
         viewModelScope.launch {
             coreLogic.getSessionScope(userId).observeTeamSettingsSelfDeletionStatus().collect { teamSettingsSelfDeletingStatus ->
                 featureFlagState = featureFlagState.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -160,7 +160,8 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
 
     fun addConversationItemToGroupSelection(conversation: ConversationItem) =
         viewModelScope.launch {
-            // TODO: change this conversation item to a list of conversation items in case we want to support sharing to multiple conversations
+            // TODO: change this conversation item to a list of conversation items in case we want to support
+            // sharing to multiple conversations
             importMediaState =
                 importMediaState.copy(selectedConversationItem = listOf(conversation))
         }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.parseConversationEventType
 import com.wire.android.ui.home.conversationslist.parsePrivateConversationEventType
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
+import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -46,8 +47,12 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
+import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,6 +60,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.joinAll
@@ -64,6 +70,7 @@ import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
+@OptIn(FlowPreview::class)
 @Suppress("LongParameterList", "TooManyFunctions")
 class ImportMediaAuthenticatedViewModel @Inject constructor(
     private val getSelf: GetSelfUserUseCase,
@@ -74,6 +81,8 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val kaliumFileSystem: KaliumFileSystem,
     private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+    private val observeTeamSettingsSelfDeletingStatusUseCase: ObserveTeamSettingsSelfDeletingStatusUseCase,
+    private val observeSelfDeletionSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     val wireSessionImageLoader: WireSessionImageLoader,
     val dispatchers: DispatcherProvider,
 ) : ViewModel() {
@@ -93,15 +102,17 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         viewModelScope.launch {
             loadUserAvatar()
             observeConversationWithSearch()
+            observeTeamSettingsSelfDeletingStatus()
         }
     }
 
     private fun loadUserAvatar() = viewModelScope.launch(dispatchers.io()) {
         getSelf().collect { selfUser ->
             withContext(dispatchers.main()) {
-                importMediaState = importMediaState.copy(avatarAsset = selfUser.previewPicture?.let {
-                    ImageAsset.UserAvatarAsset(wireSessionImageLoader, it)
-                })
+                importMediaState =
+                    importMediaState.copy(avatarAsset = selfUser.previewPicture?.let {
+                        ImageAsset.UserAvatarAsset(wireSessionImageLoader, it)
+                    })
             }
         }
     }
@@ -118,10 +129,11 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                     }
                 }, searchQueryFlow
         ) { conversations, searchQuery ->
-            val searchResult = if (searchQuery.isEmpty()) conversations else searchShareableConversation(
-                conversations,
-                searchQuery
-            )
+            val searchResult =
+                if (searchQuery.isEmpty()) conversations else searchShareableConversation(
+                    conversations,
+                    searchQuery
+                )
             ShareableConversationListState(
                 initialConversations = conversations,
                 searchQuery = searchQuery,
@@ -131,8 +143,17 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         }
             .flowOn(dispatchers.io())
             .collect { updatedState ->
-                importMediaState = importMediaState.copy(shareableConversationListState = updatedState)
+                importMediaState =
+                    importMediaState.copy(shareableConversationListState = updatedState)
             }
+    }
+
+    private suspend fun observeTeamSettingsSelfDeletingStatus() = viewModelScope.launch {
+        observeTeamSettingsSelfDeletingStatusUseCase().collect { teamSettings ->
+            importMediaState = importMediaState.copy(
+                selfDeletingTimer = teamSettings.enforcedSelfDeletionTimer
+            )
+        }
     }
 
     fun onSearchQueryChanged(searchQuery: TextFieldValue) {
@@ -145,15 +166,18 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         }
     }
 
-    fun addConversationItemToGroupSelection(conversation: ConversationItem) = viewModelScope.launch {
-        // TODO: change this conversation item to a list of conversation items in case we want to support sharing to multiple conversations
-        importMediaState = importMediaState.copy(selectedConversationItem = listOf(conversation))
-    }
+    fun addConversationItemToGroupSelection(conversation: ConversationItem) =
+        viewModelScope.launch {
+            // TODO: change this conversation item to a list of conversation items in case we want to support sharing to multiple conversations
+            importMediaState =
+                importMediaState.copy(selectedConversationItem = listOf(conversation))
+        }
 
     fun onConversationClicked(conversationId: ConversationId) {
-        importMediaState.shareableConversationListState.initialConversations.find { it.conversationId == conversationId }?.let {
-            addConversationItemToGroupSelection(it)
-        }
+        importMediaState.shareableConversationListState.initialConversations.find { it.conversationId == conversationId }
+            ?.let {
+                addConversationItemToGroupSelection(it)
+            }
     }
 
     @Suppress("LongMethod")
@@ -183,7 +207,12 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         is ConversationDetails.OneOne -> {
             ConversationItem.PrivateConversation(
                 userAvatarData = UserAvatarData(
-                    otherUser.previewPicture?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) },
+                    otherUser.previewPicture?.let {
+                        ImageAsset.UserAvatarAsset(
+                            wireSessionImageLoader,
+                            it
+                        )
+                    },
                     otherUser.availabilityStatus,
                     otherUser.connectionStatus
                 ),
@@ -213,12 +242,23 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         else -> null // We don't care about connection requests
     }
 
-    private fun searchShareableConversation(conversationDetails: List<ConversationItem>, searchQuery: String): List<ConversationItem> {
+    private fun searchShareableConversation(
+        conversationDetails: List<ConversationItem>,
+        searchQuery: String
+    ): List<ConversationItem> {
         val matchingConversations =
             conversationDetails.filter { details ->
                 when (details) {
-                    is ConversationItem.GroupConversation -> details.groupName.contains(searchQuery, true)
-                    is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(searchQuery, true)
+                    is ConversationItem.GroupConversation -> details.groupName.contains(
+                        searchQuery,
+                        true
+                    )
+
+                    is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(
+                        searchQuery,
+                        true
+                    )
+
                     is ConversationItem.ConnectionConversation -> false
                 }
             }
@@ -226,7 +266,12 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
     }
 
     fun navigateBack() = viewModelScope.launch(dispatchers.main()) {
-        navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.REMOVE_CURRENT))
+        navigationManager.navigate(
+            NavigationCommand(
+                NavigationItem.Home.getRouteWithArgs(),
+                BackStackMode.REMOVE_CURRENT
+            )
+        )
     }
 
     suspend fun handleReceivedDataFromSharingIntent(activity: AppCompatActivity) {
@@ -248,11 +293,15 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         importMediaState = importMediaState.copy(isImporting = false)
     }
 
-    private suspend fun handleSingleIntent(incomingIntent: ShareCompat.IntentReader, activity: AppCompatActivity) {
+    private suspend fun handleSingleIntent(
+        incomingIntent: ShareCompat.IntentReader,
+        activity: AppCompatActivity
+    ) {
         incomingIntent.stream?.let { uri ->
             uri.getMimeType(activity)?.let { mimeType ->
                 handleImportedAsset(activity, mimeType, uri)?.let { importedAsset ->
-                    importMediaState = importMediaState.copy(importedAssets = mutableListOf(importedAsset))
+                    importMediaState =
+                        importMediaState.copy(importedAssets = mutableListOf(importedAsset))
                 }
             }
         }
@@ -262,7 +311,11 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         val importedMediaAssets = mutableListOf<ImportedMediaAsset>()
         activity.intent.parcelableArrayList<Parcelable>(Intent.EXTRA_STREAM)?.forEach {
             val fileUri = it.toString().toUri()
-            handleImportedAsset(activity, fileUri.getMimeType(activity).toString(), fileUri)?.let { importedAsset ->
+            handleImportedAsset(
+                activity,
+                fileUri.getMimeType(activity).toString(),
+                fileUri
+            )?.let { importedAsset ->
                 importedMediaAssets.add(importedAsset)
             }
         }
@@ -299,6 +352,22 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         }
     }
 
+    fun onNewConversationPicked(conversationId: ConversationId) = viewModelScope.launch {
+        importMediaState = importMediaState.copy(
+            selfDeletingTimer = observeSelfDeletionSettingsForConversation(
+                conversationId = conversationId,
+                considerSelfUserSettings = true
+            ).first()
+        )
+    }
+
+    fun onNewSelfDeletionTimerPicked(selfDeletionDuration: SelfDeletionDuration) =
+        viewModelScope.launch {
+            importMediaState = importMediaState.copy(
+                selfDeletingTimer = SelfDeletionTimer.Enabled(selfDeletionDuration.value)
+            )
+        }
+
     private suspend fun navigateToConversation(conversationId: ConversationId) {
         navigationManager.navigate(
             NavigationCommand(
@@ -309,7 +378,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
     }
 
     fun currentSelectedConversationsCount() = if (importMediaState.importedAssets.isNotEmpty()) {
-        importMediaState.selectedConversationItem.size ?: 0
+        importMediaState.selectedConversationItem.size
     } else {
         0
     }
@@ -327,10 +396,17 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
             isAboveLimit(isImageFile(mimeType), fileMetadata.size) -> null
             isImageFile(mimeType) -> {
                 // Only resample the image if it is too large
-                val resampleSize = uri.resampleImageAndCopyToTempPath(context, tempAssetPath, ImageUtil.ImageSizeClass.Medium)
+                val resampleSize = uri.resampleImageAndCopyToTempPath(
+                    context,
+                    tempAssetPath,
+                    ImageUtil.ImageSizeClass.Medium
+                )
                 if (resampleSize <= 0) return@withContext null
 
-                val (imgWidth, imgHeight) = ImageUtil.extractImageWidthAndHeight(kaliumFileSystem, tempAssetPath)
+                val (imgWidth, imgHeight) = ImageUtil.extractImageWidthAndHeight(
+                    kaliumFileSystem,
+                    tempAssetPath
+                )
 
                 return@withContext ImportedMediaAsset.Image(
                     name = fileMetadata.name,
@@ -363,7 +439,11 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         val sizeOf1MB = SIZE_OF_1_MB * SIZE_OF_1_MB
         val isAboveLimit = size > assetLimitForCurrentUser
         if (isAboveLimit) {
-            onSnackbarMessage(ImportMediaSnackbarMessages.MaxAssetSizeExceeded(assetLimitForCurrentUser.div(sizeOf1MB)))
+            onSnackbarMessage(
+                ImportMediaSnackbarMessages.MaxAssetSizeExceeded(
+                    assetLimitForCurrentUser.div(sizeOf1MB)
+                )
+            )
         }
         return isAboveLimit
     }
@@ -384,5 +464,6 @@ data class ImportMediaState(
     val importedAssets: List<ImportedMediaAsset> = emptyList(),
     val isImporting: Boolean = false,
     val shareableConversationListState: ShareableConversationListState = ShareableConversationListState(),
-    val selectedConversationItem: List<ConversationItem> = emptyList()
+    val selectedConversationItem: List<ConversationItem> = emptyList(),
+    val selfDeletingTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled
 )

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -334,7 +334,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                         assetMimeType = importedAsset.mimeType,
                         assetWidth = if (isImage) (importedAsset as ImportedMediaAsset.Image).width else 0,
                         assetHeight = if (isImage) (importedAsset as ImportedMediaAsset.Image).height else 0,
-                        expireAfter = null
+                        expireAfter = importMediaState.selfDeletingTimer.toDuration().let { if (it == ZERO) null else it }
                     )
                 }
                 jobs = jobs.plus(job)

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -359,7 +359,10 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
             importMediaState = importMediaState.copy(
                 selfDeletingTimer = SelfDeletionTimer.Enabled(selfDeletionDuration.value)
             )
-
+            persistNewSelfDeletionTimerUseCase(
+                conversationId = importMediaState.selectedConversationItem.first().conversationId,
+                newSelfDeletionTimer = importMediaState.selfDeletingTimer
+            )
         }
 
     private suspend fun navigateToConversation(conversationId: ConversationId) {

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -16,9 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -29,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -57,7 +53,6 @@ import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
-import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
 import com.wire.android.ui.home.FeatureFlagState
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMenuItems
@@ -71,9 +66,7 @@ import com.wire.android.util.extension.getActivity
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 
 @Composable
 fun ImportMediaScreen(
@@ -273,15 +266,13 @@ private fun ImportMediaBottomBar(
     importMediaViewModel: ImportMediaAuthenticatedViewModel,
     importMediaScreenState: ImportMediaScreenState
 ) {
-    Row {
-        SendContentButton(
-            mainButtonText = stringResource(R.string.import_media_send_button_title),
-            count = importMediaViewModel.currentSelectedConversationsCount(),
-            selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer,
-            onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia,
-            onMoreButtonClick = importMediaScreenState::showBottomSheetMenu,
-        )
-    }
+    SendContentButton(
+        mainButtonText = stringResource(R.string.import_media_send_button_title),
+        count = importMediaViewModel.currentSelectedConversationsCount(),
+        selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer,
+        onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia,
+        onSelfDeletionTimerClicked = importMediaScreenState::toggleBottomSheetMenuVisibility,
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -46,6 +45,7 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.button.WirePrimaryButton
+import com.wire.android.ui.common.button.wirePrimaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
@@ -67,6 +67,7 @@ import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.SharedFlow
+import kotlin.time.Duration
 
 @Composable
 fun ImportMediaScreen(
@@ -266,12 +267,23 @@ private fun ImportMediaBottomBar(
     importMediaViewModel: ImportMediaAuthenticatedViewModel,
     importMediaScreenState: ImportMediaScreenState
 ) {
+    val selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer
+    val shortDurationLabel = selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel
+    val (mainButtonText, mainButtonColors) = if (selfDeletionTimer.toDuration() > Duration.ZERO) {
+        "${stringResource(id = R.string.self_deleting_message_label)} (${shortDurationLabel.asString()})" to wirePrimaryButtonColors().copy(
+            enabled = colorsScheme().onPrimaryButtonEnabled,
+            onEnabled = colorsScheme().primaryButtonEnabled
+        )
+    } else {
+        stringResource(id = R.string.import_media_send_button_title) to wirePrimaryButtonColors()
+    }
     SendContentButton(
-        mainButtonText = stringResource(R.string.import_media_send_button_title),
+        mainButtonText = mainButtonText,
         count = importMediaViewModel.currentSelectedConversationsCount(),
-        selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer,
         onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia,
-        onSelfDeletionTimerClicked = importMediaScreenState::toggleBottomSheetMenuVisibility,
+        selfDeletionTimer = selfDeletionTimer,
+        mainButtonColors = mainButtonColors,
+        onSelfDeletionTimerClicked = importMediaScreenState::showBottomSheetMenu,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -24,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -42,6 +48,7 @@ import com.wire.android.model.Clickable
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserProfileAvatar
+import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -52,6 +59,8 @@ import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
 import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
 import com.wire.android.ui.home.FeatureFlagState
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMenuItems
 import com.wire.android.ui.home.conversationslist.common.ConversationList
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.newconversation.common.SendContentButton
@@ -62,7 +71,9 @@ import com.wire.android.util.extension.getActivity
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 
 @Composable
 fun ImportMediaScreen(
@@ -85,6 +96,7 @@ fun ImportMediaContent(
             fileSharingRestrictedState = state,
             viewModel = unauthorizedViewModel
         )
+
         FeatureFlagState.SharingRestrictedState.RESTRICTED_IN_TEAM -> ImportMediaRestrictedContent(state)
         FeatureFlagState.SharingRestrictedState.NONE -> ImportMediaRegularContent()
         null -> {
@@ -128,7 +140,7 @@ fun ImportMediaRestrictedContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun ImportMediaRegularContent(authorizedViewModel: ImportMediaAuthenticatedViewModel = hiltViewModel()) {
     val context = LocalContext.current
@@ -137,38 +149,47 @@ fun ImportMediaRegularContent(authorizedViewModel: ImportMediaAuthenticatedViewM
             context.getActivity()?.let { authorizedViewModel.handleReceivedDataFromSharingIntent(it) }
         }
     }
+    val importMediaScreenState = rememberImportMediaScreenState()
 
-    val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
-    val searchBarState = rememberSearchbarState()
     with(authorizedViewModel.importMediaState) {
-        Scaffold(
-            topBar = {
-                WireCenterAlignedTopAppBar(
-                    elevation = 0.dp,
-                    onNavigationPressed = authorizedViewModel::navigateBack,
-                    title = stringResource(id = R.string.import_media_content_title),
-                    actions = {
-                        UserProfileAvatar(
-                            avatarData = UserAvatarData(avatarAsset),
-                            clickable = remember { Clickable(enabled = false) { } }
-                        )
-                    }
-                )
-            },
-            snackbarHost = {
-                SwipeDismissSnackbarHost(
-                    hostState = snackbarHostState,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            modifier = Modifier.background(colorsScheme().background),
-            content = { internalPadding ->
-                ImportMediaContent(this, internalPadding, authorizedViewModel, searchBarState)
-            },
-            bottomBar = { ImportMediaBottomBar(authorizedViewModel) }
-        )
+        MenuModalSheetLayout(
+            menuItems = SelfDeletionMenuItems(
+                currentlySelected = authorizedViewModel.importMediaState.selfDeletingTimer.toDuration().toSelfDeletionDuration(),
+                hideEditMessageMenu = importMediaScreenState::hideBottomSheetMenu,
+                onSelfDeletionDurationChanged = authorizedViewModel::onNewSelfDeletionTimerPicked,
+            ),
+            sheetState = importMediaScreenState.bottomSheetState,
+            coroutineScope = importMediaScreenState.coroutineScope
+        ) {
+            Scaffold(
+                topBar = {
+                    WireCenterAlignedTopAppBar(
+                        elevation = 0.dp,
+                        onNavigationPressed = authorizedViewModel::navigateBack,
+                        title = stringResource(id = R.string.import_media_content_title),
+                        actions = {
+                            UserProfileAvatar(
+                                avatarData = UserAvatarData(avatarAsset),
+                                clickable = remember { Clickable(enabled = false) { } }
+                            )
+                        }
+                    )
+                },
+                snackbarHost = {
+                    SwipeDismissSnackbarHost(
+                        hostState = importMediaScreenState.snackbarHostState,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                },
+                modifier = Modifier.background(colorsScheme().background),
+                content = { internalPadding ->
+                    ImportMediaContent(this, internalPadding, authorizedViewModel, importMediaScreenState.searchBarState)
+                },
+                bottomBar = { ImportMediaBottomBar(authorizedViewModel, importMediaScreenState) }
+            )
+        }
     }
-    SnackBarMessage(authorizedViewModel.infoMessage, snackbarHostState)
+    SnackBarMessage(authorizedViewModel.infoMessage, importMediaScreenState.snackbarHostState)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -248,12 +269,19 @@ fun FileSharingRestrictedContent(
 }
 
 @Composable
-private fun ImportMediaBottomBar(importMediaViewModel: ImportMediaAuthenticatedViewModel) {
-    SendContentButton(
-        mainButtonText = stringResource(R.string.import_media_send_button_title),
-        count = importMediaViewModel.currentSelectedConversationsCount(),
-        onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia
-    )
+private fun ImportMediaBottomBar(
+    importMediaViewModel: ImportMediaAuthenticatedViewModel,
+    importMediaScreenState: ImportMediaScreenState
+) {
+    Row {
+        SendContentButton(
+            mainButtonText = stringResource(R.string.import_media_send_button_title),
+            count = importMediaViewModel.currentSelectedConversationsCount(),
+            selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer,
+            onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia,
+            onMoreButtonClick = importMediaScreenState::showBottomSheetMenu,
+        )
+    }
 }
 
 @Composable
@@ -362,4 +390,11 @@ private fun SnackBarMessage(infoMessages: SharedFlow<SnackBarMessage>, snackbarH
 @Composable
 fun PreviewImportMediaScreen() {
     ImportMediaScreen(hiltViewModel())
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Preview(showBackground = true)
+@Composable
+fun PreviewImportMediaBottomBar() {
+    ImportMediaBottomBar(hiltViewModel(), rememberImportMediaScreenState())
 }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
@@ -45,17 +45,18 @@ fun rememberImportMediaScreenState(
         bottomSheetState = bottomSheetState
     )
 }
+
 @OptIn(ExperimentalMaterialApi::class)
-class ImportMediaScreenState (
+class ImportMediaScreenState(
     val snackbarHostState: SnackbarHostState,
     val searchBarState: SearchBarState,
     val coroutineScope: CoroutineScope,
     val bottomSheetState: ModalBottomSheetState
 ) {
 
-    fun showBottomSheetMenu(){
+    fun toggleBottomSheetMenuVisibility() {
         coroutineScope.launch {
-            bottomSheetState.animateTo(ModalBottomSheetValue.Expanded)
+            bottomSheetState.animateTo(if (bottomSheetState.isVisible) ModalBottomSheetValue.Hidden else ModalBottomSheetValue.Expanded)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
@@ -54,9 +54,9 @@ class ImportMediaScreenState(
     val bottomSheetState: ModalBottomSheetState
 ) {
 
-    fun toggleBottomSheetMenuVisibility() {
+    fun showBottomSheetMenu() {
         coroutineScope.launch {
-            bottomSheetState.animateTo(if (bottomSheetState.isVisible) ModalBottomSheetValue.Hidden else ModalBottomSheetValue.Expanded)
+            bottomSheetState.animateTo(ModalBottomSheetValue.Expanded)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.sharing
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.wire.android.ui.common.topappbar.search.SearchBarState
+import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun rememberImportMediaScreenState(
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    searchBarState: SearchBarState = rememberSearchbarState(),
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    bottomSheetState: ModalBottomSheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+): ImportMediaScreenState {
+    return ImportMediaScreenState(
+        snackbarHostState = snackbarHostState,
+        searchBarState = searchBarState,
+        coroutineScope = coroutineScope,
+        bottomSheetState = bottomSheetState
+    )
+}
+@OptIn(ExperimentalMaterialApi::class)
+class ImportMediaScreenState (
+    val snackbarHostState: SnackbarHostState,
+    val searchBarState: SearchBarState,
+    val coroutineScope: CoroutineScope,
+    val bottomSheetState: ModalBottomSheetState
+) {
+
+    fun showBottomSheetMenu(){
+        coroutineScope.launch {
+            bottomSheetState.animateTo(ModalBottomSheetValue.Expanded)
+        }
+    }
+
+    fun hideBottomSheetMenu(onComplete: () -> Unit = {}) {
+        coroutineScope.launch {
+            bottomSheetState.animateTo(ModalBottomSheetValue.Hidden)
+            onComplete()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -95,6 +95,7 @@ data class WireDimensions(
     val buttonCornerSize: Dp,
     val buttonSmallCornerSize: Dp,
     val badgeSmallMinSize: DpSize,
+    val onMoreOptionsButtonCornerRadius: Dp,
     // Dialog
     val dialogButtonsSpacing: Dp,
     val dialogTextsSpacing: Dp,
@@ -240,6 +241,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     buttonVerticalContentPadding = 8.dp,
     buttonCornerSize = 12.dp,
     buttonSmallCornerSize = 12.dp,
+    onMoreOptionsButtonCornerRadius = 16.dp,
     badgeSmallMinSize = DpSize(32.dp, 24.dp),
     dialogButtonsSpacing = 8.dp,
     dialogTextsSpacing = 16.dp,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="content_description_calling_call_unmuted">Call Unmuted</string>
     <string name="content_description_calling_call_paused_camera">Paused Camera</string>
     <string name="content_description_more_emojis">More emojis</string>
+    <string name="content_description_self_deletion_selector_button">Toggle self deletion mode, button</string>
     <!-- Non translatable strings-->
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>
     <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/en-us/articles/6655706999581-What-s-new-on-Android-</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3294" title="AR-3294" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-3294</a>  Send self deleting message (asset) from outside the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we have no way to import media assets that respect the current self deletion team and conversation settings status. Therefore, I added this mechanism to display the current self deletion settings for conversations that have enforced timers or allow the user to change and persist it for conversations where these settings still not exist.


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Just import assets to Wire.

### Attachments

https://github.com/wireapp/wire-android-reloaded/assets/2468164/86a1b149-da38-4116-a5ce-12993965788d

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
