### PR TITLE
fix: visual adjustments to learn more on remote failures link (WPB-2282)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -120,6 +120,7 @@ private fun MultiUserDeliveryFailure(
                     ),
                     textAlign = TextAlign.Start
                 )
+                OfflineBackendsLearnMoreLink()
             }
             if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
                 Text(
@@ -264,6 +265,7 @@ internal fun Modifier.customizeMessageBackground(
 @Composable
 internal fun OfflineBackendsLearnMoreLink(context: Context = LocalContext.current) {
     val learnMoreUrl = stringResource(R.string.url_message_details_offline_backends_learn_more)
+    VerticalSpace.x4()
     Text(
         modifier = Modifier.clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
         style = LocalTextStyle.current.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -120,7 +120,6 @@ private fun MultiUserDeliveryFailure(
                     ),
                     textAlign = TextAlign.Start
                 )
-                OfflineBackendsLearnMoreLink()
             }
             if (partialDeliveryFailureContent.noClients.isNotEmpty()) {
                 Text(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -17,6 +17,7 @@
  *
  *
  */
+@file:Suppress("TooManyFunctions")
 
 package com.wire.android.ui.home.conversations
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -320,6 +320,39 @@ fun PreviewSystemMessageKnock() {
     }
 }
 
+@PreviewMultipleThemes
+@Composable
+fun PreviewSystemMessageFailedToAddSingle() {
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberFailedToAdd(
+                    mapOf("wire.com" to listOf(UIText.DynamicString("Barbara Cotolina")))
+                )
+            )
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewSystemMessageFailedToAddMultiple() {
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = SystemMessage.MemberFailedToAdd(
+                    mapOf(
+                        "wire.com" to listOf(
+                            UIText.DynamicString("Barbara Cotolina"),
+                            UIText.DynamicString("Albert Lewis")
+                        )
+                    )
+                )
+            )
+        )
+    }
+}
+
 private val SystemMessage.expandable
     get() = when (this) {
         is SystemMessage.MemberAdded -> this.memberNames.size > EXPANDABLE_THRESHOLD


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2282" title="WPB-2282" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2282</a>  [Android] Add padding to button of learn more offline backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to adjust the learn more button on remote failures, it's too close to text.

### Causes (Optional)

The area for click is not enough

### Solutions

Add vertical space to the component.

### Attachments (Optional)

<img src="https://github.com/wireapp/wire-android-reloaded/assets/5806454/580348e2-1d8b-4720-b763-adcbf71685a7" width="300"/>

<img src="https://github.com/wireapp/wire-android-reloaded/assets/5806454/51f64195-7515-4c67-8266-fa624aa88fda" width="300"/>


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
