### PR TITLE
feat: send self deleting pings and clean up

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -84,8 +84,8 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
                     state = state.copy(
                         isLoading = selfDeletingMessages.isEnforcedByTeam || !isSelfAnAdmin,
                         isEnabled = selfDeletingMessages.isEnforcedByGroup,
-                        remotelySelected = selfDeletingMessages.toDuration().toSelfDeletionDuration(),
-                        locallySelected = selfDeletingMessages.toDuration().toSelfDeletionDuration()
+                        remotelySelected = selfDeletingMessages.duration?.toSelfDeletionDuration(),
+                        locallySelected = selfDeletingMessages.duration?.toSelfDeletionDuration()
                     )
                 }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -127,7 +127,7 @@ fun GroupConversationSettings(
                     title = stringResource(id = R.string.conversation_options_self_deleting_messages_label),
                     subtitle = stringResource(id = R.string.conversation_options_self_deleting_messages_description),
                     trailingOnText = if (state.selfDeletionTimer.isEnforced) {
-                        "(${state.selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel.asString()})"
+                        "(${state.selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel.asString()})"
                     } else {
                         null
                     },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMapper.kt
@@ -21,7 +21,7 @@ import com.wire.android.ui.home.messagecomposer.state.SelfDeletionDuration
 import kotlin.time.Duration
 
 object SelfDeletionMapper {
-    fun Duration.toSelfDeletionDuration(): SelfDeletionDuration = when (this) {
+    fun Duration?.toSelfDeletionDuration(): SelfDeletionDuration = when (this) {
         SelfDeletionDuration.TenSeconds.value -> SelfDeletionDuration.TenSeconds
         SelfDeletionDuration.OneMinute.value -> SelfDeletionDuration.OneMinute
         SelfDeletionDuration.FiveMinutes.value -> SelfDeletionDuration.FiveMinutes

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposeInputState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposeInputState.kt
@@ -55,12 +55,12 @@ sealed class MessageComposeInputState {
         inputFocused: Boolean = this.inputFocused,
         selfDeletionTimer: SelfDeletionTimer
     ): MessageComposeInputState {
-        val isSelfDeletingType = selfDeletionTimer !is SelfDeletionTimer.Disabled && selfDeletionTimer.toDuration() > ZERO
+        val isSelfDeletingType = selfDeletionTimer !is SelfDeletionTimer.Disabled && selfDeletionTimer.duration != null
 
         return when {
             isSelfDeletingType -> {
                 val selfDeletingType = MessageComposeInputType.SelfDeletingMessage(
-                    selfDeletionDuration = selfDeletionTimer.toDuration().toSelfDeletionDuration(),
+                    selfDeletionDuration = selfDeletionTimer.duration.toSelfDeletionDuration(),
                     isEnforced = selfDeletionTimer.isEnforced,
                     attachmentOptionsDisplayed = attachmentOptionsDisplayed
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerState.kt
@@ -349,7 +349,7 @@ data class MessageComposerState(
 
     fun updateSelfDeletionTime(newSelfDeletionTimer: SelfDeletionTimer) = with(newSelfDeletionTimer) {
         currentSelfDeletionTimer = newSelfDeletionTimer
-        val newSelfDeletionDuration = newSelfDeletionTimer.toDuration().toSelfDeletionDuration()
+        val newSelfDeletionDuration = newSelfDeletionTimer.duration.toSelfDeletionDuration()
         messageComposeInputState = MessageComposeInputState.Active(
             messageText = messageComposeInputState.messageText,
             inputFocused = true,
@@ -358,7 +358,7 @@ data class MessageComposerState(
         )
     }
 
-    fun getSelfDeletionTime(): SelfDeletionDuration = currentSelfDeletionTimer.toDuration().toSelfDeletionDuration()
+    fun getSelfDeletionTime(): SelfDeletionDuration = currentSelfDeletionTimer.duration.toSelfDeletionDuration()
 
     fun shouldShowSelfDeletionOption(): Boolean = with(currentSelfDeletionTimer) {
         // We shouldn't show the self-deleting option if there is a compulsory duration already set on the team settings level

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -169,7 +169,7 @@ fun SelfDeletionTimerButton(
     isDisabled: Boolean,
     onSelfDeletionTimerClicked: () -> Unit
 ) {
-    val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.userDuration != ZERO
+    val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.duration != null
     Box(
         modifier = modifier
             .padding(start = dimensions().spacing16x)

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -62,9 +62,9 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.extension.getActivity
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
+import com.wire.kalium.logic.util.isPositiveNotNull
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.SharedFlow
-import kotlin.time.Duration
 
 @Composable
 fun ImportMediaScreen(
@@ -169,7 +169,7 @@ fun ImportMediaRegularContent(authorizedViewModel: ImportMediaAuthenticatedViewM
         )
         MenuModalSheetLayout(
             menuItems = SelfDeletionMenuItems(
-                currentlySelected = authorizedViewModel.importMediaState.selfDeletingTimer.toDuration().toSelfDeletionDuration(),
+                currentlySelected = authorizedViewModel.importMediaState.selfDeletingTimer.duration.toSelfDeletionDuration(),
                 hideEditMessageMenu = importMediaScreenState::hideBottomSheetMenu,
                 onSelfDeletionDurationChanged = authorizedViewModel::onNewSelfDeletionTimerPicked,
             ),
@@ -261,8 +261,8 @@ private fun ImportMediaBottomBar(
     importMediaScreenState: ImportMediaScreenState
 ) {
     val selfDeletionTimer = importMediaViewModel.importMediaState.selfDeletingTimer
-    val shortDurationLabel = selfDeletionTimer.toDuration().toSelfDeletionDuration().shortLabel
-    val mainButtonText = if (selfDeletionTimer.toDuration() > Duration.ZERO) {
+    val shortDurationLabel = selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel
+    val mainButtonText = if (selfDeletionTimer.duration.isPositiveNotNull()) {
         "${stringResource(id = R.string.self_deleting_message_label)} (${shortDurationLabel.asString()})"
     } else {
         stringResource(id = R.string.import_media_send_button_title)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -26,8 +26,8 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AssetBundle
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
 import io.mockk.coVerify
@@ -359,7 +359,7 @@ class MessageComposerViewModelTest {
         // Then
         coVerify(exactly = 1) { arrangement.persistSelfDeletionStatus.invoke(arrangement.conversationId, expectedTimer) }
         assert(viewModel.messageComposerViewState.selfDeletionTimer is SelfDeletionTimer.Enabled)
-        assert(viewModel.messageComposerViewState.selfDeletionTimer.toDuration() == expectedDuration)
+        assert(viewModel.messageComposerViewState.selfDeletionTimer.duration == expectedDuration)
     }
 
     @Test
@@ -377,6 +377,6 @@ class MessageComposerViewModelTest {
         // Then
         coVerify(exactly = 1) { arrangement.observeConversationSelfDeletionStatus.invoke(arrangement.conversationId, true) }
         assert(viewModel.messageComposerViewState.selfDeletionTimer is SelfDeletionTimer.Enabled)
-        assert(viewModel.messageComposerViewState.selfDeletionTimer.toDuration() == expectedDuration)
+        assert(viewModel.messageComposerViewState.selfDeletionTimer.duration == expectedDuration)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Complementary PR for https://github.com/wireapp/kalium/pull/1877 and clean up for message duration

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
