### PR TITLE
fix: crash related to request focus when clicking on last name EditTe…

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -122,9 +122,7 @@ private fun DetailsContent(
         ) {
             val keyboardOptions = KeyboardOptions(KeyboardCapitalization.Words, true, KeyboardType.Text, ImeAction.Next)
             val keyboardController = LocalSoftwareKeyboardController.current
-            val focusRequesterFirstName = remember { FocusRequester() }
-            val focusRequesterLastName = remember { FocusRequester() }
-            val focusRequesterTeamName = remember { FocusRequester() }
+            val firstNameFocusRequester = remember { FocusRequester() }
 
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -133,13 +131,6 @@ private fun DetailsContent(
                     .weight(1f)
                     .verticalScroll(rememberScrollState())
             ) {
-
-                val requestFocus = remember<(Offset) -> Unit> {
-                    { _ ->
-                        keyboardController?.show()
-                        focusRequesterTeamName.requestFocus()
-                    }
-                }
 
                 Text(
                     text = stringResource(R.string.create_personal_account_details_text),
@@ -166,7 +157,7 @@ private fun DetailsContent(
                             end = MaterialTheme.wireDimensions.spacing16x,
                             bottom = MaterialTheme.wireDimensions.spacing16x
                         )
-                        .focusRequester(focusRequesterFirstName)
+                        .focusRequester(firstNameFocusRequester)
                         .testTag("firstName"),
                 )
 
@@ -184,10 +175,7 @@ private fun DetailsContent(
                             end = MaterialTheme.wireDimensions.spacing16x,
                             bottom = MaterialTheme.wireDimensions.spacing16x
                         )
-                        .focusRequester(focusRequesterLastName)
                         .testTag("lastName"),
-                    shouldDetectTaps = true,
-                    onTap = requestFocus
                 )
 
                 if (state.type == CreateAccountFlowType.CreateTeam) {
@@ -205,10 +193,7 @@ private fun DetailsContent(
                                 end = MaterialTheme.wireDimensions.spacing16x,
                                 bottom = MaterialTheme.wireDimensions.spacing16x
                             )
-                            .testTag("teamName")
-                            .focusRequester(focusRequesterTeamName),
-                        shouldDetectTaps = true,
-                        onTap = requestFocus
+                            .testTag("teamName"),
                     )
                 }
 
@@ -227,7 +212,6 @@ private fun DetailsContent(
                         WireTextFieldState.Default
                     },
                     autofill = false,
-                    onTap = requestFocus
                 )
 
                 WirePasswordTextField(
@@ -251,12 +235,11 @@ private fun DetailsContent(
                             WireTextFieldState.Error(stringResource(id = R.string.create_account_details_password_error))
                     } else WireTextFieldState.Default,
                     autofill = false,
-                    onTap = requestFocus
                 )
             }
 
             LaunchedEffect(Unit) {
-                focusRequesterFirstName.requestFocus()
+                firstNameFocusRequester.requestFocus()
                 keyboardController?.show()
             }
 


### PR DESCRIPTION
…xt in CreateAccountDetailsScreen

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the fix in https://github.com/wireapp/wire-android-reloaded/pull/2183 caused a different issue when clicking on the last name text field to bring it into focus 

### Solutions

the focusRequester should only be used on the first name text field to bring it into focus when the screen open

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
