### PR TITLE
fix(message): fix in-message embedded link validator (WPB-3554)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/VisitLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/VisitLinkDialog.kt
@@ -24,18 +24,23 @@ import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
-import com.wire.android.ui.home.conversations.InvalidLinkDialogState
+import com.wire.android.ui.home.conversations.VisitLinkDialogState
 
 @Composable
-fun InvalidLinkDialog(dialogState: InvalidLinkDialogState, hideDialog: () -> Unit) {
-    if (dialogState is InvalidLinkDialogState.Visible) {
+fun VisitLinkDialog(dialogState: VisitLinkDialogState, hideDialog: () -> Unit) {
+    if (dialogState is VisitLinkDialogState.Visible) {
         WireDialog(
-            title = stringResource(R.string.label_invalid_link_title),
-            text = stringResource(R.string.invalid_link_dialog_body),
+            title = stringResource(R.string.label_visit_link_title),
+            text = stringResource(R.string.visit_link_dialog_body, dialogState.link),
             buttonsHorizontalAlignment = false,
             onDismiss = hideDialog,
             optionButton1Properties = WireDialogButtonProperties(
-                text = stringResource(R.string.label_ok),
+                text = stringResource(R.string.label_open),
+                type = WireDialogButtonType.Primary,
+                onClick = dialogState.openLink
+            ),
+            optionButton2Properties = WireDialogButtonProperties(
+                text = stringResource(R.string.label_cancel),
                 type = WireDialogButtonType.Primary,
                 onClick = hideDialog
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -55,17 +55,8 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
-import com.wire.kalium.logic.feature.conversation.InteractionAvailability
-import com.wire.kalium.logic.feature.conversation.IsInteractionAvailableResult
-import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
-import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
-import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
-import com.wire.kalium.logic.feature.message.RetryFailedMessageUseCase
-import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
-import com.wire.kalium.logic.feature.message.SendKnockUseCase
-import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
+import com.wire.kalium.logic.feature.conversation.*
+import com.wire.kalium.logic.feature.message.*
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
@@ -148,6 +139,10 @@ class MessageComposerViewModel @Inject constructor(
 
     var assetTooLargeDialogState: AssetTooLargeDialogState by mutableStateOf(
         AssetTooLargeDialogState.Hidden
+    )
+
+    var visitLinkDialogState: VisitLinkDialogState by mutableStateOf(
+        VisitLinkDialogState.Hidden
     )
 
     var invalidLinkDialogState: InvalidLinkDialogState by mutableStateOf(
@@ -438,10 +433,13 @@ class MessageComposerViewModel @Inject constructor(
         assetTooLargeDialogState = AssetTooLargeDialogState.Hidden
     }
 
+    fun hideVisitLinkDialog() {
+        visitLinkDialogState = VisitLinkDialogState.Hidden
+    }
+
     fun hideInvalidLinkError() {
         invalidLinkDialogState = InvalidLinkDialogState.Hidden
     }
-
     companion object {
         private const val sizeOf1MB = 1024 * 1024
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -40,7 +40,13 @@ sealed class AssetTooLargeDialogState {
     data class Visible(val assetType: AttachmentType, val maxLimitInMB: Int, val savedToDevice: Boolean) : AssetTooLargeDialogState()
 }
 
+sealed class VisitLinkDialogState {
+    object Hidden : VisitLinkDialogState()
+    data class Visible(val link: String, val openLink: () -> Unit) : VisitLinkDialogState()
+}
+
 sealed class InvalidLinkDialogState {
     object Hidden : InvalidLinkDialogState()
     object Visible : InvalidLinkDialogState()
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
@@ -67,7 +67,7 @@ fun MarkdownText(
                     start = offset,
                     end = offset,
                 ).firstOrNull()?.let { result ->
-                    onClickLink?.invoke(annotatedString.substring(result.start, result.end))
+                    onClickLink?.invoke(result.item)
                 }
 
                 annotatedString.getStringAnnotations(

--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import java.net.URLDecoder
+
+fun containsSchema(url: String): Boolean {
+    val regexPattern = Regex(".+://.+")
+
+    return regexPattern.matches(url)
+}
+
+fun normalizeLink(url: String): String {
+    val normalizedUrl = URLDecoder.decode(url, "UTF-8") // Decode URL to human-readable format
+
+    return if (containsSchema(normalizedUrl)) {
+        normalizedUrl
+    } else {
+        "https://$normalizedUrl"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="label_new">New</string>
     <string name="label_login">Login</string>
     <string name="label_ok">OK</string>
+    <string name="label_open">Open</string>
     <string name="label_cancel">Cancel</string>
     <string name="label_confirm">Confirm</string>
     <string name="label_continue">Continue</string>
@@ -990,9 +991,13 @@
     <string name="self_deleting_messages_option_description">When this is on, all messages in this group will disappear after a certain time. This applies to all group participants.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
 
+    <!-- visit link -->
+    <string name="label_visit_link_title">Visit Link</string>
+    <string name="visit_link_dialog_body">This will take you to %s</string>
+
     <!-- invalid link -->
     <string name="label_invalid_link_title">Invalid Link</string>
-    <string name="invalid_link">The schema of the embedded link is not valid.</string>
+    <string name="invalid_link_dialog_body">Link could not be opened</string>
 
     <!-- guest room link -->
     <string name="folder_label_guest_link">Guest link</string>

--- a/app/src/test/kotlin/com/wire/android/TestUtil.kt
+++ b/app/src/test/kotlin/com/wire/android/TestUtil.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android
+
+import kotlin.random.Random
+
+val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+
+fun Random.string(length: Int) = (1..length)
+    .map { Random.nextInt(0, charPool.size).let { charPool[it] } }
+    .joinToString("")

--- a/app/src/test/kotlin/com/wire/android/util/UriUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/UriUtilTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import com.wire.android.string
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class UriUtilTest {
+    @Test
+    fun givenLink_whenTheLinkStartsWithHttps_thenReturnsTheSameLink() {
+        val input = "https://google.com"
+        val expected = "https://google.com"
+        val actual = normalizeLink(input)
+        assert(expected == actual)
+    }
+
+    @Test
+    fun givenLink_whenTheLinkStartsWithHttp_thenReturnsTheSameLink() {
+        val input = "http://google.com"
+        val expected = "http://google.com"
+        val actual = normalizeLink(input)
+        assert(expected == actual)
+    }
+
+    @Test
+    fun givenLink_whenTheLinkStartsWithRandomSchema_thenReturnsTheSameLink() {
+        val randomString = Random.string(Random.nextInt(5))
+        val input = "$randomString://google.com"
+        val expected = "$randomString://google.com"
+        val actual = normalizeLink(input)
+        assert(expected == actual)
+    }
+
+    @Test
+    fun givenLink_whenTheLinkWithoutSchema_thenReturnsTheLinkWithHttps() {
+        val input = Random.string(Random.nextInt(20))
+        val expected = "https://$input"
+        val actual = normalizeLink(input)
+        assert(expected == actual)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Update the logic to check the embedded link in a message:
1- Show a visit link confirmation dialog when the user click on an embedded link
2- if the link starts with schema [anyString]://[anystring] we don't modify the link
     ELSE -> add https:// to the link/text

### Testing
Unit tests added
#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a message with any combination of links you can imagine:
1- the visit link dialog, always must be appear
2- if the link misses the schema the shown link in the above dialog must start with https
3- if the link starts with schema, the shown link in the dialog must be the same as you posted
4- the app must not crash in any cases


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
