### PR TITLE
fix: change audio extension from .mp3 to .m4a

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -125,7 +125,7 @@ class AudioMediaRecorder @Inject constructor(
 
     private companion object {
         fun getRecordingAudioFileName(): String =
-            "wire-audio-${DateTimeUtil.currentInstant().audioFileDateTime()}.mp3"
+            "wire-audio-${DateTimeUtil.currentInstant().audioFileDateTime()}.m4a"
         const val SIZE_OF_1MB = 1024 * 1024
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Android sends audio message with `OutputFormat.MPEG_4` and `AudioEncoder.AAC` but extension is `.mp3` and iOS can't read it.

### Solutions

Change extension to `.m4a` so its readable in all platforms including iOS.
