### PR TITLE
fix: join call button height not matching design

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.common.button.WireButtonState

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
@@ -45,7 +45,7 @@ fun JoinButton(
     buttonClick: () -> Unit,
     modifier: Modifier = Modifier,
     minHeight: Dp = 32.dp,
-    minWidth: Dp = MaterialTheme.wireDimensions.buttonMinSize.width
+    minWidth: Dp = 51.dp
 ) {
     val audioPermissionCheck = AudioBluetoothPermissionCheckFlow { buttonClick() }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
@@ -22,7 +22,6 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
@@ -43,8 +43,8 @@ import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothReque
 fun JoinButton(
     buttonClick: () -> Unit,
     modifier: Modifier = Modifier,
-    minHeight: Dp = 32.dp,
-    minWidth: Dp = 51.dp
+    minHeight: Dp = MaterialTheme.wireDimensions.buttonMinSize.height,
+    minWidth: Dp = MaterialTheme.wireDimensions.buttonMinSize.width
 ) {
     val audioPermissionCheck = AudioBluetoothPermissionCheckFlow { buttonClick() }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/JoinButton.kt
@@ -22,6 +22,7 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.common.button.WireButtonState
@@ -42,7 +44,7 @@ import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothReque
 fun JoinButton(
     buttonClick: () -> Unit,
     modifier: Modifier = Modifier,
-    minHeight: Dp = MaterialTheme.wireDimensions.buttonMinSize.height,
+    minHeight: Dp = 32.dp,
     minWidth: Dp = MaterialTheme.wireDimensions.buttonMinSize.width
 ) {
     val audioPermissionCheck = AudioBluetoothPermissionCheckFlow { buttonClick() }
@@ -57,7 +59,6 @@ fun JoinButton(
         minHeight = minHeight,
         minWidth = minWidth,
         modifier = modifier.padding(
-            vertical = dimensions().spacing12x,
             horizontal = dimensions().spacing8x
         ),
         contentPadding = PaddingValues(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -49,6 +49,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getDeviceId
 import com.wire.android.util.getGitBuildId
@@ -279,6 +280,8 @@ private fun ManualMigrationOptions(
         },
         actions = {
             WirePrimaryButton(
+                minHeight = MaterialTheme.wireDimensions.buttonMinSize.height,
+                minWidth = MaterialTheme.wireDimensions.buttonMinSize.width,
                 onClick = onManualMigrationClicked,
                 text = stringResource(R.string.start_manual_migration),
                 fillMaxWidth = false
@@ -306,6 +309,8 @@ private fun DevelopmentApiVersioningOptions(
         },
         actions = {
             WirePrimaryButton(
+                minHeight = MaterialTheme.wireDimensions.buttonMinSize.height,
+                minWidth = MaterialTheme.wireDimensions.buttonMinSize.width,
                 onClick = onForceLatestDevelopmentApiChange,
                 text = stringResource(R.string.debug_settings_force_api_versioning_update_button_text),
                 fillMaxWidth = false

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -91,6 +91,7 @@ data class WireDimensions(
     // Buttons
     val buttonMinSize: DpSize,
     val buttonSmallMinSize: DpSize,
+    val buttonMediumMinSize: DpSize,
     val buttonHorizontalContentPadding: Dp,
     val buttonVerticalContentPadding: Dp,
     val buttonCornerSize: Dp,
@@ -239,6 +240,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     codeFieldItemHeight = 60.dp,
     buttonMinSize = DpSize(60.dp, 48.dp),
     buttonSmallMinSize = DpSize(40.dp, 32.dp),
+    buttonMediumMinSize = DpSize(32.dp, 51.dp),
     buttonHorizontalContentPadding = 16.dp,
     buttonVerticalContentPadding = 8.dp,
     buttonCornerSize = 12.dp,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
join conversion height is bigger than intended

### Solutions

set the height and width as it is described in Figma

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
