### PR TITLE
fix: add audio asset metadata (WPB-3334)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -56,6 +56,7 @@ import com.wire.android.ui.home.messagecomposer.state.Ping
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.getAudioLengthInMs
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.data.asset.AttachmentType
@@ -335,7 +336,8 @@ class MessageComposerViewModel @Inject constructor(
                                 assetWidth = imgWidth,
                                 assetHeight = imgHeight,
                                 assetDataSize = dataSize,
-                                assetMimeType = mimeType
+                                assetMimeType = mimeType,
+                                audioLengthInMs = 0L
                             )
                         }
 
@@ -350,7 +352,11 @@ class MessageComposerViewModel @Inject constructor(
                                     assetMimeType = mimeType,
                                     assetDataSize = dataSize,
                                     assetHeight = null,
-                                    assetWidth = null
+                                    assetWidth = null,
+                                    audioLengthInMs = getAudioLengthInMs(
+                                        dataPath = dataPath,
+                                        mimeType = mimeType
+                                    )
                                 )
                             } catch (e: OutOfMemoryError) {
                                 appLogger.e("There was an OutOfMemory error while uploading the asset")

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.getAudioLengthInMs
 import com.wire.android.util.getMetadataFromUri
 import com.wire.android.util.getMimeType
 import com.wire.android.util.isImageFile
@@ -335,6 +336,10 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                         assetMimeType = importedAsset.mimeType,
                         assetWidth = if (isImage) (importedAsset as ImportedMediaAsset.Image).width else 0,
                         assetHeight = if (isImage) (importedAsset as ImportedMediaAsset.Image).height else 0,
+                        audioLengthInMs = getAudioLengthInMs(
+                            dataPath = importedAsset.dataPath,
+                            mimeType = importedAsset.mimeType
+                        )
                     ).also {
                         if (it is ScheduleNewAssetMessageResult.Failure) {
                             appLogger.e("Failed to import asset message to conversationId=${conversation.conversationId.toLogString()} ")

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -30,6 +30,7 @@ import android.content.Context
 import android.content.Intent
 import android.database.Cursor
 import android.graphics.drawable.Drawable
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -54,6 +55,7 @@ import com.wire.android.util.ImageUtil.ImageSizeClass
 import com.wire.android.util.ImageUtil.ImageSizeClass.Medium
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.asset.isAudioMimeType
 import com.wire.kalium.logic.util.buildFileName
 import com.wire.kalium.logic.util.splitFileExtensionAndCopyCounter
 import kotlinx.coroutines.withContext
@@ -62,6 +64,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.util.Locale
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Gets the uri of any drawable or given resource
@@ -413,6 +416,18 @@ fun findFirstUniqueName(dir: File, desiredName: String): String {
     }
     return currentName
 }
+
+fun getAudioLengthInMs(dataPath: Path, mimeType: String): Long =
+    if (isAudioMimeType(mimeType)) {
+        val retriever = MediaMetadataRetriever()
+        retriever.setDataSource(dataPath.toFile().absolutePath)
+        val rawDuration = retriever
+            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            ?.toLong() ?: 0L
+        rawDuration.milliseconds.inWholeMilliseconds
+    } else {
+        0L
+    }
 
 private const val ATTACHMENT_FILENAME = "attachment"
 private const val DATA_COPY_BUFFER_SIZE = 2048

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -258,6 +258,7 @@ internal class MessageComposerViewModelArrangement {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns ScheduleNewAssetMessageResult.Success("some-message-id")

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -190,6 +190,7 @@ class MessageComposerViewModelTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                     any()
                 )
             }
@@ -226,6 +227,7 @@ class MessageComposerViewModelTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                     any()
                 )
             }
@@ -246,6 +248,7 @@ class MessageComposerViewModelTest {
 
             coVerify(inverse = true) {
                 arrangement.sendAssetMessage.invoke(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -285,6 +288,7 @@ class MessageComposerViewModelTest {
             // Then
             coVerify(inverse = true) {
                 arrangement.sendAssetMessage.invoke(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -331,6 +335,7 @@ class MessageComposerViewModelTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                     any()
                 )
             }
@@ -366,6 +371,7 @@ class MessageComposerViewModelTest {
             // Then
             coVerify(inverse = true) {
                 arrangement.sendAssetMessage.invoke(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -416,6 +422,7 @@ class MessageComposerViewModelTest {
                         any(),
                         any(),
                         any(),
+                        any(),
                         any()
                     )
                 }
@@ -447,6 +454,7 @@ class MessageComposerViewModelTest {
             // Then
             coVerify(exactly = 1) {
                 arrangement.sendAssetMessage.invoke(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -551,6 +559,7 @@ class MessageComposerViewModelTest {
             // Then
             coVerify(exactly = 1) {
                 arrangement.sendAssetMessage.invoke(
+                    any(),
                     any(),
                     any(),
                     any(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

ssues
When sending audio messages from Android it wouldn't render the audio length in Android and also other platforms

Causes (Optional)
We were not sending audio metadata.

Solutions
Add and map audio metadata correctly when sending the asset.

### Dependencies (Optional)

Needs releases with:

- [X] [Kalium PR #1969](https://github.com/wireapp/kalium/pull/1969)

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open App
- Open Conversation
- Send Audio message and check:
  - Audio contains length before sending
  - Audio contains length on messages list
  - Audio contains length (check from other platforms Web/iOS)
