### PR TITLE
feat(RC): add a different gibberish message when self is not the sender

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -268,7 +268,7 @@ fun MessageItem(
 fun EphemeralMessageExpiredLabel(isSelfMessage: Boolean, conversationDetailsData: ConversationDetailsData) {
 
     val stringResource = if (!isSelfMessage) {
-        stringResource(id = R.string.never_gonna_give_you_up)
+        stringResource(id = R.string.label_information_waiting_for_deleation_when_self_not_sender)
     } else if (conversationDetailsData is ConversationDetailsData.OneOne) {
         conversationDetailsData.otherUserName?.let {
             stringResource(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -183,7 +183,7 @@ fun MessageItem(
                         // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver
                         // timer to expire to permanently delete the message, in the meantime we show the EphemeralMessageExpiredLabel
                         if (isDeleted) {
-                            EphemeralMessageExpiredLabel(conversationDetailsData)
+                            EphemeralMessageExpiredLabel(message.isMyMessage, conversationDetailsData)
                         }
                     } else {
                         MessageStatusLabel(messageStatus = message.header.messageStatus)
@@ -265,8 +265,11 @@ fun MessageItem(
 }
 
 @Composable
-fun EphemeralMessageExpiredLabel(conversationDetailsData: ConversationDetailsData) {
-    val stringResource = if (conversationDetailsData is ConversationDetailsData.OneOne) {
+fun EphemeralMessageExpiredLabel(isSelfMessage: Boolean, conversationDetailsData: ConversationDetailsData) {
+
+    val stringResource = if (!isSelfMessage) {
+        stringResource(id = R.string.never_gonna_give_you_up)
+    } else if (conversationDetailsData is ConversationDetailsData.OneOne) {
         conversationDetailsData.otherUserName?.let {
             stringResource(
                 R.string.label_information_waiting_for_recipient_timer_to_expire_one_to_one,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1016,6 +1016,7 @@
     <string name="automatically_delete_message_after">Automatically delete message after:</string>
     <string name="label_information_waiting_for_recipient_timer_to_expire_group">After one participant has seen your message and the timer has expired on their side, this note disappears.</string>
     <string name="label_information_waiting_for_recipient_timer_to_expire_one_to_one">After %1$s has seen your message and the timer has expired on their side, this note disappears.</string>
+    <string name="label_information_waiting_for_deleation_when_self_not_sender">Message will be deleted once you are online</string>
 
     <plurals name="weeks_left">
         <item quantity="one">1 week left</item>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

atm when the message timer runs out and the user is not online the message is not deleted and the content is visible 

### Solutions

1. mark the message as deleted before sending the delete message (from kalium)
2. set a new content to indicate that the message will be deleted later

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
