### PR TITLE
fix: wait for graph subscription when handling intents 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationGraph.kt
@@ -31,8 +31,7 @@ import com.google.accompanist.navigation.animation.composable
 fun NavigationGraph(
     navController: NavHostController,
     startDestination: String,
-    appInitialArgs: List<Any> = emptyList(),
-    onComplete: () -> Unit
+    appInitialArgs: List<Any> = emptyList()
 ) {
     AnimatedNavHost(navController, startDestination) {
         NavigationItem.values().onEach { item ->
@@ -44,6 +43,5 @@ fun NavigationGraph(
                 exitTransition = { item.animationConfig.exitTransition }
             )
         }
-        onComplete()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onSubscription
 import javax.inject.Inject
 
 @OptIn(
@@ -161,23 +162,25 @@ class WireActivity : AppCompatActivity() {
         val scope = rememberCoroutineScope()
         NavigationGraph(
             navController = navController,
-            startDestination = startDestination,
-            onComplete = onComplete
+            startDestination = startDestination
         )
         // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
         // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
-        setUpNavigation(navController, scope)
+        setUpNavigation(navController, onComplete, scope)
     }
 
     @Composable
     private fun setUpNavigation(
         navController: NavHostController,
+        onComplete: () -> Unit,
         scope: CoroutineScope
     ) {
         val currentKeyboardController by rememberUpdatedState(LocalSoftwareKeyboardController.current)
         val currentNavController by rememberUpdatedState(navController)
         LaunchedEffect(scope) {
-            navigationManager.navigateState.onEach { command ->
+            navigationManager.navigateState
+                .onSubscription { onComplete() }
+                .onEach { command ->
                 if (command == null) return@onEach
                 currentKeyboardController?.hide()
                 currentNavController.navigateToItem(command)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -69,6 +69,7 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -221,6 +222,7 @@ class WireActivityViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            delay(SHORT_DELAY) // to make sure that the app is fully initialized before handling the deepLink
             val result = intent?.data?.let { deepLinkProcessor(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> openSsoLogin(result)
@@ -464,6 +466,10 @@ class WireActivityViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    companion object {
+        private val SHORT_DELAY = 100L
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -222,7 +222,7 @@ class WireActivityViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            delay(SHORT_DELAY) // to make sure that the app is fully initialized before handling the deepLink
+            delay(SHORT_DELAY) // to make sure that the app is fully initialized before handling the import intent
             val result = intent?.data?.let { deepLinkProcessor(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> openSsoLogin(result)
@@ -469,7 +469,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     companion object {
-        private val SHORT_DELAY = 100L
+        private const val SHORT_DELAY = 100L
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -69,7 +69,6 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -222,7 +221,6 @@ class WireActivityViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            delay(SHORT_DELAY) // to make sure that the app is fully initialized before handling the import intent
             val result = intent?.data?.let { deepLinkProcessor(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> openSsoLogin(result)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -465,10 +465,6 @@ class WireActivityViewModel @Inject constructor(
             }
         }
     }
-
-    companion object {
-        private const val SHORT_DELAY = 100L
-    }
 }
 
 sealed class CurrentSessionErrorState {

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -70,8 +70,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
@@ -105,7 +103,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is present, then navigation to Login with SSOLogin params is called`() = runTest {
+    fun `given Intent with SSOLogin, when currentSession is present, then navigation to Login with SSOLogin params is called`() {
         val result = DeepLinkResult.SSOLogin.Success("cookie", "config")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -113,7 +111,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         coVerify(exactly = 1) {
             arrangement.navigationManager.navigate(
@@ -124,15 +121,13 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() =
-        runTest {
+    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() {
             val (arrangement, viewModel) = Arrangement()
                 .withSomeCurrentSession()
                 .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
                 .arrange()
 
             viewModel.handleDeepLink(mockedIntent())
-            advanceUntilIdle()
 
             coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
             assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
@@ -140,15 +135,13 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() =
-        runTest {
+    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() {
             val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
@@ -171,7 +164,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is present, then startNavigation is Home and navigate to SSOLogin`() = runTest {
+    fun `given Intent with SSOLogin, when currentSession is present, then startNavigation is Home and navigate to SSOLogin`() {
         val ssoLogin = DeepLinkResult.SSOLogin.Success("cookie", "serverConfig")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -179,7 +172,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -193,7 +185,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is absent, then startNavigation is Welcome and navigate to SSOLogin`() = runTest {
+    fun `given Intent with SSOLogin, when currentSession is absent, then startNavigation is Welcome and navigate to SSOLogin`() {
         val ssoLogin = DeepLinkResult.SSOLogin.Success("cookie", "serverConfig")
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
@@ -201,7 +193,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -215,14 +206,13 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with MigrationLogin, when currentSession is present, then startNavigation is Home and navigate to Login`() = runTest {
+    fun `given Intent with MigrationLogin, when currentSession is present, then startNavigation is Home and navigate to Login`() {
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
             .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -236,15 +226,13 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() =
-        runTest {
+    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() {
             val (arrangement, viewModel) = Arrangement()
                 .withNoCurrentSession()
                 .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
                 .arrange()
 
             viewModel.handleDeepLink(mockedIntent())
-            advanceUntilIdle()
 
             assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
             coVerify(exactly = 1) {
@@ -258,8 +246,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() =
-        runTest {
+    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() {
             val conversationsId = ConversationId("val", "dom")
             val (arrangement, viewModel) = Arrangement()
                 .withSomeCurrentSession()
@@ -267,7 +254,6 @@ class WireActivityViewModelTest {
                 .arrange()
 
             viewModel.handleDeepLink(mockedIntent())
-            advanceUntilIdle()
 
             assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
             coVerify(exactly = 1) {
@@ -296,7 +282,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenConversation, when currentSession is present, then startNavigation is Home`() = runTest {
+    fun `given Intent with OpenConversation, when currentSession is present, then startNavigation is Home`() {
         val conversationsId = ConversationId("val", "dom")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -304,7 +290,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -330,7 +315,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenOtherUser, when currentSession is present, then startNavigation is Home`() = runTest {
+    fun `given Intent with OpenOtherUser, when currentSession is present, then startNavigation is Home`() {
         val userId = QualifiedID("val", "dom")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -338,7 +323,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -349,14 +333,13 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenOtherUser, when currentSession is absent, then startNavigation is Welcome`() = runTest {
+    fun `given Intent with OpenOtherUser, when currentSession is absent, then startNavigation is Welcome`() {
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(QualifiedID("val", "dom")))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 0) {
@@ -397,7 +380,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given newIntent with Join Conversation Deep link, when user is not a member, then start join converstion flow`() = runTest {
+    fun `given newIntent with Join Conversation Deep link, when user is not a member, then start join converstion flow`() {
         val (code, key, domain) = Triple("code", "key", "domain")
         val (conversationName, conversationId, isSelfMember) = Triple("conversation_name", ConversationId("id", "domain"), false)
         val (arrangement, viewModel) = Arrangement()
@@ -412,7 +395,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` JoinConversationViaCodeState.Show(
             conversationName,
@@ -424,7 +406,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given newIntent with Join Conversation Deep link, when user is a member, then navigate to the conversation`() = runTest {
+    fun `given newIntent with Join Conversation Deep link, when user is a member, then navigate to the conversation`() {
         val (code, key, domain) = Triple("code", "key", "domain")
         val (conversationName, conversationId, isSelfMember) = Triple("conversation_name", ConversationId("id", "domain"), true)
         val (arrangement, viewModel) = Arrangement()
@@ -439,7 +421,6 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` null
         coVerify(exactly = 1) {

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -124,23 +124,25 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withSomeCurrentSession()
-            .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
-            .arrange()
+    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() =
+        runTest {
+            val (arrangement, viewModel) = Arrangement()
+                .withSomeCurrentSession()
+                .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
+                .arrange()
 
-        viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
+            viewModel.handleDeepLink(mockedIntent())
+            advanceUntilIdle()
 
-        coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
-        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
-        assertEquals(newServerConfig(1).links, viewModel.globalAppState.customBackendDialog.serverLinks)
+            coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
+            assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+            assertEquals(newServerConfig(1).links, viewModel.globalAppState.customBackendDialog.serverLinks)
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() = runTest{
-        val (arrangement, viewModel) = Arrangement()
+    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() =
+        runTest {
+            val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
             .arrange()
@@ -234,43 +236,45 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNoCurrentSession()
-            .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
-            .arrange()
+    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() =
+        runTest {
+            val (arrangement, viewModel) = Arrangement()
+                .withNoCurrentSession()
+                .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
+                .arrange()
 
-        viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
+            viewModel.handleDeepLink(mockedIntent())
+            advanceUntilIdle()
 
-        assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
-        coVerify(exactly = 1) {
-            arrangement.navigationManager.navigate(
-                NavigationCommand(
-                    NavigationItem.Login.getRouteWithArgs(listOf("handle")),
-                    BackStackMode.UPDATE_EXISTED
+            assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
+            coVerify(exactly = 1) {
+                arrangement.navigationManager.navigate(
+                    NavigationCommand(
+                        NavigationItem.Login.getRouteWithArgs(listOf("handle")),
+                        BackStackMode.UPDATE_EXISTED
+                    )
                 )
-            )
         }
     }
 
     @Test
-    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() = runTest {
-        val conversationsId = ConversationId("val", "dom")
-        val (arrangement, viewModel) = Arrangement()
-            .withSomeCurrentSession()
-            .withDeepLinkResult(DeepLinkResult.IncomingCall(conversationsId))
-            .arrange()
+    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() =
+        runTest {
+            val conversationsId = ConversationId("val", "dom")
+            val (arrangement, viewModel) = Arrangement()
+                .withSomeCurrentSession()
+                .withDeepLinkResult(DeepLinkResult.IncomingCall(conversationsId))
+                .arrange()
 
-        viewModel.handleDeepLink(mockedIntent())
-        advanceUntilIdle()
+            viewModel.handleDeepLink(mockedIntent())
+            advanceUntilIdle()
 
-        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
-        coVerify(exactly = 1) {
-            arrangement.navigationManager.navigate(
-                NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationsId)))
-            )
-        }
+            assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+            coVerify(exactly = 1) {
+                arrangement.navigationManager.navigate(
+                    NavigationCommand(NavigationItem.IncomingCall.getRouteWithArgs(listOf(conversationsId)))
+                )
+            }
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -70,6 +70,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
@@ -103,7 +105,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is present, then navigation to Login with SSOLogin params is called`() {
+    fun `given Intent with SSOLogin, when currentSession is present, then navigation to Login with SSOLogin params is called`() = runTest {
         val result = DeepLinkResult.SSOLogin.Success("cookie", "config")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -111,6 +113,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         coVerify(exactly = 1) {
             arrangement.navigationManager.navigate(
@@ -121,13 +124,14 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() {
+    fun `given Intent with ServerConfig, when currentSession is present, then startNavigation is Home and customBackEnd dialog is shown`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
             .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
@@ -135,13 +139,14 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() {
+    fun `given Intent with ServerConfig, when currentSession is absent, then startNavigation is Welcome customBackEnd dialog is shown`() = runTest{
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.CustomServerConfig("url"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
@@ -164,7 +169,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is present, then startNavigation is Home and navigate to SSOLogin`() {
+    fun `given Intent with SSOLogin, when currentSession is present, then startNavigation is Home and navigate to SSOLogin`() = runTest {
         val ssoLogin = DeepLinkResult.SSOLogin.Success("cookie", "serverConfig")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -172,6 +177,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -185,7 +191,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with SSOLogin, when currentSession is absent, then startNavigation is Welcome and navigate to SSOLogin`() {
+    fun `given Intent with SSOLogin, when currentSession is absent, then startNavigation is Welcome and navigate to SSOLogin`() = runTest {
         val ssoLogin = DeepLinkResult.SSOLogin.Success("cookie", "serverConfig")
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
@@ -193,6 +199,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -206,13 +213,14 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with MigrationLogin, when currentSession is present, then startNavigation is Home and navigate to Login`() {
+    fun `given Intent with MigrationLogin, when currentSession is present, then startNavigation is Home and navigate to Login`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
             .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -226,13 +234,14 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() {
+    fun `given Intent with MigrationLogin, when currentSession is absent, then startNavigation is Welcome and navigate to Login`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.MigrationLogin("handle"))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -246,7 +255,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() {
+    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home and navigate to call is called`() = runTest {
         val conversationsId = ConversationId("val", "dom")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -254,6 +263,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -282,7 +292,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenConversation, when currentSession is present, then startNavigation is Home`() {
+    fun `given Intent with OpenConversation, when currentSession is present, then startNavigation is Home`() = runTest {
         val conversationsId = ConversationId("val", "dom")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -290,6 +300,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -315,7 +326,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenOtherUser, when currentSession is present, then startNavigation is Home`() {
+    fun `given Intent with OpenOtherUser, when currentSession is present, then startNavigation is Home`() = runTest {
         val userId = QualifiedID("val", "dom")
         val (arrangement, viewModel) = Arrangement()
             .withSomeCurrentSession()
@@ -323,6 +334,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 1) {
@@ -333,13 +345,14 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with OpenOtherUser, when currentSession is absent, then startNavigation is Welcome`() {
+    fun `given Intent with OpenOtherUser, when currentSession is absent, then startNavigation is Welcome`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(QualifiedID("val", "dom")))
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
         coVerify(exactly = 0) {
@@ -380,7 +393,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given newIntent with Join Conversation Deep link, when user is not a member, then start join converstion flow`() {
+    fun `given newIntent with Join Conversation Deep link, when user is not a member, then start join converstion flow`() = runTest {
         val (code, key, domain) = Triple("code", "key", "domain")
         val (conversationName, conversationId, isSelfMember) = Triple("conversation_name", ConversationId("id", "domain"), false)
         val (arrangement, viewModel) = Arrangement()
@@ -395,6 +408,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` JoinConversationViaCodeState.Show(
             conversationName,
@@ -406,7 +420,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given newIntent with Join Conversation Deep link, when user is a member, then navigate to the conversation`() {
+    fun `given newIntent with Join Conversation Deep link, when user is a member, then navigate to the conversation`() = runTest {
         val (code, key, domain) = Triple("code", "key", "domain")
         val (conversationName, conversationId, isSelfMember) = Triple("conversation_name", ConversationId("id", "domain"), true)
         val (arrangement, viewModel) = Arrangement()
@@ -421,6 +435,8 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent())
+        advanceUntilIdle()
+
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` null
         coVerify(exactly = 1) {
             arrangement.navigationManager.navigate(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There seems to be a racing condition when initiating app from an Intent with `Intent.action.SEND`, or `Intent.action.SEND_MULTIPLE` flags. Therefore, we as the main WireActivity gets recreated multiple times this intent doesn't get handled in the right order, and gets lost early in the pile of navigation instructions.

### Solutions

Add a minimal delay of 100ms when handling an intent that contains a flag indicating that there is some deeplink info.

#### How to Test

- Kill the app and share an asset from an external app with Wire.
or 
- Open the app normally, send it to background and share an asset from an external app with Wire.

--> Check that for both cases, the Import Media Screen gets loaded at last.

### Attachments (Optional)
| Before | After |
| ----------- | ------------ |
|  <video src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/03dde69a-edef-4533-85f9-a925844ebe94" /> |  <video src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/9930aa0c-05ce-40a1-84f8-c35f8ba54ddf" /> |
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
