### PR TITLE
fix: send audio messages (WPB-252)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -88,12 +88,10 @@ class AudioMediaRecorder @Inject constructor(
         }
     }
 
-    fun startRecording(onStarted: () -> Unit) {
+    fun startRecording() {
         try {
             mediaRecorder?.prepare()
             mediaRecorder?.start()
-
-            onStarted()
         } catch (e: IllegalStateException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${e.message}")

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -21,9 +21,11 @@ import android.content.Context
 import android.media.MediaRecorder
 import android.os.Build
 import com.wire.android.appLogger
+import com.wire.android.util.audioFileDateTime
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
+import com.wire.kalium.util.DateTimeUtil
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -73,7 +75,7 @@ class AudioMediaRecorder @Inject constructor(
             }
 
             outputFile = kaliumFileSystem
-                .tempFilePath(TEMP_RECORDING_AUDIO_FILE)
+                .tempFilePath(getRecordingAudioFileName())
                 .toFile()
 
             mediaRecorder?.setAudioSource(MediaRecorder.AudioSource.MIC)
@@ -86,10 +88,12 @@ class AudioMediaRecorder @Inject constructor(
         }
     }
 
-    fun startRecording() {
+    fun startRecording(onStarted: () -> Unit) {
         try {
             mediaRecorder?.prepare()
             mediaRecorder?.start()
+
+            onStarted()
         } catch (e: IllegalStateException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${e.message}")
@@ -122,7 +126,8 @@ class AudioMediaRecorder @Inject constructor(
     }
 
     private companion object {
-        const val TEMP_RECORDING_AUDIO_FILE = "temp_recording.mp3"
+        fun getRecordingAudioFileName(): String =
+            "wire-audio-${DateTimeUtil.currentInstant().audioFileDateTime()}.mp3"
         const val SIZE_OF_1MB = 1024 * 1024
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -117,7 +117,7 @@ fun RecordAudioButtonRecording(
         contentDescription = R.string.content_description_record_audio_button_stop,
         buttonColor = colorsScheme().recordAudioStopColor,
         bottomText = R.string.record_audio_recording_label,
-        buttonState = if(seconds > 0) WireButtonState.Default else WireButtonState.Disabled
+        buttonState = if (seconds > 0) WireButtonState.Default else WireButtonState.Disabled
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -118,7 +118,6 @@ fun RecordAudioButtonRecording(
         buttonColor = colorsScheme().recordAudioStopColor,
         bottomText = R.string.record_audio_recording_label,
         buttonState = if(seconds > 0) WireButtonState.Default else WireButtonState.Disabled
-
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -116,7 +116,9 @@ fun RecordAudioButtonRecording(
         iconResId = R.drawable.ic_stop,
         contentDescription = R.string.content_description_record_audio_button_stop,
         buttonColor = colorsScheme().recordAudioStopColor,
-        bottomText = R.string.record_audio_recording_label
+        bottomText = R.string.record_audio_recording_label,
+        buttonState = if(seconds > 0) WireButtonState.Default else WireButtonState.Disabled
+
     )
 }
 
@@ -160,7 +162,8 @@ fun RecordAudioButton(
     @DrawableRes iconResId: Int,
     @StringRes contentDescription: Int,
     buttonColor: Color,
-    @StringRes bottomText: Int
+    @StringRes bottomText: Int,
+    buttonState: WireButtonState = WireButtonState.Default
 ) {
     Column(
         modifier = modifier,
@@ -186,7 +189,7 @@ fun RecordAudioButton(
             colors = wireSecondaryButtonColors().copy(
                 enabled = buttonColor
             ),
-            state = WireButtonState.Default
+            state = buttonState
         )
         Spacer(modifier = Modifier.height(dimensions().spacing16x))
         Text(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -133,11 +133,11 @@ class RecordAudioViewModel @Inject constructor(
                 outputFile = audioMediaRecorder.outputFile
             )
 
-            audioMediaRecorder.startRecording(onStarted = {
-                state = state.copy(
-                    buttonState = RecordAudioButtonState.RECORDING
-                )
-            })
+            audioMediaRecorder.startRecording()
+
+            state = state.copy(
+                buttonState = RecordAudioButtonState.RECORDING
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -127,17 +127,17 @@ class RecordAudioViewModel @Inject constructor(
                 infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioCall.uiText)
             }
         } else {
-            state = state.copy(
-                buttonState = RecordAudioButtonState.RECORDING
-            )
-
             audioMediaRecorder.setUp()
 
             state = state.copy(
                 outputFile = audioMediaRecorder.outputFile
             )
 
-            audioMediaRecorder.startRecording()
+            audioMediaRecorder.startRecording(onStarted = {
+                state = state.copy(
+                    buttonState = RecordAudioButtonState.RECORDING
+                )
+            })
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -48,6 +48,11 @@ private val readReceiptDateTimeFormat = SimpleDateFormat(
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
 
+private val audioFileDateTimeFormat = SimpleDateFormat(
+    "yyyy-MM-dd-hh-mm-ss",
+    Locale.getDefault()
+).apply { timeZone = TimeZone.getDefault() }
+
 private val fullDateShortTimeFormatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.SHORT)
 fun String.formatMediumDateTime(): String? =
     try {
@@ -79,6 +84,9 @@ fun String.uiMessageDateTime(): String? = this
     }
 
 fun Instant.uiReadReceiptDateTime(): String = readReceiptDateTimeFormat.format(Date(this.toEpochMilliseconds()))
+
+fun Instant.audioFileDateTime(): String = audioFileDateTimeFormat
+    .format(Date(this.toEpochMilliseconds()))
 
 fun getCurrentParsedDateTime(): String = mediumDateTimeFormat.format(System.currentTimeMillis())
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While QA testing it was found out:
- If clicked super fast to stop recording right after starting to record it could crash the feature, because it was super fast the media recorder didn't had much time to `prepare()` and `start()` before calling `stop()`.
- file name was `temp_recording.mp3`

### Solutions

- Adjusted the button state for `Default` and `Disabled` based on the stopwatch, if seconds > 0 then it is enabled, otherwise (for the first second) it is disabled.
- Changed file name to this pattern: `wire-audio-date-time.mp3` // Such as: `wire-audio-2023-07-18-11-10-09.mp3`
