### PR TITLE
ci: unify multiple APK comments on PRs into a single one

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -44,12 +44,3 @@ jobs:
       with:
           name: wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
           path: ./wire-android-${{inputs.flavour}}-pr-${{ github.event.pull_request.number }}.apk
-    - name: Post link to apk
-      if: success()
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.run_id }}"
-        gh pr comment "${{github.head_ref}}" --body "Build (${{inputs.flavour}}) available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
-

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -45,3 +45,17 @@ jobs:
                   event_file: artifacts/Event File/event.json
                   event_name: ${{ github.event.workflow_run.event }}
                   files: "artifacts/test-results/**/*.xml"
+
+            - name: Post link to apks
+              if: github.event.workflow_run.conclusion == 'success'
+              env:
+                  EVENT_FILE_PATH: artifacts/Event File/event.json
+                  GITHUB_USER: ${{ github.actor }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # Get the PR number based on the event file uploaded by the test workflow.
+                  # The event file is a JSON containing the data of the event that triggered the tests.
+                  # In this case, it will contain information about the PR.
+              run: |
+                  CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.event.workflow_run.id }}"
+                  PR_NUMBER=$(jq --raw-output .pull_request.number "$EVENT_FILE_PATH")
+                  gh pr comment "$PR_NUMBER" --body "APKs built during tests are available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we have 3 comments added on the PRs for _each_ run of unit tests:

- Test results
- Beta APK
- Dev APK

### Solutions

Merge the APKs comments into a single one, by:
- Take commenting logic out of `build-app` workflow, which is run twice.
- Move it to `publish-test-results` workflow, which is run once.

### Testing

This PR should test it

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
