### PR TITLE
fix: app crash when download asset

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -383,7 +383,7 @@ private fun ConversationScreen(
                         conversationScreenState.hideContextMenu()
                     }
                 },
-                onDownloadAssetClick = conversationMessagesViewModel::downloadAssetExternally,
+                onDownloadAssetClick = conversationMessagesViewModel::downloadOrFetchAssetAndShowDialog,
                 onOpenAssetClick = conversationMessagesViewModel::downloadAndOpenAsset
             )
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When downloading an asset from the context menu, we were not checking for saving to external permission when user was on Android 9 (API level 28) or lower.

### Causes (Optional)

We were not checking permissions.

### Solutions

Change `downloadAssetExternally` to `downloadOrFetchAssetAndShowDialog` so there is a Dialog handling everything:
- Checking for device API Level + Permissions
- Save
- Open
- Cancel

And showing a snackbar when successfully saved.

### Testing

#### How to Test

- Open App
- Open Conversation
- Receive an Image or Audio file
- do not grant file storage permission to app before-hand
- Long click on Image/Audio file
- Select `Download` from the context menu
- A new Dialog should popup asking if you want to Save/Open/Cancel, if `Save` then asking permission will be shown