### PR TITLE
feat: archived conversations tab empty state (WPB-4430)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
@@ -83,7 +83,10 @@ fun HomeDrawer(
             onCloseDrawer()
         }
 
-        val topItems = listOf(HomeDestination.Conversations)
+        val topItems = listOf(
+            HomeDestination.Conversations,
+            HomeDestination.Archive
+        )
         // TODO: Re-enable once we have Archive & Vault
         // listOf(HomeDestination.Conversations, HomeDestination.Archive, HomeDestination.Vault)
         topItems.forEach { item ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
@@ -20,17 +20,60 @@
 
 package com.wire.android.ui.home.archive
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.annotation.Destination
+import com.wire.android.R
 import com.wire.android.navigation.HomeNavGraph
-import com.wire.android.ui.common.UnderConstructionScreen
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
 
 @HomeNavGraph
 @Destination
 @Composable
 fun ArchiveScreen() {
-    UnderConstructionScreen(screenName = "ArchiveScreen")
+    ArchivedConversationsEmptyStateScreen()
+}
+
+@Composable
+fun ArchivedConversationsEmptyStateScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            modifier = Modifier.padding(
+                bottom = dimensions().spacing24x,
+            ),
+            text = stringResource(R.string.archive_screen_empty_state_title),
+            style = MaterialTheme.wireTypography.title01,
+            color = MaterialTheme.wireColorScheme.onSurface,
+        )
+        Text(
+            modifier = Modifier.padding(
+                bottom = dimensions().spacing8x,
+                start = dimensions().spacing40x,
+                end = dimensions().spacing40x
+            ),
+            text = stringResource(R.string.archive_screen_empty_state_description),
+            style = MaterialTheme.wireTypography.body01,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.wireColorScheme.secondaryText,
+        )
+    }
 }
 
 @Preview(showBackground = false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,8 @@
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>
+    <string name="archive_screen_empty_state_title">Nothing archived yet 👻</string>
+    <string name="archive_screen_empty_state_description">To keep your conversation list tidy, move unused conversations here. You can always unarchive those later.</string>
     <string name="user_profile_screen_title">User Profile</string>
     <string name="settings_screen_title">Settings</string>
     <string name="app_settings_screen_title">App Settings</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4430" title="WPB-4430" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4430</a>  [UI] Empty state for archived conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no screen(nor empty screen state) for archived conversations.

### Causes (Optional)

Was not implemented. (blank Archived screen was)

### Solutions

- Add Archived tab to the hamburger menu
- Add empty screen state

### Testing

#### How to Test

- Open App
- Open Hamburger menu on the left
- Select `Archived`
- Empty Archived screen should be shown

### Attachments (Optional)

| Light Mode | Dark Mode |
| ----------- | ------------ |
|  <img src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/b8be650c-5bfa-4972-89ea-69a31a52e52f" width="200" height="400" alt="Light Mode" /> |  <img src="https://github.com/wireapp/wire-android-reloaded/assets/5890660/ccf74642-a2c8-42f5-ada7-cc9c8338ae7c" width="200" height="400" alt="Dark Mode" /> |
