### PR TITLE
fix(2fa): login button disabled after verifiction backpress [WPB-3590]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -161,12 +161,12 @@ class LoginEmailViewModel @Inject constructor(
     private suspend fun handleAuthenticationFailure(it: AuthenticationResult.Failure, authScope: AuthenticationScope) {
         when (it) {
             is AuthenticationResult.Failure.InvalidCredentials.Missing2FA -> {
-                loginState = loginState.updateEmailLoginEnabled()
+                loginState = loginState.copy(emailLoginLoading = false).updateEmailLoginEnabled()
                 request2FACode(authScope)
             }
 
             is AuthenticationResult.Failure.InvalidCredentials.Invalid2FA -> {
-                loginState = loginState.updateEmailLoginEnabled()
+                loginState = loginState.copy(emailLoginLoading = false).updateEmailLoginEnabled()
                 secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(isCurrentCodeInvalid = true)
             }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Login button is disabled after user navigates back from 2FA verification

### Causes

`loading` state is not properly reset on 2FA-related failures.

### Solutions

Properly reset the state and reenable the button.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

See videos below, requires being member of a team that requires 2FA.

### Attachments

#### Before

[Faulty 2FA backbutton.webm](https://github.com/wireapp/wire-android-reloaded/assets/9389043/f29164f5-891e-4b49-85be-b3e7953fe7aa)

#### After

[Working 2FA backbutton.webm](https://github.com/wireapp/wire-android-reloaded/assets/9389043/d0e96629-0461-4703-9a8f-50696b2c43c5)

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
