### PR TITLE
fix: remove You/null from self deleting notification (WPB-3553)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -256,13 +256,16 @@ class MessageNotificationManager
     private fun NotificationMessage.intoStyledMessage(): NotificationCompat.MessagingStyle.Message {
         val sender = Person.Builder()
             .apply {
-                if (this@intoStyledMessage !is NotificationMessage.ObfuscatedMessage) {
+                if (this@intoStyledMessage is NotificationMessage.ObfuscatedMessage) {
+                    setName(context.getString(R.string.notification_obfuscated_message_title))
+                } else {
                     author?.name.also {
                         setName(it)
                     }
-                }
-                author?.image?.toBitmap()?.let {
-                    setIcon(IconCompat.createWithAdaptiveBitmap(it))
+
+                    author?.image?.toBitmap()?.let {
+                        setIcon(IconCompat.createWithAdaptiveBitmap(it))
+                    }
                 }
             }
             .build()
@@ -273,7 +276,9 @@ class MessageNotificationManager
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
             is NotificationMessage.Knock -> italicTextFromResId(R.string.notification_knock)
-            is NotificationMessage.ObfuscatedMessage -> italicTextFromResId(R.string.notification_obfuscated_message)
+            is NotificationMessage.ObfuscatedMessage -> italicTextFromResId(
+                R.string.notification_obfuscated_message_content
+            )
         }
         return NotificationCompat.MessagingStyle.Message(message, time, sender)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,7 +1108,8 @@
     <string name="label_log_options_description">"This stores anonymized troubleshooting information locally. "</string>
 
     <string name="label_no_application_found_open_downloads_folder">"No application found to open downloads folder"</string>
-    <string name="notification_obfuscated_message">Someone sent a Message</string>
+    <string name="notification_obfuscated_message_title">Someone</string>
+    <string name="notification_obfuscated_message_content">Sent a self-deleting message</string>
     <string name="settings_licenses_settings_label">License Information</string>
     <string name="settings_myaccount_logout">Delete Account</string>
     <string name="app_not_found_for_action">No Application has been found to do Action</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving a self deleting message (either group or 1:1), it would be showing `You` or `null` as the senders name instead of Someone

### Solutions

When message is self deleting, add `Person`/sender as `Someone` as per in the mocks.

### Testing

#### How to Test

- Receive self deleting message in group and 1:1
- Verify sender name is `Someone` and not `You` or `null`

### Attachments (Optional)

<img width="432" alt="Wire 2023-08-14 at 2_39 PM" src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/ccc94401-a42f-44ad-ad97-e737075be0c8">
