### PR TITLE
fix(links): embedded links with escaped chars [e.g. plus] (WPB-4402)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -18,6 +18,7 @@
 package com.wire.android.util
 
 import java.net.URI
+import android.net.Uri
 import java.net.URLDecoder
 
 fun containsSchema(url: String): Boolean {
@@ -29,11 +30,9 @@ fun containsSchema(url: String): Boolean {
 }
 
 fun normalizeLink(url: String): String {
-    val normalizedUrl = URLDecoder.decode(url, "UTF-8") // Decode URL to human-readable format
-
-    return if (containsSchema(normalizedUrl)) {
-        normalizedUrl
+    return if (containsSchema(url)) {
+        url
     } else {
-        "https://$normalizedUrl"
+        "https://$url"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -18,8 +18,6 @@
 package com.wire.android.util
 
 import java.net.URI
-import android.net.Uri
-import java.net.URLDecoder
 
 fun containsSchema(url: String): Boolean {
     return try {

--- a/app/src/test/kotlin/com/wire/android/util/UriUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/UriUtilTest.kt
@@ -79,4 +79,11 @@ class UriUtilTest {
         val actual = normalizeLink(input)
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun givenEncodedLink_whenTheLinkIsValidWithSchema_thenReturnsTheSameLink() {
+        val input = "https://google.com/this+is+a+link+with+space"
+        val actual = normalizeLink(input)
+        assertEquals(input, actual)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4402" title="WPB-4402" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4402</a>  [Android] Links not handled properly when including https and special characters
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When the embedded link in a message, was encoded with escape chars such as +, we were decoding it unnecessary and that was causing an error in detecting the url as invalid one, in the result we were adding an extra schema [https] to the valid link.

### Issues

Adding an extra schema [https] to the valid link with escape chars.

### Causes (Optional)

Unneeded decoding. 

### Solutions

Removed the unneeded decoding, and adding more tests.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have an embedded link like: https://google.com/this+is+a+test, the link the app tried to open should be the same and with only one https.

#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
