### PR TITLE
feat: render composite messages UI [part-1]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -247,9 +247,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                 is WithUser.TeamMemberRemoved -> UILastMessageContent.None // TODO
                 is WithUser.Text -> UILastMessageContent.SenderWithMessage(
                     sender = userUIText,
-                    message = (content as WithUser.Text).messageBody?.let {
-                        UIText.DynamicString(it)
-                    },
+                    message = UIText.DynamicString((content as WithUser.Text).messageBody),
                     separator = ": "
                 )
 

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -247,7 +247,9 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                 is WithUser.TeamMemberRemoved -> UILastMessageContent.None // TODO
                 is WithUser.Text -> UILastMessageContent.SenderWithMessage(
                     sender = userUIText,
-                    message = UIText.DynamicString((content as WithUser.Text).messageBody),
+                    message = (content as WithUser.Text).messageBody?.let {
+                        UIText.DynamicString(it)
+                    },
                     separator = ": "
                 )
 

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -113,8 +113,7 @@ class RegularMessageMapper @Inject constructor(
                     MessageButton(
                         id = it.id,
                         text = it.text,
-                        isSelected = it.isSelected,
-                        isPending = it.isPending
+                        isSelected = it.isSelected
                     )
                 },
                 deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -115,8 +115,7 @@ class RegularMessageMapper @Inject constructor(
                         text = it.text,
                         isSelected = it.isSelected
                     )
-                },
-                deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
+                }
             )
         }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -25,6 +25,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.DeliveryStatusContent
 import com.wire.android.ui.home.conversations.model.MessageBody
+import com.wire.android.ui.home.conversations.model.MessageButton
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.util.time.ISOFormatter
@@ -90,6 +91,35 @@ class RegularMessageMapper @Inject constructor(
             userList,
             message.deliveryStatus
         )
+
+        is MessageContent.Composite -> {
+            val text = content.textContent?.let { textContent ->
+                val quotedMessage = textContent.quotedMessageDetails?.let { mapQuoteData(message.conversationId, it) }
+                    ?: if (textContent.quotedMessageReference?.quotedMessageId != null) {
+                        UIQuotedMessage.UnavailableData
+                    } else {
+                        null
+                    }
+
+                MessageBody(
+                    message = UIText.DynamicString(textContent.value, content.textContent?.mentions.orEmpty()),
+                    quotedMessage = quotedMessage
+                )
+            }
+
+            UIMessageContent.Composite(
+                messageBody = text,
+                buttonList = content.buttonList.map {
+                    MessageButton(
+                        id = it.id,
+                        text = it.text,
+                        isSelected = it.isSelected,
+                        isPending = it.isPending
+                    )
+                },
+                deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
+            )
+        }
 
         else -> toText(message.conversationId, content, userList, message.deliveryStatus)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+
+@HiltViewModel
+class CompositeMessageViewModel @Inject constructor() : ViewModel() {
+    private val lock: Mutex = Mutex()
+
+    var pendingButtons = mutableStateMapOf<String, String>()
+        private set
+
+    fun onButtonClicked(messageId: String, buttonId: String) {
+        if (pendingButtons.containsKey(messageId)) return
+
+        pendingButtons[messageId] = buttonId
+        viewModelScope.launch {
+            doStuff()
+        }.invokeOnCompletion {
+            pendingButtons.remove(messageId)
+        }
+    }
+
+    suspend fun doStuff() {
+        delay(5000)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
@@ -23,14 +23,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @HiltViewModel
 class CompositeMessageViewModel @Inject constructor() : ViewModel() {
-    private val lock: Mutex = Mutex()
 
     var pendingButtons = mutableStateMapOf<String, String>()
         private set
@@ -46,6 +42,7 @@ class CompositeMessageViewModel @Inject constructor() : ViewModel() {
         }
     }
 
+    @Suppress("MagicNumber")
     suspend fun doStuff() {
         delay(5000)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessagesViewModel.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.home.conversations
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -26,10 +27,11 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CompositeMessageViewModel @Inject constructor() : ViewModel() {
+class CompositeMessagesViewModel @Inject constructor() : ViewModel() {
 
     var pendingButtons = mutableStateMapOf<String, String>()
-        private set
+        @VisibleForTesting
+        set
 
     fun onButtonClicked(messageId: String, buttonId: String) {
         if (pendingButtons.containsKey(messageId)) return

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -120,7 +120,7 @@ fun ConversationScreen(
     conversationCallViewModel: ConversationCallViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     conversationMessagesViewModel: ConversationMessagesViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     messageComposerViewModel: MessageComposerViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
-    compositeMessagesViewModel: CompositeMessageViewModel = viewModel()
+    compositeMessagesViewModel: CompositeMessagesViewModel = viewModel()
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
@@ -308,7 +308,7 @@ private fun ConversationScreen(
     composerMessages: SharedFlow<SnackBarMessage>,
     conversationMessages: SharedFlow<SnackBarMessage>,
     conversationMessagesViewModel: ConversationMessagesViewModel,
-    compositeMessagesViewModel: CompositeMessageViewModel,
+    compositeMessagesViewModel: CompositeMessagesViewModel,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     onNewSelfDeletingMessagesStatus: (SelfDeletionTimer) -> Unit,
     tempWritableImageUri: Uri?,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -120,7 +120,7 @@ fun ConversationScreen(
     conversationCallViewModel: ConversationCallViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     conversationMessagesViewModel: ConversationMessagesViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     messageComposerViewModel: MessageComposerViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
-    compositeMessagesViewModel: CompositeMessagesViewModel = viewModel()
+    compositeMessagesViewModel: CompositeMessagesViewModel = hiltViewModel()
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -118,7 +119,8 @@ fun ConversationScreen(
     conversationBannerViewModel: ConversationBannerViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     conversationCallViewModel: ConversationCallViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
     conversationMessagesViewModel: ConversationMessagesViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
-    messageComposerViewModel: MessageComposerViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs)
+    messageComposerViewModel: MessageComposerViewModel = hiltSavedStateViewModel(backNavArgs = backNavArgs),
+    compositeMessagesViewModel: CompositeMessageViewModel = viewModel()
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
@@ -219,6 +221,7 @@ fun ConversationScreen(
         onFailedMessageRetryClicked = messageComposerViewModel::retrySendingMessage,
         requestMentions = messageComposerViewModel::searchMembersToMention,
         onClearMentionSearchResult = messageComposerViewModel::clearMentionSearchResult,
+        compositeMessagesViewModel = compositeMessagesViewModel
     )
     DeleteMessageDialog(
         state = messageComposerViewModel.deleteMessageDialogsState,
@@ -305,6 +308,7 @@ private fun ConversationScreen(
     composerMessages: SharedFlow<SnackBarMessage>,
     conversationMessages: SharedFlow<SnackBarMessage>,
     conversationMessagesViewModel: ConversationMessagesViewModel,
+    compositeMessagesViewModel: CompositeMessageViewModel,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     onNewSelfDeletingMessagesStatus: (SelfDeletionTimer) -> Unit,
     tempWritableImageUri: Uri?,
@@ -421,7 +425,9 @@ private fun ConversationScreen(
                     onClearMentionSearchResult = onClearMentionSearchResult,
                     tempWritableImageUri = tempWritableImageUri,
                     tempWritableVideoUri = tempWritableVideoUri,
-                    snackBarHostState = conversationScreenState.snackBarHostState
+                    snackBarHostState = conversationScreenState.snackBarHostState,
+                    onMessageButtonClicked = compositeMessagesViewModel::onButtonClicked,
+                    pendingButtonsMap = compositeMessagesViewModel.pendingButtons,
                 )
             }
             MenuModalSheetLayout(
@@ -460,6 +466,8 @@ private fun ConversationScreenContent(
     onChangeSelfDeletionClicked: () -> Unit,
     onSearchMentionQueryChanged: (String) -> Unit,
     onClearMentionSearchResult: () -> Unit,
+    onMessageButtonClicked: (messageId: String, buttonId: String) -> Unit,
+    pendingButtonsMap: Map<String, String>,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
     snackBarHostState: SnackbarHostState
@@ -491,7 +499,9 @@ private fun ConversationScreenContent(
                 onShowEditingOption = onShowEditingOptions,
                 conversationDetailsData = conversationDetailsData,
                 onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                onFailedMessageRetryClicked = onFailedMessageRetryClicked
+                onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                onMessageButtonClicked = onMessageButtonClicked,
+                pendingButtonsMap = pendingButtonsMap
             )
         },
         onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
@@ -571,7 +581,9 @@ fun MessageList(
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     conversationDetailsData: ConversationDetailsData,
     onFailedMessageRetryClicked: (String) -> Unit,
-    onFailedMessageCancelClicked: (String) -> Unit
+    onFailedMessageCancelClicked: (String) -> Unit,
+    onMessageButtonClicked: (messageId: String, buttonId: String) -> Unit,
+    pendingButtonsMap: Map<String, String>
 ) {
     val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
 
@@ -627,7 +639,9 @@ fun MessageList(
                         onResetSessionClicked = onResetSessionClicked,
                         onSelfDeletingMessageRead = onSelfDeletingMessageRead,
                         onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                        onFailedMessageRetryClicked = onFailedMessageRetryClicked
+                        onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                        onMessageButtonClicked = onMessageButtonClicked,
+                        pendingButtonsMap = pendingButtonsMap
                     )
                 }
 
@@ -700,6 +714,7 @@ fun PreviewConversationScreen() {
         tempWritableVideoUri = null,
         onFailedMessageRetryClicked = {},
         requestMentions = {},
-        onClearMentionSearchResult = {}
+        onClearMentionSearchResult = {},
+        compositeMessagesViewModel = hiltViewModel()
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -103,7 +103,9 @@ fun MessageItem(
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     onFailedMessageRetryClicked: (String) -> Unit = {},
-    onFailedMessageCancelClicked: (String) -> Unit = {}
+    onFailedMessageCancelClicked: (String) -> Unit = {},
+    onMessageButtonClicked: (messageId: String, buttonId: String) -> Unit,
+    pendingButtonsMap: Map<String, String> = emptyMap()
 ) {
     with(message) {
         val selfDeletionTimerState = rememberSelfDeletionTimer(header.messageStatus.expirationStatus)
@@ -158,7 +160,7 @@ fun MessageItem(
 
                 val isProfileRedirectEnabled =
                     header.userId != null &&
-                        !(header.isSenderDeleted || header.isSenderUnavailable)
+                            !(header.isSenderDeleted || header.isSenderUnavailable)
 
                 if (showAuthor) {
                     val avatarClickable = remember {
@@ -229,7 +231,9 @@ fun MessageItem(
                                         onAssetClick = currentOnAssetClicked,
                                         onImageClick = currentOnImageClick,
                                         onLongClick = onLongClick,
-                                        onOpenProfile = onOpenProfile
+                                        onOpenProfile = onOpenProfile,
+                                        onMessageButtonClicked = onMessageButtonClicked,
+                                        pendingButtonsMap = pendingButtonsMap,
                                     )
                                 }
                                 if (isMyMessage) {
@@ -444,6 +448,8 @@ private fun MessageContent(
     audioMessagesState: Map<String, AudioState>,
     onAssetClick: Clickable,
     onImageClick: Clickable,
+    onMessageButtonClicked: (messageId: String, buttonId: String) -> Unit,
+    pendingButtonsMap: Map<String, String>,
     onAudioClick: (String) -> Unit,
     onChangeAudioPosition: (String, Int) -> Unit,
     onLongClick: (() -> Unit)? = null,
@@ -478,6 +484,8 @@ private fun MessageContent(
                     onOpenProfile = onOpenProfile,
                     buttonList = null,
                     onButtonClick = null,
+                    pendingButton = null,
+                    messageId = message.header.messageId
                 )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }
@@ -499,7 +507,9 @@ private fun MessageContent(
                     onLongClick = onLongClick,
                     onOpenProfile = onOpenProfile,
                     buttonList = messageContent.buttonList,
-                    onButtonClick = { TODO() },
+                    onButtonClick = onMessageButtonClicked,
+                    messageId = message.header.messageId,
+                    pendingButton = pendingButtonsMap[message.header.messageId]
                 )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -511,7 +511,6 @@ private fun MessageContent(
                     messageId = message.header.messageId,
                     pendingButton = pendingButtonsMap[message.header.messageId]
                 )
-                PartialDeliveryInformation(messageContent.deliveryStatus)
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -475,7 +475,31 @@ private fun MessageContent(
                     messageBody = messageContent.messageBody,
                     isAvailable = !message.isPending && message.isAvailable,
                     onLongClick = onLongClick,
-                    onOpenProfile = onOpenProfile
+                    onOpenProfile = onOpenProfile,
+                    buttonList = null,
+                    onButtonClick = null,
+                )
+                PartialDeliveryInformation(messageContent.deliveryStatus)
+            }
+        }
+
+        is UIMessageContent.Composite -> {
+            Column {
+                messageContent.messageBody?.quotedMessage?.let {
+                    VerticalSpace.x4()
+                    when (it) {
+                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(it)
+                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(QuotedMessageStyle.COMPLETE)
+                    }
+                    VerticalSpace.x4()
+                }
+                MessageBody(
+                    messageBody = messageContent.messageBody,
+                    isAvailable = !message.isPending && message.isAvailable,
+                    onLongClick = onLongClick,
+                    onOpenProfile = onOpenProfile,
+                    buttonList = messageContent.buttonList,
+                    onButtonClick = { TODO() },
                 )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -43,13 +43,13 @@ import com.wire.android.navigation.getBackNavArg
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.model.AssetBundle
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.startFileShareIntent
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -68,6 +68,7 @@ import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -96,6 +97,7 @@ class ConversationMessagesViewModel @Inject constructor(
 ) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationMessagesViewState())
+        private set
 
     private val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
         savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -82,7 +82,7 @@ internal fun MessageBody(
 ) {
     val (displayMentions, text) = messageBody?.message?.let {
         mapToDisplayMentions(it, LocalContext.current.resources)
-    } ?: TODO()
+    } ?: Pair(emptyList(), null)
 
     val nodeData = NodeData(
         modifier = Modifier.defaultMinSize(minHeight = dimensions().spacing20x),
@@ -99,8 +99,9 @@ internal fun MessageBody(
         StrikethroughExtension.builder().requireTwoTildes(true).build(),
         TablesExtension.create()
     )
-
-    MarkdownDocument(Parser.builder().extensions(extensions).build().parse(text) as Document, nodeData)
+    text?.also {
+        MarkdownDocument(Parser.builder().extensions(extensions).build().parse(it) as Document, nodeData)
+    }
     buttonList?.also {
         MessageButtonsContent(it, onButtonClick)
     }
@@ -132,7 +133,7 @@ fun MessageButton(button: MessageButton, onClick: ((String) -> Unit)?) {
                 { }
             }
         }
-    }?: { }
+    } ?: { }
 
     WireSecondaryButton(
         text = button.text,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -140,8 +140,6 @@ fun MessageButton(button: MessageButton, onClick: ((String) -> Unit)?) {
         onClick = onCLick,
         loading = button.isSelected,
     )
-}
-
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -140,6 +140,7 @@ fun MessageButton(button: MessageButton, onClick: ((String) -> Unit)?) {
         onClick = onCLick,
         loading = button.isSelected,
     )
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -66,7 +66,8 @@ fun PreviewMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -95,7 +96,8 @@ fun PreviewMessageWithReactions() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -135,7 +137,8 @@ fun PreviewMessageWithReply() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -165,7 +168,8 @@ fun PreviewDeletedMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -196,7 +200,8 @@ fun PreviewFailedSendMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -227,7 +232,8 @@ fun PreviewFailedDecryptionMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -248,7 +254,8 @@ fun PreviewAssetMessageWithReactions() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -337,7 +344,8 @@ fun PreviewImageMessageUploaded() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -358,7 +366,8 @@ fun PreviewImageMessageUploading() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -385,7 +394,8 @@ fun PreviewImageMessageFailedUpload() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -407,7 +417,8 @@ fun PreviewMessageWithSystemMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = { },
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onMessageButtonClicked = { _, _ -> }
             )
             SystemMessageItem(
                 mockMessageWithKnock.copy(
@@ -451,7 +462,8 @@ fun PreviewMessagesWithUnavailableQuotedMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onMessageButtonClicked = { _, _ -> }
         )
     }
 }
@@ -473,7 +485,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onMessageButtonClicked = { _, _ -> }
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -495,7 +508,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onMessageButtonClicked = { _, _ -> }
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -517,7 +531,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onMessageButtonClicked = { _, _ -> }
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -185,7 +185,7 @@ sealed class UILastMessageContent {
 
     data class TextMessage(val messageBody: MessageBody) : UILastMessageContent()
 
-    data class SenderWithMessage(val sender: UIText, val message: UIText?, val separator: String = " ") : UILastMessageContent()
+    data class SenderWithMessage(val sender: UIText, val message: UIText, val separator: String = " ") : UILastMessageContent()
 
     data class MultipleMessage(val messages: List<UIText>, val separator: String = " ") : UILastMessageContent()
 
@@ -478,6 +478,5 @@ sealed interface DeliveryStatusContent {
 data class MessageButton(
     val id: String,
     val text: String,
-    val isPending: Boolean,
     val isSelected: Boolean,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -214,9 +214,8 @@ sealed class UIMessageContent {
 
     data class Composite(
         val messageBody: MessageBody?,
-        val buttonList: List<MessageButton>,
-        override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
-    ) : Regular(), PartialDeliverable
+        val buttonList: List<MessageButton>
+    ) : Regular()
 
     object Deleted : Regular()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -185,7 +185,7 @@ sealed class UILastMessageContent {
 
     data class TextMessage(val messageBody: MessageBody) : UILastMessageContent()
 
-    data class SenderWithMessage(val sender: UIText, val message: UIText, val separator: String = " ") : UILastMessageContent()
+    data class SenderWithMessage(val sender: UIText, val message: UIText?, val separator: String = " ") : UILastMessageContent()
 
     data class MultipleMessage(val messages: List<UIText>, val separator: String = " ") : UILastMessageContent()
 
@@ -209,6 +209,12 @@ sealed class UIMessageContent {
 
     data class TextMessage(
         val messageBody: MessageBody,
+        override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
+    ) : Regular(), PartialDeliverable
+
+    data class Composite(
+        val messageBody: MessageBody?,
+        val buttonList: List<MessageButton>,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
     ) : Regular(), PartialDeliverable
 
@@ -467,3 +473,11 @@ sealed interface DeliveryStatusContent {
 
     object CompleteDelivery : DeliveryStatusContent
 }
+
+@Stable
+data class MessageButton(
+    val id: String,
+    val text: String,
+    val isPending: Boolean,
+    val isSelected: Boolean,
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -44,7 +44,8 @@ fun LastMessageSubtitle(text: UIText) {
 @Composable
 fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText, separator: String) {
     Text(
-        text = "${author.asString(LocalContext.current.resources)}$separator${text.asString(LocalContext.current.resources)}",        style = MaterialTheme.wireTypography.subline01.copy(
+        text = "${author.asString(LocalContext.current.resources)}$separator${text.asString(LocalContext.current.resources)}",
+        style = MaterialTheme.wireTypography.subline01.copy(
             color = MaterialTheme.wireColorScheme.secondaryText
         ),
         maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -20,8 +20,8 @@
 
 package com.wire.android.ui.home.conversationslist.common
 
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
@@ -42,10 +42,9 @@ fun LastMessageSubtitle(text: UIText) {
 }
 
 @Composable
-fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText?, separator: String) {
+fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText, separator: String) {
     Text(
-        text = "${author.asString(LocalContext.current.resources)}$separator${text?.asString(LocalContext.current.resources)}",
-        style = MaterialTheme.wireTypography.subline01.copy(
+        text = "${author.asString(LocalContext.current.resources)}$separator${text.asString(LocalContext.current.resources)}",        style = MaterialTheme.wireTypography.subline01.copy(
             color = MaterialTheme.wireColorScheme.secondaryText
         ),
         maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -42,9 +42,9 @@ fun LastMessageSubtitle(text: UIText) {
 }
 
 @Composable
-fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText, separator: String) {
+fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText?, separator: String) {
     Text(
-        text = "${author.asString(LocalContext.current.resources)}$separator${text.asString(LocalContext.current.resources)}",
+        text = "${author.asString(LocalContext.current.resources)}$separator${text?.asString(LocalContext.current.resources)}",
         style = MaterialTheme.wireTypography.subline01.copy(
             color = MaterialTheme.wireColorScheme.secondaryText
         ),

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/CompositeMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/CompositeMessagesViewModelTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import com.wire.android.config.CoroutineTestExtension
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class CompositeMessagesViewModelTest {
+
+    @Test
+    fun `given pending button, when button is clicked, then do Nothing`() = runTest {
+        // Arrange
+        val (arrangement, viewModel) = Arrangement().arrange()
+        val messageId = "messageId"
+        val buttonId = "buttonId"
+        viewModel.pendingButtons[messageId] = buttonId
+
+        // Act
+        viewModel.onButtonClicked(messageId, buttonId)
+
+        // Assert
+        // TODO assert that the use case is not called
+    }
+
+    @Test
+    fun `given button nto pending, when button is clicked, then mark pending and then remove it once done`() = runTest {
+        // Arrange
+        val (arrangement, viewModel) = Arrangement().arrange()
+        val messageId = "messageId"
+        val buttonId = "buttonId"
+
+        // Act
+        viewModel.onButtonClicked(messageId, buttonId)
+        assertTrue(viewModel.pendingButtons.containsKey(messageId))
+        advanceUntilIdle()
+        assertFalse(viewModel.pendingButtons.containsKey(messageId))
+
+        // Assert
+        // TODO assert that the use case is called called
+    }
+
+    private class Arrangement {
+
+        private val viewModel = CompositeMessagesViewModel()
+
+        fun arrange() = this to viewModel
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

message item does not support composite messages

### Solutions

change the text message composable to accept nullable text and a list of buttons 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
