### PR TITLE
fix: E2EI required dialog cancelable

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
@@ -172,11 +172,7 @@ fun E2EIdRequiredWithSnoozeDialog(
             type = WireDialogButtonType.Secondary,
         ),
         buttonsHorizontalAlignment = false,
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false,
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false
-        )
+        properties = DialogProperties(usePlatformDefaultWidth = false)
     )
 }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

E2EI required dialog is not cancelable 

### Causes (Optional)

thought it shouldn't be

### Solutions

make it be cancelable
