### PR TITLE
chore: bump develop to 4.3.x

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,7 +35,7 @@ object AndroidClient {
     const val appId = "com.wire.android"
     const val namespace = appId
     val versionCode = Versionizer().versionCode
-    const val versionName = "4.2.0"
+    const val versionName = "4.3.0"
     const val testRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 


### PR DESCRIPTION
# What's new in this PR?

Now we have a RC branch for 4.2.x, so Bump develop to 4.3.x

