### PR TITLE
fix: drawer padding hiding the menu button [WPB-2242]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -67,7 +67,7 @@ data class NotificationConversation(
 sealed class NotificationMessage(open val author: NotificationMessageAuthor?, open val time: Long) {
     data class ObfuscatedMessage(
         override val time: Long
-    ): NotificationMessage(null, time)
+    ) : NotificationMessage(null, time)
     data class Text(
         override val author: NotificationMessageAuthor,
         override val time: Long,

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -28,10 +28,13 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.DrawerDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
@@ -46,6 +49,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.compose.NavHost
@@ -157,20 +161,23 @@ fun HomeContent(
         ModalNavigationDrawer(
             drawerState = drawerState,
             drawerContent = {
-                ModalDrawerSheet(
-                    drawerContainerColor = MaterialTheme.colorScheme.surface,
-                    drawerTonalElevation = 0.dp,
-                    drawerShape = RectangleShape,
-                    modifier = Modifier.padding(end = dimensions().homeDrawerSheetEndPadding)
-                ) {
-                    HomeDrawer(
-                        // TODO: logFilePath does not belong in the UI logic
-                        logFilePath = homeState.logFilePath,
-                        currentRoute = currentNavigationItem.route,
-                        navigateToHomeItem = ::navigateTo,
-                        navigateToItem = navigateToItem,
-                        onCloseDrawer = ::closeDrawer
-                    )
+                BoxWithConstraints {
+                    val maxWidth = min(this.maxWidth - dimensions().homeDrawerSheetEndPadding, DrawerDefaults.MaximumDrawerWidth)
+                    ModalDrawerSheet(
+                        drawerContainerColor = MaterialTheme.colorScheme.surface,
+                        drawerTonalElevation = 0.dp,
+                        drawerShape = RectangleShape,
+                        modifier = Modifier.widthIn(max = maxWidth)
+                    ) {
+                        HomeDrawer(
+                            // TODO: logFilePath does not belong in the UI logic
+                            logFilePath = homeState.logFilePath,
+                            currentRoute = currentNavigationItem.route,
+                            navigateToHomeItem = ::navigateTo,
+                            navigateToItem = navigateToItem,
+                            onCloseDrawer = ::closeDrawer
+                        )
+                    }
                 }
             },
             gesturesEnabled = drawerState.isOpen,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2242" title="WPB-2242" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2242</a>  Padding on conversation list is hiding Main Navigation button for Talkback and automated tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our tests and the Talkback function can not find the home menu navigation button (hamburger) by the content description.

### Causes (Optional)

Padding added to the drawer menu after the migration to material3, when closed, is still on screen at the left edge of the screen, here's how it look with some background color added to this padding:

<img src="https://github.com/wireapp/wire-android-reloaded/assets/30429749/eec43d71-554e-4479-aba6-4dadaa62eeeb" width="200">

and even though it's invisible, the system still thinks this button (the same happens with the search loop button on the search bar) is hidden so it hides the content description as it's not needed because it's not visible on the screen.

### Solutions

This padding was added as a fix for the other issue with drawer menu taking even the whole width of the screen.
Instead of simply adding the padding, calculate the max width that this menu should take and set this value in a modifier.

### Testing

#### How to Test

Enable Talkback on the device and try to highlight the menu button - it should be possible, so it means that its content description is available.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
