### PR TITLE
fix: inconsistent audio message length [WPB-3334]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
@@ -9,16 +9,14 @@ data class AudioState(
         val DEFAULT = AudioState(AudioMediaPlayingState.Stopped, 0, TotalTimeInMs.NotKnown)
     }
 
-    // before the user decides to play audio message, we are not able to determine total time ourself using
-    // MediaPlayer API, we are relying on the info retrieved from the other client, until then
-    fun sanitizeTotalTime(otherClientTotalTime: Int): AudioState {
-        if (totalTimeInMs is TotalTimeInMs.NotKnown) {
-            if (otherClientTotalTime != 0) {
-                return copy(totalTimeInMs = TotalTimeInMs.Known(otherClientTotalTime))
-            }
+    // if the back-end returned the total time, we use that, in case it didn't we use what we get from
+    // the [ConversationAudioMessagePlayer.kt] which will emit the time once the users play the audio.
+    fun sanitizeTotalTime(otherClientTotalTime: Int): TotalTimeInMs {
+        if (otherClientTotalTime != 0) {
+           return TotalTimeInMs.Known(otherClientTotalTime)
         }
 
-        return this
+        return totalTimeInMs
     }
 
     sealed class TotalTimeInMs {

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -2,7 +2,10 @@ package com.wire.android.media.audiomessage
 
 import android.content.Context
 import android.media.MediaPlayer
+import android.media.MediaPlayer.SEEK_CLOSEST
+import android.media.MediaPlayer.SEEK_CLOSEST_SYNC
 import android.net.Uri
+import android.util.Log
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
@@ -110,7 +113,9 @@ class ConversationAudioMessagePlayer
                     audioMessageStateHistory = audioMessageStateHistory.toMutableMap().apply {
                         put(
                             audioMessageStateUpdate.messageId,
-                            currentState.copy(totalTimeInMs = AudioState.TotalTimeInMs.Known(audioMessageStateUpdate.totalTimeInMs))
+                            currentState.copy(
+                                totalTimeInMs = AudioState.TotalTimeInMs.Known(audioMessageStateUpdate.totalTimeInMs)
+                            )
                         )
                     }
                 }
@@ -241,7 +246,7 @@ class ConversationAudioMessagePlayer
             val isAudioMessageCurrentlyPlaying = currentAudioMessageId == messageId
 
             if (isAudioMessageCurrentlyPlaying) {
-                audioMediaPlayer.seekTo(position)
+                audioMediaPlayer.seekTo(position.toLong(), SEEK_CLOSEST_SYNC)
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -2,10 +2,8 @@ package com.wire.android.media.audiomessage
 
 import android.content.Context
 import android.media.MediaPlayer
-import android.media.MediaPlayer.SEEK_CLOSEST
 import android.media.MediaPlayer.SEEK_CLOSEST_SYNC
 import android.net.Uri
-import android.util.Log
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -158,7 +158,7 @@ fun MessageItem(
 
                 val isProfileRedirectEnabled =
                     header.userId != null &&
-                        !(header.isSenderDeleted || header.isSenderUnavailable)
+                            !(header.isSenderDeleted || header.isSenderUnavailable)
 
                 if (showAuthor) {
                     val avatarClickable = remember {
@@ -524,14 +524,14 @@ private fun MessageContent(
             val audioMessageState: AudioState = audioMessagesState[message.header.messageId]
                 ?: AudioState.DEFAULT
 
-            val adjustedMessageState: AudioState = remember(audioMessagesState) {
+            val totalTimeInMs = remember(audioMessageState.totalTimeInMs) {
                 audioMessageState.sanitizeTotalTime(messageContent.audioMessageDurationInMs.toInt())
             }
 
             AudioMessage(
-                audioMediaPlayingState = adjustedMessageState.audioMediaPlayingState,
-                totalTimeInMs = adjustedMessageState.totalTimeInMs,
-                currentPositionInMs = adjustedMessageState.currentPositionInMs,
+                audioMediaPlayingState = audioMessageState.audioMediaPlayingState,
+                totalTimeInMs = totalTimeInMs,
+                currentPositionInMs = audioMessageState.currentPositionInMs,
                 onPlayButtonClick = { onAudioClick(message.header.messageId) },
                 onSliderPositionChange = { position ->
                     onChangeAudioPosition(message.header.messageId, position.toInt())

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui.home.conversations.messages
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -44,13 +43,13 @@ import com.wire.android.navigation.getBackNavArg
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.model.AssetBundle
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.startFileShareIntent
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.home.conversations.messages
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- We were taking the media player length as a source of truth, whenever it is known. Because of that the audio length was inconsistent with what back-end returned.

### Solutions

- Always use the back-end audio length, unless it is unknown, then use the media player length emitted by the MEDIAPLAYER.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
