### PR TITLE
fix: Always allow avatar changeing [WPB-2247]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -94,12 +94,10 @@ fun UserProfileInfo(
                     connectionState = connection,
                     membership = membership
                 ),
-                clickable = remember(editableState) {
-                    Clickable(
-                        enabled = editableState is EditableState.IsEditable,
-                        clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-                    ) { onUserProfileClick?.invoke() }
-                }
+                clickable = Clickable(
+                    enabled = true,
+                    clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+                ) { onUserProfileClick?.invoke() }
             )
             if (isLoading) {
                 Box(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
# What's new in this PR?

### Issues

Can't change my profile picture when I am an SSO User with SCIM
User with SCIM shouldn't be able to edit the profile, but the avatar should be always editable.

### Causes (Optional)

Avatar editing was blocked for the user with SCIM.

### Solutions

Mayke avatar editable no meter if user with SCIM or not.
