### PR TITLE
fix: line break unhandled event (WPB-3320)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
@@ -159,11 +159,7 @@ fun inlineChildren(
                 annotatedString.pop()
             }
 
-            is HardLineBreak -> {
-                annotatedString.append("\n")
-            }
-
-            is SoftLineBreak -> {
+            is HardLineBreak, is SoftLineBreak -> {
                 annotatedString.append("\n")
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
@@ -48,6 +48,7 @@ import org.commonmark.node.Link
 import org.commonmark.node.Node
 import org.commonmark.node.OrderedList
 import org.commonmark.node.Paragraph
+import org.commonmark.node.SoftLineBreak
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.node.ThematicBreak
@@ -160,7 +161,10 @@ fun inlineChildren(
 
             is HardLineBreak -> {
                 annotatedString.append("\n")
-                annotatedString.pop()
+            }
+
+            is SoftLineBreak -> {
+                annotatedString.append("\n")
             }
 
             is Link -> {

--- a/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
@@ -89,6 +89,7 @@ fun Resources.annotatedText(
                 else -> {
                     pushStyle(style = toSpanStyle(normalStyle, useErrorColorIfApplies(isErrorString, errorColor, normalColor)))
                     append(piece)
+                    pop()
                 }
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sending a message with 2 lines, the soft line break was not being handled and rendering first and second line together. example:
<img src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/09ed0521-0777-482a-9ace-cbcfee505b31" width="200" /><br>
<img src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/a16dada2-28e7-48fd-9da7-ef4b34bba2b5" width="200" />

### Causes (Optional)

`SoftLineBreak` was not being handled.

### Solutions

Add handling of `SoftLineBreak` so it renders correctly (as in the image below)

### Testing

#### How to Test

- Open App
- Open Conversation
- Receive a message like this:
```
message1
message2

message 3
```
- Should be handled as 3 correct lines and not only 2

### Attachments (Optional)
<img src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/bcad460d-1279-4390-9527-c3200bcc413e" width="200" height="400" />
