### PR TITLE
fix: attachment options in chat not working on android 14 (WPB-1846)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/KeyboardHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/KeyboardHelper.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
@@ -18,12 +17,7 @@ import androidx.core.view.WindowInsetsCompat
 object KeyboardHelper {
 
     @Composable
-    fun isKeyboardVisible(): Boolean =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            WindowInsets.isImeVisible
-        } else {
-            ViewCompat.getRootWindowInsets(LocalView.current)?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
-        }
+    fun isKeyboardVisible(): Boolean = ViewCompat.getRootWindowInsets(LocalView.current)?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
 
     @Composable
     fun getCalculatedKeyboardHeight(): Dp =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User can't attach files on when using the app on Android 14

### Causes (Optional)

On Android 14, `isImeVisible` is considering the attachments option layout as soft keyboard, causing to return wrong values when calling `isKeyboardVisible()`

### Solutions

Use `isVisible` from `WindowInsetsCompat `only 

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

You should be able to see the attachment options when you try to send a file using a device on Android 14.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
