### PR TITLE
fix: app crash when clicking next on create account screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/handle/UsernameTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/handle/UsernameTextField.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -35,9 +34,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.common.ShakeAnimation
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
-import com.wire.android.ui.common.textfield.AutoFillTextField
+import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.textfield.clearAutofillTree
 import com.wire.android.ui.theme.wireDimensions
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -50,7 +48,6 @@ fun UsernameTextField(
     onUsernameChange: (TextFieldValue) -> Unit,
     onUsernameErrorAnimated: () -> Unit
 ) {
-    clearAutofillTree()
     if (errorState is HandleUpdateErrorState.DialogError.GenericError) {
         CoreFailureErrorDialog(errorState.coreFailure, onErrorDismiss)
     }
@@ -61,8 +58,7 @@ fun UsernameTextField(
             animate()
             onUsernameErrorAnimated()
         }
-        AutoFillTextField(
-            autofillTypes = listOf(AutofillType.Username),
+        WireTextField(
             value = username,
             onValueChange = onUsernameChange,
             placeholderText = stringResource(R.string.create_account_username_placeholder),

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -242,7 +242,14 @@ private fun DetailsContent(
                         } else {
                             WireTextFieldState.Default
                         },
-                        autofill = false
+                        autofill = false,
+                        onTap = {
+                            coroutineScope.launch {
+                                keyboardController?.show()
+                                focusRequesterTeamName.requestFocus()
+                                listState.animateScrollToItem(2)
+                            }
+                        }
                     )
                 }
 
@@ -267,7 +274,14 @@ private fun DetailsContent(
 
                             CreateAccountDetailsViewState.DetailsError.TextFieldError.InvalidPasswordError ->
                                 WireTextFieldState.Error(stringResource(id = R.string.create_account_details_password_error))
-                        } else WireTextFieldState.Default
+                        } else WireTextFieldState.Default,
+                        onTap = {
+                            coroutineScope.launch {
+                                keyboardController?.show()
+                                focusRequesterTeamName.requestFocus()
+                                listState.animateScrollToItem(2)
+                            }
+                        }
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -62,7 +62,6 @@ import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.textfield.clearAutofillTree
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -72,7 +71,6 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun CreateAccountDetailsScreen(viewModel: CreateAccountDetailsViewModel, serverConfig: ServerConfig.Links) {
-    clearAutofillTree()
     DetailsContent(
         state = viewModel.detailsState,
         onFirstNameChange = { viewModel.onDetailsChange(it, CreateAccountDetailsViewModel.DetailsFieldType.FirstName) },
@@ -236,7 +234,6 @@ private fun DetailsContent(
                         labelMandatoryIcon = true,
                         descriptionText = stringResource(R.string.create_account_details_password_description),
                         imeAction = ImeAction.Next,
-                        autofillTypes = listOf(),
                         modifier = Modifier
                             .padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
                             .testTag("password"),
@@ -244,7 +241,8 @@ private fun DetailsContent(
                             WireTextFieldState.Error()
                         } else {
                             WireTextFieldState.Default
-                        }
+                        },
+                        autofill = false
                     )
                 }
 
@@ -256,7 +254,7 @@ private fun DetailsContent(
                         labelMandatoryIcon = true,
                         imeAction = ImeAction.Done,
                         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-                        autofillTypes = listOf(),
+                        autofill = false,
                         modifier = Modifier
                             .padding(
                                 horizontal = MaterialTheme.wireDimensions.spacing16x,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -99,7 +98,6 @@ private fun DetailsContent(
     serverConfig: ServerConfig.Links
 ) {
     val scrollState = rememberScrollState()
-    val coroutineScope = rememberCoroutineScope()
     Scaffold(
         topBar = {
             WireCenterAlignedTopAppBar(
@@ -122,7 +120,6 @@ private fun DetailsContent(
                 .padding(internalPadding)
                 .fillMaxHeight()
         ) {
-//            val listState = rememberLazyListState()
             val keyboardOptions = KeyboardOptions(KeyboardCapitalization.Words, true, KeyboardType.Text, ImeAction.Next)
             val keyboardController = LocalSoftwareKeyboardController.current
             val focusRequesterFirstName = remember { FocusRequester() }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
@@ -69,9 +68,8 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
-import com.wire.android.ui.common.textfield.AutoFillTextField
+import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.textfield.clearAutofillTree
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -95,7 +93,7 @@ fun CreateAccountEmailScreen(viewModel: CreateAccountEmailViewModel, serverConfi
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun EmailContent(
     state: CreateAccountEmailViewState,
@@ -109,7 +107,6 @@ private fun EmailContent(
     tosUrl: String,
     serverConfig: ServerConfig.Links
 ) {
-    clearAutofillTree()
     val focusRequester = remember { FocusRequester() }
 
     Scaffold(topBar = {
@@ -144,8 +141,7 @@ private fun EmailContent(
                     )
                     .testTag("createTeamText")
             )
-            AutoFillTextField(
-                autofillTypes = listOf(AutofillType.EmailAddress),
+            WireTextField(
                 value = state.email,
                 onValueChange = onEmailChange,
                 placeholderText = stringResource(R.string.create_account_email_placeholder),

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -171,7 +171,8 @@ private fun PasswordTextField(state: RegisterDeviceState, onPasswordChange: (Tex
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
         modifier = Modifier
             .padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
-            .testTag("password field")
+            .testTag("password field"),
+        autofill = true
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
@@ -84,7 +84,8 @@ fun RemoveDeviceDialog(
                 modifier = Modifier
                     .focusRequester(focusRequester)
                     .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
-                    .testTag("remove device password field")
+                    .testTag("remove device password field"),
+                autofill = true
             )
             LaunchedEffect(Unit) { // executed only once when showing the dialog
                 focusRequester.requestFocus()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -227,7 +227,8 @@ private fun PasswordInput(modifier: Modifier, password: TextFieldValue, onPasswo
         onValueChange = onPasswordChange,
         imeAction = ImeAction.Done,
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-        modifier = modifier.testTag("passwordField")
+        modifier = modifier.testTag("passwordField"),
+        autofill = true
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/ProxyScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/ProxyScreen.kt
@@ -152,7 +152,7 @@ private fun ProxyPasswordInput(modifier: Modifier, proxyPassword: TextFieldValue
         labelText = stringResource(R.string.label_proxy_password),
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
         modifier = modifier.testTag("passwordField"),
-        autofillTypes = listOf()
+        autofill = false
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -272,7 +272,9 @@ fun PreviewWireDialog() {
             ) {
                 WirePasswordTextField(
                     value = password,
-                    onValueChange = { password = it })
+                    onValueChange = { password = it },
+                    autofill = false
+                )
             }
         }
     }
@@ -320,7 +322,9 @@ fun PreviewWireDialogWith2OptionButtons() {
             ) {
                 WirePasswordTextField(
                     value = password,
-                    onValueChange = { password = it })
+                    onValueChange = { password = it },
+                    autofill = true
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.autofill.Autofill
 import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -71,8 +72,9 @@ internal fun AutoFillTextField(
     inputMinHeight: Dp = MaterialTheme.wireDimensions.textFieldMinHeight,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize),
     colors: WireTextFieldColors = wireTextFieldColors(),
-    modifier: Modifier = Modifier
-) {
+    modifier: Modifier = Modifier,
+    onTap: (Offset) -> Unit = { },
+    ) {
     val autofillNode = AutofillNode(
         autofillTypes = autofillTypes,
         onFill = { onValueChange(TextFieldValue(it, TextRange(it.length))) }
@@ -105,7 +107,8 @@ internal fun AutoFillTextField(
         colors = colors,
         modifier = modifier
             .fillBounds(autofillNode)
-            .defaultOnFocusAutoFill(autofill, autofillNode)
+            .defaultOnFocusAutoFill(autofill, autofillNode),
+        onTap = onTap
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.Autofill
 import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.onFocusChanged
@@ -103,18 +104,25 @@ internal fun AutoFillTextField(
         shape = shape,
         colors = colors,
         modifier = modifier
-            .onGloballyPositioned { autofillNode.boundingBox = it.boundsInWindow() }
-            .onFocusChanged { focusState ->
-                autofill?.run {
-                    if (focusState.isFocused) {
-                        requestAutofillForNode(autofillNode)
-                    } else {
-                        cancelAutofillForNode(autofillNode)
-                    }
-                }
-            }
+            .fillBounds(autofillNode)
+            .defaultOnFocusAutoFill(autofill, autofillNode)
     )
 }
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.fillBounds(autofillNode: AutofillNode) = this.then(
+    Modifier.onGloballyPositioned { autofillNode.boundingBox = it.boundsInWindow() }
+)
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.defaultOnFocusAutoFill(autofill: Autofill?, autofillNode: AutofillNode): Modifier =
+    then(Modifier.onFocusChanged { focusState ->
+        if (focusState.isFocused) {
+            autofill?.requestAutofillForNode(autofillNode)
+        } else {
+            autofill?.cancelAutofillForNode(autofillNode)
+        }
+    })
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/AutoFillTextField.kt
@@ -74,7 +74,7 @@ internal fun AutoFillTextField(
     colors: WireTextFieldColors = wireTextFieldColors(),
     modifier: Modifier = Modifier,
     onTap: (Offset) -> Unit = { },
-    ) {
+) {
     val autofillNode = AutofillNode(
         autofillTypes = autofillTypes,
         onFill = { onValueChange(TextFieldValue(it, TextRange(it.length))) }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -76,8 +77,9 @@ fun WirePasswordTextField(
     shape: Shape = RoundedCornerShape(16.dp),
     colors: WireTextFieldColors = wireTextFieldColors(),
     modifier: Modifier = Modifier,
-    autofill: Boolean
-) {
+    autofill: Boolean,
+    onTap: (Offset) -> Unit = { },
+    ) {
     var passwordVisibility by remember { mutableStateOf(false) }
 
     val keyBoardOption = remember {
@@ -130,7 +132,8 @@ fun WirePasswordTextField(
             modifier = modifier,
             visualTransformation = visualTransformation,
             trailingIcon = iconButton,
-            autofillTypes = listOf(AutofillType.Password)
+            autofillTypes = listOf(AutofillType.Password),
+            onTap = onTap
         )
     } else {
         WireTextField(
@@ -155,6 +158,7 @@ fun WirePasswordTextField(
             modifier = modifier,
             visualTransformation = visualTransformation,
             trailingIcon = iconButton,
+            onTap = onTap
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -79,7 +79,7 @@ fun WirePasswordTextField(
     modifier: Modifier = Modifier,
     autofill: Boolean,
     onTap: (Offset) -> Unit = { },
-    ) {
+) {
     var passwordVisibility by remember { mutableStateOf(false) }
 
     val keyBoardOption = remember {

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -76,57 +76,96 @@ fun WirePasswordTextField(
     shape: Shape = RoundedCornerShape(16.dp),
     colors: WireTextFieldColors = wireTextFieldColors(),
     modifier: Modifier = Modifier,
-    autofillTypes: List<AutofillType>? = null
+    autofill: Boolean
 ) {
     var passwordVisibility by remember { mutableStateOf(false) }
-    AutoFillTextField(
-        autofillTypes = autofillTypes ?: listOf(AutofillType.Password),
-        value = value,
-        onValueChange = onValueChange,
-        readOnly = readOnly,
-        singleLine = true,
-        maxLines = 1,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = imeAction),
-        keyboardActions = keyboardActions,
-        placeholderText = placeholderText,
-        labelText = labelText,
-        labelMandatoryIcon = labelMandatoryIcon,
-        descriptionText = descriptionText,
-        state = state,
-        interactionSource = interactionSource,
-        textStyle = textStyle,
-        placeholderTextStyle = placeHolderTextStyle,
-        inputMinHeight = inputMinHeight,
-        shape = shape,
-        colors = colors,
-        modifier = modifier,
-        visualTransformation = if (passwordVisibility) VisualTransformation.None else PasswordVisualTransformation(),
-        trailingIcon = {
-            val image = if (passwordVisibility) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
-            IconButton(onClick = { passwordVisibility = !passwordVisibility }) {
-                Icon(
-                    imageVector = image,
-                    contentDescription = stringResource(
-                        if (!passwordVisibility) R.string.content_description_reveal_password
-                        else R.string.content_description_hide_password
-                    ),
-                    modifier = Modifier
-                        .size(20.dp)
-                        .testTag("hidePassword")
-                )
-            }
-        },
-    )
+
+    val keyBoardOption = remember {
+        KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = imeAction)
+    }
+
+    val visualTransformation = remember(passwordVisibility) {
+        if (passwordVisibility) VisualTransformation.None else PasswordVisualTransformation()
+    }
+
+    val icon = remember(passwordVisibility) {
+        if (passwordVisibility) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+    }
+
+    val iconButton = @Composable {
+        IconButton(onClick = { passwordVisibility = !passwordVisibility }) {
+            Icon(
+                imageVector = icon,
+                contentDescription = stringResource(
+                    if (!passwordVisibility) R.string.content_description_reveal_password
+                    else R.string.content_description_hide_password
+                ),
+                modifier = Modifier
+                    .size(20.dp)
+                    .testTag("hidePassword")
+            )
+        }
+    }
+
+    if (autofill) {
+        AutoFillTextField(
+            value = value,
+            onValueChange = onValueChange,
+            readOnly = readOnly,
+            singleLine = true,
+            maxLines = 1,
+            keyboardOptions = keyBoardOption,
+            keyboardActions = keyboardActions,
+            placeholderText = placeholderText,
+            labelText = labelText,
+            labelMandatoryIcon = labelMandatoryIcon,
+            descriptionText = descriptionText,
+            state = state,
+            interactionSource = interactionSource,
+            textStyle = textStyle,
+            placeholderTextStyle = placeHolderTextStyle,
+            inputMinHeight = inputMinHeight,
+            shape = shape,
+            colors = colors,
+            modifier = modifier,
+            visualTransformation = visualTransformation,
+            trailingIcon = iconButton,
+            autofillTypes = listOf(AutofillType.Password)
+        )
+    } else {
+        WireTextField(
+            value = value,
+            onValueChange = onValueChange,
+            readOnly = readOnly,
+            singleLine = true,
+            maxLines = 1,
+            keyboardOptions = keyBoardOption,
+            keyboardActions = keyboardActions,
+            placeholderText = placeholderText,
+            labelText = labelText,
+            labelMandatoryIcon = labelMandatoryIcon,
+            descriptionText = descriptionText,
+            state = state,
+            interactionSource = interactionSource,
+            textStyle = textStyle,
+            placeholderTextStyle = placeHolderTextStyle,
+            inputMinHeight = inputMinHeight,
+            shape = shape,
+            colors = colors,
+            modifier = modifier,
+            visualTransformation = visualTransformation,
+            trailingIcon = iconButton,
+        )
+    }
 }
 
-
-@OptIn(ExperimentalComposeUiApi::class)
 @Preview(name = "Default WirePasswordTextField")
 @Composable
 fun PreviewWirePasswordTextField() {
     WirePasswordTextField(
         value = TextFieldValue(""),
         onValueChange = {},
-        modifier = Modifier.padding(16.dp)
+        modifier = Modifier.padding(16.dp),
+        autofill = false
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
@@ -52,7 +51,6 @@ import com.wire.android.util.permission.rememberCreateFileFlow
 import java.util.Locale
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SetBackupPasswordDialog(
     isBackupPasswordValid: Boolean,
@@ -85,7 +83,8 @@ fun SetBackupPasswordDialog(
             onValueChange = {
                 backupPassword = it
                 onBackupPasswordChanged(it)
-            }
+            },
+            autofill = false
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -102,7 +102,8 @@ fun EnterRestorePasswordDialog(
         ) {
             WirePasswordTextField(
                 value = restorePassword,
-                onValueChange = { restorePassword = it }
+                onValueChange = { restorePassword = it },
+                autofill = false
             )
         }
     } else {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

app crash when clicking next on create account screen

### Causes (Optional)

the `CreateAccountScren` wrap its items in a LazyColumn and when clicking next in the keyboard the password input is not in display (aka not composed) but we do request on focuseChange -> the app crash

### Solutions

disable autofill for create account screen since it does not make sense to request saved passwords when creating a new account

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
