### PR TITLE
chore(reactions): remove "More coming soon" label [WPB-4328]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
@@ -46,7 +46,7 @@ fun ReactionOption(
             Row {
                 Spacer(modifier = Modifier.width(dimensions().spacing8x))
                 Text(
-                    ("${stringResource(R.string.label_reactions)} ${stringResource(id = R.string.label_more_comming_soon)}").uppercase(),
+                    stringResource(R.string.label_reactions).uppercase(),
                     style = MaterialTheme.wireTypography.label01
                 )
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Now that 4.4.0 supports multiple reactions, we don't need the "More coming soon" label.

### Solutions

Remove it

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
