### PR TITLE
fix: Move FeatureChanged dialogs to Activity (WPB-3481)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -27,7 +27,6 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.SnackbarHostState
@@ -42,14 +41,12 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.stringResource
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import com.ramcosta.composedestinations.spec.Route
 import com.wire.android.BuildConfig
-import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.config.CustomUiConfigurationProvider
 import com.wire.android.config.LocalCustomUiConfigurationProvider
@@ -60,13 +57,8 @@ import com.wire.android.navigation.NavigationGraph
 import com.wire.android.navigation.navigateToItem
 import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.calling.ProximitySensorManager
-import com.wire.android.ui.common.WireDialog
-import com.wire.android.ui.common.WireDialogButtonProperties
-import com.wire.android.ui.common.WireDialogButtonType
-import com.wire.android.ui.common.dialogs.CustomServerDialog
 import com.wire.android.ui.common.topappbar.CommonTopAppBar
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
-import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.ImportMediaScreenDestination
@@ -78,22 +70,18 @@ import com.wire.android.ui.destinations.OtherUserProfileScreenDestination
 import com.wire.android.ui.destinations.SelfDevicesScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.WelcomeScreenDestination
-import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
-import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
-import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
+import com.wire.android.ui.home.E2EIRequiredDialog
+import com.wire.android.ui.home.E2EISnoozeDialog
+import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.ui.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.ui.userprofile.self.MaxAccountReachedDialog
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.LocalSyncStateObserver
 import com.wire.android.util.SyncStateObserver
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.DeepLinkResult
-import com.wire.android.util.formatMediumDateTime
 import com.wire.android.util.ui.updateScreenSettings
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -115,6 +103,8 @@ class WireActivity : AppCompatActivity() {
     lateinit var proximitySensorManager: ProximitySensorManager
 
     private val viewModel: WireActivityViewModel by viewModels()
+
+    private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels()
 
     private val commonTopAppBarViewModel: CommonTopAppBarViewModel by viewModels()
 
@@ -229,19 +219,67 @@ class WireActivity : AppCompatActivity() {
 
     @Composable
     private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
-        updateAppDialog({ updateTheApp() }, viewModel.globalAppState.updateAppDialog)
-        joinConversationDialog(viewModel.globalAppState.conversationJoinedDialog, navigate)
-        customBackendDialog(navigate)
-        maxAccountDialog(
+        featureFlagNotificationViewModel.loadInitialSync()
+        with(featureFlagNotificationViewModel.featureFlagState) {
+            if (showFileSharingDialog) {
+                FileRestrictionDialog(
+                    isFileSharingEnabled = isFileSharingEnabledState,
+                    hideDialogStatus = featureFlagNotificationViewModel::dismissFileSharingDialog
+                )
+            }
+
+            if (shouldShowGuestRoomLinkDialog) {
+                GuestRoomLinkFeatureFlagDialog(
+                    isGuestRoomLinkEnabled = isGuestRoomLinkEnabled,
+                    onDismiss = featureFlagNotificationViewModel::dismissGuestRoomLinkDialog
+                )
+            }
+
+            if (shouldShowSelfDeletingMessagesDialog) {
+                SelfDeletingMessagesDialog(
+                    areSelfDeletingMessagesEnabled = areSelfDeletedMessagesEnabled,
+                    enforcedTimeout = enforcedTimeoutDuration,
+                    hideDialogStatus = featureFlagNotificationViewModel::dismissSelfDeletingMessagesDialog
+                )
+            }
+
+            e2EIRequired?.let {
+                E2EIRequiredDialog(
+                    result = e2EIRequired,
+                    getCertificate = featureFlagNotificationViewModel::getE2EICertificate,
+                    snoozeDialog = featureFlagNotificationViewModel::snoozeE2EIdRequiredDialog
+                )
+            }
+
+            e2EISnoozeInfo?.let {
+                E2EISnoozeDialog(
+                    timeLeft = e2EISnoozeInfo.timeLeft,
+                    dismissDialog = featureFlagNotificationViewModel::dismissSnoozeE2EIdRequiredDialog
+                )
+            }
+        }
+        UpdateAppDialog(viewModel.globalAppState.updateAppDialog, ::updateTheApp)
+        JoinConversationDialog(
+            viewModel.globalAppState.conversationJoinedDialog,
+            navigate,
+            viewModel::onJoinConversationFlowCompleted
+        )
+        CustomBackendDialog(
+            viewModel.globalAppState,
+            viewModel::dismissCustomBackendDialog
+        ) { viewModel.customBackendDialogProceedButtonClicked { navigate(NavigationCommand(WelcomeScreenDestination)) } }
+        MaxAccountDialog(
+            shouldShow = viewModel.globalAppState.maxAccountDialog,
             onConfirm = {
                 viewModel.dismissMaxAccountDialog()
                 navigate(NavigationCommand(SelfUserProfileScreenDestination))
             },
-            onDismiss = viewModel::dismissMaxAccountDialog,
-            shouldShow = viewModel.globalAppState.maxAccountDialog
+            onDismiss = viewModel::dismissMaxAccountDialog
         )
-        accountLoggedOutDialog(viewModel.globalAppState.blockUserUI, navigate)
-        newClientDialog(
+        AccountLoggedOutDialog(
+            viewModel.globalAppState.blockUserUI
+        ) { viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate)) }
+        NewClientDialog(
             viewModel.globalAppState.newClientDialog,
             { navigate(NavigationCommand(SelfDevicesScreenDestination)) },
             {
@@ -252,193 +290,6 @@ class WireActivity : AppCompatActivity() {
             },
             viewModel::dismissNewClientsDialog
         )
-    }
-
-    @Composable
-    private fun updateAppDialog(onUpdateClick: () -> Unit, shouldShow: Boolean) {
-        if (shouldShow) {
-            WireDialog(
-                title = stringResource(id = R.string.update_app_dialog_title),
-                text = stringResource(id = R.string.update_app_dialog_body),
-                onDismiss = { },
-                optionButton1Properties = WireDialogButtonProperties(
-                    text = stringResource(id = R.string.update_app_dialog_button),
-                    onClick = onUpdateClick,
-                    type = WireDialogButtonType.Primary
-                ),
-                properties = wireDialogPropertiesBuilder(
-                    dismissOnBackPress = false,
-                    dismissOnClickOutside = false,
-                    usePlatformDefaultWidth = true
-                )
-            )
-        }
-    }
-
-    @Composable
-    private fun joinConversationDialog(joinedDialogState: JoinConversationViaCodeState?, navigate: (NavigationCommand) -> Unit) {
-        joinedDialogState?.let {
-
-            val onComplete: (convId: ConversationId?) -> Unit = remember {
-                {
-                    it?.also {
-                        appLogger.d("Join conversation via code dialog completed, navigating to conversation screen")
-                        navigate(NavigationCommand(ConversationScreenDestination(it), BackStackMode.CLEAR_TILL_START))
-                        viewModel.onJoinConversationFlowCompleted()
-                    }
-                }
-            }
-
-            when (it) {
-                is JoinConversationViaCodeState.Error -> JoinConversationViaInviteLinkError(
-                    errorState = it,
-                    onCancel = { onComplete(null) }
-                )
-
-                is JoinConversationViaCodeState.Show -> {
-                    JoinConversationViaDeepLinkDialog(
-                        name = it.conversationName,
-                        code = it.code,
-                        domain = it.domain,
-                        key = it.key,
-                        requirePassword = it.passwordProtected,
-                        onFlowCompleted = onComplete
-                    )
-                }
-            }
-        }
-    }
-
-    @Composable
-    private fun customBackendDialog(navigate: (NavigationCommand) -> Unit) {
-        with(viewModel) {
-            if (globalAppState.customBackendDialog != null) {
-                CustomServerDialog(
-                    serverLinksTitle = globalAppState.customBackendDialog!!.serverLinks.title,
-                    serverLinksApi = globalAppState.customBackendDialog!!.serverLinks.api,
-                    onDismiss = this::dismissCustomBackendDialog,
-                    onConfirm = { customBackendDialogProceedButtonClicked { navigate(NavigationCommand(WelcomeScreenDestination)) } }
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun maxAccountDialog(onConfirm: () -> Unit, onDismiss: () -> Unit, shouldShow: Boolean) {
-        if (shouldShow) {
-            MaxAccountReachedDialog(
-                onConfirm = onConfirm,
-                onDismiss = onDismiss,
-                buttonText = R.string.max_account_reached_dialog_button_open_profile
-            )
-        }
-    }
-
-    @Composable
-    private fun accountLoggedOutDialog(blockUserUI: CurrentSessionErrorState?, navigate: (NavigationCommand) -> Unit) {
-        blockUserUI?.let {
-            accountLoggedOutDialog(reason = it) { viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate)) }
-        }
-    }
-
-    @Composable
-    fun accountLoggedOutDialog(reason: CurrentSessionErrorState, navigateAway: () -> Unit) {
-        appLogger.e("AccountLongedOutDialog: $reason")
-        val (@StringRes title: Int, text: String) = when (reason) {
-            CurrentSessionErrorState.SessionExpired -> {
-                if (BuildConfig.WIPE_ON_COOKIE_INVALID) {
-                    R.string.session_expired_error_title to (
-                            stringResource(id = R.string.session_expired_error_message)
-                                    + "\n\n"
-                                    + stringResource(id = R.string.conversation_history_wipe_explanation)
-                            )
-                } else {
-                    R.string.session_expired_error_title to stringResource(id = R.string.session_expired_error_message)
-                }
-            }
-
-            CurrentSessionErrorState.RemovedClient -> {
-                if (BuildConfig.WIPE_ON_DEVICE_REMOVAL) {
-                    R.string.removed_client_error_title to (
-                            stringResource(id = R.string.removed_client_error_message)
-                                    + "\n\n"
-                                    + stringResource(id = R.string.conversation_history_wipe_explanation)
-                            )
-                } else {
-                    R.string.removed_client_error_title to stringResource(R.string.removed_client_error_message)
-                }
-            }
-
-            CurrentSessionErrorState.DeletedAccount -> {
-                R.string.deleted_user_error_title to stringResource(R.string.deleted_user_error_message)
-            }
-        }
-        WireDialog(
-            title = stringResource(id = title),
-            text = text,
-            onDismiss = remember { { } },
-            optionButton1Properties = WireDialogButtonProperties(
-                text = stringResource(R.string.label_ok),
-                onClick = navigateAway,
-                type = WireDialogButtonType.Primary
-            )
-        )
-    }
-
-    @Composable
-    private fun newClientDialog(
-        data: NewClientsData?,
-        openDeviceManager: () -> Unit,
-        switchAccountAndOpenDeviceManager: (UserId) -> Unit,
-        dismiss: (UserId) -> Unit
-    ) {
-        data?.let {
-            val title: String
-            val text: String
-            val btnText: String
-            val btnAction: () -> Unit
-            val dismissAction: () -> Unit = { dismiss(data.userId) }
-            val devicesList = data.clientsInfo.map {
-                stringResource(
-                    R.string.new_device_dialog_message_defice_info,
-                    it.date.formatMediumDateTime() ?: "",
-                    it.deviceInfo.asString()
-                )
-            }.joinToString("")
-            when (data) {
-                is NewClientsData.OtherUser -> {
-                    title = stringResource(R.string.new_device_dialog_other_user_title, data.userName ?: "", data.userHandle ?: "")
-                    text = stringResource(R.string.new_device_dialog_other_user_message, devicesList)
-                    btnText = stringResource(R.string.new_device_dialog_other_user_btn)
-                    btnAction = { switchAccountAndOpenDeviceManager(data.userId) }
-                }
-
-                is NewClientsData.CurrentUser -> {
-                    title = stringResource(R.string.new_device_dialog_current_user_title)
-                    text = stringResource(R.string.new_device_dialog_current_user_message, devicesList)
-                    btnText = stringResource(R.string.new_device_dialog_current_user_btn)
-                    btnAction = openDeviceManager
-                }
-            }
-            WireDialog(
-                title = title,
-                text = text,
-                onDismiss = dismissAction,
-                optionButton1Properties = WireDialogButtonProperties(
-                    onClick = {
-                        dismissAction()
-                        btnAction()
-                    },
-                    text = btnText,
-                    type = WireDialogButtonType.Secondary
-                ),
-                optionButton2Properties = WireDialogButtonProperties(
-                    text = stringResource(id = R.string.label_ok),
-                    onClick = dismissAction,
-                    type = WireDialogButtonType.Primary
-                )
-            )
-        }
     }
 
     private fun updateTheApp() {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -1,0 +1,399 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+@file:Suppress("TooManyFunctions")
+
+package com.wire.android.ui
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import com.wire.android.BuildConfig
+import com.wire.android.R
+import com.wire.android.appLogger
+import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.dialogs.CustomServerDialog
+import com.wire.android.ui.common.dialogs.CustomServerDialogState
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
+import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
+import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
+import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
+import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.userprofile.self.MaxAccountReachedDialog
+import com.wire.android.util.formatMediumDateTime
+import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
+
+@Composable
+fun FileRestrictionDialog(
+    isFileSharingEnabled: Boolean,
+    hideDialogStatus: () -> Unit,
+) {
+    val text: String = stringResource(id = if (isFileSharingEnabled) R.string.sharing_files_enabled else R.string.sharing_files_disabled)
+
+    WireDialog(
+        title = stringResource(id = R.string.team_settings_changed),
+        text = text,
+        onDismiss = hideDialogStatus,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = hideDialogStatus,
+            text = stringResource(id = R.string.label_ok),
+            type = WireDialogButtonType.Primary,
+        )
+    )
+}
+
+@Composable
+fun SelfDeletingMessagesDialog(
+    areSelfDeletingMessagesEnabled: Boolean,
+    enforcedTimeout: SelfDeletionDuration,
+    hideDialogStatus: () -> Unit,
+) {
+    val formattedTimeout = enforcedTimeout.longLabel.asString()
+    val text: String = when {
+        areSelfDeletingMessagesEnabled && enforcedTimeout == SelfDeletionDuration.None -> {
+            stringResource(id = R.string.self_deleting_messages_team_setting_enabled)
+        }
+
+        areSelfDeletingMessagesEnabled -> {
+            stringResource(R.string.self_deleting_messages_team_setting_enabled_enforced_timeout, formattedTimeout)
+        }
+
+        else -> {
+            stringResource(id = R.string.self_deleting_messages_team_setting_disabled)
+        }
+    }
+
+    WireDialog(
+        title = stringResource(id = R.string.team_settings_changed),
+        text = text,
+        onDismiss = hideDialogStatus,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = hideDialogStatus,
+            text = stringResource(id = R.string.label_ok),
+            type = WireDialogButtonType.Primary,
+        )
+    )
+}
+
+@Composable
+fun GuestRoomLinkFeatureFlagDialog(
+    isGuestRoomLinkEnabled: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val text: String =
+        stringResource(id = if (isGuestRoomLinkEnabled) R.string.guest_room_link_enabled else R.string.guest_room_link_disabled)
+
+    WireDialog(
+        title = stringResource(id = R.string.team_settings_changed),
+        text = text,
+        onDismiss = onDismiss,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = onDismiss,
+            text = stringResource(id = R.string.label_ok),
+            type = WireDialogButtonType.Primary,
+        )
+    )
+}
+
+@Composable
+fun UpdateAppDialog(shouldShow: Boolean, onUpdateClick: () -> Unit) {
+    if (shouldShow) {
+        WireDialog(
+            title = stringResource(id = R.string.update_app_dialog_title),
+            text = stringResource(id = R.string.update_app_dialog_body),
+            onDismiss = { },
+            optionButton1Properties = WireDialogButtonProperties(
+                text = stringResource(id = R.string.update_app_dialog_button),
+                onClick = onUpdateClick,
+                type = WireDialogButtonType.Primary
+            ),
+            properties = wireDialogPropertiesBuilder(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = true
+            )
+        )
+    }
+}
+
+@Composable
+fun JoinConversationDialog(
+    joinedDialogState: JoinConversationViaCodeState?,
+    navigate: (NavigationCommand) -> Unit,
+    onJoinConversationFlowCompleted: () -> Unit
+) {
+    joinedDialogState?.let { state ->
+
+        val onComplete: (convId: ConversationId?) -> Unit = remember {
+            { convIdNullable ->
+                convIdNullable?.also {
+                    appLogger.d("Join conversation via code dialog completed, navigating to conversation screen")
+                    navigate(
+                        NavigationCommand(
+                            com.wire.android.ui.destinations.ConversationScreenDestination(it),
+                            BackStackMode.CLEAR_TILL_START
+                        )
+                    )
+                    onJoinConversationFlowCompleted()
+                }
+            }
+        }
+
+        when (state) {
+            is JoinConversationViaCodeState.Error -> JoinConversationViaInviteLinkError(
+                errorState = state,
+                onCancel = { onComplete(null) }
+            )
+
+            is JoinConversationViaCodeState.Show -> {
+                JoinConversationViaDeepLinkDialog(
+                    name = state.conversationName,
+                    code = state.code,
+                    domain = state.domain,
+                    key = state.key,
+                    requirePassword = state.passwordProtected,
+                    onFlowCompleted = onComplete
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CustomBackendDialog(
+    globalAppState: GlobalAppState,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    if (globalAppState.customBackendDialog != null) {
+        CustomServerDialog(
+            serverLinksTitle = globalAppState.customBackendDialog.serverLinks.title,
+            serverLinksApi = globalAppState.customBackendDialog.serverLinks.api,
+            onDismiss = onDismiss,
+            onConfirm = onConfirm
+        )
+    }
+}
+
+@Composable
+fun MaxAccountDialog(shouldShow: Boolean, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    if (shouldShow) {
+        MaxAccountReachedDialog(
+            onConfirm = onConfirm,
+            onDismiss = onDismiss,
+            buttonText = R.string.max_account_reached_dialog_button_open_profile
+        )
+    }
+}
+
+@Composable
+fun AccountLoggedOutDialog(blockUserUI: CurrentSessionErrorState?, navigateAway: () -> Unit) {
+    blockUserUI?.let {
+        accountLoggedOutDialog(reason = it, navigateAway)
+    }
+}
+
+@Composable
+private fun accountLoggedOutDialog(reason: CurrentSessionErrorState, navigateAway: () -> Unit) {
+    appLogger.e("AccountLongedOutDialog: $reason")
+    val (@StringRes title: Int, text: String) = when (reason) {
+        CurrentSessionErrorState.SessionExpired -> {
+            if (BuildConfig.WIPE_ON_COOKIE_INVALID) {
+                R.string.session_expired_error_title to (
+                        stringResource(id = R.string.session_expired_error_message)
+                                + "\n\n"
+                                + stringResource(id = R.string.conversation_history_wipe_explanation)
+                        )
+            } else {
+                R.string.session_expired_error_title to stringResource(id = R.string.session_expired_error_message)
+            }
+        }
+
+        CurrentSessionErrorState.RemovedClient -> {
+            if (BuildConfig.WIPE_ON_DEVICE_REMOVAL) {
+                R.string.removed_client_error_title to (
+                        stringResource(id = R.string.removed_client_error_message)
+                                + "\n\n"
+                                + stringResource(id = R.string.conversation_history_wipe_explanation)
+                        )
+            } else {
+                R.string.removed_client_error_title to stringResource(R.string.removed_client_error_message)
+            }
+        }
+
+        CurrentSessionErrorState.DeletedAccount -> {
+            R.string.deleted_user_error_title to stringResource(R.string.deleted_user_error_message)
+        }
+    }
+    WireDialog(
+        title = stringResource(id = title),
+        text = text,
+        onDismiss = remember { { } },
+        optionButton1Properties = WireDialogButtonProperties(
+            text = stringResource(R.string.label_ok),
+            onClick = navigateAway,
+            type = WireDialogButtonType.Primary
+        )
+    )
+}
+
+@Composable
+fun NewClientDialog(
+    data: NewClientsData?,
+    openDeviceManager: () -> Unit,
+    switchAccountAndOpenDeviceManager: (UserId) -> Unit,
+    dismiss: (UserId) -> Unit
+) {
+    data?.let {
+        val title: String
+        val text: String
+        val btnText: String
+        val btnAction: () -> Unit
+        val dismissAction: () -> Unit = { dismiss(data.userId) }
+        val devicesList = data.clientsInfo.map {
+            stringResource(
+                R.string.new_device_dialog_message_defice_info,
+                it.date.formatMediumDateTime() ?: "",
+                it.deviceInfo.asString()
+            )
+        }.joinToString("")
+        when (data) {
+            is NewClientsData.OtherUser -> {
+                title = stringResource(R.string.new_device_dialog_other_user_title, data.userName ?: "", data.userHandle ?: "")
+                text = stringResource(R.string.new_device_dialog_other_user_message, devicesList)
+                btnText = stringResource(R.string.new_device_dialog_other_user_btn)
+                btnAction = { switchAccountAndOpenDeviceManager(data.userId) }
+            }
+
+            is NewClientsData.CurrentUser -> {
+                title = stringResource(R.string.new_device_dialog_current_user_title)
+                text = stringResource(R.string.new_device_dialog_current_user_message, devicesList)
+                btnText = stringResource(R.string.new_device_dialog_current_user_btn)
+                btnAction = openDeviceManager
+            }
+        }
+        WireDialog(
+            title = title,
+            text = text,
+            onDismiss = dismissAction,
+            optionButton1Properties = WireDialogButtonProperties(
+                onClick = {
+                    dismissAction()
+                    btnAction()
+                },
+                text = btnText,
+                type = WireDialogButtonType.Secondary
+            ),
+            optionButton2Properties = WireDialogButtonProperties(
+                text = stringResource(id = R.string.label_ok),
+                onClick = dismissAction,
+                type = WireDialogButtonType.Primary
+            )
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewFileRestrictionDialog() {
+    WireTheme {
+        FileRestrictionDialog(true) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewGuestRoomLinkFeatureFlagDialog() {
+    WireTheme {
+        GuestRoomLinkFeatureFlagDialog(true) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewUpdateAppDialog() {
+    WireTheme {
+        UpdateAppDialog(true) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewJoinConversationDialogWithPassword() {
+    WireTheme {
+        JoinConversationDialog(
+            JoinConversationViaCodeState.Show("convName", "code", "key", "domain", true),
+            {}) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewJoinConversationDialogWithoutPassword() {
+    WireTheme {
+        JoinConversationDialog(
+            JoinConversationViaCodeState.Show("convName", "code", "key", "domain", false),
+            {}) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewJoinConversationDialogError() {
+    WireTheme {
+        JoinConversationDialog(
+            JoinConversationViaCodeState.Error(CheckConversationInviteCodeUseCase.Result.Failure.InvalidCodeOrKey),
+            {}) {}
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewCustomBackendDialog() {
+    WireTheme {
+        CustomBackendDialog(GlobalAppState(customBackendDialog = CustomServerDialogState(ServerConfig.STAGING)), {}, {})
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewMaxAccountDialog() {
+    WireTheme {
+        MaxAccountDialog(true, {}, {})
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewAccountLoggedOutDialog() {
+    WireTheme {
+        AccountLoggedOutDialog(CurrentSessionErrorState.DeletedAccount) {}
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -426,9 +426,9 @@ class WireActivityViewModel @Inject constructor(
 }
 
 sealed class CurrentSessionErrorState {
-    object RemovedClient : CurrentSessionErrorState()
-    object DeletedAccount : CurrentSessionErrorState()
-    object SessionExpired : CurrentSessionErrorState()
+    data object RemovedClient : CurrentSessionErrorState()
+    data object DeletedAccount : CurrentSessionErrorState()
+    data object SessionExpired : CurrentSessionErrorState()
 }
 
 sealed class NewClientsData(open val clientsInfo: List<NewClientInfo>, open val userId: UserId) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
@@ -30,82 +30,9 @@ import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
-import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
-
-@Composable
-fun FileRestrictionDialog(
-    isFileSharingEnabled: Boolean,
-    hideDialogStatus: () -> Unit,
-) {
-    val text: String = stringResource(id = if (isFileSharingEnabled) R.string.sharing_files_enabled else R.string.sharing_files_disabled)
-
-    WireDialog(
-        title = stringResource(id = R.string.team_settings_changed),
-        text = text,
-        onDismiss = hideDialogStatus,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = hideDialogStatus,
-            text = stringResource(id = R.string.label_ok),
-            type = WireDialogButtonType.Primary,
-        )
-    )
-}
-
-@Composable
-fun SelfDeletingMessagesDialog(
-    areSelfDeletingMessagesEnabled: Boolean,
-    enforcedTimeout: SelfDeletionDuration,
-    hideDialogStatus: () -> Unit,
-) {
-    val formattedTimeout = enforcedTimeout.longLabel.asString()
-    val text: String = when {
-        areSelfDeletingMessagesEnabled && enforcedTimeout == SelfDeletionDuration.None -> {
-            stringResource(id = R.string.self_deleting_messages_team_setting_enabled)
-        }
-
-        areSelfDeletingMessagesEnabled -> {
-            stringResource(R.string.self_deleting_messages_team_setting_enabled_enforced_timeout, formattedTimeout)
-        }
-
-        else -> {
-            stringResource(id = R.string.self_deleting_messages_team_setting_disabled)
-        }
-    }
-
-    WireDialog(
-        title = stringResource(id = R.string.team_settings_changed),
-        text = text,
-        onDismiss = hideDialogStatus,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = hideDialogStatus,
-            text = stringResource(id = R.string.label_ok),
-            type = WireDialogButtonType.Primary,
-        )
-    )
-}
-
-@Composable
-fun GuestRoomLinkFeatureFlagDialog(
-    isGuestRoomLinkEnabled: Boolean,
-    onDismiss: () -> Unit,
-) {
-    val text: String =
-        stringResource(id = if (isGuestRoomLinkEnabled) R.string.guest_room_link_enabled else R.string.guest_room_link_disabled)
-
-    WireDialog(
-        title = stringResource(id = R.string.team_settings_changed),
-        text = text,
-        onDismiss = onDismiss,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = onDismiss,
-            text = stringResource(id = R.string.label_ok),
-            type = WireDialogButtonType.Primary,
-        )
-    )
-}
 
 @Composable
 fun WelcomeNewUserDialog(
@@ -131,22 +58,6 @@ fun WelcomeNewUserDialog(
             type = WireDialogButtonType.Primary,
         )
     )
-}
-
-@PreviewMultipleThemes
-@Composable
-fun previewFileRestrictionDialog() {
-    WireTheme {
-        FileRestrictionDialog(true) {}
-    }
-}
-
-@PreviewMultipleThemes
-@Composable
-fun previewGuestRoomLinkFeatureFlagDialog() {
-    WireTheme {
-        GuestRoomLinkFeatureFlagDialog(true) {}
-    }
 }
 
 @PreviewMultipleThemes


### PR DESCRIPTION
# What's new in this PR?

### Issues

Team Settings changed dialogues are only visible on conversation list.

### Causes (Optional)

Feature changes were observed in HomeScreen only, so the dialogs were shown only there.

### Solutions

Mode FeatureChanges observation into WireActivity.
Also extracted all the WireActivity dialogs into separate file (there are too many of them already)
