### PR TITLE
fix(RC): backup dialog can be dismissed

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -62,6 +62,7 @@ import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.dialogs.CustomBEDeeplinkDialog
 import com.wire.android.ui.common.topappbar.CommonTopAppBar
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
 import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
@@ -236,7 +237,7 @@ class WireActivity : AppCompatActivity() {
                     onClick = onUpdateClick,
                     type = WireDialogButtonType.Primary
                 ),
-                properties = DialogProperties(
+                properties = wireDialogPropertiesBuilder(
                     dismissOnBackPress = false,
                     dismissOnClickOutside = false,
                     usePlatformDefaultWidth = true

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -188,28 +188,33 @@ private fun WireDialogContent(
                 }
             }
 
-            if (buttonsHorizontalAlignment)
+            if (buttonsHorizontalAlignment) {
                 Row(Modifier.padding(top = MaterialTheme.wireDimensions.dialogButtonsSpacing)) {
                     dismissButtonProperties.getButton(Modifier.weight(1f))
-                    if (dismissButtonProperties != null)
+                    if (dismissButtonProperties != null) {
                         Spacer(Modifier.width(MaterialTheme.wireDimensions.dialogButtonsSpacing))
+                    }
                     optionButton1Properties.getButton(Modifier.weight(1f))
-                    if (optionButton2Properties != null)
+                    if (optionButton2Properties != null) {
                         Spacer(Modifier.width(MaterialTheme.wireDimensions.dialogButtonsSpacing))
+                    }
                     optionButton2Properties.getButton(Modifier.weight(1f))
                 }
-            else
+            } else {
                 Column(Modifier.padding(top = MaterialTheme.wireDimensions.dialogButtonsSpacing)) {
                     optionButton1Properties.getButton()
 
-                    if (optionButton2Properties != null)
+                    if (optionButton2Properties != null) {
                         Spacer(Modifier.height(MaterialTheme.wireDimensions.dialogButtonsSpacing))
+                    }
                     optionButton2Properties.getButton()
 
-                    if (dismissButtonProperties != null)
+                    if (dismissButtonProperties != null) {
                         Spacer(Modifier.height(MaterialTheme.wireDimensions.dialogButtonsSpacing))
+                    }
                     dismissButtonProperties.getButton()
                 }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,15 +52,25 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.WireTertiaryButton
 import com.wire.android.ui.common.textfield.WirePasswordTextField
-import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 
-@OptIn(ExperimentalComposeUiApi::class)
+@Stable
+fun wireDialogPropertiesBuilder(
+    dismissOnBackPress: Boolean = true,
+    dismissOnClickOutside: Boolean = true,
+    usePlatformDefaultWidth: Boolean = false
+): DialogProperties = DialogProperties(
+    dismissOnBackPress = dismissOnBackPress,
+    dismissOnClickOutside = dismissOnClickOutside,
+    usePlatformDefaultWidth = usePlatformDefaultWidth
+)
+
 @Composable
 fun WireDialog(
     title: String,
@@ -210,8 +221,10 @@ private fun WireDialogButtonProperties?.getButton(modifier: Modifier = Modifier)
             when (type) {
                 WireDialogButtonType.Primary ->
                     WirePrimaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
+
                 WireDialogButtonType.Secondary ->
                     WireSecondaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
+
                 WireDialogButtonType.Tertiary ->
                     WireTertiaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
@@ -43,7 +43,10 @@ internal fun CustomBEDeeplinkDialog(
     with(wireActivityViewModel) {
         WireDialog(
             title = stringResource(R.string.custom_backend_dialog_title),
-            properties = wireDialogPropertiesBuilder(false, false),
+            properties = wireDialogPropertiesBuilder(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
+            ),
             text = LocalContext.current.resources.stringWithStyledArgs(
                 R.string.custom_backend_dialog_body,
                 MaterialTheme.wireTypography.body01,

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
@@ -31,6 +31,7 @@ import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -42,6 +43,7 @@ internal fun CustomBEDeeplinkDialog(
     with(wireActivityViewModel) {
         WireDialog(
             title = stringResource(R.string.custom_backend_dialog_title),
+            properties = wireDialogPropertiesBuilder(false, false),
             text = LocalContext.current.resources.stringWithStyledArgs(
                 R.string.custom_backend_dialog_body,
                 MaterialTheme.wireTypography.body01,

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomBEDeeplinkDialog.kt
@@ -77,5 +77,4 @@ internal fun CustomBEDeeplinkDialog(
     }
 }
 
-
 data class CustomBEDeeplinkDialogState(val serverLinks: ServerConfig.Links = ServerConfig.DEFAULT, val shouldShowDialog: Boolean = false)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -99,7 +99,10 @@ fun CreateBackupDialog(
     WireDialog(
         title = stringResource(R.string.backup_dialog_create_backup_title),
         onDismiss = onDismissDialog,
-        properties = wireDialogPropertiesBuilder(false, false),
+        properties = wireDialogPropertiesBuilder(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        ),
         optionButton1Properties = WireDialogButtonProperties(
             onClick = {
                 onSaveBackup()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.theme.wireTypography
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -98,6 +99,7 @@ fun CreateBackupDialog(
     WireDialog(
         title = stringResource(R.string.backup_dialog_create_backup_title),
         onDismiss = onDismissDialog,
+        properties = wireDialogPropertiesBuilder(false, false),
         optionButton1Properties = WireDialogButtonProperties(
             onClick = {
                 onSaveBackup()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -84,7 +84,10 @@ fun EnterRestorePasswordDialog(
             title = stringResource(R.string.backup_label_enter_password),
             text = stringResource(R.string.backup_dialog_restore_backup_password_message),
             onDismiss = onCancelBackupRestore,
-            properties = wireDialogPropertiesBuilder(false, false),
+            properties = wireDialogPropertiesBuilder(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
+            ),
             dismissButtonProperties = WireDialogButtonProperties(
                 onClick = onCancelBackupRestore,
                 text = stringResource(id = R.string.label_cancel),

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.home.messagecomposer.attachment.FileBrowserFlow
 import com.wire.android.ui.theme.wireTypography
 import kotlin.math.roundToInt
@@ -83,6 +84,7 @@ fun EnterRestorePasswordDialog(
             title = stringResource(R.string.backup_label_enter_password),
             text = stringResource(R.string.backup_dialog_restore_backup_password_message),
             onDismiss = onCancelBackupRestore,
+            properties = wireDialogPropertiesBuilder(false, false),
             dismissButtonProperties = WireDialogButtonProperties(
                 onClick = onCancelBackupRestore,
                 text = stringResource(id = R.string.label_cancel),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

backup dialog can be dismissed

### Solutions

disable dismiss on back press and clicking outside  

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
