### PR TITLE
chore: enable penalty death on strict mode

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -106,24 +106,24 @@ class WireApplication : Application(), Configuration.Provider {
     }
 
     private fun enableStrictMode() {
-        if (!BuildConfig.DEBUG) return
-
-        StrictMode.setThreadPolicy(
-            StrictMode.ThreadPolicy.Builder()
-                .detectDiskReads()
-                .detectDiskWrites()
-                .penaltyLog()
-                // .penaltyDeath() TODO: add it later after fixing reported violations
-                .build()
-        )
-        StrictMode.setVmPolicy(
-            StrictMode.VmPolicy.Builder()
-                .detectLeakedSqlLiteObjects()
-                .detectLeakedClosableObjects()
-                .penaltyLog()
-                // .penaltyDeath() TODO: add it later after fixing reported violations
-                .build()
-        )
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectDiskReads()
+                    .detectDiskWrites()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build()
+            )
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .detectLeakedSqlLiteObjects()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    // .penaltyDeath() TODO: add it later after fixing reported violations
+                    .build()
+            )
+        }
     }
 
     private fun initializeApplicationLoggingFrameworks() {
@@ -199,7 +199,8 @@ class WireApplication : Application(), Configuration.Provider {
             TRIM_MEMORY_UNKNOWN(-1);
 
             companion object {
-                fun byLevel(value: Int) = values().firstOrNull { it.level == value } ?: TRIM_MEMORY_UNKNOWN
+                fun byLevel(value: Int) =
+                    values().firstOrNull { it.level == value } ?: TRIM_MEMORY_UNKNOWN
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.ui.common.imagepreview
 
+import android.graphics.Bitmap
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -29,6 +30,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.toRect
@@ -44,6 +48,19 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import coil.compose.rememberAsyncImagePainter
 import com.wire.android.ui.common.dimensions
 import com.wire.android.util.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+private fun loadBiMap(imageUri: Uri): State<Bitmap?> {
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    return produceState<Bitmap?>(initialValue = null, imageUri) {
+        coroutineScope.launch(Dispatchers.IO) {
+            value = imageUri.toBitmap(context)
+        }
+    }
+}
 
 @Composable
 fun BulletHoleImagePreview(
@@ -67,7 +84,7 @@ fun BulletHoleImagePreview(
                 }
         ) {
             Image(
-                painter = rememberAsyncImagePainter(imageUri.toBitmap(LocalContext.current)),
+                painter = rememberAsyncImagePainter(loadBiMap(imageUri).value),
                 contentScale = ContentScale.Crop,
                 contentDescription = contentDescription,
                 modifier = Modifier.fillMaxSize(),
@@ -97,7 +114,11 @@ fun BulletHoleImagePreview(
 @Suppress("MagicNumber")
 class BulletHoleShape : Shape {
 
-    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
         return Outline.Generic(
             drawBulletHolePath(size)
         )

--- a/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
-private fun loadBiMap(imageUri: Uri): State<Bitmap?> {
+private fun loadBitMap(imageUri: Uri): State<Bitmap?> {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     return produceState<Bitmap?>(initialValue = null, imageUri) {

--- a/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
@@ -84,7 +84,7 @@ fun BulletHoleImagePreview(
                 }
         ) {
             Image(
-                painter = rememberAsyncImagePainter(loadBiMap(imageUri).value),
+                painter = rememberAsyncImagePainter(loadBitMap(imageUri).value),
                 contentScale = ContentScale.Crop,
                 contentDescription = contentDescription,
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR will enable `penaltyDeath` of `StrictMode` on ThreadPolicy, which means the app will crash if we run operations on Main thread instead of worker thread.

This is only on DEBUG build 

Needs [#2075](https://github.com/wireapp/kalium/pull/2075) to be merged

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
