### PR TITLE
chore: fix wrong logic test

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -186,6 +186,10 @@ class MyAccountViewModel @Inject constructor(
     }
 
     companion object {
+        /**
+         * This is a build time flag that allows to enable/disable the change email feature.
+         * NOTE: This is using this approach to being able to test correctly and not depend on custom build behavior.
+         */
         @JvmStatic
         fun isChangeEmailEnabledByBuild(): Boolean = BuildConfig.ALLOW_CHANGE_OF_EMAIL
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -91,8 +92,8 @@ class MyAccountViewModel @Inject constructor(
         }
         myAccountState = myAccountState.copy(
             isReadOnlyAccount = !managedByWire,
-            isEditEmailAllowed = !hasSAMLCred && managedByWire,
-            isEditHandleAllowed = managedByWire && BuildConfig.ALLOW_CHANGE_OF_EMAIL
+            isEditEmailAllowed = isChangeEmailEnabledByBuild() && !hasSAMLCred && managedByWire,
+            isEditHandleAllowed = managedByWire
         )
         viewModelScope.launch {
             fetchSelfUser()
@@ -182,5 +183,10 @@ class MyAccountViewModel @Inject constructor(
     sealed interface SettingsOperationResult {
         object None : SettingsOperationResult
         class Result(val message: UIText) : SettingsOperationResult
+    }
+
+    companion object {
+        @JvmStatic
+        fun isChangeEmailEnabledByBuild(): Boolean = BuildConfig.ALLOW_CHANGE_OF_EMAIL
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
@@ -138,23 +138,23 @@ class MyAccountViewModelTest {
     }
 
     @Test
-    fun `when user is managed by Wire, then edit handle is allowed`() = runTest {
+    fun `when user IS managed by Wire, then edit handle is allowed`() = runTest {
         val (_, viewModel) = Arrangement()
             .withUserRequiresPasswordResult(Success(true))
-            .withIsReadOnlyAccountResult(true)
-            .arrange()
-
-        assertFalse(viewModel.myAccountState.isEditHandleAllowed)
-    }
-
-    @Test
-    fun `when user is not managed by Wire, then edit handle is allowed`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withUserRequiresPasswordResult(Success(false))
             .withIsReadOnlyAccountResult(false)
             .arrange()
 
         assertTrue(viewModel.myAccountState.isEditHandleAllowed)
+    }
+
+    @Test
+    fun `when user IS NOT managed by Wire, then edit handle is not allowed`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withUserRequiresPasswordResult(Success(false))
+            .withIsReadOnlyAccountResult(true)
+            .arrange()
+
+        assertFalse(viewModel.myAccountState.isEditHandleAllowed)
     }
 
     private class Arrangement {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is a unit test that was being set up wronlgly, so we are getting bad results of it, because we check for 2 conditions:
- one in compile time `ALLOW_CHANGE_OF_EMAIL` 
- and a second one coming frome a use case.

### Causes (Optional)

Failed tests when we run unit test on CI, due to using a different buildtype

### Solutions

Fix the test logic, to represent the expected coverage.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
