### PR TITLE
fix: wrong color values for import media button on dark mode [AR-3491]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -19,9 +19,9 @@
  */
 
 @file:Suppress("TooManyFunctions")
+
 package com.wire.android.ui.home.newconversation.common
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +53,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.DurationUnit
@@ -231,45 +232,9 @@ fun PreviewSelectParticipantsButtonsRowDisabledButton() {
     SelectParticipantsButtonsRow(selectedParticipantsCount = 0, mainButtonText = "Continue", onMainButtonClick = {})
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSendContentWithSelfDeletionButton() {
-    SendContentButton(
-        mainButtonText = "Send",
-        count = 1,
-        onMainButtonClick = {},
-        onSelfDeletionTimerClicked = {},
-        selfDeletionTimer = SelfDeletionTimer.Enabled(ZERO)
-    )
-}
-
-@Preview
-@Composable
-fun PreviewSendContentWithSelfDeletionDisabledButton() {
-    SendContentButton(
-        mainButtonText = "Self-deleting messages",
-        count = 0,
-        onMainButtonClick = {},
-        onSelfDeletionTimerClicked = {},
-        selfDeletionTimer = SelfDeletionTimer.Enabled(10.toDuration(DurationUnit.SECONDS))
-    )
-}
-
-@Preview
-@Composable
-fun PreviewSendContentWithSelfDeletionSelectedButton() {
-    SendContentButton(
-        mainButtonText = "Self-deleting messages",
-        count = 1,
-        onMainButtonClick = {},
-        onSelfDeletionTimerClicked = {},
-        selfDeletionTimer = SelfDeletionTimer.Enabled(10.toDuration(DurationUnit.SECONDS))
-    )
-}
-
-@Preview(uiMode = UI_MODE_NIGHT_YES, showBackground = true)
-@Composable
-fun PreviewDarkModeSendContentWithSelfDeletionButton() {
     WireTheme {
         SendContentButton(
             mainButtonText = "Send",
@@ -281,23 +246,23 @@ fun PreviewDarkModeSendContentWithSelfDeletionButton() {
     }
 }
 
-@Preview(uiMode = UI_MODE_NIGHT_YES, showBackground = true)
+@PreviewMultipleThemes
 @Composable
-fun PreviewDarkModeSendContentWithSelfDeletionDisabledButton() {
+fun PreviewSendContentWithSelfDeletionDisabledButton() {
     WireTheme {
         SendContentButton(
             mainButtonText = "Self-deleting messages",
             count = 0,
             onMainButtonClick = {},
             onSelfDeletionTimerClicked = {},
-            selfDeletionTimer = SelfDeletionTimer.Enabled(ZERO)
+            selfDeletionTimer = SelfDeletionTimer.Enabled(10.toDuration(DurationUnit.SECONDS))
         )
     }
 }
 
-@Preview(uiMode = UI_MODE_NIGHT_YES, showBackground = true)
+@PreviewMultipleThemes
 @Composable
-fun PreviewDarkModeSendContentWithSelfDeletionSelectedButton() {
+fun PreviewSendContentWithSelfDeletionSelectedButton() {
     WireTheme {
         SendContentButton(
             mainButtonText = "Self-deleting messages",

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -18,11 +18,11 @@
  *
  */
 
+@file:Suppress("TooManyFunctions")
 package com.wire.android.ui.home.newconversation.common
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -37,7 +37,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,11 +44,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
-import com.wire.android.ui.common.button.WireButtonColors
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
-import com.wire.android.ui.common.button.wirePrimaryButtonColors
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -43,7 +43,6 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.button.WirePrimaryButton
-import com.wire.android.ui.common.button.wirePrimaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -263,20 +263,16 @@ private fun ImportMediaBottomBar(
 ) {
     val selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer
     val shortDurationLabel = selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel
-    val (mainButtonText, mainButtonColors) = if (selfDeletionTimer.toDuration() > Duration.ZERO) {
-        "${stringResource(id = R.string.self_deleting_message_label)} (${shortDurationLabel.asString()})" to wirePrimaryButtonColors().copy(
-            enabled = colorsScheme().onPrimaryButtonEnabled,
-            onEnabled = colorsScheme().primaryButtonEnabled
-        )
+    val mainButtonText = if (selfDeletionTimer.toDuration() > Duration.ZERO) {
+        "${stringResource(id = R.string.self_deleting_message_label)} (${shortDurationLabel.asString()})"
     } else {
-        stringResource(id = R.string.import_media_send_button_title) to wirePrimaryButtonColors()
+        stringResource(id = R.string.import_media_send_button_title)
     }
     SendContentButton(
         mainButtonText = mainButtonText,
         count = importMediaViewModel.currentSelectedConversationsCount(),
         onMainButtonClick = importMediaViewModel::checkRestrictionsAndSendImportedMedia,
         selfDeletionTimer = selfDeletionTimer,
-        mainButtonColors = mainButtonColors,
         onSelfDeletionTimerClicked = importMediaScreenState::showBottomSheetMenu,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -252,7 +252,7 @@ private val DarkWireColorScheme = WireColorScheme(
     secondaryButtonEnabled = WireColorPalette.Gray90, onSecondaryButtonEnabled = Color.White,
     secondaryButtonEnabledOutline = WireColorPalette.Gray100,
     secondaryButtonDisabled = WireColorPalette.Gray95, onSecondaryButtonDisabled = WireColorPalette.Gray70,
-    secondaryButtonDisabledOutline = WireColorPalette.Gray90,
+    secondaryButtonDisabledOutline = WireColorPalette.Gray80,
     secondaryButtonSelected = WireColorPalette.DarkBlue800, onSecondaryButtonSelected = Color.White,
     secondaryButtonSelectedOutline = WireColorPalette.DarkBlue700,
     secondaryButtonRipple = Color.White,

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -254,7 +254,7 @@ private val DarkWireColorScheme = WireColorScheme(
     secondaryButtonDisabled = WireColorPalette.Gray95, onSecondaryButtonDisabled = WireColorPalette.Gray70,
     secondaryButtonDisabledOutline = WireColorPalette.Gray80,
     secondaryButtonSelected = WireColorPalette.DarkBlue800, onSecondaryButtonSelected = Color.White,
-    secondaryButtonSelectedOutline = WireColorPalette.DarkBlue700,
+    secondaryButtonSelectedOutline = WireColorPalette.DarkBlue600,
     secondaryButtonRipple = Color.White,
     tertiaryButtonEnabled = Color.Transparent, onTertiaryButtonEnabled = Color.White,
     tertiaryButtonDisabled = Color.Transparent, onTertiaryButtonDisabled = WireColorPalette.Gray60,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-3491" title="AR-3491" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-3491</a>  [share extension] Adjust "Send as self-deleting message" button for dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Button colors were wrongly applied (hardcoded) to the `SendContentButton` component instead of relying on the button state modifiers. The icon color though, needed to be specified to the Composable image via the `colorFilter` method.

### Attachments (Optional)
<img width="447" alt="Captura de pantalla 2023-05-31 a las 15 57 30" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/d68fb39b-0580-4379-8b8b-3e7635e365ca">


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
