### PR TITLE
fix: wrong pointerInput invoked on scroll inside message list [WPB-3525]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/ClickableText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/ClickableText.kt
@@ -64,7 +64,11 @@ fun ClickableText(
     val currentOnLongClick by rememberUpdatedState(newValue = onLongClick)
     val currentLayoutResult by rememberUpdatedState(layoutResult)
 
-    val pressIndicator = Modifier.pointerInput(Unit) {
+    // even though the rememberUpdateState, should be working, we still do not get the reference to the correct
+    // lambda's mainly when we scroll to the top of the list and then back to the bottom, it looks like, the reference
+    // does not get updated to point to the correct lambda. currentLayoutResult, should be good enough as the key
+    // because it should be updated with each "ClickableText" also we are referencing it inside pointerInput.
+    val pressIndicator = Modifier.pointerInput(currentLayoutResult.value) {
         detectTapGestures(
             onTap = { pos ->
                 currentLayoutResult.value?.let { layoutResult ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When scrolling up in the conversation list and back to bottom, the click and onlong click lambda did not get updated, causing the lambda to invoke functions with misplaced data.

### Solutions

- Update pointerInput with each change of text layout.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
