### PR TITLE
fix: correctly identify if app is visible

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -59,14 +59,14 @@ class CurrentScreenManager @Inject constructor(
 
     /**
      * An integer that counts up when a screen appears, and counts down when
-     * the screen goes to the background.
+     * the screen goes away.
      * Better than a simple boolean in cases where an activity is re-started,
      * which may result the new instance being shown BEFORE the old instance being hidden.
      */
-    private val foregroundCount = AtomicInteger(0)
-    private val isOnForegroundFlow = MutableStateFlow(false)
+    private val visibilityCount = AtomicInteger(0)
+    private val isApplicationVisibleFlow = MutableStateFlow(false)
     private val isAppVisibleFlow = screenStateObserver.screenStateFlow.combine(
-        isOnForegroundFlow
+        isApplicationVisibleFlow
     ) { isScreenOn, isOnForeground ->
         isOnForeground && isScreenOn
     }
@@ -80,16 +80,24 @@ class CurrentScreenManager @Inject constructor(
         .stateIn(scope)
 
     /**
-     * Informs if the UI was visible at least once since the app started
+     * Informs if the UI is visible at the moment.
+     * Visibility doesn't necessarily mean being on the foreground. For example,
+     * if the device screen is split into multiple activities, and the app is currently not being focused,
+     * the app is considered to be on the background, but **still visible and working** fine.
      */
-    fun isAppOnForegroundFlow(): StateFlow<Boolean> = isOnForegroundFlow
+    fun isAppVisibleFlow(): StateFlow<Boolean> = isApplicationVisibleFlow
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         appLogger.i("${TAG}: onResume called")
-        foregroundCount.getAndUpdate { currentValue ->
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        appLogger.i("${TAG}: onStart called")
+        visibilityCount.getAndUpdate { currentValue ->
             val newValue = maxOf(0, currentValue + 1)
-            isOnForegroundFlow.value = newValue > 0
+            isApplicationVisibleFlow.value = newValue > 0
             newValue
         }
     }
@@ -97,16 +105,20 @@ class CurrentScreenManager @Inject constructor(
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         appLogger.i("${TAG}: onStop called")
-        foregroundCount.getAndUpdate { currentValue ->
+        visibilityCount.getAndUpdate { currentValue ->
             val newValue = maxOf(0, currentValue - 1)
-            isOnForegroundFlow.value = newValue > 0
+            isApplicationVisibleFlow.value = newValue > 0
             newValue
         }
     }
 
     override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         val currentItem = controller.getCurrentNavigationItem()
-        currentScreenState.value = CurrentScreen.fromNavigationItem(currentItem, arguments, isOnForegroundFlow.value)
+        currentScreenState.value = CurrentScreen.fromNavigationItem(
+            currentItem,
+            arguments,
+            isApplicationVisibleFlow.value
+        )
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/CurrentScreenManagerTest.kt
@@ -33,12 +33,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 class CurrentScreenManagerTest {
 
     @Test
-    fun givenInitialState_whenThereIsNoResumeEvent_thenAppShouldNotBeOnForeground() = runTest {
+    fun givenInitialState_whenThereIsNoStartEvent_thenAppShouldNotBeOnForeground() = runTest {
         val (_, currentScreenManager) = Arrangement()
             .withScreenStateFlow(MutableStateFlow(true))
             .arrange()
 
-        currentScreenManager.isAppOnForegroundFlow().test {
+        currentScreenManager.isAppVisibleFlow().test {
             awaitItem() shouldBe false
             expectNoEvents()
             cancel()
@@ -46,14 +46,14 @@ class CurrentScreenManagerTest {
     }
 
     @Test
-    fun givenInitialState_whenThereIsAResumeEvent_thenAppShouldBeOnForeground() = runTest {
+    fun givenInitialState_whenThereIsAStartEvent_thenAppShouldBeOnForeground() = runTest {
         val (_, currentScreenManager) = Arrangement()
             .withScreenStateFlow(MutableStateFlow(true))
             .arrange()
 
-        currentScreenManager.isAppOnForegroundFlow().test {
+        currentScreenManager.isAppVisibleFlow().test {
             awaitItem() shouldBe false
-            currentScreenManager.onResume(StubLifecycleOwner())
+            currentScreenManager.onStart(StubLifecycleOwner())
             awaitItem() shouldBe true
             expectNoEvents()
             cancel()
@@ -61,35 +61,35 @@ class CurrentScreenManagerTest {
     }
 
     @Test
-    fun givenTwoResumes_whenTheresASingleStop_shouldStillMarkAsAppOnForeground() = runTest {
+    fun givenTwoStarts_whenTheresASingleStop_shouldStillMarkAsAppOnForeground() = runTest {
         val (_, currentScreenManager) = Arrangement()
             .withScreenStateFlow(MutableStateFlow(true))
             .arrange()
 
-        currentScreenManager.onResume(StubLifecycleOwner())
-        currentScreenManager.onResume(StubLifecycleOwner())
+        currentScreenManager.onStart(StubLifecycleOwner())
+        currentScreenManager.onStart(StubLifecycleOwner())
 
         currentScreenManager.onStop(StubLifecycleOwner())
 
-        currentScreenManager.isAppOnForegroundFlow().test {
+        currentScreenManager.isAppVisibleFlow().test {
             awaitItem() shouldBe true
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun givenTwoResumes_whenTheresAreTwoStops_shouldNotBeOnTheForeground() = runTest {
+    fun givenTwoStarts_whenTheresAreTwoStops_shouldNotBeOnTheForeground() = runTest {
         val (_, currentScreenManager) = Arrangement()
             .withScreenStateFlow(MutableStateFlow(true))
             .arrange()
 
-        currentScreenManager.onResume(StubLifecycleOwner())
-        currentScreenManager.onResume(StubLifecycleOwner())
+        currentScreenManager.onStart(StubLifecycleOwner())
+        currentScreenManager.onStart(StubLifecycleOwner())
 
         currentScreenManager.onStop(StubLifecycleOwner())
         currentScreenManager.onStop(StubLifecycleOwner())
 
-        currentScreenManager.isAppOnForegroundFlow().test {
+        currentScreenManager.isAppVisibleFlow().test {
             awaitItem() shouldBe false
             cancelAndIgnoreRemainingEvents()
         }

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -40,7 +40,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -116,10 +115,8 @@ class ConnectionPolicyManagerTest {
         @MockK
         lateinit var migrationManager: MigrationManager
 
-        var coroutineScope = TestCoroutineScope()
-
         private val connectionPolicyManager by lazy {
-            ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider(), migrationManager, coroutineScope)
+            ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider(), migrationManager)
         }
 
         init {
@@ -134,11 +131,11 @@ class ConnectionPolicyManagerTest {
         }
 
         fun withAppInTheBackground() = apply {
-            every { currentScreenManager.isAppOnForegroundFlow() } returns MutableStateFlow(false)
+            every { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(false)
         }
 
         fun withAppInTheForeground() = apply {
-            every { currentScreenManager.isAppOnForegroundFlow() } returns MutableStateFlow(true)
+            every { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(true)
         }
 
         fun withCurrentSession(userId: UserId) = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is not properly switching to `DISCONNECT_AFTER_PENDING_EVENTS` when going to the background.

### Causes

- #1843

On #1843 I've changed the logic for detecting if the app is on the background or not. Due to historic reasons I ended up using `onResume` and `onStop` which is not a proper pair, and can result in more `onResume` calls than `onStop`.

One way to reproduce it is:
1. Get in a call
2. Trigger the ear detection sensor, so the screen goes black

Once the screen goes back on, an `onResume` will be called. But `onStop` was never called. So the "foregroundCounter" goes up by one.

### Solutions

Use only `onStart` instead of `onResume`.

Using `onResume` is quite overkill for just checking if the app is visible and has access to all resources.

> **Note**: This PR goes hand-in-hand with this one from Kalium:
> - https://github.com/wireapp/kalium/pull/1791
> Where there are improvements to resetting the retry timer once the ConnectionPolicy is ugpraded

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

1. Get in a call
2. Trigger the ear detection sensor, so the screen goes black
3. Minimise the app (go back to your phone's home screen)
4. Re-open the app

You _should_ see the `Connecting` bar for a short time.
#1843 introduced this bug, where it wouldn't disconnect while on the background.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
