### PR TITLE
fix: display CBR indicator for only oneOnOne calls (AR-1369)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -218,7 +218,7 @@ class SharedCallingViewModel @Inject constructor(
             callState = callState.copy(
                 callStatus = call.status,
                 callerName = call.callerName,
-                isCbrEnabled = call.isCbrEnabled
+                isCbrEnabled = call.isCbrEnabled && call.conversationType.equals(ConversationType.OneOnOne)
             )
         }
     }
@@ -229,7 +229,7 @@ class SharedCallingViewModel @Inject constructor(
                 callState = callState.copy(
                     isMuted = call.isMuted,
                     callStatus = it.status,
-                    isCbrEnabled = it.isCbrEnabled,
+                    isCbrEnabled = it.isCbrEnabled && call.conversationType.equals(ConversationType.OneOnOne),
                     callerName = it.callerName,
                     participants = it.participants.map { participant -> uiCallParticipantMapper.toUICallParticipant(participant) }
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1369" title="AR-1369" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1369</a>  Indicate if call is encoded with constant bitrate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CBR indicator is being dispalyed for group calls

### Solutions

Display it only for 1:1 calls


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
