### PR TITLE
chore: building params jenkins branch adj

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
                         String flavor = x
                         String buildType = defineBuildType(flavor)
                         String stageName = "Build $flavor$buildType"
-                        String changeBranchIfMissing = handleChangeBranch(env.CHANGE_BRANCH)
+                        String definedChangeBranch = handleChangeBranch(env.CHANGE_BRANCH)
                         dynamicStages[stageName] = {
                             node {
                                 stage(stageName) {
@@ -106,7 +106,7 @@ pipeline {
                                             job: 'AR-build-pipeline',
                                             parameters: [
                                                     string(name: 'SOURCE_BRANCH', value: env.BRANCH_NAME),
-                                                    string(name: 'CHANGE_BRANCH', value: changeBranchIfMissing),
+                                                    string(name: 'CHANGE_BRANCH', value: definedChangeBranch),
                                                     string(name: 'BUILD_TYPE', value: buildType),
                                                     string(name: 'FLAVOR', value: flavor),
                                                     booleanParam(name: 'UPLOAD_TO_S3', value: true),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,18 @@ def postGithubComment(String changeId, String body) {
 
 }
 
+/**
+* Checks if the parameter is defined, otherwise sets it to the BRANCH_NAME env var
+*
+* @param changeBranch env var to use as the branch name if the changeBranch is not empty
+*/
+String handleChangeBranch(String changeBranch) {
+    if (changeBranch?.trim()) {
+        return changeBranch
+    }
+    return env.BRANCH_NAME
+}
+
 pipeline {
     agent {
         node {
@@ -86,6 +98,7 @@ pipeline {
                         String flavor = x
                         String buildType = defineBuildType(flavor)
                         String stageName = "Build $flavor$buildType"
+                        String changeBranchIfMissing = handleChangeBranch(env.CHANGE_BRANCH)
                         dynamicStages[stageName] = {
                             node {
                                 stage(stageName) {
@@ -93,7 +106,7 @@ pipeline {
                                             job: 'AR-build-pipeline',
                                             parameters: [
                                                     string(name: 'SOURCE_BRANCH', value: env.BRANCH_NAME),
-                                                    string(name: 'CHANGE_BRANCH', value: env.CHANGE_BRANCH),
+                                                    string(name: 'CHANGE_BRANCH', value: changeBranchIfMissing),
                                                     string(name: 'BUILD_TYPE', value: buildType),
                                                     string(name: 'FLAVOR', value: flavor),
                                                     booleanParam(name: 'UPLOAD_TO_S3', value: true),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing param to build from, when it's a branch.

I went to jenkins and setted up the run, with this parameter "change branch" and the build was successful as seeing here.
https://10.10.124.134/job/AR-build-pipeline/108/parameters/

### Solutions

If change branch is not defined, then replace it by branch name

#### How to Test

Cross fingers and see it running on Jenkins.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
