### PR TITLE
fix: normalize asset file name when exporting to external storage

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -24,9 +24,9 @@ import android.content.Context
 import android.net.Uri
 import com.wire.android.appLogger
 import com.wire.android.ui.home.conversations.model.AssetBundle
-import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.asset.AttachmentType
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.withContext
 import okio.Path

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -160,6 +160,8 @@ fun ContentResolver.copyFile(destinationUri: Uri, sourcePath: Path) {
 }
 
 private fun Context.saveFileDataToMediaFolder(assetName: String, downloadedDataPath: Path, fileSize: Long, mimeType: String): Uri? {
+    val normalizedFileName = assetName.normalizeFileName()
+
     val resolver = contentResolver
     val directory = Environment.getExternalStoragePublicDirectory(
         when {
@@ -171,7 +173,7 @@ private fun Context.saveFileDataToMediaFolder(assetName: String, downloadedDataP
     )
     directory.mkdirs()
     val contentValues = ContentValues().apply {
-        val availableAssetName = findFirstUniqueName(directory, assetName.ifEmpty { ATTACHMENT_FILENAME })
+        val availableAssetName = findFirstUniqueName(directory, normalizedFileName.ifEmpty { ATTACHMENT_FILENAME })
         put(DISPLAY_NAME, availableAssetName)
         put(MIME_TYPE, mimeType)
         put(SIZE, fileSize)
@@ -189,7 +191,7 @@ private fun Context.saveFileDataToMediaFolder(assetName: String, downloadedDataP
     val insertedUri = resolver.insert(externalContentUri, contentValues) ?: run {
         val authority = getProviderAuthority()
         // we need to find the next available name with copy counter by ourselves before copying
-        val availableAssetName = findFirstUniqueName(directory, assetName.ifEmpty { ATTACHMENT_FILENAME })
+        val availableAssetName = findFirstUniqueName(directory, normalizedFileName.ifEmpty { ATTACHMENT_FILENAME })
         val destinationFile = File(directory, availableAssetName)
         FileProvider.getUriForFile(this, authority, destinationFile)
     }

--- a/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/StringUtil.kt
@@ -47,3 +47,5 @@ fun String.toTitleCase(delimiter: String = " ", separator: String = " "): String
     }
 
 fun String.capitalizeFirstLetter(): String = lowercase().replaceFirstChar(Char::titlecaseChar)
+
+fun String.normalizeFileName(): String = this.replace("/", "")

--- a/app/src/test/kotlin/com/wire/android/util/StringUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/StringUtilTest.kt
@@ -36,4 +36,12 @@ class StringUtilTest {
         val actual = input.toTitleCase()
         assert(expected == actual)
     }
+
+    @Test
+    fun givenString_whenNormalizingAsFileName_thenAllSlashesAreRemoved() {
+        val input = "this/is/a/test"
+        val expected = "thisisatest"
+        val actual = input.normalizeFileName()
+        assert(expected == actual)
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if the file name contains slashes when exporting to media folder it will create a new dir within that folder

### Solutions

sanitize the file name and remove and /

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
