### PR TITLE
docs: improve wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These differences are:
 
 ## Prerequisites
 
-In order to build Wire for Android locally, it is necessary to install the following tools on the local machine:
+In order to build Wire for Android locally, it is necessary to have the following tools installed:
 
 - JDK 17
 - Android SDK


### PR DESCRIPTION
Small wording improvement on the README.

It included repeated `local` and `locally` words.