### PR TITLE
fix: issues after migrating to material3 [AR-3494] [AR-3497]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -68,6 +68,7 @@ import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.util.permission.rememberRequestPushNotificationsPermissionFlow
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.launch
 
 @Composable
 fun HomeScreen(
@@ -133,6 +134,11 @@ fun HomeScreen(
         navigateToItem = homeViewModel::navigateTo
     )
 
+    BackHandler(homeScreenState.drawerState.isOpen) {
+        homeScreenState.coroutineScope.launch {
+            homeScreenState.drawerState.close()
+        }
+    }
     BackHandler(homeScreenState.searchBarState.isSearchActive) {
         homeScreenState.searchBarState.closeSearch()
     }
@@ -155,6 +161,7 @@ fun HomeContent(
                     drawerContainerColor = MaterialTheme.colorScheme.surface,
                     drawerTonalElevation = 0.dp,
                     drawerShape = RectangleShape,
+                    modifier = Modifier.padding(end = dimensions().homeDrawerSheetEndPadding)
                 ) {
                     HomeDrawer(
                         // TODO: logFilePath does not belong in the UI logic

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -432,14 +432,14 @@ private fun ConversationScreen(
                     tempWritableImageUri = tempWritableImageUri,
                     tempWritableVideoUri = tempWritableVideoUri
                 )
-
-                MenuModalSheetLayout(
-                    header = menuModalHeader,
-                    sheetState = conversationScreenState.modalBottomSheetState,
-                    coroutineScope = conversationScreenState.coroutineScope,
-                    menuItems = menuItems
-                )
             }
+
+            MenuModalSheetLayout(
+                header = menuModalHeader,
+                sheetState = conversationScreenState.modalBottomSheetState,
+                coroutineScope = conversationScreenState.coroutineScope,
+                menuItems = menuItems
+            )
         }
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -52,6 +52,7 @@ data class WireDimensions(
     val homeDrawerLogoVerticalPadding: Dp,
     val homeDrawerLogoWidth: Dp,
     val homeDrawerLogoHeight: Dp,
+    val homeDrawerSheetEndPadding: Dp,
     // FAB
     val fabIconSize: Dp,
     // BottomNavigation
@@ -210,6 +211,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     homeDrawerLogoVerticalPadding = 32.dp,
     homeDrawerLogoWidth = 80.dp,
     homeDrawerLogoHeight = 24.dp,
+    homeDrawerSheetEndPadding = 56.dp,
     fabIconSize = 16.dp,
     bottomNavigationHorizontalPadding = 8.dp,
     bottomNavigationVerticalPadding = 4.dp,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3494" title="AR-3494" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3494</a>  PlayTest 26.05 - Last option on self deleting list overlaps with system back button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Last option on bottom sheets on conversation screen overlaps with system bottom navigation buttons.
Hamburger menu covers the entire screen on some devices.
When clicking "back", the drawer menu is not being closed, instead the whole app is being closed. 

### Causes (Optional)

Wrong placement of bottom sheet, caused WindowInsets to be applied twice for this bottom sheet.
Material3 has hardcoded minimum width of the drawer which means that on older screens with smaller resolution it can take the whole width of that screen.

### Solutions

Move this bottom sheet outside the `Scaffold`.
Apply end padding to the `ModalDrawerSheet` so that there will be always space of `56.dp` left (Material2 drawer used such padding).
Handle "back" clicks when the drawer is open to close the drawer instead of closing the whole app.

### Dependencies (Optional)

### Testing

#### How to Test

Open the conversation and long-click on a message.
Open the app on older device with smaller screen resolution and open the "hamburger" menu.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
