### PR TITLE
fix: create conversation button crash [WPB-3538]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
@@ -147,7 +147,7 @@ private fun InnerButtonBox(
     val trailingItem: (@Composable () -> Unit) = {
         Crossfade(targetState = (trailingIcon != null) to loading) { (hasTrailingIcon, loading) ->
             when {
-                hasTrailingIcon -> Tint(contentColor = contentColor, content = trailingIcon!!)
+                hasTrailingIcon -> Tint(contentColor = contentColor, content = trailingIcon ?: {})
                 loading -> WireCircularProgressIndicator(progressColor = contentColor)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
@@ -145,23 +145,25 @@ private fun InnerButtonBox(
     val contentColor = colors.contentColor(state, interactionSource).value
     val leadingItem: (@Composable () -> Unit) = { leadingIcon?.let { Tint(contentColor = contentColor, content = it) } }
     val trailingItem: (@Composable () -> Unit) = {
-        Crossfade(targetState = (trailingIcon != null) to loading) { (hasTrailingIcon, loading) ->
+        Crossfade(targetState = trailingIcon to loading) { (trailingIcon, loading) ->
             when {
-                hasTrailingIcon -> Tint(contentColor = contentColor, content = trailingIcon ?: {})
                 loading -> WireCircularProgressIndicator(progressColor = contentColor)
+                trailingIcon != null -> Tint(contentColor = contentColor, content = trailingIcon)
             }
         }
     }
-    Box(contentAlignment = Alignment.Center,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = if (fillMaxWidth) Modifier.fillMaxWidth() else Modifier.wrapContentWidth(),
     ) {
         var startItemWidth by remember { mutableStateOf(0) }
         var endItemWidth by remember { mutableStateOf(0) }
         val borderItemsMaxWidth = with(LocalDensity.current) { max(startItemWidth, endItemWidth).toDp() }
 
-        Box(modifier = Modifier
-            .align(Alignment.CenterStart)
-            .onGloballyPositioned { startItemWidth = it.size.width },
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .onGloballyPositioned { startItemWidth = it.size.width },
         ) { if (leadingIconAlignment == IconAlignment.Border) leadingItem() }
 
         Row(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was null pointer on rebuilding trailingItem with CrossFade composable, which we can't pass only composable by targetState

### Causes (Optional)

Crash when user clicks create conversation

### Solutions

Use null safe usage of composable