### PR TITLE
fix: show toast if file manager is disabled (AR-3428)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -88,6 +88,7 @@ import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.permission.CallingAudioRequestFlow
 import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothRequestFlow
 import com.wire.android.util.ui.UIText
+import com.wire.android.util.ui.openDownloadFolder
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.user.UserId
@@ -562,7 +563,6 @@ private fun SnackBarMessage(
 ) {
     val showLabel = stringResource(R.string.label_show)
     val context = LocalContext.current
-    val errorToastMessage = stringResource(R.string.label_no_application_found_open_downloads_folder)
 
     LaunchedEffect(Unit) {
         composerMessages.collect {
@@ -581,11 +581,7 @@ private fun SnackBarMessage(
             )
             // Show downloads folder when clicking on Snackbar cta button
             if (it is OnFileDownloaded && snackbarResult == SnackbarResult.ActionPerformed) {
-                try {
-                    context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
-                } catch (e: ActivityNotFoundException) {
-                    Toast.makeText(context, errorToastMessage, Toast.LENGTH_SHORT).show()
-                }
+                openDownloadFolder(context)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -21,8 +21,10 @@
 package com.wire.android.ui.home.conversations
 
 import android.app.DownloadManager
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -560,6 +562,7 @@ private fun SnackBarMessage(
 ) {
     val showLabel = stringResource(R.string.label_show)
     val context = LocalContext.current
+    val errorToastMessage = stringResource(R.string.label_no_application_found_open_downloads_folder)
 
     LaunchedEffect(Unit) {
         composerMessages.collect {
@@ -578,7 +581,11 @@ private fun SnackBarMessage(
             )
             // Show downloads folder when clicking on Snackbar cta button
             if (it is OnFileDownloaded && snackbarResult == SnackbarResult.ActionPerformed) {
-                context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
+                try {
+                    context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
+                } catch (e: ActivityNotFoundException) {
+                    Toast.makeText(context, errorToastMessage, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -20,11 +20,7 @@
 
 package com.wire.android.ui.home.conversations
 
-import android.app.DownloadManager
-import android.content.ActivityNotFoundException
-import android.content.Intent
 import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -53,6 +53,7 @@ import com.wire.android.ui.edit.ReplyMessageOption
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.util.permission.rememberWriteStorageRequestFlow
+import com.wire.android.util.ui.openDownloadFolder
 
 @Composable
 fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewModel()) {
@@ -131,11 +132,7 @@ fun MediaGalleryContent(viewModel: MediaGalleryViewModel, mediaGalleryScreenStat
         when {
             // Show downloads folder when clicking on Snackbar cta button
             messageCode is MediaGallerySnackbarMessages.OnImageDownloaded && snackbarResult == SnackbarResult.ActionPerformed -> {
-                try {
-                    context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
-                } catch (e: ActivityNotFoundException) {
-                    Toast.makeText(context, errorToastMessage, Toast.LENGTH_SHORT).show()
-                }
+                openDownloadFolder(context)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -21,8 +21,10 @@
 package com.wire.android.ui.home.gallery
 
 import android.app.DownloadManager
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.Resources
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -123,13 +125,17 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
 fun MediaGalleryContent(viewModel: MediaGalleryViewModel, mediaGalleryScreenState: MediaGalleryScreenState) {
     val context = LocalContext.current
     val uiState = viewModel.mediaGalleryViewState
-
+    val errorToastMessage = stringResource(R.string.label_no_application_found_open_downloads_folder)
     suspend fun showSnackbarMessage(message: String, actionLabel: String?, messageCode: MediaGallerySnackbarMessages) {
         val snackbarResult = mediaGalleryScreenState.snackbarHostState.showSnackbar(message = message, actionLabel = actionLabel)
         when {
             // Show downloads folder when clicking on Snackbar cta button
             messageCode is MediaGallerySnackbarMessages.OnImageDownloaded && snackbarResult == SnackbarResult.ActionPerformed -> {
-                context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
+                try {
+                    context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
+                } catch (e: ActivityNotFoundException) {
+                    Toast.makeText(context, errorToastMessage, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -20,11 +20,7 @@
 
 package com.wire.android.ui.home.gallery
 
-import android.app.DownloadManager
-import android.content.ActivityNotFoundException
-import android.content.Intent
 import android.content.res.Resources
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -126,7 +122,6 @@ fun MediaGalleryScreen(mediaGalleryViewModel: MediaGalleryViewModel = hiltViewMo
 fun MediaGalleryContent(viewModel: MediaGalleryViewModel, mediaGalleryScreenState: MediaGalleryScreenState) {
     val context = LocalContext.current
     val uiState = viewModel.mediaGalleryViewState
-    val errorToastMessage = stringResource(R.string.label_no_application_found_open_downloads_folder)
     suspend fun showSnackbarMessage(message: String, actionLabel: String?, messageCode: MediaGallerySnackbarMessages) {
         val snackbarResult = mediaGalleryScreenState.snackbarHostState.showSnackbar(message = message, actionLabel = actionLabel)
         when {

--- a/app/src/main/kotlin/com/wire/android/util/ui/DownloadFolderOpener.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/DownloadFolderOpener.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.ui
+
+import android.app.DownloadManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+
+fun openDownloadFolder(context: Context) {
+    val errorToastMessage = context.resources.getString(com.wire.android.R.string.label_no_application_found_open_downloads_folder)
+    try {
+        context.startActivity(Intent(DownloadManager.ACTION_VIEW_DOWNLOADS))
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, errorToastMessage, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1052,4 +1052,6 @@
     <string name="label_debug_data">Debug data</string>
     <string name="title_internal_debugging">Internal debugging</string>
     <string name="label_log_options_description">"This stores anonymized troubleshooting information locally. "</string>
+
+    <string name="label_no_application_found_open_downloads_folder">"No application found to open downloads folder"</string>
 </resources>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,7 @@ private object Dependencies {
     const val kluent = "org.amshove.kluent:kluent:1.68"
     const val hilt = "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
     const val spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.1.2"
-    const val junit5 = "de.mannodermaus.gradle.plugins:android-junit5:1.9.0.0-SNAPSHOT"
+    const val junit5 = "de.mannodermaus.gradle.plugins:android-junit5:1.9.3.0"
     const val grgit = "org.ajoberstar.grgit:grgit-core:5.0.0-rc.3"
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3428" title="AR-3428" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3428</a>  App crash when click on "Show" on toast to show folder after downloading image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When File Manager is disabled and user clicks on show file after downloading a file the app will crash.

### Causes (Optional)

There is no activity that could handle the intent ACTION_VIEW_DOWNLOADS

### Solutions

Catch the exception and show a toast in case of error

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
