### PR TITLE
fix(rc): call to action settings icons (WPB-3065)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -276,8 +276,8 @@ fun DebugDataOptionsContent(
             DevelopmentApiVersioningOptions(onForceLatestDevelopmentApiChange = onForceUpdateApiVersions)
         }
 
-        FolderHeader("Other Debug Options")
         if (state.isManualMigrationAllowed) {
+            FolderHeader("Other Debug Options")
             ManualMigrationOptions(onManualMigrationClicked = onStartManualMigration)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.debug
 import android.content.Context
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -53,6 +54,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getDeviceId
 import com.wire.android.util.getGitBuildId
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountResult
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
@@ -185,15 +187,36 @@ class DebugDataOptionsViewModel
 
 @Composable
 fun DebugDataOptions(
+    viewModel: DebugDataOptionsViewModel = hiltViewModel(),
     appVersion: String,
     buildVariant: String,
     onCopyText: (String) -> Unit
 ) {
+    DebugDataOptionsContent(
+        state = viewModel.state,
+        appVersion = appVersion,
+        buildVariant = buildVariant,
+        onCopyText = onCopyText,
+        onEnableEncryptedProteusStorageChange = viewModel::enableEncryptedProteusStorage,
+        onRestartSlowSyncForRecovery = viewModel::restartSlowSyncForRecovery,
+        onForceUpdateApiVersions = viewModel::forceUpdateApiVersions,
+        onStartManualMigration = viewModel::onStartManualMigration
+    )
+}
 
-    val viewModel: DebugDataOptionsViewModel = hiltViewModel()
-
+@Suppress("LongParameterList")
+@Composable
+fun DebugDataOptionsContent(
+    state: DebugDataOptionsState,
+    appVersion: String,
+    buildVariant: String,
+    onCopyText: (String) -> Unit,
+    onEnableEncryptedProteusStorageChange: (Boolean) -> Unit,
+    onRestartSlowSyncForRecovery: () -> Unit,
+    onForceUpdateApiVersions: () -> Unit,
+    onStartManualMigration: () -> Unit
+) {
     Column {
-
         FolderHeader(stringResource(R.string.label_debug_data))
 
         SettingsItem(
@@ -218,56 +241,51 @@ fun DebugDataOptions(
 
         SettingsItem(
             title = stringResource(R.string.label_code_commit_id),
-            text = viewModel.state.commitish,
+            text = state.commitish,
             trailingIcon = R.drawable.ic_copy,
             onIconPressed = Clickable(
                 enabled = true,
-                onClick = { onCopyText(viewModel.state.commitish) }
+                onClick = { onCopyText(state.commitish) }
             )
         )
 
         if (BuildConfig.PRIVATE_BUILD) {
-
             SettingsItem(
                 title = stringResource(R.string.debug_id),
-                text = viewModel.state.debugId,
+                text = state.debugId,
                 trailingIcon = R.drawable.ic_copy,
                 onIconPressed = Clickable(
                     enabled = true,
-                    onClick = { onCopyText(viewModel.state.debugId) }
+                    onClick = { onCopyText(state.debugId) }
                 )
             )
 
             ProteusOptions(
-                isEncryptedStorageEnabled = viewModel.state.isEncryptedProteusStorageEnabled,
-                onEncryptedStorageEnabledChange = viewModel::enableEncryptedProteusStorage
+                isEncryptedStorageEnabled = state.isEncryptedProteusStorageEnabled,
+                onEncryptedStorageEnabledChange = onEnableEncryptedProteusStorageChange
             )
 
             MLSOptions(
-                keyPackagesCount = viewModel.state.keyPackagesCount,
-                mlsClientId = viewModel.state.mslClientId,
-                mlsErrorMessage = viewModel.state.mlsErrorMessage,
-                restartSlowSyncForRecovery = viewModel::restartSlowSyncForRecovery,
+                keyPackagesCount = state.keyPackagesCount,
+                mlsClientId = state.mslClientId,
+                mlsErrorMessage = state.mlsErrorMessage,
+                restartSlowSyncForRecovery = onRestartSlowSyncForRecovery,
                 onCopyText = onCopyText
             )
 
-            DevelopmentApiVersioningOptions(onForceLatestDevelopmentApiChange = viewModel::forceUpdateApiVersions)
+            DevelopmentApiVersioningOptions(onForceLatestDevelopmentApiChange = onForceUpdateApiVersions)
         }
 
         FolderHeader("Other Debug Options")
-        if (viewModel.state.isManualMigrationAllowed) {
-            ManualMigrationOptions(
-                onManualMigrationClicked = viewModel::onStartManualMigration
-            )
+        if (state.isManualMigrationAllowed) {
+            ManualMigrationOptions(onManualMigrationClicked = onStartManualMigration)
         }
     }
 }
 
 //region Scala Migration Options
 @Composable
-private fun ManualMigrationOptions(
-    onManualMigrationClicked: () -> Unit,
-) {
+private fun ManualMigrationOptions(onManualMigrationClicked: () -> Unit) {
     RowItemTemplate(
         modifier = Modifier.wrapContentWidth(),
         title = {
@@ -386,7 +404,7 @@ private fun MLSOptions(
 @Composable
 private fun ProteusOptions(
     isEncryptedStorageEnabled: Boolean,
-    onEncryptedStorageEnabledChange: (Boolean) -> Unit,
+    onEncryptedStorageEnabledChange: (Boolean) -> Unit
 ) {
     FolderHeader(stringResource(R.string.label_proteus_option_title))
     EnableEncryptedProteusStorageSwitch(
@@ -398,7 +416,7 @@ private fun ProteusOptions(
 @Composable
 private fun EnableEncryptedProteusStorageSwitch(
     isEnabled: Boolean = false,
-    onCheckedChange: ((Boolean) -> Unit)?,
+    onCheckedChange: ((Boolean) -> Unit)?
 ) {
     RowItemTemplate(
         title = {
@@ -414,9 +432,32 @@ private fun EnableEncryptedProteusStorageSwitch(
                 checked = isEnabled,
                 onCheckedChange = onCheckedChange,
                 enabled = !isEnabled,
-                modifier = Modifier.padding(end = dimensions().spacing16x)
+                modifier = Modifier.padding(end = dimensions().spacing8x).size(dimensions().buttonSmallMinSize)
             )
         }
     )
 }
 //endregion
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewOtherDebugOptions() {
+    DebugDataOptionsContent(
+        appVersion = "1.0.0",
+        buildVariant = "debug",
+        onCopyText = {},
+        state = DebugDataOptionsState(
+            isEncryptedProteusStorageEnabled = true,
+            keyPackagesCount = 10,
+            mslClientId = "clientId",
+            mlsErrorMessage = "error",
+            isManualMigrationAllowed = true,
+            debugId = "debugId",
+            commitish = "commitish"
+        ),
+        onEnableEncryptedProteusStorageChange = {},
+        onForceUpdateApiVersions = {},
+        onRestartSlowSyncForRecovery = {},
+        onStartManualMigration = {}
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,6 +43,7 @@ import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun LogOptions(
@@ -98,7 +100,7 @@ private fun EnableLoggingSwitch(
                     Text(
                         style = MaterialTheme.wireTypography.body01,
                         color = MaterialTheme.wireColorScheme.onBackground,
-                        text = stringResource(R.string.label_enable_logging),
+                        text = stringResource(R.string.label_enable_logging)
                     )
                 }
                 Box(
@@ -107,7 +109,7 @@ private fun EnableLoggingSwitch(
                     WireSwitch(
                         checked = isEnabled,
                         onCheckedChange = onCheckedChange,
-                        modifier = Modifier.padding(end = dimensions().spacing16x)
+                        modifier = Modifier.size(dimensions().buttonSmallMinSize)
                     )
                 }
             }
@@ -118,4 +120,15 @@ private fun EnableLoggingSwitch(
             )
         }
     }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewLoggingOptions() {
+    LogOptions(
+        isLoggingEnabled = true,
+        onLoggingEnabledChange = {},
+        onDeleteLogs = {},
+        onShareLogs = {}
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -23,7 +23,6 @@ package com.wire.android.ui.home.settings
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -23,6 +23,7 @@ package com.wire.android.ui.home.settings
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
@@ -31,7 +32,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationItem
@@ -76,7 +76,8 @@ fun SettingsItem(
                     contentDescription = "",
                     tint = MaterialTheme.wireColorScheme.onSecondaryButtonEnabled,
                     modifier = Modifier
-                        .defaultMinSize(80.dp)
+                        .defaultMinSize(dimensions().wireIconButtonSize)
+                        .padding(end = dimensions().spacing8x)
                         .clickable(onIconPressed)
                 )
             } ?: Icons.Filled.ChevronRight
@@ -130,7 +131,7 @@ enum class SettingsItem(val id: String, val title: UIText, val navigationItem: N
         id = "other_debug_settings",
         title = UIText.StringResource(R.string.debug_settings_screen_title),
         navigationItem = NavigationItem.Debug
-    );
+    )
 }
 
 @PreviewMultipleThemes
@@ -140,7 +141,7 @@ fun previewFileRestrictionDialog() {
         SettingsItem(
             title = "Some Setting",
             text = "This is the value of the setting",
-            trailingIcon = R.drawable.ic_copy
+            trailingIcon = R.drawable.ic_arrow_right
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -122,7 +122,9 @@ private fun LazyListScope.folderWithElements(
     ) { settingsItem ->
         SettingsItem(
             text = settingsItem.title.asString(),
-            onRowPressed = remember { Clickable(enabled = true) { onItemClicked(settingsItem) } }
+            onRowPressed = remember { Clickable(enabled = true) { onItemClicked(settingsItem) } },
+            onIconPressed = remember { Clickable(enabled = true) { onItemClicked(settingsItem) } },
+            trailingIcon = R.drawable.ic_arrow_right,
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -884,7 +884,7 @@
     <string name="label_debug_title">Debug Settings</string>
     <string name="label_client_option_title">Client ID</string>
     <string name="label_device_id">Device ID: %1$s</string>
-    <string name="label_code_commit_id">Commit Hash: %1$s</string>
+    <string name="label_code_commit_id">Commit Hash</string>
     <string name="label_client_id">Client ID: %1$s</string>
     <string name="label_client_added_time">ADDED</string>
     <string name="label_client_last_active_label">LAST ACTIVE</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add icons to settings screen, and small improvements to debug settings, for later work of https://wearezeta.atlassian.net/browse/WPB-351

Needs releases with:

- [ ] GitHub link to other pull request


### Attachments (Optional)

<img src="https://github.com/wireapp/wire-android-reloaded/assets/5806454/70b992db-bee7-4ece-a2d9-bf3b134cc2e2" width="300"/>

<img src="https://github.com/wireapp/wire-android-reloaded/assets/5806454/a9d7fda5-90a1-4632-8b6d-7d51eb79afe3" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
