### PR TITLE
chore: add configuration to force websocket  (WPB-3311)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -24,7 +24,7 @@ import android.content.Context
 import android.os.Build
 import com.wire.android.BuildConfig
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.util.extension.isGoogleServicesAvailable
+import com.wire.android.util.isWebsocketEnabledByDefault
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
@@ -69,7 +69,7 @@ class KaliumConfigsModule {
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
-            isWebSocketEnabledByDefault = BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || !context.isGoogleServicesAvailable()
+            isWebSocketEnabledByDefault = isWebsocketEnabledByDefault(context)
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -69,7 +69,7 @@ class KaliumConfigsModule {
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
-            isWebSocketEnabledByDefault = !context.isGoogleServicesAvailable()
+            isWebSocketEnabledByDefault = BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || !context.isGoogleServicesAvailable()
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -31,13 +31,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.conversations.details.options.SwitchState
-import com.wire.android.util.extension.isGoogleServicesAvailable
+import com.wire.android.util.isWebsocketEnabledByDefault
 
 @Composable
 fun NetworkSettingsScreen(networkSettingsViewModel: NetworkSettingsViewModel = hiltViewModel()) {
@@ -69,31 +68,21 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            GroupConversationOptionsItem(
-                title = stringResource(R.string.settings_keep_connection_to_websocket),
-                subtitle = stringResource(
-                    R.string.settings_keep_connection_to_websocket_description,
-                    backendName
-                ),
-                switchState = getSwitchState(isWebSocketEnabled, setWebSocketState),
-                arrowType = ArrowType.NONE
-            )
+            if (!isWebsocketEnabledByDefault(LocalContext.current)) {
+                GroupConversationOptionsItem(
+                    title = stringResource(R.string.settings_keep_connection_to_websocket),
+                    subtitle = stringResource(
+                        R.string.settings_keep_connection_to_websocket_description,
+                        backendName
+                    ),
+                    switchState = SwitchState.Enabled(
+                        value = isWebSocketEnabled,
+                        onCheckedChange = setWebSocketState
+                    ),
+                    arrowType = ArrowType.NONE
+                )
+            }
         }
-    }
-}
-
-@Composable
-private fun getSwitchState(isWebSocketEnabled: Boolean, setWebSocketState: (Boolean) -> Unit): SwitchState {
-    val context = LocalContext.current
-    return if (BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || context.isGoogleServicesAvailable()) {
-        SwitchState.Enabled(
-            value = isWebSocketEnabled,
-            onCheckedChange = setWebSocketState
-        )
-    } else {
-        SwitchState.Disabled(
-            value = isWebSocketEnabled,
-        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
@@ -84,7 +85,7 @@ fun NetworkSettingsScreenContent(
 @Composable
 private fun getSwitchState(isWebSocketEnabled: Boolean, setWebSocketState: (Boolean) -> Unit): SwitchState {
     val context = LocalContext.current
-    return if (context.isGoogleServicesAvailable()) {
+    return if (BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || context.isGoogleServicesAvailable()) {
         SwitchState.Enabled(
             value = isWebSocketEnabled,
             onCheckedChange = setWebSocketState

--- a/app/src/main/kotlin/com/wire/android/util/WebsocketHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/WebsocketHelper.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.content.Context
+import com.wire.android.BuildConfig
+import com.wire.android.util.extension.isGoogleServicesAvailable
+
+/**
+ * If [BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT] is true, the websocket should be enabled by default always.
+ * Otherwise, it should be enabled by default only if Google Play Services are not available.
+ */
+fun isWebsocketEnabledByDefault(context: Context) =
+    BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || !context.isGoogleServicesAvailable()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,7 +35,7 @@ object AndroidClient {
     const val appId = "com.wire.android"
     const val namespace = appId
     val versionCode = Versionizer().versionCode
-    const val versionName = "4.2.4"
+    const val versionName = "4.2.5"
     const val testRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -46,6 +46,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     ENABLE_GUEST_ROOM_LINK("enable_guest_room_link", ConfigType.BOOLEAN),
     UPDATE_APP_URL("update_app_url", ConfigType.STRING),
     ENABLE_BLACKLIST("enable_blacklist", ConfigType.BOOLEAN),
+    WEBSOCKET_ENABLED_BY_DEFAULT("websocket_enabled_by_default", ConfigType.BOOLEAN),
 
     /**
      * Security/Cryptography stuff

--- a/default.json
+++ b/default.json
@@ -82,6 +82,7 @@
     "wipe_on_cookie_invalid": false,
     "wipe_on_device_removal": false,
     "wipe_on_rooted_device": false,
+    "websocket_enabled_by_default": true,
 
     "firebase_push_sender_id": "782078216207",
     "firebase_app_id": "1:782078216207:android:d3db2443512d2055",

--- a/default.json
+++ b/default.json
@@ -82,7 +82,7 @@
     "wipe_on_cookie_invalid": false,
     "wipe_on_device_removal": false,
     "wipe_on_rooted_device": false,
-    "websocket_enabled_by_default": true,
+    "websocket_enabled_by_default": false,
 
     "firebase_push_sender_id": "782078216207",
     "firebase_app_id": "1:782078216207:android:d3db2443512d2055",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3311" title="WPB-3311" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3311</a>  Turn on Websockets by default via config flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to provide a way to enable websocket by default using configuration.

### Solutions

Add additional condition to check for custom-build config => ` "websocket_enabled_by_default": true,`

### Dependencies (Optional)

https://github.com/wireapp/android-customization

Needs releases with:

- [x] GitHub link to other pull request

#### How to Test

After merge of https://github.com/wireapp/android-customization we can trigger a build using this branch 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
