### PR TITLE
feat(calling): show double tap indicator once per application lifetime (WPB-314)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -31,6 +31,7 @@ import com.wire.android.BuildConfig
 import com.wire.android.migration.failure.UserMigrationStatus
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -44,13 +45,18 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         private const val PREFERENCES_NAME = "global_data"
 
         // keys
+        private val SHOW_CALLING_DOUBLE_TAP_TOAST = booleanPreferencesKey("show_calling_double_tap_toast_")
         private val MIGRATION_COMPLETED = booleanPreferencesKey("migration_completed")
         private val WELCOME_SCREEN_PRESENTED = booleanPreferencesKey("welcome_screen_presented")
         private val IS_LOGGING_ENABLED = booleanPreferencesKey("is_logging_enabled")
         private val IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED = booleanPreferencesKey("is_encrypted_proteus_storage_enabled")
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
         private fun userMigrationStatusKey(userId: String): Preferences.Key<Int> = intPreferencesKey("user_migration_status_$userId")
-        private fun userLastMigrationAppVersion(userId: String): Preferences.Key<Int> = intPreferencesKey("migration_app_version_$userId")
+        private fun userDoubleTapToastStatusKey(userId: String): Preferences.Key<Boolean> =
+            booleanPreferencesKey("$SHOW_CALLING_DOUBLE_TAP_TOAST$userId")
+
+        private fun userLastMigrationAppVersion(userId: String): Preferences.Key<Int> =
+            intPreferencesKey("migration_app_version_$userId")
     }
 
     suspend fun clear() {
@@ -120,4 +126,12 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
 
     suspend fun getUserMigrationAppVersion(userId: String): Int? =
         context.dataStore.data.map { it[userLastMigrationAppVersion(userId)] }.firstOrNull()
+
+    suspend fun setShouldShowDoubleTapToastStatus(userId: String, shouldShow: Boolean) {
+        context.dataStore.edit { it[userDoubleTapToastStatusKey(userId)] = shouldShow }
+    }
+
+    suspend fun getShouldShowDoubleTapToast(userId: String): Boolean =
+        getBooleanPreference(userDoubleTapToastStatusKey(userId), true).first()
+
 }

--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -133,5 +133,4 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
 
     suspend fun getShouldShowDoubleTapToast(userId: String): Boolean =
         getBooleanPreference(userDoubleTapToastStatusKey(userId), true).first()
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -77,13 +77,7 @@ class OngoingCallViewModel @Inject constructor(
                 observeCurrentCall()
             }
         }
-        viewModelScope.launch {
-            delay(DELAY_TO_SHOW_DOUBLE_TAP_TOAST)
-            shouldShowDoubleTapToast = globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString())
-            if (shouldShowDoubleTapToast) {
-                startDoubleTapToastDisplayCountDown()
-            }
-        }
+        showDoubleTapToast()
     }
 
     private suspend fun observeCurrentCall() {
@@ -132,6 +126,16 @@ class OngoingCallViewModel @Inject constructor(
             }
         }
         doubleTapIndicatorCountDownTimer?.start()
+    }
+
+    private fun showDoubleTapToast() {
+        viewModelScope.launch {
+            delay(DELAY_TO_SHOW_DOUBLE_TAP_TOAST)
+            shouldShowDoubleTapToast = globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString())
+            if (shouldShowDoubleTapToast) {
+                startDoubleTapToastDisplayCountDown()
+            }
+        }
     }
 
     fun hideDoubleTapToast() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-314" title="WPB-314" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-314</a>  Indicate to the user that they can double click to maximise the video stream
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

double tap indicator is displayed every time we open ongoing call screen

### Solutions

Change it to be displayed only once for the current user per application lifetime.


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

1. Answer incoming call.
2. You should see the indicator
3. Second time you answer a call you should not see it
PS: If you switch to a different user you should see for the fist call as well

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
