### PR TITLE
fix(rc-message): handle invalid embedded link in messages (WPB-3554)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/InvalidLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/InvalidLinkDialog.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.common.dialogs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.home.conversations.InvalidLinkDialogState
+
+@Composable
+fun InvalidLinkDialog(dialogState: InvalidLinkDialogState, hideDialog: () -> Unit) {
+    if (dialogState is InvalidLinkDialogState.Visible) {
+        WireDialog(
+            title = stringResource(R.string.label_invalid_link_title),
+            text = stringResource(R.string.invalid_link),
+            buttonsHorizontalAlignment = false,
+            onDismiss = hideDialog,
+            optionButton1Properties = WireDialogButtonProperties(
+                text = stringResource(R.string.label_ok),
+                type = WireDialogButtonType.Primary,
+                onClick = hideDialog
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.home.conversations
 
 import android.net.Uri
+import android.webkit.URLUtil
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -162,6 +163,10 @@ class MessageComposerViewModel @Inject constructor(
 
     var assetTooLargeDialogState: AssetTooLargeDialogState by mutableStateOf(
         AssetTooLargeDialogState.Hidden
+    )
+
+    var invalidLinkDialogState: InvalidLinkDialogState by mutableStateOf(
+        InvalidLinkDialogState.Hidden
     )
 
     init {
@@ -394,6 +399,8 @@ class MessageComposerViewModel @Inject constructor(
         }
     }
 
+    fun isLinkValid(link: String) = URLUtil.isValidUrl(link)
+
     fun clearMentionSearchResult() {
         messageComposerViewState.value =
             messageComposerViewState.value.copy(mentionSearchResult = emptyList())
@@ -484,6 +491,10 @@ class MessageComposerViewModel @Inject constructor(
 
     fun hideAssetTooLargeError() {
         assetTooLargeDialogState = AssetTooLargeDialogState.Hidden
+    }
+
+    fun hideInvalidLinkError() {
+        invalidLinkDialogState = InvalidLinkDialogState.Hidden
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -20,8 +20,8 @@
 
 package com.wire.android.ui.home.conversations
 
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
@@ -38,4 +38,9 @@ data class MessageComposerViewState(
 sealed class AssetTooLargeDialogState {
     object Hidden : AssetTooLargeDialogState()
     data class Visible(val assetType: AttachmentType, val maxLimitInMB: Int, val savedToDevice: Boolean) : AssetTooLargeDialogState()
+}
+
+sealed class InvalidLinkDialogState {
+    object Hidden : InvalidLinkDialogState()
+    object Visible : InvalidLinkDialogState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -103,7 +103,8 @@ fun MessageItem(
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     onFailedMessageRetryClicked: (String) -> Unit = {},
-    onFailedMessageCancelClicked: (String) -> Unit = {}
+    onFailedMessageCancelClicked: (String) -> Unit = {},
+    onLinkClick: (String) -> Unit = {}
 ) {
     with(message) {
         val selfDeletionTimerState = rememberSelfDeletionTimer(header.messageStatus.expirationStatus)
@@ -229,7 +230,8 @@ fun MessageItem(
                                         onAssetClick = currentOnAssetClicked,
                                         onImageClick = currentOnImageClick,
                                         onLongClick = onLongClick,
-                                        onOpenProfile = onOpenProfile
+                                        onOpenProfile = onOpenProfile,
+                                        onLinkClick = onLinkClick
                                     )
                                 }
                                 if (isMyMessage) {
@@ -447,7 +449,8 @@ private fun MessageContent(
     onAudioClick: (String) -> Unit,
     onChangeAudioPosition: (String, Int) -> Unit,
     onLongClick: (() -> Unit)? = null,
-    onOpenProfile: (String) -> Unit
+    onOpenProfile: (String) -> Unit,
+    onLinkClick: (String) -> Unit
 ) {
     when (messageContent) {
         is UIMessageContent.ImageMessage -> {
@@ -475,7 +478,8 @@ private fun MessageContent(
                     messageBody = messageContent.messageBody,
                     isAvailable = !message.isPending && message.isAvailable,
                     onLongClick = onLongClick,
-                    onOpenProfile = onOpenProfile
+                    onOpenProfile = onOpenProfile,
+                    onLinkClick = onLinkClick
                 )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -72,6 +72,7 @@ internal fun MessageBody(
     isAvailable: Boolean,
     onLongClick: (() -> Unit)? = null,
     onOpenProfile: (String) -> Unit,
+    onLinkClick: (String) -> Unit
 ) {
     val (displayMentions, text) = mapToDisplayMentions(messageBody.message, LocalContext.current.resources)
 
@@ -83,7 +84,8 @@ internal fun MessageBody(
         typography = MaterialTheme.wireTypography,
         mentions = displayMentions,
         onLongClick = onLongClick,
-        onOpenProfile = onOpenProfile
+        onOpenProfile = onOpenProfile,
+        onLinkClick = onLinkClick
     )
 
     val extensions: List<Extension> = listOf(

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
@@ -42,7 +42,8 @@ fun MarkdownParagraph(paragraph: Paragraph, nodeData: NodeData, onMentionsUpdate
                 annotatedString,
                 style = nodeData.style,
                 onLongClick = nodeData.onLongClick,
-                onOpenProfile = nodeData.onOpenProfile
+                onOpenProfile = nodeData.onOpenProfile,
+                onClickLink = nodeData.onLinkClick
             )
         }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
@@ -50,7 +49,6 @@ fun MarkdownText(
     onLongClick: (() -> Unit)?,
     onOpenProfile: (String) -> Unit
 ) {
-    val uriHandler = LocalUriHandler.current
 
     if (clickable) {
         ClickableText(
@@ -69,7 +67,6 @@ fun MarkdownText(
                     start = offset,
                     end = offset,
                 ).firstOrNull()?.let { result ->
-                    uriHandler.openUri(result.item)
                     onClickLink?.invoke(annotatedString.substring(result.start, result.end))
                 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
@@ -32,7 +32,8 @@ data class NodeData(
     val typography: WireTypography,
     val mentions: List<DisplayMention>,
     val onLongClick: (() -> Unit)? = null,
-    val onOpenProfile: (String) -> Unit
+    val onOpenProfile: (String) -> Unit,
+    val onLinkClick: (String) -> Unit
 )
 
 data class DisplayMention(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -979,6 +979,10 @@
     <string name="self_deleting_messages_option_description">When this is on, all messages in this group will disappear after a certain time. This applies to all group participants.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
 
+    <!-- invalid link -->
+    <string name="label_invalid_link_title">Invalid Link</string>
+    <string name="invalid_link">The schema of the embedded link is not valid.</string>
+
     <!-- guest room link -->
     <string name="folder_label_guest_link">Guest link</string>
     <string name="guest_link_description">Invite others with a link to this conversation. Anyone with the link can join the conversation, even if they don’t have Wire.</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Handle invalid schema links embedded in a message.
* Not crashing the app
* showing an error dialog
* 
### Issues

The app was crashing in case of invalid embedded links.

### Causes (Optional)

Link validity wasn't checked.

### Solutions

Check the link schema before opening it, and in case of being invalid we show a dialog.

### Testing
No UI tests.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Send or receive a message with a wrong embedded link, when you click on the link, the app must not crash and an error dialog should appear.
![photo_2023-08-08 12 37 53](https://github.com/wireapp/wire-android-reloaded/assets/9512842/92caad6c-6415-4f89-b2d9-44e41209db71)


_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
