### PR TITLE
fix: release action by grepping last matched result on tags

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -31,7 +31,7 @@ jobs:
         
       - name: 'Set current Git tag from commit'
         if: "${{ github.event.inputs.current-release-tag == '' }}"
-        run: echo "CURRENT_TAG=$(git tag --points-at ${{github.sha}} | head | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)')" >> "$GITHUB_ENV"
+        run: echo "CURRENT_TAG=$(git tag --points-at ${{github.sha}} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | tail -n 1)" >> "$GITHUB_ENV"
 
       - name: 'Set previous Git tag from commit'
         run: echo "PREVIOUS_TAG=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | tail -n 2 | head -n 1)" >> "$GITHUB_ENV"


### PR DESCRIPTION
… the same hash

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if there are 2 tags from the same hash, then the GH action to generate the change log will fail

### Solutions

Get last match of the grepping tags on current commit HEAD result of `git tag --points-at ${{github.sha}}`  

<img width="746" alt="Bildschirmfoto 2023-08-16 um 21 45 21" src="https://github.com/wireapp/wire-android-reloaded/assets/5806454/b576af7a-9805-49da-8af8-65af5fe277ac">


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
