### PR TITLE
fix: missing self deleting text label and enabled button state[WPB-3312]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
@@ -158,7 +158,7 @@ fun AttachmentAndAdditionalOptionsMenuItems(
     onPingClicked: () -> Unit = {},
     onSelfDeletionOptionButtonClicked: () -> Unit,
     isSelfDeletingSettingEnabled: Boolean,
-    isSelfDeletingActive : Boolean,
+    isSelfDeletingActive: Boolean,
     onGifButtonClicked: () -> Unit = {},
     onRichEditingButtonClicked: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -175,7 +175,7 @@ fun AttachmentAndAdditionalOptionsMenuItems(
             onPingButtonClicked = onPingClicked,
             onSelfDeletionOptionButtonClicked = onSelfDeletionOptionButtonClicked,
             isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
-            isSelfDeletingActive= isSelfDeletingActive,
+            isSelfDeletingActive = isSelfDeletingActive,
             onGifButtonClicked = onGifButtonClicked,
             onRichEditingButtonClicked = onRichEditingButtonClicked
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
@@ -62,6 +62,7 @@ fun AdditionalOptionsMenu(
     selectedOption: AdditionalOptionSelectItem,
     isFileSharingEnabled: Boolean,
     isSelfDeletingSettingEnabled: Boolean,
+    isSelfDeletingActive: Boolean,
     isEditing: Boolean,
     isMentionActive: Boolean,
     onOnSelfDeletingOptionClicked: (() -> Unit)? = null,
@@ -82,8 +83,9 @@ fun AdditionalOptionsMenu(
                     isFileSharingEnabled = isFileSharingEnabled,
                     isEditing = isEditing,
                     isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
+                    isSelfDeletingActive = isSelfDeletingActive,
                     isMentionActive = isMentionActive,
-                    onMentionButtonClicked = onMentionButtonClicked ?: {},
+                    onMentionButtonClicked = onMentionButtonClicked,
                     onAdditionalOptionsMenuClicked = onAdditionalOptionsMenuClicked,
                     onGifButtonClicked = onGifOptionClicked ?: {},
                     onSelfDeletionOptionButtonClicked = onOnSelfDeletingOptionClicked ?: {},
@@ -156,6 +158,7 @@ fun AttachmentAndAdditionalOptionsMenuItems(
     onPingClicked: () -> Unit = {},
     onSelfDeletionOptionButtonClicked: () -> Unit,
     isSelfDeletingSettingEnabled: Boolean,
+    isSelfDeletingActive : Boolean,
     onGifButtonClicked: () -> Unit = {},
     onRichEditingButtonClicked: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -172,6 +175,7 @@ fun AttachmentAndAdditionalOptionsMenuItems(
             onPingButtonClicked = onPingClicked,
             onSelfDeletionOptionButtonClicked = onSelfDeletionOptionButtonClicked,
             isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
+            isSelfDeletingActive= isSelfDeletingActive,
             onGifButtonClicked = onGifButtonClicked,
             onRichEditingButtonClicked = onRichEditingButtonClicked
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -47,6 +47,7 @@ fun MessageComposeActions(
     isFileSharingEnabled: Boolean = true,
     isMentionActive: Boolean = true,
     isSelfDeletingSettingEnabled: Boolean = true,
+    isSelfDeletingActive : Boolean = false,
     onMentionButtonClicked: () -> Unit,
     onAdditionalOptionButtonClicked: () -> Unit,
     onPingButtonClicked: () -> Unit,
@@ -70,6 +71,7 @@ fun MessageComposeActions(
             onRichEditingButtonClicked,
             onGifButtonClicked,
             isSelfDeletingSettingEnabled,
+            isSelfDeletingActive,
             onSelfDeletionOptionButtonClicked,
             onPingButtonClicked,
             onMentionButtonClicked
@@ -86,6 +88,7 @@ private fun ComposingActions(
     onRichEditingButtonClicked: () -> Unit,
     onGifButtonClicked: () -> Unit,
     isSelfDeletingSettingEnabled: Boolean,
+    isSelfDeletingActive: Boolean,
     onSelfDeletionOptionButtonClicked: () -> Unit,
     onPingButtonClicked: () -> Unit,
     onMentionButtonClicked: () -> Unit
@@ -112,7 +115,7 @@ private fun ComposingActions(
             if (EmojiIcon) AddEmojiAction({})
             if (GifIcon) AddGifAction(onGifButtonClicked)
             if (isSelfDeletingSettingEnabled) SelfDeletingMessageAction(
-                isSelected = false,
+                isSelected = isSelfDeletingActive,
                 onButtonClicked = onSelfDeletionOptionButtonClicked
             )
             if (PingIcon) PingAction(onPingButtonClicked)
@@ -131,8 +134,6 @@ fun EditingActions(
     onRichEditingButtonClicked: () -> Unit,
     onMentionButtonClicked: () -> Unit
 ) {
-    val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
-
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -47,7 +47,7 @@ fun MessageComposeActions(
     isFileSharingEnabled: Boolean = true,
     isMentionActive: Boolean = true,
     isSelfDeletingSettingEnabled: Boolean = true,
-    isSelfDeletingActive : Boolean = false,
+    isSelfDeletingActive: Boolean = false,
     onMentionButtonClicked: () -> Unit,
     onAdditionalOptionButtonClicked: () -> Unit,
     onPingButtonClicked: () -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -79,6 +79,7 @@ import com.wire.android.util.ui.KeyboardHeight
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.util.isPositiveNotNull
 import kotlin.time.Duration
 
 @Composable
@@ -399,6 +400,7 @@ private fun ActiveMessageComposer(
                                     isEditing = messageCompositionInputStateHolder.inputType is MessageCompositionType.Editing,
                                     isFileSharingEnabled = messageComposerViewState.value.isFileSharingEnabled,
                                     isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
+                                    isSelfDeletingActive = messageComposerViewState.value.selfDeletionTimer.duration.isPositiveNotNull(),
                                     isMentionActive = messageComposerViewState.value.mentionSearchResult.isNotEmpty(),
                                     onMentionButtonClicked = {
                                         messageCompositionHolder.startMention(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -350,7 +350,7 @@ private fun ActiveMessageComposer(
                                         messageComposition = messageComposition.value,
                                         inputSize = messageCompositionInputStateHolder.inputSize,
                                         inputType = messageCompositionInputStateHolder.inputType,
-                                        inputVisiblity = messageCompositionInputStateHolder.inputVisibility,
+                                        inputVisibility = messageCompositionInputStateHolder.inputVisibility,
                                         inputFocused = messageCompositionInputStateHolder.inputFocused,
                                         onInputFocusedChanged = ::onInputFocusedChanged,
                                         onToggleInputSize = messageCompositionInputStateHolder::toggleInputSize,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -87,7 +87,7 @@ fun InactiveMessageComposerInput(
             focusColor = Color.Transparent,
             placeholderColor = colorsScheme().secondaryText
         ),
-        placeHolder = stringResource(id = R.string.label_type_a_message),
+        placeHolderText = stringResource(id = R.string.label_type_a_message),
         messageText = messageText,
         onMessageTextChanged = {
             // non functional
@@ -159,7 +159,7 @@ fun ActiveMessageComposerInput(
                     inputFocused = inputFocused,
                     colors = inputType.inputTextColor(),
                     messageText = messageComposition.messageTextFieldValue,
-                    placeHolder = inputType.labelText(),
+                    placeHolderText = inputType.labelText(),
                     onMessageTextChanged = onMessageTextChanged,
                     singleLine = false,
                     onFocusChanged = onInputFocusedChanged,
@@ -211,7 +211,7 @@ private fun MessageComposerTextInput(
     colors: WireTextFieldColors,
     singleLine: Boolean,
     messageText: TextFieldValue,
-    placeHolder: String,
+    placeHolderText: String,
     onMessageTextChanged: (TextFieldValue) -> Unit,
     onFocusChanged: (Boolean) -> Unit = {},
     onSelectedLineIndexChanged: (Int) -> Unit = { },
@@ -236,7 +236,7 @@ private fun MessageComposerTextInput(
         maxLines = Int.MAX_VALUE,
         textStyle = MaterialTheme.wireTypography.body01,
         // Add an extra space so that the cursor is placed one space before "Type a message"
-        placeholderText = " " + stringResource(R.string.label_type_a_message),
+        placeholderText = " $placeHolderText",
         modifier = modifier.then(
             Modifier
                 .onFocusChanged { focusState ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -87,6 +87,7 @@ fun InactiveMessageComposerInput(
             focusColor = Color.Transparent,
             placeholderColor = colorsScheme().secondaryText
         ),
+        placeHolder = stringResource(id = R.string.label_type_a_message),
         messageText = messageText,
         onMessageTextChanged = {
             // non functional
@@ -105,7 +106,7 @@ fun ActiveMessageComposerInput(
     messageComposition: MessageComposition,
     inputSize: MessageCompositionInputSize,
     inputType: MessageCompositionType,
-    inputVisiblity: Boolean,
+    inputVisibility: Boolean,
     inputFocused: Boolean,
     onMessageTextChanged: (TextFieldValue) -> Unit,
     onSendButtonClicked: () -> Unit,
@@ -119,7 +120,7 @@ fun ActiveMessageComposerInput(
     onLineBottomYCoordinateChanged: (Float) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    if (inputVisiblity) {
+    if (inputVisibility) {
         Column(
             modifier = modifier
                 .wrapContentSize()
@@ -158,6 +159,7 @@ fun ActiveMessageComposerInput(
                     inputFocused = inputFocused,
                     colors = inputType.inputTextColor(),
                     messageText = messageComposition.messageTextFieldValue,
+                    placeHolder = inputType.labelText(),
                     onMessageTextChanged = onMessageTextChanged,
                     singleLine = false,
                     onFocusChanged = onInputFocusedChanged,
@@ -209,6 +211,7 @@ private fun MessageComposerTextInput(
     colors: WireTextFieldColors,
     singleLine: Boolean,
     messageText: TextFieldValue,
+    placeHolder: String,
     onMessageTextChanged: (TextFieldValue) -> Unit,
     onFocusChanged: (Boolean) -> Unit = {},
     onSelectedLineIndexChanged: (Int) -> Unit = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -32,6 +32,7 @@ import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.util.isPositiveNotNull
 
 @Suppress("LongParameterList")
 @Composable
@@ -54,6 +55,7 @@ fun rememberMessageComposerStateHolder(
             messageComposerViewState.value.selfDeletionTimer
         }
     }
+
     val messageCompositionInputStateHolder = rememberSaveable(
         saver = MessageCompositionInputStateHolder.saver(
             messageComposition = messageCompositionHolder.messageComposition,
@@ -95,7 +97,6 @@ class MessageComposerStateHolder(
     val modalBottomSheetState: WireModalSheetState
 ) {
     val messageComposition = messageCompositionHolder.messageComposition
-
     val isTransitionToKeyboardOnGoing
         @Composable get() = additionalOptionStateHolder.additionalOptionsSubMenuState == AdditionalOptionSubMenuState.Hidden &&
                 !KeyboardHelper.isKeyboardVisible() &&
@@ -108,6 +109,7 @@ class MessageComposerStateHolder(
 
     val isSelfDeletingSettingEnabled = messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Disabled &&
             messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Enforced
+
 
     fun toInActive() {
         messageCompositionInputStateHolder.toInActive()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -32,7 +32,6 @@ import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
-import com.wire.kalium.logic.util.isPositiveNotNull
 
 @Suppress("LongParameterList")
 @Composable
@@ -109,7 +108,6 @@ class MessageComposerStateHolder(
 
     val isSelfDeletingSettingEnabled = messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Disabled &&
             messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Enforced
-
 
     fun toInActive() {
         messageCompositionInputStateHolder.toInActive()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -50,7 +50,6 @@ class MessageCompositionHolder(
     }
 
     val messageComposition: MutableState<MessageComposition> = mutableStateOf(MessageComposition.DEFAULT)
-
     fun setReply(message: UIMessage.Regular) {
         val senderId = message.header.userId ?: return
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.textfield.WireTextFieldColors
 import com.wire.android.ui.common.textfield.wireTextFieldColors
@@ -159,6 +161,9 @@ sealed class MessageCompositionType {
     @Composable
     open fun backgroundColor(): Color = colorsScheme().messageComposerBackgroundColor
 
+    @Composable
+    open fun labelText(): String = stringResource(R.string.label_type_a_message)
+
     class Composing(messageCompositionState: MutableState<MessageComposition>, val messageType: State<MessageType>) :
         MessageCompositionType() {
 
@@ -176,6 +181,13 @@ sealed class MessageCompositionType {
             )
         } else {
             super.inputTextColor()
+        }
+
+        @Composable
+        override fun labelText(): String = if (messageType.value is MessageType.SelfDeleting) {
+            stringResource(id = R.string.self_deleting_message_label)
+        } else {
+            super.labelText()
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When the message was self-deleting, we missed the correct label and the button state.



### Solutions

- Use correct label and enable the button when the message is self-deleting.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
