### PR TITLE
fix: do not start countdown when the message is enqueued for self delete

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -27,7 +27,9 @@ import kotlin.time.Duration.Companion.seconds
 fun rememberSelfDeletionTimer(expirationStatus: ExpirationStatus): SelfDeletionTimerHelper.SelfDeletionTimerState {
     val context = LocalContext.current
 
-    return remember { SelfDeletionTimerHelper(context).fromExpirationStatus(expirationStatus) }
+    return remember(
+        (expirationStatus as? ExpirationStatus.Expirable)?.selfDeletionStatus ?: true
+    ) { SelfDeletionTimerHelper(context).fromExpirationStatus(expirationStatus) }
 }
 
 class SelfDeletionTimerHelper(private val context: Context) {
@@ -36,7 +38,7 @@ class SelfDeletionTimerHelper(private val context: Context) {
         return if (expirationStatus is ExpirationStatus.Expirable) {
             with(expirationStatus) {
                 val timeLeft = calculateTimeLeft(selfDeletionStatus, expireAfter)
-                SelfDeletionTimerState.Expirable(context.resources, timeLeft, expireAfter)
+                SelfDeletionTimerState.Expirable(context.resources, timeLeft, expireAfter, selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started)
             }
         } else {
             SelfDeletionTimerState.NotExpirable
@@ -70,7 +72,8 @@ class SelfDeletionTimerHelper(private val context: Context) {
         class Expirable(
             private val resources: Resources,
             timeLeft: Duration,
-            private val expireAfter: Duration
+            private val expireAfter: Duration,
+            val timerStarted : Boolean
         ) : SelfDeletionTimerState() {
             companion object {
                 /**

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -38,7 +38,12 @@ class SelfDeletionTimerHelper(private val context: Context) {
         return if (expirationStatus is ExpirationStatus.Expirable) {
             with(expirationStatus) {
                 val timeLeft = calculateTimeLeft(selfDeletionStatus, expireAfter)
-                SelfDeletionTimerState.Expirable(context.resources, timeLeft, expireAfter, selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started)
+                SelfDeletionTimerState.Expirable(
+                    context.resources,
+                    timeLeft,
+                    expireAfter,
+                    selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started
+                )
             }
         } else {
             SelfDeletionTimerState.NotExpirable
@@ -73,7 +78,7 @@ class SelfDeletionTimerHelper(private val context: Context) {
             private val resources: Resources,
             timeLeft: Duration,
             private val expireAfter: Duration,
-            val timerStarted : Boolean
+            val timerStarted: Boolean
         ) : SelfDeletionTimerState() {
             companion object {
                 /**

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -106,9 +106,9 @@ fun MessageItem(
 ) {
     with(message) {
         val selfDeletionTimerState = rememberSelfDeletionTimer(header.messageStatus.expirationStatus)
-        if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable &&
-            !message.isPending &&
-            !message.sendingFailed
+        if (
+            selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable
+            && selfDeletionTimerState.
         ) {
             startDeletionTimer(
                 message = message,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -107,7 +107,8 @@ fun MessageItem(
     with(message) {
         val selfDeletionTimerState = rememberSelfDeletionTimer(header.messageStatus.expirationStatus)
         if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable &&
-            !message.isPending
+            !message.isPending &&
+            !message.sendingFailed
         ) {
             startDeletionTimer(
                 message = message,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -108,7 +108,7 @@ fun MessageItem(
         val selfDeletionTimerState = rememberSelfDeletionTimer(header.messageStatus.expirationStatus)
         if (
             selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable
-            && selfDeletionTimerState.
+            && selfDeletionTimerState.timerStarted
         ) {
             startDeletionTimer(
                 message = message,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

do not start count down when sending fails

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
