### PR TITLE
fix: TooManyRequestsException crash

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -71,6 +71,7 @@ object AppModule {
     fun provideNotificationManagerCompat(appContext: Context): NotificationManagerCompat =
         NotificationManagerCompat.from(appContext)
 
+    @Singleton
     @Provides
     fun provideNetworkStateObserver(appContext: Context): NetworkStateObserver =
         NetworkStateObserverImpl(appContext)

--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -30,8 +30,6 @@ import com.wire.android.mapper.MessageResourceProvider
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.kalium.logic.network.NetworkStateObserver
-import com.wire.kalium.logic.network.NetworkStateObserverImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -70,11 +68,6 @@ object AppModule {
     @Provides
     fun provideNotificationManagerCompat(appContext: Context): NotificationManagerCompat =
         NotificationManagerCompat.from(appContext)
-
-    @Singleton
-    @Provides
-    fun provideNetworkStateObserver(appContext: Context): NetworkStateObserver =
-        NetworkStateObserverImpl(appContext)
 
     @Provides
     fun provideNotificationManager(appContext: Context): NotificationManager =

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -124,6 +124,7 @@ import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.network.NetworkStateObserver
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -174,6 +175,11 @@ class CoreLogicModule {
             kaliumConfigs = kaliumConfigs
         )
     }
+
+    @Singleton
+    @Provides
+    fun provideNetworkStateObserver(@KaliumCoreLogic coreLogic: CoreLogic): NetworkStateObserver =
+        coreLogic.networkStateObserver
 
     @Provides
     fun provideCurrentSessionUseCase(@KaliumCoreLogic coreLogic: CoreLogic) =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes we get `android.net.ConnectivityManager.TooManyRequestsException`.

### Causes (Optional)

That's because we're not reusing the `NetworkStateObserver`, it's being created again each time it's needed and then `init` is called which registers again, so we can exceed the limit easily (the limit is 100 I think).

### Solutions

Make it singleton in `AppModule`.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/1899

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
