### PR TITLE
chore: add annotation to preview multiple themes

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -72,6 +72,7 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.ui.PreviewMultipleThemes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -277,7 +278,7 @@ private fun LoginButton(modifier: Modifier, loading: Boolean, enabled: Boolean, 
     }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewLoginEmailScreen() {
     val scope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.authentication.login.LoginError

--- a/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.ui.common
 
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -40,7 +39,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.theme.WireTheme

--- a/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
@@ -45,7 +45,6 @@ import com.wire.android.R
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.ui.PreviewLightDark
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/SecurityClassificationBanner.kt
@@ -45,6 +45,8 @@ import com.wire.android.R
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewLightDark
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 
 @Composable
@@ -126,15 +128,7 @@ private fun getIconFor(securityClassificationType: SecurityClassificationType): 
     }
 }
 
-@Preview(
-    name = "Classified Indication - Light Mode",
-    showBackground = true
-)
-@Preview(
-    name = "Classified Indication - Dark Mode",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    showBackground = true
-)
+@PreviewMultipleThemes
 @Composable
 fun PreviewClassifiedIndicator() {
     WireTheme {

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
@@ -24,13 +24,14 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun FileRestrictionDialog(
@@ -130,20 +131,26 @@ fun WelcomeNewUserDialog(
     )
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun previewFileRestrictionDialog() {
-    FileRestrictionDialog(true) {}
+    WireTheme {
+        FileRestrictionDialog(true) {}
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun previewGuestRoomLinkFeatureFlagDialog() {
-    GuestRoomLinkFeatureFlagDialog(true) {}
+    WireTheme {
+        GuestRoomLinkFeatureFlagDialog(true) {}
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun previewWelcomeNewUserDialog() {
-    WelcomeNewUserDialog({})
+    WireTheme {
+        WelcomeNewUserDialog({})
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
@@ -22,7 +22,6 @@ package com.wire.android.ui.home
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.wire.android.model.Clickable
@@ -31,6 +30,8 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 
 @Composable
@@ -56,8 +57,10 @@ fun HomeTopBar(
     )
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewTopBar() {
-    HomeTopBar(null, UserAvailabilityStatus.AVAILABLE,  "Title", 0.dp, {}, {})
+    WireTheme {
+        HomeTopBar(null, UserAvailabilityStatus.AVAILABLE, "Title", 0.dp, {}, {})
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.colorsScheme

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -64,8 +64,10 @@ import com.wire.android.ui.home.conversations.mock.mockMessageWithKnock
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent.SystemMessage
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.annotatedText
 import com.wire.android.util.ui.toUIText
@@ -180,91 +182,103 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
     }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageAdded7Users() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.MemberAdded(
-                "Barbara Cotolina".toUIText(),
-                listOf(
-                    "Albert Lewis".toUIText(),
-                    "Bert Strunk".toUIText(),
-                    "Claudia Schiffer".toUIText(),
-                    "Dorothee Friedrich".toUIText(),
-                    "Erich Weinert".toUIText(),
-                    "Frieda Kahlo".toUIText(),
-                    "Gudrun Gut".toUIText()
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberAdded(
+                    "Barbara Cotolina".toUIText(),
+                    listOf(
+                        "Albert Lewis".toUIText(),
+                        "Bert Strunk".toUIText(),
+                        "Claudia Schiffer".toUIText(),
+                        "Dorothee Friedrich".toUIText(),
+                        "Erich Weinert".toUIText(),
+                        "Frieda Kahlo".toUIText(),
+                        "Gudrun Gut".toUIText()
+                    )
                 )
             )
         )
-    )
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageAdded4Users() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.MemberAdded(
-                "Barbara Cotolina".toUIText(),
-                listOf(
-                    "Albert Lewis".toUIText(),
-                    "Bert Strunk".toUIText(),
-                    "Claudia Schiffer".toUIText(),
-                    "Dorothee Friedrich".toUIText()
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberAdded(
+                    "Barbara Cotolina".toUIText(),
+                    listOf(
+                        "Albert Lewis".toUIText(),
+                        "Bert Strunk".toUIText(),
+                        "Claudia Schiffer".toUIText(),
+                        "Dorothee Friedrich".toUIText()
+                    )
                 )
             )
         )
-    )
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageRemoved4Users() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.MemberRemoved(
-                "Barbara Cotolina".toUIText(),
-                listOf(
-                    "Albert Lewis".toUIText(),
-                    "Bert Strunk".toUIText(),
-                    "Claudia Schiffer".toUIText(),
-                    "Dorothee Friedrich".toUIText()
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberRemoved(
+                    "Barbara Cotolina".toUIText(),
+                    listOf(
+                        "Albert Lewis".toUIText(),
+                        "Bert Strunk".toUIText(),
+                        "Claudia Schiffer".toUIText(),
+                        "Dorothee Friedrich".toUIText()
+                    )
                 )
             )
         )
-    )
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageLeft() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.MemberLeft(UIText.DynamicString("Barbara Cotolina"))
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberLeft(UIText.DynamicString("Barbara Cotolina"))
+            )
         )
-    )
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageMissedCall() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.MissedCall.OtherCalled(UIText.DynamicString("Barbara Cotolina"))
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MissedCall.OtherCalled(UIText.DynamicString("Barbara Cotolina"))
+            )
         )
-    )
+    }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewSystemMessageKnock() {
-    SystemMessageItem(
-        message = mockMessageWithKnock.copy(
-            messageContent = SystemMessage.Knock(UIText.DynamicString("Barbara Cotolina"))
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.Knock(UIText.DynamicString("Barbara Cotolina"))
+            )
         )
-    )
+    }
 }
 
 private val SystemMessage.expandable

--- a/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
@@ -20,6 +20,8 @@ package com.wire.android.util.ui
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.ui.theme.WireColorScheme
+import com.wire.android.ui.theme.WireTheme
 
 @Preview(
     name = "Dark theme",
@@ -33,4 +35,15 @@ import androidx.compose.ui.tooling.preview.Preview
     backgroundColor = 0xFFEDEFF0,
     uiMode = UI_MODE_NIGHT_NO
 )
+/**
+ * Helper annotation that adds a preview for Light and Dark theme previews, _i.e._
+ * with [Preview.uiMode] set to [UI_MODE_NIGHT_NO] and [UI_MODE_NIGHT_YES].
+ * It has hardcoded background colors following the [WireColorScheme].
+ *
+ * **Important**
+ *
+ * Just like regular [Preview] annotations, it's important that the composable
+ * preview is actually reactive to the change in theme. So it might be necessary
+ * to wrap the preview in a [WireTheme] block.
+ */
 annotation class PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.ui
+
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "Dark theme",
+    showBackground = true,
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Preview(
+    name = " Light theme",
+    showBackground = true,
+    uiMode = UI_MODE_NIGHT_NO
+)
+annotation class PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
@@ -24,11 +24,13 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(
     name = "Dark theme",
     showBackground = true,
+    backgroundColor = 0xFF17181A,
     uiMode = UI_MODE_NIGHT_YES
 )
 @Preview(
     name = "Light theme",
     showBackground = true,
+    backgroundColor = 0xFFEDEFF0,
     uiMode = UI_MODE_NIGHT_NO
 )
 annotation class PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
     uiMode = UI_MODE_NIGHT_YES
 )
 @Preview(
-    name = " Light theme",
+    name = "Light theme",
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It's a bit annoying, tedious, repetitive, and error-prone, to have to add multiple `@Preview` annotations in Compose. Leading us to forget to preview the same component in multiple configurations.

### Solutions

Add a new annotation called `@PreviewMultipleThemes` that on its turn is annotated with a Light and Dark theme.

It also has bundled in `Light` and `Dark` names, so we don't need to type the `name = ` property manually.

As a plus, I took the liberty to add it to some previews so there's more chance they spread in the codebase.

It might be needed to add `WireTheme { }` around the preview to make sure the preview is using the WireTheme.

### Attachments

| Before | After |
| ----------- | ------------ |
| ![image](https://github.com/wireapp/wire-android-reloaded/assets/9389043/5ba2f64c-5520-452c-a36e-e03cd49c618e) | ![image](https://github.com/wireapp/wire-android-reloaded/assets/9389043/b319ba35-c6c5-4616-8fe4-49cba2c960c0) |

Two for the price of one!

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
