### PR TITLE
fix: handling group creation errors

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -81,6 +81,7 @@ fun NewConversationRouter() {
                     NewGroupScreen(
                         onBackPressed = newConversationNavController::popBackStack,
                         newGroupState = newConversationViewModel.newGroupState,
+                        createGroupState = newConversationViewModel.createGroupState,
                         onGroupNameChange = newConversationViewModel::onGroupNameChange,
                         onContinuePressed = {
                             if (newConversationViewModel.newGroupState.isSelfTeamMember == true) {
@@ -91,7 +92,16 @@ fun NewConversationRouter() {
                                 newConversationViewModel.createGroup()
                             }
                         },
-                        onGroupNameErrorAnimated = newConversationViewModel::onGroupNameErrorAnimated
+                        onGroupNameErrorAnimated = newConversationViewModel::onGroupNameErrorAnimated,
+                        onEditParticipantsClick = {
+                            newConversationViewModel.onCreateGroupErrorDismiss()
+                            newConversationNavController.popBackStack(
+                                route = NewConversationNavigationItem.SearchListNavHostScreens.route,
+                                inclusive = false
+                            )
+                        },
+                        onDiscardGroupCreationClick = newConversationViewModel::onDiscardGroupCreationClick,
+                        onErrorDismissed = newConversationViewModel::onCreateGroupErrorDismiss
                     )
                 }
             )
@@ -102,6 +112,7 @@ fun NewConversationRouter() {
                         onBackPressed = newConversationNavController::popBackStack,
                         onCreateGroup = newConversationViewModel::createGroup,
                         groupOptionState = newConversationViewModel.groupOptionsState,
+                        createGroupState = newConversationViewModel.createGroupState,
                         onAllowGuestChanged = newConversationViewModel::onAllowGuestStatusChanged,
                         onAllowServicesChanged = newConversationViewModel::onAllowServicesStatusChanged,
                         onReadReceiptChanged = newConversationViewModel::onReadReceiptStatusChanged,
@@ -109,14 +120,14 @@ fun NewConversationRouter() {
                         onAllowGuestsClicked = newConversationViewModel::onAllowGuestsClicked,
                         onNotAllowGuestsClicked = newConversationViewModel::onNotAllowGuestClicked,
                         onEditParticipantsClick = {
-                            newConversationViewModel.onGroupOptionsErrorDismiss()
+                            newConversationViewModel.onCreateGroupErrorDismiss()
                             newConversationNavController.popBackStack(
                                 route = NewConversationNavigationItem.SearchListNavHostScreens.route,
                                 inclusive = false
                             )
                         },
                         onDiscardGroupCreationClick = newConversationViewModel::onDiscardGroupCreationClick,
-                        onErrorDismissed = newConversationViewModel::onGroupOptionsErrorDismiss
+                        onErrorDismissed = newConversationViewModel::onCreateGroupErrorDismiss
                     )
                 }
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.common.groupname.GroupMetadataState
 import com.wire.android.ui.common.groupname.GroupNameValidator
 import com.wire.android.ui.home.conversations.search.SearchAllPeopleViewModel
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -84,6 +85,7 @@ class NewConversationViewModel @Inject constructor(
     )
 
     var groupOptionsState: GroupOptionState by mutableStateOf(GroupOptionState())
+    var createGroupState: CreateGroupState by mutableStateOf(CreateGroupState())
 
     init {
         viewModelScope.launch {
@@ -96,12 +98,12 @@ class NewConversationViewModel @Inject constructor(
         newGroupState = GroupNameValidator.onGroupNameChange(newText, newGroupState)
     }
 
-    fun onGroupOptionsErrorDismiss() {
-        groupOptionsState = groupOptionsState.copy(error = null)
+    fun onCreateGroupErrorDismiss() {
+        createGroupState = createGroupState.copy(error = null)
     }
 
     fun onDiscardGroupCreationClick() {
-        groupOptionsState = groupOptionsState.copy(error = null)
+        createGroupState = createGroupState.copy(error = null)
         viewModelScope.launch {
             navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
         }
@@ -192,7 +194,7 @@ class NewConversationViewModel @Inject constructor(
     private fun createGroupForTeamAccounts(shouldCheckGuests: Boolean = true) {
         if (shouldCheckGuests && checkIfGuestAdded()) return
         viewModelScope.launch {
-            newGroupState = newGroupState.copy(isLoading = true)
+            groupOptionsState = groupOptionsState.copy(isLoading = true)
             val result = createGroupConversation(
                 name = newGroupState.groupName.text,
                 // TODO: change the id in Contact to UserId instead of String
@@ -226,19 +228,22 @@ class NewConversationViewModel @Inject constructor(
 
             CreateGroupConversationUseCase.Result.SyncFailure -> {
                 appLogger.d("Can't create group due to SyncFailure")
-                groupOptionsState = groupOptionsState.copy(isLoading = false, error = GroupOptionState.Error.LackingConnection)
+                groupOptionsState = groupOptionsState.copy(isLoading = false)
+                newGroupState = newGroupState.copy(isLoading = false)
+                createGroupState = createGroupState.copy(error = CreateGroupState.Error.LackingConnection)
             }
 
             is CreateGroupConversationUseCase.Result.UnknownFailure -> {
                 appLogger.w("Error while creating a group ${result.cause}")
-                groupOptionsState = groupOptionsState.copy(isLoading = false, error = GroupOptionState.Error.Unknown)
+                groupOptionsState = groupOptionsState.copy(isLoading = false)
+                newGroupState = newGroupState.copy(isLoading = false)
+                createGroupState = createGroupState.copy(error = CreateGroupState.Error.Unknown)
             }
 
             is CreateGroupConversationUseCase.Result.BackendConflictFailure -> {
-                groupOptionsState = groupOptionsState.copy(
-                    isLoading = false,
-                    error = GroupOptionState.Error.ConflictedBackends(result.domains)
-                )
+                groupOptionsState = groupOptionsState.copy(isLoading = false)
+                newGroupState = newGroupState.copy(isLoading = false)
+                createGroupState = createGroupState.copy(error = CreateGroupState.Error.ConflictedBackends(result.domains))
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -1,0 +1,132 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.newconversation.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import com.wire.android.R
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.markdown.MarkdownConstants
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.DialogAnnotatedErrorStrings
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@Composable
+fun CreateGroupErrorDialog(
+    error: CreateGroupState.Error,
+    onDismiss: () -> Unit,
+    onAccept: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val dialogStrings = when (error) {
+        is CreateGroupState.Error.LackingConnection -> DialogAnnotatedErrorStrings(
+            stringResource(R.string.error_no_network_title),
+            buildAnnotatedString { append(stringResource(R.string.error_no_network_message)) }
+        )
+
+        is CreateGroupState.Error.Unknown -> DialogAnnotatedErrorStrings(
+            stringResource(R.string.error_unknown_title),
+            buildAnnotatedString { append(stringResource(R.string.error_unknown_message)) }
+        )
+
+        is CreateGroupState.Error.ConflictedBackends -> DialogAnnotatedErrorStrings(
+            title = stringResource(id = R.string.group_can_not_be_created_title),
+            annotatedMessage = buildAnnotatedString {
+                val description = stringResource(
+                    id = R.string.group_can_not_be_created_federation_conflict_description,
+                    error.domains.joinToString(", ")
+                )
+                val learnMore = stringResource(id = R.string.label_learn_more)
+
+                append(description)
+                append(' ')
+
+                withStyle(
+                    style = SpanStyle(
+                        color = colorsScheme().primary,
+                        textDecoration = TextDecoration.Underline
+                    )
+                ) {
+                    append(learnMore)
+                }
+                addStringAnnotation(
+                    tag = MarkdownConstants.TAG_URL,
+                    annotation = stringResource(id = R.string.url_support),
+                    start = description.length + 1,
+                    end = description.length + 1 + learnMore.length
+                )
+            }
+        )
+    }
+
+    WireDialog(
+        dialogStrings.title,
+        dialogStrings.annotatedMessage,
+        onDismiss = onDismiss,
+        buttonsHorizontalAlignment = false,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = if (error.isConflictedBackends) onAccept else onDismiss,
+            text = stringResource(
+                id = if (error.isConflictedBackends) {
+                    R.string.group_can_not_be_created_edit_participiant_list
+                } else {
+                    R.string.label_ok
+                }
+            ),
+            type = WireDialogButtonType.Primary,
+        ),
+        optionButton2Properties = if (error.isConflictedBackends) {
+            WireDialogButtonProperties(
+                onClick = onCancel,
+                text = stringResource(R.string.group_can_not_be_created_discard_group_creation),
+                type = WireDialogButtonType.Secondary,
+            )
+        } else {
+            null
+        },
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewCreateGroupErrorDialogLackingConnection() {
+    WireTheme {
+        CreateGroupErrorDialog(CreateGroupState.Error.LackingConnection, {}, {}, {})
+    }
+}
+@PreviewMultipleThemes
+@Composable
+private fun PreviewCreateGroupErrorDialogUnknown() {
+    WireTheme {
+        CreateGroupErrorDialog(CreateGroupState.Error.Unknown, {}, {}, {})
+    }
+}
+@PreviewMultipleThemes
+@Composable
+private fun PreviewCreateGroupErrorDialogConflictedBackends() {
+    WireTheme {
+        CreateGroupErrorDialog(CreateGroupState.Error.ConflictedBackends(listOf("some.com", "other.com")), {}, {}, {})
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -56,7 +56,8 @@ fun CreateGroupErrorDialog(
             annotatedMessage = buildAnnotatedString {
                 val description = stringResource(
                     id = R.string.group_can_not_be_created_federation_conflict_description,
-                    error.domains.joinToString(", ")
+                    error.domains.dropLast(1).joinToString(", "),
+                    error.domains.last()
                 )
                 val learnMore = stringResource(id = R.string.label_learn_more)
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
@@ -14,17 +14,17 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- *
  */
+package com.wire.android.ui.home.newconversation.common
 
-package com.wire.android.ui.home.newconversation.groupOptions
+data class CreateGroupState(
+    val error: Error? = null
+) {
+    sealed interface Error {
+        object Unknown : Error
+        object LackingConnection : Error
+        data class ConflictedBackends(val domains: List<String>) : Error
 
-data class GroupOptionState(
-    val continueEnabled: Boolean = true,
-    val isLoading: Boolean = false,
-    val isAllowGuestEnabled: Boolean = true,
-    val isAllowServicesEnabled: Boolean = true,
-    val isReadReceiptEnabled: Boolean = true,
-    val showAllowGuestsDialog: Boolean = false
-)
+        val isConflictedBackends get() = this is ConflictedBackends
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -35,12 +35,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -52,19 +48,19 @@ import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
-import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.conversations.details.options.SwitchState
-import com.wire.android.ui.markdown.MarkdownConstants
+import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
+import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
-import com.wire.android.util.DialogAnnotatedErrorStrings
 
 @Composable
 fun GroupOptionScreen(
     groupOptionState: GroupOptionState,
+    createGroupState: CreateGroupState,
     onAllowGuestChanged: ((Boolean) -> Unit),
     onAllowServicesChanged: ((Boolean) -> Unit),
     onReadReceiptChanged: ((Boolean) -> Unit),
@@ -79,6 +75,7 @@ fun GroupOptionScreen(
 ) {
     GroupOptionScreenContent(
         groupOptionState = groupOptionState,
+        createGroupState = createGroupState,
         onAllowGuestChanged = onAllowGuestChanged,
         onAllowServicesChanged = onAllowServicesChanged,
         onReadReceiptChanged = onReadReceiptChanged,
@@ -96,6 +93,7 @@ fun GroupOptionScreen(
 @Composable
 fun GroupOptionScreenContent(
     groupOptionState: GroupOptionState,
+    createGroupState: CreateGroupState,
     onAllowGuestChanged: ((Boolean) -> Unit),
     onAllowServicesChanged: ((Boolean) -> Unit),
     onReadReceiptChanged: ((Boolean) -> Unit),
@@ -125,8 +123,8 @@ fun GroupOptionScreenContent(
             )
         }
 
-        error?.let {
-            ErrorDialog(it, onErrorDismissed, onEditParticipantsClick, onDiscardGroupCreationClick)
+        createGroupState.error?.let {
+            CreateGroupErrorDialog(it, onErrorDismissed, onEditParticipantsClick, onDiscardGroupCreationClick)
         }
         if (showAllowGuestsDialog) {
             AllowGuestsDialog(onAllowGuestsDialogDismissed, onNotAllowGuestsClicked, onAllowGuestsClicked)
@@ -272,89 +270,11 @@ private fun AllowGuestsDialog(
 }
 
 @Composable
-private fun ErrorDialog(
-    error: GroupOptionState.Error,
-    onDismiss: () -> Unit,
-    onAccept: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val dialogStrings = when (error) {
-        is GroupOptionState.Error.LackingConnection -> DialogAnnotatedErrorStrings(
-            stringResource(R.string.error_no_network_title),
-            buildAnnotatedString { append(stringResource(R.string.error_no_network_message)) }
-        )
-
-        is GroupOptionState.Error.Unknown -> DialogAnnotatedErrorStrings(
-            stringResource(R.string.error_unknown_title),
-            buildAnnotatedString { append(stringResource(R.string.error_unknown_message)) }
-        )
-
-        is GroupOptionState.Error.ConflictedBackends -> DialogAnnotatedErrorStrings(
-            title = stringResource(id = R.string.group_can_not_be_created_title),
-            annotatedMessage = buildAnnotatedString {
-                val description = stringResource(
-                    id = R.string.group_can_not_be_created_federation_conflict_description,
-                    error.domains.dropLast(1).joinToString(", "),
-                    error.domains.last()
-                )
-                val learnMore = stringResource(id = R.string.label_learn_more)
-
-                append(description)
-                append(' ')
-
-                withStyle(
-                    style = SpanStyle(
-                        color = colorsScheme().primary,
-                        textDecoration = TextDecoration.Underline
-                    )
-                ) {
-                    append(learnMore)
-                }
-                addStringAnnotation(
-                    tag = MarkdownConstants.TAG_URL,
-                    annotation = stringResource(id = R.string.url_support),
-                    start = description.length + 1,
-                    end = description.length + 1 + learnMore.length
-                )
-            }
-        )
-    }
-
-    WireDialog(
-        dialogStrings.title,
-        dialogStrings.annotatedMessage,
-        onDismiss = onDismiss,
-        buttonsHorizontalAlignment = false,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = if (error.isConflictedBackends) onAccept else onDismiss,
-            text = stringResource(
-                id = if (error.isConflictedBackends) {
-                    R.string.group_can_not_be_created_edit_participiant_list
-                } else {
-                    R.string.label_ok
-                }
-            ),
-            type = WireDialogButtonType.Primary,
-        ),
-        optionButton2Properties = WireDialogButtonProperties(
-            onClick = onCancel,
-            text = stringResource(
-                id = if (error is GroupOptionState.Error.ConflictedBackends) {
-                    R.string.group_can_not_be_created_discard_group_creation
-                } else {
-                    R.string.label_ok
-                }
-            ),
-            type = WireDialogButtonType.Secondary,
-        )
-    )
-}
-
-@Composable
 @Preview
 fun PreviewGroupOptionScreen() {
     GroupOptionScreenContent(
         GroupOptionState(),
+        CreateGroupState(),
         {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
@@ -25,14 +25,20 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.ui.common.groupname.GroupMetadataState
 import com.wire.android.ui.common.groupname.GroupNameScreen
+import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
+import com.wire.android.ui.home.newconversation.common.CreateGroupState
 
 @Composable
 fun NewGroupScreen(
     newGroupState: GroupMetadataState,
+    createGroupState: CreateGroupState,
     onGroupNameChange: (TextFieldValue) -> Unit,
     onContinuePressed: () -> Unit,
     onGroupNameErrorAnimated: () -> Unit,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    onErrorDismissed: () -> Unit,
+    onEditParticipantsClick: () -> Unit,
+    onDiscardGroupCreationClick: () -> Unit
 ) {
     GroupNameScreen(
         newGroupState = newGroupState,
@@ -41,6 +47,9 @@ fun NewGroupScreen(
         onGroupNameErrorAnimated = onGroupNameErrorAnimated,
         onBackPressed = onBackPressed
     )
+    createGroupState.error?.let {
+        CreateGroupErrorDialog(it, onErrorDismissed, onEditParticipantsClick, onDiscardGroupCreationClick)
+    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,7 +385,7 @@
     <string name="group_name_exceeded_limit_error">Group name should not exceed 64 characters
     </string>
     <string name="group_can_not_be_created_title">Group can’t be created</string>
-    <string name="group_can_not_be_created_federation_conflict_description">People from backends %1$s can’t join the same group conversation.\n\nTo create the group, remove affected participants.</string>
+    <string name="group_can_not_be_created_federation_conflict_description">People from backends %1$s and %2$s can’t join the same group conversation.\n\nTo create the group, remove affected participants.</string>
     <string name="group_can_not_be_created_edit_participiant_list">Edit Participants List</string>
     <string name="group_can_not_be_created_discard_group_creation">Discard Group Creation</string>
     <string name="asset_message_tap_to_download_text">Tap to download</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -29,7 +29,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState
+import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure
@@ -232,8 +232,8 @@ internal class NewConversationViewModelArrangement {
     }
 
     fun withConflictingBackendsFailure() = apply {
-        viewModel.groupOptionsState = viewModel.groupOptionsState.copy(
-            error = GroupOptionState.Error.ConflictedBackends(listOf("bella.wire.link", "foma.wire.link"))
+        viewModel.createGroupState = viewModel.createGroupState.copy(
+            error = CreateGroupState.Error.ConflictedBackends(listOf("bella.wire.link", "foma.wire.link"))
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -33,7 +33,7 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.ui.home.conversations.search.SearchResultState
 import com.wire.android.ui.home.conversations.search.SearchResultTitle
 import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState
+import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
@@ -127,7 +127,7 @@ class NewConversationViewModelTest {
         viewModel.createGroup()
         advanceUntilIdle()
 
-        viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.LackingConnection
+        viewModel.createGroupState.error shouldBeEqualTo CreateGroupState.Error.LackingConnection
     }
 
     @Test
@@ -140,7 +140,7 @@ class NewConversationViewModelTest {
         viewModel.createGroup()
         advanceUntilIdle()
 
-        viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.Unknown
+        viewModel.createGroupState.error shouldBeEqualTo CreateGroupState.Error.Unknown
     }
 
     @Test
@@ -152,7 +152,7 @@ class NewConversationViewModelTest {
         viewModel.createGroup()
         advanceUntilIdle()
 
-        viewModel.groupOptionsState.error.shouldBeNull()
+        viewModel.createGroupState.error.shouldBeNull()
     }
 
     @Test
@@ -165,7 +165,7 @@ class NewConversationViewModelTest {
 
             viewModel.onDiscardGroupCreationClick()
             advanceUntilIdle()
-            viewModel.groupOptionsState.error.shouldBeNull()
+            viewModel.createGroupState.error.shouldBeNull()
             coVerify(exactly = 1) {
                 arrangement.navigationManager.navigate(
                     NavigationCommand(
@@ -184,9 +184,9 @@ class NewConversationViewModelTest {
                 .withConflictingBackendsFailure()
                 .arrange()
 
-            viewModel.onGroupOptionsErrorDismiss()
+            viewModel.onCreateGroupErrorDismiss()
             advanceUntilIdle()
-            viewModel.groupOptionsState.error.shouldBeNull()
+            viewModel.createGroupState.error.shouldBeNull()
         }
 
     @Test
@@ -198,7 +198,7 @@ class NewConversationViewModelTest {
         viewModel.createGroup()
         advanceUntilIdle()
 
-        viewModel.groupOptionsState.error.shouldBeNull()
+        viewModel.createGroupState.error.shouldBeNull()
 
         coVerify {
             arrangement.createGroupConversation(
@@ -227,7 +227,7 @@ class NewConversationViewModelTest {
             viewModel.createGroup()
             advanceUntilIdle()
 
-            viewModel.groupOptionsState.error.shouldBeNull()
+            viewModel.createGroupState.error.shouldBeNull()
 
             coVerify {
                 arrangement.createGroupConversation(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When merging current develop into navigation branch and syncing with @Garzas we found out that there are some issues with handling errors when creating groups. 
- For non-team member, the `GroupOptionsScreen` doesn't appear so in that case errors should be handled on `NewGroupScreen` because that's where group creation is executed.
- When showing conflicted backends, two arguments are passed to get string but the resource takes only one argument so second one won't be visible.
- For errors other than `ConflictedBackends`, there will be two "OK" buttons showed on the error dialog.


### Solutions

- Extract group creation error dialog out of the `GroupOptionsScreen` and group creation error state out of `GroupOptionState` to be reused. Add handling these errors also on `NewGroupScreen` for the non-team users.
- Edit the string resource to take also last argument in the form: "People from backends one.com, two.com and three.com..."
- Show only one button when the error is other than `ConflictedBackends`

### Testing

#### How to Test

Try to create a group with conflicting backups or other error as a non-team member.

### Attachments (Optional)

![image](https://github.com/wireapp/wire-android-reloaded/assets/30429749/ac6069e7-e199-47e7-82ce-b262e1629bcd)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
