### PR TITLE
fix: alignment of reactions [AR-3874]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
@@ -1,5 +1,6 @@
 package com.wire.android.ui.edit
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -29,8 +30,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wire.android.R
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,6 +53,7 @@ fun ReactionOption(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 listOf("❤️", "👍", "😁", "🙂", "☹️", "👎").forEach { emoji ->
                     CompositionLocalProvider(
@@ -86,4 +90,10 @@ fun ReactionOption(
             }
         }
     }
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun BasePreview() = WireTheme(isPreview = true) {
+    ReactionOption(onReactionClick = {})
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Reactions options are a bit missaligned and skewed to the start of the screen

### Solutions

Use `Arrangement.SpaceEvenly` to make sure it's all... evenly-spaced.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
| Before | After |
| ----------- | ------------ |
| <img width="422" alt="image" src="https://github.com/wireapp/wire-android-reloaded/assets/9389043/e83cdfcf-802b-412b-9dca-86e45a073d70"> | <img width="416" alt="image" src="https://github.com/wireapp/wire-android-reloaded/assets/9389043/0c6ed7c2-5974-4a63-8a35-f5c2776b34d5"> |

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
