### PR TITLE
fix: max accounts handling not respected (WPB-4818)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -261,7 +261,7 @@ class WireActivityViewModel @Inject constructor(
             viewModelScope.launch {
                 authServerConfigProvider.updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
                 dismissCustomBackendDialog()
-                if (checkNumberOfSessions() == BuildConfig.MAX_ACCOUNTS) {
+                if (checkNumberOfSessions() >= BuildConfig.MAX_ACCOUNTS) {
                     globalAppState = globalAppState.copy(maxAccountDialog = true)
                 } else {
                     onProceed()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -320,14 +320,14 @@ private fun LoginContent(
     val maxAccountsReachedDialogState = rememberVisibilityState<MaxAccountsReachedDialogState>()
     MaxAccountsReachedDialogContent(maxAccountsReachedDialogState, maxAccountsReachedDialogState::dismiss)
 
-    val action = if (maxAccountsReached) {
+    val loginClickAction = if (maxAccountsReached) {
         { maxAccountsReachedDialogState.show(maxAccountsReachedDialogState.savedState ?: MaxAccountsReachedDialogState) }
     } else {
         onLoginButtonActionClicked
     }
 
     WirePrimaryButton(
-        onClick = action,
+        onClick = loginClickAction,
         text = stringResource(R.string.label_login),
         modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding)
     )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -146,6 +146,12 @@ private fun WelcomeContent(
             modifier = Modifier
                 .padding(internalPadding)
         ) {
+            val maxAccountsReachedDialogState = rememberVisibilityState<MaxAccountsReachedDialogState>()
+            MaxAccountsReachedDialogContent(maxAccountsReachedDialogState) { navigateBack() }
+            if (maxAccountsReached) {
+                maxAccountsReachedDialogState.show(maxAccountsReachedDialogState.savedState ?: MaxAccountsReachedDialogState)
+            }
+
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_wire_logo),
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -170,10 +176,7 @@ private fun WelcomeContent(
                     horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding
                 )
             ) {
-                LoginContent(
-                    maxAccountsReached = maxAccountsReached,
-                    onLoginButtonActionClicked = { navigate(NavigationCommand(LoginScreenDestination())) }
-                )
+                LoginButton(onClick = { navigate(NavigationCommand(LoginScreenDestination())) })
                 FeatureDisabledWithProxyDialogContent(
                     dialogState = enterpriseDisabledWithProxyDialogState,
                     onActionButtonClicked = {
@@ -313,21 +316,9 @@ private fun WelcomeCarouselItem(pageIconResId: Int, pageText: String) {
 }
 
 @Composable
-private fun LoginContent(
-    maxAccountsReached: Boolean,
-    onLoginButtonActionClicked: () -> Unit,
-) {
-    val maxAccountsReachedDialogState = rememberVisibilityState<MaxAccountsReachedDialogState>()
-    MaxAccountsReachedDialogContent(maxAccountsReachedDialogState, maxAccountsReachedDialogState::dismiss)
-
-    val loginClickAction = if (maxAccountsReached) {
-        { maxAccountsReachedDialogState.show(maxAccountsReachedDialogState.savedState ?: MaxAccountsReachedDialogState) }
-    } else {
-        onLoginButtonActionClicked
-    }
-
+private fun LoginButton(onClick: () -> Unit) {
     WirePrimaryButton(
-        onClick = loginClickAction,
+        onClick = onClick,
         text = stringResource(R.string.label_login),
         modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding)
     )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -86,7 +86,6 @@ import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.CreatePersonalAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.CreateTeamAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
-import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -173,8 +172,7 @@ private fun WelcomeContent(
             ) {
                 LoginContent(
                     maxAccountsReached = maxAccountsReached,
-                    onLoginButtonActionClicked = { navigate(NavigationCommand(LoginScreenDestination())) },
-                    onActionButtonMaxAccountsClicked = { navigate(NavigationCommand(SelfUserProfileScreenDestination())) },
+                    onLoginButtonActionClicked = { navigate(NavigationCommand(LoginScreenDestination())) }
                 )
                 FeatureDisabledWithProxyDialogContent(
                     dialogState = enterpriseDisabledWithProxyDialogState,
@@ -318,10 +316,9 @@ private fun WelcomeCarouselItem(pageIconResId: Int, pageText: String) {
 private fun LoginContent(
     maxAccountsReached: Boolean,
     onLoginButtonActionClicked: () -> Unit,
-    onActionButtonMaxAccountsClicked: () -> Unit,
 ) {
     val maxAccountsReachedDialogState = rememberVisibilityState<MaxAccountsReachedDialogState>()
-    MaxAccountsReachedDialogContent(maxAccountsReachedDialogState, onActionButtonMaxAccountsClicked)
+    MaxAccountsReachedDialogContent(maxAccountsReachedDialogState, maxAccountsReachedDialogState::dismiss)
 
     val action = if (maxAccountsReached) {
         { maxAccountsReachedDialogState.show(maxAccountsReachedDialogState.savedState ?: MaxAccountsReachedDialogState) }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -36,6 +36,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -62,9 +65,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.rememberPagerState
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
@@ -77,6 +77,8 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogContent
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogState
+import com.wire.android.ui.common.dialogs.MaxAccountsReachedDialogContent
+import com.wire.android.ui.common.dialogs.MaxAccountsReachedDialogState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
@@ -84,6 +86,7 @@ import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.CreatePersonalAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.CreateTeamAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
+import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -106,12 +109,19 @@ fun WelcomeScreen(
     navigator: Navigator,
     viewModel: WelcomeViewModel = hiltViewModel()
 ) {
-    WelcomeContent(viewModel.isThereActiveSession, viewModel.state, navigator::navigateBack, navigator::navigate)
+    WelcomeContent(
+        viewModel.state.isThereActiveSession,
+        viewModel.state.maxAccountsReached,
+        viewModel.state.links,
+        navigator::navigateBack,
+        navigator::navigate
+    )
 }
 
 @Composable
 private fun WelcomeContent(
     isThereActiveSession: Boolean,
+    maxAccountsReached: Boolean,
     state: ServerConfig.Links,
     navigateBack: () -> Unit,
     navigate: (NavigationCommand) -> Unit
@@ -161,7 +171,11 @@ private fun WelcomeContent(
                     horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding
                 )
             ) {
-                LoginButton() { navigate(NavigationCommand(LoginScreenDestination())) }
+                LoginContent(
+                    maxAccountsReached = maxAccountsReached,
+                    onLoginButtonActionClicked = { navigate(NavigationCommand(LoginScreenDestination())) },
+                    onActionButtonMaxAccountsClicked = { navigate(NavigationCommand(SelfUserProfileScreenDestination())) },
+                )
                 FeatureDisabledWithProxyDialogContent(
                     dialogState = enterpriseDisabledWithProxyDialogState,
                     onActionButtonClicked = {
@@ -301,9 +315,22 @@ private fun WelcomeCarouselItem(pageIconResId: Int, pageText: String) {
 }
 
 @Composable
-private fun LoginButton(onClick: () -> Unit) {
+private fun LoginContent(
+    maxAccountsReached: Boolean,
+    onLoginButtonActionClicked: () -> Unit,
+    onActionButtonMaxAccountsClicked: () -> Unit,
+) {
+    val maxAccountsReachedDialogState = rememberVisibilityState<MaxAccountsReachedDialogState>()
+    MaxAccountsReachedDialogContent(maxAccountsReachedDialogState, onActionButtonMaxAccountsClicked)
+
+    val action = if (maxAccountsReached) {
+        { maxAccountsReachedDialogState.show(maxAccountsReachedDialogState.savedState ?: MaxAccountsReachedDialogState) }
+    } else {
+        onLoginButtonActionClicked
+    }
+
     WirePrimaryButton(
-        onClick = onClick,
+        onClick = action,
         text = stringResource(R.string.label_login),
         modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding)
     )
@@ -368,7 +395,12 @@ private fun shouldJumpToEnd(previousPage: Int, currentPage: Int, lastPage: Int):
 @Composable
 fun PreviewWelcomeScreen() {
     WireTheme(isPreview = true) {
-        WelcomeContent(false, ServerConfig.DEFAULT, {}, {})
+        WelcomeContent(
+            isThereActiveSession = false,
+            maxAccountsReached = false,
+            state = ServerConfig.DEFAULT,
+            navigateBack = {},
+            navigate = {})
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreenState.kt
@@ -14,18 +14,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- *
  */
+package com.wire.android.ui.authentication.welcome
 
-package com.wire.android.ui.common.dialogs
+import com.wire.kalium.logic.configuration.server.ServerConfig
 
-import androidx.annotation.StringRes
-import com.wire.kalium.logic.data.user.UserId
-
-data class BlockUserDialogState(val userName: String, val userId: UserId)
-data class UnblockUserDialogState(val userName: String, val userId: UserId)
-data class FeatureDisabledWithProxyDialogState(@StringRes val description: Int, val teamUrl: String = "")
-object CancelLoginDialogState
-object FileSharingRestrictedDialogState
-object MaxAccountsReachedDialogState
+data class WelcomeScreenState(
+    val links: ServerConfig.Links,
+    val isThereActiveSession: Boolean = false,
+    val maxAccountsReached: Boolean = false
+)

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.common.dialogs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.VisibilityState
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.visbility.VisibilityState
+
+// todo: parametrize the dialog with the number of accounts using BuildConfig
+@Composable
+fun MaxAccountsReachedDialogContent(
+    dialogState: VisibilityState<MaxAccountsReachedDialogState>,
+    onActionButtonClicked: () -> Unit
+) {
+    VisibilityState(dialogState) { state ->
+        WireDialog(
+            title = stringResource(id = R.string.max_account_reached_dialog_title),
+            text = stringResource(id = R.string.max_account_reached_dialog_message),
+            onDismiss = dialogState::dismiss,
+            optionButton1Properties = WireDialogButtonProperties(
+                text = stringResource(R.string.max_account_reached_dialog_button_open_profile),
+                onClick = onActionButtonClicked,
+                type = WireDialogButtonType.Primary
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
@@ -41,7 +41,7 @@ fun MaxAccountsReachedDialogContent(
             text = stringResource(id = R.string.max_account_reached_dialog_message),
             onDismiss = dialogState::dismiss,
             optionButton1Properties = WireDialogButtonProperties(
-                text = stringResource(R.string.max_account_reached_dialog_button_open_profile),
+                text = stringResource(R.string.label_ok),
                 onClick = onActionButtonClicked,
                 type = WireDialogButtonType.Primary
             )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -238,7 +238,7 @@ private fun SelfUserProfileContent(
                 onStatusChange = onStatusChange,
                 onNotShowRationaleAgainChange = onNotShowRationaleAgainChange
             )
-            
+
             LogoutOptionsDialog(
                 dialogState = logoutOptionsDialogState,
                 logout = logout

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -238,15 +238,7 @@ private fun SelfUserProfileContent(
                 onStatusChange = onStatusChange,
                 onNotShowRationaleAgainChange = onNotShowRationaleAgainChange
             )
-
-            if (state.maxAccountsReached) {
-                MaxAccountReachedDialog(
-                    onConfirm = onMaxAccountReachedDialogDismissed,
-                    onDismiss = onMaxAccountReachedDialogDismissed,
-                    buttonText = R.string.label_ok
-                )
-            }
-
+            
             LogoutOptionsDialog(
                 dialogState = logoutOptionsDialogState,
                 logout = logout

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
@@ -38,7 +38,7 @@ data class SelfUserProfileState constructor(
     val otherAccounts: List<OtherAccount> = emptyList(),
     val statusDialogData: StatusDialogData? = null, // null means no dialog to display
     val isAvatarLoading: Boolean = false,
-    val maxAccountsReached: Boolean = false,
+    val maxAccountsReached: Boolean = false, // todo. cleanup unused code
     val isReadOnlyAccount: Boolean = true,
     val isLoggingOut: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -226,7 +226,7 @@ class SelfUserProfileViewModel @Inject constructor(
         }
     }
 
-    //todo. cleanup unused code
+    // todo. cleanup unused code
     fun tryToInitAddingAccount(onSucceeded: () -> Unit) {
         viewModelScope.launch {
             // the total number of accounts is otherAccounts + 1 for the current account

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -226,6 +226,7 @@ class SelfUserProfileViewModel @Inject constructor(
         }
     }
 
+    //todo. cleanup unused code
     fun tryToInitAddingAccount(onSucceeded: () -> Unit) {
         viewModelScope.launch {
             // the total number of accounts is otherAccounts + 1 for the current account
@@ -280,6 +281,7 @@ class SelfUserProfileViewModel @Inject constructor(
         }
     }
 
+    // todo. cleanup unused code
     fun onMaxAccountReachedDialogDismissed() {
         userProfileState = userProfileState.copy(maxAccountsReached = false)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some code were removed/adjusted and now we are not handling max account check on add "new account" self profile.

### Causes (Optional)

We can add infinte? accounts.

### Solutions

- Check for max accounts when trying to login, as a safety mechanism taking into consideration the Build flag.
- Create a proper state object for `WelcomeScreen`, so we handle them unified as in the rest of the project

### Notes (Optional)

Moving forward and not for now, since this is critical for release.
- It was discovered https://wearezeta.atlassian.net/browse/WPB-1862
- Dead code, I left some marks to refactor/remove later.
- We can unify the Dialog used on deeplinks to the General Dialog approach used here, we can migrate later.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Attachments (Optional)

https://github.com/wireapp/wire-android-reloaded/assets/5806454/6887e31e-1396-493a-b1ec-5dac806ea72e

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
