### PR TITLE
fix: wrong pointerInput invoked on scroll inside message list (cherry-pick WPB-3525)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/LinkifyText.kt
@@ -223,7 +223,11 @@ private fun ClickableText(
     val currentOnLongClick by rememberUpdatedState(newValue = onLongClick)
     val currentLayoutResult by rememberUpdatedState(layoutResult)
 
-    val pressIndicator = Modifier.pointerInput(Unit) {
+    // even though the rememberUpdateState, should be working, we still do not get the reference to the correct
+    // lambda's mainly when we scroll to the top of the list and then back to the bottom, it looks like, the reference
+    // does not get updated to point to the correct lambda. currentLayoutResult, should be good enough as the key
+    // because it should be updated with each "ClickableText" also we are referencing it inside pointerInput.
+    val pressIndicator = Modifier.pointerInput(currentLayoutResult.value) {
         detectTapGestures(
             onTap = { pos ->
                 currentLayoutResult.value?.let { layoutResult ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3525" title="WPB-3525" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3525</a>  [Android] Edit not working anymore after scrolling in the conversation and tapping directly on text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick from:

- #2021 