### PR TITLE
feat: sso login with domain open login webpage

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -115,8 +115,11 @@ class LoginSSOViewModel @Inject constructor(
                         is FetchSSOSettingsUseCase.Result.Failure -> {}
                         is FetchSSOSettingsUseCase.Result.Success -> {
                             it.defaultSSOCode?.let { ssoCode ->
+                                val ssoCodeWithPrefix = ssoCode.startsWith("wire-").let { hasPrefix ->
+                                    if (hasPrefix) ssoCode else "wire-$ssoCode"
+                                }
                                 authScope.ssoLoginScope.initiate(
-                                    SSOInitiateLoginUseCase.Param.WithRedirect("wire-${ssoCode}")
+                                    SSOInitiateLoginUseCase.Param.WithRedirect(ssoCodeWithPrefix)
                                 ).let { result ->
                                     when (result) {
                                         is SSOInitiateLoginResult.Failure -> updateSSOLoginError(result.toLoginSSOError())

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -115,7 +115,9 @@ class LoginSSOViewModel @Inject constructor(
                         is FetchSSOSettingsUseCase.Result.Failure -> {}
                         is FetchSSOSettingsUseCase.Result.Success -> {
                             it.defaultSSOCode?.let { ssoCode ->
-                                authScope.ssoLoginScope.initiate(SSOInitiateLoginUseCase.Param.WithRedirect("wire-${ssoCode}" )).let { result ->
+                                authScope.ssoLoginScope.initiate(
+                                    SSOInitiateLoginUseCase.Param.WithRedirect("wire-${ssoCode}")
+                                ).let { result ->
                                     when (result) {
                                         is SSOInitiateLoginResult.Failure -> updateSSOLoginError(result.toLoginSSOError())
                                         is SSOInitiateLoginResult.Success -> openWebUrl(result.requestUrl)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -115,9 +115,7 @@ class LoginSSOViewModel @Inject constructor(
                         is FetchSSOSettingsUseCase.Result.Failure -> {}
                         is FetchSSOSettingsUseCase.Result.Success -> {
                             it.defaultSSOCode?.let { ssoCode ->
-                                val ssoCodeWithPrefix = ssoCode.startsWith("wire-").let { hasPrefix ->
-                                    if (hasPrefix) ssoCode else "wire-$ssoCode"
-                                }
+                                val ssoCodeWithPrefix = if (ssoCode.startsWith("wire-")) ssoCode else "wire-$ssoCode"
                                 authScope.ssoLoginScope.initiate(
                                     SSOInitiateLoginUseCase.Param.WithRedirect(ssoCodeWithPrefix)
                                 ).let { result ->

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.auth.sso.FetchSSOSettingsUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
@@ -90,10 +91,43 @@ class LoginSSOViewModel @Inject constructor(
     }
 
     fun onCustomServerDialogConfirm() {
-        if (loginState.customServerDialogState != null) {
-            authServerConfigProvider.updateAuthServer(loginState.customServerDialogState!!.serverLinks)
+        viewModelScope.launch {
+            if (loginState.customServerDialogState != null) {
+                authServerConfigProvider.updateAuthServer(loginState.customServerDialogState!!.serverLinks)
+
+                val authScope = coreLogic.versionedAuthenticationScope(loginState.customServerDialogState!!.serverLinks)().let {
+                    when (it) {
+                        is AutoVersionAuthScopeUseCase.Result.Failure.Generic,
+                        AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion,
+                        AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> {
+                            loginState = loginState.copy(customServerDialogState = null)
+                            return@launch
+                        }
+
+                        is AutoVersionAuthScopeUseCase.Result.Success -> {
+                            it.authenticationScope
+                        }
+                    }
+                }
+
+                authScope.ssoLoginScope.fetchSSOSettings().also {
+                    when (it) {
+                        is FetchSSOSettingsUseCase.Result.Failure -> {}
+                        is FetchSSOSettingsUseCase.Result.Success -> {
+                            it.defaultSSOCode?.let { ssoCode ->
+                                authScope.ssoLoginScope.initiate(SSOInitiateLoginUseCase.Param.WithRedirect("wire-${ssoCode}" )).let { result ->
+                                    when (result) {
+                                        is SSOInitiateLoginResult.Failure -> updateSSOLoginError(result.toLoginSSOError())
+                                        is SSOInitiateLoginResult.Success -> openWebUrl(result.requestUrl)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                loginState = loginState.copy(customServerDialogState = null)
+            }
         }
-        loginState = loginState.copy(customServerDialogState = null)
     }
 
     @VisibleForTesting

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/MicrophoneButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/MicrophoneButton.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fetch user default sso code and start sso flow 

### Solutions

after user accepts backend switch check if the new server have a default sso code, if so then start sso login flow to the new server

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
