### PR TITLE
feat: add timer to all message types

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -132,8 +132,8 @@ class MessageMapper @Inject constructor(
         }
     }
 
-    private fun provideExpirationData(message: Message.Standalone): ExpirationStatus {
-        val expirationData = (message as? Message.Regular)?.expirationData
+    private fun provideExpirationData(message: Message): ExpirationStatus {
+        val expirationData = message.expirationData
         return if (expirationData == null) {
             ExpirationStatus.NotExpirable
         } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -315,7 +315,7 @@ private fun ConversationScreen(
     conversationMessages: SharedFlow<SnackBarMessage>,
     conversationMessagesViewModel: ConversationMessagesViewModel,
     onPingClicked: () -> Unit,
-    onSelfDeletingMessageRead: (UIMessage.Regular) -> Unit,
+    onSelfDeletingMessageRead: (UIMessage) -> Unit,
     currentSelfDeletionTimer: SelfDeletionTimer,
     onNewSelfDeletingMessagesStatus: (SelfDeletionTimer) -> Unit,
     tempWritableImageUri: Uri?,
@@ -480,7 +480,7 @@ private fun ConversationScreenContent(
     onShowEditingOptions: (UIMessage.Regular) -> Unit,
     onShowSelfDeletionOption: () -> Unit,
     onPingClicked: () -> Unit,
-    onSelfDeletingMessageRead: (UIMessage.Regular) -> Unit,
+    onSelfDeletingMessageRead: (UIMessage) -> Unit,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
     conversationDetailsData: ConversationDetailsData,
@@ -610,7 +610,7 @@ fun MessageList(
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onShowEditingOption: (UIMessage.Regular) -> Unit,
-    onSelfDeletingMessageRead: (UIMessage.Regular) -> Unit,
+    onSelfDeletingMessageRead: (UIMessage) -> Unit,
     conversationDetailsData: ConversationDetailsData,
     onFailedMessageRetryClicked: (String) -> Unit,
     onFailedMessageCancelClicked: (String) -> Unit
@@ -676,7 +676,8 @@ fun MessageList(
                 is UIMessage.System -> SystemMessageItem(
                     message = message,
                     onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                    onFailedMessageRetryClicked = onFailedMessageRetryClicked
+                    onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                    onSelfDeletingMessageRead = onSelfDeletingMessageRead
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -48,7 +48,6 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveSt
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AssetBundle
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.ui.home.conversations.model.EditMessageBundle
 import com.wire.android.ui.home.conversations.model.SendMessageBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -58,6 +57,7 @@ import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.configuration.FileSharingStatus
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.OtherUser
@@ -358,7 +358,7 @@ class MessageComposerViewModel @Inject constructor(
         }
     }
 
-    fun startSelfDeletion(uiMessage: UIMessage.Regular) {
+    fun startSelfDeletion(uiMessage: UIMessage) {
         enqueueMessageSelfDeletion(conversationId, uiMessage.header.messageId)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -293,7 +293,6 @@ fun startDeletionTimer(
                 }
             }
         }
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -257,46 +257,43 @@ class SelfDeletionTimerHelper(private val context: Context) {
 
 @Composable
 fun startDeletionTimer(
-    message: UIMessage.Regular,
+    message: UIMessage,
     expirableTimer: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
-    onStartMessageSelfDeletion: (UIMessage.Regular) -> Unit
+    onStartMessageSelfDeletion: (UIMessage) -> Unit
 ) {
-    message.messageContent?.let {
-        when (val messageContent = message.messageContent) {
-            is UIMessageContent.AssetMessage -> startAssetDeletion(
-                expirableTimer = expirableTimer,
-                onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                downloadStatus = messageContent.downloadStatus
-            )
+    when (val messageContent = message.messageContent) {
+        is UIMessageContent.AssetMessage -> startAssetDeletion(
+            expirableTimer = expirableTimer,
+            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+            downloadStatus = messageContent.downloadStatus
+        )
 
-            is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
-                expirableTimer = expirableTimer,
-                onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                downloadStatus = messageContent.downloadStatus
-            )
+        is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
+            expirableTimer = expirableTimer,
+            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+            downloadStatus = messageContent.downloadStatus
+        )
 
-            is UIMessageContent.ImageMessage -> startAssetDeletion(
-                expirableTimer = expirableTimer,
-                onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                downloadStatus = messageContent.downloadStatus
-            )
+        is UIMessageContent.ImageMessage -> startAssetDeletion(
+            expirableTimer = expirableTimer,
+            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+            downloadStatus = messageContent.downloadStatus
+        )
 
-            is UIMessageContent.TextMessage -> {
-                LaunchedEffect(Unit) {
-                    onStartMessageSelfDeletion(message)
-                }
-                LaunchedEffect(expirableTimer.timeLeft) {
-                    with(expirableTimer) {
-                        if (timeLeft != ZERO) {
-                            delay(updateInterval())
-                            decreaseTimeLeft(updateInterval())
-                        }
+        else -> {
+            LaunchedEffect(Unit) {
+                onStartMessageSelfDeletion(message)
+            }
+            LaunchedEffect(expirableTimer.timeLeft) {
+                with(expirableTimer) {
+                    if (timeLeft != ZERO) {
+                        delay(updateInterval())
+                        decreaseTimeLeft(updateInterval())
                     }
                 }
             }
-
-            else -> {}
         }
+
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -100,7 +100,7 @@ fun MessageItem(
     onOpenProfile: (String) -> Unit,
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
-    onSelfDeletingMessageRead: (UIMessage.Regular) -> Unit,
+    onSelfDeletingMessageRead: (UIMessage) -> Unit,
     onFailedMessageRetryClicked: (String) -> Unit = {},
     onFailedMessageCancelClicked: (String) -> Unit = {}
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -76,8 +76,21 @@ import com.wire.android.util.ui.toUIText
 fun SystemMessageItem(
     message: UIMessage.System,
     onFailedMessageRetryClicked: (String) -> Unit = {},
-    onFailedMessageCancelClicked: (String) -> Unit = {}
+    onFailedMessageCancelClicked: (String) -> Unit = {},
+    onSelfDeletingMessageRead: (UIMessage) -> Unit = {}
 ) {
+    val selfDeletionTimerState = rememberSelfDeletionTimer(message.header.messageStatus.expirationStatus)
+    if (
+        selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable &&
+        !message.isPending &&
+        !message.sendingFailed
+    ) {
+        startDeletionTimer(
+            message = message,
+            expirableTimer = selfDeletionTimerState,
+            onStartMessageSelfDeletion = onSelfDeletingMessageRead
+        )
+    }
     val fullAvatarOuterPadding = dimensions().userAvatarClickablePadding + dimensions().userAvatarStatusBorderSize
     Row(
         Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -58,7 +58,7 @@ val mockHeader = MessageHeader(
     membership = Membership.Guest,
     isLegalHold = true,
     messageTime = MessageTime("12.23pm"),
-    messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent),
+    messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
     messageId = "",
     connectionState = ConnectionState.ACCEPTED,
     isSenderDeleted = false,
@@ -109,7 +109,7 @@ fun mockAssetMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.U
         membership = Membership.Guest,
         isLegalHold = true,
         messageTime = MessageTime("12.23pm"),
-        messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent),
+        messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
         messageId = "",
         connectionState = ConnectionState.ACCEPTED,
         isSenderDeleted = false,
@@ -140,7 +140,7 @@ fun mockedImg(
 @Suppress("MagicNumber")
 fun mockedImageUIMessage(
     uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED,
-    messageStatus: MessageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent),
+    messageStatus: MessageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
 ) = UIMessage.Regular(
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = MessageHeader(
@@ -168,7 +168,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.Guest,
             isLegalHold = true,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent),
+            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
             messageId = "1",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -194,7 +194,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.Guest,
             isLegalHold = true,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true),
+            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true, expirationStatus = TODO()),
             messageId = "2",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -213,7 +213,8 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
-                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm")
+                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
+                expirationStatus = TODO()
             ),
             messageId = "3",
             connectionState = ConnectionState.ACCEPTED,
@@ -233,7 +234,8 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
-                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm")
+                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
+                expirationStatus = TODO()
             ),
             messageId = "4",
             connectionState = ConnectionState.ACCEPTED,
@@ -251,7 +253,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.External,
             isLegalHold = false,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true),
+            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true, expirationStatus = TODO()),
             messageId = "5",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -279,7 +281,8 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
-                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm")
+                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
+                expirationStatus = TODO()
             ),
             messageId = "6",
             connectionState = ConnectionState.ACCEPTED,
@@ -299,7 +302,8 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageTime = MessageTime("12.23pm"),
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
-                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm")
+                editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
+                expirationStatus = TODO()
             ),
             messageId = "7",
             connectionState = ConnectionState.ACCEPTED,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -31,6 +31,7 @@ import coil.request.ImageResult
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageEditStatus
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
@@ -58,7 +59,10 @@ val mockHeader = MessageHeader(
     membership = Membership.Guest,
     isLegalHold = true,
     messageTime = MessageTime("12.23pm"),
-    messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
+    messageStatus = MessageStatus(
+        flowStatus = MessageFlowStatus.Sent,
+        expirationStatus = ExpirationStatus.NotExpirable
+    ),
     messageId = "",
     connectionState = ConnectionState.ACCEPTED,
     isSenderDeleted = false,
@@ -109,7 +113,10 @@ fun mockAssetMessage(uploadStatus: Message.UploadStatus = Message.UploadStatus.U
         membership = Membership.Guest,
         isLegalHold = true,
         messageTime = MessageTime("12.23pm"),
-        messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
+        messageStatus = MessageStatus(
+            flowStatus = MessageFlowStatus.Sent,
+            expirationStatus = ExpirationStatus.NotExpirable
+        ),
         messageId = "",
         connectionState = ConnectionState.ACCEPTED,
         isSenderDeleted = false,
@@ -140,7 +147,10 @@ fun mockedImg(
 @Suppress("MagicNumber")
 fun mockedImageUIMessage(
     uploadStatus: Message.UploadStatus = Message.UploadStatus.UPLOADED,
-    messageStatus: MessageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
+    messageStatus: MessageStatus = MessageStatus(
+        flowStatus = MessageFlowStatus.Sent,
+        expirationStatus = ExpirationStatus.NotExpirable
+    )
 ) = UIMessage.Regular(
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = MessageHeader(
@@ -168,7 +178,10 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.Guest,
             isLegalHold = true,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent, TODO()),
+            messageStatus = MessageStatus(
+                flowStatus = MessageFlowStatus.Sent,
+                expirationStatus = ExpirationStatus.NotExpirable
+            ),
             messageId = "1",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -194,7 +207,10 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.Guest,
             isLegalHold = true,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true, expirationStatus = TODO()),
+            messageStatus = MessageStatus(
+                flowStatus = MessageFlowStatus.Delivered, isDeleted = true,
+                expirationStatus = ExpirationStatus.NotExpirable
+            ),
             messageId = "2",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -214,7 +230,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
                 editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
-                expirationStatus = TODO()
+                expirationStatus = ExpirationStatus.NotExpirable
             ),
             messageId = "3",
             connectionState = ConnectionState.ACCEPTED,
@@ -235,7 +251,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
                 editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
-                expirationStatus = TODO()
+                expirationStatus = ExpirationStatus.NotExpirable
             ),
             messageId = "4",
             connectionState = ConnectionState.ACCEPTED,
@@ -253,7 +269,11 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             membership = Membership.External,
             isLegalHold = false,
             messageTime = MessageTime("12.23pm"),
-            messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Delivered, isDeleted = true, expirationStatus = TODO()),
+            messageStatus = MessageStatus(
+                flowStatus = MessageFlowStatus.Delivered,
+                isDeleted = true,
+                expirationStatus = ExpirationStatus.NotExpirable
+            ),
             messageId = "5",
             connectionState = ConnectionState.ACCEPTED,
             isSenderDeleted = false,
@@ -282,7 +302,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
                 editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
-                expirationStatus = TODO()
+                expirationStatus = ExpirationStatus.NotExpirable
             ),
             messageId = "6",
             connectionState = ConnectionState.ACCEPTED,
@@ -303,7 +323,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
             messageStatus = MessageStatus(
                 flowStatus = MessageFlowStatus.Sent,
                 editStatus = MessageEditStatus.Edited("May 31, 2022 12.24pm"),
-                expirationStatus = TODO()
+                expirationStatus = ExpirationStatus.NotExpirable
             ),
             messageId = "7",
             connectionState = ConnectionState.ACCEPTED,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -370,7 +370,10 @@ fun PreviewImageMessageFailedUpload() {
         MessageItem(
             message = mockedImageUIMessage(
                 uploadStatus = Message.UploadStatus.FAILED_UPLOAD,
-                messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Failure.Send.Locally(false), expirationStatus = ExpirationStatus.NotExpirable)
+                messageStatus = MessageStatus(
+                    flowStatus = MessageFlowStatus.Failure.Send.Locally(false),
+                    expirationStatus = ExpirationStatus.NotExpirable
+                )
             ),
             audioMessagesState = emptyMap(),
             onLongClicked = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -149,7 +149,8 @@ fun PreviewDeletedMessage() {
                 it.copy(
                     header = it.header.copy(
                         messageStatus = MessageStatus(
-                            flowStatus = MessageFlowStatus.Delivered, isDeleted = true
+                            flowStatus = MessageFlowStatus.Delivered, isDeleted = true,
+                            expirationStatus = ExpirationStatus.NotExpirable
                         )
                     )
                 )
@@ -178,7 +179,8 @@ fun PreviewFailedSendMessage() {
                 it.copy(
                     header = it.header.copy(
                         messageStatus = MessageStatus(
-                            flowStatus = MessageFlowStatus.Failure.Send.Locally(false)
+                            flowStatus = MessageFlowStatus.Failure.Send.Locally(false),
+                            expirationStatus = ExpirationStatus.NotExpirable
                         )
                     ),
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
@@ -208,7 +210,8 @@ fun PreviewFailedDecryptionMessage() {
                 it.copy(
                     header = it.header.copy(
                         messageStatus = MessageStatus(
-                            flowStatus = MessageFlowStatus.Failure.Decryption(false)
+                            flowStatus = MessageFlowStatus.Failure.Decryption(false),
+                            expirationStatus = ExpirationStatus.NotExpirable
                         )
                     ),
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
@@ -367,7 +370,7 @@ fun PreviewImageMessageFailedUpload() {
         MessageItem(
             message = mockedImageUIMessage(
                 uploadStatus = Message.UploadStatus.FAILED_UPLOAD,
-                messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Failure.Send.Locally(false))
+                messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Failure.Send.Locally(false), expirationStatus = ExpirationStatus.NotExpirable)
             ),
             audioMessagesState = emptyMap(),
             onLongClicked = {},
@@ -494,7 +497,10 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
             MessageItem(
                 message = mockMessageWithText.copy(
                     header = mockHeader.copy(
-                        messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Failure.Send.Locally(false))
+                        messageStatus = MessageStatus(
+                            flowStatus = MessageFlowStatus.Failure.Send.Locally(false),
+                            expirationStatus = ExpirationStatus.NotExpirable
+                        )
                     )
                 ),
                 showAuthor = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -38,24 +38,26 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.time.Duration
 
-sealed class UIMessage(
-    open val header: MessageHeader,
-    open val source: MessageSource
-) {
+sealed interface UIMessage {
+    val header: MessageHeader
+    val source: MessageSource
+    val messageContent: UIMessageContent?
+    val sendingFailed: Boolean
+    val decryptionFailed: Boolean
+    val isPending: Boolean
 
     data class Regular(
         override val header: MessageHeader,
         override val source: MessageSource,
         val userAvatarData: UserAvatarData,
-        val messageContent: UIMessageContent.Regular?,
+        override val messageContent: UIMessageContent.Regular?,
         val messageFooter: MessageFooter,
-    ) : UIMessage(header, source) {
-        val isTextMessage = messageContent is UIMessageContent.TextMessage
+    ) : UIMessage {
         val isDeleted: Boolean = header.messageStatus.isDeleted
-        val sendingFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Send
-        val decryptionFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Decryption
+        override val sendingFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Send
+        override val decryptionFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Decryption
         val isAvailable: Boolean = !isDeleted && !sendingFailed && !decryptionFailed
-        val isPending: Boolean = header.messageStatus.flowStatus == MessageFlowStatus.Sending
+        override val isPending: Boolean = header.messageStatus.flowStatus == MessageFlowStatus.Sending
         val isMyMessage = source == MessageSource.Self
         val isTextContentWithoutQuote = messageContent is UIMessageContent.TextMessage && messageContent.messageBody.quotedMessage == null
         val isAssetMessage = messageContent is UIMessageContent.AssetMessage
@@ -66,10 +68,11 @@ sealed class UIMessage(
     data class System(
         override val header: MessageHeader,
         override val source: MessageSource,
-        val messageContent: UIMessageContent.SystemMessage
-    ) : UIMessage(header, source) {
-        val sendingFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Send
-        val decryptionFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Decryption
+        override val messageContent: UIMessageContent.SystemMessage
+    ) : UIMessage {
+        override val sendingFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Send
+        override val decryptionFailed: Boolean = header.messageStatus.flowStatus is MessageFlowStatus.Failure.Decryption
+        override val isPending: Boolean = header.messageStatus.flowStatus == MessageFlowStatus.Sending
     }
 }
 
@@ -148,10 +151,11 @@ sealed class MessageFlowStatus {
     data class Read(val count: Int) : MessageFlowStatus()
 }
 
+@Stable
 data class MessageStatus(
     val flowStatus: MessageFlowStatus,
+    val expirationStatus: ExpirationStatus,
     val editStatus: MessageEditStatus = MessageEditStatus.NonEdited,
-    val expirationStatus: ExpirationStatus = ExpirationStatus.NotExpirable,
     val isDeleted: Boolean = false
 ) {
 

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -130,7 +130,8 @@ object TestMessage {
         conversationId = ConversationId("convo-id", "convo.domain"),
         date = "some-date",
         senderUserId = UserId("user-id", "domain"),
-        status = Message.Status.SENT
+        status = Message.Status.SENT,
+        expirationData = null
     )
 
     val MEMBER_REMOVED_MESSAGE = Message.System(
@@ -139,7 +140,8 @@ object TestMessage {
         conversationId = ConversationId("convo-id", "convo.domain"),
         date = "some-date",
         senderUserId = UserId("user-id", "domain"),
-        status = Message.Status.SENT
+        status = Message.Status.SENT,
+        expirationData = null
     )
     val IMAGE_ASSET_MESSAGE_DATA_TEST = AssetMessageContentMetadata(
         AssetContent(
@@ -180,7 +182,8 @@ object TestMessage {
         conversationId = ConversationId("convo-id", "convo.domain"),
         date = "some-date",
         senderUserId = UserId("user-id", "domain"),
-        status = Message.Status.SENT
+        status = Message.Status.SENT,
+        expirationData = null
     )
 
     val CONVERSATION_CREATED_MESSAGE = Message.System(
@@ -189,7 +192,8 @@ object TestMessage {
         conversationId = ConversationId("convo-id", "convo.domain"),
         date = "some-date",
         senderUserId = UserId("user-id", "domain"),
-        status = Message.Status.SENT
+        status = Message.Status.SENT,
+        expirationData = null
     )
 
     val PREVIEW = MessagePreview(

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -22,6 +22,7 @@ package com.wire.android.framework
 
 import com.wire.android.mapper.AssetMessageContentMetadata
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
 import com.wire.android.ui.home.conversations.model.MessageFooter
@@ -156,7 +157,10 @@ object TestMessage {
         membership = Membership.Guest,
         isLegalHold = true,
         messageTime = MessageTime("12.23pm"),
-        messageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent),
+        messageStatus = MessageStatus(
+            flowStatus = MessageFlowStatus.Sent,
+            expirationStatus = ExpirationStatus.NotExpirable
+        ),
         messageId = "messageID",
         connectionState = null,
         isSenderDeleted = false,

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -23,6 +23,7 @@ package com.wire.android.mapper
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestUser
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageEditStatus
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
@@ -123,7 +124,10 @@ class MessageMapperTest {
                 time = message2.date.uiMessageDateTime(),
                 source = MessageSource.OtherUser,
                 membership = Membership.Guest,
-                status = MessageStatus(flowStatus = MessageFlowStatus.Failure.Send.Locally(false))
+                status = MessageStatus(
+                    flowStatus = MessageFlowStatus.Failure.Send.Locally(false),
+                    expirationStatus = ExpirationStatus.NotExpirable
+                )
             )
         )
         assert(
@@ -132,7 +136,8 @@ class MessageMapperTest {
                 time = message3.date.uiMessageDateTime(),
                 status = MessageStatus(
                     flowStatus = MessageFlowStatus.Sent,
-                    editStatus = MessageEditStatus.Edited(now.uiMessageDateTime() ?: "")
+                    editStatus = MessageEditStatus.Edited(now.uiMessageDateTime() ?: ""),
+                    expirationStatus = ExpirationStatus.NotExpirable
                 )
             )
         )
@@ -140,7 +145,11 @@ class MessageMapperTest {
             checkMessageData(
                 uiMessage = uiMessage4,
                 time = message4.date.uiMessageDateTime(),
-                status = MessageStatus(flowStatus = MessageFlowStatus.Sent, isDeleted = true)
+                status = MessageStatus(
+                    flowStatus = MessageFlowStatus.Sent,
+                    isDeleted = true,
+                    expirationStatus = ExpirationStatus.NotExpirable
+                )
             )
         )
 
@@ -148,7 +157,11 @@ class MessageMapperTest {
             checkMessageData(
                 uiMessage = uiMessage5,
                 time = message5.date.uiMessageDateTime(),
-                status = MessageStatus(flowStatus = MessageFlowStatus.Failure.Decryption(false), isDeleted = false)
+                status = MessageStatus(
+                    flowStatus = MessageFlowStatus.Failure.Decryption(false),
+                    isDeleted = false,
+                    expirationStatus = ExpirationStatus.NotExpirable
+                )
             )
         )
 
@@ -156,7 +169,11 @@ class MessageMapperTest {
             checkMessageData(
                 uiMessage = uiMessage6,
                 time = message6.date.uiMessageDateTime(),
-                status = MessageStatus(flowStatus = MessageFlowStatus.Failure.Decryption(true), isDeleted = false)
+                status = MessageStatus(
+                    flowStatus = MessageFlowStatus.Failure.Decryption(true),
+                    isDeleted = false,
+                    expirationStatus = ExpirationStatus.NotExpirable
+                )
             )
         )
     }
@@ -166,7 +183,10 @@ class MessageMapperTest {
         time: String?,
         source: MessageSource = MessageSource.Self,
         membership: Membership = Membership.None,
-        status: MessageStatus = MessageStatus(flowStatus = MessageFlowStatus.Sent)
+        status: MessageStatus = MessageStatus(
+            flowStatus = MessageFlowStatus.Sent,
+            expirationStatus = ExpirationStatus.NotExpirable
+        )
     ): Boolean {
         return (uiMessage?.source == source && uiMessage.header.membership == membership
                 && uiMessage.header.messageTime.formattedDate == time
@@ -229,4 +249,4 @@ private fun Message.Regular.failureToDecrypt(isDecryptionResolved: Boolean) =
                 senderUserId = this.senderUserId,
                 isDecryptionResolved = isDecryptionResolved
             )
-    )
+        )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -31,6 +31,7 @@ import com.wire.android.media.PingRinger
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageSource
@@ -338,7 +339,7 @@ internal fun mockUITextMessage(id: String = "someId", userName: String = "mockUs
             every { it.username } returns UIText.DynamicString(userName)
             every { it.isLegalHold } returns false
             every { it.messageTime } returns MessageTime("")
-            every { it.messageStatus } returns MessageStatus(flowStatus = MessageFlowStatus.Sent)
+            every { it.messageStatus } returns MessageStatus(flowStatus = MessageFlowStatus.Sent, expirationStatus = ExpirationStatus.NotExpirable)
         }
         every { it.messageContent } returns null
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -339,7 +339,10 @@ internal fun mockUITextMessage(id: String = "someId", userName: String = "mockUs
             every { it.username } returns UIText.DynamicString(userName)
             every { it.isLegalHold } returns false
             every { it.messageTime } returns MessageTime("")
-            every { it.messageStatus } returns MessageStatus(flowStatus = MessageFlowStatus.Sent, expirationStatus = ExpirationStatus.NotExpirable)
+            every { it.messageStatus } returns MessageStatus(
+                flowStatus = MessageFlowStatus.Sent,
+                expirationStatus = ExpirationStatus.NotExpirable
+            )
         }
         every { it.messageContent } returns null
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

atm message timer is only applicable to Text and Asset Messages.

### Solutions


1. when mapping from proto Text, Asset, Location, Knock and Image message content have a timer. And since the message timer value in the DB is applicable to all message types.
2. map knock messages from ephemeral content.
3. remove any type check when queuing ephemeral messages  

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
