### PR TITLE
feat(v4.1): handling configuration for websocket enabled by default (WPB-967)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -20,13 +20,16 @@
 
 package com.wire.android.di
 
+import android.content.Context
 import android.os.Build
 import com.wire.android.BuildConfig
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.util.extension.isGoogleServicesAvailable
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -36,7 +39,7 @@ import kotlinx.coroutines.runBlocking
 class KaliumConfigsModule {
 
     @Provides
-    fun provideKaliumConfigs(globalDataStore: GlobalDataStore): KaliumConfigs {
+    fun provideKaliumConfigs(globalDataStore: GlobalDataStore, context: Context): KaliumConfigs {
         return KaliumConfigs(
             isChangeEmailEnabled = BuildConfig.ALLOW_CHANGE_OF_EMAIL,
             isLoggingEnabled = BuildConfig.LOGGING_ENABLED,
@@ -56,7 +59,8 @@ class KaliumConfigsModule {
             guestRoomLink = BuildConfig.ENABLE_GUEST_ROOM_LINK,
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
-            wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE
+            wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
+            isWebSocketEnabledByDefault = runBlocking { context.isGoogleServicesAvailable() }
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -59,7 +59,7 @@ class KaliumConfigsModule {
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
-            isWebSocketEnabledByDefault = runBlocking { context.isGoogleServicesAvailable() }
+            isWebSocketEnabledByDefault = runBlocking { !context.isGoogleServicesAvailable() }
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,6 +37,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.conversations.details.options.SwitchState
+import com.wire.android.util.extension.isGoogleServicesAvailable
 
 @Composable
 fun NetworkSettingsScreen(networkSettingsViewModel: NetworkSettingsViewModel = hiltViewModel()) {
@@ -56,7 +58,6 @@ fun NetworkSettingsScreenContent(
     isWebSocketEnabled: Boolean,
     setWebSocketState: (Boolean) -> Unit,
     backendName: String
-
 ) {
     Scaffold(topBar = {
         WireCenterAlignedTopAppBar(
@@ -76,13 +77,25 @@ fun NetworkSettingsScreenContent(
                     R.string.settings_keep_connection_to_websocket_description,
                     backendName
                 ),
-                switchState = SwitchState.Enabled(
-                    value = isWebSocketEnabled,
-                    onCheckedChange = setWebSocketState
-                ),
+                switchState = getSwitchState(isWebSocketEnabled, setWebSocketState),
                 arrowType = ArrowType.NONE
             )
         }
+    }
+}
+
+@Composable
+private fun getSwitchState(isWebSocketEnabled: Boolean, setWebSocketState: (Boolean) -> Unit): SwitchState {
+    val context = LocalContext.current
+    return if (context.isGoogleServicesAvailable()) {
+        SwitchState.Enabled(
+            value = isWebSocketEnabled,
+            onCheckedChange = setWebSocketState
+        )
+    } else {
+        SwitchState.Disabled(
+            value = isWebSocketEnabled,
+        )
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-967" title="WPB-967" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-967</a>  Websocket should be turned on by default on bund apps
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to enable the websocket by default on devices that doesn't support google play services. ie. col1/3/fdroid builds

### Solutions

When storing the session of the user, persist this config accordingly by configuration given by `KaliumConfig`
So we use the checks to know if this environment has google playservices and persist the account with this flag.

### Dependencies (Optional)

- https://github.com/wireapp/kalium/pull/1852

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
