### PR TITLE
ci: automatically cherry-pick from rc to develop

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -1,0 +1,47 @@
+name: "Cherry-pick from rc to develop"
+
+on:
+    pull_request:
+        branches:
+            - release/candidate
+        types:
+            - closed
+
+jobs:
+    cherry-pick:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.merged == true
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Extract branch name and remove prefix
+              id: extract
+              run: |
+                  PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+                  PREFIX=$(echo $PR_BRANCH | cut -d'/' -f 1)
+                  SUFFIX=$(echo $PR_BRANCH | cut -d'/' -f 3-)
+                  NEW_BRANCH_NAME="$PREFIX/$SUFFIX"
+                  echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+
+            - name: Cherry-pick commits
+              run: |
+                  git fetch origin develop:develop
+                  git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+                  COMMITS=$(git log --pretty=format:"%H" --reverse ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+                  for COMMIT in $COMMITS; do
+                    git cherry-pick $COMMIT --strategy-option ours
+                  done
+                  git push origin ${{ steps.extract.outputs.newBranchName }}
+
+            - name: Create PR
+              id: cpr
+              uses: peter-evans/create-pull-request@v5
+              with:
+                  title: Cherry-pick to develop
+                  base: develop
+                  branch: "${{ steps.extract.outputs.newBranchName }}"
+                  body: ${{ github.event.pull_request.body }}

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -54,5 +54,6 @@ jobs:
               with:
                   title: ${{ github.event.pull_request.title }}
                   base: develop
+                  assignees: ${{ github.event.pull_request.user.login }}
                   branch: "${{ steps.extract.outputs.newBranchName }}"
-                  body: "${{ format('Cherry pick from the original PR: #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"
+                  body: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -23,26 +23,36 @@ jobs:
               id: extract
               run: |
                   PR_BRANCH="${{ github.event.pull_request.head.ref }}"
-                  PREFIX=$(echo $PR_BRANCH | cut -d'/' -f 1)
-                  SUFFIX=$(echo $PR_BRANCH | cut -d'/' -f 3-)
-                  NEW_BRANCH_NAME="$PREFIX/$SUFFIX"
-                  echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+                  if echo "$PR_BRANCH" | grep -q "/rc-"; then
+                    NEW_BRANCH_NAME=$(echo $PR_BRANCH | sed 's|/rc-|/|')
+                    echo "New branch name: $NEW_BRANCH_NAME"
+                    echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+                    echo "::set-output name=shouldCherryPick::true"
+                  else
+                    echo "Branch name does not contain '/rc-', skipping cherry-pick"
+                    echo "::set-output name=shouldCherryPick::false"
+                  fi
 
             - name: Cherry-pick commits
+              if: steps.extract.outputs.shouldCherryPick == 'true'
               run: |
                   git fetch origin develop:develop
                   git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
                   COMMITS=$(git log --pretty=format:"%H" --reverse ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+                  echo "Cherry-picking these commits: $COMMITS"
                   for COMMIT in $COMMITS; do
-                    git cherry-pick $COMMIT --strategy-option ours
+                    git cherry-pick -x $COMMIT --strategy-option theirs || true
+                    git add .
+                    git cherry-pick --continue || true
                   done
                   git push origin ${{ steps.extract.outputs.newBranchName }}
 
             - name: Create PR
+              if: steps.extract.outputs.shouldCherryPick == 'true'
               id: cpr
               uses: peter-evans/create-pull-request@v5
               with:
-                  title: Cherry-pick to develop
+                  title: ${{ github.event.pull_request.title }}
                   base: develop
                   branch: "${{ steps.extract.outputs.newBranchName }}"
-                  body: ${{ github.event.pull_request.body }}
+                  body: "${{ format('Cherry pick from the original PR: #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -14,8 +14,9 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
+                  submodules: recursive # Needed in order to fetch Kalium sources for building
                   fetch-depth: 0
 
             - name: Extract branch name and remove prefix


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We struggles with forgetting to merge some commits added in release/candidate to develop

### Causes (Optional)

Spending a lot of time to find those commits 

### Solutions

Created github action to automatically cherry-pick commits merged to release/candidate to create new PR to develop with the same PR description. We need to stick with convention with branch naming:
- all rc branches should be like {pr_type}/rc-{branch_name}, in new branch from develop rc prefix will be removed
- to not fail on cherry picking we will force to commit to on conflicts choose changes from develop branch so for sure sometimes we will need to fix some changes