### PR TITLE
fix: Audio Message not being send with correct mimeType (WPB-3534)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -239,11 +239,16 @@ class MessageComposerViewModel @Inject constructor(
                 }
 
                 is ComposableMessageBundle.AttachmentPickedBundle -> {
-                    handleAttachment(messageBundle)
+                    handleAssetMessageBundle(
+                        attachmentUri = messageBundle.attachmentUri
+                    )
                 }
 
                 is ComposableMessageBundle.AudioMessageBundle -> {
-                    handleAudioMessageBundle(messageBundle)
+                    handleAssetMessageBundle(
+                        attachmentUri = messageBundle.attachmentUri,
+                        audioPath = messageBundle.attachmentUri.uri.path?.toPath()
+                    )
                 }
 
                 is ComposableMessageBundle.SendTextMessageBundle -> {
@@ -263,23 +268,6 @@ class MessageComposerViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    private suspend fun handleAttachment(
-        messageBundle: ComposableMessageBundle.AttachmentPickedBundle
-    ) {
-        handleAssetMessageBundle(
-            attachmentUri = messageBundle.attachmentUri
-        )
-    }
-
-    private suspend fun handleAudioMessageBundle(
-        messageBundle: ComposableMessageBundle.AudioMessageBundle
-    ) {
-        handleAssetMessageBundle(
-            attachmentUri = messageBundle.attachmentUri,
-            audioPath = messageBundle.attachmentUri.uri.path?.toPath()
-        )
     }
 
     private suspend fun handleAssetMessageBundle(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -71,6 +71,7 @@ import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionStateHolder
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuState
+import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle.AudioMessageBundle
 import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle.AttachmentPickedBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
@@ -151,9 +152,7 @@ fun MessageComposer(
                     },
                     onPingOptionClicked = { onSendMessageBundle(Ping) },
                     onAttachmentPicked = { onSendMessageBundle(AttachmentPickedBundle(it)) },
-                    onAudioRecorded = {
-                        onSendMessageBundle(AttachmentPickedBundle(it))
-                    },
+                    onAudioRecorded = { onSendMessageBundle(AudioMessageBundle(it)) },
                     onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
                     onSearchMentionQueryChanged = onSearchMentionQueryChanged,
                     onClearMentionSearchResult = onClearMentionSearchResult,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -79,10 +79,13 @@ class AudioMediaRecorder @Inject constructor(
                 .toFile()
 
             mediaRecorder?.setAudioSource(MediaRecorder.AudioSource.MIC)
+            mediaRecorder?.setAudioSamplingRate(SAMPLING_RATE)
             mediaRecorder?.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             mediaRecorder?.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-            mediaRecorder?.setOutputFile(outputFile)
+            mediaRecorder?.setAudioChannels(AUDIO_CHANNELS)
+            mediaRecorder?.setAudioEncodingBitRate(AUDIO_ENCONDING_BIT_RATE)
             mediaRecorder?.setMaxFileSize(assetLimitInMegabyte)
+            mediaRecorder?.setOutputFile(outputFile)
 
             observeAudioFileSize()
         }
@@ -127,5 +130,8 @@ class AudioMediaRecorder @Inject constructor(
         fun getRecordingAudioFileName(): String =
             "wire-audio-${DateTimeUtil.currentInstant().audioFileDateTime()}.m4a"
         const val SIZE_OF_1MB = 1024 * 1024
+        const val AUDIO_CHANNELS = 1
+        const val SAMPLING_RATE = 44100
+        const val AUDIO_ENCONDING_BIT_RATE = 96000
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -426,6 +426,10 @@ sealed class ComposableMessageBundle : MessageBundle {
     data class AttachmentPickedBundle(
         val attachmentUri: UriAsset
     ) : ComposableMessageBundle()
+
+    data class AudioMessageBundle(
+        val attachmentUri: UriAsset
+    ) : ComposableMessageBundle()
 }
 
 object Ping : MessageBundle

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -417,3 +417,4 @@ fun findFirstUniqueName(dir: File, desiredName: String): String {
 private const val ATTACHMENT_FILENAME = "attachment"
 private const val DATA_COPY_BUFFER_SIZE = 2048
 const val SDK_VERSION = 33
+const val AUDIO_MIME_TYPE = "audio/mp4"

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -274,7 +274,7 @@ internal class MessageComposerViewModelArrangement {
     }
 
     fun withGetAssetBundleFromUri(assetBundle: AssetBundle?) = apply {
-        coEvery { fileManager.getAssetBundleFromUri(any(), any(), any()) } returns assetBundle
+        coEvery { fileManager.getAssetBundleFromUri(any(), any(), any(), any()) } returns assetBundle
     }
 
     fun withSaveToExternalMediaStorage(resultFileName: String?) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -525,4 +525,42 @@ class MessageComposerViewModelTest {
             assertInstanceOf(SelfDeletionTimer.Enabled::class.java, viewModel.messageComposerViewState.value.selfDeletionTimer)
             assertEquals(expectedDuration, viewModel.messageComposerViewState.value.selfDeletionTimer.duration)
         }
+
+
+
+    @Test
+    fun `given the user sends an audio message, when invoked, then sendAssetMessageUseCase gets called`() =
+        runTest {
+            // Given
+            val limit = ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val assetPath = "mocked-asset-data-path".toPath()
+            val assetContent = "some-dummy-audio".toByteArray()
+            val assetName = "mocked_audio.m4a"
+            val assetSize = 1L
+            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withStoredAsset(assetPath, assetContent)
+                .withSuccessfulSendAttachmentMessage()
+                .withGetAssetSizeLimitUseCase(false, limit)
+                .arrange()
+            val mockedAttachment = AssetBundle(
+                "audio/mp4", assetPath, assetSize, assetName, AttachmentType.AUDIO
+            )
+
+            // When
+            viewModel.sendAttachment(mockedAttachment)
+
+            // Then
+            coVerify(exactly = 1) {
+                arrangement.sendAssetMessage.invoke(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            }
+        }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -526,8 +526,6 @@ class MessageComposerViewModelTest {
             assertEquals(expectedDuration, viewModel.messageComposerViewState.value.selfDeletionTimer.duration)
         }
 
-
-
     @Test
     fun `given the user sends an audio message, when invoked, then sendAssetMessageUseCase gets called`() =
         runTest {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Audio messages sent from Android would play on another Android device or Web, but not on iOS devices.

### Causes (Optional)

We have 3 ways to send audio messages:
- Audio recording feature (issue)
- Attach File from additional options menu (no issues)
- Share from outside the app (no issues)

When sending from the recording feature, due to using `MediaRecorder` the end file mimeType resolves into `video/mp4` and not `audio/mp4`, this doesn't occur when sending an audio message from other flows.

### Solutions

Unify sending/handling asset (normal asset and audio asset) with its respective Bundle classes and if it is an Audio asset, then we force its mimeType to `audio/mp4` with extension as `.m4a` so its playable in all platforms.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open App
- Open Conversation
- Send an Audio Message (record the audio and send from the feature, not sharing/picking the file from device).
- Audio is sent successfully and fully playable from any iOS device.
