### PR TITLE
fix: hide connectivity banner on authentications screens

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -499,6 +499,7 @@ class WireActivityViewModel @Inject constructor(
         is CurrentScreen.IncomingCallScreen,
         is CurrentScreen.OngoingCallScreen,
         is CurrentScreen.OtherUserProfile,
+        CurrentScreen.AuthRelated,
         CurrentScreen.SomeOther -> true
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -69,6 +69,7 @@ class CommonTopAppBarViewModel @Inject constructor(
                     when (it) {
                         is CurrentSessionResult.Failure.Generic,
                         CurrentSessionResult.Failure.SessionNotFound -> flowOf(ConnectivityUIState.Info.None)
+
                         is CurrentSessionResult.Success -> {
                             val userId = it.accountInfo.userId
                             combine(
@@ -104,14 +105,20 @@ class CommonTopAppBarViewModel @Inject constructor(
     ): ConnectivityUIState.Info {
         val canDisplayActiveCall = currentScreen !is CurrentScreen.OngoingCallScreen
 
+        val canDisplayConnectivityIssues = currentScreen !is CurrentScreen.AuthRelated
+
         if (activeCall != null && canDisplayActiveCall) {
             return ConnectivityUIState.Info.EstablishedCall(activeCall.conversationId, activeCall.isMuted)
         }
 
-        return when (connectivity) {
-            Connectivity.WAITING_CONNECTION -> ConnectivityUIState.Info.WaitingConnection
-            Connectivity.CONNECTING -> ConnectivityUIState.Info.Connecting
-            Connectivity.CONNECTED -> ConnectivityUIState.Info.None
+        return if (canDisplayConnectivityIssues) {
+            when (connectivity) {
+                Connectivity.WAITING_CONNECTION -> ConnectivityUIState.Info.WaitingConnection
+                Connectivity.CONNECTING -> ConnectivityUIState.Info.Connecting
+                Connectivity.CONNECTED -> ConnectivityUIState.Info.None
+            }
+        } else {
+            ConnectivityUIState.Info.None
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -203,6 +203,8 @@ sealed class CurrentScreen {
                 NavigationItem.CreatePersonalAccount,
                 NavigationItem.CreateTeam,
                 NavigationItem.CreateAccountSummary,
+                NavigationItem.Migration,
+                NavigationItem.InitialSync,
                 NavigationItem.RemoveDevices -> AuthRelated
 
                 else -> SomeOther

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -145,8 +145,12 @@ sealed class CurrentScreen {
 
     // Import media screen is opened
     object ImportMedia : CurrentScreen()
+
     // SelfDevices screen is opened
     object DeviceManager : CurrentScreen()
+
+    // Auth related screen is opened
+    object AuthRelated : CurrentScreen()
 
     // Some other screen is opened, kinda "do nothing screen"
     object SomeOther : CurrentScreen()
@@ -170,26 +174,37 @@ sealed class CurrentScreen {
                         ?.let { Conversation(it) }
                         ?: SomeOther
                 }
+
                 NavigationItem.OtherUserProfile -> {
                     arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OtherUserProfile(it) }
                         ?: SomeOther
                 }
+
                 NavigationItem.OngoingCall -> {
                     arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OngoingCallScreen(it) }
                         ?: SomeOther
                 }
+
                 NavigationItem.IncomingCall -> {
                     arguments?.getString(EXTRA_CONVERSATION_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { IncomingCallScreen(it) }
                         ?: SomeOther
                 }
+
                 NavigationItem.ImportMedia -> ImportMedia
                 NavigationItem.SelfDevices -> DeviceManager
+                NavigationItem.Welcome,
+                NavigationItem.Login,
+                NavigationItem.CreatePersonalAccount,
+                NavigationItem.CreateTeam,
+                NavigationItem.CreateAccountSummary,
+                NavigationItem.RemoveDevices -> AuthRelated
+
                 else -> SomeOther
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

connectivity banner should not be displayed before the user is logged in nor in auth related screens

### Solutions

hide it in login related screens

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
