### PR TITLE
fix(calling): scrolling the grid is not possible when every one have camera enabled (WPB-4530)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -75,7 +75,7 @@ fun FullScreenTile(
                 participantTitleState = it,
                 isSelfUser = selectedParticipant.isSelfUser,
                 shouldFill = false,
-                shouldZoom = true,
+                isZoomingEnabled = true,
                 onSelfUserVideoPreviewCreated = sharedCallingViewModel::setVideoPreview,
                 onClearSelfUserVideoPreview = sharedCallingViewModel::clearVideoPreview
             )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -89,7 +89,7 @@ fun ParticipantTile(
     avatarSize: Dp = dimensions().onGoingCallUserAvatarSize,
     isSelfUser: Boolean,
     shouldFill: Boolean = true,
-    shouldZoom: Boolean = false,
+    isZoomingEnabled: Boolean = false,
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit
 ) {
@@ -144,9 +144,9 @@ fun ParticipantTile(
                                 size = it
                             }
                             .pointerInput(Unit) {
-                                // enable zooming only when camera is on
-                                detectTransformGestures { _, gesturePan, gestureZoom, _ ->
-                                    if (shouldZoom) {
+                                // enable zooming on full screen and when video is on
+                                if (isZoomingEnabled) {
+                                    detectTransformGestures { _, gesturePan, gestureZoom, _ ->
                                         zoom = (zoom * gestureZoom).coerceIn(1f, 3f)
                                         val maxX = (size.width * (zoom - 1)) / 2
                                         val minX = -maxX


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4530" title="WPB-4530" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4530</a>  [Android] Scrolling not working as expected in large calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

scrolling the grid is not possible when every one have camera enabled

### Causes (Optional)

We are using `detectTransformGestures()` on the tile which will prevent the scrolling behaviour 

### Solutions

Use `detectTransformGestures` only on full screen and when video is enabled

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Have a large conference call more than 8 participants
- Try to swipe up to next page by tapping on a tile with video enabled

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
