### PR TITLE
fix: max accounts dialog prevent dismiss (WPB-4818) 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/MaxAccountsReachedDialog.kt
@@ -28,6 +28,7 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.visbility.VisibilityState
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
 
 // todo: parametrize the dialog with the number of accounts using BuildConfig
 @Composable
@@ -44,6 +45,10 @@ fun MaxAccountsReachedDialogContent(
                 text = stringResource(R.string.label_ok),
                 onClick = onActionButtonClicked,
                 type = WireDialogButtonType.Primary
+            ),
+            properties = wireDialogPropertiesBuilder(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
             )
         )
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Dialog can be dismissed bypassing the max accounts creation.

### Causes (Optional)

Max accounts flag not respected

### Solutions

Make the dialog stick, not dismiss outside.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
