### PR TITLE
fix: self deleting ping has no sound (WPB-3175)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -220,6 +220,11 @@ class MessageNotificationManager
                                 addAction(getActionReply(context, conversation.id, userIdString))
                             }
 
+                            is NotificationMessage.ObfuscatedKnock -> {
+                                setChannelId(NotificationConstants.getPingsChannelId(userId))
+                                setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
+                            }
+
                             null -> {
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                                 addAction(getActionReply(context, conversation.id, userIdString))
@@ -400,7 +405,8 @@ class MessageNotificationManager
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
             is NotificationMessage.Knock -> italicTextFromResId(R.string.notification_knock)
-            is NotificationMessage.ObfuscatedMessage -> italicTextFromResId(
+            is NotificationMessage.ObfuscatedMessage,
+            is NotificationMessage.ObfuscatedKnock-> italicTextFromResId(
                 R.string.notification_obfuscated_message_content
             )
         }

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -406,7 +406,7 @@ class MessageNotificationManager
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
             is NotificationMessage.Knock -> italicTextFromResId(R.string.notification_knock)
             is NotificationMessage.ObfuscatedMessage,
-            is NotificationMessage.ObfuscatedKnock-> italicTextFromResId(
+            is NotificationMessage.ObfuscatedKnock -> italicTextFromResId(
                 R.string.notification_obfuscated_message_content
             )
         }

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -92,7 +92,7 @@ sealed class NotificationMessage(open val messageId: String, open val author: No
     ) :
         NotificationMessage(messageId, author, time)
 
-    data class Knock(override val messageId: String, override val author: NotificationMessageAuthor?, override val time: Long) :
+    data class Knock(override val messageId: String, override val author: NotificationMessageAuthor, override val time: Long) :
         NotificationMessage(messageId, author, time)
 
     data class ConnectionRequest(

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -70,6 +70,11 @@ sealed class NotificationMessage(open val messageId: String, open val author: No
         override val time: Long
     ) : NotificationMessage(messageId, null, time)
 
+    data class ObfuscatedKnock(
+        override val messageId: String,
+        override val time: Long
+    ) : NotificationMessage(messageId, null, time)
+
     data class Text(
         override val messageId: String,
         override val author: NotificationMessageAuthor,
@@ -87,7 +92,7 @@ sealed class NotificationMessage(open val messageId: String, open val author: No
     ) :
         NotificationMessage(messageId, author, time)
 
-    data class Knock(override val messageId: String, override val author: NotificationMessageAuthor, override val time: Long) :
+    data class Knock(override val messageId: String, override val author: NotificationMessageAuthor?, override val time: Long) :
         NotificationMessage(messageId, author, time)
 
     data class ConnectionRequest(
@@ -204,6 +209,13 @@ fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
                 messageId,
                 notificationMessageAuthor,
                 notificationMessageTime
+            )
+        }
+
+        is LocalNotificationMessage.SelfDeleteKnock -> {
+            NotificationMessage.ObfuscatedKnock(
+                messageId = messageId,
+                time = notificationMessageTime
             )
         }
 

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -438,7 +438,10 @@ class WireNotificationManager @Inject constructor(
                 .any {
                     it.conversationId == conversationId &&
                             it is LocalNotification.Conversation &&
-                            it.messages.any { message -> message is LocalNotificationMessage.Knock }
+                            it.messages.any { message ->
+                                message is LocalNotificationMessage.Knock ||
+                                        message is LocalNotificationMessage.SelfDeleteKnock
+                            }
                 }
 
             if (containsPingMessage) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3175" title="WPB-3175" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3175</a>  No sound for Self-deleting pings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Self-deleting pings (knock message) has no sound (both from notification or inside conversation)

### Causes (Optional)

As it was being "hidden" behind self deleting message it wouldn't map correctly to Knock/Ping type

### Solutions

Correctly map knock/ping from self deleting message to self deleting ping in order to play the sound on notification and inside conversation.

### Testing

#### How to Test

**Phone must NOT be on silent mode**
- **On Conversation List:**
- Receive self deleting ping => should play a sound

- **Inside Conversation**
- Receive self deleting ping => should play a sound


### Needs before:
[ ] - https://github.com/wireapp/kalium/pull/2086
