### PR TITLE
fix: join call on back facing camera (WPB-3454)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -195,7 +195,11 @@ class SharedCallingViewModel @Inject constructor(
                     isCameraOn = it.isCameraOn,
                     isCbrEnabled = it.isCbrEnabled && call.conversationType == Conversation.Type.ONE_ON_ONE,
                     callerName = it.callerName,
-                    participants = it.participants.map { participant -> uiCallParticipantMapper.toUICallParticipant(participant) }
+                    participants = it.participants.map { participant ->
+                        uiCallParticipantMapper.toUICallParticipant(
+                            participant
+                        )
+                    }
                 )
             }
         }
@@ -205,9 +209,19 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             onCompleted()
             endCall(conversationId)
-            // we need to update mute state to false, so if the user re-join the call te mic will will be muted
-            muteCall(conversationId, false)
+            resetCallConfig()
             callRinger.stop()
+        }
+    }
+
+    private suspend fun resetCallConfig() {
+        // we need to update mute state to false, so if the user re-join the call te mic will will be muted
+        muteCall(conversationId, false)
+        if (callState.isCameraOn) {
+            flipToFrontCamera(conversationId)
+        }
+        if (callState.isCameraOn || callState.isSpeakerOn) {
+            turnLoudSpeakerOff()
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3454" title="WPB-3454" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3454</a>  [Android] Flip cam on second call is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we join a call, the default camera is by default back facing one

### Causes (Optional)

The app is taking last state of camera (for all calls)

### Solutions

Reset camera to facing to back facing one after each call end

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Join 1st call, enable your camera, flip to back camera and end the call
- Join 2nd call enable your camera
- Default camera should be front facing 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
