### PR TITLE
fix: missing username and avatar for first message after creating goup [WPB-3557]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.annotation.VisibleForTesting
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.kalium.util.DateTimeUtil
+
+object AuthorHeaderHelper {
+
+    @VisibleForTesting
+    internal const val AGGREGATION_TIME_WINDOW: Int = 30_000 // millis
+
+    internal fun shouldShowHeader(index: Int, messages: List<UIMessage>, currentMessage: UIMessage): Boolean {
+        var showHeader = currentMessage is UIMessage.Regular
+        val nextIndex = index + 1
+        if (nextIndex < messages.size) {
+            val nextUiMessage = messages[nextIndex]
+            if (currentMessage.header.userId == nextUiMessage.header.userId
+                && currentMessage is UIMessage.Regular
+                && nextUiMessage is UIMessage.Regular
+            ) {
+                val difference = DateTimeUtil.calculateMillisDifference(
+                    nextUiMessage.header.messageTime.utcISO,
+                    currentMessage.header.messageTime.utcISO,
+                )
+                showHeader = difference > AGGREGATION_TIME_WINDOW
+            }
+        }
+        return showHeader
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -94,7 +94,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ConferenceCallingResult
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -111,7 +111,6 @@ import kotlin.time.Duration.Companion.milliseconds
  * Once the user scrolls further into older messages, we stop autoscroll.
  */
 private const val MAXIMUM_SCROLLED_MESSAGES_UNTIL_AUTOSCROLL_STOPS = 5
-private const val AGGREGATION_TIME_WINDOW: Int = 30000
 
 // TODO: !! this screen definitely needs a refactor and some cleanup !!
 @Composable
@@ -648,7 +647,7 @@ fun MessageList(
                     MessageItem(
                         message = message,
                         conversationDetailsData = conversationDetailsData,
-                        showAuthor = shouldShowHeader(index, lazyPagingMessages.itemSnapshotList.items, message),
+                        showAuthor = AuthorHeaderHelper.shouldShowHeader(index, lazyPagingMessages.itemSnapshotList.items, message),
                         audioMessagesState = audioMessagesState,
                         onAudioClick = onAudioItemClicked,
                         onChangeAudioPosition = onChangeAudioPosition,
@@ -674,22 +673,6 @@ fun MessageList(
             }
         }
     }
-}
-
-private fun shouldShowHeader(index: Int, messages: List<UIMessage>, currentMessage: UIMessage): Boolean {
-    var showHeader = true
-    val nextIndex = index + 1
-    if (nextIndex < messages.size) {
-        val nextUiMessage = messages[nextIndex]
-        if (currentMessage.header.userId == nextUiMessage.header.userId) {
-            val difference = DateTimeUtil.calculateMillisDifference(
-                nextUiMessage.header.messageTime.utcISO,
-                currentMessage.header.messageTime.utcISO,
-            )
-            showHeader = difference > AGGREGATION_TIME_WINDOW
-        }
-    }
-    return showHeader
 }
 
 private fun CoroutineScope.withSmoothScreenLoad(block: () -> Unit) = launch {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import com.wire.android.framework.TestMessage
+import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.MessageBody
+import com.wire.android.ui.home.conversations.model.MessageSource
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.util.DateTimeUtil
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class AuthorHeaderHelperTest {
+
+    @Test
+    fun givenOneRegularMessage_thenShouldShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf(testRegularMessage())
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenOneSystemMessage_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf(testSystemMessage())
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenOnePingMessage_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf(testPingMessage())
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUser_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromDifferentUser_thenShouldShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = OTHER_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenSystemAndThenRegularMessageFromSameUser_thenShouldShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testSystemMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenRegularAndThenSystemMessagFromSameUsere_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testSystemMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenPingAndThenRegularMessageFromSameUser_thenShouldShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testPingMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenRegularAndThenPingMessageFromSameUser_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testPingMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUserAndTimestampsWithinThreshold_thenShouldNotShowHeaderForRecentMessage() {
+        // given
+        val timestamp = "2021-01-01T00:00:00.000Z"
+        val timestampMinusLessThanThreshold = DateTimeUtil.minusMilliseconds(timestamp, AuthorHeaderHelper.AGGREGATION_TIME_WINDOW - 1L)
+        val messages = listOf(
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestamp),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusLessThanThreshold)
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUserAndTimestampsBeyondThreshold_thenShouldShowHeaderForRecentMessage() {
+        // given
+        val timestamp = "2021-01-01T00:00:00.000Z"
+        val timestampMinusMoreThanThreshold = DateTimeUtil.minusMilliseconds(timestamp, AuthorHeaderHelper.AGGREGATION_TIME_WINDOW + 1L)
+        val messages = listOf(
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestamp),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusMoreThanThreshold)
+        )
+        // when
+        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        // then
+        assertEquals(true, result)
+    }
+
+    companion object {
+        private val SELF_USER_ID = UserId("self", "domain")
+        private val OTHER_USER_ID = UserId("other", "domain")
+
+        private fun testSystemMessage(
+            userId: UserId? = null,
+            timestamp: String = "2021-01-01T00:00:00.000Z"
+        ) = UIMessage.System(
+            header = TestMessage.UI_MESSAGE_HEADER.copy(
+                messageTime = TestMessage.UI_MESSAGE_HEADER.messageTime.copy(
+                    utcISO = timestamp
+                ),
+                messageId = UUID.randomUUID().toString(),
+                userId = userId
+            ),
+            source = MessageSource.OtherUser,
+            messageContent = UIMessageContent.SystemMessage.HistoryLost()
+        )
+
+        private fun testPingMessage(
+            userId: UserId? = null,
+            timestamp: String = "2021-01-01T00:00:00.000Z"
+        ) = UIMessage.System(
+            header = TestMessage.UI_MESSAGE_HEADER.copy(
+                messageTime = TestMessage.UI_MESSAGE_HEADER.messageTime.copy(
+                    utcISO = timestamp
+                ),
+                messageId = UUID.randomUUID().toString(),
+                userId = userId
+            ),
+            source = MessageSource.OtherUser,
+            messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("pinged")),
+        )
+
+        private fun testRegularMessage(
+            userId: UserId? = null,
+            timestamp: String = "2021-01-01T00:00:00.000Z"
+        ) = UIMessage.Regular(
+            userAvatarData = UserAvatarData(asset = null, availabilityStatus = UserAvailabilityStatus.NONE),
+            source = if (userId == SELF_USER_ID) MessageSource.Self else MessageSource.OtherUser,
+            header = TestMessage.UI_MESSAGE_HEADER.copy(
+                messageTime = TestMessage.UI_MESSAGE_HEADER.messageTime.copy(
+                    utcISO = timestamp
+                ),
+                messageId = UUID.randomUUID().toString(),
+                userId = userId
+            ),
+            messageContent = UIMessageContent.TextMessage(MessageBody(UIText.DynamicString("Some Text Message"))),
+            messageFooter = com.wire.android.ui.home.conversations.model.MessageFooter(TestMessage.UI_MESSAGE_HEADER.messageId)
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is no header with sender name and avatar after creating a group. It probably applies to all situations when user is the sender of a system message and then creates a regular message.

### Solutions

Check also types of messages when grouping messages.
Method is extracted to `AuthorHeaderHelper` for easier testing.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a group and then send a message.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
