### PR TITLE
feat: display when a self client was last active

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -47,10 +47,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -47,8 +47,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.authentication.devices.model.Device
+import com.wire.android.ui.authentication.devices.model.lastActiveDescription
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.getMinTouchMargins
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
@@ -199,11 +202,20 @@ private fun DeviceItemTexts(
 
     Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.removeDeviceItemTitleVerticalPadding))
     val details: String = if (!device.registrationTime.isNullOrBlank()) {
-        stringResource(
-            R.string.remove_device_id_and_time_label,
-            device.clientId.formatAsString(),
-            device.registrationTime.formatMediumDateTime() ?: ""
-        )
+        if (device.lastActiveInWholeWeeks != null) {
+            stringResource(
+                R.string.remove_device_id_and_time_label_active_label,
+                device.clientId.formatAsString(),
+                device.registrationTime.formatMediumDateTime() ?: "",
+                device.lastActiveDescription() ?: ""
+            )
+        } else {
+            stringResource(
+                R.string.remove_device_id_and_time_label,
+                device.clientId.formatAsString(),
+                device.registrationTime.formatMediumDateTime() ?: ""
+            )
+        }
     } else {
         stringResource(
             R.string.remove_device_id_label,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
@@ -20,17 +20,24 @@
 
 package com.wire.android.ui.authentication.devices.model
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.util.inWholeWeeks
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.datetime.Clock
 
 data class Device(
     val name: UIText = UIText.DynamicString(""),
     val clientId: ClientId = ClientId(""),
     val registrationTime: String? = null,
+    val lastActiveInWholeWeeks: Int? = null,
     val isValid: Boolean = true,
     val isVerified: Boolean = false
 ) {
@@ -38,7 +45,7 @@ data class Device(
         client.displayName(),
         client.id,
         client.registrationTime?.toIsoDateTimeString(),
-        true,
+        client.lastActiveInWholeWeeks(),
         client.isVerified
     )
 }
@@ -50,3 +57,22 @@ data class Device(
 fun Client.displayName(): UIText = (model ?: deviceType?.name)?.let {
     UIText.DynamicString(it)
 } ?: UIText.StringResource(R.string.device_name_unknown)
+
+fun Client.lastActiveInWholeWeeks(): Int? {
+    return lastActive?.let { (Clock.System.now() - it).inWholeWeeks.toInt() }
+}
+
+@Stable
+@Composable
+fun Device.lastActiveDescription(): String? =
+    lastActiveInWholeWeeks?.let {
+        if (it == 0) {
+            stringResource(R.string.label_client_last_active_time_zero_weeks)
+        } else {
+            stringResource(
+                R.string.label_client_last_active_time,
+                pluralStringResource(R.plurals.weeks_long_label, it, it)
+            )
+        }
+    }
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.client.Client
@@ -75,4 +74,3 @@ fun Device.lastActiveDescription(): String? =
             )
         }
     }
-

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -34,6 +35,7 @@ import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.hiltSavedStateViewModel
 import com.wire.android.ui.authentication.devices.model.Device
+import com.wire.android.ui.authentication.devices.model.lastActiveDescription
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialog
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialogState
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
@@ -151,6 +153,16 @@ fun DeviceDetailsContent(
                     DeviceDetailSectionContent(
                         stringResource(id = R.string.label_client_added_time),
                         AnnotatedString(it)
+                    )
+                    Divider(color = MaterialTheme.wireColorScheme.background)
+                }
+            }
+
+            state.device.lastActiveInWholeWeeks?.let {
+                item {
+                    DeviceDetailSectionContent(
+                        stringResource(id = R.string.label_client_last_active_label),
+                        AnnotatedString(state.device.lastActiveDescription() ?: "")
                     )
                     Divider(color = MaterialTheme.wireColorScheme.background)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -883,7 +883,7 @@
     <string name="label_code_commit_id">Commit Hash: %1$s</string>
     <string name="label_client_id">Client ID: %1$s</string>
     <string name="label_client_added_time">ADDED</string>
-    <string name="label_client_last_active_label">LAST_ACTIVE</string>
+    <string name="label_client_last_active_label">LAST ACTIVE</string>
     <string name="label_client_last_active_time_zero_weeks">Less than a week ago</string>
     <string name="label_client_last_active_time">%1$s ago</string>
     <string name="label_client_device_id">DEVICE ID</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,7 @@
     </string>
     <string name="remove_device_label">YOUR DEVICES</string>
     <string name="remove_device_id_and_time_label">ID: %1$s\nAdded: %2$s</string>
+    <string name="remove_device_id_and_time_label_active_label">ID: %1$s\nAdded: %2$s\nActive: %3$s</string>
     <string name="remove_device_id_label">ID: %1$s</string>
     <string name="remove_device_dialog_title">Remove the following device?</string>
     <string name="remove_device_invalid_password">Invalid password</string>
@@ -882,6 +883,9 @@
     <string name="label_code_commit_id">Commit Hash: %1$s</string>
     <string name="label_client_id">Client ID: %1$s</string>
     <string name="label_client_added_time">ADDED</string>
+    <string name="label_client_last_active_label">LAST_ACTIVE</string>
+    <string name="label_client_last_active_time_zero_weeks">Less than a week ago</string>
+    <string name="label_client_last_active_time">%1$s ago</string>
     <string name="label_client_device_id">DEVICE ID</string>
     <string name="label_key_packages_count">Key-packages count</string>
     <string name="label_mls_client_id">MLS Client ID</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestClient.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestClient.kt
@@ -30,7 +30,7 @@ object TestClient {
     val CLIENT_ID = ClientId("test")
 
     val CLIENT = Client(
-        CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, false,
+        CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, Instant.DISTANT_PAST, false,
         isValid = true, DeviceType.Desktop, "label", null
     )
 }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -201,7 +201,7 @@ class RegisterDeviceViewModelTest {
     companion object {
         val CLIENT_ID = ClientId("test")
         val CLIENT = Client(
-            CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, false,
+            CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, Instant.DISTANT_PAST, false,
             isValid = true, DeviceType.Desktop, "label", null
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -496,7 +496,7 @@ class LoginEmailViewModelTest {
     companion object {
         val CLIENT_ID = ClientId("test")
         val CLIENT = Client(
-            CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, false,
+            CLIENT_ID, ClientType.Permanent, Instant.DISTANT_FUTURE, Instant.DISTANT_PAST, false,
             isValid = true, DeviceType.Desktop, "label", null
         )
         val SSO_ID: SsoId = SsoId("scim_id", null, null)

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -536,6 +536,7 @@ class LoginSSOViewModelTest {
             CLIENT_ID,
             ClientType.Permanent,
             Instant.DISTANT_FUTURE,
+            Instant.DISTANT_PAST,
             false,
             isValid = true,
             DeviceType.Desktop,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When available display information about when a client was last active.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/1886

### Attachments

![Screenshot_20230718_142534](https://github.com/wireapp/wire-android-reloaded/assets/7156/f02b2d21-874a-4da0-aeac-99e68dd8f067)


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
