### PR TITLE
chore: Unblock button is no longer visible when we block someone (WPB-2427)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/model/ActionableState.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ActionableState.kt
@@ -25,11 +25,9 @@ package com.wire.android.model
  * like:
  * - blocking button action when some action is already triggered
  */
-data class ActionableState<T>(
-    val state: T,
+data class ActionableState(
     val isPerformingAction: Boolean = false
 )
 
-fun <T> ActionableState<T>.performAction(): ActionableState<T> = this.copy(isPerformingAction = true)
-fun <T> ActionableState<T>.finishAction(): ActionableState<T> = this.copy(isPerformingAction = false)
-fun <T> ActionableState<T>.updateState(newState: T): ActionableState<T> = this.copy(state = newState, isPerformingAction = false)
+fun ActionableState.performAction(): ActionableState = this.copy(isPerformingAction = true)
+fun ActionableState.finishAction(): ActionableState = this.copy(isPerformingAction = false)

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -571,7 +571,6 @@ const val EXTRA_USER_ID = "extra_user_id"
 const val EXTRA_USER_NAME = "extra_user_name"
 const val EXTRA_USER_DOMAIN = "extra_user_domain"
 const val EXTRA_USER_HANDLE = "extra_user_handle"
-const val EXTRA_CONNECTION_STATE = "extra_connection_state"
 
 const val EXTRA_NEW_EMAIL = "extra_new_email"
 

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -34,7 +34,6 @@ import com.sebaslogen.resaca.hilt.hiltViewModelScoped
 import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.model.ActionableState
-import com.wire.android.navigation.EXTRA_CONNECTION_STATE
 import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.EXTRA_USER_NAME
 import com.wire.android.ui.common.button.WireButtonState
@@ -53,21 +52,20 @@ fun ConnectionActionButton(
     connectionStatus: ConnectionState
 ) {
     val viewModel: ConnectionActionButtonViewModel = if (LocalInspectionMode.current) {
-        ConnectionActionButtonPreviewModel(ActionableState(connectionStatus))
+        ConnectionActionButtonPreviewModel(ActionableState())
     } else {
         hiltViewModelScoped<ConnectionActionButtonViewModelImpl>(
             key = "${ConnectionActionButtonViewModelImpl.ARGS_KEY}$userId",
             defaultArguments = bundleOf(
                 EXTRA_USER_ID to userId.toString(),
-                EXTRA_USER_NAME to userName,
-                EXTRA_CONNECTION_STATE to connectionStatus.toString()
+                EXTRA_USER_NAME to userName
             )
         ).also {
             LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = it.infoMessage)
         }
     }
 
-    when (viewModel.actionableState().state) {
+    when (connectionStatus) {
         ConnectionState.SENT -> WireSecondaryButton(
             text = stringResource(R.string.connection_label_cancel_request),
             loading = viewModel.actionableState().isPerformingAction,

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -155,7 +155,7 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (ignoreConnectionRequest(userId)) {
                 is IgnoreConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't ignore a connect request to user ${userId.toLogString()}"))
+                    appLogger.e(("Couldn't ignore a connection request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_ignore_error))
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -101,7 +101,7 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (sendConnectionRequest(userId)) {
                 is SendConnectionRequestResult.Failure -> {
-                    appLogger.d(("Couldn't send a connect request to user ${userId.toLogString()}"))
+                    appLogger.e(("Couldn't send a connection request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_sent_error))
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -119,7 +119,7 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (cancelConnectionRequest(userId)) {
                 is CancelConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't cancel a connect request to user ${userId.toLogString()}"))
+                    appLogger.e(("Couldn't cancel a connection request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_cancel_error))
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -29,10 +29,8 @@ import com.wire.android.appLogger
 import com.wire.android.model.ActionableState
 import com.wire.android.model.finishAction
 import com.wire.android.model.performAction
-import com.wire.android.model.updateState
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.EXTRA_CONNECTION_IGNORED_USER_NAME
-import com.wire.android.navigation.EXTRA_CONNECTION_STATE
 import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.EXTRA_USER_NAME
 import com.wire.android.navigation.NavigationCommand
@@ -43,7 +41,6 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
-import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseResult
 import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCase
@@ -65,7 +62,7 @@ import javax.inject.Inject
 
 interface ConnectionActionButtonViewModel {
 
-    fun actionableState(): ActionableState<ConnectionState>
+    fun actionableState(): ActionableState
     fun onSendConnectionRequest()
     fun onCancelConnectionRequest()
     fun onAcceptConnectionRequest()
@@ -91,27 +88,26 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
 
     private val userId: QualifiedID = savedStateHandle.get<String>(EXTRA_USER_ID)!!.toQualifiedID(qualifiedIdMapper)
     private val userName: String = savedStateHandle.get<String>(EXTRA_USER_NAME)!!
-    private val extraConnectionState: ConnectionState = ConnectionState.valueOf(savedStateHandle.get<String>(EXTRA_CONNECTION_STATE)!!)
 
-    private var state: ActionableState<ConnectionState> by mutableStateOf(ActionableState(extraConnectionState))
+    private var state: ActionableState by mutableStateOf(ActionableState())
 
     private val _infoMessage = MutableSharedFlow<UIText>()
     val infoMessage = _infoMessage.asSharedFlow()
 
-    override fun actionableState(): ActionableState<ConnectionState> = state
+    override fun actionableState(): ActionableState = state
 
     override fun onSendConnectionRequest() {
         viewModelScope.launch {
             state = state.performAction()
             when (sendConnectionRequest(userId)) {
                 is SendConnectionRequestResult.Failure -> {
-                    appLogger.d(("Couldn't send a connect request to user $userId"))
+                    appLogger.d(("Couldn't send a connect request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_sent_error))
                 }
 
                 is SendConnectionRequestResult.Success -> {
-                    state = state.updateState(ConnectionState.SENT)
+                    state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_sent))
                 }
             }
@@ -123,13 +119,13 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (cancelConnectionRequest(userId)) {
                 is CancelConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't cancel a connect request to user $userId"))
+                    appLogger.d(("Couldn't cancel a connect request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_cancel_error))
                 }
 
                 is CancelConnectionRequestUseCaseResult.Success -> {
-                    state = state.updateState(ConnectionState.NOT_CONNECTED)
+                    state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_canceled))
                 }
             }
@@ -141,13 +137,13 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (acceptConnectionRequest(userId)) {
                 is AcceptConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't accept a connect request to user $userId"))
+                    appLogger.d(("Couldn't accept a connect request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_accept_error))
                 }
 
                 is AcceptConnectionRequestUseCaseResult.Success -> {
-                    state = state.updateState(ConnectionState.ACCEPTED)
+                    state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_accepted))
                 }
             }
@@ -159,13 +155,13 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (ignoreConnectionRequest(userId)) {
                 is IgnoreConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't ignore a connect request to user $userId"))
+                    appLogger.d(("Couldn't ignore a connect request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_ignore_error))
                 }
 
                 is IgnoreConnectionRequestUseCaseResult.Success -> {
-                    state = state.updateState(ConnectionState.IGNORED)
+                    state = state.finishAction()
                     navigationManager.navigateBack(
                         mapOf(
                             EXTRA_CONNECTION_IGNORED_USER_NAME to userName
@@ -181,14 +177,14 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (val result = withContext(dispatchers.io()) { unblockUser(userId) }) {
                 is UnblockUserResult.Failure -> {
-                    appLogger.e("Error while unblocking user $userId ; Error ${result.coreFailure}")
+                    appLogger.e("Error while unblocking user ${userId.toLogString()} ; Error ${result.coreFailure}")
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.error_unblocking_user))
                 }
 
                 UnblockUserResult.Success -> {
-                    appLogger.i("User $userId was unblocked")
-                    state = state.updateState(ConnectionState.ACCEPTED)
+                    appLogger.i("User ${userId.toLogString()} was unblocked")
+                    state = state.finishAction()
                 }
             }
         }
@@ -220,8 +216,8 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
 }
 
 @Suppress("EmptyFunctionBlock")
-class ConnectionActionButtonPreviewModel(private val state: ActionableState<ConnectionState>) : ConnectionActionButtonViewModel {
-    override fun actionableState(): ActionableState<ConnectionState> = state
+class ConnectionActionButtonPreviewModel(private val state: ActionableState) : ConnectionActionButtonViewModel {
+    override fun actionableState(): ActionableState = state
     override fun onSendConnectionRequest() {}
     override fun onCancelConnectionRequest() {}
     override fun onAcceptConnectionRequest() {}

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -137,7 +137,7 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
             state = state.performAction()
             when (acceptConnectionRequest(userId)) {
                 is AcceptConnectionRequestUseCaseResult.Failure -> {
-                    appLogger.d(("Couldn't accept a connect request to user ${userId.toLogString()}"))
+                    appLogger.e(("Couldn't accept a connection request to user ${userId.toLogString()}"))
                     state = state.finishAction()
                     _infoMessage.emit(UIText.StringResource(R.string.connection_request_accept_error))
                 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In other profile screen, unblock button is no longer visible when block someone. We see "Open Conversation" instead

### Causes (Optional)

Main Cause: The state in `ConnectionActionButtonViewModelImpl` is not being updating when the user is blocked.

The state is initialised on viewModel creation by getting passed params and then it will never be updated.
This happens because we already have an instance of the viewModel and the system won't create another one after recomposition. Therefore we will use the same state all the time.

### Solutions

Since the `connectionState` is not something specific to `ConnectionActionButtonViewModel`, and it's already managed in `OtherUserProfileScreenViewModel`. I removed it from `ConnectionActionButtonViewModel` to be handled in one place.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
