### PR TITLE
feat: new conversation creation system messages (AR-910)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -254,6 +254,9 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                 is WithUser.MissedCall -> UILastMessageContent.TextMessage(
                     MessageBody(UIText.PluralResource(R.plurals.unread_event_call, 1, 1))
                 )
+
+                is WithUser.MembersCreationAdded -> UILastMessageContent.None
+                is WithUser.MembersFailedToAdd -> UILastMessageContent.None
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.mapper
 
-import androidx.compose.ui.text.toUpperCase
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.UIMessageContent
@@ -208,7 +207,10 @@ class SystemMessageContentMapper @Inject constructor(
                     )
                 }
 
-            is MemberChange.CreationAdded -> null // todo: add
+            is MemberChange.CreationAdded -> {
+                UIMessageContent.SystemMessage.ConversationStartedWithMembers(memberNames = memberNameList)
+            }
+
             is MemberChange.FailedToAdd -> null
         }
     }

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -56,17 +56,11 @@ class SystemMessageContentMapper @Inject constructor(
         is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
         is MessageContent.HistoryLost -> mapConversationHistoryLost()
         is MessageContent.ConversationMessageTimerChanged -> mapConversationTimerChanged(message.senderUserId, content, members)
-        is MessageContent.ConversationCreated -> mapConversationCreated(message.senderUserId, message.date, members)
+        is MessageContent.ConversationCreated -> mapConversationCreated(message.date, members)
     }
 
-    private fun mapConversationCreated(senderUserId: UserId, date: String, userList: List<User>): UIMessageContent.SystemMessage {
-        val sender = userList.findUser(userId = senderUserId)
-        val authorName = mapMemberName(
-            user = sender,
-            type = SelfNameType.ResourceTitleCase
-        )
+    private fun mapConversationCreated(date: String, userList: List<User>): UIMessageContent.SystemMessage {
         return UIMessageContent.SystemMessage.ConversationMessageCreated(
-            authorName,
             date.formatMediumDateShortTime().orDefault(date).toUpperCase()
         )
     }

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -24,7 +24,7 @@ import com.wire.android.R
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
-import com.wire.android.util.formatMediumDateShortTime
+import com.wire.android.util.formatFullDateShortTime
 import com.wire.android.util.orDefault
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.Message
@@ -68,7 +68,7 @@ class SystemMessageContentMapper @Inject constructor(
         return UIMessageContent.SystemMessage.ConversationMessageCreated(
             author = authorName,
             isAuthorSelfUser = sender is SelfUser,
-            date.formatMediumDateShortTime().orDefault(date).toUpperCase()
+            date.formatFullDateShortTime().orDefault(date).toUpperCase()
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -56,11 +56,18 @@ class SystemMessageContentMapper @Inject constructor(
         is MessageContent.ConversationReceiptModeChanged -> mapConversationReceiptModeChanged(message.senderUserId, content, members)
         is MessageContent.HistoryLost -> mapConversationHistoryLost()
         is MessageContent.ConversationMessageTimerChanged -> mapConversationTimerChanged(message.senderUserId, content, members)
-        is MessageContent.ConversationCreated -> mapConversationCreated(message.date, members)
+        is MessageContent.ConversationCreated -> mapConversationCreated(message.senderUserId, message.date, members)
     }
 
-    private fun mapConversationCreated(date: String, userList: List<User>): UIMessageContent.SystemMessage {
+    private fun mapConversationCreated(senderUserId: UserId, date: String, userList: List<User>): UIMessageContent.SystemMessage {
+        val sender = userList.findUser(userId = senderUserId)
+        val authorName = mapMemberName(
+            user = sender,
+            type = SelfNameType.ResourceTitleCase
+        )
         return UIMessageContent.SystemMessage.ConversationMessageCreated(
+            author = authorName,
+            isAuthorSelfUser = sender is SelfUser,
             date.formatMediumDateShortTime().orDefault(date).toUpperCase()
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -195,6 +195,7 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.NewConversationReceiptMode,
         is SystemMessage.ConversationMessageTimerActivated,
         is SystemMessage.ConversationMessageCreated,
+        is SystemMessage.ConversationStartedWithMembers,
         is SystemMessage.ConversationMessageTimerDeactivated -> ColorFilter.tint(colorsScheme().onBackground)
     }
 }
@@ -303,6 +304,7 @@ private val SystemMessage.expandable
         is SystemMessage.ConversationMessageTimerActivated -> false
         is SystemMessage.ConversationMessageTimerDeactivated -> false
         is SystemMessage.ConversationMessageCreated -> false
+        is SystemMessage.ConversationStartedWithMembers -> this.memberNames.size > EXPANDABLE_THRESHOLD
     }
 
 private fun List<String>.toUserNamesListString(res: Resources) = when {
@@ -360,6 +362,11 @@ fun SystemMessage.annotatedString(
 
         is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(author.asString(res))
         is SystemMessage.ConversationMessageCreated -> arrayOf(author.asString(res))
+        is SystemMessage.ConversationStartedWithMembers ->
+            arrayOf(
+                memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD)
+                    .toUserNamesListString(res)
+            )
     }
 
     return res.annotatedText(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -361,7 +361,7 @@ fun SystemMessage.annotatedString(
         )
 
         is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(author.asString(res))
-        is SystemMessage.ConversationMessageCreated -> arrayOf(author.asString(res))
+        is SystemMessage.ConversationMessageCreated -> arrayOf()
         is SystemMessage.ConversationStartedWithMembers ->
             arrayOf(
                 memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -168,7 +168,9 @@ fun SystemMessageItem(message: UIMessage.System) {
                 .fillMaxWidth()
         ) {
             Text(
-                modifier = Modifier.padding(start = dimensions().spacing56x).align(Alignment.CenterVertically),
+                modifier = Modifier
+                    .padding(start = dimensions().spacing56x)
+                    .align(Alignment.CenterVertically),
                 style = MaterialTheme.wireTypography.title03,
                 text = message.messageContent.date
             )
@@ -361,7 +363,7 @@ fun SystemMessage.annotatedString(
         )
 
         is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(author.asString(res))
-        is SystemMessage.ConversationMessageCreated -> arrayOf()
+        is SystemMessage.ConversationMessageCreated -> arrayOf(author.asString(res))
         is SystemMessage.ConversationStartedWithMembers ->
             arrayOf(
                 memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -98,8 +99,11 @@ fun SystemMessageItem(message: UIMessage.System) {
                     contentAlignment = Alignment.Center
                 ) {
                     val size =
-                        if (message.messageContent.isSmallIcon) dimensions().systemMessageIconSize
-                        else dimensions().systemMessageIconLargeSize
+                        if (message.messageContent.isSmallIcon) {
+                            dimensions().systemMessageIconSize
+                        } else {
+                            dimensions().systemMessageIconLargeSize
+                        }
                     Image(
                         painter = painterResource(id = message.messageContent.iconResId),
                         contentDescription = null,
@@ -156,6 +160,20 @@ fun SystemMessageItem(message: UIMessage.System) {
             }
         }
     }
+    if (message.messageContent is SystemMessage.ConversationMessageCreated) {
+        Row(
+            Modifier
+                .background(colorsScheme().background)
+                .height(dimensions().spacing24x)
+                .fillMaxWidth()
+        ) {
+            Text(
+                modifier = Modifier.padding(start = dimensions().spacing56x).align(Alignment.CenterVertically),
+                style = MaterialTheme.wireTypography.title03,
+                text = message.messageContent.date
+            )
+        }
+    }
 }
 
 @Suppress("ComplexMethod")
@@ -176,6 +194,7 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.HistoryLost,
         is SystemMessage.NewConversationReceiptMode,
         is SystemMessage.ConversationMessageTimerActivated,
+        is SystemMessage.ConversationMessageCreated,
         is SystemMessage.ConversationMessageTimerDeactivated -> ColorFilter.tint(colorsScheme().onBackground)
     }
 }
@@ -283,6 +302,7 @@ private val SystemMessage.expandable
         is SystemMessage.HistoryLost -> false
         is SystemMessage.ConversationMessageTimerActivated -> false
         is SystemMessage.ConversationMessageTimerDeactivated -> false
+        is SystemMessage.ConversationMessageCreated -> false
     }
 
 private fun List<String>.toUserNamesListString(res: Resources) = when {
@@ -292,8 +312,9 @@ private fun List<String>.toUserNamesListString(res: Resources) = when {
 }
 
 private fun List<UIText>.limitUserNamesList(res: Resources, threshold: Int): List<String> =
-    if (this.size <= threshold) this.map { it.asString(res) }
-    else {
+    if (this.size <= threshold) {
+        this.map { it.asString(res) }
+    } else {
         val moreCount = this.size - (threshold - 1) // the last visible place is taken by "and X more"
         this.take(threshold - 1)
             .map { it.asString(res) }
@@ -338,6 +359,7 @@ fun SystemMessage.annotatedString(
         )
 
         is SystemMessage.ConversationMessageTimerDeactivated -> arrayOf(author.asString(res))
+        is SystemMessage.ConversationMessageCreated -> arrayOf(author.asString(res))
     }
 
     return res.annotatedText(stringResId, normalStyle, boldStyle, normalColor, boldColor, *args)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -325,7 +325,6 @@ sealed class UIMessageContent {
         class HistoryLost : SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)
 
         data class ConversationMessageCreated(
-            val author: UIText,
             val date: String
         ) : SystemMessage(
             R.drawable.ic_conversation,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -325,10 +325,16 @@ sealed class UIMessageContent {
         class HistoryLost : SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)
 
         data class ConversationMessageCreated(
+            val author: UIText,
+            val isAuthorSelfUser: Boolean = false,
             val date: String
         ) : SystemMessage(
             R.drawable.ic_conversation,
-            R.string.label_system_message_conversation_started
+            if (isAuthorSelfUser) {
+                R.string.label_system_message_conversation_started_by_self
+            } else {
+                R.string.label_system_message_conversation_started_by_other
+            }
         )
 
         data class ConversationStartedWithMembers(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -331,6 +331,13 @@ sealed class UIMessageContent {
             R.drawable.ic_conversation,
             R.string.label_system_message_conversation_started
         )
+
+        data class ConversationStartedWithMembers(
+            val memberNames: List<UIText>
+        ) : SystemMessage(
+            R.drawable.ic_contact,
+            R.string.label_system_message_conversation_started_with_members
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -43,7 +43,7 @@ import kotlin.time.Duration
 
 sealed class UIMessage(
     open val header: MessageHeader,
-    open val source: MessageSource,
+    open val source: MessageSource
 ) {
 
     data class Regular(
@@ -234,8 +234,11 @@ sealed class UIMessageContent {
             val isSelfTriggered: Boolean = false
         ) : SystemMessage(
             R.drawable.ic_add,
-            if (isSelfTriggered) R.string.label_system_message_joined_the_conversation_by_self
-            else R.string.label_system_message_joined_the_conversation_by_other
+            if (isSelfTriggered) {
+                R.string.label_system_message_joined_the_conversation_by_self
+            } else {
+                R.string.label_system_message_joined_the_conversation_by_other
+            }
         )
 
         data class MemberRemoved(
@@ -252,8 +255,11 @@ sealed class UIMessageContent {
             val isSelfTriggered: Boolean = false
         ) : SystemMessage(
             R.drawable.ic_minus,
-            if (isSelfTriggered) R.string.label_system_message_left_the_conversation_by_self
-            else R.string.label_system_message_left_the_conversation_by_other
+            if (isSelfTriggered) {
+                R.string.label_system_message_left_the_conversation_by_self
+            } else {
+                R.string.label_system_message_left_the_conversation_by_other
+            }
         )
 
         sealed class MissedCall(
@@ -284,8 +290,11 @@ sealed class UIMessageContent {
             val isAuthorSelfUser: Boolean = false
         ) : SystemMessage(
             R.drawable.ic_view,
-            if (isAuthorSelfUser) R.string.label_system_message_read_receipt_changed_by_self
-            else R.string.label_system_message_read_receipt_changed_by_other
+            if (isAuthorSelfUser) {
+                R.string.label_system_message_read_receipt_changed_by_self
+            } else {
+                R.string.label_system_message_read_receipt_changed_by_other
+            }
         )
 
         data class ConversationMessageTimerActivated(
@@ -294,20 +303,34 @@ sealed class UIMessageContent {
             val selfDeletionDuration: SelfDeletionDuration
         ) : SystemMessage(
             R.drawable.ic_timer,
-            if (isAuthorSelfUser) R.string.label_system_message_conversation_message_timer_activated_by_self
-            else R.string.label_system_message_conversation_message_timer_activated_by_other
+            if (isAuthorSelfUser) {
+                R.string.label_system_message_conversation_message_timer_activated_by_self
+            } else {
+                R.string.label_system_message_conversation_message_timer_activated_by_other
+            }
         )
 
         data class ConversationMessageTimerDeactivated(
             val author: UIText,
-            val isAuthorSelfUser: Boolean = false,
+            val isAuthorSelfUser: Boolean = false
         ) : SystemMessage(
             R.drawable.ic_timer,
-            if (isAuthorSelfUser) R.string.label_system_message_conversation_message_timer_deactivated_by_self
-            else R.string.label_system_message_conversation_message_timer_deactivated_by_other
+            if (isAuthorSelfUser) {
+                R.string.label_system_message_conversation_message_timer_deactivated_by_self
+            } else {
+                R.string.label_system_message_conversation_message_timer_deactivated_by_other
+            }
         )
 
         class HistoryLost : SystemMessage(R.drawable.ic_info, R.string.label_system_message_conversation_history_lost, true)
+
+        data class ConversationMessageCreated(
+            val author: UIText,
+            val date: String
+        ) : SystemMessage(
+            R.drawable.ic_conversation,
+            R.string.label_system_message_conversation_started
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
@@ -158,9 +158,9 @@ class ServiceDetailsViewModel @Inject constructor(
             )
                 .combine(observeGroupInfo(), ::Pair)
                 .flowOn(dispatchers.io())
-                .collect { (_, groupInfo: ServiceDetailsGroupState) ->
+                .collect { (serviceMemberId: QualifiedID?, groupInfo: ServiceDetailsGroupState) ->
                     updateViewStateButton(
-                        serviceMemberId = null,
+                        serviceMemberId = serviceMemberId,
                         groupInfo = groupInfo
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
@@ -158,9 +158,9 @@ class ServiceDetailsViewModel @Inject constructor(
             )
                 .combine(observeGroupInfo(), ::Pair)
                 .flowOn(dispatchers.io())
-                .collect { (serviceMemberId: QualifiedID?, groupInfo: ServiceDetailsGroupState) ->
+                .collect { (_, groupInfo: ServiceDetailsGroupState) ->
                     updateViewStateButton(
-                        serviceMemberId = serviceMemberId,
+                        serviceMemberId = null,
                         groupInfo = groupInfo
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -48,11 +48,7 @@ private val readReceiptDateTimeFormat = SimpleDateFormat(
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
 
-private val dateTimeFormatWithDayOfWeek = SimpleDateFormat(
-    "EEE, MMM dd, hh:mm a",
-    Locale.getDefault()
-).apply { timeZone = TimeZone.getDefault() }
-
+private val fullDateShortTimeFormatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.SHORT)
 fun String.formatMediumDateTime(): String? =
     try {
         this.serverDate()?.let { mediumDateTimeFormat.format(it) }
@@ -60,9 +56,9 @@ fun String.formatMediumDateTime(): String? =
         null
     }
 
-fun String.formatMediumDateShortTime(): String? =
+fun String.formatFullDateShortTime(): String? =
     try {
-        this.serverDate()?.let { dateTimeFormatWithDayOfWeek.format(it) }
+        this.serverDate()?.let { fullDateShortTimeFormatter.format(it) }
     } catch (e: ParseException) {
         null
     }
@@ -76,11 +72,11 @@ fun String.serverDate(): Date? = try {
 
 fun String.uiMessageDateTime(): String? = this
     .serverDate()?.let { serverDate ->
-    when (DateUtils.isToday(serverDate.time)) {
-        true -> messageTimeFormatter.format(serverDate)
-        false -> messageDateTimeFormatter.format(serverDate)
+        when (DateUtils.isToday(serverDate.time)) {
+            true -> messageTimeFormatter.format(serverDate)
+            false -> messageDateTimeFormatter.format(serverDate)
+        }
     }
-}
 
 fun Instant.uiReadReceiptDateTime(): String = readReceiptDateTimeFormat.format(Date(this.toEpochMilliseconds()))
 

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -49,7 +49,7 @@ private val readReceiptDateTimeFormat = SimpleDateFormat(
 ).apply { timeZone = TimeZone.getDefault() }
 
 private val dateTimeFormatWithDayOfWeek = SimpleDateFormat(
-    "EEE, MMM dd yyyy, hh:mm a",
+    "EEE, MMM dd, hh:mm a",
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
 

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -48,9 +48,21 @@ private val readReceiptDateTimeFormat = SimpleDateFormat(
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
 
+private val dateTimeFormatWithDayOfWeek = SimpleDateFormat(
+    "EEE, MMM dd yyyy, hh:mm a",
+    Locale.getDefault()
+).apply { timeZone = TimeZone.getDefault() }
+
 fun String.formatMediumDateTime(): String? =
     try {
         this.serverDate()?.let { mediumDateTimeFormat.format(it) }
+    } catch (e: ParseException) {
+        null
+    }
+
+fun String.formatMediumDateShortTime(): String? =
+    try {
+        this.serverDate()?.let { dateTimeFormatWithDayOfWeek.format(it) }
     } catch (e: ParseException) {
         null
     }
@@ -64,11 +76,11 @@ fun String.serverDate(): Date? = try {
 
 fun String.uiMessageDateTime(): String? = this
     .serverDate()?.let { serverDate ->
-        when (DateUtils.isToday(serverDate.time)) {
-            true -> messageTimeFormatter.format(serverDate)
-            false -> messageDateTimeFormatter.format(serverDate)
-        }
+    when (DateUtils.isToday(serverDate.time)) {
+        true -> messageTimeFormatter.format(serverDate)
+        false -> messageDateTimeFormatter.format(serverDate)
     }
+}
 
 fun Instant.uiReadReceiptDateTime(): String = readReceiptDateTimeFormat.format(Date(this.toEpochMilliseconds()))
 

--- a/app/src/main/res/drawable/ic_contact.xml
+++ b/app/src/main/res/drawable/ic_contact.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:viewportWidth="16"
+        android:viewportHeight="16">
+    <path
+            android:fillColor="#000000"
+            android:fillType="evenOdd"
+            android:pathData="M10.608,10H10.997C12.655,10 14,11.347 14,13V14.27C11.91,15.375 9.528,16 7,16C4.472,16 2.09,15.375 0,14.27V13C0,11.343 1.342,10 3.003,10H3.392C4.446,10.635 5.68,11 7,11C8.32,11 9.554,10.635 10.608,10ZM7,8C9.209,8 11,6.209 11,4C11,1.791 9.209,0 7,0C4.791,0 3,1.791 3,4C3,6.209 4.791,8 7,8Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -545,6 +545,7 @@
     <string name="label_system_message_conversation_history_lost">You haven\'t used this device for a while. some messages may not appear here.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>
+    <string name="label_system_message_conversation_started">You started the conversation</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
         <item quantity="one">You added 1 person to the conversation</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -545,7 +545,8 @@
     <string name="label_system_message_conversation_history_lost">You haven\'t used this device for a while. some messages may not appear here.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>
-    <string name="label_system_message_conversation_started">**You** started the conversation</string>
+    <string name="label_system_message_conversation_started_by_self">**You** started the conversation</string>
+    <string name="label_system_message_conversation_started_by_other">%1$s started the conversation</string>
     <string name="label_system_message_conversation_started_with_members">With %1$s</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -545,7 +545,8 @@
     <string name="label_system_message_conversation_history_lost">You haven\'t used this device for a while. some messages may not appear here.</string>
     <string name="label_system_message_receipt_mode_on">on</string>
     <string name="label_system_message_receipt_mode_off">off</string>
-    <string name="label_system_message_conversation_started">You started the conversation</string>
+    <string name="label_system_message_conversation_started">**You** started the conversation</string>
+    <string name="label_system_message_conversation_started_with_members">With %1$s</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
         <item quantity="one">You added 1 person to the conversation</item>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -161,6 +161,15 @@ object TestMessage {
         status = Message.Status.SENT
     )
 
+    val CONVERSATION_CREATED_MESSAGE = Message.System(
+        id = "messageID",
+        content = MessageContent.ConversationCreated,
+        conversationId = ConversationId("convo-id", "convo.domain"),
+        date = "some-date",
+        senderUserId = UserId("user-id", "domain"),
+        status = Message.Status.SENT
+    )
+
     val PREVIEW = MessagePreview(
         id = "messageId",
         conversationId = ConversationId("value", "domain"),

--- a/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
@@ -88,12 +88,12 @@ class SystemMessageContentMapperTest {
         // Then
         assertTrue(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.name)
         assertTrue(
-            selfResLower is UIText.StringResource
-                    && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase
+            selfResLower is UIText.StringResource &&
+                selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase
         )
         assertTrue(
-            selfResTitle is UIText.StringResource
-                    && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase
+            selfResTitle is UIText.StringResource &&
+                selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase
         )
         assertTrue(deleted is UIText.StringResource && deleted.resId == arrangement.messageResourceProvider.memberNameDeleted)
         assertTrue(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.name)
@@ -103,87 +103,96 @@ class SystemMessageContentMapperTest {
     fun givenServerContent_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
         // Given
         val (arrangement, mapper) = Arrangement().arrange()
-        val userId1 = UserId("user-id1", "user-domain")
-        val userId2 = UserId("user-id2", "user-domain")
-        val userId3 = UserId("user-id3", "user-domain")
-        val contentLeft = MessageContent.MemberChange.Removed(listOf(userId1))
-        val contentRemoved = MessageContent.MemberChange.Removed(listOf(userId2))
-        val contentAdded = MessageContent.MemberChange.Added(listOf(userId2, userId3))
-        val contentAddedSelf = MessageContent.MemberChange.Added(listOf(userId1))
         val member1 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId1))
-        val member2 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId2))
-        val member3 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId3))
         val missedCallMessage = TestMessage.MISSED_CALL_MESSAGE
         val selfCaller = MemberDetails(TestUser.SELF_USER.copy(id = missedCallMessage.senderUserId), Member.Role.Admin)
         val otherCallerInfo = (member1.user as OtherUser).copy(id = missedCallMessage.senderUserId)
         val otherCaller = member1.copy(user = otherCallerInfo)
         // When
-        val resultContentLeft = mapper.mapMemberChangeMessage(contentLeft, userId1, listOf(member1.user))
-        val resultContentRemoved = mapper.mapMemberChangeMessage(contentRemoved, userId1, listOf(member1.user, member2.user))
-        val resultContentAdded = mapper.mapMemberChangeMessage(contentAdded, userId1, listOf(member1.user, member2.user, member3.user))
-        val resultContentAddedSelf = mapper.mapMemberChangeMessage(contentAddedSelf, userId1, listOf(member1.user))
+
         val resultMyMissedCall = mapper.mapMessage(missedCallMessage, listOf(selfCaller.user))
         val resultOtherMissedCall = mapper.mapMessage(missedCallMessage, listOf(otherCaller.user))
-
-        val resultStartedWith =
-            mapper.mapMemberChangeMessage(
-                MessageContent.MemberChange.CreationAdded(listOf(userId1, userId2)),
-                userId1, listOf(member1.user, member2.user)
-            )
-
-        val resultStartedWithFailed =
-            mapper.mapMemberChangeMessage(
-                MessageContent.MemberChange.FailedToAdd(listOf(userId1, userId2)),
-                userId1, listOf(member1.user, member2.user)
-            )
 
         val resultConversationCreated = mapper.mapMessage(CONVERSATION_CREATED_MESSAGE, listOf(member1.user))
 
         // Then
         assertTrue(
+            resultOtherMissedCall is SystemMessage.MissedCall &&
+                resultOtherMissedCall.author.asString(arrangement.resources) == TestUser.OTHER_USER.name
+        )
+        assertTrue(
+            resultMyMissedCall is SystemMessage.MissedCall &&
+                (resultMyMissedCall.author as UIText.StringResource).resId == arrangement.messageResourceProvider.memberNameYouTitlecase
+        )
+
+        assertTrue(
+            resultConversationCreated is SystemMessage.ConversationMessageCreated &&
+                (resultConversationCreated.author as UIText.StringResource).resId == 10584735 &&
+                resultConversationCreated.date == "SOME-DATE"
+        )
+    }
+
+    fun givenServerContent_whenMappingMemberChangeMessagesToUIMessageContent_thenCorrectValuesShouldBeReturned() {
+        val (arrangement, mapper) = Arrangement().arrange()
+        val contentLeft = MessageContent.MemberChange.Removed(listOf(userId1))
+        val contentRemoved = MessageContent.MemberChange.Removed(listOf(userId2))
+        val contentAdded = MessageContent.MemberChange.Added(listOf(userId2, userId3))
+        val contentAddedSelf = MessageContent.MemberChange.Added(listOf(userId1))
+
+        val member1 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId1))
+        val member2 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId2))
+        val member3 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId3))
+
+        val resultContentLeft = mapper.mapMemberChangeMessage(contentLeft, userId1, listOf(member1.user))
+        val resultContentRemoved = mapper.mapMemberChangeMessage(contentRemoved, userId1, listOf(member1.user, member2.user))
+        val resultContentAdded = mapper.mapMemberChangeMessage(contentAdded, userId1, listOf(member1.user, member2.user, member3.user))
+        val resultContentAddedSelf = mapper.mapMemberChangeMessage(contentAddedSelf, userId1, listOf(member1.user))
+
+        assertTrue(
             resultContentLeft is SystemMessage.MemberLeft &&
-                    resultContentLeft.author.asString(arrangement.resources) == member1.name
+                resultContentLeft.author.asString(arrangement.resources) == member1.name
         )
         assertTrue(
             resultContentRemoved is SystemMessage.MemberRemoved &&
-                    resultContentRemoved.author.asString(arrangement.resources) == member1.name &&
-                    resultContentRemoved.memberNames.size == 1 &&
-                    resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.name
+                resultContentRemoved.author.asString(arrangement.resources) == member1.name &&
+                resultContentRemoved.memberNames.size == 1 &&
+                resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.name
 
         )
         assertTrue(
             resultContentAdded is SystemMessage.MemberAdded &&
-                    resultContentAdded.author.asString(arrangement.resources) == member1.name &&
-                    resultContentAdded.memberNames.size == 2 &&
-                    resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.name &&
-                    resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.name
+                resultContentAdded.author.asString(arrangement.resources) == member1.name &&
+                resultContentAdded.memberNames.size == 2 &&
+                resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.name &&
+                resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.name
         )
         assertTrue(
             resultContentAddedSelf is SystemMessage.MemberJoined &&
-                    resultContentAddedSelf.author.asString(arrangement.resources) == member1.name
+                resultContentAddedSelf.author.asString(arrangement.resources) == member1.name
         )
-        assertTrue(
-            resultOtherMissedCall is SystemMessage.MissedCall &&
-                    resultOtherMissedCall.author.asString(arrangement.resources) == TestUser.OTHER_USER.name
-        )
-        assertTrue(
-            resultMyMissedCall is SystemMessage.MissedCall &&
-                    (resultMyMissedCall.author as UIText.StringResource).resId == arrangement.messageResourceProvider.memberNameYouTitlecase
-        )
+
+        val resultStartedWith =
+            mapper.mapMemberChangeMessage(
+                MessageContent.MemberChange.CreationAdded(listOf(userId1, userId2)),
+                userId1,
+                listOf(member1.user, member2.user)
+            )
+
+        val resultStartedWithFailed =
+            mapper.mapMemberChangeMessage(
+                MessageContent.MemberChange.FailedToAdd(listOf(userId1, userId2)),
+                userId1,
+                listOf(member1.user, member2.user)
+            )
+
         assertTrue(
             resultStartedWith is SystemMessage.ConversationStartedWithMembers &&
-                    resultStartedWith.memberNames.size == 2 &&
-                    resultStartedWith.memberNames[0].asString(arrangement.resources) == member2.name &&
-                    resultStartedWith.memberNames[1].asString(arrangement.resources) == member3.name
+                resultStartedWith.memberNames.size == 2 &&
+                resultStartedWith.memberNames[0].asString(arrangement.resources) == member2.name &&
+                resultStartedWith.memberNames[1].asString(arrangement.resources) == member3.name
         )
 
         assertTrue(resultStartedWithFailed == null)
-
-        assertTrue(
-            resultConversationCreated is SystemMessage.ConversationMessageCreated &&
-                    (resultConversationCreated.author as UIText.StringResource).resId == 10584735 &&
-                    resultConversationCreated.date == "SOME-DATE"
-        )
     }
 
     private class Arrangement {
@@ -207,5 +216,11 @@ class SystemMessageContentMapperTest {
         }
 
         fun arrange() = this to messageContentMapper
+    }
+
+    private companion object {
+        val userId1 = UserId("user-id1", "user-domain")
+        val userId2 = UserId("user-id2", "user-domain")
+        val userId3 = UserId("user-id3", "user-domain")
     }
 }

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -64,7 +64,7 @@ val detektAll by tasks.registering(Detekt::class) {
     config.setFrom("$rootDir/config/detekt/detekt.yml")
 
     include("**/*.kt")
-    exclude("**/*.kts", "*/build/*", "/buildSrc", "**/test/**/*")
+    exclude("**/*.kts", "*/build/*", "/buildSrc")
 
     baseline.set(file("$rootDir/config/detekt/baseline.xml"))
 

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -64,7 +64,7 @@ val detektAll by tasks.registering(Detekt::class) {
     config.setFrom("$rootDir/config/detekt/detekt.yml")
 
     include("**/*.kt")
-    exclude("**/*.kts", "*/build/*", "/buildSrc")
+    exclude("**/*.kts", "*/build/*", "/buildSrc", "**/test/**/*")
 
     baseline.set(file("$rootDir/config/detekt/baseline.xml"))
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-910" title="AR-910" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-910</a>  Initial Group Introduction System Message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we don't show a system message when starting a group conversation.

### Solutions

This PR:
- Add the system message info, in conversation creation flow, about members the conversation was started with.
- Adds initial system message about conversation creation date
- Prepares the code for later offline backend handling for conversation creation with remote participants.

Needs to be merged **after** merging:
- https://github.com/wireapp/kalium/pull/1762

### Attachments

https://github.com/wireapp/wire-android-reloaded/assets/5806454/7ec16409-6b5e-4c23-be07-bbc04cfc34e3

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
