### PR TITLE
chore: upgrade compose to fix NavBackStackEntry crashes [WPB-2321]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
@@ -22,7 +22,6 @@ package com.wire.android.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
@@ -58,7 +57,7 @@ enum class HomeNavigationItem(
     @DrawableRes val icon: Int,
     val isSearchable: Boolean = false,
     val withNewConversationFab: Boolean = false,
-    val content: (HomeStateHolder) -> (@Composable AnimatedContentScope.(NavBackStackEntry) -> Unit)
+    val content: (HomeStateHolder) -> (@Composable (NavBackStackEntry) -> Unit)
 ) {
     Conversations(
         route = HomeDestinationsRoutes.conversations,

--- a/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeNavigation.kt
@@ -22,6 +22,7 @@ package com.wire.android.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
@@ -57,7 +58,7 @@ enum class HomeNavigationItem(
     @DrawableRes val icon: Int,
     val isSearchable: Boolean = false,
     val withNewConversationFab: Boolean = false,
-    val content: (HomeStateHolder) -> (@Composable (NavBackStackEntry) -> Unit)
+    val content: (HomeStateHolder) -> (@Composable AnimatedContentScope.(NavBackStackEntry) -> Unit)
 ) {
     Conversations(
         route = HomeDestinationsRoutes.conversations,

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -20,11 +20,13 @@
 
 package com.wire.android.navigation
 
+import android.annotation.SuppressLint
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import com.wire.android.appLogger
 import com.wire.kalium.logger.obfuscateId
 
+@SuppressLint("RestrictedApi")
 internal fun NavController.navigateToItem(command: NavigationCommand) {
     appLogger.d("[$TAG] -> command: ${command.destination.obfuscateId()}")
     currentBackStackEntry?.savedStateHandle?.remove<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
@@ -32,20 +34,21 @@ internal fun NavController.navigateToItem(command: NavigationCommand) {
         when (command.backStackMode) {
             BackStackMode.CLEAR_WHOLE, BackStackMode.CLEAR_TILL_START -> {
                 val inclusive = command.backStackMode == BackStackMode.CLEAR_WHOLE
-                popBackStack(inclusive) { backQueue.firstOrNull { it.destination.route != null } }
+                popBackStack(inclusive) {
+                    currentBackStack.value.firstOrNull { it.destination.route != null } }
             }
             BackStackMode.REMOVE_CURRENT -> {
-                popBackStack(true) { backQueue.lastOrNull { it.destination.route != null } }
+                popBackStack(true) { currentBackStack.value.lastOrNull { it.destination.route != null } }
             }
             BackStackMode.REMOVE_CURRENT_AND_REPLACE -> {
-                popBackStack(true) { backQueue.lastOrNull { it.destination.route != null } }
+                popBackStack(true) { currentBackStack.value.lastOrNull { it.destination.route != null } }
                 NavigationItem.fromRoute(command.destination)?.let { navItem ->
-                    popBackStack(true) { backQueue.firstOrNull { it.destination.route == navItem.getCanonicalRoute() } }
+                    popBackStack(true) { currentBackStack.value.firstOrNull { it.destination.route == navItem.getCanonicalRoute() } }
                 }
             }
             BackStackMode.UPDATE_EXISTED -> {
                 NavigationItem.fromRoute(command.destination)?.let { navItem ->
-                    popBackStack(true) { backQueue.firstOrNull { it.destination.route == navItem.getCanonicalRoute() } }
+                    popBackStack(true) { currentBackStack.value.firstOrNull { it.destination.route == navItem.getCanonicalRoute() } }
                 }
             }
             BackStackMode.NONE -> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ compose-activity = "1.6.1"
 compose-compiler = "1.4.7"
 compose-constraint = "1.0.1"
 compose-material3 = "1.1.0"
-compose-navigation = "2.5.3"
+compose-navigation = "2.6.0"
 
 # Hilt
 hilt = "2.45"
@@ -49,7 +49,7 @@ hilt-composeNavigation = "1.0.0"
 hilt-work = "1.0.0"
 
 # Android UI
-accompanist = "0.31.5-beta"
+accompanist = "0.31.3-beta"
 material = "1.5.0"
 coil = "2.4.0"
 commonmark = "0.21.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ androidx-workManager = "2.8.1"
 androidx-browser = "1.3.0"
 
 # Compose
-compose = "1.4.3"
+compose = "1.5.0-beta03"
 compose-material = "1.4.3"
 compose-activity = "1.6.1"
 compose-compiler = "1.4.7"
@@ -49,7 +49,7 @@ hilt-composeNavigation = "1.0.0"
 hilt-work = "1.0.0"
 
 # Android UI
-accompanist = "0.28.0"
+accompanist = "0.31.5-beta"
 material = "1.5.0"
 coil = "2.4.0"
 commonmark = "0.21.0"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users still have the infamous NavBackStackEntry crashes.

### Causes (Optional)

In some places, we inject view model (using `hiltViewModel()` for instance) inside a composable that uses `SubcomposeLayout` which means the injection happens inside the subcomposition. When the parent `NavBackStackEntry` is being destroyed, the subcomposition still can happen but it will crash because this destroyed entry is the `ViewModelStoreOwner`.

### Solutions

Google provided a fix in a new version of compose, more info here: https://issuetracker.google.com/issues/254645321
With the new compose, unfortunately `backQueue` is private, the only way to get the stack is by using internal `currentBackStack`.

### Testing

#### How to Test

Try to navigate to other user profile and back quickly so that subcomposition isn't yet executed, or just do something like this:
```
LaunchedEffect(Unit) {
    delay(50L)
    eventsHandler.navigateBack()
}
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
