### PR TITLE
fix: crash when web client send message with broken mentions [WPB-3044]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -46,8 +46,8 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMess
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageParams
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImportedImageMessage
 import com.wire.android.ui.markdown.DisplayMention
-import com.wire.android.ui.markdown.MarkdownDocument
 import com.wire.android.ui.markdown.MarkdownConsts.MENTION_MARK
+import com.wire.android.ui.markdown.MarkdownDocument
 import com.wire.android.ui.markdown.NodeData
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -178,16 +178,21 @@ private fun mapToDisplayMentions(uiText: UIText, resources: Resources): Pair<Lis
     return if (uiText is UIText.DynamicString) {
         val stringBuilder: StringBuilder = StringBuilder(uiText.value)
         val mentions = uiText.mentions.sortedBy { it.start }.reversed()
-        val mentionList = mentions.map {
-            val mentionName = uiText.value.substring(it.start, it.start + it.length)
-            stringBuilder.insert(it.start + it.length, MENTION_MARK)
-            stringBuilder.insert(it.start, MENTION_MARK)
-            DisplayMention(
-                it.userId,
-                it.length,
-                it.isSelfMention,
-                mentionName
-            )
+        val mentionList = mentions.mapNotNull {
+            // secured crash for mentions caused by web when text without mentions contains mention data
+            if (it.start + it.length < uiText.value.length) {
+                val mentionName = uiText.value.substring(it.start, it.start + it.length)
+                stringBuilder.insert(it.start + it.length, MENTION_MARK)
+                stringBuilder.insert(it.start, MENTION_MARK)
+                DisplayMention(
+                    it.userId,
+                    it.length,
+                    it.isSelfMention,
+                    mentionName
+                )
+            } else {
+                null
+            }
         }.reversed()
         Pair(mentionList, stringBuilder.toString())
     } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -180,7 +180,7 @@ private fun mapToDisplayMentions(uiText: UIText, resources: Resources): Pair<Lis
         val mentions = uiText.mentions.sortedBy { it.start }.reversed()
         val mentionList = mentions.mapNotNull {
             // secured crash for mentions caused by web when text without mentions contains mention data
-            if (it.start + it.length < uiText.value.length) {
+            if (it.start + it.length < uiText.value.length && uiText.value.elementAt(it.start) == '@') {
                 val mentionName = uiText.value.substring(it.start, it.start + it.length)
                 stringBuilder.insert(it.start + it.length, MENTION_MARK)
                 stringBuilder.insert(it.start, MENTION_MARK)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3044" title="WPB-3044" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3044</a>  Crash when opening a conversation which contains a message with double mention and a link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The issue is because of web bug:
STR (Web or MacOS client):
1. Write long message with links and mentions
2. Don’t send it, just select entire text and remove it
3. Write normal text without mentions and send it
4. When you open conversation with that message on Android it will crash

### Causes (Optional)

Crash in AR, because mentions data are in normal text message without mentions

### Solutions

Secure that crash by checking if mentions position + length are shorter than text message length