### PR TITLE
fix: missed activity icon size (WPB-3896)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
@@ -66,12 +66,15 @@ fun EventBadgeFactory(eventType: BadgeEventType, modifier: Modifier = Modifier) 
 @Composable
 private fun MissedCallBadge(modifier: Modifier = Modifier) {
     NotificationBadgeContainer(
-        modifier = modifier.width(24.dp).height(18.dp),
+        modifier = modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x),
         notificationIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_event_badge_missed_call),
                 contentDescription = null,
                 colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
+                modifier = Modifier.height(dimensions().spacing18x)
             )
         }
     )
@@ -80,12 +83,15 @@ private fun MissedCallBadge(modifier: Modifier = Modifier) {
 @Composable
 private fun UnreadMentionBadge(modifier: Modifier = Modifier) {
     NotificationBadgeContainer(
-        modifier = modifier.width(24.dp).height(18.dp),
+        modifier = modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x),
         notificationIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_event_badge_unread_mention),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge)
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
+                modifier = Modifier.height(dimensions().spacing18x)
             )
         }
     )
@@ -94,12 +100,15 @@ private fun UnreadMentionBadge(modifier: Modifier = Modifier) {
 @Composable
 private fun UnreadReplyBadge(modifier: Modifier = Modifier) {
     NotificationBadgeContainer(
-        modifier = modifier.width(24.dp).height(18.dp),
+        modifier = modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x),
         notificationIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_event_badge_unread_reply),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge)
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
+                modifier = Modifier.height(dimensions().spacing18x)
             )
         }
     )
@@ -108,12 +117,15 @@ private fun UnreadReplyBadge(modifier: Modifier = Modifier) {
 @Composable
 fun UnreadKnockBadge(modifier: Modifier = Modifier) {
     NotificationBadgeContainer(
-        modifier = modifier.width(24.dp).height(18.dp),
+        modifier = modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x),
         notificationIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_event_badge_unread_knock),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge)
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
+                modifier = Modifier.height(dimensions().spacing18x)
             )
         }
     )
@@ -122,12 +134,15 @@ fun UnreadKnockBadge(modifier: Modifier = Modifier) {
 @Composable
 fun ConnectRequestBadge(modifier: Modifier = Modifier) {
     NotificationBadgeContainer(
-        modifier = modifier.width(24.dp).height(18.dp),
+        modifier = modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x),
         notificationIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_event_badge_connect_request),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge)
+                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
+                modifier = Modifier.height(dimensions().spacing18x)
             )
         }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.BlockedLabel
 import com.wire.android.ui.common.DeletedLabel

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.colorsScheme
@@ -57,7 +56,7 @@ fun MutedConversationBadge(onClick: () -> Unit) {
             minHeight = dimensions().badgeSmallMinSize.height,
             minWidth = dimensions().badgeSmallMinSize.width,
             shape = RoundedCornerShape(size = dimensions().spacing6x),
-            contentPadding = PaddingValues(0.dp),
+            contentPadding = PaddingValues(dimensions().spacing0x),
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -42,14 +42,14 @@ import com.wire.android.ui.common.dimensions
 fun MutedConversationBadge(onClick: () -> Unit) {
     Box(modifier = Modifier
         .width(dimensions().spacing24x)
-        .height(dimensions().spacing18x)) {
+        .height(dimensions().spacing20x)) {
         WireSecondaryButton(
             onClick = onClick,
             leadingIcon = {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_mute),
                     contentDescription = stringResource(R.string.content_description_muted_conversation),
-                    modifier = Modifier.size(dimensions().spacing12x),
+                    modifier = Modifier.size(dimensions().spacing18x),
                     tint = colorsScheme().onSecondaryButtonEnabled
                 )
             },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -49,7 +49,7 @@ fun MutedConversationBadge(onClick: () -> Unit) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_mute),
                     contentDescription = stringResource(R.string.content_description_muted_conversation),
-                    modifier = Modifier.size(dimensions().spacing18x),
+                    modifier = Modifier.size(dimensions().spacing12x),
                     tint = colorsScheme().onSecondaryButtonEnabled
                 )
             },


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation icons were misaligned on height dimension

### Solutions

Adjust height of icons to match with Unread Messages icon+text

#### How to Test

- Open App
- Receive (Reply, Mention, Ping, Normal messages) and verify each shown icon

### Attachments (Optional)
| Before | After |
| ----------- | ------------ |
| <img width="357" alt="Screenshot 2023-08-28 at 16 54 49" src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/04161fcc-8e3c-4f6a-a41c-9a396b7b258a"> | <img width="392" alt="Screenshot 2023-08-28 at 17 00 02" src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/6926cd4c-55ca-4003-8859-4519714e7725"> |