### PR TITLE
fix: Self video disappears when scrolling through video grid (RC) (WPB-4651)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
@@ -81,6 +80,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.id.ConversationId
 import java.util.Locale
 
@@ -250,12 +250,8 @@ private fun OngoingCallContent(
                             onSelfVideoPreviewCreated = setVideoPreview,
                             onSelfClearVideoPreview = clearVideoPreview,
                             requestVideoStreams = requestVideoStreams,
-                            onDoubleTap = { selectedUserId, selectedClientId, isSelf ->
-                                selectedParticipantForFullScreen = SelectedParticipant(
-                                    userId = selectedUserId,
-                                    clientId = selectedClientId,
-                                    isSelfUser = isSelf
-                                )
+                            onDoubleTap = { selectedParticipant ->
+                                selectedParticipantForFullScreen = selectedParticipant
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             }
                         )
@@ -295,7 +291,9 @@ private fun OngoingCallTopBar(
                     .fillMaxWidth()
                     .offset(y = -(5).dp),
                 textAlign = TextAlign.Center,
-                text = stringResource(id = R.string.calling_constant_bit_rate_indication).uppercase(Locale.getDefault()),
+                text = stringResource(id = R.string.calling_constant_bit_rate_indication).uppercase(
+                    Locale.getDefault()
+                ),
                 color = colorsScheme().secondaryText,
                 style = MaterialTheme.wireTypography.title03,
             )
@@ -353,8 +351,8 @@ private fun CallingControls(
     }
 }
 
+@PreviewMultipleThemes
 @Composable
-@Preview
 fun PreviewOngoingCallTopBar() {
     OngoingCallTopBar("Default", true) { }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -43,6 +42,7 @@ import com.wire.android.ui.calling.SharedCallingViewModel
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel.Companion.DOUBLE_TAP_TOAST_DISPLAY_TIME
 import com.wire.android.ui.calling.ongoing.participantsview.ParticipantTile
 import com.wire.android.ui.common.dimensions
+import com.wire.android.util.ui.PreviewMultipleThemes
 import kotlinx.coroutines.delay
 
 @Composable
@@ -74,6 +74,8 @@ fun FullScreenTile(
                     ),
                 participantTitleState = it,
                 isSelfUser = selectedParticipant.isSelfUser,
+                isSelfUserCameraOn = selectedParticipant.isSelfUserCameraOn,
+                isSelfUserMuted = selectedParticipant.isSelfUserMuted,
                 shouldFill = false,
                 isZoomingEnabled = true,
                 onSelfUserVideoPreviewCreated = sharedCallingViewModel::setVideoPreview,
@@ -98,7 +100,7 @@ fun FullScreenTile(
     }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
 fun PreviewFullScreenVideoCall() {
     FullScreenTile(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
@@ -22,5 +22,7 @@ import com.wire.kalium.logic.data.user.UserId
 data class SelectedParticipant(
     val userId: UserId = UserId("", ""),
     val clientId: String = "",
-    val isSelfUser: Boolean = false
+    val isSelfUser: Boolean = false,
+    val isSelfUserCameraOn: Boolean = false,
+    val isSelfUserMuted: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -32,22 +32,20 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.wire.android.ui.calling.ConversationName
-import com.wire.android.ui.calling.getConversationName
 import com.wire.android.ui.calling.model.UICallParticipant
+import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.calling.ongoing.participantsview.ParticipantTile
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.UserId
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -59,7 +57,7 @@ fun GroupCallGrid(
     contentHeight: Dp,
     onSelfVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit,
-    onDoubleTap: (userId: UserId, clientId: String, isSelfUser: Boolean) -> Unit
+    onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit
 ) {
     val config = LocalConfiguration.current
 
@@ -78,17 +76,13 @@ fun GroupCallGrid(
         ) { participant ->
             // since we are getting participants by chunk of 8 items,
             // we need to check that we are on first page for self user
-            val isSelfUser = pageIndex == 0 && participants.first() == participant
-
+            val isSelfUser = remember(pageIndex, participants.first()) {
+                pageIndex == 0 && participants.first() == participant
+            }
             // We need the number of tiles rows needed to calculate their height
-            val numberOfTilesRows = tilesRowsCount(participants.size)
-            val isCameraOn = if (isSelfUser) {
-                isSelfUserCameraOn
-            } else participant.isCameraOn
-            // for self user we don't need to get the muted value from participants list
-            // if we do, this will show visuals with some delay
-            val isMuted = if (isSelfUser) isSelfUserMuted
-            else participant.isMuted
+            val numberOfTilesRows = remember(participants.size) {
+                tilesRowsCount(participants.size)
+            }
 
             // if we have more than 6 participants then we reduce avatar size
             val userAvatarSize = if (participants.size <= 6 || config.screenHeightDp > MIN_SCREEN_HEIGHT) {
@@ -96,52 +90,39 @@ fun GroupCallGrid(
             } else {
                 dimensions().onGoingCallUserAvatarMinimizedSize
             }
-            val usernameString = when (val conversationName = getConversationName(participant.name)) {
-                is ConversationName.Known -> conversationName.name
-                is ConversationName.Unknown -> stringResource(id = conversationName.resourceId)
-            }
 
-            val participantState = UICallParticipant(
-                id = participant.id,
-                clientId = participant.clientId,
-                name = usernameString,
-                isMuted = isMuted,
-                isSpeaking = participant.isSpeaking,
-                isCameraOn = isCameraOn,
-                isSharingScreen = participant.isSharingScreen,
-                avatar = participant.avatar,
-                membership = participant.membership
-            )
-            val tileHeight = (contentHeight - dimensions().spacing4x) / numberOfTilesRows
+            val spacing4x = dimensions().spacing4x
+            val tileHeight = remember(numberOfTilesRows) {
+                (contentHeight - spacing4x) / numberOfTilesRows
+            }
 
             ParticipantTile(
                 modifier = Modifier
-                    .pointerInput(Unit) {
+                    .pointerInput(isSelfUserCameraOn, isSelfUserMuted) {
                         detectTapGestures(
-                            onPress = { /* Called when the gesture starts */ },
                             onDoubleTap = {
-                                onDoubleTap(participantState.id, participantState.clientId, isSelfUser)
-                            },
-                            onLongPress = { /* Called on Long Press */ },
-                            onTap = { /* Called on Tap */ }
+                                onDoubleTap(
+                                    SelectedParticipant(
+                                        userId = participant.id,
+                                        clientId = participant.clientId,
+                                        isSelfUser = isSelfUser,
+                                        isSelfUserCameraOn = isSelfUserCameraOn,
+                                        isSelfUserMuted = isSelfUserMuted
+                                    )
+                                )
+                            }
                         )
                     }
                     .height(tileHeight)
                     .animateItemPlacement(tween(durationMillis = 200)),
-                participantTitleState = participantState,
-                onGoingCallTileUsernameMaxWidth = MaterialTheme.wireDimensions.onGoingCallTileUsernameMaxWidth,
+                participantTitleState = participant,
+                onGoingCallTileUsernameMaxWidth = dimensions().onGoingCallTileUsernameMaxWidth,
                 avatarSize = userAvatarSize,
                 isSelfUser = isSelfUser,
-                onSelfUserVideoPreviewCreated = {
-                    if (isSelfUser) {
-                        onSelfVideoPreviewCreated(it)
-                    }
-                },
-                onClearSelfUserVideoPreview = {
-                    if (isSelfUser) {
-                        onSelfClearVideoPreview()
-                    }
-                }
+                isSelfUserMuted = isSelfUserMuted,
+                isSelfUserCameraOn = isSelfUserCameraOn,
+                onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
+                onClearSelfUserVideoPreview = onSelfClearVideoPreview
             )
         }
     }
@@ -196,6 +177,6 @@ fun PreviewGroupCallGrid() {
         isSelfUserCameraOn = false,
         onSelfVideoPreviewCreated = { },
         onSelfClearVideoPreview = { },
-        onDoubleTap = { _, _, _ -> {} }
+        onDoubleTap = { }
     )
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Self camera preview is black when scrolling between pages in a call

### Causes (Optional)

We are not passing the created camera preview, of the current visible screen to AVS, when scrolling from page 3 to page 1.
This is because Pager library prepares the previous page before scrolling to it.

### Solutions

- Pass the cameraPreview on every update of the AndroidView

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Have a call with 3 pages of participants
- Turn on your camera
- Scroll to page 3
- Go back to first page
- You should see your camera again on

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
