### PR TITLE
fix: remove unnecessary values for custom saver of rememberSaveable

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -55,11 +55,14 @@ fun rememberMessageComposerStateHolder(
         }
     }
     val messageCompositionInputStateHolder = rememberSaveable(
-        saver = MessageCompositionInputStateHolder.saver()
+        saver = MessageCompositionInputStateHolder.saver(
+            messageComposition = messageCompositionHolder.messageComposition,
+            selfDeletionTimer = selfDeletionTimer
+        )
     ) {
         MessageCompositionInputStateHolder(
             messageComposition = messageCompositionHolder.messageComposition,
-            selfDeletionTimer = selfDeletionTimer,
+            selfDeletionTimer = selfDeletionTimer
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.logic.util.isPositiveNotNull
 
 class MessageCompositionInputStateHolder(
     private val messageComposition: MutableState<MessageComposition>,
-    private val selfDeletionTimer: State<SelfDeletionTimer>
+    selfDeletionTimer: State<SelfDeletionTimer>
 ) {
     var inputFocused: Boolean by mutableStateOf(false)
         private set
@@ -122,28 +122,25 @@ class MessageCompositionInputStateHolder(
 
     companion object {
         @Suppress("MagicNumber")
-        fun saver(): Saver<MessageCompositionInputStateHolder, *> = Saver(
+        fun saver(
+            messageComposition: MutableState<MessageComposition>,
+            selfDeletionTimer: State<SelfDeletionTimer>
+        ): Saver<MessageCompositionInputStateHolder, *> = Saver(
             save = {
                 listOf(
-                    it.messageComposition,
-                    it.selfDeletionTimer,
                     it.inputFocused,
-                    it.inputType,
                     it.inputVisibility,
                     it.inputState,
-                    it.inputSize
                 )
             },
             restore = {
                 MessageCompositionInputStateHolder(
-                    messageComposition = it[0] as MutableState<MessageComposition>,
-                    selfDeletionTimer = it[1] as State<SelfDeletionTimer>
+                    messageComposition = messageComposition,
+                    selfDeletionTimer = selfDeletionTimer
                 ).apply {
-                    inputFocused = it[2] as Boolean
-                    inputType = it[3] as MessageCompositionType
-                    inputVisibility = it[4] as Boolean
-                    inputState = it[5] as MessageCompositionInputState
-                    inputSize = it[6] as MessageCompositionInputSize
+                    inputFocused = it[0] as Boolean
+                    inputVisibility = it[1] as Boolean
+                    inputState = it[2] as MessageCompositionInputState
                 }
             }
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Custom saver for MessageCompositionInputStateHolder was saving unnecessary field values.

### Solutions

Remove unnecessary fields
