### PR TITLE
fix: hide sender name from notification if message is ephemeral (WPB-2431)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -256,8 +256,10 @@ class MessageNotificationManager
     private fun NotificationMessage.intoStyledMessage(): NotificationCompat.MessagingStyle.Message {
         val sender = Person.Builder()
             .apply {
-                author?.name.also {
-                    setName(it)
+                if (this@intoStyledMessage !is NotificationMessage.ObfuscatedMessage) {
+                    author?.name.also {
+                        setName(it)
+                    }
                 }
                 author?.image?.toBitmap()?.let {
                     setIcon(IconCompat.createWithAdaptiveBitmap(it))
@@ -265,7 +267,7 @@ class MessageNotificationManager
             }
             .build()
 
-        val message = when (this) {
+        val message = when (this@intoStyledMessage) {
             is NotificationMessage.Text -> if (isQuotingSelfUser) context.getString(R.string.notification_reply, text) else text
             is NotificationMessage.Comment -> italicTextFromResId(textResId.value)
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving a ephemeral message notification, sender name would show either `null` or `You` (but you were not the sender, thus receiving a notification)

### Solutions

Verify if message type is ephemeral, if so then hide setting sender name into the notification

#### How to Test

- Open App
- Receive an ephemeral notification from another user
- Check that neither `null` or `You` is shown on the left side of the message, along with `Someone sent a Message`

### Attachments (Optional)
<img width="360" alt="Screenshot 2023-07-20 at 12 21 16" src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/6b3843e1-e5e6-41cb-bdce-df07473f903d">
<img width="357" alt="Screenshot 2023-07-20 at 12 21 10" src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/60d8b1b2-1510-405c-bd10-f287c5cfe53e">
