### PR TITLE
feat: screenshot censoring [WPB-2880]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -121,6 +121,8 @@ import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.UpdateDisplayNameUseCase
 import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
 import dagger.Provides
@@ -1199,4 +1201,18 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): DeleteAccountUseCase =
         coreLogic.getSessionScope(currentAccount).users.deleteAccount
+
+    @ViewModelScoped
+    @Provides
+    fun providePersistScreenshotCensoringConfigUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): PersistScreenshotCensoringConfigUseCase = coreLogic.getSessionScope(currentAccount).persistScreenshotCensoringConfig
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveScreenshotCensoringConfigUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): ObserveScreenshotCensoringConfigUseCase = coreLogic.getSessionScope(currentAccount).observeScreenshotCensoringConfig
 }

--- a/app/src/main/kotlin/com/wire/android/di/ObserveScreenshotCensoringConfigUseCaseProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ObserveScreenshotCensoringConfigUseCaseProvider.kt
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di
+
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class ObserveScreenshotCensoringConfigUseCaseProvider @AssistedInject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    @Assisted private val userId: UserId
+) {
+    val observeScreenshotCensoringConfig: ObserveScreenshotCensoringConfigUseCase
+        get() = coreLogic.getSessionScope(userId).observeScreenshotCensoringConfig
+
+    @AssistedFactory
+    interface Factory {
+        fun create(userId: UserId): ObserveScreenshotCensoringConfigUseCaseProvider
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.ui
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -37,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -137,7 +139,8 @@ class WireActivity : AppCompatActivity() {
                 LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
                 LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
                 LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
-                LocalSnackbarHostState provides snackbarHostState
+                LocalSnackbarHostState provides snackbarHostState,
+                LocalActivity provides this
             ) {
                 WireTheme {
                     Column {
@@ -435,4 +438,8 @@ class WireActivity : AppCompatActivity() {
     companion object {
         private const val HANDLED_DEEPLINK_FLAG = "deeplink_handled_flag_key"
     }
+}
+
+val LocalActivity = staticCompositionLocalOf<Activity> {
+    error("No Activity provided")
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -24,6 +24,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -152,6 +153,7 @@ class WireActivity : AppCompatActivity() {
                             startDestination = startDestination,
                             onComplete = onComplete
                         )
+                        handleScreenshotCensoring()
                         handleDialogs()
                     }
                 }
@@ -208,6 +210,17 @@ class WireActivity : AppCompatActivity() {
             onDispose {
                 navController.removeOnDestinationChangedListener(updateScreenSettingsListener)
                 navController.removeOnDestinationChangedListener(currentScreenManager)
+            }
+        }
+    }
+
+    @Composable
+    private fun handleScreenshotCensoring() {
+        LaunchedEffect(viewModel.globalAppState.screenshotCensoringEnabled) {
+            if (viewModel.globalAppState.screenshotCensoringEnabled) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            } else {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui.home.conversations
 
 import android.net.Uri
-import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -33,7 +32,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -54,7 +52,6 @@ import com.wire.android.appLogger
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.hiltSavedStateViewModel
-import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialog
@@ -125,18 +122,6 @@ fun ConversationScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
-
-    val activity = LocalActivity.current
-    DisposableEffect(conversationInfoViewModel.conversationInfoViewState.screenshotCensoringEnabled) {
-        if (conversationInfoViewModel.conversationInfoViewState.screenshotCensoringEnabled) {
-            activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        } else {
-            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
-        onDispose {
-            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
-    }
 
     val startCallAudioPermissionCheck = StartCallAudioBluetoothPermissionCheckFlow {
         conversationCallViewModel.navigateToInitiatingCallScreen()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -20,7 +20,9 @@
 
 package com.wire.android.ui.home.conversations
 
+import android.app.Activity
 import android.net.Uri
+import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -31,6 +33,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -51,6 +54,7 @@ import com.wire.android.appLogger
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.hiltSavedStateViewModel
+import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialog
@@ -121,6 +125,18 @@ fun ConversationScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
+
+    val activity = LocalActivity.current
+    DisposableEffect(conversationInfoViewModel.conversationInfoViewState.screenshotCensoringEnabled) {
+        if (conversationInfoViewModel.conversationInfoViewState.screenshotCensoringEnabled) {
+            activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        onDispose {
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
 
     val startCallAudioPermissionCheck = StartCallAudioBluetoothPermissionCheckFlow {
         conversationCallViewModel.navigateToInitiatingCallScreen()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.ui.home.conversations
 
-import android.app.Activity
 import android.net.Uri
 import android.view.WindowManager
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -48,8 +48,6 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
-import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
-import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -63,7 +61,6 @@ class ConversationInfoViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val observerSelfUser: GetSelfUserUseCase,
-    private val observeScreenshotCensoringConfigUseCase: ObserveScreenshotCensoringConfigUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val dispatchers: DispatcherProvider
 ) : SavedStateViewModel(savedStateHandle) {
@@ -78,22 +75,11 @@ class ConversationInfoViewModel @Inject constructor(
 
     init {
         getSelfUserId()
-        observeScreenshotCensoringConfig()
     }
 
     private fun getSelfUserId() {
         viewModelScope.launch {
             selfUserId = observerSelfUser().first().id
-        }
-    }
-
-    private fun observeScreenshotCensoringConfig() {
-        viewModelScope.launch {
-            observeScreenshotCensoringConfigUseCase().collect {
-                conversationInfoViewState = conversationInfoViewState.copy(
-                    screenshotCensoringEnabled = it is ObserveScreenshotCensoringConfigResult.Enabled
-                )
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -48,6 +48,8 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -61,6 +63,7 @@ class ConversationInfoViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val observerSelfUser: GetSelfUserUseCase,
+    private val observeScreenshotCensoringConfigUseCase: ObserveScreenshotCensoringConfigUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val dispatchers: DispatcherProvider
 ) : SavedStateViewModel(savedStateHandle) {
@@ -74,8 +77,23 @@ class ConversationInfoViewModel @Inject constructor(
     private lateinit var selfUserId: UserId
 
     init {
+        getSelfUserId()
+        observeScreenshotCensoringConfig()
+    }
+
+    private fun getSelfUserId() {
         viewModelScope.launch {
             selfUserId = observerSelfUser().first().id
+        }
+    }
+
+    private fun observeScreenshotCensoringConfig() {
+        viewModelScope.launch {
+            observeScreenshotCensoringConfigUseCase().collect {
+                conversationInfoViewState = conversationInfoViewState.copy(
+                    screenshotCensoringEnabled = it is ObserveScreenshotCensoringConfigResult.Enabled
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
 class ConversationInfoViewModel @Inject constructor(
     private val qualifiedIdMapper: QualifiedIdMapper,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -34,7 +34,6 @@ data class ConversationInfoViewState(
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val hasUserPermissionToEdit: Boolean = false,
     val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE,
-    val screenshotCensoringEnabled: Boolean = true,
 )
 
 sealed class ConversationDetailsData {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -33,7 +33,8 @@ data class ConversationInfoViewState(
     val conversationDetailsData: ConversationDetailsData = ConversationDetailsData.None,
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val hasUserPermissionToEdit: Boolean = false,
-    val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE
+    val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE,
+    val screenshotCensoringEnabled: Boolean = true,
 )
 
 sealed class ConversationDetailsData {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -44,6 +44,8 @@ fun PrivacySettingsConfigScreen(
         PrivacySettingsScreenContent(
             isReadReceiptsEnabled = state.isReadReceiptsEnabled,
             setReadReceiptsState = ::setReadReceiptsState,
+            screenshotCensoringConfig = state.screenshotCensoringConfig,
+            setScreenshotCensoringConfig = ::setScreenshotCensoringConfig,
             onBackPressed = ::navigateBack
         )
     }
@@ -53,6 +55,8 @@ fun PrivacySettingsConfigScreen(
 fun PrivacySettingsScreenContent(
     isReadReceiptsEnabled: Boolean,
     setReadReceiptsState: (Boolean) -> Unit,
+    screenshotCensoringConfig: ScreenshotCensoringConfig,
+    setScreenshotCensoringConfig: (Boolean) -> Unit,
     onBackPressed: () -> Unit
 ) {
     Scaffold(topBar = {
@@ -73,6 +77,26 @@ fun PrivacySettingsScreenContent(
                 arrowType = ArrowType.NONE,
                 subtitle = stringResource(id = R.string.settings_send_read_receipts_description)
             )
+            GroupConversationOptionsItem(
+                title = stringResource(R.string.settings_censor_screenshots),
+                switchState = when (screenshotCensoringConfig) {
+                    ScreenshotCensoringConfig.DISABLED ->
+                        SwitchState.Enabled(value = false, onCheckedChange = setScreenshotCensoringConfig)
+
+                    ScreenshotCensoringConfig.ENABLED_BY_USER ->
+                        SwitchState.Enabled(value = true, onCheckedChange = setScreenshotCensoringConfig)
+
+                    ScreenshotCensoringConfig.ENFORCED_BY_TEAM ->
+                        SwitchState.Disabled(value = true)
+                },
+                arrowType = ArrowType.NONE,
+                subtitle = stringResource(
+                    id = when (screenshotCensoringConfig) {
+                        ScreenshotCensoringConfig.ENFORCED_BY_TEAM -> R.string.settings_censor_screenshots_enforced_by_team_description
+                        else -> R.string.settings_censor_screenshots_description
+                    }
+                )
+            )
         }
     }
 }
@@ -80,5 +104,5 @@ fun PrivacySettingsScreenContent(
 @Composable
 @Preview
 fun PreviewSendReadReceipts() {
-    PrivacySettingsScreenContent(true, {}, {})
+    PrivacySettingsScreenContent(true, {}, ScreenshotCensoringConfig.DISABLED, {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
@@ -22,4 +22,9 @@ package com.wire.android.ui.home.settings.privacy
 
 data class PrivacySettingsState(
     val isReadReceiptsEnabled: Boolean = true,
+    val screenshotCensoringConfig: ScreenshotCensoringConfig = ScreenshotCensoringConfig.ENABLED_BY_USER
 )
+
+enum class ScreenshotCensoringConfig {
+    DISABLED, ENABLED_BY_USER, ENFORCED_BY_TEAM
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -36,14 +36,9 @@ import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotC
 import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
 @HiltViewModel

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -99,7 +99,7 @@ class PrivacySettingsViewModel @Inject constructor(
 
     fun setScreenshotCensoringConfig(isEnabled: Boolean) {
         viewModelScope.launch {
-            when (withContext(dispatchers.io()) { persistScreenshotCensoringConfig(isEnabled) }) {
+            when (persistScreenshotCensoringConfig(isEnabled)) {
                 is PersistScreenshotCensoringConfigResult.Failure -> {
                     appLogger.e("Something went wrong while updating screenshot censoring config")
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -31,9 +31,19 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.user.readReceipts.ObserveReadReceiptsEnabledUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.PersistReadReceiptsStatusConfigUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.ReadReceiptStatusConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
 @HiltViewModel
@@ -42,6 +52,8 @@ class PrivacySettingsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val persistReadReceiptsStatusConfig: PersistReadReceiptsStatusConfigUseCase,
     private val observeReadReceiptsEnabled: ObserveReadReceiptsEnabledUseCase,
+    private val persistScreenshotCensoringConfig: PersistScreenshotCensoringConfigUseCase,
+    private val observeScreenshotCensoringConfig: ObserveScreenshotCensoringConfigUseCase
 ) : ViewModel() {
 
     var state by mutableStateOf(PrivacySettingsState())
@@ -49,8 +61,24 @@ class PrivacySettingsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            observeReadReceiptsEnabled().collect {
-                state = state.copy(isReadReceiptsEnabled = it)
+            combine(
+                observeReadReceiptsEnabled(),
+                observeScreenshotCensoringConfig(),
+                ::Pair
+            ).collect { (readReceiptsEnabled, screenshotCensoringConfig) ->
+                state = state.copy(
+                    isReadReceiptsEnabled = readReceiptsEnabled,
+                    screenshotCensoringConfig = when (screenshotCensoringConfig) {
+                        ObserveScreenshotCensoringConfigResult.Disabled ->
+                            ScreenshotCensoringConfig.DISABLED
+
+                        ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser ->
+                            ScreenshotCensoringConfig.ENABLED_BY_USER
+
+                        ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings ->
+                            ScreenshotCensoringConfig.ENFORCED_BY_TEAM
+                    }
+                )
             }
         }
     }
@@ -69,6 +97,20 @@ class PrivacySettingsViewModel @Inject constructor(
                 is ReadReceiptStatusConfigResult.Success -> {
                     appLogger.d("Read receipts config changed")
                     state = state.copy(isReadReceiptsEnabled = isEnabled)
+                }
+            }
+        }
+    }
+
+    fun setScreenshotCensoringConfig(isEnabled: Boolean) {
+        viewModelScope.launch {
+            when (withContext(dispatchers.io()) { persistScreenshotCensoringConfig(isEnabled) }) {
+                is PersistScreenshotCensoringConfigResult.Failure -> {
+                    appLogger.e("Something went wrong while updating screenshot censoring config")
+                }
+
+                is PersistScreenshotCensoringConfigResult.Success -> {
+                    appLogger.d("Screenshot censoring config changed")
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -844,6 +844,9 @@
     <!--Privacy Settings -->
     <string name="settings_send_read_receipts">Send read receipts</string>
     <string name="settings_send_read_receipts_description">If this is OFF, you won’t be able to see read receipts from other people. This setting does not apply to group conversations.</string>
+    <string name="settings_censor_screenshots">Censor screenshots</string>
+    <string name="settings_censor_screenshots_description">If this is ON, then the content of the messages will not be visible on the screenshot or screen recording.</string>
+    <string name="settings_censor_screenshots_enforced_by_team_description">This is enforced by the self-deleting message team setting and cannot be changed.\nThe content of the messages will not be visible on the screenshot or screen recording.</string>
     <!--Devices -->
     <string name="devices_title">Your Devices</string>
     <string name="current_device_label">Current Device</string>

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -643,7 +643,6 @@ class WireActivityViewModelTest {
         coVerify(exactly = 1) { arrangement.clearNewClientsForUser(USER_ID) }
     }
 
-
     @Test
     fun `given screenshot censoring disabled, when observing it, then set screenshotCensoringEnabled state to false`() = runTest {
         val (_, viewModel) = Arrangement()

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -32,6 +32,8 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -66,6 +68,9 @@ class ConversationInfoViewModelArrangement {
     @MockK
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
+    @MockK
+    private lateinit var observeScreenshotCensoringConfigUseCase: ObserveScreenshotCensoringConfigUseCase
+
     private val viewModel: ConversationInfoViewModel by lazy {
         ConversationInfoViewModel(
             qualifiedIdMapper,
@@ -73,6 +78,7 @@ class ConversationInfoViewModelArrangement {
             navigationManager,
             observeConversationDetails,
             observerSelfUser,
+            observeScreenshotCensoringConfigUseCase,
             wireSessionImageLoader,
             TestDispatcherProvider()
         )
@@ -88,6 +94,7 @@ class ConversationInfoViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow().map {
             ObserveConversationDetailsUseCase.Result.Success(it)
         }
+        coEvery { observeScreenshotCensoringConfigUseCase() } returns flowOf(ObserveScreenshotCensoringConfigResult.Disabled)
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
@@ -99,6 +106,10 @@ class ConversationInfoViewModelArrangement {
 
     suspend fun withSelfUser() = apply {
         coEvery { observerSelfUser() } returns flowOf(TestUser.SELF_USER)
+    }
+
+    suspend fun withScreenshotCensoringConfig(result: ObserveScreenshotCensoringConfigResult) = apply {
+        coEvery { observeScreenshotCensoringConfigUseCase() } returns flowOf(result)
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
-
 class ConversationInfoViewModelArrangement {
 
     val conversationId: ConversationId = ConversationId("some-dummy-value", "some.dummy.domain")

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -32,8 +32,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
-import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
-import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -67,9 +65,6 @@ class ConversationInfoViewModelArrangement {
     @MockK
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
-    @MockK
-    private lateinit var observeScreenshotCensoringConfigUseCase: ObserveScreenshotCensoringConfigUseCase
-
     private val viewModel: ConversationInfoViewModel by lazy {
         ConversationInfoViewModel(
             qualifiedIdMapper,
@@ -77,7 +72,6 @@ class ConversationInfoViewModelArrangement {
             navigationManager,
             observeConversationDetails,
             observerSelfUser,
-            observeScreenshotCensoringConfigUseCase,
             wireSessionImageLoader,
             TestDispatcherProvider()
         )
@@ -93,7 +87,6 @@ class ConversationInfoViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow().map {
             ObserveConversationDetailsUseCase.Result.Success(it)
         }
-        coEvery { observeScreenshotCensoringConfigUseCase() } returns flowOf(ObserveScreenshotCensoringConfigResult.Disabled)
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
@@ -105,10 +98,6 @@ class ConversationInfoViewModelArrangement {
 
     suspend fun withSelfUser() = apply {
         coEvery { observerSelfUser() } returns flowOf(TestUser.SELF_USER)
-    }
-
-    suspend fun withScreenshotCensoringConfig(result: ObserveScreenshotCensoringConfigResult) = apply {
-        coEvery { observeScreenshotCensoringConfigUseCase() } returns flowOf(result)
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -268,5 +269,35 @@ class ConversationInfoViewModelTest {
             assertEquals(otherUserAvatar, (actualAvatar as ConversationAvatar.OneOne).avatarAsset?.userAssetId)
             cancel()
         }
+    }
+
+    @Test
+    fun `given screenshot censoring disabled, when observing it, then set screenshotCensoringEnabled state to false`() = runTest {
+        val (_, viewModel) = ConversationInfoViewModelArrangement()
+            .withSelfUser()
+            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Disabled)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(false, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
+    }
+
+    @Test
+    fun `given screenshot censoring enabled by user, when observing it, then set screenshotCensoringEnabled state to true`() = runTest {
+        val (_, viewModel) = ConversationInfoViewModelArrangement()
+            .withSelfUser()
+            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(true, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
+    }
+
+    @Test
+    fun `given screenshot censoring enforced by team, when observing it, then set screenshotCensoringEnabled state to true`() = runTest {
+        val (_, viewModel) = ConversationInfoViewModelArrangement()
+            .withSelfUser()
+            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(true, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -269,35 +268,5 @@ class ConversationInfoViewModelTest {
             assertEquals(otherUserAvatar, (actualAvatar as ConversationAvatar.OneOne).avatarAsset?.userAssetId)
             cancel()
         }
-    }
-
-    @Test
-    fun `given screenshot censoring disabled, when observing it, then set screenshotCensoringEnabled state to false`() = runTest {
-        val (_, viewModel) = ConversationInfoViewModelArrangement()
-            .withSelfUser()
-            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Disabled)
-            .arrange()
-        advanceUntilIdle()
-        assertEquals(false, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
-    }
-
-    @Test
-    fun `given screenshot censoring enabled by user, when observing it, then set screenshotCensoringEnabled state to true`() = runTest {
-        val (_, viewModel) = ConversationInfoViewModelArrangement()
-            .withSelfUser()
-            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser)
-            .arrange()
-        advanceUntilIdle()
-        assertEquals(true, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
-    }
-
-    @Test
-    fun `given screenshot censoring enforced by team, when observing it, then set screenshotCensoringEnabled state to true`() = runTest {
-        val (_, viewModel) = ConversationInfoViewModelArrangement()
-            .withSelfUser()
-            .withScreenshotCensoringConfig(ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings)
-            .arrange()
-        advanceUntilIdle()
-        assertEquals(true, viewModel.conversationInfoViewState.screenshotCensoringEnabled)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to restrict team members from taking screenshots of the app when self deleting messages are enforced in team settings.

### Solutions

Implement blocking content when making screenshots or screen recording when the team self-deleting setting is enforced. Also, provide a switch in the privacy settings for the user to enable it manually.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/1887

### Testing

#### How to Test

Enforce team self-deleting setting or enable screenshot censoring in the privacy settings and make a screenshot.

### Attachments (Optional)

https://github.com/wireapp/wire-android-reloaded/assets/30429749/d23b86b5-8269-4b47-94c9-7fe610ec91d4

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
