### PR TITLE
chore: config crowdin action

### DIFF
--- a/.github/workflows/localization-crowdin-updater.yml
+++ b/.github/workflows/localization-crowdin-updater.yml
@@ -1,0 +1,52 @@
+name: "Crowdin Action"
+
+# **What it does**: Upload strings to crowdin project for translations and creates a PR when new updates.
+# **Why we have it**: We want to externalize and automate the translations process.
+# **Who does it impact**: Everyone collaborating on the project.
+# For more info: https://github.com/crowdin/github-action/blob/master/action.yml
+
+on:
+    push:
+        branches: [ develop ]
+
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    synchronize-with-crowdin:
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v3
+
+            -   name: Crowdin action
+                uses: crowdin/github-action@1.12.0
+                with:
+                    project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+                    token: ${{ secrets.CROWDIN_API_TOKEN }}
+
+                    upload_sources: true
+                    download_translations: true
+                    upload_translations: false
+
+                    create_pull_request: true
+                    localization_branch_name: chore/sync-and-update-localization
+                    commit_message: "chore: update localization strings via Crowdin"
+                    pull_request_title: "chore: update localization strings via Crowdin"
+                    pull_request_body: "This PR pulls in the latest localization translations from Crowdin."
+                    github_user_name: "zebot"
+                    github_user_email: "zebot@users.noreply.github.com"
+
+                    pull_request_labels: "l10n, crowdin"
+                    pull_request_assignees: "crowdin-bot"
+                    pull_request_team_reviewers: "android"
+
+                    source: "/app/src/main/res/values/strings.xml"
+                    translation: "/app/src/main/res/values-%two_letters_code%/%original_file_name%"
+
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/localization-crowdin-updater.yml
+++ b/.github/workflows/localization-crowdin-updater.yml
@@ -57,8 +57,8 @@ jobs:
                     commit_message: "chore: update localization strings via Crowdin"
                     pull_request_title: "chore: update localization strings via Crowdin"
                     pull_request_body: "This PR pulls in the latest localization translations from Crowdin."
-                    github_user_name: "zebot"
-                    github_user_email: "zebot@users.noreply.github.com"
+                    github_user_name: "AndroidBob"
+                    github_user_email: "AndroidBob@users.noreply.github.com"
 
                     pull_request_labels: "l10n, crowdin"
                     pull_request_assignees: "crowdin-bot"

--- a/.github/workflows/localization-crowdin-updater.yml
+++ b/.github/workflows/localization-crowdin-updater.yml
@@ -40,7 +40,7 @@ jobs:
 
             -   name: "Set base branch to default branch"
                 if: "${{ github.event.inputs.baseBranch == '' }}"
-                run: echo "BASE_BRANCH=$develop" >> "$GITHUB_ENV"
+                run: echo "BASE_BRANCH=develop" >> "$GITHUB_ENV"
 
             -   name: Crowdin action
                 uses: crowdin/github-action@v1

--- a/.github/workflows/localization-crowdin-updater.yml
+++ b/.github/workflows/localization-crowdin-updater.yml
@@ -61,7 +61,7 @@ jobs:
                     github_user_email: "AndroidBob@users.noreply.github.com"
 
                     pull_request_labels: "l10n, crowdin"
-                    pull_request_assignees: "crowdin-bot"
+                    pull_request_assignees: "AndroidBob"
                     pull_request_team_reviewers: "android"
                     pull_request_base_branch_name: ${{env.BASE_BRANCH}}
 

--- a/.github/workflows/localization-crowdin-updater.yml
+++ b/.github/workflows/localization-crowdin-updater.yml
@@ -1,6 +1,6 @@
 name: "Crowdin Action"
 
-# **What it does**: Upload strings to crowdin project for translations and creates a PR when new updates.
+# **What it does**: Upload strings to crowdin project for translations and creates a PR with updates.
 # **Why we have it**: We want to externalize and automate the translations process.
 # **Who does it impact**: Everyone collaborating on the project.
 # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
@@ -10,6 +10,15 @@ on:
         branches: [ develop ]
 
     workflow_dispatch:
+        inputs:
+            baseBranch:
+                description: "Base branch to create the PR and update the localization strings"
+                required: true
+                default: "develop"
+                type: choice
+                options:
+                    - "develop"
+                    - "release/candidate"
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,8 +32,18 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v3
 
+            -   name: "Set base branch from input"
+                env:
+                    INPUT_BASE_BRANCH: ${{github.event.inputs.baseBranch}}
+                if: "${{ github.event.inputs.baseBranch != '' }}"
+                run: echo "BASE_BRANCH=$INPUT_BASE_BRANCH" >> "$GITHUB_ENV"
+
+            -   name: "Set base branch to default branch"
+                if: "${{ github.event.inputs.baseBranch == '' }}"
+                run: echo "BASE_BRANCH=$develop" >> "$GITHUB_ENV"
+
             -   name: Crowdin action
-                uses: crowdin/github-action@1.12.0
+                uses: crowdin/github-action@v1
                 with:
                     project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
                     token: ${{ secrets.CROWDIN_API_TOKEN }}
@@ -44,9 +63,9 @@ jobs:
                     pull_request_labels: "l10n, crowdin"
                     pull_request_assignees: "crowdin-bot"
                     pull_request_team_reviewers: "android"
+                    pull_request_base_branch_name: ${{env.BASE_BRANCH}}
 
-                    source: "/app/src/main/res/values/strings.xml"
-                    translation: "/app/src/main/res/values-%two_letters_code%/%original_file_name%"
+                    config: "crowdin.yml"
 
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Wire™
 [![codecov](https://codecov.io/gh/wireapp/wire-android-reloaded/branch/develop/graph/badge.svg?token=9ELBEPM793)](https://codecov.io/gh/wireapp/wire-android-reloaded)
+[![Crowdin](https://badges.crowdin.net/wire-android-reloaded/localized.svg)](https://crowdin.com/project/wire-android-reloaded)
 
 [![Wire logo](https://github.com/wireapp/wire/blob/master/assets/header-small.png?raw=true)](https://wire.com/jobs/)
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,12 @@
-pull_request_title: 'chore: update translation strings via Crowdin'
-pull_request_labels:
-  - crowdin
-  - l10n
-files:
-  - source: /app/src/main/res/values/strings.xml
-    translation: /app/src/main/res/values-%two_letters_code%/%original_file_name%
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_API_TOKEN"
+"base_path": "."
+"base_url": "https://api.crowdin.com"
+"preserve_hierarchy": true
+
+files: [
+    {
+        "source": "/app/src/main/res/values/strings.xml",
+        "translation": "/app/src/main/res/values-%two_letters_code%/%original_file_name%",
+    }
+]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we depend on a number of users with priveleges, that can trigger sync from crowdin to the repo.

### Causes (Optional)

With this action, we can now trigger PR localization update.
- Executing a manual workflow execution as an alternative, to target either develop as default or release candidate
- Pushing to develop triggers automatically the sync (feature maintained)
- Assign the android team as a reviewer

### Testing

You can see at the execution from the fork I tested.
https://github.com/yamilmedina/wire-android-reloaded/pulls

![Screenshot 2023-08-28 at 18 31 41](https://github.com/wireapp/wire-android-reloaded/assets/5806454/4f0a04b1-3784-4eae-aa4d-2c8711b73844)


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
