### PR TITLE
fix: Keep screen active when user is recording audio (WPB-3479)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -17,7 +17,9 @@
  */
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
+import android.app.Activity
 import android.text.format.DateUtils
+import android.view.WindowManager
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
@@ -30,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
@@ -98,6 +102,14 @@ fun RecordAudioButtonRecording(
         while (true) {
             delay(1000L)
             seconds += 1
+        }
+    }
+    val activity = LocalContext.current as Activity
+
+    DisposableEffect(Unit) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user was recording an audio, the screen would not be kept on and would lock the phone, thus stopping the recording.

### Causes (Optional)

Not implemented.

### Solutions

Add a disposable effect to add flag `FLAG_KEEP_SCREEN_ON` when user is recording an audio, and dispose of the flag when it is ready to send or discarded.

### Testing

#### How to Test

- Open App
- Open Conversation
- Open Record Audio Component
- If audio recording State is RECORDING (red button to stop recording is shown) then the device won't lock the screen by itself.