### PR TITLE
fix: show unblock user confirmation dialog (WPB-2427)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -32,14 +32,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.os.bundleOf
 import com.sebaslogen.resaca.hilt.hiltViewModelScoped
 import com.wire.android.R
-import com.wire.android.model.ClickBlockParams
 import com.wire.android.model.ActionableState
+import com.wire.android.model.ClickBlockParams
 import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.EXTRA_USER_NAME
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
+import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.snackbar.collectAndShowSnackbar
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -64,6 +67,17 @@ fun ConnectionActionButton(
             LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = it.infoMessage)
         }
     }
+    val unblockUserDialogState = rememberVisibilityState<UnblockUserDialogState>()
+
+    UnblockUserDialogContent(
+        dialogState = unblockUserDialogState,
+        onUnblock = { viewModel.onUnblockUser() },
+        isLoading = viewModel.actionableState().isPerformingAction,
+    )
+
+    if (!viewModel.actionableState().isPerformingAction) {
+        unblockUserDialogState.dismiss()
+    }
 
     when (connectionStatus) {
         ConnectionState.SENT -> WireSecondaryButton(
@@ -72,11 +86,13 @@ fun ConnectionActionButton(
             onClick = viewModel::onCancelConnectionRequest,
             clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
         )
+
         ConnectionState.ACCEPTED -> WirePrimaryButton(
             text = stringResource(R.string.label_open_conversation),
             loading = viewModel.actionableState().isPerformingAction,
             onClick = viewModel::onOpenConversation,
         )
+
         ConnectionState.IGNORED -> WirePrimaryButton(
             text = stringResource(R.string.connection_label_accept),
             loading = viewModel.actionableState().isPerformingAction,
@@ -90,6 +106,7 @@ fun ConnectionActionButton(
                 )
             }
         )
+
         ConnectionState.PENDING -> Column {
             WirePrimaryButton(
                 text = stringResource(R.string.connection_label_accept),
@@ -120,14 +137,23 @@ fun ConnectionActionButton(
                 }
             )
         }
+
         ConnectionState.BLOCKED -> {
             WireSecondaryButton(
                 text = stringResource(R.string.user_profile_unblock_user),
                 loading = viewModel.actionableState().isPerformingAction,
-                onClick = viewModel::onUnblockUser,
+                onClick = {
+                    unblockUserDialogState.show(
+                        UnblockUserDialogState(
+                            userId = userId,
+                            userName = userName
+                        )
+                    )
+                },
                 clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
             )
         }
+
         ConnectionState.NOT_CONNECTED,
         ConnectionState.CANCELLED,
         ConnectionState.MISSING_LEGALHOLD_CONSENT -> WirePrimaryButton(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -136,10 +136,6 @@ fun OtherUserProfileScreen(viewModel: OtherUserProfileScreenViewModel = hiltView
 }
 
 @SuppressLint("UnusedCrossfadeTargetStateParameter", "LongParameterList")
-@OptIn(
-    ExperimentalPagerApi::class,
-    ExperimentalMaterial3Api::class,
-)
 @Composable
 fun OtherProfileScreenContent(
     scope: CoroutineScope,
@@ -332,7 +328,6 @@ private fun TopBarCollapsing(state: OtherUserProfileState) {
     }
 }
 
-@OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun TopBarFooter(
     state: OtherUserProfileState,
@@ -363,7 +358,7 @@ private fun TopBarFooter(
     }
 }
 
-@OptIn(ExperimentalPagerApi::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Content(
     state: OtherUserProfileState,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fixing this issue #2012, the confirmation dialog is no longer displayed when unblocking someone.

### Causes (Optional)

Missed that 🤷‍♂️

### Solutions

Add the dialog and handle its state

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
