### PR TITLE
fix: app stuck on connecting after opening a summary notification [WPB-763]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -74,18 +74,7 @@ fun otherUserProfilePendingIntent(context: Context, destinationUserId: String, u
 fun callMessagePendingIntent(context: Context, conversationId: String, userId: String?): PendingIntent =
     messagePendingIntent(context, conversationId, userId)
 
-fun summaryMessagePendingIntent(context: Context): PendingIntent {
-    val intent = Intent(context.applicationContext, WireActivity::class.java).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-    }
-
-    return PendingIntent.getActivity(
-        context.applicationContext,
-        MESSAGE_NOTIFICATIONS_SUMMARY_REQUEST_CODE,
-        intent,
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-    )
-}
+fun summaryMessagePendingIntent(context: Context): PendingIntent = openAppPendingIntent(context)
 
 fun replyMessagePendingIntent(context: Context, conversationId: String, userId: String?): PendingIntent = PendingIntent.getBroadcast(
     context,
@@ -186,7 +175,11 @@ fun openMigrationLoginPendingIntent(context: Context, userHandle: String): Pendi
     )
 
 fun openAppPendingIntent(context: Context): PendingIntent {
-    val appIntent = Intent(context.applicationContext, WireActivity::class.java)
+    val appIntent = Intent(context.applicationContext, WireActivity::class.java).apply {
+        // pass empty URI so the OS will call onNewIntent instead of onCreate
+        // for the WireActivity, keeping it open
+        data = Uri.Builder().build()
+    }
     return PendingIntent.getActivity(
         context.applicationContext,
         MESSAGE_NOTIFICATIONS_SUMMARY_REQUEST_CODE,

--- a/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import app.cash.turbine.test
+import com.wire.android.config.CoroutineTestExtension
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class CurrentScreenManagerTest {
+
+    @Test
+    fun givenInitialState_whenThereIsNoResumeEvent_thenAppShouldNotBeOnForeground() = runTest {
+        val (_, currentScreenManager) = Arrangement()
+            .withScreenStateFlow(MutableStateFlow(true))
+            .arrange()
+
+        currentScreenManager.isAppOnForegroundFlow().test {
+            awaitItem() shouldBe false
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun givenInitialState_whenThereIsAResumeEvent_thenAppShouldBeOnForeground() = runTest {
+        val (_, currentScreenManager) = Arrangement()
+            .withScreenStateFlow(MutableStateFlow(true))
+            .arrange()
+
+        currentScreenManager.isAppOnForegroundFlow().test {
+            awaitItem() shouldBe false
+            currentScreenManager.onResume(StubLifecycleOwner())
+            awaitItem() shouldBe true
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun givenTwoResumes_whenTheresASingleStop_shouldStillMarkAsAppOnForeground() = runTest {
+        val (_, currentScreenManager) = Arrangement()
+            .withScreenStateFlow(MutableStateFlow(true))
+            .arrange()
+
+        currentScreenManager.onResume(StubLifecycleOwner())
+        currentScreenManager.onResume(StubLifecycleOwner())
+
+        currentScreenManager.onStop(StubLifecycleOwner())
+
+        currentScreenManager.isAppOnForegroundFlow().test {
+            awaitItem() shouldBe true
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenTwoResumes_whenTheresAreTwoStops_shouldNotBeOnTheForeground() = runTest {
+        val (_, currentScreenManager) = Arrangement()
+            .withScreenStateFlow(MutableStateFlow(true))
+            .arrange()
+
+        currentScreenManager.onResume(StubLifecycleOwner())
+        currentScreenManager.onResume(StubLifecycleOwner())
+
+        currentScreenManager.onStop(StubLifecycleOwner())
+        currentScreenManager.onStop(StubLifecycleOwner())
+
+        currentScreenManager.isAppOnForegroundFlow().test {
+            awaitItem() shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var screenStateObserver: ScreenStateObserver
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun withScreenStateFlow(flow: StateFlow<Boolean>) = apply {
+            every { screenStateObserver.screenStateFlow } returns flow
+        }
+
+        fun arrange() = this to CurrentScreenManager(
+            screenStateObserver
+        )
+
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
@@ -111,6 +111,5 @@ class CurrentScreenManagerTest {
         fun arrange() = this to CurrentScreenManager(
             screenStateObserver
         )
-
     }
 }

--- a/app/src/test/kotlin/com/wire/android/util/StubLifecycle.kt
+++ b/app/src/test/kotlin/com/wire/android/util/StubLifecycle.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+class StubLifecycle(override var currentState: State = State.CREATED) : Lifecycle() {
+
+    override fun addObserver(observer: LifecycleObserver) = Unit
+
+    override fun removeObserver(observer: LifecycleObserver) = Unit
+}
+
+class StubLifecycleOwner(override val lifecycle: Lifecycle = StubLifecycle()) : LifecycleOwner


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-763" title="WPB-763" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-763</a>  Stuck on connecting when tapping on grouped notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When clicking on the notification summary, persistent websocket, or `Ongoing call` notification, the app would go offline and not recover until paused/resumed.

### Causes

For some reason that I couldn't figure out, a simple `Intent(context.applicationContext, WireActivity::class.java)` can recreate the `WireActivity` even with `singleTask`, `allowTaskReparenting` and whatnot.

This would cause the following calls to be made, in order:
1. New `WireActivity` being initialised, calling `onResume`.
2. Past `WireActivity` being destroyed, calling `onStop`.

This switches the connection policy to `DISCONNECT_AFTER_PENDING_EVENTS` and the websocket is disconnected without any intention to reconnect.

### Solutions

Two parts:

1. Add an empty `Uri.Builder().build` to the Intent data when launching the `WireActivity`. This seems to solve the case where the activity is already on top and prevents the recreation of the activity.
2. Make the `CurrentScreenManager` sturdier and behave well even if the `WireActivity` is recreated for whatever reason beyond our control.

The second approach consists of keeping an integer, that counts up when the UI elements go to the foreground, and counts down when they go to the background.

If the integer is positive, the app is considered to be on the foreground.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Receive 2 notifications on 2 different conversations.
Keep the application on the foreground.
Make sure the system notification is collapsed.
Click on the collapsed/summary notification.

### Attachments 

#### Before

Notice that the `Connecting...` status bar shows up. And before that, the whole Activity is recreated.

https://github.com/wireapp/wire-android-reloaded/assets/9389043/887e12dc-9c5a-4194-87be-a1fb1844334b   

#### After

No more Activity recreation. App stays connected.

https://github.com/wireapp/wire-android-reloaded/assets/9389043/db2805a4-8631-4cae-86c5-008198a9a6cd

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
