### PR TITLE
fix: click on notification from lock screen  opens app  in the background (AR-3434)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Wire
   ~ Copyright (C) 2023 Wire Swiss GmbH
   ~
@@ -70,8 +69,7 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="false"
             android:theme="@style/AppTheme.SplashScreen"
-            tools:replace="android:allowBackup,android:supportsRtl"
-            >
+            tools:replace="android:allowBackup,android:supportsRtl">
 
         <activity
                 android:name=".ui.WireActivity"
@@ -79,7 +77,6 @@
                 android:hardwareAccelerated="true"
                 android:launchMode="singleTask"
                 android:screenOrientation="portrait"
-                android:showOnLockScreen="true"
                 android:theme="@style/AppTheme.SplashScreen"
                 android:windowSoftInputMode="adjustResize|stateHidden">
             <intent-filter>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3434" title="AR-3434" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3434</a>  Clicking on a notification with the device locked is opening the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

STR:

- Have your device locked with app in the background
- Receive a notification
- Tap on the notification displayed on my lock screen (but don’t unlock your phone, stay on the lock screen)
- Tap back button or do something else to lock the screen again fully
- Unlock the phone fully without tapping on any notification

Expected:
Wire app should not be opened

Actual:
Wire app is opened the moment I tapped on the 

### Causes (Optional)

Activity with `android:showOnLockScreen="true"` in AndroidManifest.

### Solutions

remove `android:showOnLockScreen="true"`, it's redundant as we set a similar flag in `ScreenSettingsUtil` for each screen when it's needed (IncomingCall)
